### PR TITLE
chore(bench): Phase 0 harness + Next.js and Vike/GemStack baseline apps

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,67 @@
+# GemStack AI benchmark: "our AI" vs Next.js
+
+Tracking issue: [#75](https://github.com/gemstack-land/gemstack/issues/75). This is the harness for measuring how an AI coding agent performs with the GemStack orchestration layer in reach versus a vanilla Next.js app, on two metrics:
+
+1. **Time-to-task** - wall clock from task start to the acceptance script passing.
+2. **Human interventions** - count of times a human had to step in (see the rubric below).
+
+This is **not** the self-healing loop. It measures an AI agent building and changing apps.
+
+## Layout
+
+```
+benchmarks/
+  README.md            <- you are here
+  spec/
+    product.md         <- the product surface both apps implement (shared HTTP contract)
+    task-001-tags.md   <- the Phase 0 task + acceptance criteria
+  tasks/
+    task-001-tags/
+      accept.mjs        <- contract-level acceptance script (BASE_URL env, exit 0 = pass)
+examples/
+  bench-app-next/       <- Next.js baseline app (vanilla)
+  bench-app-gemstack/   <- Vike + React app wired with @gemstack/ai-*
+```
+
+Both apps implement the **same HTTP contract** (`spec/product.md`), so a single acceptance script runs against either by pointing `BASE_URL` at the running server.
+
+## Phases
+
+- **Phase 0** ([#78](https://github.com/gemstack-land/gemstack/issues/78)) - one task, both apps, manual stopwatch + manual intervention tally. Proves the method and the rubric. **(this directory)**
+- **Phase 1** ([#79](https://github.com/gemstack-land/gemstack/issues/79)) - semi-automated runner over a 3 to 5 task set.
+- **Phase 2** ([#80](https://github.com/gemstack-land/gemstack/issues/80)) - full suite, aggregator, committed baseline.
+
+## Running Phase 0 by hand
+
+For each app (`bench-app-next`, `bench-app-gemstack`):
+
+1. Reset the app to its starting commit (clean baseline).
+2. Start the dev server, note the URL.
+3. Start a stopwatch. Give the agent the task prompt from `spec/task-001-tags.md`.
+4. Let the agent work. Tally every **human intervention** (rubric below).
+5. After each agent step, run the acceptance script: `BASE_URL=<url> node benchmarks/tasks/task-001-tags/accept.mjs`. Exit 0 means done; stop the stopwatch.
+6. Record seconds, intervention count, and status (pass / DNF) in a run log.
+
+Stop at acceptance pass, or at the hard timeout / max-intervention cap (record as DNF).
+
+## Intervention rubric
+
+Counts as **one human intervention**:
+
+- a manual code correction by a human
+- unblocking a stuck agent with a hint
+- a clarification the agent had to ask before it could proceed
+- an approval gate that required a human
+- a manual retry / rerun a human had to trigger
+
+Does **not** count (this is the point of the orchestration layer):
+
+- the agent's own internal retries, planning, and autopilot worker dispatch
+- skill / MCP tool calls the agent makes autonomously
+
+## Fairness rules
+
+- Same agent, same model, same harness on both sides.
+- Both apps start from a clean, functionally-equivalent baseline implementing the contract.
+- The acceptance gate is objective (the script's exit code); no human judgement.
+- The Next.js app must be idiomatic, not a strawman.

--- a/benchmarks/spec/product.md
+++ b/benchmarks/spec/product.md
@@ -1,0 +1,55 @@
+# Product spec: the "Notes" app (shared by both benchmark apps)
+
+Both `bench-app-next` (Next.js) and `bench-app-gemstack` (Vike + React + `@gemstack/ai-*`) implement the **same product** and the **same HTTP contract**. Equivalence is what makes the comparison fair; the contract is what lets one acceptance script run against both.
+
+## Surface
+
+A single-user notes app:
+
+- **Auth** - email + password sign-in for one seeded user. A session cookie guards the app and the API.
+- **CRUD resource: `notes`** - fields `id`, `title`, `body`, `createdAt`. List, create, view, delete.
+- **AI feature: summarize** - produce a one-sentence summary of a note's body.
+  - GemStack app: via `@gemstack/ai-sdk` (the orchestration layer in reach).
+  - Next.js app: a vanilla inline provider call.
+  - Both default to a **deterministic stub model** (no network, no API key) so the baseline is reproducible. The stub returns the first sentence of the body, trimmed to <= 140 chars. Real providers are a later, opt-in concern.
+
+## Storage
+
+SQLite via `better-sqlite3` (already allowed in the workspace), one file per app, seeded on first boot. Same schema both sides:
+
+```sql
+CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT UNIQUE NOT NULL, password TEXT NOT NULL);
+CREATE TABLE notes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  title TEXT NOT NULL,
+  body TEXT NOT NULL,
+  summary TEXT,
+  created_at TEXT NOT NULL
+);
+```
+
+Seed user: `demo@example.com` / `password`.
+
+## HTTP contract (identical on both apps)
+
+All endpoints return JSON. Auth endpoints set / clear a `session` cookie; protected endpoints require it and return `401` without it.
+
+| Method | Path | Body | Success | Notes |
+|---|---|---|---|---|
+| POST | `/api/login` | `{ email, password }` | `200 { ok: true }` + `session` cookie | `401` on bad creds |
+| POST | `/api/logout` | - | `200 { ok: true }` | clears cookie |
+| GET | `/api/notes` | - | `200 { notes: Note[] }` | newest first |
+| POST | `/api/notes` | `{ title, body }` | `201 { note: Note }` | |
+| GET | `/api/notes/:id` | - | `200 { note: Note }` | `404` if absent |
+| DELETE | `/api/notes/:id` | - | `200 { ok: true }` | |
+| POST | `/api/notes/:id/summarize` | - | `200 { note: Note }` | sets `summary` |
+
+`Note` shape: `{ id: number, title: string, body: string, summary: string | null, createdAt: string }`.
+
+## UI
+
+Minimal but real React pages (server-rendered on both): a login page, a notes list (with a create form and per-note delete + summarize buttons), and a note detail page. Parity of surface matters more than polish.
+
+## Baseline = starting commit
+
+The committed state of each app is the Phase 0 **starting point**. Tasks (e.g. `task-001-tags`) ask the agent to extend it; the acceptance script verifies the result against the contract.

--- a/benchmarks/spec/task-001-tags.md
+++ b/benchmarks/spec/task-001-tags.md
@@ -1,0 +1,32 @@
+# Task 001: add tags to notes
+
+A representative full-stack feature: it touches the data model, the HTTP contract, and the UI. The same prompt is given to the agent on both apps.
+
+## Agent prompt (verbatim, given on both apps)
+
+> Add tagging to notes. A note can have zero or more tags (short text labels). Update the create form so a user can enter comma-separated tags when creating a note. Show each note's tags in the list and on the detail page. Add the ability to list notes filtered to a single tag. Keep the existing HTTP contract working and extend it as described in the acceptance criteria.
+
+## Required contract changes
+
+- `Note` gains `tags: string[]` (empty array when none).
+- `POST /api/notes` accepts an optional `tags: string[]` in the body and persists it.
+- `GET /api/notes` accepts an optional `?tag=<t>` query param; when present, only notes carrying that exact tag are returned.
+- `GET /api/notes/:id` includes `tags`.
+
+## Acceptance criteria (checked by `tasks/task-001-tags/accept.mjs`)
+
+1. Log in as the seeded user.
+2. Create note A with `tags: ["work", "urgent"]`.
+3. Create note B with `tags: ["home"]`.
+4. `GET /api/notes?tag=work` returns A and not B.
+5. `GET /api/notes?tag=home` returns B and not A.
+6. `GET /api/notes/<A.id>` includes `tags` containing `work` and `urgent`.
+7. `GET /api/notes` (no filter) returns both, each with a `tags` array.
+
+The script exits `0` only when all checks pass. Any non-zero exit is a fail.
+
+## Guardrails
+
+- Hard timeout: 30 minutes wall clock.
+- Max interventions before DNF: 5.
+- A UI must exist for entering and displaying tags (spot-checked by the human), but the automated gate is the contract above.

--- a/benchmarks/tasks/task-001-tags/accept.mjs
+++ b/benchmarks/tasks/task-001-tags/accept.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Contract-level acceptance check for task-001-tags.
+// Runs against a running benchmark app. Usage: BASE_URL=http://localhost:3000 node accept.mjs
+// Exit 0 = all checks pass; non-zero = fail.
+
+const BASE = (process.env.BASE_URL || 'http://localhost:3000').replace(/\/$/, '')
+
+let cookie = ''
+let failures = 0
+
+function check(label, cond) {
+  if (cond) {
+    console.log(`  ok   ${label}`)
+  } else {
+    console.log(`  FAIL ${label}`)
+    failures++
+  }
+}
+
+async function req(method, path, body) {
+  const headers = { 'content-type': 'application/json' }
+  if (cookie) headers.cookie = cookie
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  const setCookie = res.headers.get('set-cookie')
+  if (setCookie) cookie = setCookie.split(';')[0]
+  let json = null
+  try {
+    json = await res.json()
+  } catch {
+    /* non-JSON body */
+  }
+  return { status: res.status, json }
+}
+
+async function main() {
+  console.log(`acceptance: task-001-tags against ${BASE}`)
+
+  // 1. login
+  const login = await req('POST', '/api/login', { email: 'demo@example.com', password: 'password' })
+  check('login returns 200', login.status === 200)
+  check('login set a session cookie', cookie.length > 0)
+
+  // 2 + 3. create two tagged notes
+  const a = await req('POST', '/api/notes', { title: 'Note A', body: 'Body A.', tags: ['work', 'urgent'] })
+  check('create A returns 201', a.status === 201)
+  const b = await req('POST', '/api/notes', { title: 'Note B', body: 'Body B.', tags: ['home'] })
+  check('create B returns 201', b.status === 201)
+  const aId = a.json?.note?.id
+  const bId = b.json?.note?.id
+  check('A has an id', typeof aId === 'number')
+  check('B has an id', typeof bId === 'number')
+
+  // 4. filter by "work" -> A only
+  const work = await req('GET', '/api/notes?tag=work')
+  const workIds = (work.json?.notes || []).map((n) => n.id)
+  check('?tag=work returns A', workIds.includes(aId))
+  check('?tag=work excludes B', !workIds.includes(bId))
+
+  // 5. filter by "home" -> B only
+  const home = await req('GET', '/api/notes?tag=home')
+  const homeIds = (home.json?.notes || []).map((n) => n.id)
+  check('?tag=home returns B', homeIds.includes(bId))
+  check('?tag=home excludes A', !homeIds.includes(aId))
+
+  // 6. detail includes tags
+  const detail = await req('GET', `/api/notes/${aId}`)
+  const tags = detail.json?.note?.tags || []
+  check('detail A includes tag work', tags.includes('work'))
+  check('detail A includes tag urgent', tags.includes('urgent'))
+
+  // 7. unfiltered list returns both, each with a tags array
+  const all = await req('GET', '/api/notes')
+  const allNotes = all.json?.notes || []
+  check('unfiltered list includes A and B', allNotes.some((n) => n.id === aId) && allNotes.some((n) => n.id === bId))
+  check('every note has a tags array', allNotes.every((n) => Array.isArray(n.tags)))
+
+  console.log(failures === 0 ? '\nPASS' : `\nFAIL (${failures} check(s) failed)`)
+  process.exit(failures === 0 ? 0 : 1)
+}
+
+main().catch((err) => {
+  console.error('acceptance crashed:', err)
+  process.exit(2)
+})

--- a/examples/bench-app-gemstack/.gitignore
+++ b/examples/bench-app-gemstack/.gitignore
@@ -1,0 +1,9 @@
+# Local SQLite database (seeded on first boot)
+data/
+*.sqlite
+*.sqlite-journal
+*.sqlite-wal
+*.sqlite-shm
+
+# Vite / Vike build artifacts
+dist/

--- a/examples/bench-app-gemstack/README.md
+++ b/examples/bench-app-gemstack/README.md
@@ -1,0 +1,77 @@
+# bench-app-gemstack
+
+The **GemStack** side of the AI benchmark (see `benchmarks/`). A minimal but real
+**Vike + React (SSR)** Notes app whose **AI summarize** feature is wired through
+[`@gemstack/ai-sdk`](../../packages/ai-sdk) — the orchestration layer "in reach".
+
+Its twin, `bench-app-next`, implements the **same product and the same HTTP
+contract** (`benchmarks/spec/product.md`) with a vanilla inline provider call, so
+one acceptance script runs against either by pointing `BASE_URL` at the server.
+
+> Baseline scope: notes have `id`, `title`, `body`, `summary`, `createdAt` only.
+> Tags are a later agent task and are intentionally **not** implemented here.
+
+## Run
+
+From the repo root, build the SDK once, then start the app:
+
+```bash
+pnpm --filter @gemstack/ai-sdk build      # the app imports the SDK's dist
+cd examples/bench-app-gemstack
+pnpm dev                                   # http://localhost:3100
+```
+
+Fixed port **3100** (override with `PORT`). It differs from the Next.js sibling's
+3000 so both can run at once. The server is Express in Vite middleware mode: it
+serves `/api/*` directly and hands every other route to Vike for React SSR.
+
+Seed user: `demo@example.com` / `password` (seeded into SQLite on first boot).
+
+## HTTP contract
+
+JSON everywhere. Auth endpoints set/clear a `session` cookie; protected
+endpoints require it and return `401` without it.
+
+| Method | Path | Body | Success |
+|---|---|---|---|
+| POST | `/api/login` | `{ email, password }` | `200 { ok: true }` + cookie (`401` on bad creds) |
+| POST | `/api/logout` | – | `200 { ok: true }` |
+| GET | `/api/notes` | – | `200 { notes: Note[] }` (newest first) |
+| POST | `/api/notes` | `{ title, body }` | `201 { note: Note }` |
+| GET | `/api/notes/:id` | – | `200 { note: Note }` (`404` if absent) |
+| DELETE | `/api/notes/:id` | – | `200 { ok: true }` |
+| POST | `/api/notes/:id/summarize` | – | `200 { note: Note }` (sets `summary`) |
+
+`Note` = `{ id: number, title: string, body: string, summary: string | null, createdAt: string }`.
+
+## How summarize uses `@gemstack/ai-sdk`
+
+`server/ai.ts` registers a **deterministic stub provider** on the SDK's provider
+seam (`AiRegistry.register` with a `ProviderFactory` / `ProviderAdapter`) and sets
+it as the default model. `summarize()` then calls the SDK facade, `AI.prompt(body,
+{ model: 'stub/summarize-v1' })` — so the path runs through the GemStack agent
+loop, not a direct model call. The stub computes the result from the prompt it
+receives (first sentence of the body, trimmed to ≤ 140 chars): no network, no API
+key, fully reproducible. Swapping in a real provider later is a one-line change to
+the model string.
+
+## Storage
+
+`better-sqlite3`, one file at `data/bench.sqlite` (git-ignored), created and
+seeded on first boot. Schema matches the spec (`users`, `notes`).
+
+## Layout
+
+```
+server/
+  index.ts   Express + Vite-middleware dev server (API + Vike SSR catch-all)
+  api.ts     the HTTP contract (session-cookie auth)
+  db.ts      better-sqlite3 schema, seed, queries
+  ai.ts      @gemstack/ai-sdk stub provider + summarize()
+pages/
+  +config.ts        vike-react config
+  index/+Page.tsx   notes list (create form, per-note delete + summarize)
+  login/+Page.tsx   sign-in
+  note/@id/+Page.tsx note detail
+  api.ts            client-side fetch wrapper over the contract
+```

--- a/examples/bench-app-gemstack/package.json
+++ b/examples/bench-app-gemstack/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@gemstack/example-bench-app-gemstack",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Benchmark baseline: a Vike + React (SSR) Notes app whose AI summarize feature is wired through @gemstack/ai-sdk. Twin of bench-app-next.",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx server/index.ts"
+  },
+  "dependencies": {
+    "@gemstack/ai-sdk": "workspace:^",
+    "better-sqlite3": "^12.11.1",
+    "express": "^5.2.1",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "vike": "^0.4.260",
+    "vike-react": "^0.6.25"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/express": "^5.0.6",
+    "@types/node": "^20.0.0",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "@vitejs/plugin-react": "^5.2.0",
+    "tsx": "^4.22.4",
+    "typescript": "^5.4.0",
+    "vite": "^7.3.6"
+  }
+}

--- a/examples/bench-app-gemstack/pages/+config.ts
+++ b/examples/bench-app-gemstack/pages/+config.ts
@@ -1,0 +1,8 @@
+import vikeReact from 'vike-react/config'
+import type { Config } from 'vike/types'
+
+// SSR React app powered by vike-react. Client routing on by default.
+export default {
+  extends: vikeReact,
+  title: 'Notes — bench-app-gemstack',
+} satisfies Config

--- a/examples/bench-app-gemstack/pages/api.ts
+++ b/examples/bench-app-gemstack/pages/api.ts
@@ -1,0 +1,49 @@
+// Tiny client-side wrapper over the HTTP contract used by the React pages.
+export interface Note {
+  id: number
+  title: string
+  body: string
+  summary: string | null
+  createdAt: string
+}
+
+async function json<T>(res: Response): Promise<T> {
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+  return res.json() as Promise<T>
+}
+
+export const api = {
+  async login(email: string, password: string): Promise<void> {
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    })
+    if (!res.ok) throw new Error('Invalid credentials')
+  },
+  async logout(): Promise<void> {
+    await fetch('/api/logout', { method: 'POST' })
+  },
+  async list(): Promise<Note[]> {
+    const { notes } = await json<{ notes: Note[] }>(await fetch('/api/notes'))
+    return notes
+  },
+  async create(title: string, body: string): Promise<Note> {
+    const res = await fetch('/api/notes', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ title, body }),
+    })
+    return (await json<{ note: Note }>(res)).note
+  },
+  async get(id: number): Promise<Note> {
+    return (await json<{ note: Note }>(await fetch(`/api/notes/${id}`))).note
+  },
+  async remove(id: number): Promise<void> {
+    await fetch(`/api/notes/${id}`, { method: 'DELETE' })
+  },
+  async summarize(id: number): Promise<Note> {
+    const res = await fetch(`/api/notes/${id}/summarize`, { method: 'POST' })
+    return (await json<{ note: Note }>(res)).note
+  },
+}

--- a/examples/bench-app-gemstack/pages/index/+Page.tsx
+++ b/examples/bench-app-gemstack/pages/index/+Page.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react'
+import { api, type Note } from '../api.js'
+
+export default function NotesPage() {
+  const [notes, setNotes] = useState<Note[]>([])
+  const [title, setTitle] = useState('')
+  const [body, setBody] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  async function refresh() {
+    try {
+      setNotes(await api.list())
+    } catch {
+      window.location.href = '/login'
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void refresh()
+  }, [])
+
+  async function onCreate(e: React.FormEvent) {
+    e.preventDefault()
+    if (!title.trim() || !body.trim()) return
+    await api.create(title, body)
+    setTitle('')
+    setBody('')
+    await refresh()
+  }
+
+  async function onDelete(id: number) {
+    await api.remove(id)
+    await refresh()
+  }
+
+  async function onSummarize(id: number) {
+    await api.summarize(id)
+    await refresh()
+  }
+
+  async function onLogout() {
+    await api.logout()
+    window.location.href = '/login'
+  }
+
+  return (
+    <main style={{ maxWidth: 640, margin: '2rem auto', fontFamily: 'system-ui' }}>
+      <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h1>Notes</h1>
+        <button onClick={onLogout}>Log out</button>
+      </header>
+
+      <form onSubmit={onCreate} style={{ marginBottom: 24 }}>
+        <input
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          style={{ display: 'block', width: '100%', marginBottom: 8 }}
+        />
+        <textarea
+          placeholder="Body"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          rows={3}
+          style={{ display: 'block', width: '100%', marginBottom: 8 }}
+        />
+        <button type="submit">Add note</button>
+      </form>
+
+      {loading ? (
+        <p>Loading…</p>
+      ) : notes.length === 0 ? (
+        <p>No notes yet.</p>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0 }}>
+          {notes.map((note) => (
+            <li key={note.id} style={{ border: '1px solid #ddd', borderRadius: 8, padding: 12, marginBottom: 12 }}>
+              <strong>
+                <a href={`/note/${note.id}`}>{note.title}</a>
+              </strong>
+              <p style={{ margin: '4px 0' }}>{note.body}</p>
+              {note.summary && (
+                <p style={{ margin: '4px 0', color: '#555' }}>
+                  <em>Summary: {note.summary}</em>
+                </p>
+              )}
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button onClick={() => onSummarize(note.id)}>Summarize</button>
+                <button onClick={() => onDelete(note.id)}>Delete</button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  )
+}

--- a/examples/bench-app-gemstack/pages/login/+Page.tsx
+++ b/examples/bench-app-gemstack/pages/login/+Page.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+import { api } from '../api.js'
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('demo@example.com')
+  const [password, setPassword] = useState('password')
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setBusy(true)
+    try {
+      await api.login(email, password)
+      window.location.href = '/'
+    } catch {
+      setError('Invalid credentials')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <main style={{ maxWidth: 360, margin: '4rem auto', fontFamily: 'system-ui' }}>
+      <h1>Sign in</h1>
+      <form onSubmit={onSubmit}>
+        <label style={{ display: 'block', marginBottom: 8 }}>
+          Email
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            style={{ display: 'block', width: '100%' }}
+          />
+        </label>
+        <label style={{ display: 'block', marginBottom: 8 }}>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            style={{ display: 'block', width: '100%' }}
+          />
+        </label>
+        {error && <p style={{ color: 'crimson' }}>{error}</p>}
+        <button type="submit" disabled={busy}>
+          {busy ? 'Signing in…' : 'Sign in'}
+        </button>
+      </form>
+    </main>
+  )
+}

--- a/examples/bench-app-gemstack/pages/note/@id/+Page.tsx
+++ b/examples/bench-app-gemstack/pages/note/@id/+Page.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react'
+import { usePageContext } from 'vike-react/usePageContext'
+import { api, type Note } from '../../api.js'
+
+export default function NoteDetailPage() {
+  const pageContext = usePageContext()
+  const id = Number(pageContext.routeParams!.id)
+  const [note, setNote] = useState<Note | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function refresh() {
+    try {
+      setNote(await api.get(id))
+    } catch {
+      setError('Note not found (or you are signed out).')
+    }
+  }
+
+  useEffect(() => {
+    void refresh()
+  }, [id])
+
+  async function onSummarize() {
+    await api.summarize(id)
+    await refresh()
+  }
+
+  return (
+    <main style={{ maxWidth: 640, margin: '2rem auto', fontFamily: 'system-ui' }}>
+      <p>
+        <a href="/">← Back to notes</a>
+      </p>
+      {error && <p style={{ color: 'crimson' }}>{error}</p>}
+      {note && (
+        <article>
+          <h1>{note.title}</h1>
+          <p style={{ color: '#888' }}>{new Date(note.createdAt).toLocaleString()}</p>
+          <p>{note.body}</p>
+          {note.summary ? (
+            <p style={{ color: '#555' }}>
+              <em>Summary: {note.summary}</em>
+            </p>
+          ) : (
+            <button onClick={onSummarize}>Summarize</button>
+          )}
+        </article>
+      )}
+    </main>
+  )
+}

--- a/examples/bench-app-gemstack/server/ai.ts
+++ b/examples/bench-app-gemstack/server/ai.ts
@@ -1,0 +1,86 @@
+/**
+ * AI summarize, wired through the GemStack orchestration layer.
+ *
+ * The summarize feature does NOT call a model directly. It goes through
+ * `@gemstack/ai-sdk`'s facade (`AI.prompt`) and agent loop. The deterministic
+ * baseline behaviour is supplied by registering a custom *provider* on the
+ * SDK's provider seam (`AiRegistry.register` + a `ProviderFactory` /
+ * `ProviderAdapter`). No network, no API key: the stub adapter computes the
+ * summary from the prompt it receives. Swapping in a real provider later is a
+ * one-line change to the default model string.
+ */
+import {
+  AI,
+  AiRegistry,
+  type AiMessage,
+  type ProviderAdapter,
+  type ProviderFactory,
+  type ProviderRequestOptions,
+  type ProviderResponse,
+  type StreamChunk,
+} from '@gemstack/ai-sdk'
+
+const STUB_MODEL = 'stub/summarize-v1'
+
+/** First sentence of `text`, trimmed to <= 140 chars. */
+export function summaryOf(text: string): string {
+  const trimmed = text.trim()
+  const match = trimmed.match(/^[\s\S]*?[.!?](?:\s|$)/)
+  const sentence = (match ? match[0] : trimmed).trim()
+  return sentence.length > 140 ? sentence.slice(0, 140).trim() : sentence
+}
+
+/** Extract the latest user-message text from a provider request. */
+function lastUserText(messages: AiMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]!
+    if (m.role !== 'user') continue
+    if (typeof m.content === 'string') return m.content
+    return m.content
+      .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+      .map((p) => p.text)
+      .join('')
+  }
+  return ''
+}
+
+const stubAdapter: ProviderAdapter = {
+  async generate(opts: ProviderRequestOptions): Promise<ProviderResponse> {
+    const summary = summaryOf(lastUserText(opts.messages))
+    return {
+      message: { role: 'assistant', content: summary },
+      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+      finishReason: 'stop',
+    }
+  },
+  async *stream(opts: ProviderRequestOptions): AsyncIterable<StreamChunk> {
+    const summary = summaryOf(lastUserText(opts.messages))
+    yield { type: 'text-delta', text: summary }
+    yield { type: 'finish', finishReason: 'stop', usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 } }
+  },
+}
+
+const stubFactory: ProviderFactory = {
+  name: 'stub',
+  create: () => stubAdapter,
+}
+
+let registered = false
+function ensureAi(): void {
+  if (registered) return
+  AiRegistry.register(stubFactory)
+  AiRegistry.setDefault(STUB_MODEL)
+  registered = true
+}
+
+/**
+ * Summarize a note body through `@gemstack/ai-sdk`.
+ *
+ * Goes through the SDK facade + agent loop; the deterministic stub provider
+ * produces the output. Returns the one-sentence summary string.
+ */
+export async function summarize(body: string): Promise<string> {
+  ensureAi()
+  const response = await AI.prompt(body, { model: STUB_MODEL })
+  return response.text.trim()
+}

