### PR TITLE
test(ai-sdk): scrub residual @rudderjs mentions from test comments

### DIFF
--- a/packages/ai-sdk/src/agent-run-store.test.ts
+++ b/packages/ai-sdk/src/agent-run-store.test.ts
@@ -128,7 +128,7 @@ describe('InMemoryAgentRunStore', () => {
 
 // ─── CachedAgentRunStore ───────────────────────────────────
 
-/** Minimal in-process fake of `@rudderjs/cache`'s adapter surface, with TTL capture. */
+/** Minimal in-process fake of the `CacheAdapter` surface, with TTL capture. */
 function fakeCache() {
   const map = new Map<string, unknown>()
   const ttls: Record<string, number | undefined> = {}

--- a/packages/ai-sdk/src/react/agent-run.test.ts
+++ b/packages/ai-sdk/src/react/agent-run.test.ts
@@ -10,7 +10,7 @@ import {
 import type { ToolCall } from '../types.js'
 
 // The React hook (`useAgentRun`) is a thin wrapper over the pieces here —
-// same posture as `@rudderjs/sync`'s `seedShareTypeOnSync` vs `useCollabSeed`.
+// same posture as a runtime-agnostic seed helper vs its React hook wrapper.
 // The framework ships no React testing harness, so we exhaustively cover the
 // transcript reducer, the client-tool batch, and the run/resume driver here.
 

--- a/packages/ai-sdk/src/sub-agent-run-store.test.ts
+++ b/packages/ai-sdk/src/sub-agent-run-store.test.ts
@@ -69,7 +69,7 @@ describe('InMemorySubAgentRunStore.load', () => {
 
 // ─── CachedSubAgentRunStore ────────────────────────────────
 
-/** Minimal in-process fake of `@rudderjs/cache`'s adapter surface. */
+/** Minimal in-process fake of the `CacheAdapter` surface. */
 function fakeCache() {
   const map = new Map<string, unknown>()
   return {


### PR DESCRIPTION
Final tidy for the decouple epic (#35). After #49 and #51, the only `@rudderjs` strings left in `packages/ai-sdk/src` were three explanatory comments in test files describing what the in-process fakes mimic (the cache adapter surface; a sync seed helper). No imports, no deps, no behavior.

Reworded them to be framework-neutral so the epic's acceptance gate is literally true:

```
grep -rn '@rudderjs' packages/ai-sdk/src   # now returns nothing
```

Test-comment-only, so no changeset (nothing to publish).