### PR TITLE
feat(framework): dashboard browser notifications for run-end + choice gates (#317)

### DIFF
--- a/.changeset/dashboard-browser-notifications.md
+++ b/.changeset/dashboard-browser-notifications.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/framework': minor
+---
+
+feat(framework): opt-in browser notifications on the dashboard for run-end and choice gates (#317)
+
+The localhost dashboard can now notify you when a run finishes (or fails/stops) and when a run reaches a `<Choices>` gate that needs your input (e.g. a PLAN.md approval). Opt in via the header bell; it only nudges when the dashboard tab is backgrounded, so a run you are watching stays quiet.

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -34,6 +34,11 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   #stop:hover { background: #2f2118; border-color: #6a4a2e; }
   #stop:disabled { opacity: .5; cursor: default; }
   #stop[hidden] { display: none; }
+  #notify { margin-left: 12px; font: inherit; font-size: 13px; cursor: pointer; line-height: 1;
+    color: #b7c0d0; background: #141a24; border: 1px solid #24344a; border-radius: 6px; padding: 4px 8px; }
+  #notify:hover { background: #17212f; }
+  #notify.on { border-color: #2f6f4a; background: #12241a; }
+  #notify.denied { opacity: .5; cursor: not-allowed; }
   #app-banner { display: flex; align-items: center; gap: 8px; padding: 10px 20px;
     background: #0f2417; border-bottom: 1px solid #1c3a28; font-size: 13px; }
   #app-banner .dot { color: #67d98f; }
@@ -124,6 +129,7 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   <span class="sub" id="session">connecting…</span>
   <span id="session-link"></span>
   <span id="status">●</span>
+  <button id="notify" title="Notify me when a run finishes or needs my input">🔕</button>
   <button id="stop" hidden>■ Stop</button>
 </header>
 <div id="layout">
@@ -325,6 +331,9 @@ function render(fe) {
     if (mode === 'live') { ended = true; $('stop').hidden = true; }
     closeChoice();
     $('status').textContent = fe.ok ? '\\u25cf finished' : fe.stopped ? '\\u25a0 stopped' : '\\u25cf failed';
+    notify(
+      fe.ok ? '\\u2713 Run finished' : fe.stopped ? '\\u25a0 Run stopped' : '\\u2717 Run failed',
+      fe.ok ? 'Your build is ready on the dashboard.' : fe.detail || '');
   }
 }
 function stopRun() {
@@ -365,6 +374,7 @@ function showChoice(req) {
   $('autopilot-toggle').checked = autopilotOn();
   $('choice-panel').hidden = false;
   startCountdown();
+  notify('The run needs your input', req.title || 'A choice is waiting for you.');
 }
 function selectedChoice() {
   const el = document.querySelector('input[name="choice-opt"]:checked');
@@ -484,6 +494,47 @@ function renderRuns(runs) {
 function loadRuns() {
   fetch('api/runs').then(r => r.ok ? r.json() : { runs: [] }).then(d => renderRuns(d.runs || [])).catch(() => {});
 }
+
+// Browser notifications (#309): tell the human when a run finishes or reaches a
+// point that needs them (a <Choices> gate, e.g. a PLAN.md approval) while the tab
+// is backgrounded. Opt-in via the header bell; the choice is remembered. Fully
+// client-side and best-effort — a browser without the API just hides the bell.
+const notifyBtn = $('notify');
+const notifySupported = () => 'Notification' in window;
+const notifyEnabled = () => localStorage.getItem('framework:notify') === '1';
+function syncNotifyBtn() {
+  if (!notifySupported()) { notifyBtn.hidden = true; return; }
+  const denied = Notification.permission === 'denied';
+  const on = notifyEnabled() && Notification.permission === 'granted';
+  notifyBtn.classList.toggle('on', on);
+  notifyBtn.classList.toggle('denied', denied);
+  notifyBtn.textContent = on ? '\\uD83D\\uDD14' : '\\uD83D\\uDD15';
+  notifyBtn.title = denied ? 'Notifications are blocked in your browser settings'
+    : on ? 'Notifications on \\u2014 click to mute'
+    : 'Notify me when a run finishes or needs my input';
+}
+async function toggleNotify() {
+  if (!notifySupported() || Notification.permission === 'denied') return;
+  if (notifyEnabled() && Notification.permission === 'granted') {
+    localStorage.setItem('framework:notify', '0');
+  } else {
+    const perm = Notification.permission === 'granted' ? 'granted' : await Notification.requestPermission();
+    localStorage.setItem('framework:notify', perm === 'granted' ? '1' : '0');
+  }
+  syncNotifyBtn();
+}
+function notify(title, body) {
+  // Live run only, opt-in + permitted, and only when the tab is backgrounded: if
+  // the user is already looking at the dashboard the panels say it all.
+  if (mode !== 'live' || !notifyEnabled() || !notifySupported()) return;
+  if (Notification.permission !== 'granted' || !document.hidden) return;
+  try {
+    const n = new Notification(title, { body: body || '', tag: 'framework-run' });
+    n.onclick = () => { window.focus(); n.close(); };
+  } catch {}
+}
+notifyBtn.addEventListener('click', toggleNotify);
+syncNotifyBtn();
 
 $('stop').addEventListener('click', stopRun);
 $('back-live').addEventListener('click', showLive);

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -73,6 +73,24 @@ test('dashboard serves the HTML page with the title', async () => {
   }
 })
 
+test('page ships opt-in browser notifications for run-end and choice gates (#309)', async () => {
+  const dash = await startDashboard({ port: 0 })
+  try {
+    const { body } = await fetchText(dash.url + '/')
+    // The header bell + its permission-gated notify helper ship in the page.
+    assert.match(body, /id="notify"/)
+    assert.match(body, /function notify\(title, body\)/)
+    assert.match(body, /Notification\.requestPermission/)
+    // Fired on a run end and when a choice gate needs the human.
+    assert.match(body, /Run finished/)
+    assert.match(body, /The run needs your input/)
+    // Only nudges when the tab is backgrounded, so a watched run stays quiet.
+    assert.match(body, /document\.hidden/)
+  } finally {
+    await dash.close()
+  }
+})
+
 test('dashboard replays buffered events and streams them over SSE', async () => {
   const dash = await startDashboard({ port: 0 })
   try {


### PR DESCRIPTION
## What

Part of the MVP UI (#309): *"Browser notifications (when AI is done, when potential user intervention (e.g. PLAN.md))."*

The localhost dashboard can now notify the human:
- when a live run **finishes** (or fails / stops), and
- when a run reaches a **`<Choices>` gate** that needs their input (e.g. a PLAN.md approval).

## UX

- A header **bell** enables/mutes it. Enabling asks browser permission once and remembers the choice (localStorage).
- Notifications only fire when the dashboard **tab is backgrounded** (`document.hidden`), so a run you are actively watching stays quiet.
- Live run only (history replay never notifies).
- Fully client-side and best-effort: a browser without the Notification API just hides the bell.

## Test

Added a page test asserting the bell, the permission-gated `notify()` helper, the two triggers, and the `document.hidden` gate all ship in the served page (the repo's existing convention for client behavior; a headless-browser smoke is tracked separately in #311). Full suite: 180 pass, 1 skip (docker).

Closes #317