### PR TITLE
feat(framework): hosted run relay — watch one run from multiple browsers (#230)

### DIFF
--- a/.changeset/hosted-run-relay.md
+++ b/.changeset/hosted-run-relay.md
@@ -1,0 +1,9 @@
+---
+'@gemstack/framework': minor
+---
+
+feat(framework): hosted run relay — watch one run from multiple browsers (#230)
+
+The first slice toward shared team sessions: a run can now be watched live from more than one machine. `framework relay` hosts a relay; a run started with `framework "..." --share <relay-url>` publishes its event stream to it and prints a shareable URL. Anyone who opens that URL gets the same dashboard over SSE, replaying the run's full history and then following live — so two teammates watch one build together.
+
+Reuses the existing dashboard: the SSE serving is factored into a shared helper and the page's stream/stop paths are now relative so they resolve both on the localhost dashboard and under the relay's `/r/<id>/`. New exports: `startRelay`, `relayPublisher`. Deliberately unauthenticated — accounts, teams, RBAC, and authorized steering layer on later; the relay only projects the stream, it never runs an agent.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -95,6 +95,18 @@ test('parseArgs reads --sandbox and rejects an unknown value (#229)', () => {
   assert.match(parseArgs(['--sandbox', 'vm', 'x']).error!, /invalid --sandbox/)
 })
 
+test('parseArgs reads the relay subcommand and --share (#230)', () => {
+  const relay = parseArgs(['relay', '--port', '5000'])
+  assert.equal(relay.relayServe, true)
+  assert.equal(relay.intent, '') // 'relay' is a subcommand, not an intent word
+  assert.equal(relay.port, 5000)
+  const share = parseArgs(['--share', 'http://host:4488', 'a', 'blog'])
+  assert.equal(share.share, 'http://host:4488')
+  assert.equal(share.intent, 'a blog')
+  assert.equal(parseArgs(['x']).relayServe, false)
+  assert.equal(parseArgs(['x']).share, undefined)
+})
+
 test('workspaceSummary describes an empty vs an existing workspace', async () => {
   const empty = await mkdtemp(join(tmpdir(), 'framework-ws-'))
   try {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -14,6 +14,8 @@ import {
 import { ClaudeCodeDriver, type ClaudeCodeDriverOptions, type Driver, type DriverSession, type PermissionMode } from './driver/index.js'
 import { hostExecutor } from './host-exec.js'
 import { startDashboard, type Dashboard } from './dashboard/index.js'
+import { startRelay, relayPublisher, type RelayPublisher } from './relay.js'
+import { randomUUID } from 'node:crypto'
 import { formatFrameworkEvent, CLAUDE_CODE_SESSION_LINK, type FrameworkEvent } from './events.js'
 import {
   runFramework,
@@ -74,6 +76,7 @@ Usage:
   framework [intent...]           Build what you describe, from scratch.
   framework --fake                Run the offline demo (no CLI, no model, deterministic).
   framework doctor                Check prerequisites (Claude Code installed, etc.).
+  framework relay                 Host a run relay so teammates can watch a run (#230).
 
 Options:
   --fake                 Use the fake driver + scripted run (offline / CI).
@@ -115,8 +118,10 @@ Options:
   --cf-project <name>    Cloudflare Pages project name (for a Pages deploy).
   --dokploy-url <url>    Dokploy instance URL (required for --deploy dokploy).
   --dokploy-app <id>     Dokploy application id (required for --deploy dokploy).
-  --port <n>             Dashboard port (default: 4477).
+  --port <n>             Dashboard port (default: 4477); with the relay, the relay port (4488).
   --no-dashboard         Do not start the localhost dashboard.
+  --share <relay-url>    Publish this run to a relay (from "framework relay") so
+                         teammates can watch it live; prints the shareable URL.
   --resume               Reopen the last run's dashboard from .framework/ in --cwd
                          (read-only replay; no new agent run). Survives a restart.
   --no-persist           Do not write the orchestration state to .framework/.
@@ -164,6 +169,8 @@ export interface CliOptions {
   sandbox?: 'local' | 'docker' | undefined
   port?: number
   dashboard: boolean
+  relayServe: boolean
+  share?: string | undefined
   composeExtensions: boolean
   sessionLink?: string | undefined
   permissionMode?: PermissionMode | undefined
@@ -187,6 +194,7 @@ export function parseArgs(argv: string[]): CliOptions {
     autopilot: false,
     technical: false,
     dashboard: true,
+    relayServe: false,
     composeExtensions: false,
     skipPermissions: false,
     resume: false,
@@ -292,6 +300,9 @@ export function parseArgs(argv: string[]): CliOptions {
         else opts.sandbox = where
         break
       }
+      case '--share':
+        opts.share = argv[++i]
+        break
       case '--session-link':
         opts.sessionLink = argv[++i]
         break
@@ -318,9 +329,12 @@ export function parseArgs(argv: string[]): CliOptions {
         else words.push(arg)
     }
   }
-  // `framework doctor` is a subcommand, not an intent.
+  // `framework doctor` / `framework relay` are subcommands, not an intent.
   if (words[0] === 'doctor') {
     opts.doctor = true
+    words.shift()
+  } else if (words[0] === 'relay') {
+    opts.relayServe = true
     words.shift()
   }
   opts.intent = words.join(' ').trim()
@@ -476,6 +490,10 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     io.out(result.ok ? '\nAll good. You are ready to build.' : '\nSome checks failed. Fix them, then try again.')
     return result.ok ? 0 : 1
   }
+
+  // `framework relay` hosts the run relay: teammates open a run's URL and watch it
+  // live (#230). It runs until interrupted; a run publishes to it with `--share`.
+  if (opts.relayServe) return runRelayServer(opts, io)
 
   // Resume a previous run's dashboard from its persisted log — the reload half of
   // #211. No agent runs; we just replay the saved events into a fresh stream so
@@ -635,10 +653,21 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     }
   }
 
+  // Publish the run to a relay (#230) so teammates can watch it live. Best-effort:
+  // a relay that is down never fails the run (relayPublisher swallows POST errors).
+  let publisher: RelayPublisher | undefined
+  if (opts.share) {
+    publisher = relayPublisher(opts.share, randomUUID(), err =>
+      io.err(`relay publish failed (${err instanceof Error ? err.message : String(err)})`),
+    )
+    io.out(`◆ shared run: ${publisher.url}`)
+  }
+
   const onEvent = (event: FrameworkEvent) => {
     io.out(formatFrameworkEvent(event))
     dashboard?.push(event)
     void store?.append(event)
+    publisher?.publish(event)
   }
 
   // Discover installed `framework-*` capability packages (#190) from the signals
@@ -720,7 +749,26 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     io.err(`\n✗ run failed: ${err instanceof Error ? err.message : String(err)}`)
     await dashboard?.close()
     return 1
+  } finally {
+    // Make sure every event (including the final `end`) reached the relay before exit.
+    if (publisher) await publisher.flush()
   }
+}
+
+/**
+ * `framework relay`: host the run relay (#230). Teammates open a run's URL
+ * (printed when a run uses `--share <this-url>`) and watch it live with full
+ * history replay. Runs until interrupted. Unauthenticated by design — anyone with
+ * a run URL can watch; accounts/teams/steering come later.
+ */
+async function runRelayServer(opts: CliOptions, io: CliIO): Promise<number> {
+  const relay = await startRelay(opts.port !== undefined ? { port: opts.port } : {})
+  io.out(`◆ relay listening at ${relay.url}`)
+  io.out(`  Runs published with \`framework "..." --share ${relay.url}\` are watchable at ${relay.url}/r/<id>/`)
+  io.out(`  Press Ctrl+C to stop.`)
+  await waitForInterrupt()
+  await relay.close()
+  return 0
 }
 
 /**

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -2,7 +2,7 @@ import { CLAUDE_CODE_SESSION_LINK } from '../events.js'
 
 /**
  * The single self-contained dashboard page: HTML + inline CSS + inline JS, no
- * assets, no build step. The client opens an `EventSource` to `/events` and
+ * assets, no build step. The client opens an `EventSource` to `events` and
  * projects the {@link import('../events.js').FrameworkEvent} stream into panels
  * that foreground the orchestration (stack rationale, loop status, decisions)
  * beside a tail of the wrapped agent's own activity.
@@ -261,11 +261,11 @@ function stopRun() {
   const btn = $('stop');
   btn.disabled = true;
   btn.textContent = 'stopping\\u2026';
-  fetch('/stop', { method: 'POST' }).catch(() => {});
+  fetch('stop', { method: 'POST' }).catch(() => {});
 }
 function esc(s) { const d = document.createElement('div'); d.textContent = String(s); return d.innerHTML; }
 $('stop').addEventListener('click', stopRun);
-const src = new EventSource('/events');
+const src = new EventSource('events');
 src.onmessage = ev => { try { onEvent(JSON.parse(ev.data)); } catch {} };
 src.onerror = () => { $('status').textContent = '\\u25cb offline'; };
 `

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -59,7 +59,9 @@ test('dashboard serves the HTML page with the title', async () => {
     const { status, body } = await fetchText(dash.url + '/')
     assert.equal(status, 200)
     assert.match(body, /My Framework/)
-    assert.match(body, /new EventSource\('\/events'\)/)
+    // Relative path so it resolves against the page's base URL — /events on the
+    // localhost dashboard, /r/<id>/events when re-served by the relay (#230).
+    assert.match(body, /new EventSource\('events'\)/)
     // The Modes panel + its renderer ship in the page (#272), hidden until a modes event.
     assert.match(body, /id="modes-panel" hidden/)
     assert.match(body, /function renderModes/)

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -3,6 +3,7 @@ import type { AddressInfo } from 'node:net'
 import { EventStream } from '@gemstack/ai-autopilot'
 import type { FrameworkEvent } from '../events.js'
 import { dashboardHtml } from './page.js'
+import { serveSSE } from './sse.js'
 
 /** Options for {@link startDashboard}. */
 export interface DashboardOptions {
@@ -83,7 +84,7 @@ function handle(
     return
   }
   if (url === '/events') {
-    streamEvents(req, res, stream, clients)
+    serveSSE(req, res, stream, clients)
     return
   }
   if (url === '/stop') {
@@ -107,39 +108,6 @@ function handle(
   }
   res.writeHead(404, { 'content-type': 'text/plain' })
   res.end('not found')
-}
-
-function streamEvents(
-  req: IncomingMessage,
-  res: ServerResponse,
-  stream: EventStream<FrameworkEvent>,
-  clients: Set<ServerResponse>,
-): void {
-  res.writeHead(200, {
-    'content-type': 'text/event-stream',
-    'cache-control': 'no-cache',
-    connection: 'keep-alive',
-  })
-  clients.add(res)
-
-  const send = (event: FrameworkEvent) => res.write(`data: ${JSON.stringify(event)}\n\n`)
-  // Replay history, then follow live. A fresh iterator gives this client its own
-  // cursor, so a late browser still sees the whole run from the start.
-  void (async () => {
-    try {
-      for await (const event of stream[Symbol.asyncIterator]()) send(event)
-    } catch {
-      // client went away
-    } finally {
-      clients.delete(res)
-      res.end()
-    }
-  })()
-
-  req.on('close', () => {
-    clients.delete(res)
-    res.end()
-  })
 }
 
 function closeServer(

--- a/packages/framework/src/dashboard/sse.ts
+++ b/packages/framework/src/dashboard/sse.ts
@@ -1,0 +1,41 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { EventStream } from '@gemstack/ai-autopilot'
+import type { FrameworkEvent } from '../events.js'
+
+/**
+ * Serve one client the {@link FrameworkEvent} stream over Server-Sent Events:
+ * replay the whole run's history, then follow live. A fresh async iterator gives
+ * this client its own cursor from the start, so a late browser still sees the run
+ * from the beginning. Shared by the localhost dashboard and the hosted relay (#230)
+ * so both project the identical stream.
+ */
+export function serveSSE(
+  req: IncomingMessage,
+  res: ServerResponse,
+  stream: EventStream<FrameworkEvent>,
+  clients: Set<ServerResponse>,
+): void {
+  res.writeHead(200, {
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-cache',
+    connection: 'keep-alive',
+  })
+  clients.add(res)
+
+  const send = (event: FrameworkEvent) => res.write(`data: ${JSON.stringify(event)}\n\n`)
+  void (async () => {
+    try {
+      for await (const event of stream[Symbol.asyncIterator]()) send(event)
+    } catch {
+      // client went away
+    } finally {
+      clients.delete(res)
+      res.end()
+    }
+  })()
+
+  req.on('close', () => {
+    clients.delete(res)
+    res.end()
+  })
+}

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -59,6 +59,13 @@ export {
 } from './run.js'
 export { snapshotWorkspace, SANDBOX_IGNORE, type SnapshotOptions } from './sandbox.js'
 export {
+  startRelay,
+  relayPublisher,
+  type Relay,
+  type RelayOptions,
+  type RelayPublisher,
+} from './relay.js'
+export {
   discoverExtensions,
   readProjectSignals,
   type DiscoverExtensionsResult,

--- a/packages/framework/src/relay.test.ts
+++ b/packages/framework/src/relay.test.ts
@@ -1,0 +1,137 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { get, request } from 'node:http'
+import { startRelay, relayPublisher } from './relay.js'
+import type { FrameworkEvent } from './events.js'
+
+function fetchFull(url: string): Promise<{ status: number; headers: Record<string, string | string[] | undefined>; body: string }> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    get(url, res => {
+      let body = ''
+      res.on('data', c => (body += c))
+      res.on('end', () => resolvePromise({ status: res.statusCode ?? 0, headers: res.headers, body }))
+    }).on('error', rejectPromise)
+  })
+}
+
+function send(url: string, method: string, body?: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const req = request(url, { method }, res => {
+      let b = ''
+      res.on('data', c => (b += c))
+      res.on('end', () => resolvePromise({ status: res.statusCode ?? 0, body: b }))
+    })
+    req.on('error', rejectPromise)
+    if (body !== undefined) req.write(body)
+    req.end()
+  })
+}
+
+// Read SSE `data:` frames until `count` have arrived, then disconnect.
+function readSse(url: string, count: number): Promise<FrameworkEvent[]> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const req = get(url, res => {
+      let buffer = ''
+      const collected: FrameworkEvent[] = []
+      res.on('data', chunk => {
+        buffer += chunk
+        let nl: number
+        while ((nl = buffer.indexOf('\n\n')) !== -1) {
+          const frame = buffer.slice(0, nl)
+          buffer = buffer.slice(nl + 2)
+          const line = frame.split('\n').find(l => l.startsWith('data: '))
+          if (line) collected.push(JSON.parse(line.slice(6)) as FrameworkEvent)
+          if (collected.length >= count) {
+            req.destroy()
+            resolvePromise(collected)
+            return
+          }
+        }
+      })
+    })
+    req.on('error', rejectPromise)
+  })
+}
+
+const local = { host: '127.0.0.1', port: 0 as const }
+
+test('relay re-serves one run to two browsers, each replaying full history (#230)', async () => {
+  const relay = await startRelay(local)
+  try {
+    relay.ingest('run-1', { kind: 'log', message: 'a' })
+    relay.ingest('run-1', { kind: 'log', message: 'b' })
+    relay.ingest('run-1', { kind: 'log', message: 'c' })
+
+    // Two independent viewers connect after the fact; both replay the whole run.
+    const [one, two] = await Promise.all([
+      readSse(`${relay.url}/r/run-1/events`, 3),
+      readSse(`${relay.url}/r/run-1/events`, 3),
+    ])
+    assert.deepEqual(one.map(e => (e as { message: string }).message), ['a', 'b', 'c'])
+    assert.deepEqual(two.map(e => (e as { message: string }).message), ['a', 'b', 'c'])
+  } finally {
+    await relay.close()
+  }
+})
+
+test('relayPublisher POSTs a run to the relay, which re-serves it live', async () => {
+  const relay = await startRelay(local)
+  try {
+    // A viewer connects first; then the run publishes over HTTP.
+    const seen = readSse(`${relay.url}/r/pub/events`, 2)
+    const pub = relayPublisher(relay.url, 'pub')
+    assert.equal(pub.url, `${relay.url}/r/pub/`)
+    pub.publish({ kind: 'log', message: 'from-cli-1' })
+    pub.publish({ kind: 'end', ok: true } as FrameworkEvent)
+    await pub.flush()
+    const events = await seen
+    assert.equal((events[0] as { message: string }).message, 'from-cli-1')
+    assert.equal(events[1]!.kind, 'end')
+  } finally {
+    await relay.close()
+  }
+})
+
+test('runs are isolated by id', async () => {
+  const relay = await startRelay(local)
+  try {
+    relay.ingest('run-a', { kind: 'log', message: 'only-a' })
+    relay.ingest('run-b', { kind: 'log', message: 'only-b' })
+    const a = await readSse(`${relay.url}/r/run-a/events`, 1)
+    assert.deepEqual(
+      a.map(e => (e as { message: string }).message),
+      ['only-a'],
+    )
+    assert.deepEqual(relay.runIds().sort(), ['run-a', 'run-b'])
+  } finally {
+    await relay.close()
+  }
+})
+
+test('GET /r/:id redirects to the trailing-slash page; the page loads relative SSE', async () => {
+  const relay = await startRelay(local)
+  try {
+    const redirect = await fetchFull(`${relay.url}/r/xyz`)
+    assert.equal(redirect.status, 302)
+    assert.equal(redirect.headers.location, '/r/xyz/')
+
+    const page = await fetchFull(`${relay.url}/r/xyz/`)
+    assert.equal(page.status, 200)
+    assert.match(page.body, /new EventSource\('events'\)/) // resolves under /r/xyz/
+  } finally {
+    await relay.close()
+  }
+})
+
+test('healthz is 200; a bad publish is rejected without crashing the run', async () => {
+  const relay = await startRelay(local)
+  try {
+    assert.equal((await fetchFull(`${relay.url}/healthz`)).status, 200)
+    assert.equal((await send(`${relay.url}/r/x/publish`, 'GET')).status, 405) // must POST
+    assert.equal((await send(`${relay.url}/r/x/publish`, 'POST', 'not json')).status, 400)
+    const ok = await send(`${relay.url}/r/x/publish`, 'POST', JSON.stringify({ kind: 'log', message: 'ok' }))
+    assert.equal(ok.status, 202)
+  } finally {
+    await relay.close()
+  }
+})

