### PR TITLE
feat(framework): interactive plan-approval choice + autopilot (#304)

### DIFF
--- a/.changeset/interactive-choices-autopilot.md
+++ b/.changeset/interactive-choices-autopilot.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/framework': minor
+---
+
+feat(framework): interactive plan-approval choice + autopilot in the dashboard (#304)
+
+The run now pauses at a plan-approval gate right after the architect decides the stack (the AWAIT point of the plan-then-AWAIT flow): the dashboard shows a "Your call" panel with "Proceed" plus each architect alternative as "Use X instead". Accept with the button or Ctrl+Enter, or leave the `[x] autopilot` countdown auto-accept the recommended plan after 10s (moving the mouse cancels it). Picking an alternative re-architects the run around it. New `requestChoice` option on `runFramework`, `choice` / `choice-resolved` events, and a `POST /choice` dashboard route; a headless run with no handler auto-accepts the recommended plan, so nothing else changes. Closes #304.

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -16,7 +16,7 @@ import { hostExecutor } from './host-exec.js'
 import { startDashboard, type Dashboard } from './dashboard/index.js'
 import { startRelay, relayPublisher, type RelayPublisher } from './relay.js'
 import { randomUUID } from 'node:crypto'
-import { formatFrameworkEvent, CLAUDE_CODE_SESSION_LINK, type FrameworkEvent } from './events.js'
+import { formatFrameworkEvent, CLAUDE_CODE_SESSION_LINK, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 import {
   runFramework,
   type DeployDecision,
@@ -673,12 +673,29 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // The dashboard Stop button aborts the run-wide controller created above.
   // runFramework checks the signal between phases and the driver kills its current
   // turn on it, so a stop takes effect promptly.
+  //
+  // Interactive choices (#304): the run's requestChoice handler parks a resolver
+  // here keyed by the choice id; the dashboard's Accept / autopilot POSTs the pick
+  // to /choice, which resolves it. Aborting the run resolves any pending choice
+  // (proceed) so the gate never hangs a stopped run.
+  const pendingChoices = new Map<string, (pick: ChoicePick) => void>()
+  controller.signal.addEventListener('abort', () => {
+    for (const resolve of pendingChoices.values()) resolve({ picked: 'proceed', by: 'auto' })
+    pendingChoices.clear()
+  })
   let dashboard: Dashboard | undefined
   if (opts.dashboard) {
     try {
       dashboard = await startDashboard({
         ...(opts.port !== undefined ? { port: opts.port } : {}),
         onStop: () => controller.abort(),
+        onChoice: (id, pick, by) => {
+          const resolve = pendingChoices.get(id)
+          if (resolve) {
+            pendingChoices.delete(id)
+            resolve({ picked: pick, by })
+          }
+        },
         cwd,
       })
       io.out(`◆ dashboard: ${dashboard.url}`)
@@ -747,6 +764,14 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     onEvent,
     signals,
     signal: controller.signal,
+    // Pause the plan-approval gate on the dashboard when one is live to accept the
+    // pick; without a dashboard the gate auto-accepts the recommended plan (#304).
+    ...(dashboard
+      ? {
+          requestChoice: (req: ChoiceRequest) =>
+            new Promise<ChoicePick>(resolve => pendingChoices.set(req.id, resolve)),
+        }
+      : {}),
     ...(opts.model ? { model: opts.model } : {}),
     ...(opts.maxPasses ? { maxPasses: opts.maxPasses } : {}),
     ...(deploy ? { deploy } : {}),

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -7,7 +7,7 @@ import { CLAUDE_CODE_SESSION_LINK } from '../events.js'
  * that foreground the orchestration (stack rationale, loop status, decisions)
  * beside a tail of the wrapped agent's own activity.
  */
-export function dashboardHtml(title: string, stoppable = false): string {
+export function dashboardHtml(title: string, stoppable = false, choiceable = false): string {
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -92,6 +92,26 @@ export function dashboardHtml(title: string, stoppable = false): string {
   #modes .box { color: #6ea8fe; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
   #modes li.off { color: #5c657a; }
   #modes li.off .box { color: #3a4256; }
+  /* Interactive plan-approval / choice panel (#304): full-width, accented so it
+     reads as the one thing awaiting the human. */
+  #choice-panel { grid-column: 1 / -1; background: #131a2a; border: 1px solid #2b3b5c;
+    border-left: 3px solid #6ea8fe; border-radius: 10px; padding: 14px 18px; }
+  #choice-panel[hidden] { display: none; }
+  #choice-panel h2 { color: #9db4d6; }
+  #choice-title { font-size: 15px; font-weight: 600; color: #e8ecf3; margin: 2px 0 10px; }
+  #choice-options { margin-bottom: 12px; }
+  #choice-options li { border-bottom: 0; padding: 4px 0; }
+  #choice-options label { display: flex; align-items: baseline; gap: 8px; cursor: pointer; }
+  #choice-options .opt-label { color: #e8ecf3; }
+  #choice-options .opt-detail { color: #8b93a3; font-size: 12px; }
+  #choice-actions { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+  #choice-accept { font: inherit; font-size: 13px; font-weight: 600; cursor: pointer; color: #0b0e14;
+    background: #6ea8fe; border: 0; border-radius: 6px; padding: 6px 16px; }
+  #choice-accept:hover { background: #8bbaff; }
+  #autopilot-row { display: flex; align-items: center; gap: 6px; color: #b7c0d0; font-size: 13px; cursor: pointer; }
+  #choice-count { color: #6ea8fe; font-size: 12px; }
+  .kbd { color: #26324a; background: #aebfe0; border-radius: 4px; padding: 0 5px; font-size: 10px;
+    font-weight: 700; margin-left: 4px; }
   #activity { grid-column: 1 / -1; }
   #log { font: 12px/1.6 ui-monospace, SFMono-Regular, Menlo, monospace; color: #96a0b3;
     max-height: 320px; overflow-y: auto; white-space: pre-wrap; }
@@ -122,6 +142,16 @@ export function dashboardHtml(title: string, stoppable = false): string {
   <span class="run">live until you stop the run</span>
 </div>
 <main>
+  <section id="choice-panel" hidden>
+    <h2>Your call</h2>
+    <div id="choice-title"></div>
+    <ul id="choice-options"></ul>
+    <div id="choice-actions">
+      <button id="choice-accept">Accept<span class="kbd">Ctrl+Enter</span></button>
+      <label id="autopilot-row"><input type="checkbox" id="autopilot-toggle" /> autopilot</label>
+      <span id="choice-count"></span>
+    </div>
+  </section>
   <section id="stack-panel">
     <h2>Stack &amp; rationale</h2>
     <div class="stack muted" id="stack">deciding…</div>
@@ -153,16 +183,18 @@ export function dashboardHtml(title: string, stoppable = false): string {
 </div>
 </div>
 <script>
-${clientScript(stoppable)}
+${clientScript(stoppable, choiceable)}
 </script>
 </body>
 </html>`
 }
 
-function clientScript(stoppable: boolean): string {
+function clientScript(stoppable: boolean, choiceable: boolean): string {
   // Runs in the browser. Keep it dependency-free.
   return `
 const STOPPABLE = ${stoppable ? 'true' : 'false'};
+const CHOICEABLE = ${choiceable ? 'true' : 'false'};
+const AUTO_ACCEPT_MS = 10000;
 const GENERIC_SESSION_LINK = ${JSON.stringify(CLAUDE_CODE_SESSION_LINK)};
 let ended = false;
 const $ = id => document.getElementById(id);
@@ -286,9 +318,12 @@ function render(fe) {
   else if (fe.kind === 'bootstrap') bootstrap(fe.event);
   else if (fe.kind === 'driver') driver(fe.event);
   else if (fe.kind === 'modes') renderModes(fe.all, fe.active);
+  else if (fe.kind === 'choice') showChoice(fe);
+  else if (fe.kind === 'choice-resolved') resolveChoice(fe);
   else if (fe.kind === 'log') log(fe.message);
   else if (fe.kind === 'end') {
     if (mode === 'live') { ended = true; $('stop').hidden = true; }
+    closeChoice();
     $('status').textContent = fe.ok ? '\\u25cf finished' : fe.stopped ? '\\u25a0 stopped' : '\\u25cf failed';
   }
 }
@@ -299,6 +334,77 @@ function stopRun() {
   fetch('stop', { method: 'POST' }).catch(() => {});
 }
 function esc(s) { const d = document.createElement('div'); d.textContent = String(s); return d.innerHTML; }
+
+// Interactive plan-approval / choice panel (#304). The run pauses on a 'choice'
+// event; we render the options with the recommended one pre-selected, accept on
+// click / Ctrl+Enter, and (when autopilot is on) auto-accept the recommended
+// after a countdown that any mouse movement cancels. The pick is POSTed to
+// /choice, which resolves the run; the run echoes a 'choice-resolved' back.
+let activeChoice = null;
+let choiceTimer = null;
+let choiceLeft = 0;
+function autopilotOn() {
+  const v = localStorage.getItem('framework:autopilot');
+  return v === null ? true : v === '1'; // default on, per the demo default
+}
+function showChoice(req) {
+  // Live only: a past run's choices are already resolved (read-only history), and
+  // if the server can't take a pick there is nothing to accept into.
+  if (!CHOICEABLE || mode !== 'live') return;
+  activeChoice = req;
+  $('choice-title').textContent = req.title || 'Your call';
+  const ul = $('choice-options'); ul.innerHTML = '';
+  for (const o of (req.options || [])) {
+    const li = document.createElement('li');
+    const checked = o.id === req.recommended ? ' checked' : '';
+    li.innerHTML = '<label><input type="radio" name="choice-opt" value="' + esc(o.id) + '"' + checked + '>' +
+      '<span class="opt-label">' + esc(o.label) + '</span>' +
+      (o.detail ? '<span class="opt-detail">' + esc(o.detail) + '</span>' : '') + '</label>';
+    ul.appendChild(li);
+  }
+  $('autopilot-toggle').checked = autopilotOn();
+  $('choice-panel').hidden = false;
+  startCountdown();
+}
+function selectedChoice() {
+  const el = document.querySelector('input[name="choice-opt"]:checked');
+  return el ? el.value : (activeChoice ? activeChoice.recommended : null);
+}
+function renderCount() {
+  $('choice-count').textContent = '\\u25cf autopilot accepting in ' + choiceLeft + 's \\u2014 move the mouse to cancel';
+}
+function startCountdown() {
+  stopCountdown();
+  if (!autopilotOn() || !activeChoice) { $('choice-count').textContent = ''; return; }
+  choiceLeft = Math.ceil((activeChoice.autoAcceptMs || AUTO_ACCEPT_MS) / 1000);
+  renderCount();
+  choiceTimer = setInterval(() => {
+    choiceLeft -= 1;
+    if (choiceLeft <= 0) { stopCountdown(); acceptChoice('autopilot'); }
+    else renderCount();
+  }, 1000);
+}
+function stopCountdown() { if (choiceTimer) { clearInterval(choiceTimer); choiceTimer = null; } }
+function cancelAutopilot() {
+  if (choiceTimer) { stopCountdown(); $('choice-count').textContent = 'autopilot canceled \\u2014 pick manually'; }
+}
+function acceptChoice(by) {
+  if (!activeChoice) return;
+  const id = activeChoice.id;
+  const pick = selectedChoice();
+  stopCountdown();
+  activeChoice = null;
+  $('choice-panel').hidden = true;
+  fetch('choice', { method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ id: id, pick: pick, by: by }) }).catch(() => {});
+}
+function resolveChoice(fe) {
+  if (activeChoice && activeChoice.id === fe.id) {
+    stopCountdown(); activeChoice = null; $('choice-panel').hidden = true;
+  }
+  log('\\u2713 chose ' + fe.picked + ' (' + fe.by + ')');
+}
+function closeChoice() { stopCountdown(); activeChoice = null; $('choice-panel').hidden = true; }
 
 // Run history (#303): the live stream is one run; past runs come from /api/runs and
 // replay through the very same render() into the panels. We keep every live event so
@@ -318,6 +424,7 @@ function resetPanels() {
   $('grade').textContent = 'building\\u2026'; $('grade').classList.add('muted');
   $('passes').innerHTML = '';
   $('modes-panel').hidden = true; $('modes').innerHTML = '';
+  closeChoice();
   $('deploy').textContent = 'not decided yet'; $('deploy').classList.add('muted');
   $('ledger').innerHTML = '';
   $('log').textContent = '';
@@ -380,6 +487,16 @@ function loadRuns() {
 
 $('stop').addEventListener('click', stopRun);
 $('back-live').addEventListener('click', showLive);
+$('choice-accept').addEventListener('click', () => acceptChoice('user'));
+$('autopilot-toggle').addEventListener('change', ev => {
+  localStorage.setItem('framework:autopilot', ev.target.checked ? '1' : '0');
+  if (ev.target.checked) startCountdown(); else { stopCountdown(); $('choice-count').textContent = 'autopilot off'; }
+});
+// Any mouse movement cancels the running autopilot countdown (cheap no-op once cleared).
+document.addEventListener('mousemove', cancelAutopilot);
+document.addEventListener('keydown', ev => {
+  if (activeChoice && (ev.ctrlKey || ev.metaKey) && ev.key === 'Enter') { ev.preventDefault(); acceptChoice('user'); }
+});
 const src = new EventSource('events');
 src.onmessage = ev => {
   let fe; try { fe = JSON.parse(ev.data); } catch { return; }

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -193,3 +193,50 @@ test('/stop is 405 for a non-POST and 404 when stopping is not wired (#218)', as
     await noStop.close()
   }
 })
+
+function postJson(url: string, body: unknown): Promise<{ status: number; body: string }> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const payload = JSON.stringify(body)
+    const req = request(url, { method: 'POST', headers: { 'content-type': 'application/json' } }, res => {
+      let out = ''
+      res.on('data', c => (out += c))
+      res.on('end', () => resolvePromise({ status: res.statusCode ?? 0, body: out }))
+    })
+    req.on('error', rejectPromise)
+    req.end(payload)
+  })
+}
+
+test('POST /choice invokes onChoice with the pick and the page reports it is choiceable (#304)', async () => {
+  const picks: Array<{ id: string; pick: string; by: string }> = []
+  const dash = await startDashboard({ port: 0, onChoice: (id, pick, by) => picks.push({ id, pick, by }) })
+  try {
+    const { status } = await postJson(dash.url + '/choice', { id: 'plan-approval', pick: 'alt:0', by: 'autopilot' })
+    assert.equal(status, 202)
+    assert.deepEqual(picks, [{ id: 'plan-approval', pick: 'alt:0', by: 'autopilot' }])
+    // An unknown `by` is normalized to 'user'.
+    await postJson(dash.url + '/choice', { id: 'plan-approval', pick: 'proceed' })
+    assert.equal(picks[1]!.by, 'user')
+    const page = await fetchText(dash.url + '/')
+    assert.match(page.body, /CHOICEABLE = true/)
+  } finally {
+    await dash.close()
+  }
+})
+
+test('/choice is 405 for a non-POST and 404 when choices are not wired (#304)', async () => {
+  const withChoice = await startDashboard({ port: 0, onChoice: () => {} })
+  try {
+    assert.equal((await send(withChoice.url + '/choice', 'GET')).status, 405)
+  } finally {
+    await withChoice.close()
+  }
+  const noChoice = await startDashboard({ port: 0 })
+  try {
+    assert.equal((await postJson(noChoice.url + '/choice', { id: 'x', pick: 'y' })).status, 404)
+    const page = await fetchText(noChoice.url + '/')
+    assert.match(page.body, /CHOICEABLE = false/)
+  } finally {
+    await noChoice.close()
+  }
+})

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -1,7 +1,7 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { EventStream } from '@gemstack/ai-autopilot'
-import type { FrameworkEvent } from '../events.js'
+import type { ChoiceBy, FrameworkEvent } from '../events.js'
 import { listRuns, loadRunEvents } from '../store/index.js'
 import { dashboardHtml } from './page.js'
 import { serveSSE } from './sse.js'
@@ -20,6 +20,14 @@ export interface DashboardOptions {
    * the page hides the button when the server reports no stop handler.
    */
   onStop?: () => void
+  /**
+   * Called when the browser posts an interactive-choice pick (#304): `POST /choice`
+   * with a JSON `{ id, pick, by }` body. Wire this to resolve the run's pending
+   * choice (e.g. settle the promise a `requestChoice` handler returned). Omit to
+   * disable interactive choices; the page still renders them but the route reports
+   * no handler (404).
+   */
+  onChoice?: (id: string, pick: string, by: ChoiceBy) => void
   /**
    * The workspace whose `.framework/runs/` archive backs the run-history sidebar
    * (#303): `GET /api/runs` lists it, `GET /api/runs/<id>` replays one run. Omit
@@ -55,11 +63,12 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
   const port = opts.port ?? 4477
   const title = opts.title ?? 'The Framework'
   const onStop = opts.onStop
+  const onChoice = opts.onChoice
   const cwd = opts.cwd
   const stream = new EventStream<FrameworkEvent>()
   const clients = new Set<ServerResponse>()
 
-  const server = createServer((req, res) => handle(req, res, stream, clients, title, onStop, cwd))
+  const server = createServer((req, res) => handle(req, res, stream, clients, title, onStop, onChoice, cwd))
 
   return new Promise<Dashboard>((resolvePromise, rejectPromise) => {
     server.once('error', rejectPromise)
@@ -84,12 +93,13 @@ function handle(
   clients: Set<ServerResponse>,
   title: string,
   onStop: (() => void) | undefined,
+  onChoice: ((id: string, pick: string, by: ChoiceBy) => void) | undefined,
   cwd: string | undefined,
 ): void {
   const url = req.url ?? '/'
   if (url === '/' || url.startsWith('/?')) {
     res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
-    res.end(dashboardHtml(title, Boolean(onStop)))
+    res.end(dashboardHtml(title, Boolean(onStop), Boolean(onChoice)))
     return
   }
   if (url === '/events') {
@@ -125,8 +135,50 @@ function handle(
     res.end('{"ok":true}')
     return
   }
+  if (url === '/choice') {
+    // An interactive-choice pick (#304). Same guards as /stop: 405 for a non-POST
+    // so a stray GET can't resolve a choice, 404 when no handler is wired.
+    if (req.method !== 'POST') {
+      res.writeHead(405, { 'content-type': 'text/plain', allow: 'POST' })
+      res.end('method not allowed')
+      return
+    }
+    if (!onChoice) {
+      res.writeHead(404, { 'content-type': 'text/plain' })
+      res.end('choices not enabled')
+      return
+    }
+    readJsonBody(req, body => {
+      const id = typeof body['id'] === 'string' ? body['id'] : ''
+      const pick = typeof body['pick'] === 'string' ? body['pick'] : ''
+      const by: ChoiceBy = body['by'] === 'autopilot' ? 'autopilot' : body['by'] === 'auto' ? 'auto' : 'user'
+      if (id && pick) onChoice(id, pick, by)
+      res.writeHead(202, { 'content-type': 'application/json' })
+      res.end('{"ok":true}')
+    })
+    return
+  }
   res.writeHead(404, { 'content-type': 'text/plain' })
   res.end('not found')
+}
+
+/** Read a small JSON request body, tolerant of malformed input (yields `{}`). */
+function readJsonBody(req: IncomingMessage, cb: (body: Record<string, unknown>) => void): void {
+  let data = ''
+  req.on('data', (chunk: Buffer) => {
+    data += chunk
+    if (data.length > 64_000) req.destroy() // cap the body; a pick is tiny
+  })
+  req.on('end', () => {
+    let body: unknown
+    try {
+      body = JSON.parse(data || '{}')
+    } catch {
+      body = {}
+    }
+    cb(body && typeof body === 'object' ? (body as Record<string, unknown>) : {})
+  })
+  req.on('error', () => cb({}))
 }
 
 /** `GET /api/runs` — the project's archived runs, most-recent first (or `[]`). */

--- a/packages/framework/src/events.ts
+++ b/packages/framework/src/events.ts
@@ -1,6 +1,45 @@
 import type { BootstrapEvent } from '@gemstack/ai-autopilot'
 import type { DriverEvent } from './driver/index.js'
 
+/** One selectable option in an interactive {@link ChoiceRequest} (#304). */
+export interface ChoiceOption {
+  /** Stable id posted back when this option is picked. */
+  id: string
+  /** The option shown to the user. */
+  label: string
+  /** Optional one-line detail under the label (e.g. why an alternative lost). */
+  detail?: string
+}
+
+/**
+ * An interactive choice the run pauses on until a pick arrives (#304). Emitted as
+ * a `choice` {@link FrameworkEvent}; the dashboard renders it in a panel and posts
+ * the pick back. The recommended option is the default the autopilot auto-accepts.
+ */
+export interface ChoiceRequest {
+  /** Unique id for this pending choice; the pick is posted back against it. */
+  id: string
+  /** The question shown above the options (e.g. "Approve this plan?"). */
+  title: string
+  /** The options to choose between (at least one). */
+  options: readonly ChoiceOption[]
+  /** The option id pre-selected as the default (autopilot auto-accepts it). */
+  recommended: string
+  /** Auto-accept the recommended option after this many ms when autopilot is on. Default 10000. */
+  autoAcceptMs?: number
+}
+
+/** Who resolved a {@link ChoiceRequest}: a human, the autopilot countdown, or a headless auto-accept. */
+export type ChoiceBy = 'user' | 'autopilot' | 'auto'
+
+/** What a {@link import('./run.js').RunFrameworkOptions.requestChoice} handler resolves with. */
+export interface ChoicePick {
+  /** The picked option id. */
+  picked: string
+  /** Who picked it. Default `'user'`. */
+  by?: ChoiceBy
+}
+
 /**
  * The single event type the whole run streams over. It unifies three sources so
  * the dashboard (and terminal) render one timeline: bootstrap-phase narration
@@ -38,6 +77,14 @@ export type FrameworkEvent =
    */
   | { kind: 'modes'; all: readonly string[]; active: readonly string[] }
   /**
+   * The run paused on an interactive choice (#304) and is awaiting a pick. The
+   * dashboard renders the options with the recommended default pre-selected and
+   * posts the pick back; a headless run auto-accepts the recommended option.
+   */
+  | ({ kind: 'choice' } & ChoiceRequest)
+  /** A pending {@link ChoiceRequest} was resolved — the run continues on `picked`. */
+  | { kind: 'choice-resolved'; id: string; picked: string; by: ChoiceBy }
+  /**
    * The run finished. `ok` is false when it threw. `stopped` marks the common,
    * non-error case where the user interrupted it (the dashboard Stop button /
    * Ctrl+C), so a surface can show "stopped" rather than "failed".
@@ -61,6 +108,14 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
       const shown = event.all.map(m => `${event.active.includes(m) ? '[x]' : '[ ]'} ${m}`).join('  ')
       return `  modes: ${shown}`
     }
+    case 'choice': {
+      const opts = event.options
+        .map(o => `    ${o.id === event.recommended ? '●' : '○'} ${o.label}`)
+        .join('\n')
+      return `? ${event.title}\n${opts}`
+    }
+    case 'choice-resolved':
+      return `  ✓ chose ${event.picked} (${event.by})`
     case 'driver':
       return formatDriverEvent(event.event)
     case 'bootstrap':

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -35,6 +35,7 @@
 export * from './driver/index.js'
 export {
   driverArchitect,
+  reArchitect,
   driverBuild,
   driverChecklist,
   driverImprove,
@@ -73,6 +74,10 @@ export {
 export { hostExecutor, type HostExecutorOptions } from './host-exec.js'
 export {
   type FrameworkEvent,
+  type ChoiceOption,
+  type ChoiceRequest,
+  type ChoicePick,
+  type ChoiceBy,
   formatFrameworkEvent,
   resolveSessionLink,
   hasSessionIdPlaceholder,

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -5,7 +5,7 @@ import type { Prompt } from '@gemstack/ai-autopilot'
 import { DEFAULT_MAX_PASSES, runFramework } from './run.js'
 import { FAKE_DEPLOY, FAKE_INTENT, FAKE_SIGNALS, fakeDriver } from './fake-script.js'
 import { FakeDriver, type Driver, type DriverSession } from './driver/index.js'
-import type { FrameworkEvent } from './events.js'
+import type { ChoiceRequest, FrameworkEvent } from './events.js'
 
 /** A driver that records the `system` framing it is started with, delegating the run to the fake. */
 function recordingDriver(): { driver: Driver; system: () => string } {
@@ -426,4 +426,102 @@ test('runFramework prototype scope skips the full-fledged loop', async () => {
   })
   assert.equal(result.passes, 0)
   assert.equal(result.productionGrade, false)
+})
+
+test('the plan-approval gate (#304) pauses on a choice, proceeds, and keeps the plan', async () => {
+  const events: FrameworkEvent[] = []
+  const seen: ChoiceRequest[] = []
+  const { result } = await runFramework({
+    intent: FAKE_INTENT,
+    driver: fakeDriver(),
+    cwd: '/tmp/ws',
+    signals: FAKE_SIGNALS,
+    deploy: FAKE_DEPLOY,
+    onEvent: e => events.push(e),
+    requestChoice: async req => {
+      seen.push(req)
+      return { picked: 'proceed', by: 'user' }
+    },
+  })
+
+  // The gate emitted one choice, offering "proceed" (recommended) plus the
+  // architect's alternative as "Use Next.js instead".
+  assert.equal(seen.length, 1)
+  const choice = events.find(e => e.kind === 'choice')
+  assert.ok(choice && choice.kind === 'choice')
+  assert.equal(choice.recommended, 'proceed')
+  assert.ok(choice.options.some(o => o.id === 'proceed'))
+  assert.ok(choice.options.some(o => o.id === 'alt:0' && /Next\.js/.test(o.label)))
+
+  // It resolved to the pick, and the choice came before the architect narration.
+  const resolved = events.find(e => e.kind === 'choice-resolved')
+  assert.ok(resolved && resolved.kind === 'choice-resolved')
+  assert.equal(resolved.picked, 'proceed')
+  assert.equal(resolved.by, 'user')
+  const ci = events.findIndex(e => e.kind === 'choice')
+  const ai = events.findIndex(e => e.kind === 'bootstrap' && e.event.type === 'architect')
+  assert.ok(ci >= 0 && ai > ci)
+
+  // Proceeding kept the original stack and still reached production-grade.
+  const architect = events.find(e => e.kind === 'bootstrap' && e.event.type === 'architect')
+  assert.ok(architect && architect.kind === 'bootstrap' && architect.event.type === 'architect')
+  assert.match(architect.event.stack, /Vike \+ Prisma/)
+  assert.equal(result.productionGrade, true)
+})
+
+test('without a requestChoice handler no choice events are emitted (#304)', async () => {
+  const events: FrameworkEvent[] = []
+  await runFramework({
+    intent: FAKE_INTENT,
+    driver: fakeDriver(),
+    cwd: '/tmp/ws',
+    signals: FAKE_SIGNALS,
+    onEvent: e => events.push(e),
+  })
+  assert.equal(events.some(e => e.kind === 'choice'), false)
+  assert.equal(events.some(e => e.kind === 'choice-resolved'), false)
+})
+
+test('picking an alternative re-architects the run around it (#304)', async () => {
+  const first = {
+    stack: 'Vike + Prisma',
+    narration: 'first plan',
+    decisions: [{ choice: 'SSR', why: 'per-request data' }],
+    alternatives: [{ option: 'Next.js', whyNot: 'edge deploy is more constrained' }],
+  }
+  const second = {
+    stack: 'Next.js + Postgres',
+    narration: 'second plan',
+    decisions: [{ choice: 'App Router', why: 'the user chose it' }],
+    alternatives: [],
+  }
+  // A driver that answers by prompt: the steered re-architect returns the Next.js
+  // plan, the first architect the Vike plan, the checklist passes clean.
+  const driver = new FakeDriver({
+    respond: (prompt: string): string => {
+      if (/You are the architect/.test(prompt) && /prefers Next\.js/.test(prompt))
+        return '```json\n' + JSON.stringify(second) + '\n```'
+      if (/You are the architect/.test(prompt)) return '```json\n' + JSON.stringify(first) + '\n```'
+      if (/production-grade checklist/.test(prompt)) return 'Reviewed.\n```json\n{ "blockers": [] }\n```'
+      return 'done'
+    },
+    sessionId: 'fake-realt',
+  })
+
+  const events: FrameworkEvent[] = []
+  const { result } = await runFramework({
+    intent: FAKE_INTENT,
+    driver,
+    cwd: '/tmp/ws',
+    signals: FAKE_SIGNALS,
+    onEvent: e => events.push(e),
+    requestChoice: async () => ({ picked: 'alt:0', by: 'user' }),
+  })
+
+  // Re-architecting was narrated, and the final narrated stack is the alternative.
+  assert.ok(events.some(e => e.kind === 'log' && /Re-architecting around your choice: Next\.js/.test(e.message)))
+  const architect = events.find(e => e.kind === 'bootstrap' && e.event.type === 'architect')
+  assert.ok(architect && architect.kind === 'bootstrap' && architect.event.type === 'architect')
+  assert.match(architect.event.stack, /Next\.js \+ Postgres/)
+  assert.equal(result.productionGrade, true)
 })

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -17,6 +17,8 @@ import {
   serveCheck,
   skillInstructions,
   skillPersonas,
+  type ArchitectContext,
+  type ArchitectPlan,
   type BootstrapEvent,
   type BootstrapResult,
   type BootstrapScope,
@@ -34,8 +36,8 @@ import { snapshotWorkspace } from './sandbox.js'
 import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { memoryFraming, type LoadedMemory } from './memory.js'
 import { systemPromptBlock } from './system-prompt.js'
-import { decideDeploy, deployWith, domainLoopChecklist, driverArchitect, driverBuild, driverChecklist, driverImprove, driverLoopPrompts } from './steps.js'
-import { hasSessionIdPlaceholder, OPEN_LOOP_MODES, resolveSessionLink, type FrameworkEvent } from './events.js'
+import { decideDeploy, deployWith, domainLoopChecklist, driverArchitect, driverBuild, driverChecklist, driverImprove, driverLoopPrompts, reArchitect } from './steps.js'
+import { hasSessionIdPlaceholder, OPEN_LOOP_MODES, resolveSessionLink, type ChoiceOption, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 
 /**
  * The framework's default full-fledged pass budget. Higher than ai-autopilot's
@@ -189,6 +191,15 @@ export interface RunFrameworkOptions {
   sessionLink?: string
   /** Interrupt the run between phases. */
   signal?: AbortSignal
+  /**
+   * Pause the run on an interactive choice and await a pick (#304). Called at the
+   * plan-approval gate right after the architect decides the stack: the run emits a
+   * `choice` event, calls this, and resumes on the returned option — proceeding as
+   * planned, or re-architecting around a picked alternative. Omit for a headless
+   * run: the gate then auto-accepts the recommended option without pausing. The CLI
+   * wires this to the dashboard's Accept button + autopilot countdown.
+   */
+  requestChoice?: (req: ChoiceRequest) => Promise<ChoicePick>
   /** Observe the unified event stream. */
   onEvent?: (event: FrameworkEvent) => void
 }
@@ -429,7 +440,10 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
       onEvent: (event: BootstrapEvent) => emit({ kind: 'bootstrap', event }),
       steps: {
         scope: () => ({ scope: opts.scope ?? 'full', intent: opts.intent }),
-        architect: driverArchitect(session),
+        architect: planApprovalGate(driverArchitect(session), session, {
+          ...(opts.requestChoice ? { requestChoice: opts.requestChoice } : {}),
+          emit,
+        }),
         build: driverBuild(session, workspaceOpt),
         checklist,
         improve: driverImprove(session, workspaceOpt),
@@ -461,6 +475,58 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     await session.dispose()
     // Keep the runner alive only when it owns a live preview handed to the caller.
     if (runner && !preview) await runner.dispose()
+  }
+}
+
+/**
+ * The plan-approval gate (#304): the AWAIT point of Rom's plan-then-AWAIT flow.
+ * Wraps the architect step so that once the stack is decided, the run pauses on a
+ * `choice` — "Approve this plan?", recommended = proceed, plus each architect
+ * alternative as "Use <X> instead" — and resumes on the pick. Picking an
+ * alternative re-architects around it (a fresh, coherent plan, not just a swapped
+ * name). A no-op unless a {@link RunFrameworkOptions.requestChoice} handler is
+ * wired, so a headless / programmatic run is byte-identical to before.
+ */
+function planApprovalGate(
+  base: (ctx: ArchitectContext) => Promise<ArchitectPlan>,
+  session: DriverSession,
+  deps: {
+    requestChoice?: (req: ChoiceRequest) => Promise<ChoicePick>
+    emit: (event: FrameworkEvent) => void
+  },
+): (ctx: ArchitectContext) => Promise<ArchitectPlan> {
+  return async ctx => {
+    const plan = await base(ctx)
+    const { requestChoice, emit } = deps
+    if (!requestChoice) return plan
+
+    const alternatives = plan.alternatives ?? []
+    const options: ChoiceOption[] = [
+      { id: 'proceed', label: `Proceed: ${plan.stack}` },
+      ...alternatives.map((a, i) => ({
+        id: `alt:${i}`,
+        label: `Use ${a.option} instead`,
+        ...(a.whyNot ? { detail: a.whyNot } : {}),
+      })),
+    ]
+    const req: ChoiceRequest = { id: 'plan-approval', title: 'Approve this plan?', options, recommended: 'proceed' }
+    emit({ kind: 'choice', ...req })
+
+    // A handler that rejects (or a run aborted mid-await) must not hang the gate:
+    // fall back to the recommended option so the next phase's signal check ends it.
+    let pick: ChoicePick
+    try {
+      pick = await requestChoice(req)
+    } catch {
+      pick = { picked: 'proceed', by: 'auto' }
+    }
+    emit({ kind: 'choice-resolved', id: req.id, picked: pick.picked, by: pick.by ?? 'user' })
+
+    const altMatch = /^alt:(\d+)$/.exec(pick.picked)
+    const chosen = altMatch ? alternatives[Number(altMatch[1])] : undefined
+    if (!chosen) return plan
+    emit({ kind: 'log', message: `Re-architecting around your choice: ${chosen.option}` })
+    return reArchitect(session, ctx, plan.stack, chosen.option)
   }
 }
 

--- a/packages/framework/src/steps.ts
+++ b/packages/framework/src/steps.ts
@@ -37,11 +37,17 @@ import type { DriverSession } from './driver/index.js'
 
 const ZERO_USAGE = { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
 
-/** Compose the architect prompt for an intent. Exported so callers can override. */
-export function architectPrompt(intent: string): string {
+/**
+ * Compose the architect prompt for an intent. Exported so callers can override.
+ * `steer` is an optional extra constraint (e.g. the user overrode the stack at the
+ * plan-approval gate, #304), inserted right after the intent so it frames the whole
+ * decision.
+ */
+export function architectPrompt(intent: string, steer?: string): string {
   return [
     'You are the architect for a new app. Decide the stack and the key architectural choices.',
     `What the user wants: ${intent}`,
+    ...(steer ? [steer] : []),
     'Prefer a modern, well-supported stack. Keep the choices minimal and justified.',
     'Justify the stack honestly: give its real PROS and its CONS, and name the main',
     'alternative you rejected and why it lost. This is shown to the user as the rationale.',
@@ -186,6 +192,23 @@ export function driverArchitect(
     })
     return parseArchitectPlan(turn.text, ctx.intent)
   }
+}
+
+/**
+ * Re-run the architect after the user overrode the stack at the plan-approval gate
+ * (#304): same intent, same app goal, but steered to build around the alternative
+ * they picked instead of the stack originally chosen. Returns a fresh plan.
+ */
+export function reArchitect(
+  session: DriverSession,
+  ctx: ArchitectContext,
+  fromStack: string,
+  toOption: string,
+): Promise<ArchitectPlan> {
+  const steer = `The user reviewed your first choice (${fromStack}) and prefers ${toOption}. Re-decide the stack around ${toOption}, keeping the same app goal.`
+  return session
+    .prompt(architectPrompt(ctx.intent, steer), { ...(ctx.signal ? { signal: ctx.signal } : {}) })
+    .then(turn => parseArchitectPlan(turn.text, ctx.intent))
 }
 
 /**


### PR DESCRIPTION
MVP slice 3 of 3 for #299 (the demo money-shot). The run now pauses on a **plan-approval gate** right after the architect decides the stack, the AWAIT point of Rom's plan-then-AWAIT flow.

## What it does
- After the architect proposes a stack, the dashboard shows a **"Your call"** panel: **Proceed: <stack>** (recommended) plus each architect alternative as **"Use X instead"**.
- **Accept** button or **Ctrl+Enter** picks the selected option.
- **`[x] autopilot`** (default on) counts down 10s and auto-accepts the recommended plan; moving the mouse cancels the countdown.
- Picking an alternative **re-architects** the run around it (a fresh, coherent plan, not just a swapped name).

## How it's wired
- `events.ts`: `choice` / `choice-resolved` events + `ChoiceRequest`/`ChoiceOption`/`ChoicePick`/`ChoiceBy`.
- `run.ts`: new `requestChoice` option + `planApprovalGate` wrapping the architect step. **No-op unless a handler is wired**, so headless/programmatic/`--fake --no-dashboard` runs are byte-identical (auto-accept the recommended plan). `reArchitect` (in `steps.ts`) steers a fresh plan around a picked alternative.
- `server.ts`: `POST /choice` route + `onChoice` (mirrors `onStop`: 405 non-POST, 404 when unwired).
- `page.ts`: the interactive panel, keyboard + autopilot, `POST /choice`. Live-only; history replay stays read-only.
- `cli.ts`: parks a resolver per pending choice, resolves it on the pick, and resolves pending choices on abort so a stopped run never hangs.

## Verification
- 5 new tests (2 server, 3 run-flow) + full suite green (180 tests, 0 fail).
- Drove it end-to-end against the built `dist`: run pauses on the gate, a simulated browser `POST /choice` picks the alternative, the run re-architects around Next.js and finishes production-grade.

Closes #304.