### PR TITLE
fix(framework): narrate auto-preset routing so the dashboard is not blank (#310)

### DIFF
--- a/.changeset/dashboard-preset-routing-narration.md
+++ b/.changeset/dashboard-preset-routing-narration.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/framework': patch
+---
+
+fix(framework): narrate the auto-preset routing turn so the dashboard is not blank at the start of a run (#310)
+
+A preset-less live run first does a real Claude routing turn to auto-select a domain preset. The dashboard was started only after that turn, so its first few seconds looked dead. The dashboard now starts before the routing turn and the turn narrates a log line into it.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -18,6 +18,7 @@ import {
   type CliIO,
 } from './cli.js'
 import { FakeDriver } from './driver/index.js'
+import type { FrameworkEvent } from './events.js'
 
 function capture(): { io: CliIO; out: string[]; err: string[] } {
   const out: string[] = []
@@ -140,6 +141,22 @@ test('autoSelectPreset routes the pick through an injected driver and returns th
     const { io } = capture()
     const selection = await autoSelectPreset({ intent: 'fix a crash', cwd: empty, signals: {}, claudeOpts: {}, io, driver })
     assert.deepEqual(selection, { preset: 'software-development', modes: ['technical'], buildEvent: 'bug-fix', why: 'a fix' })
+  } finally {
+    await rm(empty, { recursive: true, force: true })
+  }
+})
+
+test('autoSelectPreset narrates the routing turn through onEvent so the dashboard is not blank (#310)', async () => {
+  const empty = await mkdtemp(join(tmpdir(), 'framework-ws-'))
+  try {
+    const driver = new FakeDriver({
+      turns: [{ text: '```json\n{ "preset": "none", "modes": [], "why": "n/a" }\n```' }],
+    })
+    const { io } = capture()
+    const events: FrameworkEvent[] = []
+    await autoSelectPreset({ intent: 'anything', cwd: empty, signals: {}, claudeOpts: {}, io, driver, onEvent: e => events.push(e) })
+    // Emitted before the routing turn resolves, so the dashboard shows activity during it.
+    assert.ok(events.some(e => e.kind === 'log' && /auto-selecting the best-fit preset/.test(e.message)))
   } finally {
     await rm(empty, { recursive: true, force: true })
   }

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -455,10 +455,15 @@ export async function autoSelectPreset(opts: {
   io: CliIO
   /** The driver to route the pick through. Defaults to a Claude Code driver; injected in tests. */
   driver?: Driver
+  /** Narrate the routing turn to the dashboard + terminal (#310), so it isn't a blank while the pick runs. */
+  onEvent?: (event: FrameworkEvent) => void
 }): Promise<MetaSelection | undefined> {
   const catalog = presetCatalog(await builtinDomainPresets())
   if (catalog.length === 0) return undefined
   const driver = opts.driver ?? new ClaudeCodeDriver(opts.claudeOpts)
+  // The routing turn is a real Claude turn that emits no run events, so without
+  // this the dashboard sits blank for its first few seconds (#310).
+  opts.onEvent?.({ kind: 'log', message: '◆ auto-selecting the best-fit preset from your prompt + workspace…' })
   let session: DriverSession | undefined
   try {
     session = await driver.start({
@@ -605,74 +610,11 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   process.on('SIGINT', onInterrupt)
   process.on('SIGTERM', onInterrupt)
 
-  // AI meta-select: with no preset chosen explicitly, infer the best fit (+ modes +
-  // build event) from the intent + workspace, then resolve it with the active modes.
-  if (!fake && opts.autoPreset && !presetName) {
-    const selection = await autoSelectPreset({ intent, cwd, signals, claudeOpts, signal: controller.signal, io })
-    if (selection?.preset) {
-      presetName = selection.preset
-      modeList = [...new Set([...modeList, ...selection.modes])]
-      buildEvent = buildEvent ?? selection.buildEvent
-      domainPreset = (await resolveDomainPreset(presetName, modeList)).preset
-      const modeNote = modeList.length ? ` (modes: ${modeList.join(', ')})` : ''
-      const kindNote = selection.buildEvent && !merged.buildEvent ? `, ${selection.buildEvent}` : ''
-      io.out(`◆ auto-selected preset: ${presetName}${modeNote}${kindNote}${selection.why ? ` — ${selection.why}` : ''}`)
-    } else {
-      io.out(`◆ auto-select: no preset fits${selection?.why ? ` (${selection.why})` : ''}; using the plain framework flow.`)
-    }
-  }
-
-  // A mode/kind given with no preset in effect has nothing to act on: note it.
-  if (modeList.length && !domainPreset) {
-    io.err(`note: ${modeList.join(' + ')} mode(s) have no effect without a preset.`)
-  }
-  if (buildEvent && !domainPreset) {
-    io.err(`note: build event "${buildEvent}" has no effect without a preset.`)
-  }
-  // The sandbox only wraps the serve verification, so it is a no-op without --serve.
-  if (opts.sandbox === 'docker' && !opts.serve) {
-    io.err(`note: --sandbox docker has no effect without --serve.`)
-  }
-
-  const driver: Driver = fake ? fakeDriver() : new ClaudeCodeDriver(claudeOpts)
-  // The fake demo defaults to a Cloudflare deploy decision so the flow ends with
-  // a deploy phase; a live run only narrates deploy when asked.
-  const deploy: DeployDecision | undefined = opts.deploy
-    ? { render: 'ssr', target: opts.deploy, reason: `deploy to ${opts.deploy}` }
-    : fake
-      ? FAKE_DEPLOY
-      : undefined
-
-  // A real deploy target actually ships the app. Only for live runs against a
-  // known target; --fake stays plan-only and deterministic. An unknown target
-  // just narrates the decision. Real targets never throw on missing creds.
-  let deployTarget: DeployTarget | undefined
-  if (!fake && opts.deploy) {
-    const built = buildDeployTarget(opts.deploy, opts, cwd)
-    if (built.error) {
-      io.err(built.error)
-      io.err('Run `framework --help` for usage.')
-      return 2
-    }
-    deployTarget = built.target
-  }
-
-  const serve: ServeConfig | undefined = opts.serve
-    ? {
-        command: opts.serve,
-        // The CLI keeps the dashboard (and app) up until Ctrl+C, so leave the app
-        // serving with a preview link once the run succeeds.
-        keepAlive: true,
-        ...(opts.serveInstall ? { install: opts.serveInstall } : {}),
-        ...(opts.serveBuild ? { build: opts.serveBuild } : {}),
-        ...(opts.servePort !== undefined ? { port: opts.servePort } : {}),
-        ...(opts.servePath ? { healthPath: opts.servePath } : {}),
-      }
-    : undefined
-
   // The dashboard Stop button aborts the run-wide controller created above.
   // runFramework checks the signal between phases and the driver kills its current
-  // turn on it, so a stop takes effect promptly.
+  // turn on it, so a stop takes effect promptly. Started here — before the AI
+  // meta-select turn — so that routing turn narrates into a live dashboard instead
+  // of leaving it blank for its first few seconds (#310).
   //
   // Interactive choices (#304): the run's requestChoice handler parks a resolver
   // here keyed by the choice id; the dashboard's Accept / autopilot POSTs the pick
@@ -733,6 +675,72 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     void store?.append(event)
     publisher?.publish(event)
   }
+
+  // AI meta-select: with no preset chosen explicitly, infer the best fit (+ modes +
+  // build event) from the intent + workspace, then resolve it with the active modes.
+  // Narrates through onEvent so the routing turn is visible on the dashboard (#310).
+  if (!fake && opts.autoPreset && !presetName) {
+    const selection = await autoSelectPreset({ intent, cwd, signals, claudeOpts, signal: controller.signal, io, onEvent })
+    if (selection?.preset) {
+      presetName = selection.preset
+      modeList = [...new Set([...modeList, ...selection.modes])]
+      buildEvent = buildEvent ?? selection.buildEvent
+      domainPreset = (await resolveDomainPreset(presetName, modeList)).preset
+      const modeNote = modeList.length ? ` (modes: ${modeList.join(', ')})` : ''
+      const kindNote = selection.buildEvent && !merged.buildEvent ? `, ${selection.buildEvent}` : ''
+      onEvent({ kind: 'log', message: `◆ auto-selected preset: ${presetName}${modeNote}${kindNote}${selection.why ? ` — ${selection.why}` : ''}` })
+    } else {
+      onEvent({ kind: 'log', message: `◆ auto-select: no preset fits${selection?.why ? ` (${selection.why})` : ''}; using the plain framework flow.` })
+    }
+  }
+
+  // A mode/kind given with no preset in effect has nothing to act on: note it.
+  if (modeList.length && !domainPreset) {
+    io.err(`note: ${modeList.join(' + ')} mode(s) have no effect without a preset.`)
+  }
+  if (buildEvent && !domainPreset) {
+    io.err(`note: build event "${buildEvent}" has no effect without a preset.`)
+  }
+  // The sandbox only wraps the serve verification, so it is a no-op without --serve.
+  if (opts.sandbox === 'docker' && !opts.serve) {
+    io.err(`note: --sandbox docker has no effect without --serve.`)
+  }
+
+  const driver: Driver = fake ? fakeDriver() : new ClaudeCodeDriver(claudeOpts)
+  // The fake demo defaults to a Cloudflare deploy decision so the flow ends with
+  // a deploy phase; a live run only narrates deploy when asked.
+  const deploy: DeployDecision | undefined = opts.deploy
+    ? { render: 'ssr', target: opts.deploy, reason: `deploy to ${opts.deploy}` }
+    : fake
+      ? FAKE_DEPLOY
+      : undefined
+
+  // A real deploy target actually ships the app. Only for live runs against a
+  // known target; --fake stays plan-only and deterministic. An unknown target
+  // just narrates the decision. Real targets never throw on missing creds.
+  let deployTarget: DeployTarget | undefined
+  if (!fake && opts.deploy) {
+    const built = buildDeployTarget(opts.deploy, opts, cwd)
+    if (built.error) {
+      io.err(built.error)
+      io.err('Run `framework --help` for usage.')
+      return 2
+    }
+    deployTarget = built.target
+  }
+
+  const serve: ServeConfig | undefined = opts.serve
+    ? {
+        command: opts.serve,
+        // The CLI keeps the dashboard (and app) up until Ctrl+C, so leave the app
+        // serving with a preview link once the run succeeds.
+        keepAlive: true,
+        ...(opts.serveInstall ? { install: opts.serveInstall } : {}),
+        ...(opts.serveBuild ? { build: opts.serveBuild } : {}),
+        ...(opts.servePort !== undefined ? { port: opts.servePort } : {}),
+        ...(opts.servePath ? { healthPath: opts.servePath } : {}),
+      }
+    : undefined
 
   // Discover installed `framework-*` capability packages (#190) from the signals
   // read above and register them; each still activates by signal or the


### PR DESCRIPTION
## What

A preset-less live run first runs a real Claude routing turn to auto-select a domain preset (#204). The dashboard was started only *after* that turn, so the first few seconds of a run looked dead before scope even started (the blank reported in #310, found while dogfooding #308).

## Fix

- Start the dashboard (and the store / relay / `onEvent` sink) *before* the meta-select turn.
- `autoSelectPreset` narrates the routing turn through `onEvent`: a `log` line `auto-selecting the best-fit preset…` emitted before the turn resolves, and the resolved pick as a log line after. Both now show on the dashboard (and terminal) instead of a blank.

No behavior change for `--fake`, `--preset`, or `--no-auto-preset` runs (they skip auto-select).

## Test

Added a unit test asserting `autoSelectPreset` emits the narration `log` event through `onEvent`. Full suite: 180 pass, 1 skip (docker).

Closes #310