### PR TITLE
refactor(ai-sdk): rebrand [Rudder AI] error prefix to [ai-sdk], fix issue URL

### DIFF
--- a/.changeset/ai-sdk-quality-pass.md
+++ b/.changeset/ai-sdk-quality-pass.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/ai-sdk": patch
+---
+
+Quality pass for ai-sdk: rebrand the error/log message prefix from the migration leftover `[Rudder AI]` to `[ai-sdk]` (108 messages across 38 modules), matching the sibling packages' package-name prefix convention, and fix the "file an issue" URL in the Bedrock provider to point at `gemstack-land/gemstack`. No API or behavior change beyond the message text.

--- a/packages/ai-sdk/src/agent-run-store.ts
+++ b/packages/ai-sdk/src/agent-run-store.ts
@@ -202,7 +202,7 @@ export class CachedAgentRunStore implements AgentRunStore {
     }
     const adapter = mod.CacheRegistry?.get?.()
     if (!adapter) {
-      throw new Error('[Rudder AI] CachedAgentRunStore needs a cache adapter. Install `@rudderjs/cache`, register a driver, or pass `{ cache }` explicitly.')
+      throw new Error('[ai-sdk] CachedAgentRunStore needs a cache adapter. Install `@rudderjs/cache`, register a driver, or pass `{ cache }` explicitly.')
     }
     this.resolvedCache = adapter
     return adapter

