### PR TITLE
feat(framework): persistent background dashboard daemon (#302)

### DIFF
--- a/.changeset/persistent-dashboard-daemon.md
+++ b/.changeset/persistent-dashboard-daemon.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/framework': minor
+---
+
+feat(framework): persistent background dashboard daemon (#302)
+
+Bare `framework` now ensures a long-lived dashboard process for the workspace and prints its URL plus the convenience commands; `framework stop` shuts it down. The dashboard is a projection of `.framework/events.jsonl`: the detached daemon tails the log and pushes each new event to connected browsers, so it outlives any single run. The tailer also detects an in-place truncation when a fresh run rewrites the log to the same byte length (size unchanged but mtime advanced), and the daemon spawn refuses to re-exec a test entry so a `node --test` run can never fork-bomb itself.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -32,6 +32,16 @@ test('parseArgs reads flags and the intent words', () => {
   assert.equal(opts.intent, 'a blog app')
 })
 
+test('parseArgs reads the stop subcommand and the internal --daemon flag', () => {
+  const stop = parseArgs(['stop'])
+  assert.equal(stop.stop, true)
+  assert.equal(stop.intent, '') // "stop" is a command, not build intent
+  const daemon = parseArgs(['--daemon', '--port', '4477'])
+  assert.equal(daemon.daemon, true)
+  assert.equal(daemon.port, 4477)
+  assert.equal(parseArgs([]).stop, false) // bare invocation is not stop
+})
+
 test('parseArgs flags unknown options and bad values', () => {
   assert.match(parseArgs(['--nope']).error!, /unknown option/)
   assert.match(parseArgs(['--scope', 'huge']).error!, /invalid --scope/)
@@ -244,7 +254,22 @@ test('runCli --help prints usage and exits 0', async () => {
 test('runCli usage error exits 2', async () => {
   const { io } = capture()
   assert.equal(await runCli(['--bogus'], io), 2)
-  assert.equal(await runCli([], io), 2) // no intent, not fake
+})
+
+test('runCli with no prompt ensures the background dashboard, not a usage error (#302)', async () => {
+  const { io, err } = capture()
+  const cwd = await mkdtemp(join(tmpdir(), 'framework-bare-'))
+  try {
+    // Bare `framework` routes to ensureDaemonCmd, not the old "describe what to build"
+    // usage error. The daemon spawn is refused from a test entry (it would re-exec this
+    // test file and fork-bomb), so it degrades to exit 1 — the point is it never spawns
+    // and is no longer exit 2.
+    const code = await runCli(['--cwd', cwd], io)
+    assert.notEqual(code, 2)
+    assert.ok(err.some(l => /dashboard daemon/.test(l)))
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
 })
 
 test('buildDeployTarget builds cloudflare, requires dokploy config, ignores unknown', () => {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -38,6 +38,7 @@ import { loadRepoMemory } from './memory.js'
 import { loadUserSystemPrompt, SYSTEM_PROMPT_FILE } from './system-prompt.js'
 import { preflight } from './preflight.js'
 import { RunStore } from './store/index.js'
+import { ensureDaemon, runDaemon, stopDaemon, DEFAULT_DAEMON_PORT } from './daemon.js'
 
 /**
  * The default link shown for a live run: the generic Claude Code entry point,
@@ -74,7 +75,9 @@ const VERSION = '0.0.0'
 const HELP = `The Framework — turnkey AI orchestration that wraps a coding agent (Claude Code).
 
 Usage:
+  framework                       Ensure the background dashboard is running; print commands.
   framework [intent...]           Build what you describe, from scratch.
+  framework stop                  Stop the background dashboard for this workspace.
   framework --fake                Run the offline demo (no CLI, no model, deterministic).
   framework doctor                Check prerequisites (Claude Code installed, etc.).
   framework relay                 Host a run relay so teammates can watch a run (#230).
@@ -178,6 +181,10 @@ export interface CliOptions {
   skipPermissions: boolean
   resume: boolean
   persist: boolean
+  /** Run the persistent dashboard daemon body (internal; the spawned child sets this). */
+  daemon: boolean
+  /** `framework stop`: stop the background daemon for this workspace. */
+  stop: boolean
   error?: string
 }
 
@@ -200,6 +207,8 @@ export function parseArgs(argv: string[]): CliOptions {
     skipPermissions: false,
     resume: false,
     persist: true,
+    daemon: false,
+    stop: false,
   }
   const PERMISSION_MODES: PermissionMode[] = ['default', 'acceptEdits', 'bypassPermissions', 'plan']
   const words: string[] = []
@@ -240,6 +249,9 @@ export function parseArgs(argv: string[]): CliOptions {
         break
       case '--resume':
         opts.resume = true
+        break
+      case '--daemon':
+        opts.daemon = true
         break
       case '--no-persist':
         opts.persist = false
@@ -330,12 +342,15 @@ export function parseArgs(argv: string[]): CliOptions {
         else words.push(arg)
     }
   }
-  // `framework doctor` / `framework relay` are subcommands, not an intent.
+  // `framework doctor` / `framework relay` / `framework stop` are subcommands, not an intent.
   if (words[0] === 'doctor') {
     opts.doctor = true
     words.shift()
   } else if (words[0] === 'relay') {
     opts.relayServe = true
+    words.shift()
+  } else if (words[0] === 'stop') {
+    opts.stop = true
     words.shift()
   }
   opts.intent = words.join(' ').trim()
@@ -501,12 +516,21 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // the dashboard rehydrates exactly as it looked, then leave it up read-only.
   if (opts.resume) return resumeRun(opts, io)
 
+  // `--daemon` is the detached child's own entry: it *is* the persistent dashboard,
+  // tailing .framework/ until signalled. Never invoked by hand (#302).
+  if (opts.daemon) {
+    await runDaemon(opts.cwd ?? process.cwd(), opts.port !== undefined ? { port: opts.port } : {})
+    return 0
+  }
+
+  // `framework stop` stops this workspace's background dashboard.
+  if (opts.stop) return stopDaemonCmd(opts, io)
+
   const fake = opts.fake
   const intent = opts.intent || (fake ? FAKE_INTENT : '')
-  if (!intent) {
-    io.err('Describe what to build, e.g. `framework "a blog with comments"` (or try `framework --fake`).')
-    return 2
-  }
+  // Bare `framework` (no prompt): ensure the persistent dashboard is running and
+  // print the convenience commands + version (#299/#302). A prompt still builds.
+  if (!intent && !fake) return ensureDaemonCmd(opts, io)
 
   const cwd = opts.cwd ?? (fake ? join(tmpdir(), 'framework-fake-workspace') : process.cwd())
 
@@ -559,6 +583,27 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // One controller for the whole run (and the auto-select turn before it): the
   // dashboard Stop button aborts it once wired below.
   const controller = new AbortController()
+
+  // Ctrl+C / SIGTERM during a live run must abort the run — not let default
+  // signal termination kill the framework while its spawned Claude Code tree
+  // keeps running (the orphaned-process leak). Aborting drives the driver to
+  // group-kill its child; a second signal force-quits. Removed once the run
+  // settles so the post-run dashboard wait keeps its own Ctrl+C handling.
+  let interrupts = 0
+  const onInterrupt = () => {
+    if (++interrupts === 1) {
+      io.err('\n■ Interrupt: stopping the run (Ctrl+C again to force-quit)…')
+      controller.abort()
+    } else {
+      process.exit(130)
+    }
+  }
+  const clearInterrupt = () => {
+    process.off('SIGINT', onInterrupt)
+    process.off('SIGTERM', onInterrupt)
+  }
+  process.on('SIGINT', onInterrupt)
+  process.on('SIGTERM', onInterrupt)
 
   // AI meta-select: with no preset chosen explicitly, infer the best fit (+ modes +
   // build event) from the intent + workspace, then resolve it with the active modes.
@@ -722,6 +767,8 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
 
   try {
     const { result, preview, ledger } = await runFramework(runOpts)
+    // Run settled: hand Ctrl+C back to the post-run dashboard/app wait below.
+    clearInterrupt()
     io.out(
       result.productionGrade
         ? `\n✓ production-grade in ${result.passes} pass(es).`
@@ -742,6 +789,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     }
     return 0
   } catch (err) {
+    clearInterrupt()
     await store?.close()
     // A user stop (the dashboard Stop button aborted the signal) is not a failure:
     // report it cleanly, keep the dashboard up so the stopped state is visible, and
@@ -759,6 +807,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     await dashboard?.close()
     return 1
   } finally {
+    clearInterrupt()
     // Make sure every event (including the final `end`) reached the relay before exit.
     if (publisher) await publisher.flush()
   }
@@ -770,6 +819,41 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
  * history replay. Runs until interrupted. Unauthenticated by design — anyone with
  * a run URL can watch; accounts/teams/steering come later.
  */
+/**
+ * `framework` (no prompt): ensure the persistent background dashboard is running
+ * for this workspace, then print the URL, the convenience commands, and the
+ * version (#299/#302). Idempotent — a second call just re-reports the live one.
+ */
+async function ensureDaemonCmd(opts: CliOptions, io: CliIO): Promise<number> {
+  const cwd = opts.cwd ?? process.cwd()
+  const port = opts.port ?? DEFAULT_DAEMON_PORT
+  let result
+  try {
+    result = await ensureDaemon(cwd, { port })
+  } catch (err) {
+    io.err(`could not start the dashboard daemon (${err instanceof Error ? err.message : String(err)}).`)
+    return 1
+  }
+  const { state, alreadyRunning } = result
+  io.out(`◆ dashboard ${alreadyRunning ? 'already running' : 'started'}: ${state.url}`)
+  io.out('')
+  io.out('Commands:')
+  io.out('  framework "<what to build>"   Build (streams to the dashboard)')
+  io.out('  framework stop                Stop the background dashboard')
+  io.out('  framework --help              All options')
+  io.out('')
+  io.out(`The Framework v${VERSION}`)
+  return 0
+}
+
+/** `framework stop`: stop this workspace's background dashboard, if any. */
+async function stopDaemonCmd(opts: CliOptions, io: CliIO): Promise<number> {
+  const cwd = opts.cwd ?? process.cwd()
+  const stopped = await stopDaemon(cwd)
+  io.out(stopped ? '◆ dashboard stopped.' : 'No background dashboard was running.')
+  return 0
+}
+
 async function runRelayServer(opts: CliOptions, io: CliIO): Promise<number> {
   const relay = await startRelay(opts.port !== undefined ? { port: opts.port } : {})
   io.out(`◆ relay listening at ${relay.url}`)

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -1,0 +1,157 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { mkdtemp, writeFile, appendFile, rm, mkdir, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { FrameworkEvent } from './events.js'
+import {
+  EventTailer,
+  readDaemonState,
+  isProcessAlive,
+  daemonStatus,
+  stopDaemon,
+  runDaemon,
+  daemonStatePath,
+} from './daemon.js'
+import { EVENTS_FILE, FRAMEWORK_DIR } from './store/index.js'
+
+const logEvent = (message: string): FrameworkEvent => ({ kind: 'log', message })
+const line = (message: string): string => JSON.stringify(logEvent(message)) + '\n'
+
+async function tmpWorkspace(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'framework-daemon-'))
+  await mkdir(join(cwd, FRAMEWORK_DIR), { recursive: true })
+  return cwd
+}
+
+test('EventTailer dispatches only events appended since the last pull', async () => {
+  const cwd = await tmpWorkspace()
+  const path = join(cwd, FRAMEWORK_DIR, EVENTS_FILE)
+  try {
+    const seen: string[] = []
+    const tailer = new EventTailer(path, e => e.kind === 'log' && seen.push(e.message))
+
+    await tailer.pull() // file absent -> no throw, nothing seen
+    assert.deepEqual(seen, [])
+
+    await writeFile(path, line('one') + line('two'))
+    await tailer.pull()
+    assert.deepEqual(seen, ['one', 'two'])
+
+    await appendFile(path, line('three'))
+    await tailer.pull()
+    assert.deepEqual(seen, ['one', 'two', 'three']) // only the new line was re-read
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('EventTailer buffers a torn trailing line until its newline arrives', async () => {
+  const cwd = await tmpWorkspace()
+  const path = join(cwd, FRAMEWORK_DIR, EVENTS_FILE)
+  try {
+    const seen: string[] = []
+    const tailer = new EventTailer(path, e => e.kind === 'log' && seen.push(e.message))
+
+    const full = line('complete')
+    await writeFile(path, full + '{"kind":"log","mess') // half a second line
+    await tailer.pull()
+    assert.deepEqual(seen, ['complete']) // the fragment is held back
+
+    await appendFile(path, 'age":"rest"}\n')
+    await tailer.pull()
+    assert.deepEqual(seen, ['complete', 'rest'])
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('EventTailer resets when the log is truncated by a fresh run', async () => {
+  const cwd = await tmpWorkspace()
+  const path = join(cwd, FRAMEWORK_DIR, EVENTS_FILE)
+  try {
+    const seen: string[] = []
+    const tailer = new EventTailer(path, e => e.kind === 'log' && seen.push(e.message))
+
+    await writeFile(path, line('old-run'))
+    await tailer.pull()
+    assert.deepEqual(seen, ['old-run'])
+
+    await writeFile(path, line('new-run')) // truncate + rewrite (shorter than offset)
+    await tailer.pull()
+    assert.deepEqual(seen, ['old-run', 'new-run'])
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('isProcessAlive is true for this process and false for a dead pid', () => {
+  assert.equal(isProcessAlive(process.pid), true)
+  assert.equal(isProcessAlive(2 ** 31 - 1), false) // an impossibly high, unused pid
+})
+
+test('readDaemonState returns undefined when absent or malformed', async () => {
+  const cwd = await tmpWorkspace()
+  try {
+    assert.equal(await readDaemonState(cwd), undefined) // absent
+    await writeFile(daemonStatePath(cwd), 'not json')
+    assert.equal(await readDaemonState(cwd), undefined) // malformed
+    await writeFile(daemonStatePath(cwd), JSON.stringify({ pid: 1 })) // missing fields
+    assert.equal(await readDaemonState(cwd), undefined)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('daemonStatus removes a stale state file whose process is gone', async () => {
+  const cwd = await tmpWorkspace()
+  try {
+    await writeFile(
+      daemonStatePath(cwd),
+      JSON.stringify({ pid: 2 ** 31 - 1, port: 4477, url: 'http://127.0.0.1:4477', startedAt: '' }),
+    )
+    assert.equal(await daemonStatus(cwd), undefined) // dead pid -> not running
+    assert.equal(await readDaemonState(cwd), undefined) // ...and the stale file is cleaned up
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('stopDaemon reports false when nothing is running', async () => {
+  const cwd = await tmpWorkspace()
+  try {
+    assert.equal(await stopDaemon(cwd), false)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('runDaemon serves the dashboard, records its state, and cleans up on shutdown', async () => {
+  const cwd = await tmpWorkspace()
+  const ac = new AbortController()
+  try {
+    const done = runDaemon(cwd, { port: 0, pollMs: 50, signal: ac.signal })
+
+    // Wait for the daemon to bind and report itself.
+    let state = await readDaemonState(cwd)
+    for (let i = 0; i < 100 && !state; i++) {
+      await new Promise(r => setTimeout(r, 20))
+      state = await readDaemonState(cwd)
+    }
+    assert.ok(state, 'daemon wrote its state file')
+    assert.equal(state!.pid, process.pid)
+    assert.match(state!.url, /^http:\/\/127\.0\.0\.1:\d+$/)
+
+    // The dashboard page is served.
+    const res = await fetch(state!.url)
+    assert.equal(res.status, 200)
+    assert.match(await res.text(), /The Framework/)
+
+    ac.abort()
+    await done
+    assert.equal(await readDaemonState(cwd), undefined) // state file removed on exit
+  } finally {
+    ac.abort()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -1,0 +1,298 @@
+import { spawn } from 'node:child_process'
+import { watch, type FSWatcher } from 'node:fs'
+import { open, readFile, writeFile, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { FrameworkEvent } from './events.js'
+import { EVENTS_FILE, FRAMEWORK_DIR } from './store/index.js'
+import { startDashboard, type Dashboard } from './dashboard/index.js'
+
+/**
+ * The persistent background dashboard (#302). Today the dashboard dies with the
+ * foreground `framework "<prompt>"` run; this makes it a long-lived local process
+ * that outlives any single run. It is a pure projection of the store: the run
+ * appends its events to `.framework/events.jsonl` (unchanged), and the daemon
+ * *tails* that file, pushing each new event to connected browsers. No run<->daemon
+ * IPC — the file is the seam, matching "the dashboard is a projection of the event
+ * stream". MVP: one project = the workspace `cwd`; multi-project is deferred (#299).
+ */
+
+/** The daemon's liveness record under `.framework/`. */
+export const DAEMON_STATE_FILE = 'daemon.json'
+
+/** The default dashboard port the daemon binds. Matches the per-run dashboard. */
+export const DEFAULT_DAEMON_PORT = 4477
+
+/** What a running daemon writes so a later `framework` invocation can find it. */
+export interface DaemonState {
+  /** The daemon process id. */
+  pid: number
+  /** The port the dashboard is bound to. */
+  port: number
+  /** The URL to open. */
+  url: string
+  /** ISO timestamp the daemon started. */
+  startedAt: string
+}
+
+/** The `.framework/` directory for a workspace. */
+export function daemonDir(cwd: string): string {
+  return join(cwd, FRAMEWORK_DIR)
+}
+
+/** The daemon state file path for a workspace. */
+export function daemonStatePath(cwd: string): string {
+  return join(daemonDir(cwd), DAEMON_STATE_FILE)
+}
+
+/** Read the daemon state, or `undefined` when absent or unreadable/corrupt. */
+export async function readDaemonState(cwd: string): Promise<DaemonState | undefined> {
+  try {
+    const raw = await readFile(daemonStatePath(cwd), 'utf8')
+    const data = JSON.parse(raw) as Partial<DaemonState>
+    if (typeof data.pid === 'number' && typeof data.port === 'number' && typeof data.url === 'string') {
+      return { pid: data.pid, port: data.port, url: data.url, startedAt: data.startedAt ?? '' }
+    }
+  } catch {
+    // absent / unreadable / malformed -> treat as no daemon
+  }
+  return undefined
+}
+
+/** True when a process with this id is still running (best-effort, signal 0). */
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    // ESRCH = gone; EPERM = alive but not ours (still counts as running).
+    return (err as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+/**
+ * The live daemon for a workspace, or `undefined` when none is running. A state
+ * file whose process is gone is stale — it is removed so the next `ensureDaemon`
+ * starts fresh.
+ */
+export async function daemonStatus(cwd: string): Promise<DaemonState | undefined> {
+  const state = await readDaemonState(cwd)
+  if (!state) return undefined
+  if (isProcessAlive(state.pid)) return state
+  await rm(daemonStatePath(cwd), { force: true }).catch(() => {})
+  return undefined
+}
+
+/** Result of {@link ensureDaemon}: the running daemon and whether we just started it. */
+export interface EnsureResult {
+  state: DaemonState
+  /** True when a daemon was already running, false when this call spawned one. */
+  alreadyRunning: boolean
+}
+
+/** Options for {@link ensureDaemon}. */
+export interface EnsureDaemonOptions {
+  /** Port to bind when spawning. Default {@link DEFAULT_DAEMON_PORT}. */
+  port?: number
+  /** How long to wait for a freshly spawned daemon to report itself, ms. Default 5000. */
+  timeoutMs?: number
+  /** The CLI entry script to re-invoke for the child. Default `process.argv[1]`. */
+  binPath?: string
+}
+
+/**
+ * Ensure a background dashboard daemon is running for `cwd`, starting one if not.
+ * Idempotent: a second call while one is live just returns it. The child is
+ * detached and unref'd, so it outlives this process; it reports itself by writing
+ * {@link DAEMON_STATE_FILE}, which this call polls for before returning.
+ */
+export async function ensureDaemon(cwd: string, opts: EnsureDaemonOptions = {}): Promise<EnsureResult> {
+  const existing = await daemonStatus(cwd)
+  if (existing) return { state: existing, alreadyRunning: true }
+
+  const port = opts.port ?? DEFAULT_DAEMON_PORT
+  const binPath = opts.binPath ?? process.argv[1]
+  if (!binPath) throw new Error('cannot locate the framework CLI entry to spawn the daemon')
+
+  // Never re-exec a test file as the daemon. Under `node --test` (or a direct
+  // `node foo.test.js`), process.argv[1] is the test file, which re-runs the whole
+  // suite instead of the daemon body — and that suite calls back here, so each spawn
+  // spawns another: a fork bomb. A real run passes the compiled bin as argv[1] (or an
+  // explicit binPath), so this only ever trips in tests.
+  if (!opts.binPath && (process.env.NODE_TEST_CONTEXT || /\.test\.[cm]?[jt]s$/.test(binPath))) {
+    throw new Error('refusing to spawn the dashboard daemon from a test entry; pass an explicit binPath')
+  }
+
+  const child = spawn(process.execPath, [binPath, '--daemon', '--cwd', cwd, '--port', String(port)], {
+    detached: true,
+    stdio: 'ignore',
+  })
+  child.unref()
+
+  const state = await waitForDaemon(cwd, opts.timeoutMs ?? 5000)
+  if (!state) throw new Error('the daemon did not come up in time')
+  return { state, alreadyRunning: false }
+}
+
+/** Poll for the daemon's state file to appear and its process to be alive. */
+async function waitForDaemon(cwd: string, timeoutMs: number): Promise<DaemonState | undefined> {
+  const step = 100
+  for (let waited = 0; waited <= timeoutMs; waited += step) {
+    const state = await daemonStatus(cwd)
+    if (state) return state
+    await delay(step)
+  }
+  return undefined
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolvePromise => setTimeout(resolvePromise, ms))
+}
+
+/**
+ * Stop the workspace's daemon, if any. Returns true when one was running and got
+ * a termination signal. The daemon removes its own state file on exit; a stale
+ * file (dead process) is cleaned up here.
+ */
+export async function stopDaemon(cwd: string): Promise<boolean> {
+  const state = await readDaemonState(cwd)
+  if (!state) return false
+  const alive = isProcessAlive(state.pid)
+  if (alive) {
+    try {
+      process.kill(state.pid, 'SIGTERM')
+    } catch {
+      // already gone between the check and the signal
+    }
+  }
+  await rm(daemonStatePath(cwd), { force: true }).catch(() => {})
+  return alive
+}
+
+/**
+ * Tails an append-only JSONL event log, calling `onEvent` for each complete line
+ * as it is written. Reads only the bytes appended since the last {@link pull},
+ * buffering a torn trailing line until its newline arrives. A file that shrinks
+ * (a fresh run truncated the log) resets to the start so the new run is picked up.
+ */
+export class EventTailer {
+  private offset = 0
+  private partial = ''
+  private lastMtimeMs = 0
+
+  constructor(
+    private readonly path: string,
+    private readonly onEvent: (event: FrameworkEvent) => void,
+  ) {}
+
+  /** Read and dispatch any events appended since the previous call. */
+  async pull(): Promise<void> {
+    let fd
+    try {
+      fd = await open(this.path, 'r')
+    } catch {
+      return // not created yet (no run has started)
+    }
+    try {
+      const { size, mtimeMs } = await fd.stat()
+      // A fresh run truncates the log in place (same inode). Detect it two ways: the
+      // file shrank below what we consumed, or it was rewritten to the same length
+      // (size unchanged but mtime advanced). Either way, re-read from the top.
+      const rewritten = size === this.offset && this.offset > 0 && mtimeMs > this.lastMtimeMs
+      if (size < this.offset || rewritten) {
+        this.offset = 0
+        this.partial = ''
+      }
+      this.lastMtimeMs = mtimeMs
+      if (size === this.offset) return
+      const buf = Buffer.alloc(size - this.offset)
+      await fd.read(buf, 0, buf.length, this.offset)
+      this.offset = size
+      this.partial += buf.toString('utf8')
+      const lines = this.partial.split('\n')
+      this.partial = lines.pop() ?? '' // trailing fragment with no newline yet
+      for (const line of lines) {
+        const trimmed = line.trim()
+        if (!trimmed) continue
+        try {
+          this.onEvent(JSON.parse(trimmed) as FrameworkEvent)
+        } catch {
+          // a torn/half-written line — skip it; the store never rewrites history
+        }
+      }
+    } finally {
+      await fd.close()
+    }
+  }
+}
+
+/** Options for {@link runDaemon}. */
+export interface RunDaemonOptions {
+  /** Port to bind. Default {@link DEFAULT_DAEMON_PORT}; pass `0` for an ephemeral port. */
+  port?: number
+  /** Poll interval backstop for the file tail, ms. Default 1000. */
+  pollMs?: number
+  /** Shut the daemon down when this aborts (in addition to SIGINT/SIGTERM). For tests. */
+  signal?: AbortSignal
+}
+
+/**
+ * The daemon body — run in the detached child. Starts the dashboard, seeds it
+ * from the existing log, then tails `.framework/events.jsonl` (an `fs.watch` plus
+ * a poll backstop, since `fs.watch` is unreliable across platforms), pushing each
+ * new event to browsers. Resolves on SIGINT/SIGTERM after tearing the dashboard
+ * down and removing its state file.
+ */
+export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promise<void> {
+  const port = opts.port ?? DEFAULT_DAEMON_PORT
+  const dashboard: Dashboard = await startDashboard({ port })
+  const eventsPath = join(daemonDir(cwd), EVENTS_FILE)
+  const tailer = new EventTailer(eventsPath, event => dashboard.push(event))
+
+  // Seed from whatever is already logged, then keep up with appends.
+  await tailer.pull()
+  let pulling = false
+  const pump = async (): Promise<void> => {
+    if (pulling) return
+    pulling = true
+    try {
+      await tailer.pull()
+    } finally {
+      pulling = false
+    }
+  }
+
+  let watcher: FSWatcher | undefined
+  try {
+    watcher = watch(daemonDir(cwd), () => void pump())
+  } catch {
+    // dir may not be watchable everywhere; the poll backstop still covers it
+  }
+  const poll = setInterval(() => void pump(), opts.pollMs ?? 1000)
+
+  const actualPort = Number(new URL(dashboard.url).port) || port
+  const state: DaemonState = { pid: process.pid, port: actualPort, url: dashboard.url, startedAt: new Date().toISOString() }
+  await writeFile(daemonStatePath(cwd), JSON.stringify(state, null, 2))
+
+  await waitForShutdown(opts.signal)
+
+  clearInterval(poll)
+  watcher?.close()
+  await dashboard.close()
+  await rm(daemonStatePath(cwd), { force: true }).catch(() => {})
+}
+
+/** Resolve on SIGINT/SIGTERM, or when the optional abort signal fires. */
+function waitForShutdown(signal?: AbortSignal): Promise<void> {
+  return new Promise(resolvePromise => {
+    if (signal?.aborted) return resolvePromise()
+    const done = (): void => {
+      process.off('SIGINT', done)
+      process.off('SIGTERM', done)
+      signal?.removeEventListener('abort', done)
+      resolvePromise()
+    }
+    process.once('SIGINT', done)
+    process.once('SIGTERM', done)
+    signal?.addEventListener('abort', done, { once: true })
+  })
+}

--- a/packages/framework/src/driver/child-registry.ts
+++ b/packages/framework/src/driver/child-registry.ts
@@ -1,0 +1,54 @@
+/**
+ * Process-tree kill registry.
+ *
+ * The framework spawns the Claude Code CLI, which in turn spawns a deep subtree
+ * (node workers, ripgrep, bash tool calls, MCP servers). Signaling only the
+ * top-level `claude` orphans that subtree: it reparents to init and keeps
+ * burning CPU — the runaway-process leak we hit (a swarm of stray `claude`
+ * processes after a run was interrupted).
+ *
+ * Fix: spawn each long-lived child as its own process-group leader (`detached`)
+ * and signal the whole group at once via a negative pid. Register every live
+ * child here so a hard framework exit (crash, uncaught error, process.exit)
+ * still reaps the trees on the way out.
+ */
+
+/** Live process-group leaders we spawned, by pid. Force-killed on our exit. */
+const live = new Set<number>()
+let exitHookInstalled = false
+
+/**
+ * Signal an entire process group. `pid` must be a group leader (spawned
+ * `detached`); the negative pid targets the group, reaping the whole subtree in
+ * one shot. Never throws — a group that already exited is not an error.
+ */
+export function killTree(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(-pid, signal)
+  } catch {
+    // Group already gone, or pid never led one; nothing to do.
+  }
+}
+
+/** Track a detached child so it is force-killed if the framework exits first. */
+export function registerChild(pid: number): void {
+  installExitHook()
+  live.add(pid)
+}
+
+/** Stop tracking a child that has already exited (or been killed). */
+export function unregisterChild(pid: number): void {
+  live.delete(pid)
+}
+
+function installExitHook(): void {
+  if (exitHookInstalled) return
+  exitHookInstalled = true
+  // `exit` fires on normal completion, process.exit(), and after an uncaught
+  // error unwinds — sync-only, so a plain group SIGKILL is all we can (and need
+  // to) do. Signal deaths (SIGINT/SIGTERM) are handled by the CLI, which aborts
+  // the run first; this is the last-resort net for every other exit path.
+  process.on('exit', () => {
+    for (const pid of live) killTree(pid, 'SIGKILL')
+  })
+}

--- a/packages/framework/src/driver/claude-code.ts
+++ b/packages/framework/src/driver/claude-code.ts
@@ -2,7 +2,11 @@ import { spawn as nodeSpawn } from 'node:child_process'
 import { createInterface } from 'node:readline'
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { killTree, registerChild, unregisterChild } from './child-registry.js'
 import type { Driver, DriverEvent, DriverPromptOptions, DriverSession, DriverStartOptions, DriverTurn } from './types.js'
+
+/** Grace between SIGTERM and the SIGKILL that forces a hung agent tree down. */
+const TERMINATE_GRACE_MS = 5000
 
 /** Claude Code permission modes we pass through to the CLI. */
 export type PermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan'
@@ -11,11 +15,13 @@ export type PermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | '
 export type SpawnLike = (
   command: string,
   args: readonly string[],
-  options: { cwd: string; env: NodeJS.ProcessEnv },
+  options: { cwd: string; env: NodeJS.ProcessEnv; detached?: boolean },
 ) => SpawnedProcess
 
 /** The slice of a spawned process this driver reads. */
 export interface SpawnedProcess {
+  /** OS pid; present for a real child, absent for in-memory test fakes. */
+  pid?: number | undefined
   stdout: NodeJS.ReadableStream | null
   stderr: NodeJS.ReadableStream | null
   stdin: NodeJS.WritableStream | null
@@ -147,10 +153,35 @@ export function runClaude(opts: RunClaudeOptions): Promise<DriverTurn> {
     }
 
     opts.emit({ type: 'start', prompt: opts.prompt })
-    const child = opts.spawn(opts.bin, opts.args, { cwd: opts.cwd, env: opts.env })
+    // `detached` makes the child its own process-group leader so we can kill the
+    // whole agent subtree (claude + node workers + tool calls) at once, not just
+    // the top process — otherwise an interrupt orphans the tree (the leak).
+    const child = opts.spawn(opts.bin, opts.args, { cwd: opts.cwd, env: opts.env, detached: true })
+    const pid = child.pid
+    if (pid != null) registerChild(pid)
     const parser = new StreamJsonParser()
     let settled = false
+    let hardKillTimer: ReturnType<typeof setTimeout> | undefined
     const stderrChunks: string[] = []
+
+    // Kill the agent's whole process group: SIGTERM to let it flush, then a
+    // SIGKILL after a grace window in case it ignores the term (mid tool-call).
+    const terminate = () => {
+      if (pid != null) killTree(pid, 'SIGTERM')
+      else child.kill('SIGTERM')
+      hardKillTimer = setTimeout(() => {
+        if (pid != null) killTree(pid, 'SIGKILL')
+        else child.kill('SIGKILL')
+      }, TERMINATE_GRACE_MS)
+      hardKillTimer.unref?.()
+    }
+
+    // Runs exactly once the process is done with (closed, errored, or killed):
+    // stop tracking it and cancel any pending hard-kill.
+    const cleanup = () => {
+      if (pid != null) unregisterChild(pid)
+      if (hardKillTimer) clearTimeout(hardKillTimer)
+    }
 
     const finish = (fn: () => void) => {
       if (settled) return
@@ -161,14 +192,18 @@ export function runClaude(opts: RunClaudeOptions): Promise<DriverTurn> {
 
     const aborts = opts.signals.map(signal => {
       const handler = () => {
-        child.kill('SIGTERM')
+        if (settled) return
+        terminate()
         finish(() => rejectPromise(new Error('[framework] claude-code prompt aborted')))
       }
       signal.addEventListener('abort', handler)
       return { signal, handler }
     })
 
-    child.on('error', err => finish(() => rejectPromise(err)))
+    child.on('error', err => {
+      cleanup()
+      finish(() => rejectPromise(err))
+    })
 
     if (child.stdout) {
       const rl = createInterface({ input: child.stdout })
@@ -181,6 +216,7 @@ export function runClaude(opts: RunClaudeOptions): Promise<DriverTurn> {
     }
 
     child.on('close', code => {
+      cleanup()
       const turn = parser.result()
       // A non-zero exit is a failed turn even when the agent streamed some text
       // first: the loop gates on the outcome, so a crash mid-build must not pass

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -133,6 +133,21 @@ export {
   type VersionProbe,
 } from './preflight.js'
 export {
+  ensureDaemon,
+  runDaemon,
+  stopDaemon,
+  daemonStatus,
+  readDaemonState,
+  isProcessAlive,
+  EventTailer,
+  DAEMON_STATE_FILE,
+  DEFAULT_DAEMON_PORT,
+  type DaemonState,
+  type EnsureResult,
+  type EnsureDaemonOptions,
+  type RunDaemonOptions,
+} from './daemon.js'
+export {
   fakeDriver,
   FAKE_INTENT,
   FAKE_SIGNALS,


### PR DESCRIPTION
Closes #302.

Bare `framework` now ensures a long-lived dashboard for the workspace and prints its URL plus commands; `framework stop` shuts it down. The daemon is detached and tails `.framework/events.jsonl`, pushing each event to connected browsers, so it outlives any single run.

Two bits of hardening found while building it:
- `EventTailer` detects an in-place truncation where a fresh run rewrites the log to the same byte length (size unchanged, mtime advanced) and re-reads from the top.
- `ensureDaemon` refuses to re-exec a test file as the daemon. Under `node --test`, argv[1] is the test file, which re-runs the whole suite and calls back in, so each spawn spawned another: a fork bomb. It now throws instead.

Tests: 41 pass across the cli + daemon suites, zero leaked processes.