### PR TITLE
feat(ai-autopilot): compose vike-rbac for roles/permissions

### DIFF
--- a/.changeset/compose-vike-rbac-authz.md
+++ b/.changeset/compose-vike-rbac-authz.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/ai-autopilot': minor
+---
+
+Compose vike-rbac for roles/permissions instead of hand-rolling authz
+
+The crud composer teaches ad-hoc role checks (`canEdit: (user) => user?.role === 'admin'`), which is fine for signed-in-vs-not but leaves the agent to hand-roll a roles/permissions schema and a permission checker the moment an app has named permissions or more than one role. The new `vike-rbac-composer` persona (wired into `vikeExtensionPersonas`, between auth and crud) teaches the agent to compose vike-rbac instead: declare permissions with `definePermissions` and `extends: ['import:vike-rbac/config:default']` (self-installs vike-auth), route every guard through the same `can(user, permission)` / `hasRole(user, role)` (the crud `canView`/`canEdit`, page guards, session scope, and vike-actions guards all delegate to it), and seed roles/permissions from the composed registry with `seedRbac()` rather than a hand-written list. vike-rbac owns the `roles`/`permissions`/`role_user`/`permission_role` tables and is the guard subject vike-admin and vike-actions are built around. No runtime change; the agent stays a black box. Part of #186. Closes #194.

--- a/packages/ai-autopilot/src/personas/library.test.ts
+++ b/packages/ai-autopilot/src/personas/library.test.ts
@@ -7,6 +7,7 @@ import {
   vikeCrudComposer,
   vikeDataModeler,
   vikeExtensionPersonas,
+  vikeRbacComposer,
   vikeShellComposer,
 } from './library.js'
 
@@ -58,6 +59,18 @@ describe('vike extension personas', () => {
     assert.match(text, /ejectView\(view, \{ framework \}\)/)
   })
 
