### PR TITLE
ci: deploy docs to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,53 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
+
+# Allow the workflow to publish to GitHub Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One in-flight deploy at a time; let a newer push supersede an older one
+# (but don't cancel a run mid-publish).
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Build docs
+        env:
+          # Project-pages base path (gemstack-land.github.io/gemstack/).
+          # Remove this once a custom domain serves the site at the root.
+          DOCS_BASE: /gemstack/
+        run: pnpm --filter @gemstack/docs docs:build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -4,6 +4,11 @@ export default defineConfig({
   title: 'GemStack',
   description: 'Framework-agnostic tools for building AI applications in Node.',
   lang: 'en-US',
+  // Served at the site root by default (local dev, and a custom domain like
+  // gemstack.land). The GitHub Pages workflow sets DOCS_BASE=/gemstack/ for the
+  // project-pages URL (gemstack-land.github.io/gemstack/). Drop that env once a
+  // custom domain is attached so the base returns to '/'.
+  base: process.env.DOCS_BASE || '/',
   ignoreDeadLinks: 'localhostLinks',
 
   head: [


### PR DESCRIPTION
Makes the docs site reachable. Pages is already enabled on the repo with GitHub Actions as the source.

## What

- **`.github/workflows/deploy-docs.yml`** - builds the VitePress site and deploys it to GitHub Pages, on pushes to `main` that touch `docs/**` (or the workflow itself) and via manual `workflow_dispatch`. Standard `configure-pages` -> `upload-pages-artifact` -> `deploy-pages` flow with `pages: write` / `id-token: write` permissions and a `pages` concurrency group.
- **`config.ts`** - `base` is now `process.env.DOCS_BASE || '/'`. The workflow sets `DOCS_BASE=/gemstack/` so assets resolve under the project-pages path; local dev and a future custom domain keep the root base.

## Result

On merge, the site publishes at **https://gemstack-land.github.io/gemstack/**.

## Follow-ups (not blocking)

- When `gemstack.land` is ready, attach it as the Pages custom domain and remove `DOCS_BASE` from the workflow (base returns to `/`).
- Repoint the interim GitHub `blob` links in the rudder docs (`ai.md` / `mcp.md`) and this repo's README to the live site.

Verified locally: `DOCS_BASE=/gemstack/ pnpm --filter @gemstack/docs docs:build` is green and bakes `/gemstack/` into the asset URLs. No changeset.