### PR TITLE
refactor: drop dead code in the driver and runner adapters

### DIFF
--- a/packages/ai-autopilot/src/runner/docker.ts
+++ b/packages/ai-autopilot/src/runner/docker.ts
@@ -330,7 +330,7 @@ export class DockerRunner implements Runner {
     const publish = this.opts.preview ? ['-p', `127.0.0.1:0:${this.opts.previewPort}`] : []
     const run = await docker(['run', '-d', '--name', name, '-w', WORKSPACE, ...publish, this.image, 'tail', '-f', '/dev/null'])
     if (run.exitCode !== 0) {
-      throw new RunnerError(`failed to boot container: ${(run.stderr.trim() || run.stdout.trim()) ?? ''}`)
+      throw new RunnerError(`failed to boot container: ${run.stderr.trim() || run.stdout.trim()}`)
     }
     try {
       const session = new DockerRunnerSession(id, name, opts, this.opts)

--- a/packages/ai-autopilot/src/runner/webcontainer.ts
+++ b/packages/ai-autopilot/src/runner/webcontainer.ts
@@ -213,7 +213,7 @@ export class WebContainerRunnerSession implements RunnerSession {
             timer = setTimeout(() => {
               timedOut = true
               proc.kill()
-              res(137)
+              res(124) // discarded; the timedOut branch below sets the real code
             }, timeoutMs)
           })
         : undefined

--- a/packages/framework/src/driver/claude-code.ts
+++ b/packages/framework/src/driver/claude-code.ts
@@ -70,7 +70,6 @@ let sessionCounter = 0
 export class ClaudeCodeSession implements DriverSession {
   readonly id: string
   readonly cwd: string
-  private lastSessionId?: string
 
   constructor(
     private readonly config: ClaudeCodeDriverOptions,
@@ -102,9 +101,6 @@ export class ClaudeCodeSession implements DriverSession {
       spawn: this.config.spawn ?? (nodeSpawn as unknown as SpawnLike),
       emit,
       signals,
-    }).then(turn => {
-      if (turn.sessionId) this.lastSessionId = turn.sessionId
-      return turn
     })
   }
 
@@ -114,8 +110,7 @@ export class ClaudeCodeSession implements DriverSession {
 
   dispose(): Promise<void> {
     // Each prompt spawns and reaps its own process, so there is nothing durable
-    // to tear down. The last session id is kept only for a UI link.
-    void this.lastSessionId
+    // to tear down. The session id reaches the UI via the emitted result event.
     return Promise.resolve()
   }
 


### PR DESCRIPTION
Three small dead-code cleanups from the review, no behavior change:

- claude-code driver: remove the `lastSessionId` field (written, never read).
- docker runner: drop an unreachable `?? ''` on a trimmed string.
- webcontainer runner: the timeout race value is discarded by the timedOut branch; resolve the same 124 it returns instead of a stray 137.

Both packages build and test green. No changeset (internal only).

Closes #234