### PR TITLE
feat(framework): inject a system prompt into every prompt (anti-lazy-pill + SYSTEM.md)

### DIFF
--- a/.changeset/framework-system-prompt-injection.md
+++ b/.changeset/framework-system-prompt-injection.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/framework': minor
+---
+
+feat(framework): inject a system prompt into every prompt (anti-lazy-pill + SYSTEM.md)
+
+Every run is now framed with a built-in system prompt: the validated anti-lazy-pill (#297), which turns unclear scope into a ranked list, a large scope into a `PLAN.md`, and a very large one into a `TODO.md` backlog, so the agent builds a real backend and declares what it descopes instead of silently faking it. Drop a `SYSTEM.md` at the workspace root to add project-specific instructions on top, or set `antiLazyPill: false` in `the-framework.yml` to remove the built-in default. Closes #301.

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -211,6 +211,7 @@ preset: software-development
 autopilot: true      # activate the preset's Autopilot mode variants
 technical: false
 event: bug-fix        # the build event kind its review loop fires for
+antiLazyPill: false   # remove the built-in anti-lazy-pill system prompt (default: on)
 ```
 
 Every field is optional. CLI flags override the file, so the precedence is:
@@ -221,6 +222,18 @@ Every field is optional. CLI flags override the file, so the precedence is:
 
 When the file contributes anything, the run narrates it (`◆ the-framework.yml: ...`).
 A malformed file is a warning, never a failed run.
+
+### System prompt: the anti-lazy-pill + `SYSTEM.md`
+
+Every prompt is framed with a built-in system prompt (the validated "anti-lazy-pill",
+#297): unclear scope becomes a ranked list to approve, a large scope becomes a
+`PLAN.md`, a very large one also spins off a `TODO.md` backlog. It turns a mock UI
+shell into a real backend and declares what it descopes instead of faking it.
+
+Drop a `SYSTEM.md` at the workspace root to add your own instructions on top (it
+travels with the repo, like the memory files). To remove the built-in pill and keep
+only your own, set `antiLazyPill: false` in `the-framework.yml`. The run narrates
+what it picked up (`◆ system prompt: SYSTEM.md`).
 
 ## Extensions (#190)
 

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -35,6 +35,7 @@ import {
 import { isWorkspaceEmpty } from './steps.js'
 import { loadFrameworkConfig, type FrameworkFileConfig } from './config.js'
 import { loadRepoMemory } from './memory.js'
+import { loadUserSystemPrompt, SYSTEM_PROMPT_FILE } from './system-prompt.js'
 import { preflight } from './preflight.js'
 import { RunStore } from './store/index.js'
 
@@ -686,6 +687,12 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   const memory = await loadRepoMemory(cwd)
   if (memory.some(m => m.content)) io.out(`◆ project memory: ${memory.filter(m => m.content).map(m => m.name).join(', ')}`)
 
+  // A user SYSTEM.md and the-framework.yml's anti-lazy-pill toggle shape the system
+  // prompt injected into every prompt (#301). The built-in pill is on unless removed.
+  const userSystemPrompt = await loadUserSystemPrompt(cwd)
+  if (userSystemPrompt) io.out(`◆ system prompt: ${SYSTEM_PROMPT_FILE}`)
+  if (fileConfig.antiLazyPill === false) io.out('◆ anti-lazy-pill: off (the-framework.yml)')
+
   const runOpts: RunFrameworkOptions = {
     intent,
     scope: opts.scope,
@@ -705,6 +712,8 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     ...(domainPreset ? { preset: domainPreset, ...(modeList.length ? { modes: modeList } : {}) } : {}),
     ...(buildEvent ? { buildEvent } : {}),
     ...(memory.length ? { memory } : {}),
+    ...(userSystemPrompt ? { systemPrompt: userSystemPrompt } : {}),
+    ...(fileConfig.antiLazyPill === false ? { antiLazyPill: false } : {}),
     ...((): { sessionLink?: string } => {
       const link = chooseSessionLink(opts, fake)
       return link ? { sessionLink: link } : {}

--- a/packages/framework/src/config.test.ts
+++ b/packages/framework/src/config.test.ts
@@ -17,6 +17,11 @@ test('parseFrameworkConfig reads preset + mode booleans + event', () => {
   )
 })
 
+test('parseFrameworkConfig reads the antiLazyPill toggle', () => {
+  assert.deepEqual(parseFrameworkConfig('antiLazyPill: false\n'), { antiLazyPill: false })
+  assert.throws(() => parseFrameworkConfig('antiLazyPill: nope\n'), /"antiLazyPill" must be a boolean/)
+})
+
 test('parseFrameworkConfig treats an empty document as {}', () => {
   assert.deepEqual(parseFrameworkConfig(''), {})
   assert.deepEqual(parseFrameworkConfig('# just a comment\n'), {})

--- a/packages/framework/src/config.ts
+++ b/packages/framework/src/config.ts
@@ -16,6 +16,8 @@ export interface FrameworkFileConfig {
   technical?: boolean
   /** Build event kind the preset's review loop fires for, e.g. `bug-fix` (#265). */
   event?: string
+  /** Inject the built-in anti-lazy-pill system prompt (#301). Default `true`; set false to remove it. */
+  antiLazyPill?: boolean
 }
 
 /** Config file names read from the workspace root, in precedence order. */
@@ -67,7 +69,7 @@ export function parseFrameworkConfig(raw: string, source = 'the-framework.yml'):
       config[key] = obj[key] as string
     }
   }
-  for (const key of ['autopilot', 'technical'] as const) {
+  for (const key of ['autopilot', 'technical', 'antiLazyPill'] as const) {
     if (obj[key] !== undefined) {
       if (typeof obj[key] !== 'boolean') throw new Error(`${source}: "${key}" must be a boolean`)
       config[key] = obj[key] as boolean

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -119,6 +119,13 @@ export {
   type LoadedMemory,
 } from './memory.js'
 export {
+  loadUserSystemPrompt,
+  systemPromptBlock,
+  ANTI_LAZY_PILL,
+  SYSTEM_PROMPT_FILE,
+  type SystemPromptOptions,
+} from './system-prompt.js'
+export {
   preflight,
   type PreflightResult,
   type PreflightCheck,

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -33,6 +33,7 @@ import {
 import { snapshotWorkspace } from './sandbox.js'
 import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { memoryFraming, type LoadedMemory } from './memory.js'
+import { systemPromptBlock } from './system-prompt.js'
 import { decideDeploy, deployWith, domainLoopChecklist, driverArchitect, driverBuild, driverChecklist, driverImprove, driverLoopPrompts } from './steps.js'
 import { hasSessionIdPlaceholder, OPEN_LOOP_MODES, resolveSessionLink, type FrameworkEvent } from './events.js'
 
@@ -99,6 +100,17 @@ export interface RunFrameworkOptions {
    * `loadRepoMemory(cwd)`. Omit or pass `[]` to frame no memory.
    */
   memory?: readonly LoadedMemory[]
+  /**
+   * A user-authored system prompt (from `SYSTEM.md`) injected into every prompt
+   * (#301). Load with `loadUserSystemPrompt(cwd)`. Composed after the built-in
+   * anti-lazy-pill, so a repo can add its own instructions on top of the default.
+   */
+  systemPrompt?: string
+  /**
+   * Inject the built-in anti-lazy-pill (#297) into every prompt (#301). Default
+   * `true`; pass `false` (e.g. from `the-framework.yml`) to remove it.
+   */
+  antiLazyPill?: boolean
   /**
    * A user-picked Open Loop domain preset ({loops, prompts, skills}) to run the
    * build under (#251). Its skills (and their personas) frame every phase, and
@@ -281,7 +293,11 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
   // The repo's own memory files (#260) frame the agent alongside personas + skills:
   // their contents give context, and the agent is told to keep the ones it owns current.
   const memoryBlock = opts.memory && opts.memory.length ? memoryFraming(opts.memory) : ''
+  // The anti-lazy-pill + any user SYSTEM.md lead the system prompt so its working
+  // agreement frames every prompt before the role/skill/memory context (#301).
+  const promptBlock = systemPromptBlock({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt })
   const system = [
+    ...(promptBlock ? [promptBlock] : []),
     ...personas.map(personaInstructions),
     ...skills.map(skillInstructions),
     ...(memoryBlock ? [memoryBlock] : []),

--- a/packages/framework/src/system-prompt.test.ts
+++ b/packages/framework/src/system-prompt.test.ts
@@ -1,0 +1,53 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  ANTI_LAZY_PILL,
+  loadUserSystemPrompt,
+  systemPromptBlock,
+  SYSTEM_PROMPT_FILE,
+} from './system-prompt.js'
+
+test('loadUserSystemPrompt reads and trims SYSTEM.md', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'system-prompt-'))
+  try {
+    await writeFile(join(dir, SYSTEM_PROMPT_FILE), '\n  Always write tests first.\n')
+    assert.equal(await loadUserSystemPrompt(dir), 'Always write tests first.')
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('loadUserSystemPrompt is undefined when the file is absent or empty', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'system-prompt-'))
+  try {
+    assert.equal(await loadUserSystemPrompt(dir), undefined) // absent
+    await writeFile(join(dir, SYSTEM_PROMPT_FILE), '   \n') // whitespace only
+    assert.equal(await loadUserSystemPrompt(dir), undefined)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('systemPromptBlock defaults to the anti-lazy-pill alone', () => {
+  assert.equal(systemPromptBlock(), ANTI_LAZY_PILL)
+})
+
+test('systemPromptBlock appends the user prompt after the pill', () => {
+  const block = systemPromptBlock({ user: 'Ship small PRs.' })
+  assert.ok(block.startsWith(ANTI_LAZY_PILL))
+  assert.ok(block.endsWith('Ship small PRs.'))
+  assert.match(block, /AWAIT[\s\S]*Ship small PRs\./) // pill first, then user
+})
+
+test('systemPromptBlock removes the pill when antiLazyPill is false', () => {
+  assert.equal(systemPromptBlock({ antiLazyPill: false }), '')
+  assert.equal(systemPromptBlock({ antiLazyPill: false, user: 'Only mine.' }), 'Only mine.')
+})
+
+test('systemPromptBlock ignores a whitespace-only user prompt', () => {
+  assert.equal(systemPromptBlock({ user: '   ' }), ANTI_LAZY_PILL)
+  assert.equal(systemPromptBlock({ antiLazyPill: false, user: '  \n ' }), '')
+})

--- a/packages/framework/src/system-prompt.ts
+++ b/packages/framework/src/system-prompt.ts
@@ -1,0 +1,69 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+/**
+ * The built-in system prompt injected into every run (#301): Rom's validated
+ * "anti-lazy-pill" (#297). It decouples what the agent *thinks* it should build
+ * from what we actually build next: unclear scope becomes a ranked list to show,
+ * a large scope becomes a `PLAN.md` to approve, a very large one also spins off a
+ * `TODO.md` backlog. In our Instagram-clone test this turned a mock UI shell
+ * (0/7 real) into a real persisted backend (~4.5/7), and it declares what it
+ * descopes instead of silently faking it.
+ *
+ * `SHOW_IT` / `AWAIT` fully wire up with the interactive `<Choices>` panel (#304);
+ * until then a headless run still writes the `PLAN.md` / `TODO.md`, which is the
+ * ambition lever we want.
+ */
+export const ANTI_LAZY_PILL = `## How to work
+- If it isn't clear what you should do (e.g. unclear scope, unclear user prompt), make a list of interpretations sorted by plausibility, SHOW_IT, AWAIT.
+- If the scope of what you'll work on is large, create a \`PLAN.md\` of what you'll work on, SHOW_IT, AWAIT.
+  - If the scope is potentially very large (e.g. spans over many hours of work), also create a \`TODO.md\` (backlog of follow-up tasks) and SHOW_IT
+
+SHOW_IT: Show it to the user
+AWAIT: Stop, await user answer before resuming`
+
+/**
+ * The canonical user system-prompt file at the workspace root. Its contents are
+ * injected into every prompt, so a project's own instructions travel with the
+ * code (Rom's repo-as-database model, like the memory files in {@link ./memory}).
+ */
+export const SYSTEM_PROMPT_FILE = 'SYSTEM.md'
+
+/**
+ * Read the user's system prompt from {@link SYSTEM_PROMPT_FILE} at the workspace
+ * root. Returns `undefined` when the file is absent or empty, so the caller falls
+ * back to the built-in default alone.
+ */
+export async function loadUserSystemPrompt(
+  dir: string,
+  file: string = SYSTEM_PROMPT_FILE,
+): Promise<string | undefined> {
+  try {
+    const content = (await readFile(join(dir, file), 'utf8')).trim()
+    return content || undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** Inputs to {@link systemPromptBlock}. */
+export interface SystemPromptOptions {
+  /** Include the built-in {@link ANTI_LAZY_PILL}. Default `true`; set false per repo to remove it. */
+  antiLazyPill?: boolean | undefined
+  /** The user's own system prompt (e.g. from `SYSTEM.md`), injected after the pill. */
+  user?: string | undefined
+}
+
+/**
+ * Compose the system-prompt block injected into every prompt: the built-in
+ * anti-lazy-pill (unless removed) followed by the user's own prompt. Additive, so
+ * a repo can keep the pill *and* add its instructions, remove the pill and keep
+ * only its own, or leave both off. Returns `''` when there is nothing to inject.
+ */
+export function systemPromptBlock(opts: SystemPromptOptions = {}): string {
+  const parts: string[] = []
+  if (opts.antiLazyPill !== false) parts.push(ANTI_LAZY_PILL)
+  const user = opts.user?.trim()
+  if (user) parts.push(user)
+  return parts.join('\n\n')
+}


### PR DESCRIPTION
Closes #301. First dogfooding slice from Discord: the ability to add a system prompt to every prompt, and the delivery vehicle for the #297 anti-lazy-pill.

## What
- New `system-prompt.ts`: the built-in `ANTI_LAZY_PILL` (Rom's validated #297 prompt), a `loadUserSystemPrompt(cwd)` that reads `SYSTEM.md` from the workspace root, and `systemPromptBlock()` that composes them.
- `runFramework` prepends the composed block to the `system` string, ahead of personas/skills/memory, so it frames every prompt (each Claude Code prompt is a fresh session that re-reads `system`).
- `the-framework.yml` gains `antiLazyPill: false` to remove the built-in default per repo.
- CLI loads `SYSTEM.md` + the toggle and narrates them (`◆ system prompt: SYSTEM.md`), mirroring the memory + config wiring.

## Model
- Default (no config): the anti-lazy-pill alone.
- `SYSTEM.md` present: appended after the pill (additive, keep both).
- `antiLazyPill: false`: pill removed; `SYSTEM.md` (if any) stands alone.

`SHOW_IT` / `AWAIT` in the pill fully wire up with the interactive `<Choices>` panel (#304); a headless run today still writes the `PLAN.md` / `TODO.md`, which is the ambition lever.

## Tests
159 pass. New coverage for the loader (trim, absent, empty), the compose model (default / additive / removed / whitespace), and the `antiLazyPill` config parse.
