### PR TITLE
fix(framework): default the CLI to bypassPermissions so the headless loop can build/verify

### DIFF
--- a/.changeset/headless-permission-default.md
+++ b/.changeset/headless-permission-default.md
@@ -1,0 +1,23 @@
+---
+'@gemstack/framework': patch
+---
+
+Default the CLI to bypassPermissions so the headless loop can build/verify
+
+Every framework turn is a headless `claude -p` invocation, which can't answer an
+interactive approval. The driver's library default (`acceptEdits`) auto-approves
+edits but not Bash, so installs/builds/tests were silently denied: the
+production-grade checklist tried `npm run build` / dev-boot, hit "Build needs
+interactive approval which isn't available," failed pass 1 as "could not be
+executed this session," and the loop ground on listing blockers it couldn't
+verify.
+
+The `framework` CLI now defaults its Claude Code driver to `bypassPermissions` so
+the full loop (install, build, test, dev-boot) runs unattended and the checklist
+verifies for real. This is a permissive default appropriate to a headless
+autonomous builder; `--permission-mode <mode>` still overrides it (e.g.
+`--permission-mode acceptEdits` for the old, conservative behavior), and
+`--dangerously-skip-permissions` still takes precedence. The `ClaudeCodeDriver`
+library default is unchanged (still `acceptEdits`); only the CLI opts up.
+
+Closes #225.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -3,6 +3,7 @@ import { test } from 'node:test'
 import {
   buildDeployTarget,
   chooseSessionLink,
+  claudeDriverOptions,
   CLAUDE_CODE_SESSION_LIST,
   parseArgs,
   runCli,
@@ -33,6 +34,19 @@ test('parseArgs reads permission-mode and skip-permissions', () => {
   const opts = parseArgs(['--permission-mode', 'bypassPermissions', '--dangerously-skip-permissions', 'x'])
   assert.equal(opts.permissionMode, 'bypassPermissions')
   assert.equal(opts.skipPermissions, true)
+})
+
+test('claudeDriverOptions defaults the headless CLI to bypassPermissions (#225)', () => {
+  // Default run: acceptEdits would deny installs/builds/tests headlessly, so the CLI opts up.
+  assert.deepEqual(claudeDriverOptions({ skipPermissions: false }), { permissionMode: 'bypassPermissions' })
+  // An explicit --permission-mode still wins.
+  assert.deepEqual(claudeDriverOptions({ permissionMode: 'acceptEdits', skipPermissions: false }), {
+    permissionMode: 'acceptEdits',
+  })
+  // --dangerously-skip-permissions takes precedence over the mode.
+  assert.deepEqual(claudeDriverOptions({ permissionMode: 'plan', skipPermissions: true }), {
+    dangerouslySkipPermissions: true,
+  })
 })
 
 test('parseArgs persists by default and reads --resume / --no-persist (#211)', () => {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -67,7 +67,8 @@ Options:
                          auto-activate either way (default: off, hand-rolled + Prisma).
   --max-passes <n>       Full-fledged loop pass budget (default: 5).
   --permission-mode <mode>   Claude Code permission mode: default | acceptEdits |
-                             bypassPermissions | plan (default: acceptEdits).
+                             bypassPermissions | plan (default: bypassPermissions,
+                             so the headless loop can run installs/builds/tests).
   --dangerously-skip-permissions   Bypass all agent permission checks (sandboxes only).
   --serve <cmd>          Gate the loop on the app actually running (e.g. "npm run dev"),
                          then keep it serving with a preview link on the dashboard.
@@ -262,6 +263,21 @@ export function parseArgs(argv: string[]): CliOptions {
 }
 
 /**
+ * Resolve the Claude Code driver options for a live CLI run. The CLI is a
+ * headless autonomous builder: every turn is `claude -p`, which cannot answer an
+ * interactive approval. The driver's library default (`acceptEdits`) silently
+ * denies installs/builds/tests, so the production-grade checklist can never
+ * verify the app actually builds/runs (#225). Default the CLI to
+ * `bypassPermissions` so the full loop runs unattended; `--permission-mode` and
+ * `--dangerously-skip-permissions` still override.
+ */
+export function claudeDriverOptions(opts: Pick<CliOptions, 'permissionMode' | 'skipPermissions'>): ClaudeCodeDriverOptions {
+  return opts.skipPermissions
+    ? { dangerouslySkipPermissions: true }
+    : { permissionMode: opts.permissionMode ?? 'bypassPermissions' }
+}
+
+/**
  * The `framework` command. Wires the parsed options into {@link runFramework}
  * over a live dashboard + terminal narration, and resolves with an exit code.
  * Returns 0 on success, 1 on a run error, 2 on a usage error.
@@ -310,10 +326,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     }
   }
 
-  const claudeOpts: ClaudeCodeDriverOptions = {
-    ...(opts.permissionMode ? { permissionMode: opts.permissionMode } : {}),
-    ...(opts.skipPermissions ? { dangerouslySkipPermissions: true } : {}),
-  }
+  const claudeOpts = claudeDriverOptions(opts)
   const driver: Driver = fake ? fakeDriver() : new ClaudeCodeDriver(claudeOpts)
   const cwd = opts.cwd ?? (fake ? join(tmpdir(), 'framework-fake-workspace') : process.cwd())
   // The fake demo defaults to a Cloudflare deploy decision so the flow ends with


### PR DESCRIPTION
Every framework turn is a headless `claude -p`, which can't answer an interactive approval. The driver's library default (`acceptEdits`) auto-approves edits but not Bash, so installs/builds/tests get silently denied. The production-grade checklist tried `npm run build` / dev-boot, hit **"Build needs interactive approval which isn't available"**, failed pass 1 as "could not be executed this session", and the loop ground on listing blockers it couldn't verify.

**Fix:** the `framework` CLI now defaults its Claude Code driver to `bypassPermissions`, so the full headless loop (install, build, test, dev-boot) runs unattended and the checklist verifies for real. `--permission-mode` still overrides (e.g. `--permission-mode acceptEdits` for the old conservative behavior), and `--dangerously-skip-permissions` still wins. The `ClaudeCodeDriver` **library** default is unchanged (still `acceptEdits`) — only the CLI opts up.

Verified:
- `acceptEdits` denies `npm run build` headless; `bypassPermissions` runs it (isolated `claude -p` test).
- New `claudeDriverOptions()` helper + unit test (default → bypassPermissions; `--permission-mode` wins; `--dangerously-skip-permissions` wins).
- Real run against a Vike example with **default flags**: Bash runs in the build phase, zero approval blocks, exit 0. Framework 91 tests green.

**Heads-up (security posture):** this makes a default `framework` run an unattended agent that executes arbitrary Bash with no per-action approval gate — appropriate for a headless autonomous builder, but a permissive default. Flagging for your call; opt down with `--permission-mode acceptEdits`.

Closes #225.