### PR TITLE
ci: build docs on PRs to catch dead links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,17 @@ jobs:
       - run: pnpm build
       - run: pnpm typecheck
       - run: pnpm test
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # vitepress build fails on dead internal links (config ignores only
+      # localhost), so this doubles as a link check on every PR.
+      - run: pnpm --filter @gemstack/docs docs:build


### PR DESCRIPTION
Closes #59.

Adds a `docs` job to CI that runs `pnpm --filter @gemstack/docs docs:build` on every PR. VitePress fails its build on dead internal links (the docs config whitelists only `localhost`), so this doubles as a dead-link check — verified locally: a bogus `/packages/does-not-exist` link makes the build exit non-zero with `1 dead link(s) found`.

Runs as a separate job (parallel to build/typecheck/test) so a docs-only break is a distinct red check.