### PR TITLE
feat(mcp): promote introspect() + schema/uri helpers to public API

### DIFF
--- a/.changeset/mcp-public-introspection-helpers.md
+++ b/.changeset/mcp-public-introspection-helpers.md
@@ -1,0 +1,12 @@
+---
+"@gemstack/mcp": minor
+---
+
+Promote MCP-authoring utilities to the public API so inspectors and tooling no longer need internal access.
+
+- `McpServer.introspect()`: a public introspection surface returning the registered tool / resource / prompt classes (constructors, not instances) without starting a session. The supported alternative to the internal `_tools()` / `_resources()` / `_prompts()` accessors, which stay `@internal`.
+- `zodToJsonSchema(schema)`: convert a Zod schema to the JSON Schema MCP advertises (exported from the package entry).
+- `matchUriTemplate(template, uri)`: match a URI against a `resource://{template}` pattern and extract params.
+- New `McpServerIntrospection` and `ZodLikeObject` types exported alongside.
+
+This lets a thin framework binding (e.g. `@rudderjs/mcp`) build a server inspector against the published surface instead of re-declaring internal shapes or carrying local copies of the helpers.

--- a/packages/mcp/src/McpServer.ts
+++ b/packages/mcp/src/McpServer.ts
@@ -10,6 +10,18 @@ export interface McpServerMetadata {
   instructions?: string
 }
 
+/**
+ * The tool / resource / prompt classes a server declares, surfaced for
+ * inspectors and tooling that enumerate a server without starting a session.
+ * These are the class constructors (not instances) so a caller can resolve or
+ * construct them with its own DI. See {@link McpServer.introspect}.
+ */
+export interface McpServerIntrospection {
+  tools: (new () => McpTool)[]
+  resources: (new () => McpResource)[]
+  prompts: (new () => McpPrompt)[]
+}
+
 export interface McpServerOptions {
   /**
    * DI resolver used to construct tool / resource / prompt classes and to
@@ -87,6 +99,17 @@ export abstract class McpServer {
   /** @internal — runtime/inspector/testing only. Exposes the protected prompt classes array. */
   _prompts(): (new () => McpPrompt)[] {
     return this.prompts
+  }
+
+  /**
+   * Public introspection surface: the registered tool / resource / prompt
+   * classes, without starting a session. Returns the class constructors (not
+   * instances) so inspectors and tooling can resolve or construct them with
+   * their own DI. This is the supported alternative to the internal
+   * underscore-prefixed `_tools()` / `_resources()` / `_prompts()` accessors.
+   */
+  introspect(): McpServerIntrospection {
+    return { tools: this.tools, resources: this.resources, prompts: this.prompts }
   }
 
   /** @internal — exposed for tests; counts active notification targets. */

--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -274,6 +274,68 @@ describe('McpTool', () => {
   })
 })
 
