### PR TITLE
feat(ai-autopilot): runner start() + reachable preview — boot-and-serve (#137)

### DIFF
--- a/.changeset/runner-start-preview.md
+++ b/.changeset/runner-start-preview.md
@@ -1,0 +1,9 @@
+---
+'@gemstack/ai-autopilot': minor
+---
+
+Runner seam: long-running processes + reachable previews (boot-and-serve).
+
+`RunnerSession.start(command)` launches a long-running command (a dev server) in the background and returns a `RunnerProcess` handle (`{ command, exit, stop() }`) — unlike `exec`, which awaits the command to finish. `preview({ waitMs })` now waits for the port to accept connections before resolving, so the URL is live on return. A `start_server` runner tool exposes this to agents.
+
+`LocalRunner` implements it for real: `start` spawns in its own process group so `stop()` (and `dispose()`) kill the whole tree; `preview` polls the port. `FakeRunner` mirrors it for tests. This is the contract every sandboxed adapter (Docker / WebContainer / Flue) must satisfy, and it's what makes "produce a running app" reachable end to end.

--- a/packages/ai-autopilot/src/index.ts
+++ b/packages/ai-autopilot/src/index.ts
@@ -127,11 +127,13 @@ export {
   type BootOptions,
   type ExecOptions,
   type ExecResult,
+  type RunnerProcess,
   type Preview,
   type PreviewOptions,
   type FakeRunnerOptions,
   type FakeExec,
   type RecordedExec,
+  type RecordedStart,
   type LocalRunnerOptions,
   type RunnerToolsOptions,
 } from './runner/index.js'

--- a/packages/ai-autopilot/src/runner/fake.test.ts
+++ b/packages/ai-autopilot/src/runner/fake.test.ts
@@ -76,6 +76,40 @@ describe('FakeRunnerSession.preview', () => {
   })
 })
 