--- a/examples/bench-app-gemstack/server/api.ts
+++ b/examples/bench-app-gemstack/server/api.ts
@@ -1,0 +1,105 @@
+import { randomUUID } from 'node:crypto'
+import type { Express, Request, Response, NextFunction } from 'express'
+import { createNote, deleteNote, findUser, getNote, listNotes, setSummary } from './db.js'
+import { summarize } from './ai.js'
+
+const COOKIE = 'session'
+
+/** token -> userId. In-memory; fine for a single-process baseline. */
+const sessions = new Map<string, number>()
+
+function parseCookies(req: Request): Record<string, string> {
+  const header = req.headers.cookie
+  if (!header) return {}
+  const out: Record<string, string> = {}
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=')
+    if (eq === -1) continue
+    out[part.slice(0, eq).trim()] = decodeURIComponent(part.slice(eq + 1).trim())
+  }
+  return out
+}
+
+function currentUser(req: Request): number | undefined {
+  const token = parseCookies(req)[COOKIE]
+  if (!token) return undefined
+  return sessions.get(token)
+}
+
+function requireAuth(req: Request, res: Response, next: NextFunction): void {
+  if (currentUser(req) === undefined) {
+    res.status(401).json({ error: 'unauthenticated' })
+    return
+  }
+  next()
+}
+
+/** Register the HTTP contract on an Express app. Returns the app for chaining. */
+export function registerApi(app: Express): Express {
+  // POST /api/login
+  app.post('/api/login', (req: Request, res: Response) => {
+    const { email, password } = (req.body ?? {}) as { email?: string; password?: string }
+    const user = email && password ? findUser(email, password) : undefined
+    if (!user) {
+      res.status(401).json({ error: 'invalid credentials' })
+      return
+    }
+    const token = randomUUID()
+    sessions.set(token, user.id)
+    res.cookie(COOKIE, token, { httpOnly: true, sameSite: 'lax', path: '/' })
+    res.status(200).json({ ok: true })
+  })
+
+  // POST /api/logout
+  app.post('/api/logout', (req: Request, res: Response) => {
+    const token = parseCookies(req)[COOKIE]
+    if (token) sessions.delete(token)
+    res.clearCookie(COOKIE, { path: '/' })
+    res.status(200).json({ ok: true })
+  })
+
+  // GET /api/notes
+  app.get('/api/notes', requireAuth, (_req: Request, res: Response) => {
+    res.status(200).json({ notes: listNotes() })
+  })
+
+  // POST /api/notes
+  app.post('/api/notes', requireAuth, (req: Request, res: Response) => {
+    const { title, body } = (req.body ?? {}) as { title?: string; body?: string }
+    if (typeof title !== 'string' || typeof body !== 'string') {
+      res.status(400).json({ error: 'title and body are required' })
+      return
+    }
+    res.status(201).json({ note: createNote(title, body) })
+  })
+
+  // GET /api/notes/:id
+  app.get('/api/notes/:id', requireAuth, (req: Request, res: Response) => {
+    const note = getNote(Number(req.params.id))
+    if (!note) {
+      res.status(404).json({ error: 'not found' })
+      return
+    }
+    res.status(200).json({ note })
+  })
+
+  // DELETE /api/notes/:id
+  app.delete('/api/notes/:id', requireAuth, (req: Request, res: Response) => {
+    deleteNote(Number(req.params.id))
+    res.status(200).json({ ok: true })
+  })
+
+  // POST /api/notes/:id/summarize
+  app.post('/api/notes/:id/summarize', requireAuth, async (req: Request, res: Response) => {
+    const id = Number(req.params.id)
+    const note = getNote(id)
+    if (!note) {
+      res.status(404).json({ error: 'not found' })
+      return
+    }
+    const summary = await summarize(note.body)
+    res.status(200).json({ note: setSummary(id, summary) })
+  })
+
+  return app
+}

