### PR TITLE
feat(ai-sdk): export GoogleCacheRegistry + eval fixtures helpers (#46)

### DIFF
--- a/.changeset/ai-sdk-export-cache-registry-eval-helpers.md
+++ b/.changeset/ai-sdk-export-cache-registry-eval-helpers.md
@@ -1,0 +1,7 @@
+---
+"@gemstack/ai-sdk": minor
+---
+
+Export `GoogleCacheRegistry` (+ `GoogleCacheRegistryOptions` / `CacheStoreLike`) from the main entry, and `defaultFixturesDir` / `readFixture` / `writeFixture` from the `./eval` subpath.
+
+These were gemstack-internal symbols that framework bindings could not reach against a published build. Surfacing them lets a binding construct the Gemini context-cache registry with its own `CacheAdapter` (`new GoogleCacheRegistry({ store })`) and lets an `ai:eval` CLI binding read/write recorded fixtures. Purely additive; unblocks relocating the `/server` provider and the `ai-eval` command to the Rudder side.

--- a/packages/ai-sdk/src/eval/index.ts
+++ b/packages/ai-sdk/src/eval/index.ts
@@ -42,7 +42,7 @@ import { z } from 'zod'
 
 export { reportJson } from './json-reporter.js'
 export type { SuiteJson, SuiteJsonCase } from './json-reporter.js'
-export { stepsFromResponse } from './fixtures.js'
+export { stepsFromResponse, defaultFixturesDir, readFixture, writeFixture } from './fixtures.js'
 export type { EvalFixture } from './fixtures.js'
 export { reportHtml } from './html-reporter.js'
 export type { HtmlReportOptions } from './html-reporter.js'

--- a/packages/ai-sdk/src/index.ts
+++ b/packages/ai-sdk/src/index.ts
@@ -81,6 +81,12 @@ export { AiRegistry } from './registry.js'
 export { AnthropicProvider, type AnthropicConfig } from './providers/anthropic.js'
 export { OpenAIProvider, OpenAIAdapter, type OpenAIConfig } from './providers/openai.js'
 export { GoogleProvider, type GoogleConfig } from './providers/google.js'
+// Google context-cache registry — the runtime class that backs Gemini's
+// `cachedContent` resources. Exported so framework bindings can construct
+// it with their own `CacheAdapter` (`new GoogleCacheRegistry({ store })`)
+// and wire it into the Google provider.
+export { GoogleCacheRegistry } from './providers/google-cache-registry.js'
+export type { GoogleCacheRegistryOptions, CacheStoreLike } from './providers/google-cache-registry.js'
 export { OllamaProvider, type OllamaConfig } from './providers/ollama.js'
 export { DeepSeekProvider, type DeepSeekConfig } from './providers/deepseek.js'
 export { XaiProvider, type XaiConfig } from './providers/xai.js'


### PR DESCRIPTION
Closes #46.

## Why
Relocating the `/server` provider (#39) and the `ai-eval` CLI command (part of #40) to `@rudderjs/ai` is blocked because the code they move imports gemstack-internal symbols that are not on any public entry, so the inline can't compile against a *published* `@gemstack/ai-sdk`:

- `/server`'s `AiProvider` constructs `GoogleCacheRegistry` (a runtime **class**) and wires the app cache into it. A class can't be re-created on the consumer side.
- `commands/ai-eval` imports `defaultFixturesDir` / `readFixture` / `writeFixture`; the `./eval` subpath only re-exported `stepsFromResponse` + the `EvalFixture` type.

## What
Purely additive (minor):

- Export `GoogleCacheRegistry` + `GoogleCacheRegistryOptions` + `CacheStoreLike` from the main entry. A binding constructs it with its own `CacheAdapter`: `new GoogleCacheRegistry({ store })`.
- Export `defaultFixturesDir`, `readFixture`, `writeFixture` from `./eval`.

No behavior change, no new dependency. Build green, all 905 tests pass.

## Sequencing
This publishes first, then Rudder inlines `/server` + `make:agent` + `ai-eval` (#39 / #40), then gemstack removes those subpaths + drops the `@rudderjs/core` / `@rudderjs/console` peers (#41) - the 3-release sequence noted in the epic (#35).