--- a/packages/ai-sdk/src/agent.ts
+++ b/packages/ai-sdk/src/agent.ts
@@ -465,7 +465,7 @@ export abstract class Agent {
     suspendable?: AsToolSuspendableOption
   }): ServerToolBuilder<unknown, AgentResponse> {
     if (options.suspendable && !options.streaming) {
-      throw new Error('[Rudder AI] asTool: `suspendable` requires `streaming: true` (or a projector). Silent suspend would leave the parent UI with no progress signal between sub-agent invocations.')
+      throw new Error('[ai-sdk] asTool: `suspendable` requires `streaming: true` (or a projector). Silent suspend would leave the parent UI with no progress signal between sub-agent invocations.')
     }
 
     const schema      = options.inputSchema ?? z.object({ prompt: z.string() })
@@ -621,7 +621,7 @@ export abstract class Agent {
   > {
     const snapshot = await options.runStore.consume(subRunId)
     if (!snapshot) {
-      throw new Error(`[Rudder AI] resumeAsTool: subRunId "${subRunId}" expired or never existed.`)
+      throw new Error(`[ai-sdk] resumeAsTool: subRunId "${subRunId}" expired or never existed.`)
     }
 
     const pauseKind: SubAgentPauseKind = snapshot.pauseKind ?? 'client_tool'
@@ -635,10 +635,10 @@ export abstract class Agent {
       const seen = new Set<string>()
       for (const r of clientToolResults) {
         if (!pending.has(r.toolCallId)) {
-          throw new Error(`[Rudder AI] resumeAsTool: toolCallId "${r.toolCallId}" was not in the pending set.`)
+          throw new Error(`[ai-sdk] resumeAsTool: toolCallId "${r.toolCallId}" was not in the pending set.`)
         }
         if (seen.has(r.toolCallId)) {
-          throw new Error(`[Rudder AI] resumeAsTool: duplicate result for toolCallId "${r.toolCallId}".`)
+          throw new Error(`[ai-sdk] resumeAsTool: duplicate result for toolCallId "${r.toolCallId}".`)
         }
         seen.add(r.toolCallId)
       }
@@ -656,22 +656,22 @@ export abstract class Agent {
       // Approval-pause resume — clientToolResults must be empty; either an
       // approval or a rejection must be supplied for the pending id.
       if (clientToolResults.length > 0) {
-        throw new Error('[Rudder AI] resumeAsTool: snapshot.pauseKind === "approval" but clientToolResults was non-empty. Pass `approvedToolCallIds` or `rejectedToolCallIds` instead.')
+        throw new Error('[ai-sdk] resumeAsTool: snapshot.pauseKind === "approval" but clientToolResults was non-empty. Pass `approvedToolCallIds` or `rejectedToolCallIds` instead.')
       }
       const approved = options.approvedToolCallIds ?? []
       const rejected = options.rejectedToolCallIds ?? []
       for (const id of approved) {
         if (!pending.has(id)) {
-          throw new Error(`[Rudder AI] resumeAsTool: approvedToolCallId "${id}" was not in the pending set.`)
+          throw new Error(`[ai-sdk] resumeAsTool: approvedToolCallId "${id}" was not in the pending set.`)
         }
       }
       for (const id of rejected) {
         if (!pending.has(id)) {
-          throw new Error(`[Rudder AI] resumeAsTool: rejectedToolCallId "${id}" was not in the pending set.`)
+          throw new Error(`[ai-sdk] resumeAsTool: rejectedToolCallId "${id}" was not in the pending set.`)
         }
       }
       if (approved.length === 0 && rejected.length === 0) {
-        throw new Error('[Rudder AI] resumeAsTool: snapshot.pauseKind === "approval" requires `approvedToolCallIds` or `rejectedToolCallIds`.')
+        throw new Error('[ai-sdk] resumeAsTool: snapshot.pauseKind === "approval" requires `approvedToolCallIds` or `rejectedToolCallIds`.')
       }
 
       messages = [...snapshot.messages]
@@ -1008,7 +1008,7 @@ export class ConversableAgent {
   private toSpec(): ConversationalSpec {
     if (this._conversationId) return { user: this._userId ?? '', id: this._conversationId }
     if (this._userId)         return { user: this._userId }
-    throw new Error('[Rudder AI] ConversableAgent requires forUser() or continue() to be called before prompt().')
+    throw new Error('[ai-sdk] ConversableAgent requires forUser() or continue() to be called before prompt().')
   }
 }
 
@@ -1774,7 +1774,7 @@ function runAgentLoopStreaming(a: Agent, input: string, options?: AgentPromptOpt
       }
 
       if (r._pendingHandoff) {
-        throw new Error(`[Rudder AI] Exceeded max handoffs (${MAX_HANDOFFS}). Likely a cycle between agents.`)
+        throw new Error(`[ai-sdk] Exceeded max handoffs (${MAX_HANDOFFS}). Likely a cycle between agents.`)
       }
 
       finalResponse = handoffPath.length === 0
@@ -1784,7 +1784,7 @@ function runAgentLoopStreaming(a: Agent, input: string, options?: AgentPromptOpt
     }
 
     if (!finalResponse) {
-      throw new Error(`[Rudder AI] Exceeded max handoffs (${MAX_HANDOFFS}). Likely a cycle between agents.`)
+      throw new Error(`[ai-sdk] Exceeded max handoffs (${MAX_HANDOFFS}). Likely a cycle between agents.`)
     }
     resolveResponse(finalResponse)
   }

--- a/packages/ai-sdk/src/attachment.ts
+++ b/packages/ai-sdk/src/attachment.ts
@@ -23,7 +23,7 @@ export class DocumentAttachment {
   /** Create from a URL (fetches the content) */
   static async fromUrl(url: string): Promise<DocumentAttachment> {
     const res = await fetch(url)
-    if (!res.ok) throw new Error(`[Rudder AI] Failed to fetch document: ${res.status} ${url}`)
+    if (!res.ok) throw new Error(`[ai-sdk] Failed to fetch document: ${res.status} ${url}`)
     const bytes = new Uint8Array(await res.arrayBuffer())
     const mimeType = res.headers.get('content-type')?.split(';')[0] ?? 'application/octet-stream'
     const name = url.split('/').pop()?.split('?')[0]
@@ -59,7 +59,7 @@ export class ImageAttachment {
   /** Create from a URL (fetches the image) */
   static async fromUrl(url: string): Promise<ImageAttachment> {
     const res = await fetch(url)
-    if (!res.ok) throw new Error(`[Rudder AI] Failed to fetch image: ${res.status} ${url}`)
+    if (!res.ok) throw new Error(`[ai-sdk] Failed to fetch image: ${res.status} ${url}`)
     const bytes = new Uint8Array(await res.arrayBuffer())
     const mimeType = res.headers.get('content-type')?.split(';')[0] ?? 'image/png'
     return new ImageAttachment(toBase64(bytes), mimeType)

--- a/packages/ai-sdk/src/audio.ts
+++ b/packages/ai-sdk/src/audio.ts
@@ -72,7 +72,7 @@ export class AudioGenerator {
 
       if (!factory.createTts) {
         throw new Error(
-          `[Rudder AI] Provider "${providerName}" does not support text-to-speech. ` +
+          `[ai-sdk] Provider "${providerName}" does not support text-to-speech. ` +
           `Use a provider that implements createTts() (e.g. openai).`,
         )
       }
@@ -100,7 +100,7 @@ export class AudioGenerator {
       return path
     } catch {
       throw new Error(
-        '[Rudder AI] @rudderjs/storage is required for AudioGenerator.store(). ' +
+        '[ai-sdk] @rudderjs/storage is required for AudioGenerator.store(). ' +
         'Install it: pnpm add @rudderjs/storage',
       )
     }

--- a/packages/ai-sdk/src/budget-orm/index.ts
+++ b/packages/ai-sdk/src/budget-orm/index.ts
@@ -85,10 +85,10 @@ export class BudgetUsageRecord extends Model {
 export class OrmBudgetStorage implements BudgetStorage {
   async checkAndDebit(opts: BudgetCheckOptions): Promise<BudgetCheckResult> {
     if (!Number.isFinite(opts.cap) || opts.cap < 0) {
-      throw new Error(`[Rudder AI] BudgetStorage: cap must be a non-negative finite number, got ${opts.cap}`)
+      throw new Error(`[ai-sdk] BudgetStorage: cap must be a non-negative finite number, got ${opts.cap}`)
     }
     if (!Number.isFinite(opts.costUsd) || opts.costUsd < 0) {
-      throw new Error(`[Rudder AI] BudgetStorage: costUsd must be a non-negative finite number, got ${opts.costUsd}`)
+      throw new Error(`[ai-sdk] BudgetStorage: costUsd must be a non-negative finite number, got ${opts.costUsd}`)
     }
 
     const now = opts.now ?? new Date()

--- a/packages/ai-sdk/src/budget/pricing.ts
+++ b/packages/ai-sdk/src/budget/pricing.ts
@@ -191,7 +191,7 @@ export class UnknownModelPricingError extends Error {
     const snapshotDate = sample ? (pricing[sample]?._snapshotDate ?? null) : null
     const sampleSuffix = snapshotDate ? ` (catalog snapshot ${snapshotDate})` : ''
     super(
-      `[Rudder AI] No pricing entry for model "${model}"${sampleSuffix}. ` +
+      `[ai-sdk] No pricing entry for model "${model}"${sampleSuffix}. ` +
       `Either the model id is misspelled, or the catalog is stale — ` +
       `add an override entry: \`pricing: { ...ModelPricing, "${model}": { inputPer1k, outputPer1k, _snapshotDate } }\`.`,
     )
@@ -215,7 +215,7 @@ export class BudgetExceededError extends Error {
 
   constructor(opts: { userId: string; period: 'daily' | 'monthly'; spent: number; cap: number }) {
     super(
-      `[Rudder AI] ${opts.period} budget of $${opts.cap.toFixed(2)} exceeded for user ${opts.userId} ` +
+      `[ai-sdk] ${opts.period} budget of $${opts.cap.toFixed(2)} exceeded for user ${opts.userId} ` +
       `(spent $${opts.spent.toFixed(4)}).`,
     )
     this.name = 'BudgetExceededError'

--- a/packages/ai-sdk/src/commands/ai-eval.ts
+++ b/packages/ai-sdk/src/commands/ai-eval.ts
@@ -121,7 +121,7 @@ export function parseArgs(args: string[]): AiEvalOptions {
     if (VALUE_FLAGS.has(name)) {
       const value = inline ?? args[i + 1]
       if (!inline) i++   // consumed the next arg
-      if (!value) throw new Error(`[Rudder AI] ${name} requires a value`)
+      if (!value) throw new Error(`[ai-sdk] ${name} requires a value`)
       if (name === '--html') opts.html = value
       continue
     }
@@ -404,7 +404,7 @@ function parsePattern(pattern: string): { root: string; suffix: string } {
   }
   if (!postfix.startsWith('*')) {
     throw new Error(
-      `[Rudder AI] Unsupported eval pattern "${pattern}". ` +
+      `[ai-sdk] Unsupported eval pattern "${pattern}". ` +
       `Expected <dir>/**/*<suffix> or *<suffix>.`,
     )
   }

--- a/packages/ai-sdk/src/computer-use/errors.ts
+++ b/packages/ai-sdk/src/computer-use/errors.ts
@@ -27,7 +27,7 @@ export class ComputerUseProviderError extends Error {
 
   constructor(model: string) {
     super(
-      `[Rudder AI] computerUseTool is Anthropic-only in v1; got model "${model}". ` +
+      `[ai-sdk] computerUseTool is Anthropic-only in v1; got model "${model}". ` +
       `Use an "anthropic/*" or "bedrock/<region.>?anthropic.*" model, or remove the tool.`,
     )
     this.name = 'ComputerUseProviderError'
@@ -50,7 +50,7 @@ export class ComputerUseLimitError extends Error {
 
   constructor(maxActions: number) {
     super(
-      `[Rudder AI] computerUseTool exceeded maxActions cap of ${maxActions}. ` +
+      `[ai-sdk] computerUseTool exceeded maxActions cap of ${maxActions}. ` +
       `Bump the cap with computerUseTool({ page, maxActions: <n> }) if your agent legitimately needs more steps.`,
     )
     this.name = 'ComputerUseLimitError'

--- a/packages/ai-sdk/src/continuation-validation.ts
+++ b/packages/ai-sdk/src/continuation-validation.ts
@@ -186,7 +186,7 @@ export class ContinuationValidationError extends Error {
   readonly code: ContinuationRejectionCode
   readonly index: number | undefined
   constructor(result: ContinuationValidationResult) {
-    super(`[Rudder AI] Rejected continuation: ${result.reason ?? result.code ?? 'invalid'}`)
+    super(`[ai-sdk] Rejected continuation: ${result.reason ?? result.code ?? 'invalid'}`)
     this.name = 'ContinuationValidationError'
     this.code = result.code ?? 'not-a-prefix'
     this.index = result.index

--- a/packages/ai-sdk/src/conversation-orm/index.ts
+++ b/packages/ai-sdk/src/conversation-orm/index.ts
@@ -217,7 +217,7 @@ model AiConversationMessage {
 // ─── Helpers ──────────────────────────────────────────────
 
 function notFound(conversationId: string): Error {
-  return new Error(`[Rudder AI] Conversation "${conversationId}" not found.`)
+  return new Error(`[ai-sdk] Conversation "${conversationId}" not found.`)
 }
 
 function messageToRow(conversationId: string, position: number, m: AiMessage): Record<string, unknown> {

--- a/packages/ai-sdk/src/conversation-persistence.ts
+++ b/packages/ai-sdk/src/conversation-persistence.ts
@@ -100,7 +100,7 @@ async function preparePersistence(
       convId = await store.create(undefined, { userId: spec.user, agent: agentKey })
     }
   } else {
-    throw new Error('[Rudder AI] ConversationalSpec must include either `user` or `id`.')
+    throw new Error('[ai-sdk] ConversationalSpec must include either `user` or `id`.')
   }
 
   // Snapshot the trusted baseline before any limit slice — the validation
@@ -169,7 +169,7 @@ export async function runWithPersistence(
   inner:          (effOptions: AgentPromptOptions | undefined) => Promise<AgentResponse>,
 ): Promise<AgentResponse> {
   const store = storeLookup()
-  if (!store) throw new Error('[Rudder AI] No ConversationStore registered. Bind one via `setConversationStore()` or the `ai.conversations` DI key.')
+  if (!store) throw new Error('[ai-sdk] No ConversationStore registered. Bind one via `setConversationStore()` or the `ai.conversations` DI key.')
 
   const ctx = await preparePersistence(spec, agentClassName, store, options?.history)
   await runValidation(ctx, options)
@@ -201,7 +201,7 @@ export function runWithPersistenceStreaming(
   async function* outer(): AsyncIterable<StreamChunk> {
     const store = storeLookup()
     if (!store) {
-      const err = new Error('[Rudder AI] No ConversationStore registered. Bind one via `setConversationStore()` or the `ai.conversations` DI key.')
+      const err = new Error('[ai-sdk] No ConversationStore registered. Bind one via `setConversationStore()` or the `ai.conversations` DI key.')
       rejectResponse!(err)
       throw err
     }

--- a/packages/ai-sdk/src/conversation.ts
+++ b/packages/ai-sdk/src/conversation.ts
@@ -29,20 +29,20 @@ export class MemoryConversationStore implements ConversationStore {
 
   async load(conversationId: string): Promise<AiMessage[]> {
     const conv = this.conversations.get(conversationId)
-    if (!conv) throw new Error(`[Rudder AI] Conversation "${conversationId}" not found.`)
+    if (!conv) throw new Error(`[ai-sdk] Conversation "${conversationId}" not found.`)
     return [...conv.messages]
   }
 
   async append(conversationId: string, messages: AiMessage[]): Promise<void> {
     const conv = this.conversations.get(conversationId)
-    if (!conv) throw new Error(`[Rudder AI] Conversation "${conversationId}" not found.`)
+    if (!conv) throw new Error(`[ai-sdk] Conversation "${conversationId}" not found.`)
     conv.messages.push(...messages)
     conv.updatedAt = new Date()
   }
 
   async setTitle(conversationId: string, title: string): Promise<void> {
     const conv = this.conversations.get(conversationId)
-    if (!conv) throw new Error(`[Rudder AI] Conversation "${conversationId}" not found.`)
+    if (!conv) throw new Error(`[ai-sdk] Conversation "${conversationId}" not found.`)
     conv.title = title
   }
 

--- a/packages/ai-sdk/src/eval/fixtures.ts
+++ b/packages/ai-sdk/src/eval/fixtures.ts
@@ -106,7 +106,7 @@ export async function readFixture(
   const parsed = JSON.parse(raw) as EvalFixture
   if (parsed.version !== 1) {
     throw new Error(
-      `[Rudder AI] Fixture ${file} is version ${String(parsed.version)}; expected 1. ` +
+      `[ai-sdk] Fixture ${file} is version ${String(parsed.version)}; expected 1. ` +
       `Re-record with \`pnpm rudder ai:eval --record\`.`,
     )
   }

--- a/packages/ai-sdk/src/eval/index.ts
+++ b/packages/ai-sdk/src/eval/index.ts
@@ -191,12 +191,12 @@ export interface SuiteReport {
  * footgun.
  */
 export function evalSuite(name: string, spec: EvalSuiteSpec): EvalSuite {
-  if (!name) throw new Error('[Rudder AI] evalSuite() requires a name.')
+  if (!name) throw new Error('[ai-sdk] evalSuite() requires a name.')
   if (!spec || typeof spec.agent !== 'function') {
-    throw new Error('[Rudder AI] evalSuite() requires { agent: () => Agent, cases: [...] }.')
+    throw new Error('[ai-sdk] evalSuite() requires { agent: () => Agent, cases: [...] }.')
   }
   if (!Array.isArray(spec.cases) || spec.cases.length === 0) {
-    throw new Error('[Rudder AI] evalSuite() requires at least one case.')
+    throw new Error('[ai-sdk] evalSuite() requires at least one case.')
   }
   return Object.freeze({ name, spec })
 }

--- a/packages/ai-sdk/src/facade.ts
+++ b/packages/ai-sdk/src/facade.ts
@@ -119,7 +119,7 @@ export class AI {
 
     if (!factory.createEmbedding) {
       throw new Error(
-        `[Rudder AI] Provider "${providerName}" does not support embeddings. ` +
+        `[ai-sdk] Provider "${providerName}" does not support embeddings. ` +
         `Use a provider that implements createEmbedding() (e.g. openai, google, mistral).`,
       )
     }

--- a/packages/ai-sdk/src/fake.ts
+++ b/packages/ai-sdk/src/fake.ts
@@ -228,7 +228,7 @@ export class AiFake {
     const fake = new AiFake()
 
     const strayError = (stepIndex: number): Error => new Error(
-      `[Rudder AI] Stray prompt: no scripted response at step ${stepIndex}. ` +
+      `[ai-sdk] Stray prompt: no scripted response at step ${stepIndex}. ` +
       `Add an entry via respondWithSequence([...]) or remove preventStrayPrompts().`,
     )
 
@@ -369,7 +369,7 @@ export class AiFake {
 
   /** Assert at least one prompt was sent, optionally matching a predicate */
   assertPrompted(predicate?: (input: string) => boolean): void {
-    if (this.calls.length === 0) throw new Error('[Rudder AI] Expected at least one prompt, but none were sent.')
+    if (this.calls.length === 0) throw new Error('[ai-sdk] Expected at least one prompt, but none were sent.')
     if (predicate) {
       const match = this.calls.some(c => {
         const userMsg = c.messages.find(m => m.role === 'user')
@@ -377,41 +377,41 @@ export class AiFake {
         const text = typeof userMsg.content === 'string' ? userMsg.content : userMsg.content.filter(p => p.type === 'text').map(p => (p as { text: string }).text).join('')
         return predicate(text)
       })
-      if (!match) throw new Error('[Rudder AI] No prompt matched the predicate.')
+      if (!match) throw new Error('[ai-sdk] No prompt matched the predicate.')
     }
   }
 
   /** Assert no prompts were sent */
   assertNothingPrompted(): void {
     if (this.calls.length > 0) {
-      throw new Error(`[Rudder AI] Expected no prompts, but ${this.calls.length} were sent.`)
+      throw new Error(`[ai-sdk] Expected no prompts, but ${this.calls.length} were sent.`)
     }
   }
 
   /** Assert at least one image generation was made */
   assertImageGenerated(predicate?: (prompt: string) => boolean): void {
-    if (this.imageCalls.length === 0) throw new Error('[Rudder AI] Expected at least one image generation, but none were made.')
+    if (this.imageCalls.length === 0) throw new Error('[ai-sdk] Expected at least one image generation, but none were made.')
     if (predicate) {
       const match = this.imageCalls.some(c => predicate(c.prompt))
-      if (!match) throw new Error('[Rudder AI] No image generation matched the predicate.')
+      if (!match) throw new Error('[ai-sdk] No image generation matched the predicate.')
     }
   }
 
   /** Assert at least one TTS generation was made */
   assertAudioGenerated(predicate?: (text: string) => boolean): void {
-    if (this.ttsCalls.length === 0) throw new Error('[Rudder AI] Expected at least one audio generation, but none were made.')
+    if (this.ttsCalls.length === 0) throw new Error('[ai-sdk] Expected at least one audio generation, but none were made.')
     if (predicate) {
       const match = this.ttsCalls.some(c => predicate(c.text))
-      if (!match) throw new Error('[Rudder AI] No audio generation matched the predicate.')
+      if (!match) throw new Error('[ai-sdk] No audio generation matched the predicate.')
     }
   }
 
   /** Assert at least one transcription was made */
   assertTranscribed(predicate?: (opts: SpeechToTextOptions) => boolean): void {
-    if (this.sttCalls.length === 0) throw new Error('[Rudder AI] Expected at least one transcription, but none were made.')
+    if (this.sttCalls.length === 0) throw new Error('[ai-sdk] Expected at least one transcription, but none were made.')
     if (predicate) {
       const match = this.sttCalls.some(c => predicate(c))
-      if (!match) throw new Error('[Rudder AI] No transcription matched the predicate.')
+      if (!match) throw new Error('[ai-sdk] No transcription matched the predicate.')
     }
   }
 
@@ -437,19 +437,19 @@ export class AiFake {
 
   /** Assert at least one embedding was made */
   assertEmbedded(predicate?: (input: string | string[]) => boolean): void {
-    if (this.embedCalls.length === 0) throw new Error('[Rudder AI] Expected at least one embedding, but none were made.')
+    if (this.embedCalls.length === 0) throw new Error('[ai-sdk] Expected at least one embedding, but none were made.')
     if (predicate) {
       const match = this.embedCalls.some(c => predicate(c.input))
-      if (!match) throw new Error('[Rudder AI] No embedding matched the predicate.')
+      if (!match) throw new Error('[ai-sdk] No embedding matched the predicate.')
     }
   }
 
   /** Assert at least one reranking was made */
   assertReranked(predicate?: (opts: RerankingOptions) => boolean): void {
-    if (this.rerankCalls.length === 0) throw new Error('[Rudder AI] Expected at least one reranking, but none were made.')
+    if (this.rerankCalls.length === 0) throw new Error('[ai-sdk] Expected at least one reranking, but none were made.')
     if (predicate) {
       const match = this.rerankCalls.some(c => predicate(c))
-      if (!match) throw new Error('[Rudder AI] No reranking matched the predicate.')
+      if (!match) throw new Error('[ai-sdk] No reranking matched the predicate.')
     }
   }
 
@@ -466,10 +466,10 @@ export class AiFake {
   /** Assert at least one file upload was made */
   assertFileUploaded(predicate?: (filePath: string) => boolean): void {
     const uploads = this.fileCalls.filter(c => c.method === 'upload')
-    if (uploads.length === 0) throw new Error('[Rudder AI] Expected at least one file upload, but none were made.')
+    if (uploads.length === 0) throw new Error('[ai-sdk] Expected at least one file upload, but none were made.')
     if (predicate) {
       const match = uploads.some(c => predicate((c.args as FileUploadOptions).filePath))
-      if (!match) throw new Error('[Rudder AI] No file upload matched the predicate.')
+      if (!match) throw new Error('[ai-sdk] No file upload matched the predicate.')
     }
   }
 

--- a/packages/ai-sdk/src/file-search.ts
+++ b/packages/ai-sdk/src/file-search.ts
@@ -160,7 +160,7 @@ export interface FileSearchTool extends Tool<{ query: string }, unknown> {
 export function fileSearch<TInstance = unknown>(opts: FileSearchOptions<TInstance>): FileSearchTool {
   if (!Array.isArray(opts.stores) || opts.stores.length === 0) {
     throw new Error(
-      '[Rudder AI] fileSearch({ stores }) requires at least one vector-store id. ' +
+      '[ai-sdk] fileSearch({ stores }) requires at least one vector-store id. ' +
       'Create a store via `VectorStores.create(...)` and pass its `id`.',
     )
   }
@@ -245,7 +245,7 @@ export function normalizeWhere(where: FileSearchWhereSugar | FileSearchFilter): 
 
   const entries = Object.entries(where)
   if (entries.length === 0) {
-    throw new Error('[Rudder AI] fileSearch({ where }) must contain at least one key.')
+    throw new Error('[ai-sdk] fileSearch({ where }) must contain at least one key.')
   }
   const eqs: FileSearchFilter[] = entries.map(([key, value]) => ({ type: 'eq', key, value }))
   return eqs.length === 1 ? eqs[0]! : { type: 'and', filters: eqs }

--- a/packages/ai-sdk/src/files.ts
+++ b/packages/ai-sdk/src/files.ts
@@ -40,7 +40,7 @@ export class FileManager {
   async retrieve(fileId: string): Promise<FileContent> {
     const adapter = AiRegistry.resolveFiles(this.providerName)
     if (!adapter.retrieve) {
-      throw new Error(`[Rudder AI] Provider "${this.providerName}" does not support file retrieval.`)
+      throw new Error(`[ai-sdk] Provider "${this.providerName}" does not support file retrieval.`)
     }
     return adapter.retrieve(fileId)
   }

--- a/packages/ai-sdk/src/gateway/http-gateway-adapter.ts
+++ b/packages/ai-sdk/src/gateway/http-gateway-adapter.ts
@@ -87,7 +87,7 @@ export abstract class HttpGatewayAdapter implements ProviderAdapter {
   async *stream(options: ProviderRequestOptions): AsyncIterable<StreamChunk> {
     const res = await this.send(options, { stream: true })
     if (!res.body) {
-      throw new Error('[Rudder AI] Gateway stream response had no body')
+      throw new Error('[ai-sdk] Gateway stream response had no body')
     }
     for await (const event of parseSseStream(res.body, options.signal)) {
       for (const chunk of this.parseStreamEvent(event)) yield chunk
@@ -129,7 +129,7 @@ export abstract class HttpGatewayAdapter implements ProviderAdapter {
   protected async onErrorResponse(res: Response): Promise<never> {
     const body = await res.text().catch(() => '')
     throw new Error(
-      `[Rudder AI] Gateway request failed: ${res.status} ${res.statusText}${body ? ` — ${body}` : ''}`,
+      `[ai-sdk] Gateway request failed: ${res.status} ${res.statusText}${body ? ` — ${body}` : ''}`,
     )
   }
 

--- a/packages/ai-sdk/src/handoffs-driver.ts
+++ b/packages/ai-sdk/src/handoffs-driver.ts
@@ -59,7 +59,7 @@ export async function driveHandoffs(
 
   for (;;) {
     if (hopCount >= MAX_HANDOFFS) {
-      throw new Error(`[Rudder AI] Exceeded max handoffs (${MAX_HANDOFFS}). Likely a cycle between agents.`)
+      throw new Error(`[ai-sdk] Exceeded max handoffs (${MAX_HANDOFFS}). Likely a cycle between agents.`)
     }
     const ChildClass = currentPending.spec.AgentClass
     handoffPath.push(ChildClass.name)

--- a/packages/ai-sdk/src/image.ts
+++ b/packages/ai-sdk/src/image.ts
@@ -71,7 +71,7 @@ export class ImageGenerator {
       const factory = AiRegistry.getFactory(providerName)
 
       if (!factory.createImage) {
-        throw new Error(`[Rudder AI] Provider "${providerName}" does not support image generation.`)
+        throw new Error(`[ai-sdk] Provider "${providerName}" does not support image generation.`)
       }
 
       const adapter = factory.createImage(modelName)
@@ -93,7 +93,7 @@ export class ImageGenerator {
   async store(path: string): Promise<string> {
     const result = await this.generate()
     const image = result.images[0]
-    if (!image) throw new Error('[Rudder AI] No image generated.')
+    if (!image) throw new Error('[ai-sdk] No image generated.')
 
     try {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -111,7 +111,7 @@ export class ImageGenerator {
 
       return path
     } catch {
-      throw new Error('[Rudder AI] Image storage requires @rudderjs/storage to be installed.')
+      throw new Error('[ai-sdk] Image storage requires @rudderjs/storage to be installed.')
     }
   }
 }

--- a/packages/ai-sdk/src/memory-embedding/index.ts
+++ b/packages/ai-sdk/src/memory-embedding/index.ts
@@ -186,7 +186,7 @@ export class EmbeddingUserMemory implements UserMemory {
   private async embed(text: string): Promise<number[]> {
     const result = await AI.embed(text, this.model ? { model: this.model } : undefined)
     const vec = result.embeddings[0]
-    if (!vec) throw new Error('[Rudder AI] embed() returned no vectors')
+    if (!vec) throw new Error('[ai-sdk] embed() returned no vectors')
     return vec
   }
 }

--- a/packages/ai-sdk/src/output.ts
+++ b/packages/ai-sdk/src/output.ts
@@ -65,7 +65,7 @@ function extractJson(text: string): unknown {
     return JSON.parse(stripped)
   } catch (err) {
     throw new Error(
-      `[Rudder AI] Failed to parse JSON from model output: ${err instanceof Error ? err.message : String(err)}`,
+      `[ai-sdk] Failed to parse JSON from model output: ${err instanceof Error ? err.message : String(err)}`,
       { cause: err },
     )
   }

--- a/packages/ai-sdk/src/providers/bedrock.ts
+++ b/packages/ai-sdk/src/providers/bedrock.ts
@@ -80,8 +80,8 @@ class BedrockAdapter implements ProviderAdapter {
   ) {
     if (!isAnthropicOnBedrock(model)) {
       throw new Error(
-        `[Rudder AI] Bedrock model "${model}" is not yet supported. v1 only supports Anthropic Claude models on Bedrock ` +
-        `(model id starts with "anthropic."). File an issue at https://github.com/rudderjs/rudder/issues if you need another family.`,
+        `[ai-sdk] Bedrock model "${model}" is not yet supported. v1 only supports Anthropic Claude models on Bedrock ` +
+        `(model id starts with "anthropic."). File an issue at https://github.com/gemstack-land/gemstack/issues if you need another family.`,
       )
     }
   }

--- a/packages/ai-sdk/src/providers/cohere.ts
+++ b/packages/ai-sdk/src/providers/cohere.ts
@@ -24,7 +24,7 @@ export class CohereProvider implements ProviderFactory {
   }
 
   create(_model: string): ProviderAdapter {
-    throw new Error('[Rudder AI] Cohere does not support text generation. Use it for reranking and embeddings.')
+    throw new Error('[ai-sdk] Cohere does not support text generation. Use it for reranking and embeddings.')
   }
 
   createEmbedding(model: string): EmbeddingAdapter {

--- a/packages/ai-sdk/src/providers/elevenlabs.ts
+++ b/packages/ai-sdk/src/providers/elevenlabs.ts
@@ -112,7 +112,7 @@ export class ElevenLabsProvider implements ProviderFactory {
   }
 
   create(_model: string): ProviderAdapter {
-    throw new Error('[Rudder AI] ElevenLabs does not support text generation. Use it for text-to-speech and speech-to-text.')
+    throw new Error('[ai-sdk] ElevenLabs does not support text generation. Use it for text-to-speech and speech-to-text.')
   }
 
   createTts(model: string): TextToSpeechAdapter {
@@ -164,7 +164,7 @@ class ElevenLabsTtsAdapter implements TextToSpeechAdapter {
 
     if (!response.ok) {
       const text = await safeText(response)
-      throw new Error(`[Rudder AI] ElevenLabs TTS failed (${response.status}): ${text}`)
+      throw new Error(`[ai-sdk] ElevenLabs TTS failed (${response.status}): ${text}`)
     }
 
     const arrayBuffer = await response.arrayBuffer()
@@ -207,7 +207,7 @@ class ElevenLabsSttAdapter implements SpeechToTextAdapter {
 
     if (!response.ok) {
       const text = await safeText(response)
-      throw new Error(`[Rudder AI] ElevenLabs STT failed (${response.status}): ${text}`)
+      throw new Error(`[ai-sdk] ElevenLabs STT failed (${response.status}): ${text}`)
     }
 
     const data = await response.json() as {
@@ -238,7 +238,7 @@ function elevenLabsOutputFormat(format: NonNullable<TextToSpeechOptions['format'
     case 'aac':
     case 'flac':
       throw new Error(
-        `[Rudder AI] ElevenLabs TTS does not support format '${format}'. ` +
+        `[ai-sdk] ElevenLabs TTS does not support format '${format}'. ` +
         `Supported: 'mp3' (default), 'opus'. ` +
         `Generate the source as mp3 and re-encode if you need ${format}, or use a provider with native ${format} support.`,
       )

--- a/packages/ai-sdk/src/providers/google-cache-registry.ts
+++ b/packages/ai-sdk/src/providers/google-cache-registry.ts
@@ -126,14 +126,14 @@ export class GoogleCacheRegistry {
         if (isTooSmallError(err)) {
           await this.remember(storeKey, { tooSmall: true, expiresAt: this.now() + TOO_SMALL_TTL_MS })
           console.warn(
-            `[Rudder AI] Google cache for hash ${args.cacheKey} below model minimum — running uncached. ` +
+            `[ai-sdk] Google cache for hash ${args.cacheKey} below model minimum — running uncached. ` +
             `Future calls with the same prefix will skip cache attempts for 5m.`,
           )
           return null
         }
         // Any other error — let the caller fall back to uncached for THIS request,
         // but don't poison the registry with a "tooSmall" entry.
-        console.warn(`[Rudder AI] Google caches.create failed for hash ${args.cacheKey} — running uncached. ${(err as Error).message}`)
+        console.warn(`[ai-sdk] Google caches.create failed for hash ${args.cacheKey} — running uncached. ${(err as Error).message}`)
         return null
       } finally {
         this.inFlight.delete(storeKey)
@@ -167,7 +167,7 @@ export class GoogleCacheRegistry {
     if (!this.warnedNoStore) {
       this.warnedNoStore = true
       console.warn(
-        '[Rudder AI] Google prompt caching is using in-memory storage; ' +
+        '[ai-sdk] Google prompt caching is using in-memory storage; ' +
         'install @rudderjs/cache for cross-process/restart persistence.',
       )
     }

--- a/packages/ai-sdk/src/providers/google.ts
+++ b/packages/ai-sdk/src/providers/google.ts
@@ -394,7 +394,7 @@ export function filterToGeminiString(filter: FileSearchFilter): string {
     case 'or': {
       if (filter.filters.length === 0) {
         throw new Error(
-          `[Rudder AI] Gemini metadataFilter: ${filter.type.toUpperCase()} requires at least one sub-filter.`,
+          `[ai-sdk] Gemini metadataFilter: ${filter.type.toUpperCase()} requires at least one sub-filter.`,
         )
       }
       const joiner = filter.type === 'and' ? ' AND ' : ' OR '
@@ -538,7 +538,7 @@ class GoogleImageAdapter implements ImageGenerationAdapter {
     })
 
     if (!res.ok) {
-      throw new Error(`[Rudder AI] Google image generation error: ${res.status} ${await res.text()}`)
+      throw new Error(`[ai-sdk] Google image generation error: ${res.status} ${await res.text()}`)
     }
 
     const data = await res.json() as {
@@ -656,13 +656,13 @@ class GoogleVectorStoreAdapter implements VectorStoreAdapter {
   async create(opts: VectorStoreCreateOptions): Promise<VectorStoreInfo> {
     if (opts.metadata) {
       throw new Error(
-        '[Rudder AI] Gemini FileSearchStores does not support store-level metadata. ' +
+        '[ai-sdk] Gemini FileSearchStores does not support store-level metadata. ' +
         'Attach searchable metadata per-document via addFile({ attributes }).',
       )
     }
     if (opts.expiresAfter) {
       throw new Error(
-        '[Rudder AI] Gemini FileSearchStores does not support expiresAfter. ' +
+        '[ai-sdk] Gemini FileSearchStores does not support expiresAfter. ' +
         'Stores persist until explicitly deleted via VectorStores.delete().',
       )
     }
@@ -743,7 +743,7 @@ class GoogleVectorStoreAdapter implements VectorStoreAdapter {
     }
 
     throw new Error(
-      '[Rudder AI] addFile requires fileId, filePath, or fileBuffer. ' +
+      '[ai-sdk] addFile requires fileId, filePath, or fileBuffer. ' +
       'Pass an existing Gemini Files API id via { fileId } (e.g. `files/abc-123`) or ' +
       'a local source via { filePath } / { fileBuffer }.',
     )
@@ -808,7 +808,7 @@ async function finishVectorStoreOperation(
   while (!current?.done) {
     if (Date.now() > deadline) {
       throw new Error(
-        `[Rudder AI] Gemini FileSearchStore ingestion timed out after ${pollTimeout}ms ` +
+        `[ai-sdk] Gemini FileSearchStore ingestion timed out after ${pollTimeout}ms ` +
         `(store=${storeId}). Increase pollTimeout or set wait: false for fire-and-forget.`,
       )
     }

--- a/packages/ai-sdk/src/providers/jina.ts
+++ b/packages/ai-sdk/src/providers/jina.ts
@@ -21,7 +21,7 @@ export class JinaProvider implements ProviderFactory {
   }
 
   create(_model: string): ProviderAdapter {
-    throw new Error('[Rudder AI] Jina does not support text generation. Use it for reranking and embeddings.')
+    throw new Error('[ai-sdk] Jina does not support text generation. Use it for reranking and embeddings.')
   }
 
   createEmbedding(model: string): EmbeddingAdapter {
@@ -58,7 +58,7 @@ class JinaRerankingAdapter implements RerankingAdapter {
 
     if (!response.ok) {
       const text = await response.text()
-      throw new Error(`[Rudder AI] Jina rerank failed (${response.status}): ${text}`)
+      throw new Error(`[ai-sdk] Jina rerank failed (${response.status}): ${text}`)
     }
 
     const data: any = await response.json()
@@ -99,7 +99,7 @@ class JinaEmbeddingAdapter implements EmbeddingAdapter {
 
     if (!response.ok) {
       const text = await response.text()
-      throw new Error(`[Rudder AI] Jina embed failed (${response.status}): ${text}`)
+      throw new Error(`[ai-sdk] Jina embed failed (${response.status}): ${text}`)
     }
 
     const data: any = await response.json()

--- a/packages/ai-sdk/src/providers/mistral.ts
+++ b/packages/ai-sdk/src/providers/mistral.ts
@@ -50,7 +50,7 @@ class MistralEmbeddingAdapter implements EmbeddingAdapter {
       body: JSON.stringify({ model: this.model, input: inputs }),
     })
 
-    if (!res.ok) throw new Error(`[Rudder AI] Mistral embeddings error: ${res.status} ${await res.text()}`)
+    if (!res.ok) throw new Error(`[ai-sdk] Mistral embeddings error: ${res.status} ${await res.text()}`)
 
     const data = await res.json() as {
       data: { embedding: number[] }[]

--- a/packages/ai-sdk/src/providers/openai.ts
+++ b/packages/ai-sdk/src/providers/openai.ts
@@ -460,7 +460,7 @@ class OpenAIEmbeddingAdapter implements EmbeddingAdapter {
       body: JSON.stringify({ model: this.model, input: inputs }),
     })
 
-    if (!res.ok) throw new Error(`[Rudder AI] OpenAI embeddings error: ${res.status} ${await res.text()}`)
+    if (!res.ok) throw new Error(`[ai-sdk] OpenAI embeddings error: ${res.status} ${await res.text()}`)
 
     const data = await res.json() as {
       data: { embedding: number[] }[]
@@ -782,7 +782,7 @@ class OpenAIVectorStoreAdapter implements VectorStoreAdapter {
       }
       if (Date.now() > deadline) {
         throw new Error(
-          `[Rudder AI] vector-store file ingestion timed out after ${pollTimeout}ms ` +
+          `[ai-sdk] vector-store file ingestion timed out after ${pollTimeout}ms ` +
           `(store=${storeId}, file=${fileId}, status=${info.status}). ` +
           'Increase pollTimeout or set wait: false for fire-and-forget.',
         )
@@ -825,7 +825,7 @@ class OpenAIVectorStoreAdapter implements VectorStoreAdapter {
       return uploaded.id
     }
     throw new Error(
-      '[Rudder AI] addFile requires fileId, filePath, or fileBuffer. ' +
+      '[ai-sdk] addFile requires fileId, filePath, or fileBuffer. ' +
       'Pass an existing OpenAI file id via { fileId } or a local source via { filePath }.',
     )
   }

--- a/packages/ai-sdk/src/providers/voyage.ts
+++ b/packages/ai-sdk/src/providers/voyage.ts
@@ -103,7 +103,7 @@ export class VoyageProvider implements ProviderFactory {
   }
 
   create(_model: string): ProviderAdapter {
-    throw new Error('[Rudder AI] Voyage does not support text generation. Use it for embeddings and reranking.')
+    throw new Error('[ai-sdk] Voyage does not support text generation. Use it for embeddings and reranking.')
   }
 
   createEmbedding(model: string): EmbeddingAdapter {
@@ -143,7 +143,7 @@ class VoyageEmbeddingAdapter implements EmbeddingAdapter {
 
     if (!response.ok) {
       const text = await safeText(response)
-      throw new Error(`[Rudder AI] Voyage embed failed (${response.status}): ${text}`)
+      throw new Error(`[ai-sdk] Voyage embed failed (${response.status}): ${text}`)
     }
 
     const data = await response.json() as {
@@ -194,7 +194,7 @@ class VoyageRerankingAdapter implements RerankingAdapter {
 
     if (!response.ok) {
       const text = await safeText(response)
-      throw new Error(`[Rudder AI] Voyage rerank failed (${response.status}): ${text}`)
+      throw new Error(`[ai-sdk] Voyage rerank failed (${response.status}): ${text}`)
     }
 
     const data = await response.json() as {

--- a/packages/ai-sdk/src/queue-job.ts
+++ b/packages/ai-sdk/src/queue-job.ts
@@ -161,7 +161,7 @@ async function defaultLoadDispatch(): Promise<DispatchFn> {
     return mod['dispatch'] as DispatchFn
   } catch {
     throw new Error(
-      '[Rudder AI] @rudderjs/queue is required for agent.queue(). Install it: pnpm add @rudderjs/queue',
+      '[ai-sdk] @rudderjs/queue is required for agent.queue(). Install it: pnpm add @rudderjs/queue',
     )
   }
 }
@@ -209,12 +209,12 @@ async function runStreamingAndBroadcast(
   const broadcastFn = await loadBroadcast()
   if (broadcastFn === null) {
     throw new Error(
-      '[Rudder AI] @rudderjs/broadcast is required for .broadcast(). Install it: pnpm add @rudderjs/broadcast',
+      '[ai-sdk] @rudderjs/broadcast is required for .broadcast(). Install it: pnpm add @rudderjs/broadcast',
     )
   }
   if (typeof agentRef.stream !== 'function') {
     throw new Error(
-      '[Rudder AI] .broadcast() requires an agent with .stream(); the wrapper passed to QueuedPromptBuilder is missing it.',
+      '[ai-sdk] .broadcast() requires an agent with .stream(); the wrapper passed to QueuedPromptBuilder is missing it.',
     )
   }
 

--- a/packages/ai-sdk/src/registry.ts
+++ b/packages/ai-sdk/src/registry.ts
@@ -32,7 +32,7 @@ export async function tryWithFailover<T>(
       lastError = err instanceof Error ? err : new Error(String(err))
     }
   }
-  throw lastError ?? new Error('[Rudder AI] No provider available for failover.')
+  throw lastError ?? new Error('[ai-sdk] No provider available for failover.')
 }
 
 /**
@@ -86,7 +86,7 @@ export class AiRegistry {
   /** Get a registered provider factory by name */
   static getFactory(name: string): ProviderFactory {
     const f = _store.factories.get(name)
-    if (!f) throw new Error(`[Rudder AI] Unknown AI provider "${name}". Register it first.`)
+    if (!f) throw new Error(`[ai-sdk] Unknown AI provider "${name}". Register it first.`)
     return f
   }
 
@@ -97,14 +97,14 @@ export class AiRegistry {
 
   /** Get the default provider/model string */
   static getDefault(): string {
-    if (!_store.default) throw new Error('[Rudder AI] No default model set. Add ai() to providers with a config.')
+    if (!_store.default) throw new Error('[ai-sdk] No default model set. Add ai() to providers with a config.')
     return _store.default
   }
 
   /** Parse 'provider/model' string into [providerName, modelId] */
   static parseModelString(modelString: string): [string, string] {
     const slash = modelString.indexOf('/')
-    if (slash === -1) throw new Error(`[Rudder AI] Invalid model string "${modelString}". Expected "provider/model" format.`)
+    if (slash === -1) throw new Error(`[ai-sdk] Invalid model string "${modelString}". Expected "provider/model" format.`)
     return [modelString.slice(0, slash), modelString.slice(slash + 1)]
   }
 
@@ -121,7 +121,7 @@ export class AiRegistry {
     const factory = this.getFactory(providerName)
     if (!factory.createReranking) {
       throw new Error(
-        `[Rudder AI] Provider "${providerName}" does not support reranking. ` +
+        `[ai-sdk] Provider "${providerName}" does not support reranking. ` +
         `Use a provider that implements createReranking() (e.g. cohere, jina).`,
       )
     }
@@ -133,7 +133,7 @@ export class AiRegistry {
     const factory = this.getFactory(providerName)
     if (!factory.createFiles) {
       throw new Error(
-        `[Rudder AI] Provider "${providerName}" does not support file management. ` +
+        `[ai-sdk] Provider "${providerName}" does not support file management. ` +
         `Use a provider that implements createFiles() (e.g. openai, anthropic, google).`,
       )
     }
@@ -145,7 +145,7 @@ export class AiRegistry {
     const factory = this.getFactory(providerName)
     if (!factory.createVectorStores) {
       throw new Error(
-        `[Rudder AI] Provider "${providerName}" does not support hosted vector stores. ` +
+        `[ai-sdk] Provider "${providerName}" does not support hosted vector stores. ` +
         `Use a provider that implements createVectorStores() (e.g. openai). ` +
         `For self-hosted RAG, use similaritySearch() against an @rudderjs/orm Model with a pgvector column.`,
       )

--- a/packages/ai-sdk/src/server/provider.ts
+++ b/packages/ai-sdk/src/server/provider.ts
@@ -70,7 +70,7 @@ const DRIVERS: Record<string, DriverBuilder> = {
   azure: async (name, cfg) => {
     const apiKey = requireKey(name, cfg); if (apiKey === null) return null
     if (!cfg.baseUrl) {
-      throw new Error(`[Rudder AI] config('ai').providers.${name} is missing baseUrl (driver "azure" requires it).`)
+      throw new Error(`[ai-sdk] config('ai').providers.${name} is missing baseUrl (driver "azure" requires it).`)
     }
     const { AzureOpenAIProvider } = await import('../providers/azure.js')
     return new AzureOpenAIProvider({ apiKey, baseUrl: cfg.baseUrl })

--- a/packages/ai-sdk/src/similarity-search.ts
+++ b/packages/ai-sdk/src/similarity-search.ts
@@ -200,18 +200,18 @@ export function similaritySearch<TInstance>(
 
   if (!embedWith || typeof embedWith !== 'string') {
     throw new Error(
-      '[Rudder AI] similaritySearch requires opts.embedWith (e.g. "openai/text-embedding-3-small"). ' +
+      '[ai-sdk] similaritySearch requires opts.embedWith (e.g. "openai/text-embedding-3-small"). ' +
       'No default — fail loud so embeddings never silently route through whichever provider happens to be the AI default.',
     )
   }
   if (!column || typeof column !== 'string') {
-    throw new Error('[Rudder AI] similaritySearch requires opts.column — the Model column declared with vector({ dimensions }).')
+    throw new Error('[ai-sdk] similaritySearch requires opts.column — the Model column declared with vector({ dimensions }).')
   }
   if (!model || typeof model.query !== 'function') {
-    throw new Error('[Rudder AI] similaritySearch requires opts.model — a Model class with a static query() method.')
+    throw new Error('[ai-sdk] similaritySearch requires opts.model — a Model class with a static query() method.')
   }
   if (limit <= 0 || !Number.isFinite(limit)) {
-    throw new Error(`[Rudder AI] similaritySearch limit must be a positive finite number; got ${String(limit)}.`)
+    throw new Error(`[ai-sdk] similaritySearch limit must be a positive finite number; got ${String(limit)}.`)
   }
 
   const toolName = name ?? `similarity_search_${model.name.toLowerCase()}`
@@ -229,7 +229,7 @@ export function similaritySearch<TInstance>(
       const vector = embedResult.embeddings[0]
       if (!vector || vector.length === 0) {
         throw new Error(
-          `[Rudder AI] similaritySearch: AI.embed("${query}", { model: "${embedWith}" }) returned no embedding.`,
+          `[ai-sdk] similaritySearch: AI.embed("${query}", { model: "${embedWith}" }) returned no embedding.`,
         )
       }
 
@@ -239,7 +239,7 @@ export function similaritySearch<TInstance>(
       const selectDist = scopedQb.selectVectorDistance
       if (typeof whereVec !== 'function' || typeof selectDist !== 'function') {
         throw new Error(
-          `[Rudder AI] similaritySearch: ${model.name}'s ORM adapter does not implement vector queries. ` +
+          `[ai-sdk] similaritySearch: ${model.name}'s ORM adapter does not implement vector queries. ` +
           'Use @rudderjs/orm-prisma against a Postgres + pgvector connection.',
         )
       }

--- a/packages/ai-sdk/src/sub-agent-run-store.ts
+++ b/packages/ai-sdk/src/sub-agent-run-store.ts
@@ -195,7 +195,7 @@ export class CachedSubAgentRunStore implements SubAgentRunStore {
     }
     const adapter = mod.CacheRegistry?.get?.()
     if (!adapter) {
-      throw new Error('[Rudder AI] CachedSubAgentRunStore needs a cache adapter. Install `@rudderjs/cache`, register a driver, or pass `{ cache }` explicitly.')
+      throw new Error('[ai-sdk] CachedSubAgentRunStore needs a cache adapter. Install `@rudderjs/cache`, register a driver, or pass `{ cache }` explicitly.')
     }
     this.resolvedCache = adapter
     return adapter

--- a/packages/ai-sdk/src/transcription.ts
+++ b/packages/ai-sdk/src/transcription.ts
@@ -70,7 +70,7 @@ export class Transcription {
 
       if (!factory.createStt) {
         throw new Error(
-          `[Rudder AI] Provider "${providerName}" does not support speech-to-text. ` +
+          `[ai-sdk] Provider "${providerName}" does not support speech-to-text. ` +
           `Use a provider that implements createStt() (e.g. openai).`,
         )
       }


### PR DESCRIPTION
Code quality pass for `@gemstack/ai-sdk` (the flagship leg of the per-package GemStack quality sweep).

## What
- **Rebrand the message prefix** - 108 user-facing error/log messages across 38 modules still used the migration leftover `[Rudder AI]`. Renamed to `[ai-sdk]`, matching the sibling packages (`[ai-skills]`, `[ai-autopilot]`) which prefix with their package name.
- **Fix the issue URL** - the Bedrock provider's "file an issue" link pointed at `github.com/rudderjs/rudder`; now `github.com/gemstack-land/gemstack`.

## Deliberately NOT changed
Only the bracketed `[Rudder AI]` literal was touched. The serialized `__rudderjs` tool discriminators, `Symbol.for('rudderjs.ai.*')` keys, and the `@rudderjs/*` optional-integration specifiers/comments are **untouched** - they're cross-version-compat identifiers and real (optional, lazy) integrations. Removing the `@rudderjs/*` coupling is a separate, design-first effort tracked under its own epic.

## Verification
Pure message-text change. Typecheck clean, **977 tests pass**. Patch changeset included (user-visible message wording).