--- a/examples/bench-app-gemstack/server/db.ts
+++ b/examples/bench-app-gemstack/server/db.ts
@@ -1,0 +1,104 @@
+import Database from 'better-sqlite3'
+import { mkdirSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const DB_PATH = resolve(here, '../data/bench.sqlite')
+
+export interface NoteRow {
+  id: number
+  title: string
+  body: string
+  summary: string | null
+  created_at: string
+}
+
+/** Public `Note` shape from the HTTP contract. */
+export interface Note {
+  id: number
+  title: string
+  body: string
+  summary: string | null
+  createdAt: string
+}
+
+function toNote(row: NoteRow): Note {
+  return {
+    id: row.id,
+    title: row.title,
+    body: row.body,
+    summary: row.summary,
+    createdAt: row.created_at,
+  }
+}
+
+let _db: Database.Database | null = null
+
+/** Lazily open + migrate + seed the SQLite database (idempotent). */
+export function db(): Database.Database {
+  if (_db) return _db
+
+  mkdirSync(dirname(DB_PATH), { recursive: true })
+  const conn = new Database(DB_PATH)
+  conn.pragma('journal_mode = WAL')
+
+  conn.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY,
+      email TEXT UNIQUE NOT NULL,
+      password TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS notes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      title TEXT NOT NULL,
+      body TEXT NOT NULL,
+      summary TEXT,
+      created_at TEXT NOT NULL
+    );
+  `)
+
+  // Seed the single demo user on first boot.
+  const seeded = conn.prepare('SELECT 1 FROM users WHERE email = ?').get('demo@example.com')
+  if (!seeded) {
+    conn.prepare('INSERT INTO users (email, password) VALUES (?, ?)').run('demo@example.com', 'password')
+  }
+
+  _db = conn
+  return conn
+}
+
+export function findUser(email: string, password: string): { id: number } | undefined {
+  return db()
+    .prepare('SELECT id FROM users WHERE email = ? AND password = ?')
+    .get(email, password) as { id: number } | undefined
+}
+
+export function listNotes(): Note[] {
+  const rows = db().prepare('SELECT * FROM notes ORDER BY id DESC').all() as NoteRow[]
+  return rows.map(toNote)
+}
+
+export function getNote(id: number): Note | undefined {
+  const row = db().prepare('SELECT * FROM notes WHERE id = ?').get(id) as NoteRow | undefined
+  return row ? toNote(row) : undefined
+}
+
+export function createNote(title: string, body: string): Note {
+  const createdAt = new Date().toISOString()
+  const info = db()
+    .prepare('INSERT INTO notes (title, body, summary, created_at) VALUES (?, ?, NULL, ?)')
+    .run(title, body, createdAt)
+  return getNote(Number(info.lastInsertRowid))!
+}
+
+export function deleteNote(id: number): boolean {
+  const info = db().prepare('DELETE FROM notes WHERE id = ?').run(id)
+  return info.changes > 0
+}
+
+export function setSummary(id: number, summary: string): Note | undefined {
+  const info = db().prepare('UPDATE notes SET summary = ? WHERE id = ?').run(summary, id)
+  if (info.changes === 0) return undefined
+  return getNote(id)
+}

--- a/examples/bench-app-gemstack/server/index.ts
+++ b/examples/bench-app-gemstack/server/index.ts
@@ -1,0 +1,44 @@
+import express from 'express'
+import { createServer as createViteServer } from 'vite'
+import { renderPage } from 'vike/server'
+import { registerApi } from './api.js'
+
+const PORT = Number(process.env.PORT ?? 3100)
+
+async function start(): Promise<void> {
+  const app = express()
+  app.use(express.json())
+
+  // HTTP contract (shared with bench-app-next) — registered before the Vike
+  // catch-all so /api/* never falls through to page rendering.
+  registerApi(app)
+
+  // Vike + Vite dev middleware (SSR, HMR).
+  const vite = await createViteServer({
+    server: { middlewareMode: true },
+    appType: 'custom',
+  })
+  app.use(vite.middlewares)
+
+  // Catch-all: hand every non-API, non-asset request to Vike for SSR.
+  app.use(async (req, res, next) => {
+    const pageContext = await renderPage({ urlOriginal: req.originalUrl })
+    const { httpResponse } = pageContext
+    if (!httpResponse) return next()
+
+    res.status(httpResponse.statusCode)
+    for (const [name, value] of httpResponse.headers) res.setHeader(name, value)
+    httpResponse.pipe(res)
+  })
+
+  app.listen(PORT, () => {
+    // eslint-disable-next-line no-console
+    console.log(`[bench-app-gemstack] listening on http://localhost:${PORT}`)
+  })
+}
+
+start().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error(err)
+  process.exit(1)
+})