--- a/packages/framework/src/relay.ts
+++ b/packages/framework/src/relay.ts
@@ -1,0 +1,227 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { EventStream } from '@gemstack/ai-autopilot'
+import type { FrameworkEvent } from './events.js'
+import { dashboardHtml } from './dashboard/page.js'
+import { serveSSE } from './dashboard/sse.js'
+
+/**
+ * The hosted run relay (#230): the first slice toward shared team sessions. It
+ * ingests a run's {@link FrameworkEvent} stream over HTTP and re-serves the exact
+ * same dashboard (SSE + history replay) to N remote browsers, keyed by run id. So
+ * two people on different machines open one run URL and both watch it live.
+ *
+ * Deliberately unauthenticated: anyone with a run's URL can watch it. Accounts,
+ * teams, RBAC, and authorized steering layer on later (via vike-auth/-rbac). The
+ * relay only projects the stream — it never runs an agent.
+ *
+ * Endpoints (per run id):
+ * - `POST /r/:id/publish` — ingest one event (JSON object) or a batch (JSON array)
+ * - `GET  /r/:id/`        — the dashboard page (read-only: no Stop button)
+ * - `GET  /r/:id/events`  — the SSE stream (replays history, then follows live)
+ * - `GET  /r/:id`         — redirects to `/r/:id/` so the page's relative paths resolve
+ * - `GET  /healthz`       — liveness probe for the host
+ */
+export interface RelayOptions {
+  /** Port to bind. Default `4488`; pass `0` for an ephemeral port. */
+  port?: number
+  /**
+   * Host to bind. Default `0.0.0.0` — the relay exists to be reached from other
+   * machines. Bind `127.0.0.1` to keep it local (e.g. tests).
+   */
+  host?: string
+  /** Page title. Default `"The Framework"`. */
+  title?: string
+  /** Max bytes accepted per publish request body. Default 256 KiB. */
+  maxBodyBytes?: number
+}
+
+/** A running relay. Ingest events programmatically or over HTTP; browsers watch by run id. */
+export interface Relay {
+  /** The base URL of the relay (e.g. `http://0.0.0.0:4488`). */
+  readonly url: string
+  /** The viewer URL for a run id (`<url>/r/<id>/`). */
+  viewerUrl(runId: string): string
+  /** Push one event into a run's stream, creating the run on first use. */
+  ingest(runId: string, event: FrameworkEvent): void
+  /** The run ids seen so far. */
+  runIds(): string[]
+  /** Close every stream and stop the server. Idempotent. */
+  close(): Promise<void>
+}
+
+interface Run {
+  stream: EventStream<FrameworkEvent>
+  clients: Set<ServerResponse>
+}
+
+const RUN_PATH = /^\/r\/([^/]+)(\/[^?]*)?/
+
+/** Start the hosted run relay. See {@link Relay}. */
+export function startRelay(opts: RelayOptions = {}): Promise<Relay> {
+  const host = opts.host ?? '0.0.0.0'
+  const port = opts.port ?? 4488
+  const title = opts.title ?? 'The Framework'
+  const maxBody = opts.maxBodyBytes ?? 256 * 1024
+  const runs = new Map<string, Run>()
+
+  const run = (id: string): Run => {
+    let r = runs.get(id)
+    if (!r) {
+      r = { stream: new EventStream<FrameworkEvent>(), clients: new Set() }
+      runs.set(id, r)
+    }
+    return r
+  }
+
+  const server = createServer((req, res) => handle(req, res, { runs, run, title, maxBody }))
+
+  return new Promise<Relay>((resolvePromise, rejectPromise) => {
+    server.once('error', rejectPromise)
+    server.listen(port, host, () => {
+      server.removeListener('error', rejectPromise)
+      const address = server.address() as AddressInfo
+      const url = `http://${host}:${address.port}`
+      resolvePromise({
+        url,
+        viewerUrl: id => `${url}/r/${encodeURIComponent(id)}/`,
+        ingest: (id, event) => run(id).stream.push(event),
+        runIds: () => [...runs.keys()],
+        close: () => closeRelay(server, runs),
+      })
+    })
+  })
+}
+
+interface HandleCtx {
+  runs: Map<string, Run>
+  run: (id: string) => Run
+  title: string
+  maxBody: number
+}
+
+function handle(req: IncomingMessage, res: ServerResponse, ctx: HandleCtx): void {
+  const url = req.url ?? '/'
+  if (url === '/healthz') {
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end('ok')
+    return
+  }
+  const m = RUN_PATH.exec(url)
+  if (!m) {
+    res.writeHead(404, { 'content-type': 'text/plain' })
+    res.end('not found')
+    return
+  }
+  const id = decodeURIComponent(m[1]!)
+  const rest = m[2] ?? ''
+
+  // No trailing slash: redirect so the page's relative `events`/`stop` resolve under /r/:id/.
+  if (rest === '') {
+    res.writeHead(302, { location: `/r/${encodeURIComponent(id)}/` })
+    res.end()
+    return
+  }
+  if (rest === '/') {
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+    res.end(dashboardHtml(ctx.title, false)) // read-only: steering is out of scope for the keystone
+    return
+  }
+  if (rest === '/events') {
+    const r = ctx.run(id)
+    serveSSE(req, res, r.stream, r.clients)
+    return
+  }
+  if (rest === '/publish') {
+    if (req.method !== 'POST') {
+      res.writeHead(405, { 'content-type': 'text/plain', allow: 'POST' })
+      res.end('method not allowed')
+      return
+    }
+    ingestBody(req, res, ctx.run(id), ctx.maxBody)
+    return
+  }
+  res.writeHead(404, { 'content-type': 'text/plain' })
+  res.end('not found')
+}
+
+/** Read a JSON body (one event or an array) and push each event into the run's stream. */
+function ingestBody(req: IncomingMessage, res: ServerResponse, r: Run, maxBody: number): void {
+  let body = ''
+  let tooBig = false
+  req.on('data', (chunk: Buffer) => {
+    if (tooBig) return
+    body += chunk
+    if (body.length > maxBody) {
+      tooBig = true
+      res.writeHead(413, { 'content-type': 'text/plain' })
+      res.end('payload too large')
+      req.destroy()
+    }
+  })
+  req.on('end', () => {
+    if (tooBig) return
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(body)
+    } catch {
+      res.writeHead(400, { 'content-type': 'text/plain' })
+      res.end('invalid json')
+      return
+    }
+    const events = (Array.isArray(parsed) ? parsed : [parsed]) as FrameworkEvent[]
+    for (const event of events) r.stream.push(event)
+    res.writeHead(202, { 'content-type': 'application/json' })
+    res.end(`{"ok":true,"received":${events.length}}`)
+  })
+}
+
+function closeRelay(server: Server, runs: Map<string, Run>): Promise<void> {
+  for (const { stream, clients } of runs.values()) {
+    stream.close()
+    for (const res of clients) res.end()
+    clients.clear()
+  }
+  runs.clear()
+  return new Promise(resolvePromise => server.close(() => resolvePromise()))
+}
+
+/** A publisher that forwards a run's events to a relay. Best-effort and ordered. */
+export interface RelayPublisher {
+  /** The viewer URL to share (`<base>/r/<id>/`). */
+  readonly url: string
+  /** Queue one event to POST to the relay (serialized, so the relay replays in order). */
+  publish(event: FrameworkEvent): void
+  /** Resolve once every queued POST has been sent (or failed), for a clean shutdown. */
+  flush(): Promise<void>
+}
+
+/**
+ * Forward a live run's {@link FrameworkEvent}s to a {@link startRelay} relay so
+ * remote browsers can watch it. POSTs are serialized (chained) so the relay's
+ * replay order matches the run, and best-effort: a failed POST is reported via
+ * `onError` but never interrupts the run.
+ */
+export function relayPublisher(base: string, runId: string, onError?: (err: unknown) => void): RelayPublisher {
+  const root = `${base.replace(/\/+$/, '')}/r/${encodeURIComponent(runId)}`
+  let chain: Promise<void> = Promise.resolve()
+  return {
+    url: `${root}/`,
+    publish(event) {
+      chain = chain.then(async () => {
+        try {
+          await fetch(`${root}/publish`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(event),
+          })
+        } catch (err) {
+          onError?.(err)
+        }
+      })
+    },
+    flush() {
+      return chain
+    },
+  }
+}


