### PR TITLE
feat(framework): The (AI) Framework CLI - wrap Claude Code + localhost dashboard

### DIFF
--- a/.changeset/framework-cli-driver-dashboard.md
+++ b/.changeset/framework-cli-driver-dashboard.md
@@ -1,0 +1,11 @@
+---
+"@gemstack/framework": minor
+---
+
+feat: @gemstack/framework - The (AI) Framework product shell
+
+The turnkey CLI + localhost dashboard that wraps a coding-agent CLI (Claude Code)
+as a black box and drives the ai-autopilot bootstrap flow through it: preset
+detect, architect, build, full-fledged loop, deploy. Adds the swappable `Driver`
+seam (`ClaudeCodeDriver` + `FakeDriver`), driver-backed bootstrap steps, an event
+stream we own, and a `--fake` offline path for CI. `npm i -g @gemstack/framework`.

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -1,0 +1,82 @@
+# @gemstack/framework
+
+**The (AI) Framework** - turnkey, zero-config AI orchestration. Vite for AI.
+
+It wraps a coding-agent CLI (Claude Code today) as a **black box** and takes you
+from an idea to a running app, with a localhost dashboard that foregrounds the
+orchestration the agent's own chat cannot show: the chosen stack and its
+rationale, the loop status, and the decisions ledger.
+
+```bash
+npm i -g @gemstack/framework
+
+framework "a paginated orders page backed by an orders table, with sign-in"
+# or the deterministic offline demo (no CLI, no model):
+framework --fake
+```
+
+## How it works
+
+The Framework does not run its own agent. It drives a coding agent as a **black
+box**: it sends a prompt, lets the agent's *own* loop run, reads the code it
+produced, and gates on the **outcome** (builds / serves / review-passes), then
+re-prompts. The seam is the code, never the agent's individual tool calls, so the
+wrapped agent keeps its subscription-based auth and stays swappable.
+
+It runs on `@gemstack/ai-autopilot`'s spine (bootstrap flow, the loop, the
+decisions ledger, framework presets, deploy targets) and adds the two missing
+pieces:
+
+- **The driver seam** ([`Driver`](./src/driver/types.ts)) - the one abstraction
+  we wrap an agent CLI behind. [`ClaudeCodeDriver`](./src/driver/claude-code.ts)
+  is the first real driver (`claude -p` in stream-json mode, one fresh invocation
+  per loop pass). [`FakeDriver`](./src/driver/fake.ts) is a deterministic offline
+  driver for `--fake` and tests. Codex / opencode slot in behind the same three
+  methods.
+- **The product shell** - the `framework` CLI and the localhost
+  [dashboard](./src/dashboard/server.ts) over an event stream we own.
+
+Everything runs *through* the driver (single execution path): the architect is a
+small structured JSON decision the agent returns; build and improve are prompts;
+the production-grade checklist gates on the `{ blockers }` verdict the agent ends
+its output with.
+
+## Library API
+
+```ts
+import { runFramework, ClaudeCodeDriver, startDashboard } from '@gemstack/framework'
+
+const dashboard = await startDashboard()
+console.log(dashboard.url)
+
+await runFramework({
+  intent: 'a blog with comments',
+  driver: new ClaudeCodeDriver(),
+  cwd: process.cwd(),
+  onEvent: dashboard.push,
+})
+```
+
+## CLI
+
+```
+framework [intent...]          Build what you describe, from scratch.
+framework --fake               Offline demo (no CLI, no model, deterministic).
+
+  --cwd <dir>            Workspace the agent builds in (default: cwd).
+  --model <id>           Model to pass through to the wrapped agent.
+  --scope <prototype|full>   How much app to build (default: full).
+  --deploy <target>      Narrate a deploy decision (e.g. cloudflare, dokploy).
+  --port <n>             Dashboard port (default: 4477).
+  --no-dashboard         Run headless.
+  --session-link <url>   Link to the live agent session (shown on the dashboard).
+```
+
+The live path needs the Claude Code CLI installed (`claude` on `PATH`). The
+`--fake` path needs neither a CLI nor a model, so it is what CI runs.
+
+## Status
+
+MVP (#166): the driver seam, the Claude Code driver, the CLI, and the dashboard,
+verified end-to-end via `--fake`. Real deploy shipping and additional drivers are
+follow-ups.

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@gemstack/framework",
+  "version": "0.0.0",
+  "description": "The (AI) Framework: turnkey, zero-config AI orchestration that wraps a coding-agent CLI (Claude Code) as a black box and takes you from an idea to a running app. Vite for AI.",
+  "keywords": [
+    "ai",
+    "agent",
+    "claude-code",
+    "orchestration",
+    "framework",
+    "codegen",
+    "cli",
+    "turnkey",
+    "gemstack"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/gemstack-land/gemstack/tree/main/packages/framework#readme",
+  "bugs": {
+    "url": "https://github.com/gemstack-land/gemstack/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gemstack-land/gemstack",
+    "directory": "packages/framework"
+  },
+  "type": "module",
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "framework": "./dist/bin.js"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "tsc -p tsconfig.test.json && cd dist-test && node --test",
+    "clean": "rm -rf dist dist-test"
+  },
+  "dependencies": {
+    "@gemstack/ai-autopilot": "workspace:^"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.0"
+  },
+  "author": "Suleiman Shahbari"
+}

--- a/packages/framework/src/bin.ts
+++ b/packages/framework/src/bin.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { runCli } from './cli.js'
+
+runCli(process.argv.slice(2))
+  .then(code => {
+    process.exitCode = code
+  })
+  .catch((err: unknown) => {
+    console.error(err)
+    process.exitCode = 1
+  })

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -1,0 +1,46 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { parseArgs, runCli, type CliIO } from './cli.js'
+
+function capture(): { io: CliIO; out: string[]; err: string[] } {
+  const out: string[] = []
+  const err: string[] = []
+  return { io: { out: l => out.push(l), err: l => err.push(l) }, out, err }
+}
+
+test('parseArgs reads flags and the intent words', () => {
+  const opts = parseArgs(['--fake', '--scope', 'prototype', 'a', 'blog', 'app'])
+  assert.equal(opts.fake, true)
+  assert.equal(opts.scope, 'prototype')
+  assert.equal(opts.intent, 'a blog app')
+})
+
+test('parseArgs flags unknown options and bad values', () => {
+  assert.match(parseArgs(['--nope']).error!, /unknown option/)
+  assert.match(parseArgs(['--scope', 'huge']).error!, /invalid --scope/)
+  assert.match(parseArgs(['--max-passes', '0']).error!, /max-passes/)
+})
+
+test('runCli --help prints usage and exits 0', async () => {
+  const { io, out } = capture()
+  const code = await runCli(['--help'], io)
+  assert.equal(code, 0)
+  assert.match(out.join('\n'), /Usage:/)
+})
+
+test('runCli usage error exits 2', async () => {
+  const { io } = capture()
+  assert.equal(await runCli(['--bogus'], io), 2)
+  assert.equal(await runCli([], io), 2) // no intent, not fake
+})
+
+test('runCli --fake --no-dashboard runs the whole flow offline to production-grade', async () => {
+  const { io, out } = capture()
+  const code = await runCli(['--fake', '--no-dashboard'], io)
+  assert.equal(code, 0)
+  const text = out.join('\n')
+  assert.match(text, /architect:/)
+  assert.match(text, /checklist pass 1/)
+  assert.match(text, /production-grade/)
+  assert.match(text, /deploy: SSR/)
+})

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -1,0 +1,220 @@
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ClaudeCodeDriver, type Driver } from './driver/index.js'
+import { startDashboard, type Dashboard } from './dashboard/index.js'
+import { formatFrameworkEvent, type FrameworkEvent } from './events.js'
+import { runFramework, type DeployDecision, type RunFrameworkOptions } from './run.js'
+import { FAKE_DEPLOY, FAKE_INTENT, FAKE_SIGNALS, fakeDriver } from './fake-script.js'
+
+/** Where the CLI writes. Injectable so tests capture output. */
+export interface CliIO {
+  out: (line: string) => void
+  err: (line: string) => void
+}
+
+const defaultIO: CliIO = {
+  out: line => process.stdout.write(line + '\n'),
+  err: line => process.stderr.write(line + '\n'),
+}
+
+const VERSION = '0.0.0'
+
+const HELP = `The Framework — turnkey AI orchestration that wraps a coding agent (Claude Code).
+
+Usage:
+  framework [intent...]           Build what you describe, from scratch.
+  framework --fake                Run the offline demo (no CLI, no model, deterministic).
+
+Options:
+  --fake                 Use the fake driver + scripted run (offline / CI).
+  --cwd <dir>            Workspace the agent builds in (default: current directory).
+  --model <id>           Model to pass through to the wrapped agent.
+  --scope <prototype|full>   How much app to build (default: full).
+  --max-passes <n>       Full-fledged loop pass budget (default: 3).
+  --deploy <target>      Narrate a deploy decision to this target (e.g. cloudflare, dokploy).
+  --port <n>             Dashboard port (default: 4477).
+  --no-dashboard         Do not start the localhost dashboard.
+  --session-link <url>   Link to the live agent session (shown on the dashboard).
+  -h, --help             Show this help.
+  -v, --version          Print the version.
+
+The Framework drives the wrapped agent as a black box: it prompts, reads the code,
+and gates on the outcome (builds / serves / review-passes), then re-prompts. The
+localhost dashboard foregrounds the stack rationale, the loop status, and the
+decisions ledger beside the agent's own session.`
+
+/** Parsed CLI options. */
+export interface CliOptions {
+  help: boolean
+  version: boolean
+  fake: boolean
+  intent: string
+  cwd?: string | undefined
+  model?: string | undefined
+  scope: 'prototype' | 'full'
+  maxPasses?: number
+  deploy?: string | undefined
+  port?: number
+  dashboard: boolean
+  sessionLink?: string | undefined
+  error?: string
+}
+
+/** Parse argv (without the node/script prefix). Pure and testable. */
+export function parseArgs(argv: string[]): CliOptions {
+  const opts: CliOptions = { help: false, version: false, fake: false, intent: '', scope: 'full', dashboard: true }
+  const words: string[] = []
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!
+    switch (arg) {
+      case '-h':
+      case '--help':
+        opts.help = true
+        break
+      case '-v':
+      case '--version':
+        opts.version = true
+        break
+      case '--fake':
+        opts.fake = true
+        break
+      case '--no-dashboard':
+        opts.dashboard = false
+        break
+      case '--cwd':
+        opts.cwd = argv[++i]
+        break
+      case '--model':
+        opts.model = argv[++i]
+        break
+      case '--deploy':
+        opts.deploy = argv[++i]
+        break
+      case '--session-link':
+        opts.sessionLink = argv[++i]
+        break
+      case '--scope': {
+        const value = argv[++i]
+        if (value !== 'prototype' && value !== 'full') opts.error = `invalid --scope: ${value ?? '(missing)'}`
+        else opts.scope = value
+        break
+      }
+      case '--max-passes': {
+        const n = Number(argv[++i])
+        if (!Number.isInteger(n) || n < 1) opts.error = `invalid --max-passes: must be a positive integer`
+        else opts.maxPasses = n
+        break
+      }
+      case '--port': {
+        const n = Number(argv[++i])
+        if (!Number.isInteger(n) || n < 0) opts.error = `invalid --port: must be a non-negative integer`
+        else opts.port = n
+        break
+      }
+      default:
+        if (arg.startsWith('-')) opts.error = `unknown option: ${arg}`
+        else words.push(arg)
+    }
+  }
+  opts.intent = words.join(' ').trim()
+  return opts
+}
+
+/**
+ * The `framework` command. Wires the parsed options into {@link runFramework}
+ * over a live dashboard + terminal narration, and resolves with an exit code.
+ * Returns 0 on success, 1 on a run error, 2 on a usage error.
+ */
+export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<number> {
+  const opts = parseArgs(argv)
+  if (opts.error) {
+    io.err(opts.error)
+    io.err('Run `framework --help` for usage.')
+    return 2
+  }
+  if (opts.help) {
+    io.out(HELP)
+    return 0
+  }
+  if (opts.version) {
+    io.out(VERSION)
+    return 0
+  }
+
+  const fake = opts.fake
+  const intent = opts.intent || (fake ? FAKE_INTENT : '')
+  if (!intent) {
+    io.err('Describe what to build, e.g. `framework "a blog with comments"` (or try `framework --fake`).')
+    return 2
+  }
+
+  const driver: Driver = fake ? fakeDriver() : new ClaudeCodeDriver()
+  const cwd = opts.cwd ?? (fake ? join(tmpdir(), 'framework-fake-workspace') : process.cwd())
+  // The fake demo defaults to a Cloudflare deploy decision so the flow ends with
+  // a deploy phase; a live run only narrates deploy when asked.
+  const deploy: DeployDecision | undefined = opts.deploy
+    ? { render: 'ssr', target: opts.deploy, reason: `deploy to ${opts.deploy}` }
+    : fake
+      ? FAKE_DEPLOY
+      : undefined
+
+  let dashboard: Dashboard | undefined
+  if (opts.dashboard) {
+    try {
+      dashboard = await startDashboard(opts.port !== undefined ? { port: opts.port } : {})
+      io.out(`◆ dashboard: ${dashboard.url}`)
+    } catch (err) {
+      io.err(`could not start dashboard (${err instanceof Error ? err.message : String(err)}); continuing headless`)
+    }
+  }
+
+  const onEvent = (event: FrameworkEvent) => {
+    io.out(formatFrameworkEvent(event))
+    dashboard?.push(event)
+  }
+
+  const runOpts: RunFrameworkOptions = {
+    intent,
+    scope: opts.scope,
+    driver,
+    cwd,
+    onEvent,
+    ...(opts.model ? { model: opts.model } : {}),
+    ...(opts.maxPasses ? { maxPasses: opts.maxPasses } : {}),
+    ...(deploy ? { deploy } : {}),
+    ...(fake ? { signals: FAKE_SIGNALS } : {}),
+    ...(opts.sessionLink ? { sessionLink: opts.sessionLink } : {}),
+  }
+
+  try {
+    const { result } = await runFramework(runOpts)
+    io.out(
+      result.productionGrade
+        ? `\n✓ production-grade in ${result.passes} pass(es).`
+        : `\n• prototype ready${result.stoppedEarly ? ` (stopped with ${result.blockers.length} blocker(s))` : ''}.`,
+    )
+    if (dashboard) {
+      io.out(`\nDashboard still live at ${dashboard.url}. Press Ctrl+C to exit.`)
+      await waitForInterrupt()
+      await dashboard.close()
+    }
+    return 0
+  } catch (err) {
+    io.err(`\n✗ run failed: ${err instanceof Error ? err.message : String(err)}`)
+    await dashboard?.close()
+    return 1
+  }
+}
+
+/** Resolve when the process is interrupted (Ctrl+C), so the dashboard stays up. */
+function waitForInterrupt(): Promise<void> {
+  return new Promise(resolvePromise => {
+    const done = () => {
+      process.off('SIGINT', done)
+      process.off('SIGTERM', done)
+      resolvePromise()
+    }
+    process.once('SIGINT', done)
+    process.once('SIGTERM', done)
+  })
+}