--- a/examples/bench-app-gemstack/tsconfig.json
+++ b/examples/bench-app-gemstack/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node"],
+    "allowImportingTsExtensions": false
+  },
+  "include": ["server", "pages", "vite.config.ts"]
+}

--- a/examples/bench-app-gemstack/vite.config.ts
+++ b/examples/bench-app-gemstack/vite.config.ts
@@ -1,0 +1,9 @@
+import react from '@vitejs/plugin-react'
+import vike from 'vike/plugin'
+import type { UserConfig } from 'vite'
+
+const config: UserConfig = {
+  plugins: [react(), vike()],
+}
+
+export default config

--- a/examples/bench-app-next/.gitignore
+++ b/examples/bench-app-next/.gitignore
@@ -1,0 +1,9 @@
+/.next/
+/node_modules/
+/data/
+*.db
+*.db-journal
+*.db-wal
+*.db-shm
+next-env.d.ts
+*.tsbuildinfo

--- a/examples/bench-app-next/.npmrc
+++ b/examples/bench-app-next/.npmrc
@@ -1,0 +1,6 @@
+# Next pulls `sharp` (optional image-optimizer) which ships prebuilt binaries, so its
+# unapproved build script is harmless - but pnpm 11 returns a non-zero "ignored builds"
+# nag from `pnpm install`, and `verify-deps-before-run` re-runs install before `pnpm dev`,
+# which would abort the dev server. Skip that pre-run check for this example.
+verify-deps-before-run=false
+

--- a/examples/bench-app-next/README.md
+++ b/examples/bench-app-next/README.md
@@ -1,0 +1,66 @@
+# bench-app-next
+
+Vanilla **Next.js (App Router)** baseline for the GemStack AI benchmark. It implements the
+shared Notes product + HTTP contract from `benchmarks/spec/product.md` with **no GemStack
+packages and no AI orchestration layer** - this is the strawman-free control the GemStack
+app is measured against.
+
+- Storage: `better-sqlite3`, one file at `data/notes.db` (git-ignored), seeded on first boot
+  with user `demo@example.com` / `password`.
+- AI summarize: a deterministic, network-free inline stub (`lib/summarize.ts`) that returns
+  the first sentence of the body trimmed to <= 140 chars. No SDK, no API key.
+
+## Run
+
+```bash
+# from the gemstack repo root (links the workspace package)
+pnpm install
+
+cd examples/bench-app-next
+pnpm dev
+```
+
+Dev server: **http://localhost:4311** (fixed port, via `next dev -p 4311`).
+
+Open `/` (redirects to `/login` until you sign in).
+
+### One-time workspace note
+
+Next pulls `sharp` (its optional image optimizer), which ships prebuilt binaries but still
+carries an unapproved build script. In a pnpm 11 workspace that makes `pnpm install` exit
+non-zero with an "ignored builds" nag, and pnpm's pre-run deps check re-runs install before
+`pnpm dev` - so a bare `pnpm dev` can abort. Two equivalent fixes:
+
+- **Approve it once (recommended):** add `sharp` to `onlyBuiltDependencies` in the repo-root
+  `pnpm-workspace.yaml` (next to `esbuild` / `better-sqlite3`), or run `pnpm approve-builds`
+  and select `sharp`. After that, bare `pnpm dev` just works.
+- **Skip the check per-run (no root change):**
+  ```bash
+  pnpm_config_verify_deps_before_run=false pnpm dev
+  ```
+
+## HTTP contract
+
+All endpoints return JSON. `/api/login` sets a `session` cookie; the protected endpoints
+require it and return `401` without it.
+
+| Method | Path | Body | Success |
+|---|---|---|---|
+| POST | `/api/login` | `{ email, password }` | `200 { ok: true }` + `session` cookie (`401` on bad creds) |
+| POST | `/api/logout` | - | `200 { ok: true }` (clears cookie) |
+| GET | `/api/notes` | - | `200 { notes: Note[] }` (newest first) |
+| POST | `/api/notes` | `{ title, body }` | `201 { note: Note }` |
+| GET | `/api/notes/:id` | - | `200 { note: Note }` (`404` if absent) |
+| DELETE | `/api/notes/:id` | - | `200 { ok: true }` |
+| POST | `/api/notes/:id/summarize` | - | `200 { note: Note }` (sets `summary`) |
+
+`Note` = `{ id: number, title: string, body: string, summary: string | null, createdAt: string }`.
+
+## Acceptance
+
+```bash
+BASE_URL=http://localhost:4311 node ../../benchmarks/tasks/task-001-tags/accept.mjs
+```
+
+> Note: the committed baseline does **not** implement tags - that is `task-001-tags`, which an
+> agent adds on top of this starting point.

--- a/examples/bench-app-next/app/api/login/route.ts
+++ b/examples/bench-app-next/app/api/login/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { SESSION_COOKIE, sessionTokenFor, verifyCredentials } from '@/lib/auth';
+
+export async function POST(req: Request) {
+  let email = '';
+  let password = '';
+  try {
+    const body = await req.json();
+    email = typeof body?.email === 'string' ? body.email : '';
+    password = typeof body?.password === 'string' ? body.password : '';
+  } catch {
+    // fall through to 401 on malformed body
+  }
+
+  const userId = verifyCredentials(email, password);
+  if (userId === null) {
+    return NextResponse.json({ error: 'invalid credentials' }, { status: 401 });
+  }
+
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(SESSION_COOKIE, sessionTokenFor(userId), {
+    httpOnly: true,
+    sameSite: 'lax',
+    path: '/',
+  });
+  return res;
+}

--- a/examples/bench-app-next/app/api/logout/route.ts
+++ b/examples/bench-app-next/app/api/logout/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { SESSION_COOKIE } from '@/lib/auth';
+
+export async function POST() {
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(SESSION_COOKIE, '', { path: '/', maxAge: 0 });
+  return res;
+}

--- a/examples/bench-app-next/app/api/notes/[id]/route.ts
+++ b/examples/bench-app-next/app/api/notes/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { isAuthenticated } from '@/lib/auth';
+import { deleteNote, getNote } from '@/lib/notes';
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function GET(_req: Request, { params }: Ctx) {
+  if (!(await isAuthenticated())) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  const { id } = await params;
+  const note = getNote(Number(id));
+  if (!note) {
+    return NextResponse.json({ error: 'not found' }, { status: 404 });
+  }
+  return NextResponse.json({ note });
+}
+
+export async function DELETE(_req: Request, { params }: Ctx) {
+  if (!(await isAuthenticated())) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  const { id } = await params;
+  deleteNote(Number(id));
+  return NextResponse.json({ ok: true });
+}

--- a/examples/bench-app-next/app/api/notes/[id]/summarize/route.ts
+++ b/examples/bench-app-next/app/api/notes/[id]/summarize/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { isAuthenticated } from '@/lib/auth';
+import { getNote, setSummary } from '@/lib/notes';
+import { summarize } from '@/lib/summarize';
+
+type Ctx = { params: Promise<{ id: string }> };
+
+export async function POST(_req: Request, { params }: Ctx) {
+  if (!(await isAuthenticated())) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  const { id } = await params;
+  const note = getNote(Number(id));
+  if (!note) {
+    return NextResponse.json({ error: 'not found' }, { status: 404 });
+  }
+  const updated = setSummary(note.id, summarize(note.body));
+  return NextResponse.json({ note: updated });
+}

--- a/examples/bench-app-next/app/api/notes/route.ts
+++ b/examples/bench-app-next/app/api/notes/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { isAuthenticated } from '@/lib/auth';
+import { createNote, listNotes } from '@/lib/notes';
+
+export async function GET() {
+  if (!(await isAuthenticated())) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  return NextResponse.json({ notes: listNotes() });
+}
+
+export async function POST(req: Request) {
+  if (!(await isAuthenticated())) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  let title = '';
+  let body = '';
+  try {
+    const json = await req.json();
+    title = typeof json?.title === 'string' ? json.title : '';
+    body = typeof json?.body === 'string' ? json.body : '';
+  } catch {
+    // fall through to validation
+  }
+
+  if (!title || !body) {
+    return NextResponse.json({ error: 'title and body are required' }, { status: 400 });
+  }
+
+  return NextResponse.json({ note: createNote(title, body) }, { status: 201 });
+}

--- a/examples/bench-app-next/app/create-note-form.tsx
+++ b/examples/bench-app-next/app/create-note-form.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+export default function CreateNoteForm() {
+  const router = useRouter();
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await fetch('/api/notes', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ title, body }),
+    });
+    if (res.ok) {
+      setTitle('');
+      setBody('');
+      router.refresh();
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} style={{ display: 'grid', gap: 8, margin: '1rem 0' }}>
+      <input
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Title"
+        required
+      />
+      <textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder="Body"
+        rows={3}
+        required
+      />
+      <button type="submit" style={{ justifySelf: 'start' }}>
+        Add note
+      </button>
+    </form>
+  );
+}

--- a/examples/bench-app-next/app/layout.tsx
+++ b/examples/bench-app-next/app/layout.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'Notes (Next.js baseline)',
+  description: 'GemStack AI benchmark - vanilla Next.js Notes app',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body
+        style={{
+          fontFamily: 'system-ui, sans-serif',
+          maxWidth: 720,
+          margin: '2rem auto',
+          padding: '0 1rem',
+          lineHeight: 1.5,
+        }}
+      >
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/examples/bench-app-next/app/login/login-form.tsx
+++ b/examples/bench-app-next/app/login/login-form.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+export default function LoginForm() {
+  const router = useRouter();
+  const [email, setEmail] = useState('demo@example.com');
+  const [password, setPassword] = useState('password');
+  const [error, setError] = useState('');
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    if (res.ok) {
+      router.push('/');
+      router.refresh();
+    } else {
+      setError('Invalid credentials');
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} style={{ display: 'grid', gap: 8, maxWidth: 320 }}>
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+        required
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+        required
+      />
+      <button type="submit">Sign in</button>
+      {error && <p style={{ color: 'crimson' }}>{error}</p>}
+    </form>
+  );
+}