### PR DESCRIPTION
Closes #230.

First concrete slice toward shared team sessions (#204): prove two people can watch the same run before we build any accounts/teams/billing.

- `framework relay` hosts a relay (a tiny HTTP server).
- `framework "..." --share <relay-url>` publishes the run's event stream to it and prints a shareable URL.
- Open that URL from any machine and you get the same dashboard over SSE, replaying the run's full history and then following live. Two teammates watch one build together.

Why it's small: the dashboard is already a multi-client SSE projection of one event stream with per-client history replay. This factors the SSE serving into a shared helper and makes the page's stream/stop paths relative so they resolve both on the localhost dashboard (`/events`) and under the relay (`/r/<id>/events`). The genuinely new pieces are the relay server (multi-run, keyed by id) and the CLI publisher. New exports: `startRelay`, `relayPublisher`.

Out of scope by design (keeps it a keystone): accounts/auth, teams, RBAC, billing, authorized steering. The relay is unauthenticated — anyone with a run URL can watch — and never runs an agent; it only projects the stream. Those layer on later via vike-auth/-rbac/-data.

Verified end to end: hosted a relay, ran `--fake --share` against it, then a viewer connecting after the run finished replayed the full 42-event run (session -> ... -> end ok=true); `/r/:id` redirects to the trailing-slash page; the page loads its SSE relatively. 150 framework tests green (relay: two browsers replay one run, HTTP publish re-serves live, run isolation, redirect + page, healthz + bad-publish handling).

Note: run streams accumulate in memory for the process lifetime (late joiners replay) — fine for the keystone; a TTL/cap is a follow-up. Real hosting + identity is the next layer, not this PR.