+describe('FakeRunnerSession.start', () => {
+  it('records start calls and returns a controllable process handle', async () => {
+    const s = await new FakeRunner().boot()
+    const proc = await s.start!('npm run dev', { cwd: 'app' })
+    assert.deepEqual(s.startCalls, [{ command: 'npm run dev', opts: { cwd: 'app' } }])
+    assert.equal(s.processes.length, 1)
+    assert.equal(proc.command, 'npm run dev')
+
+    let exited = false
+    void proc.exit.then(() => (exited = true))
+    assert.equal(exited, false) // still "running" until stopped
+    await proc.stop()
+    assert.equal((await proc.exit).exitCode, 0)
+  })
+
+  it('omits start when background is disabled (capability signal)', async () => {
+    const s = await new FakeRunner({ background: false }).boot()
+    assert.equal(s.start, undefined)
+  })
+
+  it('dispose stops still-running processes', async () => {
+    const s = await new FakeRunner().boot()
+    const proc = await s.start!('node server.js')
+    await s.dispose()
+    assert.equal((await proc.exit).exitCode, 0) // resolved by dispose
+  })
+
+  it('rejects start on a disposed session', async () => {
+    const s = await new FakeRunner().boot()
+    await s.dispose()
+    await assert.rejects(() => s.start!('node server.js'), RunnerError)
+  })
+})
+
 describe('FakeRunnerSession.dispose', () => {
   it('marks disposed and blocks further exec/preview', async () => {
     const s = await new FakeRunner().boot()

--- a/packages/ai-autopilot/src/runner/fake.ts
+++ b/packages/ai-autopilot/src/runner/fake.ts
@@ -2,6 +2,7 @@ import type {
   Runner,
   RunnerSession,
   RunnerFs,
+  RunnerProcess,
   BootOptions,
   ExecOptions,
   ExecResult,
@@ -20,6 +21,8 @@ export interface FakeRunnerOptions {
   preview?: boolean
   /** Base URL returned by `preview()`. Default `https://preview.fake.local`. */
   previewUrl?: string
+  /** Whether booted sessions can `start` background processes. Default `true`. */
+  background?: boolean
 }
 
 /** Normalize a workspace path to a canonical relative form. */
@@ -60,6 +63,12 @@ export interface RecordedExec {
   opts: ExecOptions
 }
 
+/** A recorded `start` invocation, for test assertions. */
+export interface RecordedStart {
+  command: string
+  opts: ExecOptions
+}
+
 /** The session a {@link FakeRunner} boots — exposes its state for assertions. */
 export class FakeRunnerSession implements RunnerSession {
   readonly id: string
@@ -76,12 +85,19 @@ export class FakeRunnerSession implements RunnerSession {
    */
   readonly preview?: (opts?: PreviewOptions) => Promise<Preview>
 
+  /** Present only when the runner supports background processes (capability signal). */
+  readonly start?: (command: string, opts?: ExecOptions) => Promise<RunnerProcess>
+  /** Every `start` call in order, so tests can assert what autopilot launched. */
+  readonly startCalls: RecordedStart[] = []
+  /** The background processes started this session, in order. */
+  readonly processes: RunnerProcess[] = []
+
   private readonly files = new Map<string, string>()
 
   constructor(
     id: string,
     boot: BootOptions,
-    private readonly opts: Required<Pick<FakeRunnerOptions, 'onExec' | 'preview' | 'previewUrl'>>,
+    private readonly opts: Required<Pick<FakeRunnerOptions, 'onExec' | 'preview' | 'previewUrl' | 'background'>>,
   ) {
     this.id = id
     for (const [path, contents] of Object.entries(boot.files ?? {})) {
@@ -93,6 +109,26 @@ export class FakeRunnerSession implements RunnerSession {
         if (this.disposed) throw new RunnerError('preview on a disposed session')
         const port = previewOpts.port ?? 3000
         return { url: `${this.opts.previewUrl}:${port}`, port }
+      }
+    }
+    if (opts.background) {
+      this.start = async (command: string, startOpts: ExecOptions = {}): Promise<RunnerProcess> => {
+        if (this.disposed) throw new RunnerError('start on a disposed session')
+        this.startCalls.push({ command, opts: startOpts })
+        let resolveExit!: (r: ExecResult) => void
+        const exit = new Promise<ExecResult>(res => (resolveExit = res))
+        let settled = false
+        const proc: RunnerProcess = {
+          command,
+          exit,
+          stop: async () => {
+            if (settled) return
+            settled = true
+            resolveExit({ stdout: '', stderr: '', exitCode: 0 })
+          },
+        }
+        this.processes.push(proc)
+        return proc
       }
     }
   }
@@ -110,6 +146,7 @@ export class FakeRunnerSession implements RunnerSession {
 
   async dispose(): Promise<void> {
     this.disposed = true
+    await Promise.all(this.processes.map(p => p.stop().catch(() => {})))
   }
 }
 
@@ -132,7 +169,7 @@ export class FakeRunner implements Runner {
   /** Every session this runner has booted. */
   readonly sessions: FakeRunnerSession[] = []
 
-  private readonly opts: Required<Pick<FakeRunnerOptions, 'onExec' | 'preview' | 'previewUrl'>>
+  private readonly opts: Required<Pick<FakeRunnerOptions, 'onExec' | 'preview' | 'previewUrl' | 'background'>>
   private counter = 0
 
   constructor(options: FakeRunnerOptions = {}) {
@@ -140,6 +177,7 @@ export class FakeRunner implements Runner {
       onExec: options.onExec ?? (async () => ({ stdout: '', stderr: '', exitCode: 0 })),
       preview: options.preview ?? true,
       previewUrl: options.previewUrl ?? 'https://preview.fake.local',
+      background: options.background ?? true,
     }
   }
 

--- a/packages/ai-autopilot/src/runner/index.ts
+++ b/packages/ai-autopilot/src/runner/index.ts
@@ -15,6 +15,7 @@ export type {
   Runner,
   RunnerSession,
   RunnerFs,
+  RunnerProcess,
   FileTree,
   BootOptions,
   ExecOptions,
@@ -29,6 +30,7 @@ export {
   type FakeRunnerOptions,
   type FakeExec,
   type RecordedExec,
+  type RecordedStart,
 } from './fake.js'
 export { LocalRunner, LocalRunnerSession, type LocalRunnerOptions } from './local.js'
 export { runnerTools, type RunnerToolsOptions } from './tools.js'

--- a/packages/ai-autopilot/src/runner/local.test.ts
+++ b/packages/ai-autopilot/src/runner/local.test.ts
@@ -1,8 +1,25 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { existsSync } from 'node:fs'
+import { createServer } from 'node:net'
 import { LocalRunner } from './local.js'
 import { RunnerError } from './types.js'
+
+/** Grab an ephemeral free port so the boot-and-serve tests don't collide in CI. */
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer()
+    srv.on('error', reject)
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address()
+      const port = typeof addr === 'object' && addr ? addr.port : 0
+      srv.close(() => resolve(port))
+    })
+  })
+}
+
+const httpServer = (port: number, body: string): string =>
+  `const http=require('http');http.createServer((_,res)=>{res.writeHead(200);res.end(${JSON.stringify(body)})}).listen(${port},'127.0.0.1')`
 
 describe('LocalRunner.boot', () => {
   it('seeds a real workspace with files, including nested paths', async () => {
@@ -145,5 +162,52 @@ describe('LocalRunnerSession.dispose', () => {
     await s.dispose() // idempotent
     await assert.rejects(() => s.exec('ls'), RunnerError)
     await assert.rejects(() => s.preview!(), RunnerError)
+  })
+})
+
+describe('LocalRunnerSession.start (boot and serve)', () => {
+  it('runs a real background server that preview can reach, then stop kills it', async () => {
+    const port = await freePort()
+    const s = await new LocalRunner().boot({ files: { 'server.js': httpServer(port, 'hello from runner') } })
+    try {
+      const proc = await s.start('node server.js')
+      assert.equal(proc.command, 'node server.js')
+
+      const preview = await s.preview!({ port, waitMs: 5000 })
+      assert.equal(preview.port, port)
+
+      const res = await fetch(preview.url)
+      assert.equal(await res.text(), 'hello from runner') // the app is actually serving
+
+      await proc.stop()
+      await assert.rejects(fetch(preview.url)) // port no longer listening
+    } finally {
+      await s.dispose()
+    }
+  })
+
+  it('start does not block on a long-running process', async () => {
+    const port = await freePort()
+    const s = await new LocalRunner().boot({ files: { 'server.js': httpServer(port, 'x') } })
+    try {
+      // Would hang forever with exec(); start() must resolve immediately.
+      const proc = await s.start('node server.js')
+      let exited = false
+      void proc.exit.then(() => (exited = true))
+      assert.equal(exited, false) // still running right after start
+      await proc.stop()
+    } finally {
+      await s.dispose()
+    }
+  })
+
+  it('dispose stops a still-running process', async () => {
+    const port = await freePort()
+    const s = await new LocalRunner().boot({ files: { 'server.js': httpServer(port, 'x') } })
+    const proc = await s.start('node server.js')
+    await s.preview!({ port, waitMs: 5000 })
+    await s.dispose()
+    const result = await proc.exit // resolves because dispose stopped it
+    assert.notEqual(result.exitCode, 0) // killed, not a clean exit
   })
 })

--- a/packages/ai-autopilot/src/runner/local.ts
+++ b/packages/ai-autopilot/src/runner/local.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process'
+import { connect } from 'node:net'
 import { mkdtemp, mkdir, readFile, writeFile, rm, readdir, access } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, dirname, resolve, relative, sep } from 'node:path'
@@ -6,6 +7,7 @@ import type {
   Runner,
   RunnerSession,
   RunnerFs,
+  RunnerProcess,
   BootOptions,
   ExecOptions,
   ExecResult,
@@ -13,6 +15,27 @@ import type {
   PreviewOptions,
 } from './types.js'
 import { RunnerError } from './types.js'
+
+const delay = (ms: number): Promise<void> => new Promise(res => setTimeout(res, ms))
+
+/** Resolve once something is accepting TCP connections on `host:port`, or after `timeoutMs`. */
+async function waitForPort(host: string, port: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const ok = await new Promise<boolean>(res => {
+      const socket = connect({ host, port }, () => {
+        socket.destroy()
+        res(true)
+      })
+      socket.on('error', () => {
+        socket.destroy()
+        res(false)
+      })
+    })
+    if (ok || Date.now() >= deadline) return
+    await delay(100)
+  }
+}
 
 export interface LocalRunnerOptions {
   /** Base directory to create workspaces under. Default: the OS temp dir. */
@@ -105,6 +128,8 @@ export class LocalRunnerSession implements RunnerSession {
 
   private readonly cwd: string
   private readonly env: Record<string, string>
+  /** Long-running processes started with {@link start}, so `dispose` can stop them. */
+  private readonly procs = new Set<RunnerProcess>()
 
   constructor(
     id: string,
@@ -121,9 +146,64 @@ export class LocalRunnerSession implements RunnerSession {
       this.preview = async (previewOpts: PreviewOptions = {}): Promise<Preview> => {
         if (this.disposed) throw new RunnerError('preview on a disposed session')
         const port = previewOpts.port ?? 3000
+        // Wait for the started server to accept connections, so the URL is live on return.
+        if (previewOpts.waitMs && previewOpts.waitMs > 0) await waitForPort('127.0.0.1', port, previewOpts.waitMs)
         return { url: `${opts.previewHost}:${port}`, port }
       }
     }
+  }
+
+  /**
+   * Start a long-running command in the background. Spawns it in its own process
+   * group (`detached`) so `stop` can kill the whole tree (the shell AND the server
+   * it launched), and returns immediately with a handle — it does NOT await exit.
+   */
+  async start(command: string, opts: ExecOptions = {}): Promise<RunnerProcess> {
+    if (this.disposed) throw new RunnerError('start on a disposed session')
+    const cwd = within(this.root, opts.cwd ?? (this.cwd || '.'))
+    const env = { ...process.env, ...this.env, ...(opts.env ?? {}) }
+    const child = spawn(command, { cwd, env, shell: true, detached: true })
+    let stdout = ''
+    let stderr = ''
+    child.stdout?.on('data', d => (stdout += d))
+    child.stderr?.on('data', d => (stderr += d))
+
+    let resolveExit!: (r: ExecResult) => void
+    const exit = new Promise<ExecResult>(res => (resolveExit = res))
+    let settled = false
+    const settle = (r: ExecResult): void => {
+      if (settled) return
+      settled = true
+      resolveExit(r)
+    }
+    child.on('close', (code, signal) => settle({ stdout, stderr, exitCode: code ?? (signal ? 137 : 0) }))
+    child.on('error', err => settle({ stdout, stderr: stderr + `\n[ai-autopilot] failed to spawn: ${(err as Error).message}`, exitCode: 1 }))
+
+    // Kill the whole process group (negative pid), escalating SIGTERM → SIGKILL.
+    const signal = (sig: NodeJS.Signals): void => {
+      if (settled || child.pid == null) return
+      try {
+        process.kill(-child.pid, sig)
+      } catch {
+        // group gone already
+      }
+    }
+    const proc: RunnerProcess = {
+      command,
+      exit,
+      stop: async () => {
+        if (!settled) {
+          signal('SIGTERM')
+          const raced = await Promise.race([exit, delay(2000).then(() => 'timeout' as const)])
+          if (raced === 'timeout') signal('SIGKILL')
+          await exit
+        }
+        this.procs.delete(proc)
+      },
+    }
+    exit.then(() => this.procs.delete(proc))
+    this.procs.add(proc)
+    return proc
   }
 
   async exec(command: string, opts: ExecOptions = {}): Promise<ExecResult> {
@@ -166,6 +246,8 @@ export class LocalRunnerSession implements RunnerSession {
   async dispose(): Promise<void> {
     if (this.disposed) return
     this.disposed = true
+    // Stop any still-running background processes before removing the workspace.
+    await Promise.all([...this.procs].map(p => p.stop().catch(() => {})))
     await rm(this.root, { recursive: true, force: true })
   }
 }
@@ -183,8 +265,12 @@ export class LocalRunnerSession implements RunnerSession {
  * ```ts
  * const runner = new LocalRunner()
  * const s = await runner.boot({ files: { 'app.js': "console.log('hi')" } })
- * await s.exec('node app.js') // → { stdout: 'hi\n', stderr: '', exitCode: 0 }
- * await s.dispose()           // removes the temp workspace
+ * await s.exec('node app.js')            // one-shot → { stdout: 'hi\n', … }
+ *
+ * const dev = await s.start('npm run dev')          // long-running, returns at once
+ * const { url } = await s.preview({ port: 3000, waitMs: 5000 }) // waits until reachable
+ * await dev.stop()                                   // kills the server (process group)
+ * await s.dispose()                                  // stops leftovers + removes the workspace
  * ```
  */
 export class LocalRunner implements Runner {

--- a/packages/ai-autopilot/src/runner/tools.test.ts
+++ b/packages/ai-autopilot/src/runner/tools.test.ts
@@ -40,6 +40,18 @@ describe('runnerTools', () => {
     assert.ok(!without.includes('preview'))
   })
 
+  it('includes start_server only when the session supports background processes', async () => {
+    const withStart = runnerTools(await new FakeRunner().boot()).map(t => t.definition.name)
+    assert.ok(withStart.includes('start_server'))
+    const without = runnerTools(await new FakeRunner({ background: false }).boot()).map(t => t.definition.name)
+    assert.ok(!without.includes('start_server'))
+  })
+
+  it('start_server rides the exec toggle (dropped from a read-only surface)', async () => {
+    const names = runnerTools(await new FakeRunner().boot(), { exec: false }).map(t => t.definition.name)
+    assert.ok(!names.includes('start_server'))
+  })
+
   it('honors the write/exec toggles and the name prefix', async () => {
     const s = await new FakeRunner().boot()
     const names = runnerTools(s, { write: false, exec: false, prefix: 'sandbox' }).map(

--- a/packages/ai-autopilot/src/runner/tools.ts
+++ b/packages/ai-autopilot/src/runner/tools.ts
@@ -92,6 +92,25 @@ export function runnerTools(session: RunnerSession, opts: RunnerToolsOptions = {
     )
   }
 
+  if (opts.exec !== false && session.start) {
+    const start = session.start.bind(session)
+    tools.push(
+      toolDefinition({
+        name: name('start_server'),
+        description: 'Start a long-running command (e.g. a dev server) in the background. Returns immediately; use preview to get its URL.',
+        inputSchema: z.object({
+          command: z.string().describe('The shell command to start (e.g. "npm run dev").'),
+          cwd: z.string().optional().describe('Working directory, relative to the workspace root.'),
+        }),
+      })
+        .server(async ({ command, cwd }) => {
+          await start(command, cwd ? { cwd } : {})
+          return { started: command }
+        })
+        .modelOutput(r => `started ${r.started}`) as unknown as AnyTool,
+    )
+  }
+
   if (session.preview) {
     const preview = session.preview.bind(session)
     tools.push(

--- a/packages/ai-autopilot/src/runner/types.ts
+++ b/packages/ai-autopilot/src/runner/types.ts
@@ -42,6 +42,21 @@ export interface ExecResult {
   exitCode: number
 }
 
+/**
+ * A handle to a long-running process started with {@link RunnerSession.start} —
+ * a dev server, a watcher, anything that does not exit on its own. Unlike `exec`
+ * (which resolves when the command finishes), `start` returns immediately with
+ * this handle so the caller can serve a {@link RunnerSession.preview} against it.
+ */
+export interface RunnerProcess {
+  /** The command that was started. */
+  readonly command: string
+  /** Resolves when the process exits — on its own, or after {@link stop}. */
+  readonly exit: Promise<ExecResult>
+  /** Stop the process. Idempotent; resolves once it has exited. */
+  stop(): Promise<void>
+}
+
 /** A virtual filesystem scoped to a single session's workspace. */
 export interface RunnerFs {
   read(path: string): Promise<string>
@@ -56,6 +71,12 @@ export interface RunnerFs {
 export interface PreviewOptions {
   /** Port the server listens on inside the sandbox. */
   port?: number
+  /**
+   * Wait up to this many milliseconds for the port to accept connections before
+   * returning, so the URL is reachable the moment `preview` resolves. Default `0`
+   * (return immediately — a runner that can't probe readiness ignores it).
+   */
+  waitMs?: number
 }
 
 /** A reachable URL for the running app. */
@@ -76,6 +97,12 @@ export interface RunnerSession {
   readonly id: string
   readonly fs: RunnerFs
   exec(command: string, opts?: ExecOptions): Promise<ExecResult>
+  /**
+   * Start a long-running command (a dev server) in the background and return a
+   * handle to it, without waiting for it to exit. Absent when the runner only
+   * supports one-shot `exec` — presence is the capability signal, like `preview`.
+   */
+  start?(command: string, opts?: ExecOptions): Promise<RunnerProcess>
   /** Expose a running dev server and return its URL. Absent when unsupported. */
   preview?(opts?: PreviewOptions): Promise<Preview>
   /** Tear down the workspace and release its resources. Idempotent. */


### PR DESCRIPTION
Closes #137. Enabler for #109 and the honest completion of the live capstone (#124).

## The gap

The runner seam couldn't actually run an app: `RunnerSession.exec` awaits the process to **exit** (so a dev server hangs until timeout), and `preview()` was a stub that formatted a URL with nothing listening behind it. "Produce a **running** app" was unreachable — #124 proved file-scaffolding, not serving.

## What's added

- **`RunnerSession.start(command, opts)`** → `RunnerProcess { command, exit, stop() }` — launch a long-running command (a dev server) in the background, returning immediately. Optional, like `preview` (presence = capability).
- **`PreviewOptions.waitMs`** — `preview()` waits for the port to accept connections before resolving, so the URL is live on return.
- **`start_server`** runner tool (exposed when the session supports `start`, and rides the `exec` toggle).

## Implementations

- **`LocalRunner`** (the reference): `start` spawns in its own process group (`detached`) so `stop()` kills the whole tree (the shell *and* the server it launched), escalating SIGTERM → SIGKILL; `dispose()` stops any leftover processes; `preview` polls the port with `net.connect`.
- **`FakeRunner`**: mirrors `start` (records calls, controllable process) for tests.

## Verified

Real **boot-and-serve** test (no external infra, no deps): boot a Node HTTP server into a `LocalRunner` workspace, `start` it, `preview({ waitMs })` waits until reachable, `fetch` the URL and assert the body (`hello from runner`), `stop` it and confirm the port is dead; a separate test asserts `dispose` stops a still-running process. **213 tests green** (204 + 9), typecheck + build clean.

This is the contract each sandboxed adapter in #109 (Docker / WebContainer / Flue) must satisfy; LocalRunner is the reference they mirror.