### PR TITLE
fix(ai-autopilot): export DockerRunner from package entry

### DIFF
--- a/.changeset/autopilot-docker-export.md
+++ b/.changeset/autopilot-docker-export.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/ai-autopilot': patch
+---
+
+Export `DockerRunner`, `DockerRunnerSession`, `dockerAvailable`, and `DockerRunnerOptions` from the package entry.
+
+The runner barrel exported these symbols, but the main entry point omitted them, so the shipped `DockerRunner` adapter could not actually be imported from `@gemstack/ai-autopilot`. They are now reachable alongside `FakeRunner`/`LocalRunner`.

--- a/packages/ai-autopilot/src/index.ts
+++ b/packages/ai-autopilot/src/index.ts
@@ -27,6 +27,7 @@
  *
  * - {@link FakeRunner} — in-memory runner for tests
  * - {@link LocalRunner} — real host workspace (fs + child processes); the first real adapter
+ * - {@link DockerRunner} — sandboxed workspace in a container (via the `docker` CLI)
  * - {@link runnerTools} — expose a booted session to an agent as sandbox tools
  *
  * Surfaces run the same autopilot in the terminal, an in-page UI, or a

--- a/packages/ai-autopilot/src/index.ts
+++ b/packages/ai-autopilot/src/index.ts
@@ -118,6 +118,9 @@ export {
   FakeRunnerSession,
   LocalRunner,
   LocalRunnerSession,
+  DockerRunner,
+  DockerRunnerSession,
+  dockerAvailable,
   RunnerError,
   runnerTools,
   type Runner,
@@ -135,6 +138,7 @@ export {
   type RecordedExec,
   type RecordedStart,
   type LocalRunnerOptions,
+  type DockerRunnerOptions,
   type RunnerToolsOptions,
 } from './runner/index.js'
 export {


### PR DESCRIPTION
Closes #150.

`runner/index.ts` exported `DockerRunner`, `DockerRunnerSession`, `dockerAvailable`, and `DockerRunnerOptions`, but the hand-written main `src/index.ts` runner re-export block listed only Fake/Local and omitted all four Docker symbols. The shipped adapter (`runner/docker.ts`) could not be imported from `@gemstack/ai-autopilot`.

Added the four symbols to the `./runner/index.js` re-export.

Verified: `pnpm typecheck` clean, and a built `import('./dist/index.js')` resolves `DockerRunner`, `DockerRunnerSession`, and `dockerAvailable` at runtime. Patch changeset included.