--- a/packages/framework/src/dashboard/index.ts
+++ b/packages/framework/src/dashboard/index.ts
@@ -1,0 +1,2 @@
+export { startDashboard, type Dashboard, type DashboardOptions } from './server.js'
+export { dashboardHtml } from './page.js'

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -1,0 +1,172 @@
+/**
+ * The single self-contained dashboard page: HTML + inline CSS + inline JS, no
+ * assets, no build step. The client opens an `EventSource` to `/events` and
+ * projects the {@link import('../events.js').FrameworkEvent} stream into panels
+ * that foreground the orchestration (stack rationale, loop status, decisions)
+ * beside a tail of the wrapped agent's own activity.
+ */
+export function dashboardHtml(title: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>${escapeHtml(title)}</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body { margin: 0; font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, sans-serif;
+    background: #0b0e14; color: #d7dce5; }
+  header { display: flex; align-items: baseline; gap: 12px; padding: 16px 20px;
+    border-bottom: 1px solid #1c2230; }
+  header h1 { margin: 0; font-size: 16px; font-weight: 600; letter-spacing: .2px; }
+  header .sub { color: #7b8496; font-size: 12px; }
+  header a { color: #6ea8fe; text-decoration: none; }
+  #status { margin-left: auto; font-size: 12px; color: #7b8496; }
+  main { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; padding: 18px 20px; max-width: 1100px; }
+  section { background: #10141d; border: 1px solid #1c2230; border-radius: 10px; padding: 14px 16px; }
+  section h2 { margin: 0 0 10px; font-size: 12px; text-transform: uppercase;
+    letter-spacing: .8px; color: #7b8496; font-weight: 600; }
+  .stack { font-size: 15px; font-weight: 600; color: #e8ecf3; margin-bottom: 8px; }
+  ul { margin: 0; padding-left: 0; list-style: none; }
+  li { padding: 6px 0; border-bottom: 1px solid #161b26; }
+  li:last-child { border-bottom: 0; }
+  .choice { color: #e8ecf3; }
+  .why { color: #8b93a3; font-size: 13px; }
+  .pass-ok { color: #67d98f; }
+  .pass-bad { color: #f0a35e; }
+  .blocker { color: #f0a35e; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 11px;
+    font-weight: 600; }
+  .badge.grade { background: #14371f; color: #67d98f; }
+  .badge.proto { background: #2a2320; color: #f0a35e; }
+  #activity { grid-column: 1 / -1; }
+  #log { font: 12px/1.6 ui-monospace, SFMono-Regular, Menlo, monospace; color: #96a0b3;
+    max-height: 320px; overflow-y: auto; white-space: pre-wrap; }
+  .muted { color: #5c657a; }
+</style>
+</head>
+<body>
+<header>
+  <h1>${escapeHtml(title)}</h1>
+  <span class="sub" id="session">connecting…</span>
+  <span id="status">●</span>
+</header>
+<main>
+  <section id="stack-panel">
+    <h2>Stack &amp; rationale</h2>
+    <div class="stack muted" id="stack">deciding…</div>
+    <ul id="decisions"></ul>
+  </section>
+  <section id="loop-panel">
+    <h2>Loop status</h2>
+    <div id="grade" class="muted">building…</div>
+    <ul id="passes"></ul>
+  </section>
+  <section id="deploy-panel">
+    <h2>Deploy</h2>
+    <div id="deploy" class="muted">not decided yet</div>
+  </section>
+  <section id="ledger-panel">
+    <h2>Decisions ledger</h2>
+    <ul id="ledger"></ul>
+  </section>
+  <section id="activity">
+    <h2>Agent activity</h2>
+    <div id="log"></div>
+  </section>
+</main>
+<script>
+${clientScript()}
+</script>
+</body>
+</html>`
+}
+
+function clientScript(): string {
+  // Runs in the browser. Keep it dependency-free.
+  return `
+const $ = id => document.getElementById(id);
+const log = line => {
+  const el = $('log');
+  el.textContent += (el.textContent ? '\\n' : '') + line;
+  el.scrollTop = el.scrollHeight;
+};
+const decided = new Set();
+function bootstrap(e) {
+  switch (e.type) {
+    case 'scope':
+      $('session').textContent += '  ·  ' + e.scope + ': "' + e.intent + '"';
+      break;
+    case 'architect': {
+      $('stack').textContent = e.stack; $('stack').classList.remove('muted');
+      const ul = $('decisions'); ul.innerHTML = '';
+      for (const d of e.decisions) {
+        const li = document.createElement('li');
+        li.innerHTML = '<div class="choice">' + esc(d.choice) + '</div><div class="why">' + esc(d.why) + '</div>';
+        ul.appendChild(li);
+      }
+      break;
+    }
+    case 'checklist': {
+      const li = document.createElement('li');
+      li.className = e.passing ? 'pass-ok' : 'pass-bad';
+      li.textContent = (e.passing ? '\\u2713' : '\\u2717') + ' pass ' + e.pass +
+        (e.passing ? ': production-grade' : ': ' + e.blockers.join('; '));
+      $('passes').appendChild(li);
+      break;
+    }
+    case 'improve':
+      log('\\u2192 improving: ' + e.blockers.join('; '));
+      break;
+    case 'deploy':
+      $('deploy').textContent = e.plan.render.toUpperCase() + ' \\u2192 ' + e.plan.target + '  (' + e.plan.reason + ')';
+      $('deploy').classList.remove('muted');
+      break;
+    case 'done': {
+      const g = $('grade');
+      g.classList.remove('muted');
+      g.innerHTML = e.result.productionGrade
+        ? '<span class="badge grade">production-grade</span> in ' + e.result.passes + ' pass(es)'
+        : '<span class="badge proto">prototype</span>';
+      // Reflect the recorded architecture choices as the ledger.
+      const ul = $('ledger'); ul.innerHTML = '';
+      for (const d of (e.result.plan?.decisions || [])) {
+        const li = document.createElement('li');
+        li.innerHTML = '<div class="choice">' + esc(d.choice) + '</div><div class="why">' + esc(d.why) + '</div>';
+        ul.appendChild(li);
+      }
+      break;
+    }
+  }
+}
+function driver(e) {
+  if (e.type === 'text') log('  ' + e.text.replace(/\\s+/g, ' ').trim().slice(0, 160));
+  else if (e.type === 'action') log('  \\u00b7 ' + e.label);
+  else if (e.type === 'error') log('  ! ' + e.message);
+  else if (e.type === 'start') log('\\u203a prompt sent');
+}
+function onEvent(fe) {
+  if (fe.kind === 'session') {
+    let s = fe.fake ? 'fake driver' : fe.driver;
+    s += '  in  ' + fe.workspace;
+    $('session').innerHTML = esc(s) + (fe.sessionLink ? '  ·  <a href="' + esc(fe.sessionLink) + '" target="_blank">live session</a>' : '');
+  } else if (fe.kind === 'bootstrap') bootstrap(fe.event);
+  else if (fe.kind === 'driver') driver(fe.event);
+  else if (fe.kind === 'log') log(fe.message);
+  else if (fe.kind === 'end') { $('status').textContent = fe.ok ? '\\u25cf done' : '\\u25cf failed'; }
+}
+function esc(s) { const d = document.createElement('div'); d.textContent = String(s); return d.innerHTML; }
+const src = new EventSource('/events');
+src.onmessage = ev => { try { onEvent(JSON.parse(ev.data)); } catch {} };
+src.onerror = () => { $('status').textContent = '\\u25cb offline'; };
+`
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -1,0 +1,77 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { get } from 'node:http'
+import { startDashboard } from './server.js'
+import type { FrameworkEvent } from '../events.js'
+
+function fetchText(url: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    get(url, res => {
+      let body = ''
+      res.on('data', c => (body += c))
+      res.on('end', () => resolvePromise({ status: res.statusCode ?? 0, body }))
+    }).on('error', rejectPromise)
+  })
+}
+
+// Read SSE `data:` lines until `count` have arrived, then resolve and disconnect.
+function readSse(url: string, count: number): Promise<FrameworkEvent[]> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const req = get(url, res => {
+      let buffer = ''
+      const collected: FrameworkEvent[] = []
+      res.on('data', chunk => {
+        buffer += chunk
+        let nl: number
+        while ((nl = buffer.indexOf('\n\n')) !== -1) {
+          const frame = buffer.slice(0, nl)
+          buffer = buffer.slice(nl + 2)
+          const line = frame.split('\n').find(l => l.startsWith('data: '))
+          if (line) collected.push(JSON.parse(line.slice(6)) as FrameworkEvent)
+          if (collected.length >= count) {
+            req.destroy()
+            resolvePromise(collected)
+            return
+          }
+        }
+      })
+    })
+    req.on('error', () => {}) // destroy() triggers an expected error; ignore
+    setTimeout(() => rejectPromise(new Error('SSE timeout')), 3000).unref?.()
+  })
+}
+
+test('dashboard serves the HTML page with the title', async () => {
+  const dash = await startDashboard({ port: 0, title: 'My Framework' })
+  try {
+    const { status, body } = await fetchText(dash.url + '/')
+    assert.equal(status, 200)
+    assert.match(body, /My Framework/)
+    assert.match(body, /new EventSource\('\/events'\)/)
+  } finally {
+    await dash.close()
+  }
+})
+
+test('dashboard replays buffered events and streams them over SSE', async () => {
+  const dash = await startDashboard({ port: 0 })
+  try {
+    dash.push({ kind: 'session', driver: 'fake', workspace: '/ws', fake: true })
+    dash.push({ kind: 'log', message: 'hello' })
+    const events = await readSse(dash.url + '/events', 2)
+    assert.equal(events[0]!.kind, 'session')
+    assert.equal(events[1]!.kind, 'log')
+  } finally {
+    await dash.close()
+  }
+})
+
+test('dashboard returns 404 for unknown paths', async () => {
+  const dash = await startDashboard({ port: 0 })
+  try {
+    const { status } = await fetchText(dash.url + '/nope')
+    assert.equal(status, 404)
+  } finally {
+    await dash.close()
+  }
+})

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -1,0 +1,127 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { EventStream } from '@gemstack/ai-autopilot'
+import type { FrameworkEvent } from '../events.js'
+import { dashboardHtml } from './page.js'
+
+/** Options for {@link startDashboard}. */
+export interface DashboardOptions {
+  /** Port to bind. Default `4477`; pass `0` for an ephemeral port. */
+  port?: number
+  /** Host to bind. Default `127.0.0.1` (localhost only). */
+  host?: string
+  /** Page title. Default `"The Framework"`. */
+  title?: string
+}
+
+/** A running localhost dashboard. Push {@link FrameworkEvent}s; it renders them live. */
+export interface Dashboard {
+  /** The URL to open. */
+  readonly url: string
+  /** The event stream backing the page (own it here, guardrail #2). */
+  readonly stream: EventStream<FrameworkEvent>
+  /** Push one event to every connected browser (and the replay buffer). */
+  push(event: FrameworkEvent): void
+  /** Close connections and stop the server. Idempotent. */
+  close(): Promise<void>
+}
+
+/**
+ * Start the localhost dashboard: a tiny `node:http` server that serves one HTML
+ * page and streams {@link FrameworkEvent}s to it over Server-Sent Events. The
+ * page foregrounds what the wrapped agent's own chat cannot: the chosen stack
+ * and its PROS/CONS rationale, the loop status + checklist blockers, the
+ * decisions ledger, and a link to the live agent session (#165).
+ *
+ * We own the stream, so the same events feed the terminal and the browser, and a
+ * late-connecting browser replays history via {@link EventStream}.
+ */
+export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> {
+  const host = opts.host ?? '127.0.0.1'
+  const port = opts.port ?? 4477
+  const title = opts.title ?? 'The Framework'
+  const stream = new EventStream<FrameworkEvent>()
+  const clients = new Set<ServerResponse>()
+
+  const server = createServer((req, res) => handle(req, res, stream, clients, title))
+
+  return new Promise<Dashboard>((resolvePromise, rejectPromise) => {
+    server.once('error', rejectPromise)
+    server.listen(port, host, () => {
+      server.removeListener('error', rejectPromise)
+      const address = server.address() as AddressInfo
+      const url = `http://${host}:${address.port}`
+      resolvePromise({
+        url,
+        stream,
+        push: event => stream.push(event),
+        close: () => closeServer(server, clients, stream),
+      })
+    })
+  })
+}
+
+function handle(
+  req: IncomingMessage,
+  res: ServerResponse,
+  stream: EventStream<FrameworkEvent>,
+  clients: Set<ServerResponse>,
+  title: string,
+): void {
+  const url = req.url ?? '/'
+  if (url === '/' || url.startsWith('/?')) {
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+    res.end(dashboardHtml(title))
+    return
+  }
+  if (url === '/events') {
+    streamEvents(req, res, stream, clients)
+    return
+  }
+  res.writeHead(404, { 'content-type': 'text/plain' })
+  res.end('not found')
+}
+
+function streamEvents(
+  req: IncomingMessage,
+  res: ServerResponse,
+  stream: EventStream<FrameworkEvent>,
+  clients: Set<ServerResponse>,
+): void {
+  res.writeHead(200, {
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-cache',
+    connection: 'keep-alive',
+  })
+  clients.add(res)
+
+  const send = (event: FrameworkEvent) => res.write(`data: ${JSON.stringify(event)}\n\n`)
+  // Replay history, then follow live. A fresh iterator gives this client its own
+  // cursor, so a late browser still sees the whole run from the start.
+  void (async () => {
+    try {
+      for await (const event of stream[Symbol.asyncIterator]()) send(event)
+    } catch {
+      // client went away
+    } finally {
+      clients.delete(res)
+      res.end()
+    }
+  })()
+
+  req.on('close', () => {
+    clients.delete(res)
+    res.end()
+  })
+}
+
+function closeServer(
+  server: Server,
+  clients: Set<ServerResponse>,
+  stream: EventStream<FrameworkEvent>,
+): Promise<void> {
+  stream.close()
+  for (const res of clients) res.end()
+  clients.clear()
+  return new Promise(resolvePromise => server.close(() => resolvePromise()))
+}

--- a/packages/framework/src/driver/claude-code.test.ts
+++ b/packages/framework/src/driver/claude-code.test.ts
@@ -1,0 +1,108 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { Readable, Writable } from 'node:stream'
+import { ClaudeCodeDriver, StreamJsonParser, runClaude, type SpawnLike, type SpawnedProcess } from './claude-code.js'
+import type { DriverEvent } from './types.js'
+
+test('StreamJsonParser surfaces assistant text + tool names, keeps the result', () => {
+  const p = new StreamJsonParser()
+  assert.deepEqual(p.push(JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sess-1' })), [])
+  const assistant = p.push(
+    JSON.stringify({
+      type: 'assistant',
+      session_id: 'sess-1',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'Working' }, { type: 'tool_use', name: 'Write' }] },
+    }),
+  )
+  assert.deepEqual(assistant, [
+    { type: 'text', text: 'Working' },
+    { type: 'action', label: 'Write' },
+  ])
+  assert.deepEqual(p.push(JSON.stringify({ type: 'result', subtype: 'success', result: 'All done', session_id: 'sess-1' })), [])
+  assert.deepEqual(p.result(), { text: 'All done', sessionId: 'sess-1' })
+})
+
+test('StreamJsonParser ignores non-JSON noise and falls back to assistant text', () => {
+  const p = new StreamJsonParser()
+  assert.deepEqual(p.push('some banner line'), [])
+  p.push(JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'partial' }] } }))
+  assert.deepEqual(p.result(), { text: 'partial' })
+})
+
+// A fake process that streams the given stream-json lines then closes.
+function fakeSpawn(lines: string[], code = 0, stderr = ''): SpawnLike {
+  return () => {
+    const stdout = Readable.from([lines.map(l => l + '\n').join('')])
+    const stderrStream = Readable.from(stderr ? [stderr] : [])
+    const stdin = new Writable({ write: (_c, _e, cb) => cb() })
+    const proc: SpawnedProcess = {
+      stdout,
+      stderr: stderrStream,
+      stdin,
+      on(event, listener) {
+        if (event === 'close') stdout.on('end', () => (listener as (c: number | null) => void)(code))
+        return proc
+      },
+      kill: () => undefined,
+    }
+    return proc
+  }
+}
+
+test('runClaude drives a fake process and returns the final turn', async () => {
+  const events: DriverEvent[] = []
+  const lines = [
+    JSON.stringify({ type: 'system', subtype: 'init', session_id: 's9' }),
+    JSON.stringify({ type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Bash' }] } }),
+    JSON.stringify({ type: 'result', subtype: 'success', result: 'built it', session_id: 's9' }),
+  ]
+  const turn = await runClaude({
+    bin: 'claude',
+    args: ['-p'],
+    cwd: '/ws',
+    env: {},
+    prompt: 'build',
+    spawn: fakeSpawn(lines),
+    emit: e => events.push(e),
+    signals: [],
+  })
+  assert.deepEqual(turn, { text: 'built it', sessionId: 's9' })
+  assert.equal(events[0]!.type, 'start')
+  assert.ok(events.some(e => e.type === 'action' && e.label === 'Bash'))
+  assert.equal(events.at(-1)!.type, 'result')
+})
+
+test('runClaude rejects on a non-zero exit with no result text', async () => {
+  await assert.rejects(
+    () =>
+      runClaude({
+        bin: 'claude',
+        args: [],
+        cwd: '/ws',
+        env: {},
+        prompt: 'x',
+        spawn: fakeSpawn([], 1, 'boom'),
+        emit: () => {},
+        signals: [],
+      }),
+    /boom/,
+  )
+})
+
+test('ClaudeCodeDriver builds correct CLI args (permission mode, system, model)', async () => {
+  let captured: string[] = []
+  const spawn: SpawnLike = (_cmd, args) => {
+    captured = [...args]
+    return fakeSpawn([JSON.stringify({ type: 'result', result: 'ok' })])(_cmd, args, { cwd: '/ws', env: {} })
+  }
+  const driver = new ClaudeCodeDriver({ spawn })
+  const session = await driver.start({ cwd: '/ws', system: 'You are a Vike expert', model: 'claude-haiku-4-5-20251001' })
+  await session.prompt('go')
+  assert.deepEqual(captured.slice(0, 4), ['-p', '--output-format', 'stream-json', '--verbose'])
+  assert.ok(captured.includes('--permission-mode'))
+  assert.ok(captured.includes('acceptEdits'))
+  assert.ok(captured.includes('--append-system-prompt'))
+  assert.ok(captured.includes('You are a Vike expert'))
+  assert.ok(captured.includes('--model'))
+  assert.ok(captured.includes('claude-haiku-4-5-20251001'))
+})

--- a/packages/framework/src/driver/claude-code.ts
+++ b/packages/framework/src/driver/claude-code.ts
@@ -1,0 +1,266 @@
+import { spawn as nodeSpawn } from 'node:child_process'
+import { createInterface } from 'node:readline'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import type { Driver, DriverEvent, DriverPromptOptions, DriverSession, DriverStartOptions, DriverTurn } from './types.js'
+
+/** Claude Code permission modes we pass through to the CLI. */
+export type PermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan'
+
+/** The slice of `child_process.spawn` this driver needs. Injectable for tests. */
+export type SpawnLike = (
+  command: string,
+  args: readonly string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+) => SpawnedProcess
+
+/** The slice of a spawned process this driver reads. */
+export interface SpawnedProcess {
+  stdout: NodeJS.ReadableStream | null
+  stderr: NodeJS.ReadableStream | null
+  stdin: NodeJS.WritableStream | null
+  on(event: 'close', listener: (code: number | null) => void): unknown
+  on(event: 'error', listener: (err: Error) => void): unknown
+  kill(signal?: NodeJS.Signals): unknown
+}
+
+/** Options for {@link ClaudeCodeDriver}. */
+export interface ClaudeCodeDriverOptions {
+  /** CLI binary to spawn. Default `"claude"` (resolved on `PATH`). */
+  bin?: string
+  /**
+   * Permission mode. Default `"acceptEdits"` so file writes are non-interactive.
+   * A fully autonomous build that also runs installs / tests needs
+   * `"bypassPermissions"` (or {@link dangerouslySkipPermissions}).
+   */
+  permissionMode?: PermissionMode
+  /** Add `--dangerously-skip-permissions`. Only for sandboxes with no network. */
+  dangerouslySkipPermissions?: boolean
+  /** Extra CLI args appended verbatim (escape hatch). */
+  extraArgs?: string[]
+  /** Environment for the child process. Default `process.env`. */
+  env?: NodeJS.ProcessEnv
+  /** `spawn` override for tests. Default `node:child_process.spawn`. */
+  spawn?: SpawnLike
+}
+
+/**
+ * The first real {@link Driver}: wraps the **Claude Code CLI** in print mode
+ * (`claude -p --output-format stream-json`). Each {@link DriverSession.prompt}
+ * spawns a fresh non-interactive invocation, so every loop pass gets fresh
+ * context (option A). We stream its JSON events to {@link DriverStartOptions.onEvent}
+ * for the dashboard and return the final `result` text as the turn.
+ *
+ * True black box: we prompt and read the result; Claude Code owns its own loop,
+ * tools, and (subscription-based) auth. A second agent slots in behind the same
+ * `Driver` interface without touching the orchestration above it.
+ */
+export class ClaudeCodeDriver implements Driver {
+  readonly name = 'claude-code'
+  constructor(private readonly opts: ClaudeCodeDriverOptions = {}) {}
+
+  start(opts: DriverStartOptions): Promise<DriverSession> {
+    return Promise.resolve(new ClaudeCodeSession(this.opts, opts))
+  }
+}
+
+let sessionCounter = 0
+
+/** One workspace-bound Claude Code session. `prompt` is a fresh CLI invocation. */
+export class ClaudeCodeSession implements DriverSession {
+  readonly id: string
+  readonly cwd: string
+  private lastSessionId?: string
+
+  constructor(
+    private readonly config: ClaudeCodeDriverOptions,
+    private readonly startOpts: DriverStartOptions,
+  ) {
+    this.cwd = startOpts.cwd
+    this.id = `claude-code-${++sessionCounter}`
+  }
+
+  prompt(text: string, opts: DriverPromptOptions = {}): Promise<DriverTurn> {
+    const system = [this.startOpts.system, opts.system].filter(Boolean).join('\n\n')
+    const args = this.buildArgs(system)
+    const emit = (event: DriverEvent) => {
+      const on = this.startOpts.onEvent
+      if (!on) return
+      try {
+        on(event)
+      } catch (err) {
+        console.error('[framework] claude-code onEvent threw; ignoring:', err)
+      }
+    }
+    const signals = [this.startOpts.signal, opts.signal].filter((s): s is AbortSignal => s != null)
+    return runClaude({
+      bin: this.config.bin ?? 'claude',
+      args,
+      cwd: this.cwd,
+      env: this.config.env ?? process.env,
+      prompt: text,
+      spawn: this.config.spawn ?? (nodeSpawn as unknown as SpawnLike),
+      emit,
+      signals,
+    }).then(turn => {
+      if (turn.sessionId) this.lastSessionId = turn.sessionId
+      return turn
+    })
+  }
+
+  async readCode(path: string): Promise<string> {
+    return readFile(resolve(this.cwd, path), 'utf8')
+  }
+
+  dispose(): Promise<void> {
+    // Each prompt spawns and reaps its own process, so there is nothing durable
+    // to tear down. The last session id is kept only for a UI link.
+    void this.lastSessionId
+    return Promise.resolve()
+  }
+
+  private buildArgs(system: string): string[] {
+    const args = ['-p', '--output-format', 'stream-json', '--verbose']
+    if (this.config.dangerouslySkipPermissions) args.push('--dangerously-skip-permissions')
+    else args.push('--permission-mode', this.config.permissionMode ?? 'acceptEdits')
+    if (system) args.push('--append-system-prompt', system)
+    if (this.startOpts.model) args.push('--model', this.startOpts.model)
+    if (this.config.extraArgs) args.push(...this.config.extraArgs)
+    return args
+  }
+}
+
+interface RunClaudeOptions {
+  bin: string
+  args: string[]
+  cwd: string
+  env: NodeJS.ProcessEnv
+  prompt: string
+  spawn: SpawnLike
+  emit: (event: DriverEvent) => void
+  signals: AbortSignal[]
+}
+
+/** Spawn one Claude Code invocation and resolve with its final turn. */
+export function runClaude(opts: RunClaudeOptions): Promise<DriverTurn> {
+  return new Promise<DriverTurn>((resolvePromise, rejectPromise) => {
+    for (const s of opts.signals) {
+      if (s.aborted) {
+        rejectPromise(new Error('[framework] claude-code prompt aborted'))
+        return
+      }
+    }
+
+    opts.emit({ type: 'start', prompt: opts.prompt })
+    const child = opts.spawn(opts.bin, opts.args, { cwd: opts.cwd, env: opts.env })
+    const parser = new StreamJsonParser()
+    let settled = false
+    const stderrChunks: string[] = []
+
+    const finish = (fn: () => void) => {
+      if (settled) return
+      settled = true
+      for (const { signal, handler } of aborts) signal.removeEventListener('abort', handler)
+      fn()
+    }
+
+    const aborts = opts.signals.map(signal => {
+      const handler = () => {
+        child.kill('SIGTERM')
+        finish(() => rejectPromise(new Error('[framework] claude-code prompt aborted')))
+      }
+      signal.addEventListener('abort', handler)
+      return { signal, handler }
+    })
+
+    child.on('error', err => finish(() => rejectPromise(err)))
+
+    if (child.stdout) {
+      const rl = createInterface({ input: child.stdout })
+      rl.on('line', line => {
+        for (const event of parser.push(line)) opts.emit(event)
+      })
+    }
+    if (child.stderr) {
+      child.stderr.on('data', (chunk: Buffer | string) => stderrChunks.push(String(chunk)))
+    }
+
+    child.on('close', code => {
+      const turn = parser.result()
+      if (code !== 0 && !turn.text) {
+        const detail = stderrChunks.join('').trim() || `exit code ${code ?? 'null'}`
+        opts.emit({ type: 'error', message: detail })
+        finish(() => rejectPromise(new Error(`[framework] claude-code exited: ${detail}`)))
+        return
+      }
+      opts.emit({ type: 'result', text: turn.text, ...(turn.sessionId ? { sessionId: turn.sessionId } : {}) })
+      finish(() => resolvePromise(turn))
+    })
+
+    // Feed the prompt over stdin so long prompts never hit arg-length limits.
+    if (child.stdin) {
+      child.stdin.write(opts.prompt)
+      child.stdin.end()
+    }
+  })
+}
+
+/**
+ * Incremental parser for Claude Code's `stream-json` output: newline-delimited
+ * JSON, one object per line. We surface assistant text + tool names as
+ * {@link DriverEvent}s and keep the final `result` line as the turn text.
+ * Kept separate from the process plumbing so it is unit-testable in isolation.
+ */
+export class StreamJsonParser {
+  private finalText = ''
+  private assistantText = ''
+  private sessionId?: string
+
+  /** Feed one line; returns the events it produced (may be empty). */
+  push(line: string): DriverEvent[] {
+    const trimmed = line.trim()
+    if (!trimmed) return []
+    let obj: Record<string, unknown>
+    try {
+      obj = JSON.parse(trimmed) as Record<string, unknown>
+    } catch {
+      return [] // Non-JSON noise (banners etc.); ignore.
+    }
+
+    if (typeof obj['session_id'] === 'string') this.sessionId = obj['session_id']
+    const type = obj['type']
+
+    if (type === 'assistant') return this.handleAssistant(obj)
+    if (type === 'result') {
+      const result = obj['result']
+      if (typeof result === 'string') this.finalText = result
+      return [] // The `result` event is emitted by the runner after `close`.
+    }
+    return []
+  }
+
+  private handleAssistant(obj: Record<string, unknown>): DriverEvent[] {
+    const message = obj['message']
+    if (typeof message !== 'object' || message === null) return []
+    const content = (message as Record<string, unknown>)['content']
+    if (!Array.isArray(content)) return []
+    const events: DriverEvent[] = []
+    for (const item of content) {
+      if (typeof item !== 'object' || item === null) continue
+      const block = item as Record<string, unknown>
+      if (block['type'] === 'text' && typeof block['text'] === 'string') {
+        this.assistantText += block['text']
+        events.push({ type: 'text', text: block['text'] })
+      } else if (block['type'] === 'tool_use' && typeof block['name'] === 'string') {
+        events.push({ type: 'action', label: block['name'] })
+      }
+    }
+    return events
+  }
+
+  /** The final turn: the `result` text, falling back to accumulated assistant text. */
+  result(): DriverTurn {
+    const text = this.finalText || this.assistantText
+    return { text, ...(this.sessionId ? { sessionId: this.sessionId } : {}) }
+  }
+}

--- a/packages/framework/src/driver/fake.test.ts
+++ b/packages/framework/src/driver/fake.test.ts
@@ -1,0 +1,45 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { FakeDriver } from './fake.js'
+import type { DriverEvent } from './types.js'
+
+test('FakeDriver replays scripted turns in order and repeats the last', async () => {
+  const driver = new FakeDriver({ turns: [{ text: 'one' }, { text: 'two' }] })
+  const session = await driver.start({ cwd: '/ws' })
+  assert.equal((await session.prompt('a')).text, 'one')
+  assert.equal((await session.prompt('b')).text, 'two')
+  assert.equal((await session.prompt('c')).text, 'two') // last repeats
+  assert.deepEqual(session.prompts, ['a', 'b', 'c'])
+})
+
+test('FakeDriver answers dynamically when respond is given', async () => {
+  const driver = new FakeDriver({ respond: (prompt, i) => `${i}:${prompt.toUpperCase()}` })
+  const session = await driver.start({ cwd: '/ws' })
+  assert.equal((await session.prompt('hi')).text, '0:HI')
+  assert.equal((await session.prompt('yo')).text, '1:YO')
+})
+
+test('FakeDriver emits start, actions, text, result events', async () => {
+  const events: DriverEvent[] = []
+  const driver = new FakeDriver({ turns: [{ text: 'done', actions: ['Write', 'Bash'] }] })
+  const session = await driver.start({ cwd: '/ws', onEvent: e => events.push(e) })
+  const turn = await session.prompt('go')
+  assert.equal(turn.sessionId, 'fake-session')
+  assert.deepEqual(
+    events.map(e => e.type),
+    ['start', 'action', 'action', 'text', 'result'],
+  )
+})
+
+test('FakeDriver readCode returns seeded files and rejects unknown ones', async () => {
+  const driver = new FakeDriver({ files: { 'a.txt': 'hello' } })
+  const session = await driver.start({ cwd: '/ws' })
+  assert.equal(await session.readCode!('a.txt'), 'hello')
+  await assert.rejects(() => session.readCode!('missing.txt'))
+})
+
+test('FakeDriver rejects when the session signal is aborted', async () => {
+  const driver = new FakeDriver({ turns: [{ text: 'x' }] })
+  const session = await driver.start({ cwd: '/ws', signal: AbortSignal.abort() })
+  await assert.rejects(() => session.prompt('go'))
+})

--- a/packages/framework/src/driver/fake.ts
+++ b/packages/framework/src/driver/fake.ts
@@ -1,0 +1,105 @@
+import type { Driver, DriverEvent, DriverPromptOptions, DriverSession, DriverStartOptions, DriverTurn } from './types.js'
+
+/** One scripted turn the {@link FakeDriver} replays. */
+export interface FakeTurn {
+  /** The final assistant text. */
+  text: string
+  /** Tool names to emit as `action` events before the result (visual only). */
+  actions?: string[]
+}
+
+/** Options for {@link FakeDriver}. */
+export interface FakeDriverOptions {
+  /**
+   * Scripted turns, consumed in order across all `prompt` calls of a session.
+   * Once exhausted the last one repeats, so a short script never starves a
+   * longer run. Ignored when {@link respond} is set.
+   */
+  turns?: FakeTurn[]
+  /** Answer dynamically from the prompt. Takes precedence over {@link turns}. */
+  respond?: (prompt: string, index: number) => FakeTurn | string
+  /** Files each session is pre-seeded with, exposed via {@link DriverSession.readCode}. */
+  files?: Record<string, string>
+  /** Session id to report (default `"fake-session"`). */
+  sessionId?: string
+}
+
+function asTurn(value: FakeTurn | string): FakeTurn {
+  return typeof value === 'string' ? { text: value } : value
+}
+
+/**
+ * An in-memory {@link Driver} for tests and `--fake` runs: it never spawns a
+ * process, replays scripted turns deterministically, and emits the same
+ * {@link DriverEvent} shape a real driver does. Mirrors `AiFake` /
+ * `FakeRunner`, so the whole flow runs offline with no CLI and no model.
+ */
+export class FakeDriver implements Driver {
+  readonly name = 'fake'
+  constructor(private readonly opts: FakeDriverOptions = {}) {}
+
+  // Narrowed to the concrete session so callers can read `prompts` for assertions.
+  start(opts: DriverStartOptions): Promise<FakeDriverSession> {
+    return Promise.resolve(new FakeDriverSession(this.opts, opts))
+  }
+}
+
+/** A single {@link FakeDriver} session. Records every prompt for assertions. */
+export class FakeDriverSession implements DriverSession {
+  readonly id: string
+  readonly cwd: string
+  /** Every prompt this session received, in order. */
+  readonly prompts: string[] = []
+  private index = 0
+
+  constructor(
+    private readonly config: FakeDriverOptions,
+    private readonly startOpts: DriverStartOptions,
+  ) {
+    this.id = config.sessionId ?? 'fake-session'
+    this.cwd = startOpts.cwd
+  }
+
+  prompt(text: string, opts: DriverPromptOptions = {}): Promise<DriverTurn> {
+    if (this.startOpts.signal?.aborted || opts.signal?.aborted) {
+      return Promise.reject(new Error('[framework] fake prompt aborted'))
+    }
+    const i = this.index++
+    this.prompts.push(text)
+    const turn = this.resolveTurn(text, i)
+
+    this.emit({ type: 'start', prompt: text })
+    for (const label of turn.actions ?? []) this.emit({ type: 'action', label })
+    if (turn.text) this.emit({ type: 'text', text: turn.text })
+    this.emit({ type: 'result', text: turn.text, sessionId: this.id })
+
+    return Promise.resolve({ text: turn.text, sessionId: this.id })
+  }
+
+  readCode(path: string): Promise<string> {
+    const contents = this.config.files?.[path]
+    if (contents === undefined) return Promise.reject(new Error(`[framework] fake driver has no file ${path}`))
+    return Promise.resolve(contents)
+  }
+
+  dispose(): Promise<void> {
+    return Promise.resolve()
+  }
+
+  private resolveTurn(text: string, i: number): FakeTurn {
+    if (this.config.respond) return asTurn(this.config.respond(text, i))
+    const turns = this.config.turns ?? []
+    if (turns.length === 0) return { text: '' }
+    return turns[Math.min(i, turns.length - 1)]!
+  }
+
+  private emit(event: DriverEvent): void {
+    const on = this.startOpts.onEvent
+    if (!on) return
+    try {
+      on(event)
+    } catch (err) {
+      console.error('[framework] fake driver onEvent threw; ignoring:', err)
+    }
+  }
+}

--- a/packages/framework/src/driver/index.ts
+++ b/packages/framework/src/driver/index.ts
@@ -1,0 +1,19 @@
+export type {
+  Driver,
+  DriverSession,
+  DriverStartOptions,
+  DriverPromptOptions,
+  DriverTurn,
+  DriverEvent,
+} from './types.js'
+export { FakeDriver, FakeDriverSession, type FakeTurn, type FakeDriverOptions } from './fake.js'
+export {
+  ClaudeCodeDriver,
+  ClaudeCodeSession,
+  StreamJsonParser,
+  runClaude,
+  type ClaudeCodeDriverOptions,
+  type PermissionMode,
+  type SpawnLike,
+  type SpawnedProcess,
+} from './claude-code.js'

--- a/packages/framework/src/driver/types.ts
+++ b/packages/framework/src/driver/types.ts
@@ -1,0 +1,107 @@
+/**
+ * The **driver** seam: the one abstraction The Framework wraps a coding-agent
+ * CLI behind. A driver treats the agent (Claude Code today, Codex / opencode
+ * later) as a **black box**: we hand it a prompt, let its *own* loop run to
+ * completion, then read the code it produced and gate on the outcome ourselves.
+ *
+ * The seam is deliberately the **code and the outcome**, never the agent's
+ * individual tool calls (guardrail from #165). We drive by prompting and verify
+ * by result (builds / serves / review-passes), so the wrapped agent keeps its
+ * subscription-based auth and its internal loop stays untouched and swappable.
+ *
+ * Decision (#166, option A): a single execution path. Everything runs *through*
+ * the driver; personas become prompt-framing ({@link DriverStartOptions.system}),
+ * and each loop pass (review / security / QA / UX) is a **fresh** {@link
+ * DriverSession.prompt} call, so `prompt` is the fresh-context unit.
+ *
+ * `Driver` is intentionally tiny: `start` a session, `prompt` it, read the code,
+ * `dispose`. It mirrors the runner seam's shape so a second agent slots in behind
+ * the same three methods.
+ */
+
+/** A wrapped coding-agent CLI. Boots {@link DriverSession}s bound to a workspace. */
+export interface Driver {
+  /** Stable name for the wrapped agent, e.g. `"claude-code"`. */
+  readonly name: string
+  /** Boot a session bound to a workspace directory. */
+  start(opts: DriverStartOptions): Promise<DriverSession>
+}
+
+/** How to boot a {@link DriverSession}. */
+export interface DriverStartOptions {
+  /** Absolute path to the workspace the agent reads and edits. */
+  cwd: string
+  /**
+   * Role framing prepended to every prompt in this session (option A: personas
+   * are prompt-framing, not a separate agent). Maps to the agent's system prompt.
+   */
+  system?: string
+  /** Model id to pass through when the wrapped agent supports selecting one. */
+  model?: string
+  /** Abort the whole session; disposing kills the underlying process. */
+  signal?: AbortSignal
+  /**
+   * Observe the agent's *own* progress as it works. Black-box granularity: we
+   * forward these for visibility (the dashboard) but never branch control flow
+   * on them. Isolated: a throwing callback must not break the run.
+   */
+  onEvent?: (event: DriverEvent) => void
+}
+
+/** A booted agent session, bound to one workspace. */
+export interface DriverSession {
+  /** Stable id (the agent's own session id when it exposes one). */
+  readonly id: string
+  /** Absolute workspace path the agent is bound to. */
+  readonly cwd: string
+  /**
+   * Send one prompt, let the agent's built-in loop run to completion, and
+   * resolve with its final turn. Each call is a **fresh** invocation (fresh
+   * context per loop pass) unless a driver documents otherwise.
+   */
+  prompt(text: string, opts?: DriverPromptOptions): Promise<DriverTurn>
+  /**
+   * Read a file the agent produced (the seam is the code). Optional: a driver
+   * whose workspace is not host-readable may omit it and rely on a runner.
+   */
+  readCode?(path: string): Promise<string>
+  /** Tear the session down (kill the process, free resources). Idempotent. */
+  dispose(): Promise<void>
+}
+
+/** Per-prompt overrides. */
+export interface DriverPromptOptions {
+  /** Extra framing for just this prompt, appended after the session `system`. */
+  system?: string
+  /** Abort just this prompt (the in-flight invocation). */
+  signal?: AbortSignal
+}
+
+/** The outcome of one {@link DriverSession.prompt} turn. */
+export interface DriverTurn {
+  /** The agent's final assistant text for this prompt. */
+  text: string
+  /**
+   * The agent's session id for this turn, when it exposes one. The MVP
+   * persistence shortcut is to forward the agent's own transcript rather than
+   * keep our own store (#165), so this is the handle a UI links to.
+   */
+  sessionId?: string
+}
+
+/**
+ * A black-box progress event from the wrapped agent. We forward these to the
+ * dashboard for visibility but never gate on them: the loop gates on the code /
+ * outcome, not on which tool the agent reached for.
+ */
+export type DriverEvent =
+  /** A prompt was sent; the agent's loop is starting. */
+  | { type: 'start'; prompt: string }
+  /** An assistant text chunk streamed out. */
+  | { type: 'text'; text: string }
+  /** The agent used a tool. We surface the name only, not the arguments. */
+  | { type: 'action'; label: string }
+  /** The turn settled with this final text. */
+  | { type: 'result'; text: string; sessionId?: string }
+  /** The agent (or its transport) errored. */
+  | { type: 'error'; message: string }

--- a/packages/framework/src/events.ts
+++ b/packages/framework/src/events.ts
@@ -1,0 +1,82 @@
+import type { BootstrapEvent } from '@gemstack/ai-autopilot'
+import type { DriverEvent } from './driver/index.js'
+
+/**
+ * The single event type the whole run streams over. It unifies three sources so
+ * the dashboard (and terminal) render one timeline: bootstrap-phase narration
+ * (the moat: architect rationale, checklist verdicts, deploy), the wrapped
+ * agent's own black-box progress, and framework-level status. We own this stream
+ * (guardrail #2, #165) rather than surfacing the agent's transport directly.
+ */
+export type FrameworkEvent =
+  /** Emitted once at start: which agent is wrapped, the workspace, and a link. */
+  | { kind: 'session'; driver: string; workspace: string; fake: boolean; sessionLink?: string }
+  /** A bootstrap-phase narration event (scope / architect / checklist / deploy / ...). */
+  | { kind: 'bootstrap'; event: BootstrapEvent }
+  /** The wrapped agent's own progress, forwarded verbatim (never gated on). */
+  | { kind: 'driver'; event: DriverEvent }
+  /** A framework-level log line. */
+  | { kind: 'log'; message: string }
+  /** The run finished. `ok` is false when it threw. */
+  | { kind: 'end'; ok: boolean; detail?: string }
+
+/** Render a {@link FrameworkEvent} as one human-readable line (terminal surface). */
+export function formatFrameworkEvent(event: FrameworkEvent): string {
+  switch (event.kind) {
+    case 'session':
+      return `◆ ${event.fake ? 'fake' : event.driver} in ${event.workspace}${
+        event.sessionLink ? ` — ${event.sessionLink}` : ''
+      }`
+    case 'log':
+      return `  ${event.message}`
+    case 'driver':
+      return formatDriverEvent(event.event)
+    case 'bootstrap':
+      return formatBootstrapEvent(event.event)
+    case 'end':
+      return event.ok ? '✓ done' : `✗ failed: ${event.detail ?? 'unknown error'}`
+  }
+}
+
+function formatDriverEvent(event: DriverEvent): string {
+  switch (event.type) {
+    case 'start':
+      return `  › prompt sent`
+    case 'text':
+      return `    ${truncate(event.text)}`
+    case 'action':
+      return `    · ${event.label}`
+    case 'result':
+      return `  ‹ turn complete`
+    case 'error':
+      return `  ! agent error: ${event.message}`
+  }
+}
+
+function formatBootstrapEvent(event: BootstrapEvent): string {
+  switch (event.type) {
+    case 'scope':
+      return `▶ scope: ${event.scope} — "${event.intent}"`
+    case 'architect':
+      return `▶ architect: ${event.stack}\n${event.decisions.map(d => `    · ${d.choice} — ${d.why}`).join('\n')}`
+    case 'narrate':
+      return `  ${event.message}`
+    case 'build':
+      return `    build/${event.event.type}`
+    case 'checklist':
+      return event.passing
+        ? `  ✓ checklist pass ${event.pass}: production-grade`
+        : `  ✗ checklist pass ${event.pass}: ${event.blockers.join('; ')}`
+    case 'improve':
+      return `  → improving: ${event.blockers.join('; ')}`
+    case 'deploy':
+      return `▶ deploy: ${event.plan.render.toUpperCase()} → ${event.plan.target} (${event.plan.reason})`
+    case 'done':
+      return `✓ ${event.result.productionGrade ? 'production-grade' : 'prototype'} in ${event.result.passes} pass(es)`
+  }
+}
+
+function truncate(text: string, max = 100): string {
+  const flat = text.replace(/\s+/g, ' ').trim()
+  return flat.length > max ? flat.slice(0, max - 1) + '…' : flat
+}

--- a/packages/framework/src/fake-script.ts
+++ b/packages/framework/src/fake-script.ts
@@ -1,0 +1,55 @@
+import type { FrameworkSignals } from '@gemstack/ai-autopilot'
+import { FakeDriver, type FakeTurn } from './driver/index.js'
+import type { DeployDecision } from './run.js'
+
+/**
+ * The deterministic `--fake` scenario: a small Vike + universal-orm orders app.
+ * It wires a {@link FakeDriver} whose scripted turns walk the exact prompt order
+ * the flow issues (architect JSON, build summary, checklist-with-blocker,
+ * improve, clean checklist), so the whole scope -> deploy flow runs offline with
+ * no CLI and no model, ending production-grade. Mirrors the ai-autopilot
+ * bootstrap-quickstart, but driven entirely *through* the driver seam.
+ */
+
+/** The default intent the `--fake` demo builds. */
+export const FAKE_INTENT = 'A paginated orders page backed by an orders table, with sign-in.'
+
+/** Deps that make the Vike preset win detection in the demo. */
+export const FAKE_SIGNALS: FrameworkSignals = {
+  dependencies: { 'vike-react': '1.0.0', react: '18.0.0', '@universal-orm/core': '1.0.0' },
+}
+
+/** The deploy decision narrated at the end of the demo. */
+export const FAKE_DEPLOY: DeployDecision = {
+  render: 'ssr',
+  target: 'cloudflare',
+  reason: 'per-request orders data + server-side auth',
+}
+
+const ARCHITECT = {
+  stack: 'Vike + universal-orm on Postgres, with vike-auth',
+  narration: 'Server-rendered orders app: Vike pages, a universal-orm data layer, sessions via vike-auth.',
+  decisions: [
+    { choice: 'universal-orm on Postgres', why: 'the orders catalog is relational and needs typed queries' },
+    { choice: 'SSR over SPA', why: 'orders need per-request data and auth on the server' },
+  ],
+}
+
+const TURNS: FakeTurn[] = [
+  { text: '```json\n' + JSON.stringify(ARCHITECT) + '\n```', actions: ['Read'] },
+  {
+    text: 'Built the orders app: an orders schema and migration, a paginated /orders page, and a sign-in stub.',
+    actions: ['Write', 'Write', 'Bash'],
+  },
+  {
+    text: 'Reviewed the app.\n```json\n{ "blockers": ["No authentication on the orders page yet"] }\n```',
+    actions: ['Read', 'Grep'],
+  },
+  { text: 'Added a +guard to the orders page (vike-auth) so it requires a signed-in user.', actions: ['Edit'] },
+  { text: 'Reviewed again.\n```json\n{ "blockers": [] }\n```', actions: ['Read'] },
+]
+
+/** Build the scripted {@link FakeDriver} for the demo. */
+export function fakeDriver(): FakeDriver {
+  return new FakeDriver({ turns: TURNS, sessionId: 'fake-orders-app' })
+}

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -1,0 +1,58 @@
+/**
+ * `@gemstack/framework` — **The (AI) Framework**: turnkey, zero-config AI
+ * orchestration. It wraps a coding-agent CLI (Claude Code today) as a **black
+ * box** and takes a user from an idea to a running app, with a localhost
+ * dashboard that foregrounds the orchestration the agent's own chat cannot show.
+ *
+ * The whole product is built on `@gemstack/ai-autopilot`'s already-shipped
+ * spine (bootstrap, the loop, the decisions ledger, presets, deploy targets);
+ * this package adds the two missing pieces from #166: the **driver** seam that
+ * wraps the agent, and the **product shell** (CLI + dashboard) that drives it.
+ *
+ * ## Driver seam
+ * The one abstraction we wrap a coding-agent CLI behind. We prompt it, let its
+ * own loop run, read the code, and gate on the outcome (guardrail: the seam is
+ * the code, never the agent's tool calls). Swappable, so Codex / opencode slot
+ * in behind the same three methods.
+ *
+ * - {@link Driver} / {@link DriverSession} — the contract
+ * - {@link ClaudeCodeDriver} — the first real driver (`claude -p` stream-json)
+ * - {@link FakeDriver} — deterministic offline driver for `--fake` / tests
+ *
+ * ## Driver-backed steps
+ * ai-autopilot's `Bootstrap` steps, re-implemented to run everything *through*
+ * the driver (option A): the architect is a structured JSON decision, build /
+ * improve are prompts, the checklist gates on the `{ blockers }` verdict.
+ *
+ * - {@link driverArchitect} / {@link driverBuild} / {@link driverChecklist} / {@link driverImprove}
+ *
+ * ## Run + product shell
+ * - {@link runFramework} — detect the preset, frame the agent with its personas,
+ *   drive the whole bootstrap flow, and stream {@link FrameworkEvent}s
+ * - {@link startDashboard} — the localhost UI over the event stream
+ * - {@link runCli} / {@link parseArgs} — the `framework` command
+ */
+export * from './driver/index.js'
+export {
+  driverArchitect,
+  driverBuild,
+  driverChecklist,
+  driverImprove,
+  decideDeploy,
+  parseArchitectPlan,
+  architectPrompt,
+  buildPrompt,
+  improvePrompt,
+  PRODUCTION_GRADE_PROMPT,
+  type DriverStepOptions,
+} from './steps.js'
+export { runFramework, type RunFrameworkOptions, type RunFrameworkResult, type DeployDecision } from './run.js'
+export { type FrameworkEvent, formatFrameworkEvent } from './events.js'
+export { startDashboard, dashboardHtml, type Dashboard, type DashboardOptions } from './dashboard/index.js'
+export { runCli, parseArgs, type CliIO, type CliOptions } from './cli.js'
+export {
+  fakeDriver,
+  FAKE_INTENT,
+  FAKE_SIGNALS,
+  FAKE_DEPLOY,
+} from './fake-script.js'

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -1,0 +1,49 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { runFramework } from './run.js'
+import { FAKE_DEPLOY, FAKE_INTENT, FAKE_SIGNALS, fakeDriver } from './fake-script.js'
+import type { FrameworkEvent } from './events.js'
+
+test('runFramework drives the whole flow through the driver, offline, to production-grade', async () => {
+  const events: FrameworkEvent[] = []
+  const { result, detection } = await runFramework({
+    intent: FAKE_INTENT,
+    driver: fakeDriver(),
+    cwd: '/tmp/ws',
+    signals: FAKE_SIGNALS,
+    deploy: FAKE_DEPLOY,
+    onEvent: e => events.push(e),
+  })
+
+  // Preset detection picked Vike from the deps.
+  assert.equal(detection.framework, 'Vike')
+
+  // The full-fledged loop blocked once (no auth) then cleared.
+  assert.equal(result.productionGrade, true)
+  assert.equal(result.passes, 2)
+  assert.deepEqual(result.blockers, [])
+
+  // The architect's choices were recorded and narrated.
+  const architect = events.find(e => e.kind === 'bootstrap' && e.event.type === 'architect')
+  assert.ok(architect)
+
+  // The deploy phase decided SSR -> cloudflare.
+  assert.equal(result.deploy?.plan.target, 'cloudflare')
+
+  // We surfaced the wrapped agent's own progress and framed with personas.
+  assert.ok(events.some(e => e.kind === 'driver'))
+  assert.ok(events.some(e => e.kind === 'session' && e.fake === true))
+  assert.equal(events.at(-1)!.kind, 'end')
+})
+
+test('runFramework prototype scope skips the full-fledged loop', async () => {
+  const { result } = await runFramework({
+    intent: 'a quick landing page',
+    scope: 'prototype',
+    driver: fakeDriver(),
+    cwd: '/tmp/ws',
+    signals: FAKE_SIGNALS,
+  })
+  assert.equal(result.passes, 0)
+  assert.equal(result.productionGrade, false)
+})

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -1,0 +1,130 @@
+import {
+  Bootstrap,
+  DecisionLedger,
+  builtinPresetRegistry,
+  personaInstructions,
+  presetPersonas,
+  type BootstrapEvent,
+  type BootstrapResult,
+  type BootstrapScope,
+  type FrameworkDetection,
+  type FrameworkSignals,
+} from '@gemstack/ai-autopilot'
+import type { Driver, DriverSession } from './driver/index.js'
+import { decideDeploy, driverArchitect, driverBuild, driverChecklist, driverImprove } from './steps.js'
+import type { FrameworkEvent } from './events.js'
+
+/** The deploy decision to narrate at the end (plan-only in v1: it does not ship). */
+export interface DeployDecision {
+  render: 'ssr' | 'ssg' | 'spa'
+  target: string
+  reason: string
+}
+
+/** Options for {@link runFramework}. */
+export interface RunFrameworkOptions {
+  /** What the user wants built (the one scope question's answer). */
+  intent: string
+  /** How much app: a quick prototype (no full-fledged loop) or the full thing. Default `"full"`. */
+  scope?: BootstrapScope
+  /** The wrapped coding agent. */
+  driver: Driver
+  /** Absolute workspace path the agent builds in. */
+  cwd: string
+  /** Model id to pass through to the driver. */
+  model?: string
+  /** Signals for preset detection (deps/files). Default: none, so the flagship preset wins. */
+  signals?: FrameworkSignals
+  /** Max full-fledged passes. Default 3 (ai-autopilot's default). */
+  maxPasses?: number
+  /** A deploy decision to narrate at the end. Omit to skip the deploy phase. */
+  deploy?: DeployDecision
+  /** A claude.ai/code (or other) link to the live agent session, for the dashboard. */
+  sessionLink?: string
+  /** Interrupt the run between phases. */
+  signal?: AbortSignal
+  /** Observe the unified event stream. */
+  onEvent?: (event: FrameworkEvent) => void
+}
+
+/** What a run returns. */
+export interface RunFrameworkResult {
+  result: BootstrapResult
+  detection: FrameworkDetection
+  events: FrameworkEvent[]
+  ledger: DecisionLedger
+}
+
+/**
+ * Run the whole turnkey flow: detect the framework preset, frame the wrapped
+ * agent with that preset's personas, then drive ai-autopilot's `Bootstrap`
+ * (scope → architect → build → full-fledged loop → deploy) entirely *through*
+ * the driver (option A). Every phase, plus the agent's own progress, streams as
+ * a {@link FrameworkEvent}. Reversible: swap in a real deploy target, or a
+ * different `Driver`, without touching this wiring.
+ */
+export async function runFramework(opts: RunFrameworkOptions): Promise<RunFrameworkResult> {
+  const events: FrameworkEvent[] = []
+  const emit = (event: FrameworkEvent) => {
+    events.push(event)
+    if (opts.onEvent) {
+      try {
+        opts.onEvent(event)
+      } catch (err) {
+        console.error('[framework] onEvent threw; ignoring:', err)
+      }
+    }
+  }
+
+  // 1. Preset: detect the framework and turn its personas into prompt-framing.
+  const { preset, detection } = builtinPresetRegistry().select(opts.signals ?? {})
+  const personas = presetPersonas(preset)
+  const system = personas.map(personaInstructions).join('\n\n')
+
+  emit({
+    kind: 'session',
+    driver: opts.driver.name,
+    workspace: opts.cwd,
+    fake: opts.driver.name === 'fake',
+    ...(opts.sessionLink ? { sessionLink: opts.sessionLink } : {}),
+  })
+  emit({
+    kind: 'log',
+    message: `Detected ${detection.framework ?? preset.framework} (confidence ${detection.confidence}); framing with ${personas.length} persona(s)`,
+  })
+
+  // 2. One driver session for the whole run; each prompt is a fresh invocation.
+  const session: DriverSession = await opts.driver.start({
+    cwd: opts.cwd,
+    system,
+    ...(opts.model ? { model: opts.model } : {}),
+    ...(opts.signal ? { signal: opts.signal } : {}),
+    onEvent: event => emit({ kind: 'driver', event }),
+  })
+
+  const ledger = new DecisionLedger()
+  try {
+    const bootstrap = new Bootstrap({
+      ledger,
+      ...(opts.maxPasses ? { maxPasses: opts.maxPasses } : {}),
+      ...(opts.signal ? { signal: opts.signal } : {}),
+      onEvent: (event: BootstrapEvent) => emit({ kind: 'bootstrap', event }),
+      steps: {
+        scope: () => ({ scope: opts.scope ?? 'full', intent: opts.intent }),
+        architect: driverArchitect(session),
+        build: driverBuild(session),
+        checklist: driverChecklist(session),
+        improve: driverImprove(session),
+        ...(opts.deploy ? { deploy: decideDeploy(opts.deploy) } : {}),
+      },
+    })
+    const result = await bootstrap.run()
+    emit({ kind: 'end', ok: true })
+    return { result, detection, events, ledger }
+  } catch (err) {
+    emit({ kind: 'end', ok: false, detail: err instanceof Error ? err.message : String(err) })
+    throw err
+  } finally {
+    await session.dispose()
+  }
+}

--- a/packages/framework/src/steps.test.ts
+++ b/packages/framework/src/steps.test.ts
@@ -1,0 +1,64 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { DecisionLedger, type SupervisorEvent } from '@gemstack/ai-autopilot'
+import { FakeDriver } from './driver/index.js'
+import { driverArchitect, driverBuild, driverChecklist, driverImprove, parseArchitectPlan } from './steps.js'
+
+const PLAN = { stack: 'Vike + universal-orm', narration: 'orders app', decisions: [] }
+
+test('parseArchitectPlan reads a fenced json plan', () => {
+  const text = 'Here is the plan:\n```json\n{"stack":"Vike","narration":"n","decisions":[{"choice":"SSR","why":"data"}]}\n```'
+  const plan = parseArchitectPlan(text, 'an app')
+  assert.equal(plan.stack, 'Vike')
+  assert.deepEqual(plan.decisions, [{ choice: 'SSR', why: 'data' }])
+})
+
+test('parseArchitectPlan falls back safely on garbage', () => {
+  const plan = parseArchitectPlan('no json here', 'a blog')
+  assert.match(plan.stack, /a blog/)
+  assert.deepEqual(plan.decisions, [])
+})
+
+test('driverArchitect returns the parsed plan from the driver turn', async () => {
+  const session = await new FakeDriver({
+    turns: [{ text: '```json\n{"stack":"Next.js","narration":"n","decisions":[]}\n```' }],
+  }).start({ cwd: '/ws' })
+  const plan = await driverArchitect(session)({ intent: 'x', scope: 'full', ledger: new DecisionLedger() })
+  assert.equal(plan.stack, 'Next.js')
+})
+
+test('driverBuild emits supervisor events and returns the driver summary', async () => {
+  const session = await new FakeDriver({ turns: [{ text: 'Built the app.' }] }).start({ cwd: '/ws' })
+  const events: SupervisorEvent[] = []
+  const run = await driverBuild(session)({
+    plan: PLAN,
+    scope: 'full',
+    intent: 'orders app',
+    onEvent: e => events.push(e),
+  })
+  assert.equal(run.text, 'Built the app.')
+  assert.deepEqual(
+    events.map(e => e.type),
+    ['plan', 'dispatch-start', 'dispatch-result', 'synthesize'],
+  )
+})
+
+test('driverChecklist parses the { blockers } verdict', async () => {
+  const session = await new FakeDriver({
+    turns: [{ text: 'review\n```json\n{"blockers":["no auth"]}\n```' }],
+  }).start({ cwd: '/ws' })
+  const verdict = await driverChecklist(session)({ pass: 1, plan: PLAN, intent: 'x', blockers: [] })
+  assert.deepEqual(verdict.blockers, ['no auth'])
+})
+
+test('driverChecklist treats a verdict-less reply as passing', async () => {
+  const session = await new FakeDriver({ turns: [{ text: 'looks fine to me' }] }).start({ cwd: '/ws' })
+  const verdict = await driverChecklist(session)({ pass: 1, plan: PLAN, intent: 'x', blockers: [] })
+  assert.deepEqual(verdict.blockers, [])
+})
+
+test('driverImprove prompts the driver with the blockers', async () => {
+  const session = await new FakeDriver({ turns: [{ text: 'fixed' }] }).start({ cwd: '/ws' })
+  await driverImprove(session)({ pass: 1, plan: PLAN, intent: 'x', blockers: ['add auth'] })
+  assert.match(session.prompts[0]!, /add auth/)
+})

--- a/packages/framework/src/steps.ts
+++ b/packages/framework/src/steps.ts
@@ -1,0 +1,214 @@
+import { parseVerdict } from '@gemstack/ai-autopilot'
+import type {
+  ArchitectContext,
+  ArchitectDecision,
+  ArchitectPlan,
+  BuildContext,
+  DeployContext,
+  DeployOutcome,
+  LoopPassContext,
+  PlannedSubtask,
+  SubtaskResult,
+  SupervisorRun,
+  Verdict,
+} from '@gemstack/ai-autopilot'
+import type { DriverSession } from './driver/index.js'
+
+/**
+ * Driver-backed {@link https://github.com/gemstack-land/gemstack | Bootstrap} steps.
+ *
+ * These implement the injectable steps of ai-autopilot's `Bootstrap` by running
+ * everything *through* a {@link DriverSession} (option A, #166): the architect is
+ * a structured decision the driver returns as JSON; build / improve are prompts
+ * that let the wrapped agent's own loop do the work; the checklist re-prompts and
+ * gates on the `{ blockers }` verdict the agent ends its output with. Reusing the
+ * `Bootstrap` spine keeps scope, narration, the decisions ledger, the loop gate,
+ * and deploy for free; only *who runs the inner loop* changes.
+ */
+
+const ZERO_USAGE = { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
+
+/** Compose the architect prompt for an intent. Exported so callers can override. */
+export function architectPrompt(intent: string): string {
+  return [
+    'You are the architect for a new app. Decide the stack and the key architectural choices.',
+    `What the user wants: ${intent}`,
+    'Prefer a modern, well-supported stack. Keep the choices minimal and justified.',
+    'Respond with ONLY a fenced ```json block of the shape:',
+    '{ "stack": "<one line>", "narration": "<what you are building and why>", "decisions": [{ "choice": "<one line>", "why": "<one line>" }] }',
+  ].join('\n')
+}
+
+/** Compose the build prompt from the architect's plan. */
+export function buildPrompt(plan: ArchitectPlan, intent: string): string {
+  return [
+    `Build this app end to end: ${intent}`,
+    `Stack: ${plan.stack}`,
+    plan.narration,
+    'Create every file needed and make the app run. Follow the stack conventions.',
+    'When done, summarize what you built in one short paragraph.',
+  ].join('\n')
+}
+
+/** The default production-grade checklist prompt. Ends with a `{ blockers }` verdict. */
+export const PRODUCTION_GRADE_PROMPT = [
+  'Review the app in this workspace against a production-grade checklist:',
+  'correctness, error handling, auth where user data is involved, input validation,',
+  'sensible structure, and that it actually builds and runs.',
+  'Do NOT fix anything now. Report only.',
+  'End your reply with a fenced ```json block: { "blockers": ["<concrete work still required>", ...] }.',
+  'An empty blockers array means the app is production-grade.',
+].join('\n')
+
+/** Compose the improve prompt for a set of blockers. */
+export function improvePrompt(blockers: readonly string[]): string {
+  return [
+    'Address these blockers in the app, then stop:',
+    ...blockers.map(b => `- ${b}`),
+    'Make the smallest changes that clear them. Do not add unrelated features.',
+  ].join('\n')
+}
+
+/** Options shared by the driver-backed steps. */
+export interface DriverStepOptions {
+  /** Extra per-step framing appended to the session system prompt. */
+  system?: string
+}
+
+/**
+ * The architect step: ask the driver for a structured stack decision and parse
+ * it. A single small structured decision, exactly what option A reserves this
+ * shape for (returned as JSON by the black box rather than a separate agent).
+ */
+export function driverArchitect(
+  session: DriverSession,
+  opts: { prompt?: (intent: string) => string } & DriverStepOptions = {},
+): (ctx: ArchitectContext) => Promise<ArchitectPlan> {
+  const compose = opts.prompt ?? architectPrompt
+  return async ctx => {
+    const turn = await session.prompt(compose(ctx.intent), {
+      ...(opts.system ? { system: opts.system } : {}),
+      ...(ctx.signal ? { signal: ctx.signal } : {}),
+    })
+    return parseArchitectPlan(turn.text, ctx.intent)
+  }
+}
+
+/**
+ * The build step: prompt the driver to build the app and let its own loop run.
+ * Emits synthetic Supervisor events so the bootstrap narration still shows a
+ * build phase, and returns a {@link SupervisorRun} carrying the driver's summary.
+ */
+export function driverBuild(
+  session: DriverSession,
+  opts: { prompt?: (plan: ArchitectPlan, intent: string) => string } & DriverStepOptions = {},
+): (ctx: BuildContext) => Promise<SupervisorRun> {
+  const compose = opts.prompt ?? buildPrompt
+  return async ctx => {
+    const subtask: PlannedSubtask = { id: 'build-1', description: `Build with the wrapped agent` }
+    ctx.onEvent({ type: 'plan', task: ctx.intent, subtasks: [subtask] })
+    ctx.onEvent({ type: 'dispatch-start', subtask })
+
+    const turn = await session.prompt(compose(ctx.plan, ctx.intent), {
+      ...(opts.system ? { system: opts.system } : {}),
+      ...(ctx.signal ? { signal: ctx.signal } : {}),
+    })
+
+    const result: SubtaskResult = { subtask, text: turn.text, ok: true, usage: ZERO_USAGE }
+    ctx.onEvent({ type: 'dispatch-result', result })
+    ctx.onEvent({ type: 'synthesize', results: [result] })
+    return { text: turn.text, plan: [subtask], results: [result], usage: ZERO_USAGE, stoppedEarly: false }
+  }
+}
+
+/**
+ * The checklist step: re-prompt the driver with the production-grade checklist
+ * and parse the `{ blockers }` verdict from its output. This is the outcome
+ * gate: the loop repeats until the verdict is empty (#113 / guardrail #3).
+ */
+export function driverChecklist(
+  session: DriverSession,
+  opts: { prompt?: string } & DriverStepOptions = {},
+): (ctx: LoopPassContext) => Promise<Verdict> {
+  const prompt = opts.prompt ?? PRODUCTION_GRADE_PROMPT
+  return async ctx => {
+    const turn = await session.prompt(prompt, {
+      ...(opts.system ? { system: opts.system } : {}),
+      ...(ctx.signal ? { signal: ctx.signal } : {}),
+    })
+    // A missing verdict is treated as "reported nothing concrete": passing, so a
+    // terse agent does not wedge the loop. parseVerdict returns undefined then.
+    return parseVerdict(turn.text) ?? { blockers: [] }
+  }
+}
+
+/** The improve step: a fresh invocation that fixes the current blockers. */
+export function driverImprove(
+  session: DriverSession,
+  opts: { prompt?: (blockers: readonly string[]) => string } & DriverStepOptions = {},
+): (ctx: LoopPassContext) => Promise<void> {
+  const compose = opts.prompt ?? improvePrompt
+  return async ctx => {
+    await session.prompt(compose(ctx.blockers), {
+      ...(opts.system ? { system: opts.system } : {}),
+      ...(ctx.signal ? { signal: ctx.signal } : {}),
+    })
+  }
+}
+
+/**
+ * A minimal deploy step that only *decides* (does not ship). The real deploy
+ * targets (cloudflareTarget / dokployTarget) live in ai-autopilot and are wired
+ * by the caller; this keeps the driver flow runnable with no deploy creds.
+ */
+export function decideDeploy(
+  plan: { render: 'ssr' | 'ssg' | 'spa'; target: string; reason: string },
+): (ctx: DeployContext) => DeployOutcome {
+  return () => ({ plan, result: { deployed: false, detail: 'plan-only (no deploy target wired)' } })
+}
+
+/**
+ * Parse the architect's JSON out of a driver turn, with safe fallbacks so a
+ * loose reply never crashes the flow. Exported for testing.
+ */
+export function parseArchitectPlan(text: string, intent: string): ArchitectPlan {
+  const obj = lastJsonObject(text)
+  const stack = typeof obj?.['stack'] === 'string' && obj['stack'].trim() ? obj['stack'].trim() : `A sensible stack for: ${intent}`
+  const narration =
+    typeof obj?.['narration'] === 'string' && obj['narration'].trim() ? obj['narration'].trim() : `Building: ${intent}`
+  const decisions = Array.isArray(obj?.['decisions'])
+    ? (obj['decisions'] as unknown[]).flatMap(coerceDecision)
+    : []
+  return { stack, narration, decisions }
+}
+
+function coerceDecision(value: unknown): ArchitectDecision[] {
+  if (typeof value !== 'object' || value === null) return []
+  const obj = value as Record<string, unknown>
+  const choice = typeof obj['choice'] === 'string' ? obj['choice'].trim() : ''
+  const why = typeof obj['why'] === 'string' ? obj['why'].trim() : ''
+  return choice && why ? [{ choice, why }] : []
+}
+
+const FENCE = /```(?:[a-zA-Z0-9]*)\n([\s\S]*?)```/g
+
+/** Extract the last JSON object from text: last fenced block, else a trailing `{...}`. */
+function lastJsonObject(text: string): Record<string, unknown> | undefined {
+  if (!text) return undefined
+  const candidates: string[] = []
+  for (const m of text.matchAll(FENCE)) candidates.push(m[1]!)
+  const open = text.lastIndexOf('{')
+  const close = text.lastIndexOf('}')
+  if (open !== -1 && close > open) candidates.push(text.slice(open, close + 1))
+  for (let i = candidates.length - 1; i >= 0; i--) {
+    try {
+      const parsed = JSON.parse(candidates[i]!.trim())
+      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>
+      }
+    } catch {
+      // try the next candidate
+    }
+  }
+  return undefined
+}

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/framework/tsconfig.json
+++ b/packages/framework/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "noEmit": true, "rootDir": "src" },
+  "include": ["src"]
+}

--- a/packages/framework/tsconfig.test.json
+++ b/packages/framework/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist-test", "rootDir": "src" },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,19 @@ importers:
         specifier: ^5.4.0
         version: 5.9.3
 
+  packages/framework:
+    dependencies:
+      '@gemstack/ai-autopilot':
+        specifier: workspace:^
+        version: link:../ai-autopilot
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.43
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+
   packages/mcp:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
Closes #166.

The product layer the announcement promises: `npm i -g @gemstack/framework` giving a CLI that wraps Claude Code, plus a localhost dashboard. Built on the ai-autopilot spine, so nothing is rewritten.

**Driver seam** (the swappable part). We wrap a coding-agent CLI as a black box: prompt it, let its own loop run, read the code, gate on the outcome, re-prompt. The seam is the code, never the tool calls. `ClaudeCodeDriver` = `claude -p` stream-json (fresh invocation per loop pass); `FakeDriver` = deterministic offline. Codex/opencode slot in behind the same 3 methods later.

**Single execution path** (option A on #166). Everything runs through the driver: architect = a small JSON decision, build/improve = prompts, the production-grade checklist gates on the `{ blockers }` verdict the agent ends with.

**Dashboard.** node:http + SSE over an event stream we own. Foregrounds what the agent's chat can't: chosen stack + why, loop status + blockers, decisions ledger, live-session link.

**Verify.** 27 tests. `framework --fake` runs the whole flow offline (Vike orders app to production-grade in 2 passes); live dashboard smoke passes. Live path needs `claude` on PATH.

```
framework "a blog with comments"
framework --fake
```

Canonical name pinned: `@gemstack/framework`. First publish ships 0.1.0 (changeset included).