### PR TITLE
fix(framework): fail the turn on a non-zero claude-code exit

### DIFF
--- a/.changeset/claude-code-nonzero-exit.md
+++ b/.changeset/claude-code-nonzero-exit.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Fix the Claude Code driver treating a non-zero agent exit as success when the agent had already streamed some text. A crash mid-build now fails the turn (surfacing stderr or the partial text) instead of resolving as a result the loop can score production-grade.

--- a/packages/framework/src/driver/claude-code.test.ts
+++ b/packages/framework/src/driver/claude-code.test.ts
@@ -89,6 +89,27 @@ test('runClaude rejects on a non-zero exit with no result text', async () => {
   )
 })
 
+test('runClaude rejects on a non-zero exit even when the agent streamed text', async () => {
+  const events: DriverEvent[] = []
+  const lines = [JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text: 'started building' }] } })]
+  await assert.rejects(
+    () =>
+      runClaude({
+        bin: 'claude',
+        args: [],
+        cwd: '/ws',
+        env: {},
+        prompt: 'x',
+        spawn: fakeSpawn(lines, 1),
+        emit: e => events.push(e),
+        signals: [],
+      }),
+    /exited \(1\): started building/,
+  )
+  assert.equal(events.at(-1)!.type, 'error')
+  assert.ok(!events.some(e => e.type === 'result'))
+})
+
 test('ClaudeCodeDriver builds correct CLI args (permission mode, system, model)', async () => {
   let captured: string[] = []
   const spawn: SpawnLike = (_cmd, args) => {

--- a/packages/framework/src/driver/claude-code.ts
+++ b/packages/framework/src/driver/claude-code.ts
@@ -187,10 +187,13 @@ export function runClaude(opts: RunClaudeOptions): Promise<DriverTurn> {
 
     child.on('close', code => {
       const turn = parser.result()
-      if (code !== 0 && !turn.text) {
-        const detail = stderrChunks.join('').trim() || `exit code ${code ?? 'null'}`
+      // A non-zero exit is a failed turn even when the agent streamed some text
+      // first: the loop gates on the outcome, so a crash mid-build must not pass
+      // as a result. Surface stderr, else the partial text, as context.
+      if (code !== 0) {
+        const detail = stderrChunks.join('').trim() || turn.text.trim() || `exit code ${code ?? 'null'}`
         opts.emit({ type: 'error', message: detail })
-        finish(() => rejectPromise(new Error(`[framework] claude-code exited: ${detail}`)))
+        finish(() => rejectPromise(new Error(`[framework] claude-code exited (${code ?? 'null'}): ${detail}`)))
         return
       }
       opts.emit({ type: 'result', text: turn.text, ...(turn.sessionId ? { sessionId: turn.sessionId } : {}) })


### PR DESCRIPTION
The Claude Code driver only failed a turn on a non-zero exit when the agent produced no text. If it streamed some text and then crashed (exit != 0, or SIGKILL with code null), the driver resolved a result turn and the loop could score the crash as production-grade and stop.

Now any non-zero exit fails the turn, surfacing stderr (else the partial text) as context. Added a regression test.

Closes #231