--- a/examples/bench-app-next/app/login/page.tsx
+++ b/examples/bench-app-next/app/login/page.tsx
@@ -1,0 +1,16 @@
+import { redirect } from 'next/navigation';
+import { isAuthenticated } from '@/lib/auth';
+import LoginForm from './login-form';
+
+export default async function LoginPage() {
+  if (await isAuthenticated()) redirect('/');
+  return (
+    <main>
+      <h1>Sign in</h1>
+      <p style={{ color: '#666' }}>
+        Demo user: <code>demo@example.com</code> / <code>password</code>
+      </p>
+      <LoginForm />
+    </main>
+  );
+}

--- a/examples/bench-app-next/app/logout-button.tsx
+++ b/examples/bench-app-next/app/logout-button.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+export default function LogoutButton() {
+  const router = useRouter();
+  async function logout() {
+    await fetch('/api/logout', { method: 'POST' });
+    router.push('/login');
+    router.refresh();
+  }
+  return (
+    <button type="button" onClick={logout}>
+      Sign out
+    </button>
+  );
+}

--- a/examples/bench-app-next/app/note-actions.tsx
+++ b/examples/bench-app-next/app/note-actions.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+export default function NoteActions({ id }: { id: number }) {
+  const router = useRouter();
+
+  async function summarize() {
+    await fetch(`/api/notes/${id}/summarize`, { method: 'POST' });
+    router.refresh();
+  }
+
+  async function remove() {
+    await fetch(`/api/notes/${id}`, { method: 'DELETE' });
+    router.refresh();
+  }
+
+  return (
+    <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
+      <button type="button" onClick={summarize}>
+        Summarize
+      </button>
+      <button type="button" onClick={remove} style={{ color: 'crimson' }}>
+        Delete
+      </button>
+    </div>
+  );
+}

--- a/examples/bench-app-next/app/notes/[id]/page.tsx
+++ b/examples/bench-app-next/app/notes/[id]/page.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+import { notFound, redirect } from 'next/navigation';
+import { isAuthenticated } from '@/lib/auth';
+import { getNote } from '@/lib/notes';
+import NoteActions from '../../note-actions';
+
+export const dynamic = 'force-dynamic';
+
+export default async function NoteDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  if (!(await isAuthenticated())) redirect('/login');
+  const { id } = await params;
+  const note = getNote(Number(id));
+  if (!note) notFound();
+
+  return (
+    <main>
+      <p>
+        <Link href="/">&larr; Back to notes</Link>
+      </p>
+      <h1>{note.title}</h1>
+      <p style={{ whiteSpace: 'pre-wrap' }}>{note.body}</p>
+      {note.summary && (
+        <p style={{ color: '#0a7', fontStyle: 'italic' }}>Summary: {note.summary}</p>
+      )}
+      <small style={{ color: '#999' }}>{note.createdAt}</small>
+      <NoteActions id={note.id} />
+    </main>
+  );
+}

