### PR TITLE
ci: add Changesets release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Version & Publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Authenticate git with a PAT (or GitHub App token) rather than the
+          # default GITHUB_TOKEN so the commits the changesets action pushes to
+          # `changeset-release/main` trigger CI. GitHub suppresses workflow runs
+          # on GITHUB_TOKEN-authored pushes (recursion guard), which leaves the
+          # version PR with no required status checks and unmergeable until
+          # someone re-triggers it. Falls back to GITHUB_TOKEN when RELEASE_PAT
+          # isn't configured, so releases keep working regardless.
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - run: pnpm install --frozen-lockfile
+
+      # The `release` script builds packages/* before `changeset publish`.
+      - name: Create Release PR or Publish
+        uses: changesets/action@v1
+        with:
+          title: "chore: version packages"
+          commit: "chore: version packages"
+          version: pnpm changeset:version
+          publish: pnpm release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What

Adds `.github/workflows/release.yml` so GemStack releases the same way Rudder does. On push to `main`, `changesets/action`:

- **opens / updates** a `chore: version packages` PR while changesets are pending (runs `pnpm changeset:version`), and
- **publishes** via `pnpm release` (`turbo build --filter=./packages/*` + `changeset publish`) once that PR merges and no changesets remain.

This removes the manual `pnpm changeset version` + passkey `npm publish` loop used for `@gemstack/ai-sdk@0.1.0` and `0.2.0`.

## Required before it can publish

- [ ] **`NPM_TOKEN`** repo (or org) secret — an npm **automation** token with publish rights on the `@gemstack` scope (automation tokens bypass the passkey/OTP prompt, which is what blocked CI publishing before).
- [ ] *(optional)* **`RELEASE_PAT`** — a PAT/App token so the bot's pushes to `changeset-release/main` trigger CI on the version PR. Falls back to `GITHUB_TOKEN` if unset (releases still work; the version PR just may need a nudge to get checks).

Until `NPM_TOKEN` is set the workflow runs but the publish step no-ops/fails at auth, so add the secret before relying on it.

## Notes

- Mirrors `rudderjs/rudder`'s `release.yml` intent, in GemStack's lighter `@v4`-pinned style (matches the existing `ci.yml`).
- No changeset needed (CI-only change).