### PR TITLE
refactor: dedup neutral guardrail persona + flatten run.ts wiring

### DIFF
--- a/packages/ai-autopilot/src/personas/library.ts
+++ b/packages/ai-autopilot/src/personas/library.ts
@@ -453,13 +453,21 @@ style it with the theme's CSS variables so it tracks light/dark and the brand.`,
 })
 
 /**
+ * The framework- and path-neutral guardrails that apply on every path — plain
+ * Prisma or composed extensions, Vike or Next. Kept as one named tail so both
+ * {@link sharedPersonas} and {@link vikeExtensionPersonas} spread it instead of
+ * re-listing it, and adding a neutral guardrail can't silently drop from a path.
+ */
+const neutralGuardrails: readonly Persona[] = Object.freeze([uiIntentDesigner])
+
+/**
  * The framework-neutral personas shared by every preset — the data layer and the
  * intent-based UI guardrail apply the same whether the app is on Vike or Next.
  * A preset adds its framework-specific page builder on top (see the presets seam).
  */
 export const sharedPersonas: readonly Persona[] = Object.freeze([
   dataModeler,
-  uiIntentDesigner,
+  ...neutralGuardrails,
 ])
 
 /**
@@ -478,7 +486,7 @@ export const vikeExtensionPersonas: readonly Persona[] = Object.freeze([
   vikeRbacComposer,
   vikeCrudComposer,
   vikeShellComposer,
-  uiIntentDesigner,
+  ...neutralGuardrails,
 ])
 
 /** All built-in stack personas (the Vike stack), in a stable order. */

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -236,6 +236,7 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
   // nothing (its whole workspace is always "empty"), so it opts out to stay
   // deterministic.
   const verifyWorkspace = opts.driver.name !== 'fake'
+  const workspaceOpt = verifyWorkspace ? { verifyWorkspace: true } : {}
 
   const ledger = new DecisionLedger()
   let preview: AppPreview | undefined
@@ -248,14 +249,16 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
       steps: {
         scope: () => ({ scope: opts.scope ?? 'full', intent: opts.intent }),
         architect: driverArchitect(session),
-        build: driverBuild(session, verifyWorkspace ? { verifyWorkspace: true } : {}),
+        build: driverBuild(session, workspaceOpt),
         checklist,
-        improve: driverImprove(session, verifyWorkspace ? { verifyWorkspace: true } : {}),
-        ...(opts.deploy && opts.deployTarget
-          ? { deploy: deployWith(opts.deploy, opts.deployTarget) }
-          : opts.deploy
-            ? { deploy: decideDeploy(opts.deploy) }
-            : {}),
+        improve: driverImprove(session, workspaceOpt),
+        ...(opts.deploy
+          ? {
+              deploy: opts.deployTarget
+                ? deployWith(opts.deploy, opts.deployTarget)
+                : decideDeploy(opts.deploy),
+            }
+          : {}),
       },
     })
     const result = await bootstrap.run()


### PR DESCRIPTION
Internal quality pass over the compose-personas code. No behavior change; typecheck + tests green (ai-autopilot 265, framework 57).

## What
- **personas/library.ts** — `uiIntentDesigner` was hand-listed in both `sharedPersonas` and `vikeExtensionPersonas`. Named the path-neutral tail once (`neutralGuardrails`) and spread it into both. Emitted persona order is byte-identical; the "neutral guardrails apply on every path" invariant is now structural instead of copy-maintained.
- **framework/src/run.ts** — hoisted the duplicated `verifyWorkspace ? { verifyWorkspace: true } : {}` (used by the build and improve steps) into one const, and flattened the deploy step's double-nested ternary that tested `opts.deploy` twice into a single top-level branch.

No user-facing surface changed, so no changeset.

Closes #196