### PR TITLE
fix: enforce the Vike-only constraint on --compose-extensions

### DIFF
--- a/.changeset/compose-extensions-vike-only-guard.md
+++ b/.changeset/compose-extensions-vike-only-guard.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/framework': patch
+---
+
+Enforce the Vike-only constraint on `--compose-extensions`
+
+`--compose-extensions` is documented as Vike-only, but `runFramework` applied the vike-* composer personas regardless of the detected preset, so a Next project would be framed with `nextPageBuilder` plus composers telling the agent to install vike-auth/vike-crud/etc.: an incoherent prompt. It now gates compose on the Vike preset and, on any other preset, falls back to the hand-rolled + Prisma path and emits a log explaining why.

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -127,6 +127,28 @@ test('--compose-extensions frames the agent with vike-auth, not hand-rolled auth
   assert.match(system(), /npm install vike-auth/)
 })
 
+test('--compose-extensions is ignored on a non-Vike preset and falls back with a log (#202)', async () => {
+  const events: FrameworkEvent[] = []
+  const { driver, system } = recordingDriver()
+  const { detection } = await runFramework({
+    intent: FAKE_INTENT,
+    driver,
+    cwd: '/tmp/ws',
+    signals: { dependencies: ['next'] }, // detect Next, not Vike
+    composeExtensions: true,
+    onEvent: e => events.push(e),
+  })
+
+  // The vike-* extensions are Vike-only, so a Next project does not get them.
+  assert.equal(detection.framework, 'Next.js')
+  assert.doesNotMatch(system(), /vike-auth/)
+  // And we say why, rather than silently framing Next with vike composers.
+  assert.ok(
+    events.some(e => e.kind === 'log' && /--compose-extensions ignored/.test(e.message)),
+    'expected a log explaining the compose fallback',
+  )
+})
+
 test('without --compose-extensions the default framing has no vike-auth (publish-safe)', async () => {
   const { driver, system } = recordingDriver()
   await runFramework({

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -163,11 +163,21 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
   }
 
   // 1. Preset: detect the framework and turn its personas into prompt-framing.
-  // With --compose-extensions, swap the shared personas for the vike-extension
-  // set (compose vike-auth/vike-rbac/vike-crud/vike-themes + the universal-orm
-  // data layer instead of hand-rolling them); default keeps Prisma.
+  // --compose-extensions swaps the shared personas for the vike-extension set
+  // (compose vike-auth/vike-rbac/vike-crud/vike-themes + the universal-orm data
+  // layer instead of hand-rolling them); default keeps Prisma. The extensions
+  // are Vike-only and resolve only in the vike-data workspace, so guard it: on a
+  // non-Vike preset, fall back to the hand-rolled + Prisma path and say why
+  // rather than framing (e.g.) Next with vike composers.
   const { preset, detection } = builtinPresetRegistry().select(opts.signals ?? {})
-  const personas = opts.composeExtensions
+  const composeExtensions = opts.composeExtensions === true && preset.name === 'vike'
+  if (opts.composeExtensions && !composeExtensions) {
+    emit({
+      kind: 'log',
+      message: `--compose-extensions ignored: the vike-* extensions are Vike-only, but the detected preset is "${preset.name}". Using the hand-rolled + Prisma path.`,
+    })
+  }
+  const personas = composeExtensions
     ? presetPersonas(preset, vikeExtensionPersonas)
     : presetPersonas(preset)
   const system = personas.map(personaInstructions).join('\n\n')


### PR DESCRIPTION
`--compose-extensions` is documented as Vike-only, but `runFramework` applied `vikeExtensionPersonas` regardless of the detected preset. On a Next project it framed the agent with `nextPageBuilder` + the five vike-* composers telling it to install vike-auth/vike-crud/etc.: an incoherent prompt. Latent (compose defaults off; an empty dir falls back to the flagship Vike preset), but the stated contract was unenforced.

## Fix
Gate compose on `preset.name === 'vike'`. On any other preset, fall back to the hand-rolled + Prisma path and emit a log explaining why. Kept in `run.ts` at the two-line wiring level (not pushed into the preset registry, which would be speculative generality for a single extension set).

## Test
Added a case: a Next-detected project with `composeExtensions: true` gets no vike-auth framing and emits a `--compose-extensions ignored` log. Framework tests 58 pass (was 57); typecheck clean.

Found during the compose-personas quality sweep (pass 1). Patch changeset since it changes behavior on the non-Vike + compose path.

Note: touches the same `run.ts` comment block as #199, so whichever merges second may need a trivial rebase.

Closes #202