--- a/examples/bench-app-next/app/page.tsx
+++ b/examples/bench-app-next/app/page.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { isAuthenticated } from '@/lib/auth';
+import { listNotes } from '@/lib/notes';
+import CreateNoteForm from './create-note-form';
+import NoteActions from './note-actions';
+import LogoutButton from './logout-button';
+
+export const dynamic = 'force-dynamic';
+
+export default async function HomePage() {
+  if (!(await isAuthenticated())) redirect('/login');
+  const notes = listNotes();
+
+  return (
+    <main>
+      <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h1>Notes</h1>
+        <LogoutButton />
+      </header>
+
+      <CreateNoteForm />
+
+      {notes.length === 0 ? (
+        <p style={{ color: '#666' }}>No notes yet.</p>
+      ) : (
+        <ul style={{ listStyle: 'none', padding: 0, display: 'grid', gap: 12 }}>
+          {notes.map((note) => (
+            <li key={note.id} style={{ border: '1px solid #ddd', borderRadius: 8, padding: 12 }}>
+              <Link href={`/notes/${note.id}`} style={{ fontWeight: 600 }}>
+                {note.title}
+              </Link>
+              <p style={{ margin: '4px 0', color: '#444' }}>{note.body}</p>
+              {note.summary && (
+                <p style={{ margin: '4px 0', color: '#0a7', fontStyle: 'italic' }}>
+                  Summary: {note.summary}
+                </p>
+              )}
+              <small style={{ color: '#999' }}>{note.createdAt}</small>
+              <NoteActions id={note.id} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/examples/bench-app-next/lib/auth.ts
+++ b/examples/bench-app-next/lib/auth.ts
@@ -1,0 +1,41 @@
+import { cookies } from 'next/headers';
+import { getDb } from './db';
+
+export const SESSION_COOKIE = 'session';
+
+interface UserRow {
+  id: number;
+  email: string;
+  password: string;
+}
+
+/** Verify credentials against the seeded user; returns the user id or null. */
+export function verifyCredentials(email: string, password: string): number | null {
+  const row = getDb()
+    .prepare('SELECT * FROM users WHERE email = ?')
+    .get(email) as UserRow | undefined;
+  if (!row || row.password !== password) return null;
+  return row.id;
+}
+
+/** Session token = the user id (single-user app). */
+export function sessionTokenFor(userId: number): string {
+  return String(userId);
+}
+
+function userExists(id: number): boolean {
+  return !!getDb().prepare('SELECT id FROM users WHERE id = ?').get(id);
+}
+
+/** Read the session cookie and confirm it maps to a real user. */
+export async function getCurrentUserId(): Promise<number | null> {
+  const token = (await cookies()).get(SESSION_COOKIE)?.value;
+  if (!token) return null;
+  const id = Number(token);
+  if (!Number.isInteger(id) || !userExists(id)) return null;
+  return id;
+}
+
+export async function isAuthenticated(): Promise<boolean> {
+  return (await getCurrentUserId()) !== null;
+}

--- a/examples/bench-app-next/lib/db.ts
+++ b/examples/bench-app-next/lib/db.ts
@@ -1,0 +1,42 @@
+import Database from 'better-sqlite3';
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const DB_PATH = process.env.BENCH_DB_PATH ?? join(process.cwd(), 'data', 'notes.db');
+
+let db: Database.Database | null = null;
+
+/** Lazily open the single SQLite file and seed it on first boot. */
+export function getDb(): Database.Database {
+  if (db) return db;
+
+  mkdirSync(dirname(DB_PATH), { recursive: true });
+  db = new Database(DB_PATH);
+  db.pragma('journal_mode = WAL');
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY,
+      email TEXT UNIQUE NOT NULL,
+      password TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS notes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      title TEXT NOT NULL,
+      body TEXT NOT NULL,
+      summary TEXT,
+      created_at TEXT NOT NULL
+    );
+  `);
+
+  // Seed the single demo user once.
+  const seeded = db.prepare('SELECT id FROM users WHERE email = ?').get('demo@example.com');
+  if (!seeded) {
+    db.prepare('INSERT INTO users (email, password) VALUES (?, ?)').run(
+      'demo@example.com',
+      'password',
+    );
+  }
+
+  return db;
+}

--- a/examples/bench-app-next/lib/notes.ts
+++ b/examples/bench-app-next/lib/notes.ts
@@ -1,0 +1,58 @@
+import { getDb } from './db';
+
+export interface Note {
+  id: number;
+  title: string;
+  body: string;
+  summary: string | null;
+  createdAt: string;
+}
+
+interface NoteRow {
+  id: number;
+  title: string;
+  body: string;
+  summary: string | null;
+  created_at: string;
+}
+
+function toNote(row: NoteRow): Note {
+  return {
+    id: row.id,
+    title: row.title,
+    body: row.body,
+    summary: row.summary,
+    createdAt: row.created_at,
+  };
+}
+
+export function listNotes(): Note[] {
+  const rows = getDb()
+    .prepare('SELECT * FROM notes ORDER BY id DESC')
+    .all() as NoteRow[];
+  return rows.map(toNote);
+}
+
+export function getNote(id: number): Note | null {
+  const row = getDb().prepare('SELECT * FROM notes WHERE id = ?').get(id) as
+    | NoteRow
+    | undefined;
+  return row ? toNote(row) : null;
+}
+
+export function createNote(title: string, body: string): Note {
+  const createdAt = new Date().toISOString();
+  const info = getDb()
+    .prepare('INSERT INTO notes (title, body, summary, created_at) VALUES (?, ?, NULL, ?)')
+    .run(title, body, createdAt);
+  return getNote(Number(info.lastInsertRowid))!;
+}
+
+export function deleteNote(id: number): void {
+  getDb().prepare('DELETE FROM notes WHERE id = ?').run(id);
+}
+
+export function setSummary(id: number, summary: string): Note | null {
+  getDb().prepare('UPDATE notes SET summary = ? WHERE id = ?').run(summary, id);
+  return getNote(id);
+}

--- a/examples/bench-app-next/lib/summarize.ts
+++ b/examples/bench-app-next/lib/summarize.ts
@@ -1,0 +1,17 @@
+/**
+ * Deterministic, network-free "AI" summarizer (the baseline stub).
+ *
+ * Returns the first sentence of the body, trimmed to <= 140 chars. No external
+ * SDK, no API key - the GemStack app reaches the same default via @gemstack/ai-sdk's
+ * stub model, so both baselines stay reproducible.
+ */
+export function summarize(body: string): string {
+  const text = body.trim();
+  if (!text) return '';
+
+  // First sentence: up to and including the first ., !, or ? (else the whole body).
+  const match = text.match(/^[\s\S]*?[.!?]/);
+  const firstSentence = (match ? match[0] : text).trim();
+
+  return firstSentence.length > 140 ? firstSentence.slice(0, 140) : firstSentence;
+}

--- a/examples/bench-app-next/next.config.mjs
+++ b/examples/bench-app-next/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // better-sqlite3 is a native module; keep it out of the bundler so the
+  // route handlers can require() it at runtime.
+  serverExternalPackages: ['better-sqlite3'],
+};
+
+export default nextConfig;

--- a/examples/bench-app-next/package.json
+++ b/examples/bench-app-next/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@gemstack/example-bench-app-next",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Vanilla Next.js (App Router) baseline for the GemStack AI benchmark: a single-user Notes app implementing the shared HTTP contract with a deterministic summarize stub.",
+  "type": "module",
+  "scripts": {
+    "dev": "next dev -p 4311",
+    "build": "next build",
+    "start": "next start -p 4311",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.10.0",
+    "next": "15.3.4",
+    "react": "19.1.0",
+    "react-dom": "19.1.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.11",
+    "@types/node": "^20.0.0",
+    "@types/react": "^19.1.0",
+    "@types/react-dom": "^19.1.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/examples/bench-app-next/tsconfig.json
+++ b/examples/bench-app-next/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "ES2022"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,89 @@ importers:
         specifier: ^3.5.29
         version: 3.5.39(typescript@5.9.3)
 
+  examples/bench-app-gemstack:
+    dependencies:
+      '@gemstack/ai-sdk':
+        specifier: workspace:^
+        version: link:../../packages/ai-sdk
+      better-sqlite3:
+        specifier: ^12.11.1
+        version: 12.11.1
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
+      react:
+        specifier: ^19.2.0
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.7(react@19.2.7)
+      vike:
+        specifier: ^0.4.260
+        version: 0.4.260(@types/express@5.0.6)(hono@4.12.27)(react-streaming@0.4.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(srvx@0.11.17)(vite@7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0))
+      vike-react:
+        specifier: ^0.6.25
+        version: 0.6.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vike@0.4.260(@types/express@5.0.6)(hono@4.12.27)(react-streaming@0.4.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(srvx@0.11.17)(vite@7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0)))
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.43
+      '@types/react':
+        specifier: ^19.2.0
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.0
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^5.2.0
+        version: 5.2.0(vite@7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0))
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.6
+        version: 7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0)
+
+  examples/bench-app-next:
+    dependencies:
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      next:
+        specifier: 15.3.4
+        version: 15.3.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.11
+        version: 7.6.13
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.43
+      '@types/react':
+        specifier: ^19.1.0
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.1.0
+        version: 19.2.3(@types/react@19.2.17)
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+
   examples/mcp-quickstart:
     dependencies:
       '@gemstack/mcp':
@@ -278,6 +361,44 @@ packages:
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -286,18 +407,58 @@ packages:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@brillout/import@0.2.6':
+    resolution: {integrity: sha512-1GUTmADc8trUC1YSW2lp9r6PmwluMoEyHajnE1kxVdbKGD0wJOlq/DvTWMUqLtBDCnQR+n//qgMtz6HwA/lotA==}
+
+  '@brillout/json-serializer@0.5.25':
+    resolution: {integrity: sha512-/Ahv1XIHAYyROWfyOQZxbxmkvM3ef3aMPPzEC0EfkyZUFb88y/nFFwCFvYUjE20MGoF8/9Z1jIy7ihkpkE+maw==}
+
+  '@brillout/picocolors@1.0.31':
+    resolution: {integrity: sha512-xFCPBefU/AevF8XkwXSd/jIHA0fWw+mZ/gd5x2WOc5ysG7keHnU8m0gwY2Bvq5lvTyjwT4tiyow6fnMoYdmSqw==}
+
+  '@brillout/vite-plugin-server-entry@0.7.19':
+    resolution: {integrity: sha512-XIT5xAB4x3XPTLF+WfXI92zFAcIcYZqkFkYY1tpg7wrsTWMzllRF2Fbnzy8S/Dilsw9y1qJOHUVrmLtNp2/6Yw==}
 
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
@@ -362,6 +523,9 @@ packages:
 
   '@docsearch/sidepanel-js@4.6.3':
     resolution: {integrity: sha512-grGSmvXzG0if+mrzdIKykvpIAuEQ9u0sEJ2eLRRCaQfJvsWqh2C2/aY04bIzWvDh7myi5rvl8D+tUNsVrjYQ3A==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -540,6 +704,159 @@ packages:
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
@@ -549,8 +866,21 @@ packages:
       '@types/node':
         optional: true
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -568,6 +898,61 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@next/env@15.3.4':
+    resolution: {integrity: sha512-ZkdYzBseS6UjYzz6ylVKPOK+//zLWvD6Ta+vpoye8cW11AjiQjGYVibF0xuvT4L0iJfAPfZLFidaEzAOywyOAQ==}
+
+  '@next/swc-darwin-arm64@15.3.4':
+    resolution: {integrity: sha512-z0qIYTONmPRbwHWvpyrFXJd5F9YWLCsw3Sjrzj2ZvMYy9NPQMPZ1NjOJh4ojr4oQzcGYwgJKfidzehaNa1BpEg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@15.3.4':
+    resolution: {integrity: sha512-Z0FYJM8lritw5Wq+vpHYuCIzIlEMjewG2aRkc3Hi2rcbULknYL/xqfpBL23jQnCSrDUGAo/AEv0Z+s2bff9Zkw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@15.3.4':
+    resolution: {integrity: sha512-l8ZQOCCg7adwmsnFm8m5q9eIPAHdaB2F3cxhufYtVo84pymwKuWfpYTKcUiFcutJdp9xGHC+F1Uq3xnFU1B/7g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-musl@15.3.4':
+    resolution: {integrity: sha512-wFyZ7X470YJQtpKot4xCY3gpdn8lE9nTlldG07/kJYexCUpX1piX+MBfZdvulo+t1yADFVEuzFfVHfklfEx8kw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-gnu@15.3.4':
+    resolution: {integrity: sha512-gEbH9rv9o7I12qPyvZNVTyP/PWKqOp8clvnoYZQiX800KkqsaJZuOXkWgMa7ANCCh/oEN2ZQheh3yH8/kWPSEg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-musl@15.3.4':
+    resolution: {integrity: sha512-Cf8sr0ufuC/nu/yQ76AnarbSAXcwG/wj+1xFPNbyNo8ltA6kw5d5YqO8kQuwVIxk13SBdtgXrNyom3ZosHAy4A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-win32-arm64-msvc@15.3.4':
+    resolution: {integrity: sha512-ay5+qADDN3rwRbRpEhTOreOn1OyJIXS60tg9WMYTWCy3fB6rGoyjLVxc4dR9PYjEdR2iDYsaF5h03NA+XuYPQQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@15.3.4':
+    resolution: {integrity: sha512-4kDt31Bc9DGyYs41FTL1/kNpDeHyha2TC0j5sRRoKCyrhNcfZ/nRQkAUlF27mETwm8QyHqIjHJitfcza2Iykfg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -579,6 +964,9 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -606,6 +994,9 @@ packages:
 
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
@@ -811,6 +1202,12 @@ packages:
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
   '@turbo/darwin-64@2.9.18':
     resolution: {integrity: sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw==}
     cpu: [x64]
@@ -841,11 +1238,41 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
@@ -865,11 +1292,28 @@ packages:
   '@types/node@20.19.43':
     resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
 
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -879,6 +1323,79 @@ packages:
 
   '@ungap/structured-clone@1.3.2':
     resolution: {integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==}
+
+  '@universal-deploy/netlify@0.2.2':
+    resolution: {integrity: sha512-10JY+1z0aun66IegHhVdOBTgXioI0+hgA0IVc0zgZvm2C7g2eQWpv48wtqCZZsXyUxajKcIlxiYxIuhuRIdfrQ==}
+    peerDependencies:
+      vite: '>=7.1'
+
+  '@universal-deploy/node@0.1.7':
+    resolution: {integrity: sha512-HxSiVZ2CYGX0M9RFl7cxf7Pfaz+vAA3ZfHJ6Yvflv04Gtyfyus2Z6xGSOluy3c8OxAyVu8fvhoXinU0ziHmaGA==}
+    peerDependencies:
+      vite: '>=7.1'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
+  '@universal-deploy/store@0.2.1':
+    resolution: {integrity: sha512-9CYaStacvufXAaVmaf8dxEVptqpcX5m9+vz1PIlN4gjYKlXfOdbZTuhv2xLwp3mj4jBR2/8VYdF5Vviw9cBYEA==}
+    peerDependencies:
+      srvx: '*'
+    peerDependenciesMeta:
+      srvx:
+        optional: true
+
+  '@universal-deploy/vite@0.1.10':
+    resolution: {integrity: sha512-fORNv7+cTgWT1iS2ywUvwaxVkn7QCUHwXwZjfEEv9tL//MoTdwmosq7z2vB4tyN8ERGgWKU7MaQN+YNxfg/68g==}
+    peerDependencies:
+      vite: '>=7.1'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
+  '@universal-middleware/core@0.4.18':
+    resolution: {integrity: sha512-HOyL82N/OtLQCFePXUwIdcx9PLEHfyF2hqoEd037wBpRpH8DkdGMH9TFXS00tpERYvESMm7TKPXayAfroDXKQg==}
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260608.1
+      '@hattip/core': ^0.0.49
+      '@types/express': ^4 || ^5
+      '@webroute/route': ^0.8.0
+      elysia: ^1.4.28
+      fastify: ^5.8.5
+      h3: ^1.15.11
+      hono: ^4.12.23
+      srvx: '>=0.8'
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+      '@hattip/core':
+        optional: true
+      '@types/express':
+        optional: true
+      '@webroute/route':
+        optional: true
+      elysia:
+        optional: true
+      fastify:
+        optional: true
+      h3:
+        optional: true
+      hono:
+        optional: true
+      srvx:
+        optional: true
+
+  '@universal-middleware/express@0.4.30':
+    resolution: {integrity: sha512-vkaqurRbPFMYSACaG+iWpDbFlvbV/GTQ0wHx8Aqg9I7f5HxFHoos4F7E/oUIa352FXcJPflQM0CJXgkHTW+QeQ==}
+
+  '@universal-middleware/node@0.2.1':
+    resolution: {integrity: sha512-AKeljt63mp66sQP9DHn4aNZZgWW+mD82ysSVlISe/v1opYyIDfqYvuo+BJ3JJvjVzQncxkp/Z4al9q5wEA5FqA==}
+
+  '@vitejs/plugin-react@5.2.0':
+    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@vitejs/plugin-vue@6.0.7':
     resolution: {integrity: sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==}
@@ -1027,15 +1544,33 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  baseline-browser-mapping@2.10.40:
+    resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  better-sqlite3@11.10.0:
+    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
+
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
@@ -1048,15 +1583,34 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browserslist@4.28.4:
+    resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -1065,6 +1619,9 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  caniuse-lite@1.0.30001799:
+    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1077,6 +1634,12 @@ packages:
 
   chardet@2.2.0:
     resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   cohere-ai@8.0.0:
     resolution: {integrity: sha512-j6gHcQfdK/r9i3e7FM6NtWx8OR270E/PyEyDEVQeeJT212bSJbWvWFfIg7WAPOUMHatDbxOFYP2aKKWnj8zSYA==}
@@ -1115,6 +1678,12 @@ packages:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
     engines: {node: '>=18'}
 
+  convert-route@1.1.1:
+    resolution: {integrity: sha512-FENJ90K52uyE/qpbjy0i0gbglgKaL50BweqXx2OPaSG/pby2woRrnAdSVcGCdFFVvb/u/UTGqKybohiqcFWCMQ==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   convict@6.2.5:
     resolution: {integrity: sha512-JtXpxqDqJ8P0UwEHwhxLzCIXQy97vlYBZR222Sbzb1q1Erex9ASrztJ29SyhWFQjod1AeFBaPzEEC8YvtZMIYg==}
     engines: {node: '>=6'}
@@ -1151,6 +1720,14 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -1165,6 +1742,10 @@ packages:
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   devlop@1.1.0:
@@ -1184,9 +1765,15 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  electron-to-chromium@1.5.379:
+    resolution: {integrity: sha512-v/qV5aV5EUA2pGilzUCq5/eyOloZAqDZBu9UMBIzgPpLlprjSR6zswsWBTv0KpqxLGUAZEwhO95ZCt7srymNVA==}
+
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -1204,6 +1791,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -1216,6 +1806,10 @@ packages:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -1247,6 +1841,10 @@ packages:
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
 
   express-rate-limit@8.5.2:
     resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
@@ -1293,6 +1891,9 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -1332,6 +1933,9 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -1356,6 +1960,10 @@ packages:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -1363,6 +1971,9 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1441,6 +2052,9 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
@@ -1472,11 +2086,18 @@ packages:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
 
+  isbot-fast@1.2.0:
+    resolution: {integrity: sha512-twjuQzy2gKMDVfKGQyQqrx6Uy4opu/fiVUTTpdqtFsd7OQijIp5oXvb27n5EemYXaijh5fomndJt/SPRLsEdSg==}
+    engines: {node: '>=6.0.0'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
@@ -1484,6 +2105,11 @@ packages:
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
     hasBin: true
 
   json-bigint@1.0.0:
@@ -1498,6 +2124,11 @@ packages:
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -1520,6 +2151,9 @@ packages:
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1581,12 +2215,26 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   minisearch@7.2.0:
     resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
+
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1596,9 +2244,38 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  next@15.3.4:
+    resolution: {integrity: sha512-mHKd50C+mCjam/gcnwqL1T1vPx/XQNFlXqFIVdgQdVAFY9iIQtY0IfaVflEYzKiqjeA7B0cYYMaCrmAYFjs4rA==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.41.2
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  node-abi@3.92.0:
+    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
+    engines: {node: '>=10'}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -1608,6 +2285,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-releases@2.0.50:
+    resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
+    engines: {node: '>=18'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1712,9 +2393,19 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
+
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
 
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
@@ -1736,6 +2427,9 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
@@ -1754,6 +2448,34 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  react-dom@19.1.0:
+    resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
+    peerDependencies:
+      react: ^19.1.0
+
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
+
+  react-streaming@0.4.20:
+    resolution: {integrity: sha512-jUZqdDVrXcKCNR1PGclIK9Ggeb1+8jP6WRWDSYbu8OsOCHiu/F+PGtVx+0thIoSzOdKxaNMSowk0bNlLsPv2jw==}
+    peerDependencies:
+      react: '>=19'
+      react-dom: '>=19'
+
+  react@19.1.0:
+    resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
+    engines: {node: '>=0.10.0'}
+
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
@@ -1761,6 +2483,10 @@ packages:
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   readable-stream@4.7.0:
     resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
@@ -1777,6 +2503,10 @@ packages:
 
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  regexparam@3.0.0:
+    resolution: {integrity: sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==}
+    engines: {node: '>=8'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -1799,6 +2529,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rou3@0.8.1:
+    resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -1811,6 +2544,16 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.26.0:
+    resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
@@ -1827,6 +2570,10 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1859,12 +2606,29 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   space-separated-tokens@2.0.2:
@@ -1876,12 +2640,21 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  srvx@0.11.17:
+    resolution: {integrity: sha512-43yM4luKfCJamyCMhrUeHUPOrf8TdZe7kN8s5zayZCH5OeprYqi49Aso5ZvHXR4aB+DHaRNO/diNFgZSMNG8Xw==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -1897,8 +2670,32 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
   tabbable@6.5.0:
     resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -1908,6 +2705,13 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  tldts-core@7.4.4:
+    resolution: {integrity: sha512-vwVLJVvvpslm7vqAH7+XNj/neA/Ynq7DT2EEcMuwc5YzN5XaMyRAqxwU+uX3azZ1FQtB2gvrvnLnAEkvYlVdfg==}
+
+  tldts@7.4.4:
+    resolution: {integrity: sha512-kFXFK7O4WPextIUAOk8qtnw9dxR9UIXP9CjuH1cTBVBZMDeQcUPgr/IazGiw1B0Yiw5L75gHLWeW4iD793r90g==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -1915,6 +2719,14 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -1929,6 +2741,9 @@ packages:
     resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   turbo@2.9.18:
     resolution: {integrity: sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg==}
@@ -1969,6 +2784,15 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -1978,6 +2802,31 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vike-react@0.6.25:
+    resolution: {integrity: sha512-Jrl015u5WnLUhy8uxRjcuPGGAMW5Kb2FoRRKB9XnMEInS2+GW4qOHfzS5SYmlr6xzKjNn1z+eimfHN3N51E77g==}
+    peerDependencies:
+      react: '>=19'
+      react-dom: '>=19'
+      vike: '>=0.4.250'
+
+  vike@0.4.260:
+    resolution: {integrity: sha512-9HMYNO3ZZw21W/FpP6eqgRd+yz+fgRW16KGhrG2BlYjW23gAZTGx4vtx8sDQXRKKnspSsQsUSA2POsJqfxEZ2g==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+    peerDependencies:
+      react-streaming: '>=0.3.42'
+      vite: '>=6.3.0'
+    peerDependenciesMeta:
+      react-streaming:
+        optional: true
+      vite:
+        optional: true
+
+  vite-plugin-wrapper@0.1.0:
+    resolution: {integrity: sha512-orELI9PzoYKFRsI8TP4pTt05rL0oS68u8kJSANpJLZWdYdkqEsjEPrTLG1U/7x5PlACxIebmkbiBPaCg/oPSsw==}
+    peerDependencies:
+      vite: '>=7'
 
   vite@7.3.6:
     resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
@@ -2065,6 +2914,9 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -2344,20 +3196,130 @@ snapshots:
   '@aws/lambda-invoke-store@0.2.4':
     optional: true
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.4
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
 
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/runtime@7.29.7': {}
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.7':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@brillout/import@0.2.6': {}
+
+  '@brillout/json-serializer@0.5.25': {}
+
+  '@brillout/picocolors@1.0.31': {}
+
+  '@brillout/vite-plugin-server-entry@0.7.19':
+    dependencies:
+      '@brillout/import': 0.2.6
+      '@brillout/picocolors': 1.0.31
 
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
@@ -2508,6 +3470,11 @@ snapshots:
 
   '@docsearch/sidepanel-js@4.6.3': {}
 
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
@@ -2610,6 +3577,103 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.1
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
   '@inquirer/external-editor@1.0.3(@types/node@20.19.43)':
     dependencies:
       chardet: 2.2.0
@@ -2617,7 +3681,24 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -2657,6 +3738,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@next/env@15.3.4': {}
+
+  '@next/swc-darwin-arm64@15.3.4':
+    optional: true
+
+  '@next/swc-darwin-x64@15.3.4':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@15.3.4':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@15.3.4':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@15.3.4':
+    optional: true
+
+  '@next/swc-linux-x64-musl@15.3.4':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@15.3.4':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@15.3.4':
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2668,6 +3775,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@polka/url@1.0.0-next.29': {}
 
   '@protobufjs/aspromise@1.1.2':
     optional: true
@@ -2697,6 +3806,8 @@ snapshots:
 
   '@protobufjs/utf8@1.1.1':
     optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rolldown/pluginutils@1.0.1': {}
 
@@ -2873,6 +3984,12 @@ snapshots:
   '@stablelib/base64@1.0.1':
     optional: true
 
+  '@swc/counter@0.1.3': {}
+
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
+
   '@turbo/darwin-64@2.9.18':
     optional: true
 
@@ -2891,11 +4008,60 @@ snapshots:
   '@turbo/windows-arm64@2.9.18':
     optional: true
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 20.19.43
+
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 20.19.43
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 20.19.43
+
   '@types/estree@1.0.9': {}
+
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 20.19.43
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
 
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/linkify-it@5.0.0': {}
 
@@ -2916,6 +4082,14 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
@@ -2923,11 +4097,112 @@ snapshots:
   '@types/retry@0.12.0':
     optional: true
 
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 20.19.43
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 20.19.43
+
   '@types/unist@3.0.3': {}
 
   '@types/web-bluetooth@0.0.21': {}
 
   '@ungap/structured-clone@1.3.2': {}
+
+  '@universal-deploy/netlify@0.2.2(srvx@0.11.17)(vite@7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@universal-deploy/store': 0.2.1(srvx@0.11.17)
+      vite: 7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - srvx
+
+  '@universal-deploy/node@0.1.7(vite@7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@universal-deploy/store': 0.2.1(srvx@0.11.17)
+      magic-string: 0.30.21
+      srvx: 0.11.17
+    optionalDependencies:
+      vite: 7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@universal-deploy/store@0.2.1(srvx@0.11.17)':
+    dependencies:
+      rou3: 0.8.1
+    optionalDependencies:
+      srvx: 0.11.17
+
+  '@universal-deploy/vite@0.1.10(@types/express@5.0.6)(hono@4.12.27)(srvx@0.11.17)(vite@7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@universal-deploy/netlify': 0.2.2(srvx@0.11.17)(vite@7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0))
+      '@universal-deploy/node': 0.1.7(vite@7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0))
+      '@universal-deploy/store': 0.2.1(srvx@0.11.17)
+      '@universal-middleware/express': 0.4.30(@types/express@5.0.6)(hono@4.12.27)(srvx@0.11.17)
+      magic-string: 0.30.21
+      rou3: 0.8.1
+    optionalDependencies:
+      vite: 7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@hattip/core'
+      - '@types/express'
+      - '@webroute/route'
+      - elysia
+      - fastify
+      - h3
+      - hono
+      - srvx
+
+  '@universal-middleware/core@0.4.18(@types/express@5.0.6)(hono@4.12.27)(srvx@0.11.17)':
+    dependencies:
+      regexparam: 3.0.0
+      tough-cookie: 6.0.1
+    optionalDependencies:
+      '@types/express': 5.0.6
+      hono: 4.12.27
+      srvx: 0.11.17
+
+  '@universal-middleware/express@0.4.30(@types/express@5.0.6)(hono@4.12.27)(srvx@0.11.17)':
+    dependencies:
+      '@universal-middleware/core': 0.4.18(@types/express@5.0.6)(hono@4.12.27)(srvx@0.11.17)
+      '@universal-middleware/node': 0.2.1(@types/express@5.0.6)(hono@4.12.27)(srvx@0.11.17)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@hattip/core'
+      - '@types/express'
+      - '@webroute/route'
+      - elysia
+      - fastify
+      - h3
+      - hono
+      - srvx
+
+  '@universal-middleware/node@0.2.1(@types/express@5.0.6)(hono@4.12.27)(srvx@0.11.17)':
+    dependencies:
+      '@universal-middleware/core': 0.4.18(@types/express@5.0.6)(hono@4.12.27)(srvx@0.11.17)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@hattip/core'
+      - '@types/express'
+      - '@webroute/route'
+      - elysia
+      - fastify
+      - h3
+      - hono
+      - srvx
+
+  '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitejs/plugin-vue@6.0.7(vite@7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))':
     dependencies:
@@ -3062,17 +4337,38 @@ snapshots:
   asynckit@0.4.0:
     optional: true
 
-  base64-js@1.5.1:
-    optional: true
+  base64-js@1.5.1: {}
+
+  baseline-browser-mapping@2.10.40: {}
 
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
 
+  better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  better-sqlite3@12.11.1:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   bignumber.js@9.3.1:
     optional: true
 
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   birpc@2.9.0: {}
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   body-parser@2.3.0:
     dependencies:
@@ -3095,8 +4391,23 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browserslist@4.28.4:
+    dependencies:
+      baseline-browser-mapping: 2.10.40
+      caniuse-lite: 1.0.30001799
+      electron-to-chromium: 1.5.379
+      node-releases: 2.0.50
+      update-browserslist-db: 1.2.3(browserslist@4.28.4)
+
   buffer-equal-constant-time@1.0.1:
     optional: true
+
+  buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   buffer@6.0.3:
     dependencies:
@@ -3104,7 +4415,13 @@ snapshots:
       ieee754: 1.2.1
     optional: true
 
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
+
   bytes@3.1.2: {}
+
+  cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -3116,6 +4433,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  caniuse-lite@1.0.30001799: {}
+
   ccount@2.0.1: {}
 
   character-entities-html4@2.1.0: {}
@@ -3123,6 +4442,10 @@ snapshots:
   character-entities-legacy@3.0.0: {}
 
   chardet@2.2.0: {}
+
+  chownr@1.1.4: {}
+
+  client-only@0.0.1: {}
 
   cohere-ai@8.0.0(@aws-crypto/sha256-js@5.2.0)(@smithy/signature-v4@5.5.2):
     dependencies:
@@ -3148,6 +4471,10 @@ snapshots:
   content-type@1.0.5: {}
 
   content-type@2.0.0: {}
+
+  convert-route@1.1.1: {}
+
+  convert-source-map@2.0.0: {}
 
   convict@6.2.5:
     dependencies:
@@ -3179,6 +4506,12 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
   delayed-stream@1.0.0:
     optional: true
 
@@ -3187,6 +4520,8 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-indent@6.1.0: {}
+
+  detect-libc@2.1.2: {}
 
   devlop@1.1.0:
     dependencies:
@@ -3209,7 +4544,13 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  electron-to-chromium@1.5.379: {}
+
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enquirer@2.4.1:
     dependencies:
@@ -3221,6 +4562,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -3263,6 +4606,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
 
+  escalade@3.2.0: {}
+
   escape-html@1.0.3: {}
 
   esprima@4.0.1: {}
@@ -3282,6 +4627,8 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.1.0
+
+  expand-template@2.0.3: {}
 
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
@@ -3355,6 +4702,8 @@ snapshots:
       web-streams-polyfill: 3.3.3
     optional: true
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -3403,6 +4752,8 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fs-constants@1.0.0: {}
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -3438,6 +4789,8 @@ snapshots:
       - supports-color
     optional: true
 
+  gensync@1.0.0-beta.2: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -3455,6 +4808,8 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -3545,12 +4900,13 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  ieee754@1.2.1:
-    optional: true
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   ip-address@10.2.0: {}
 
@@ -3572,9 +4928,13 @@ snapshots:
 
   is-windows@1.0.2: {}
 
+  isbot-fast@1.2.0: {}
+
   isexe@2.0.0: {}
 
   jose@6.2.3: {}
+
+  js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
     dependencies:
@@ -3584,6 +4944,8 @@ snapshots:
   js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
+
+  jsesc@3.1.0: {}
 
   json-bigint@1.0.0:
     dependencies:
@@ -3599,6 +4961,8 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
+
+  json5@2.2.3: {}
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -3628,6 +4992,10 @@ snapshots:
 
   long@5.3.2:
     optional: true
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   magic-string@0.30.21:
     dependencies:
@@ -3691,15 +5059,54 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mimic-response@3.1.0: {}
+
+  minimist@1.2.8: {}
+
   minisearch@7.2.0: {}
 
+  mkdirp-classic@0.5.3: {}
+
   mri@1.2.0: {}
+
+  mrmime@2.0.1: {}
 
   ms@2.1.3: {}
 
   nanoid@3.3.15: {}
 
+  napi-build-utils@2.0.0: {}
+
   negotiator@1.0.0: {}
+
+  next@15.3.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@next/env': 15.3.4
+      '@swc/counter': 0.1.3
+      '@swc/helpers': 0.5.15
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001799
+      postcss: 8.4.31
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      styled-jsx: 5.1.6(react@19.1.0)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.3.4
+      '@next/swc-darwin-x64': 15.3.4
+      '@next/swc-linux-arm64-gnu': 15.3.4
+      '@next/swc-linux-arm64-musl': 15.3.4
+      '@next/swc-linux-x64-gnu': 15.3.4
+      '@next/swc-linux-x64-musl': 15.3.4
+      '@next/swc-win32-arm64-msvc': 15.3.4
+      '@next/swc-win32-x64-msvc': 15.3.4
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  node-abi@3.92.0:
+    dependencies:
+      semver: 7.8.5
 
   node-domexception@1.0.0:
     optional: true
@@ -3710,6 +5117,8 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
     optional: true
+
+  node-releases@2.0.50: {}
 
   object-assign@4.1.1: {}
 
@@ -3787,11 +5196,32 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postcss@8.5.15:
     dependencies:
       nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.92.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
 
   prettier@2.8.8: {}
 
@@ -3820,6 +5250,11 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.1
@@ -3837,6 +5272,36 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
+  react-dom@19.1.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      scheduler: 0.26.0
+
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react-refresh@0.18.0: {}
+
+  react-streaming@0.4.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@brillout/import': 0.2.6
+      '@brillout/json-serializer': 0.5.25
+      '@brillout/picocolors': 1.0.31
+      isbot-fast: 1.2.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  react@19.1.0: {}
+
   react@19.2.7: {}
 
   read-yaml-file@1.1.0:
@@ -3845,6 +5310,12 @@ snapshots:
       js-yaml: 3.14.2
       pify: 4.0.1
       strip-bom: 3.0.0
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   readable-stream@4.7.0:
     dependencies:
@@ -3866,6 +5337,8 @@ snapshots:
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
+
+  regexparam@3.0.0: {}
 
   require-from-string@2.0.2: {}
 
@@ -3907,6 +5380,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
+  rou3@0.8.1: {}
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -3921,10 +5396,15 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  safe-buffer@5.2.1:
-    optional: true
+  safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  scheduler@0.26.0: {}
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
 
   semver@7.8.5: {}
 
@@ -3954,6 +5434,38 @@ snapshots:
       - supports-color
 
   setprototypeof@1.2.0: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -4002,9 +5514,30 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   slash@3.0.0: {}
 
   source-map-js@1.2.1: {}
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
 
   space-separated-tokens@2.0.2: {}
 
@@ -4015,6 +5548,8 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  srvx@0.11.17: {}
+
   standardwebhooks@1.0.0:
     dependencies:
       '@stablelib/base64': 1.0.1
@@ -4023,10 +5558,11 @@ snapshots:
 
   statuses@2.0.2: {}
 
+  streamsearch@1.1.0: {}
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   stringify-entities@4.0.4:
     dependencies:
@@ -4039,7 +5575,29 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-json-comments@2.0.1: {}
+
+  styled-jsx@5.1.6(react@19.1.0):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.1.0
+
   tabbable@6.5.0: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   term-size@2.2.1: {}
 
@@ -4048,25 +5606,40 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tldts-core@7.4.4: {}
+
+  tldts@7.4.4:
+    dependencies:
+      tldts-core: 7.4.4
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
 
+  totalist@3.0.1: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.4
+
   trim-lines@3.0.1: {}
 
   ts-algebra@2.0.0:
     optional: true
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsx@4.22.4:
     dependencies:
       esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   turbo@2.9.18:
     optionalDependencies:
@@ -4114,6 +5687,14 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  update-browserslist-db@1.2.3(browserslist@4.28.4):
+    dependencies:
+      browserslist: 4.28.4
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  util-deprecate@1.0.2: {}
+
   vary@1.1.2: {}
 
   vfile-message@4.0.3:
@@ -4125,6 +5706,56 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  vike-react@0.6.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vike@0.4.260(@types/express@5.0.6)(hono@4.12.27)(react-streaming@0.4.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(srvx@0.11.17)(vite@7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0))):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-streaming: 0.4.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      vike: 0.4.260(@types/express@5.0.6)(hono@4.12.27)(react-streaming@0.4.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(srvx@0.11.17)(vite@7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0))
+
+  vike@0.4.260(@types/express@5.0.6)(hono@4.12.27)(react-streaming@0.4.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(srvx@0.11.17)(vite@7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/types': 7.29.7
+      '@brillout/import': 0.2.6
+      '@brillout/json-serializer': 0.5.25
+      '@brillout/picocolors': 1.0.31
+      '@brillout/vite-plugin-server-entry': 0.7.19
+      '@universal-deploy/store': 0.2.1(srvx@0.11.17)
+      '@universal-deploy/vite': 0.1.10(@types/express@5.0.6)(hono@4.12.27)(srvx@0.11.17)(vite@7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0))
+      '@universal-middleware/core': 0.4.18(@types/express@5.0.6)(hono@4.12.27)(srvx@0.11.17)
+      '@universal-middleware/node': 0.2.1(@types/express@5.0.6)(hono@4.12.27)(srvx@0.11.17)
+      cac: 6.7.14
+      convert-route: 1.1.1
+      es-module-lexer: 1.7.0
+      esbuild: 0.28.1
+      json5: 2.2.3
+      magic-string: 0.30.21
+      picomatch: 4.0.4
+      semver: 7.8.5
+      sirv: 3.0.2
+      source-map-support: 0.5.21
+      tinyglobby: 0.2.17
+      vite-plugin-wrapper: 0.1.0(vite@7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0))
+    optionalDependencies:
+      react-streaming: 0.4.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      vite: 7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@hattip/core'
+      - '@types/express'
+      - '@webroute/route'
+      - elysia
+      - fastify
+      - h3
+      - hono
+      - srvx
+      - supports-color
+
+  vite-plugin-wrapper@0.1.0(vite@7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      vite: 7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0)
 
   vite@7.3.6(@types/node@20.19.43)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
@@ -4209,6 +5840,8 @@ snapshots:
 
   ws@8.21.0:
     optional: true
+
+  yallist@3.1.1: {}
 
   yaml@2.9.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ allowBuilds:
   better-sqlite3: true
   '@google/genai': false
   protobufjs: false
+  sharp: false
 
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
Phase 0 of the "our AI vs Next.js" benchmark (#75). Closes #78.

Lays down a runnable Phase 0 baseline: two functionally-equivalent apps and a contract-level acceptance harness, ready to time an AI agent against.

## What's here
- `benchmarks/README.md` - harness overview, manual run steps, the intervention rubric, and fairness rules.
- `benchmarks/spec/product.md` - the shared "Notes" product and a single HTTP contract both apps implement (the trick that lets one acceptance script grade either).
- `benchmarks/spec/task-001-tags.md` - the Phase 0 task (add tags) and its acceptance criteria.
- `benchmarks/tasks/task-001-tags/accept.mjs` - contract-level acceptance check; `BASE_URL=<url> node accept.mjs`, exit 0 = pass.
- `examples/bench-app-next` - vanilla Next.js (App Router) baseline. `pnpm dev` -> :4311.
- `examples/bench-app-gemstack` - Vike + React baseline; summarize wired through `@gemstack/ai-sdk` via a deterministic stub provider (no network, no key). `pnpm dev` -> :3100.
- `pnpm-workspace.yaml` - declare `sharp:false` so `pnpm dev` runs cleanly (both frameworks pull the optional, prebuilt `sharp`).

## Verification
- `pnpm install` + `pnpm --filter @gemstack/ai-sdk build` clean.
- Both apps boot and pass the full baseline contract (login/cookie/create/list/get/summarize/delete + 401 when unauthenticated).
- Running `accept.mjs` against each baseline fails the **identical** 5 tag-specific checks and passes everything else - confirming the two apps are equivalent and the acceptance script correctly detects the unimplemented task. Adding tags correctly turns it green.

## Notes
- The apps are private `@gemstack/example-*` workspace packages (no build/publish, mirroring `mcp-quickstart`); no changeset needed.
- Next step is the actual Phase 0 measurement: run the same agent on each app against task-001 and record time + interventions per the rubric.