+// ─── McpServer.introspect ─────────────────────────────────
+
+describe('McpServer.introspect', () => {
+  class EchoTool extends McpTool {
+    schema() { return z.object({ name: z.string() }) }
+    async handle() { return McpResponse.text('hi') }
+  }
+  class DocResource extends McpResource {
+    uri() { return 'doc://readme' }
+    async handle() { return '# readme' }
+  }
+  class GreetPrompt extends McpPrompt {
+    async handle() { return [{ role: 'user' as const, content: 'hi' }] }
+  }
+
+  it('returns the registered tool / resource / prompt classes', () => {
+    @Name('demo')
+    class DemoServer extends McpServer {
+      protected tools = [EchoTool]
+      protected resources = [DocResource]
+      protected prompts = [GreetPrompt]
+    }
+
+    const { tools, resources, prompts } = new DemoServer().introspect()
+    assert.deepEqual(tools, [EchoTool])
+    assert.deepEqual(resources, [DocResource])
+    assert.deepEqual(prompts, [GreetPrompt])
+  })
+
+  it('mirrors the @internal _tools()/_resources()/_prompts() accessors', () => {
+    @Name('demo')
+    class DemoServer extends McpServer {
+      protected tools = [EchoTool]
+    }
+
+    const server = new DemoServer()
+    const internal = server as unknown as { _tools(): unknown[]; _resources(): unknown[]; _prompts(): unknown[] }
+    const view = server.introspect()
+    assert.deepEqual(view.tools, internal._tools())
+    assert.deepEqual(view.resources, internal._resources())
+    assert.deepEqual(view.prompts, internal._prompts())
+  })
+
+  it('returns empty arrays for a server that declares nothing', () => {
+    @Name('empty')
+    class EmptyServer extends McpServer {}
+    const view = new EmptyServer().introspect()
+    assert.deepEqual(view, { tools: [], resources: [], prompts: [] })
+  })
+})
+
+// ─── public MCP-authoring helpers ─────────────────────────
+
+describe('public helper exports', () => {
+  it('re-exports zodToJsonSchema and matchUriTemplate from the package entry', async () => {
+    const entry = await import('./index.js')
+    assert.equal(typeof entry.zodToJsonSchema, 'function')
+    assert.equal(typeof entry.matchUriTemplate, 'function')
+    assert.deepEqual(entry.matchUriTemplate('doc://{id}', 'doc://42'), { id: '42' })
+  })
+})
+
 // ─── McpPrompt ────────────────────────────────────────────
 
 describe('McpPrompt', () => {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,5 +1,5 @@
 export { McpServer } from './McpServer.js'
-export type { McpServerMetadata, McpServerOptions } from './McpServer.js'
+export type { McpServerMetadata, McpServerOptions, McpServerIntrospection } from './McpServer.js'
 export { McpTool } from './McpTool.js'
 export type { McpToolResult, McpToolProgress, McpToolReturn } from './McpTool.js'
 export { McpResource } from './McpResource.js'
@@ -31,3 +31,9 @@ export { createMcpHttpHandler } from './runtime/node-handler.js'
 export { McpTestClient } from './testing.js'
 export type { McpTestClientOptions } from './testing.js'
 export type { McpObserverEvent, McpObserver, McpObserverRegistry } from './observers.js'
+// MCP-authoring utilities, useful for custom inspectors / tooling built on the
+// core: convert a Zod schema to the JSON Schema MCP advertises, and match a URI
+// against a `resource://{template}` pattern. Both are pure and dependency-light.
+export { zodToJsonSchema } from './zod-to-json-schema.js'
+export type { ZodLikeObject } from './types.js'
+export { matchUriTemplate } from './uri-template.js'


### PR DESCRIPTION
Closes #24. Follow-up from Phase 2 (the `@rudderjs/mcp` thin-binding repoint, rudderjs/rudder#1448).

## Problem

The binding's inspector reached into `@gemstack/mcp` internals two ways, both smells for a thin binding:

1. It re-declared the shape of `McpServer._tools()/_resources()/_prompts()` and cast through `unknown`, because those accessors are `@internal` and `stripInternal` removes them from the published `.d.ts`.
2. It carried **local copies** of `zod-to-json-schema.ts` + `uri-template.ts`, duplicating the core's logic, because neither helper was in the public API.

## Change

Promote a clean public surface so the binding needs no internal access:

- **`McpServer.introspect()`** returns the registered tool / resource / prompt classes (constructors, not instances) without starting a session. The internal `_tools()/_resources()/_prompts()` accessors stay `@internal` and remain stripped from the published types.
- **`zodToJsonSchema(schema)`** and **`matchUriTemplate(template, uri)`** are now exported from the package entry as pure MCP-authoring utilities.
- New **`McpServerIntrospection`** and **`ZodLikeObject`** types exported alongside.

## Verification

- Typecheck + build clean.
- 104 tests pass (+4: `introspect()` returns/mirrors the internal accessors/empty-server case, plus a public-export smoke for the two helpers).
- Confirmed in the built `.d.ts`: `introspect(): McpServerIntrospection` is present; `_tools/_resources/_prompts/attachSdk` are still stripped.
- Minor changeset bumps `@gemstack/mcp` to 0.2.0.

## Downstream

Once 0.2.0 publishes, a small rudderjs/rudder cleanup PR will delete the binding's local `zod-to-json-schema.ts` + `uri-template.ts`, swap the inspector's internal cast for `server.introspect()`, and bump the `@gemstack/mcp` dep.