### PR TITLE
docs: document the compose personas, --compose-extensions, and the publish gate

### DIFF
--- a/.changeset/help-compose-extensions-full-set.md
+++ b/.changeset/help-compose-extensions-full-set.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/framework': patch
+---
+
+Fix the `--compose-extensions` help text to name the full composer set
+
+The `framework --help` output described `--compose-extensions` as composing "vike-auth for auth" only, but the flag frames the agent with the whole vike-* composer set: auth, the universal-orm data layer, rbac, crud/admin, and themes/layouts. The help text now names them accurately.

--- a/packages/ai-autopilot/README.md
+++ b/packages/ai-autopilot/README.md
@@ -43,12 +43,12 @@ Each stage is a plain function, so you mix LLM and deterministic logic freely:
 ## Personas — the stack-aware layer
 
 The Supervisor is stack-agnostic. **Personas** add the opinionated knowledge that
-makes autopilot know the GemStack stack (Vike + universal-orm) instead of
+makes autopilot know the GemStack stack (Vike + Prisma) instead of
 guessing. A persona is *data*: a name, a one-line role, a system-prompt fragment,
 and the skills/tools it brings (composed over [`@gemstack/ai-skills`](https://github.com/gemstack-land/gemstack/tree/main/packages/ai-skills)).
 
 Three are built in: `vikePageBuilder` (Vike `+` file conventions, renderer-agnostic),
-`universalOrmModeler` (schema-first data, derived migrations), and
+`dataModeler` (schema-first data on Prisma, derived migrations), and
 `uiIntentDesigner` — the "declare intent, decouple implementation" guardrail that
 expresses UI as intent so an AI can't hardcode the wrong markup.
 
@@ -69,6 +69,20 @@ await supervisor.run('Add a paginated orders page backed by an orders table')
 Define your own with `definePersona({ name, role, systemPrompt, skills?, tools? })`,
 or materialize a single persona into an agent with `personaAgent(persona)`. Because
 a persona is data, it can be inspected and listed without building an agent first.
+
+### Composing vike-* extensions (opt-in)
+
+For a Vike app, an opt-in set swaps the hand-rolled default for personas that
+**compose** the vike-* extensions instead of reinventing them: `vikeAuthComposer`
+(vike-auth for identity/sessions), `vikeDataModeler` (the universal-orm data layer),
+`vikeRbacComposer` (vike-rbac roles/permissions), `vikeCrudComposer`
+(vike-crud/vike-admin for schema-derived CRUD + admin UI), and `vikeShellComposer`
+(vike-themes/vike-layouts for styling and the app shell), plus the shared
+`uiIntentDesigner` guardrail. They ship as the `vikeExtensionPersonas` array.
+
+This path is opt-in because the vike-* packages currently resolve only inside the
+vike-data workspace (they are not published to npm), so the default `stackPersonas`
+path stays publish-safe. `@gemstack/framework` exposes it as `--compose-extensions`.
 
 ## Runner — the pluggable execution seam
 

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -66,6 +66,7 @@ framework --fake               Offline demo (no CLI, no model, deterministic).
   --cwd <dir>            Workspace the agent builds in (default: cwd).
   --model <id>           Model to pass through to the wrapped agent.
   --scope <prototype|full>   How much app to build (default: full).
+  --compose-extensions   Compose the vike-* extensions instead of hand-rolling them (Vike-only, opt-in).
   --deploy <target>      Narrate a deploy decision (e.g. cloudflare, dokploy).
   --port <n>             Dashboard port (default: 4477).
   --no-dashboard         Run headless.
@@ -74,6 +75,18 @@ framework --fake               Offline demo (no CLI, no model, deterministic).
 
 The live path needs the Claude Code CLI installed (`claude` on `PATH`). The
 `--fake` path needs neither a CLI nor a model, so it is what CI runs.
+
+## Composing vike-* extensions
+
+By default the agent hand-rolls auth and models data with Prisma, a fully
+publish-safe stack. Pass `--compose-extensions` (Vike-only) to instead frame the
+agent with the **composer personas**: compose vike-auth for identity, the
+universal-orm data layer for domain data, vike-rbac for roles/permissions,
+vike-crud/vike-admin for schema-derived CRUD + admin UI, and vike-themes/vike-layouts
+for styling and the app shell, rather than reinventing each. It is opt-in because
+those vike-* packages currently resolve only inside the vike-data workspace, so the
+default path is the one that stays publishable. See `@gemstack/ai-autopilot`'s
+`vikeExtensionPersonas`.
 
 ## Status
 

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -34,9 +34,10 @@ Options:
   --cwd <dir>            Workspace the agent builds in (default: current directory).
   --model <id>           Model to pass through to the wrapped agent.
   --scope <prototype|full>   How much app to build (default: full).
-  --compose-extensions   Compose the vike-* extensions (vike-auth for auth) instead
-                         of hand-rolling them. Vike-only; extensions resolve in the
-                         vike-data workspace (default: off, hand-rolled + Prisma).
+  --compose-extensions   Compose the vike-* extensions (auth, data, rbac, crud,
+                         themes/layouts) instead of hand-rolling them. Vike-only;
+                         extensions resolve in the vike-data workspace
+                         (default: off, hand-rolled + Prisma).
   --max-passes <n>       Full-fledged loop pass budget (default: 5).
   --permission-mode <mode>   Claude Code permission mode: default | acceptEdits |
                              bypassPermissions | plan (default: acceptEdits).


### PR DESCRIPTION
Pass-4 docs alignment: the compose-personas work shipped but the docs never caught up. Docs-only; framework tests green (57).

## Fixed drift
- **ai-autopilot/README.md** - the Personas section named a nonexistent `universalOrmModeler` and called the default stack "Vike + universal-orm". The built-in data persona is `dataModeler` (Prisma) and the code's canonical default is "Vike + Prisma" (`steps.ts`, `index.ts`, `library.ts`). Corrected both, and added a short "Composing vike-* extensions (opt-in)" subsection documenting the `vikeExtensionPersonas` set (auth, data, rbac, crud, themes/layouts + the neutral guardrail) and the publish gate.
- **framework/README.md** - added `--compose-extensions` to the CLI list and a "Composing vike-* extensions" section explaining the composer path and why it is opt-in (publish-safe default).
- **framework/src/cli.ts** - the `--help` text described the flag as "vike-auth for auth" only; it now names the full set. Patch changeset since it changes user-facing `--help` output.

## Out of scope (flagged, not fixed here)
"Vike + universal-orm" also appears across the 7 shipped prompt bodies (`prompts/*.md`) and test fixtures, while the code default is Prisma. That is a separate, agent-facing inconsistency (the prompt bodies steer the reviewer's assumed stack) that predates this work and needs a product call on whether the default is Prisma or universal-orm. Happy to take it as a follow-up.

Closes #200