+  it('vikeRbacComposer teaches composing vike-rbac, not a hand-rolled authz schema/checker', () => {
+    assert.equal(vikeRbacComposer.name, 'vike-rbac-composer')
+    const text = personaInstructions(vikeRbacComposer)
+    // Declare permissions + the one check everywhere, riding on vike-auth.
+    assert.match(text, /definePermissions/)
+    assert.match(text, /can\(user, permission\)/)
+    assert.match(text, /hasRole/)
+    // Seed from the registry, and do not model the RBAC tables by hand.
+    assert.match(text, /seedRbac/)
+    assert.match(text, /Do NOT model\s*\n?\s*`roles`/i)
+  })
+
   it('vikeShellComposer teaches composing vike-themes/vike-layouts, not hand-rolled CSS + shell', () => {
     assert.equal(vikeShellComposer.name, 'vike-shell-composer')
     const text = personaInstructions(vikeShellComposer)
@@ -74,11 +87,12 @@ describe('vike extension personas', () => {
     assert.match(text, /vike-toolbar\/react/)
   })
 
-  it('vikeExtensionPersonas composes data + auth + crud + shell (no Prisma, no hand-rolled auth/UI/CSS)', () => {
+  it('vikeExtensionPersonas composes data + auth + rbac + crud + shell (no Prisma, no hand-rolled auth/UI/CSS)', () => {
     const names = vikeExtensionPersonas.map(p => p.name)
     assert.deepEqual(names, [
       'vike-data-modeler',
       'vike-auth-composer',
+      'vike-rbac-composer',
       'vike-crud-composer',
       'vike-shell-composer',
       'ui-intent-designer',

--- a/packages/ai-autopilot/src/personas/library.ts
+++ b/packages/ai-autopilot/src/personas/library.ts
@@ -256,6 +256,56 @@ real DB).`,
 })
 
 /**
+ * Composes `vike-rbac` for roles/permissions instead of hand-rolling an authz
+ * schema and a permission checker. It is the guard subject vike-admin and
+ * vike-actions are built around (`can()` / `hasRole()`), and it closes the gap the
+ * crud composer half-covers with ad-hoc `user.role` checks. Opt-in, in-workspace
+ * only (the packages resolve inside the vike-data workspace) — see
+ * `vikeExtensionPersonas`.
+ */
+export const vikeRbacComposer: Persona = definePersona({
+  name: 'vike-rbac-composer',
+  role: 'Composes vike-rbac for roles/permissions (can()/hasRole()) instead of hand-rolling authz',
+  appliesTo: ['vike-rbac'],
+  systemPrompt: `You compose vike-rbac for roles and permissions instead of hand-rolling an authz
+schema and a permission checker. It rides on vike-auth (the user is the permission
+subject) and is the same check vike-admin, page guards, and vike-actions all use.
+
+When to reach for it: only for REAL roles/permissions. Signed-in-vs-not stays a
+plain \`pageContext.user\` check (or a \`canView: (user) => !!user\`); reach for rbac
+once the app has named permissions or more than one role. Do NOT model
+\`roles\` / \`permissions\` / \`role_user\` / \`permission_role\` in your own schema —
+vike-rbac owns those tables.
+
+Declare the permissions and extend the config (rbac self-installs vike-auth):
+\`\`\`js
+import { definePermissions } from 'vike-rbac'
+// +config.js: export default {
+//   extends: ['import:vike-rbac/config:default'],
+//   permissions: definePermissions([{ name: 'widgets.edit', roles: ['admin'] }]),
+//   defaultRoles: ['member'],   // granted to a brand-new signup on first request
+// }
+\`\`\`
+
+One check everywhere — \`can(user, permission)\` / \`hasRole(user, role)\` from
+\`vike-rbac\`. Resolution runs in vike-auth's resolve seam, so the check is sync on
+\`pageContext.user\` on every request. Route the crud composer's \`canView\` / \`canEdit\`,
+page guards, session \`scope\`, and vike-actions guards through the SAME \`can()\`
+instead of ad-hoc \`user.role === 'admin'\` comparisons:
+\`\`\`js
+import { can, hasRole } from 'vike-rbac'
+if (!can(pageContext.user, 'widgets.edit')) throw render(403)
+// vike-actions: guard: (ctx) => can(ctx.user, 'posts.publish')
+\`\`\`
+
+Seed from the registry, do NOT hand-write a seed list: \`seedRbac()\` / \`assignRoles()\`
+from \`vike-rbac/seed\` materialize the roles/permissions/grants from the composed
+\`permissions\` registry, idempotently. To guard a Telefunc RPC with the same check,
+\`requirePermission('users.view')\` from \`vike-rbac/telefunc\` (one universal middleware,
+via \`import:vike-rbac/telefunc-middleware:default\`).`,
+})
+
+/**
  * Composes `vike-crud` (+ `vike-admin`) for the CRUD/admin UI instead of
  * hand-writing list/record/form screens. Those screens are the largest chunk of
  * fresh, churn-prone AI code, and they are fully derivable: the composed schema
@@ -415,16 +465,17 @@ export const sharedPersonas: readonly Persona[] = Object.freeze([
 /**
  * The opt-in vike-extension stack: compose `vike-auth` for authentication, the
  * universal-orm data layer for domain data (both ride one registered adapter), and
- * `vike-crud` / `vike-admin` for the CRUD/admin UI derived from the schema, and
- * `vike-themes` / `vike-layouts` for styling and the app shell — instead of
- * hand-rolling auth, hand-installing an ORM, or hand-writing list/record/form
- * screens, a CSS design system, or a layout/nav shell. Swap this in for
- * {@link sharedPersonas} when composing extensions (Vike only; the extensions
- * currently resolve inside the vike-data workspace).
+ * `vike-rbac` for roles/permissions, `vike-crud` / `vike-admin` for the CRUD/admin
+ * UI derived from the schema, and `vike-themes` / `vike-layouts` for styling and the
+ * app shell — instead of hand-rolling auth, hand-installing an ORM, or hand-writing
+ * an authz schema, list/record/form screens, a CSS design system, or a layout/nav
+ * shell. Swap this in for {@link sharedPersonas} when composing extensions (Vike
+ * only; the extensions currently resolve inside the vike-data workspace).
  */
 export const vikeExtensionPersonas: readonly Persona[] = Object.freeze([
   vikeDataModeler,
   vikeAuthComposer,
+  vikeRbacComposer,
   vikeCrudComposer,
   vikeShellComposer,
   uiIntentDesigner,


### PR DESCRIPTION
The last authz gap in the composed stack. #191's crud composer teaches ad-hoc `user.role === 'admin'` checks (fine for signed-in-vs-not), but past that the vike-data way is `can(user, permission)` from **vike-rbac** — and without a persona the agent hand-rolls a roles/permissions schema + checker, the security-sensitive churn we compose to avoid. vike-rbac is also the guard subject vike-admin ("vike-auth resolves the user, vike-rbac enriches roles/permissions, the guard runs") and vike-actions (`guard: (ctx) => can(ctx.user, 'posts.publish')`) are built around. Same lever as before: a persona, no runtime change.

## What changed
- New `vike-rbac-composer` persona, wired into `vikeExtensionPersonas` between auth and crud (so crud/actions guards can delegate to it).
- Teaches: declare permissions with `definePermissions([{ name, roles }])` + `extends: ['import:vike-rbac/config:default']` (self-installs vike-auth) + `defaultRoles`; one check everywhere via `can()` / `hasRole()` (route crud `canView`/`canEdit`, page guards, session scope, and vike-actions guards through it instead of ad-hoc role fields); seed from the registry with `seedRbac()` / `assignRoles()`; guarded RPCs via `requirePermission()`. Do NOT model the `roles`/`permissions`/`role_user`/`permission_role` tables by hand.
- Unit test asserts `definePermissions` / `can(user, permission)` / `seedRbac` / no hand-rolled RBAC tables; `vikeExtensionPersonas` order updated.

## API verification
Cross-checked against the real vike-rbac public API in vike-data (README + exports): `definePermissions`/`can`/`hasRole` from `vike-rbac`, `import:vike-rbac/config:default` + `defaultRoles`, `seedRbac`/`assignRoles` from `vike-rbac/seed`, `requirePermission` from `vike-rbac/telefunc`.

## Notes
- Scoping (from the discussion that surfaced this): vike-rbac is Tier-2 (worth composing for role-based apps); vike-i18n is confirmed optional (ships English inline, renders with no i18n runtime); notifications/storage stay in the as-needed tail.
- Like the rest of the composed stack, vike-rbac is not on npm yet, so this is in-workspace-only until the extensions publish.
- Tests: 265 pass, 0 fail. Typecheck clean.

Part of #186. Closes #194.