### PR TITLE
feat(framework): dashboard document sidebar rendering PLAN.md / TODO.md (#319)

### DIFF
--- a/.changeset/dashboard-document-sidebar.md
+++ b/.changeset/dashboard-document-sidebar.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/framework': minor
+---
+
+feat(framework): document sidebar on the dashboard, rendering the run's PLAN.md / TODO.md (#319)
+
+The localhost dashboard now surfaces the `PLAN.md` and `TODO.md` the agent writes at the workspace root (via the anti-lazy-pill) in a right sidebar, rendered as markdown with a sticky tab nav to jump between them. A new `GET /api/docs` endpoint reads the surfaced docs (fixed filenames, gated on the workspace `cwd` like `/api/runs`); the sidebar polls it so a plan written mid-run appears, and stays hidden when there are no docs.

--- a/packages/framework/src/dashboard/docs.test.ts
+++ b/packages/framework/src/dashboard/docs.test.ts
@@ -1,0 +1,37 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { readDocs, SURFACED_DOCS } from './docs.js'
+
+test('readDocs returns the surfaced docs present at the workspace root, in order (#319)', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'framework-docs-'))
+  try {
+    // Write TODO first to prove the result follows SURFACED_DOCS order, not write order.
+    await writeFile(join(cwd, 'TODO.md'), '- [ ] later\n')
+    await writeFile(join(cwd, 'PLAN.md'), '# Plan\n')
+    const docs = await readDocs(cwd)
+    assert.deepEqual(docs.map(d => d.name), ['PLAN.md', 'TODO.md'])
+    assert.equal(docs[0]!.content, '# Plan\n')
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('readDocs skips missing and blank docs, and never throws', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'framework-docs-'))
+  try {
+    await writeFile(join(cwd, 'PLAN.md'), '   \n\n')
+    // TODO.md absent; PLAN.md blank -> nothing surfaced.
+    assert.deepEqual(await readDocs(cwd), [])
+    // A workspace that does not exist reads as empty, not an error.
+    assert.deepEqual(await readDocs(join(cwd, 'nope')), [])
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('SURFACED_DOCS are fixed workspace-root filenames (no traversal)', () => {
+  for (const name of SURFACED_DOCS) assert.doesNotMatch(name, /[\\/]|\.\./)
+})

--- a/packages/framework/src/dashboard/docs.ts
+++ b/packages/framework/src/dashboard/docs.ts
@@ -1,0 +1,40 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+/**
+ * The workspace documents the dashboard surfaces in its document sidebar (#319,
+ * part of the MVP UI #309). The anti-lazy-pill (#301) has the agent write these
+ * at the workspace root, so showing them lets the human read the plan + backlog
+ * beside the run. Fixed filenames — never user input — so there is no path
+ * traversal to guard against.
+ */
+export const SURFACED_DOCS = ['PLAN.md', 'TODO.md'] as const
+
+/** One surfaced document: its filename and current contents. */
+export interface WorkspaceDoc {
+  name: string
+  content: string
+}
+
+/** Cap a single doc so a runaway file can't bloat the `/api/docs` payload. */
+const MAX_DOC_BYTES = 200_000
+
+/**
+ * Read the {@link SURFACED_DOCS} present at the workspace root, in that order.
+ * Missing or blank files are skipped; a file over the size cap is truncated. Never
+ * throws — a read error just omits that doc.
+ */
+export async function readDocs(cwd: string): Promise<WorkspaceDoc[]> {
+  const docs: WorkspaceDoc[] = []
+  for (const name of SURFACED_DOCS) {
+    try {
+      let content = await readFile(join(cwd, name), 'utf8')
+      if (!content.trim()) continue
+      if (content.length > MAX_DOC_BYTES) content = content.slice(0, MAX_DOC_BYTES) + '\n\n… (truncated)'
+      docs.push({ name, content })
+    } catch {
+      // absent or unreadable — skip it
+    }
+  }
+  return docs
+}

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -121,6 +121,33 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   #log { font: 12px/1.6 ui-monospace, SFMono-Regular, Menlo, monospace; color: #96a0b3;
     max-height: 320px; overflow-y: auto; white-space: pre-wrap; }
   .muted { color: #5c657a; }
+  /* Document sidebar (#319): the PLAN.md / TODO.md the agent writes, rendered
+     beside the run with a sticky tab nav. Hidden until a doc exists. */
+  #docs { flex: 0 0 340px; width: 340px; border-left: 1px solid #1c2230;
+    overflow-y: auto; max-height: calc(100vh - 57px); }
+  #docs[hidden] { display: none; }
+  #docs-nav { position: sticky; top: 0; display: flex; gap: 4px; padding: 10px 12px;
+    background: #0b0e14; border-bottom: 1px solid #1c2230; }
+  .doc-tab { font: inherit; font-size: 12px; font-weight: 600; cursor: pointer; color: #7b8496;
+    background: #10141d; border: 1px solid #1c2230; border-radius: 6px; padding: 4px 10px; }
+  .doc-tab:hover { color: #b7c0d0; }
+  .doc-tab.active { color: #e8ecf3; background: #17212f; border-color: #24344a; }
+  #docs-body { padding: 4px 16px 24px; font-size: 13px; color: #c3cad6; line-height: 1.6; }
+  #docs-body h1, #docs-body h2, #docs-body h3, #docs-body h4 { color: #e8ecf3; line-height: 1.3;
+    margin: 16px 0 8px; }
+  #docs-body h1 { font-size: 17px; } #docs-body h2 { font-size: 15px; } #docs-body h3 { font-size: 13px; }
+  #docs-body p { margin: 8px 0; }
+  #docs-body ul, #docs-body ol { margin: 8px 0; padding-left: 20px; list-style: revert; }
+  #docs-body li { padding: 2px 0; border-bottom: 0; }
+  #docs-body li.task { list-style: none; margin-left: -20px; }
+  #docs-body li.task input { margin-right: 6px; }
+  #docs-body code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px;
+    background: #161b26; color: #b7c0d0; padding: 1px 5px; border-radius: 4px; }
+  #docs-body pre { background: #0f141d; border: 1px solid #1c2230; border-radius: 8px;
+    padding: 10px 12px; overflow-x: auto; }
+  #docs-body pre code { background: none; padding: 0; color: #96a0b3; }
+  #docs-body a { color: #6ea8fe; text-decoration: none; }
+  #docs-body a:hover { text-decoration: underline; }
 </style>
 </head>
 <body>
@@ -187,6 +214,10 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   </section>
 </main>
 </div>
+<aside id="docs" hidden>
+  <div id="docs-nav"></div>
+  <div id="docs-body"></div>
+</aside>
 </div>
 <script>
 ${clientScript(stoppable, choiceable)}
@@ -495,6 +526,88 @@ function loadRuns() {
   fetch('api/runs').then(r => r.ok ? r.json() : { runs: [] }).then(d => renderRuns(d.runs || [])).catch(() => {});
 }
 
+// Document sidebar (#319): render the PLAN.md / TODO.md the agent writes at the
+// workspace root, with a sticky tab nav to jump between them. Minimal, dependency-
+// free markdown so the page stays a single self-contained file.
+function mdInline(s) {
+  // s is already HTML-escaped; add inline spans and safe (http/relative) links only.
+  return s
+    .replace(/\`([^\`]+)\`/g, '<code>$1</code>')
+    .replace(/\\*\\*([^*]+)\\*\\*/g, '<strong>$1</strong>')
+    .replace(/\\*([^*]+)\\*/g, '<em>$1</em>')
+    .replace(/\\[([^\\]]+)\\]\\(([^)\\s"]+)\\)/g, function (m, t, u) {
+      return /^(https?:|\\/|#)/.test(u) ? '<a href="' + u + '" target="_blank" rel="noopener">' + t + '</a>' : t;
+    });
+}
+function renderMarkdown(md) {
+  const lines = String(md).replace(/\\r\\n/g, '\\n').split('\\n');
+  let html = '', i = 0, inList = false, listTag = '';
+  const closeList = function () { if (inList) { html += '</' + listTag + '>'; inList = false; } };
+  while (i < lines.length) {
+    const line = lines[i];
+    if (/^\`\`\`/.test(line)) {
+      closeList(); i++;
+      let code = '';
+      while (i < lines.length && !/^\`\`\`/.test(lines[i])) { code += lines[i] + '\\n'; i++; }
+      i++; // closing fence
+      html += '<pre><code>' + esc(code) + '</code></pre>';
+      continue;
+    }
+    const h = line.match(/^(#{1,6})\\s+(.*)$/);
+    if (h) { closeList(); const n = h[1].length; html += '<h' + n + '>' + mdInline(esc(h[2])) + '</h' + n + '>'; i++; continue; }
+    const li = line.match(/^\\s*[-*]\\s+(.*)$/);
+    if (li) {
+      if (!inList || listTag !== 'ul') { closeList(); html += '<ul>'; inList = true; listTag = 'ul'; }
+      const task = li[1].match(/^\\[([ xX])\\]\\s+(.*)$/);
+      if (task) {
+        const on = task[1].toLowerCase() === 'x';
+        html += '<li class="task"><input type="checkbox" disabled' + (on ? ' checked' : '') + '>' + mdInline(esc(task[2])) + '</li>';
+      } else html += '<li>' + mdInline(esc(li[1])) + '</li>';
+      i++; continue;
+    }
+    const oli = line.match(/^\\s*\\d+\\.\\s+(.*)$/);
+    if (oli) {
+      if (!inList || listTag !== 'ol') { closeList(); html += '<ol>'; inList = true; listTag = 'ol'; }
+      html += '<li>' + mdInline(esc(oli[1])) + '</li>';
+      i++; continue;
+    }
+    if (!line.trim()) { closeList(); i++; continue; }
+    closeList();
+    html += '<p>' + mdInline(esc(line)) + '</p>';
+    i++;
+  }
+  closeList();
+  return html;
+}
+let docs = [];
+let activeDoc = null;
+function showDoc(name) {
+  const doc = docs.find(function (d) { return d.name === name; });
+  if (!doc) return;
+  activeDoc = name;
+  $('docs-body').innerHTML = renderMarkdown(doc.content);
+  for (const b of $('docs-nav').children) b.classList.toggle('active', b.dataset && b.dataset.name === name);
+}
+function renderDocs(list) {
+  docs = list || [];
+  const aside = $('docs');
+  if (!docs.length) { aside.hidden = true; activeDoc = null; $('docs-nav').innerHTML = ''; $('docs-body').innerHTML = ''; return; }
+  const nav = $('docs-nav'); nav.innerHTML = '';
+  for (const d of docs) {
+    const b = document.createElement('button');
+    b.className = 'doc-tab'; b.dataset.name = d.name; b.textContent = d.name;
+    b.addEventListener('click', function () { showDoc(d.name); });
+    nav.appendChild(b);
+  }
+  aside.hidden = false;
+  // Keep the open tab if it still exists, else fall back to the first doc.
+  showDoc(docs.some(function (d) { return d.name === activeDoc; }) ? activeDoc : docs[0].name);
+}
+function loadDocs() {
+  fetch('api/docs').then(function (r) { return r.ok ? r.json() : { docs: [] }; })
+    .then(function (d) { renderDocs(d.docs || []); }).catch(function () {});
+}
+
 // Browser notifications (#309): tell the human when a run finishes or reaches a
 // point that needs them (a <Choices> gate, e.g. a PLAN.md approval) while the tab
 // is backgrounded. Opt-in via the header bell; the choice is remembered. Fully
@@ -555,10 +668,15 @@ src.onmessage = ev => {
   if (mode === 'live') render(fe);
   // A finished run has just been archived; refresh the list so it appears.
   if (fe.kind === 'end') setTimeout(loadRuns, 1500);
+  // A plan/backlog is usually written right before a choice gate or at run end;
+  // refresh the doc sidebar promptly so PLAN.md / TODO.md appear without waiting.
+  if (fe.kind === 'choice' || fe.kind === 'end') setTimeout(loadDocs, 500);
 };
 src.onerror = () => { if (mode === 'live') $('status').textContent = '\\u25cb offline'; };
 loadRuns();
 setInterval(loadRuns, 10000);
+loadDocs();
+setInterval(loadDocs, 4000);
 `
 }
 

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -91,6 +91,46 @@ test('page ships opt-in browser notifications for run-end and choice gates (#309
   }
 })
 
+test('page ships the document sidebar with a dependency-free markdown renderer (#319)', async () => {
+  const dash = await startDashboard({ port: 0 })
+  try {
+    const { body } = await fetchText(dash.url + '/')
+    assert.match(body, /id="docs"/)
+    assert.match(body, /id="docs-nav"/)
+    assert.match(body, /function renderMarkdown/)
+    assert.match(body, /fetch\('api\/docs'\)/)
+  } finally {
+    await dash.close()
+  }
+})
+
+test('GET /api/docs serves the workspace PLAN.md / TODO.md, or [] without a cwd (#319)', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'framework-docs-'))
+  try {
+    await writeFile(join(cwd, 'PLAN.md'), '# Plan\n\nBuild it.\n')
+    const withCwd = await startDashboard({ port: 0, cwd })
+    try {
+      const { status, body } = await fetchText(withCwd.url + '/api/docs')
+      assert.equal(status, 200)
+      const parsed = JSON.parse(body)
+      assert.equal(parsed.docs.length, 1)
+      assert.equal(parsed.docs[0].name, 'PLAN.md')
+      assert.match(parsed.docs[0].content, /Build it\./)
+    } finally {
+      await withCwd.close()
+    }
+    // No cwd wired -> empty list, never an error.
+    const noCwd = await startDashboard({ port: 0 })
+    try {
+      assert.deepEqual(JSON.parse((await fetchText(noCwd.url + '/api/docs')).body), { docs: [] })
+    } finally {
+      await noCwd.close()
+    }
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
 test('dashboard replays buffered events and streams them over SSE', async () => {
   const dash = await startDashboard({ port: 0 })
   try {

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -3,6 +3,7 @@ import type { AddressInfo } from 'node:net'
 import { EventStream } from '@gemstack/ai-autopilot'
 import type { ChoiceBy, FrameworkEvent } from '../events.js'
 import { listRuns, loadRunEvents } from '../store/index.js'
+import { readDocs } from './docs.js'
 import { dashboardHtml } from './page.js'
 import { serveSSE } from './sse.js'
 
@@ -116,6 +117,12 @@ function handle(
     void serveRun(res, cwd, decodeURIComponent(url.slice('/api/runs/'.length)))
     return
   }
+  // Document sidebar (#319): the PLAN.md / TODO.md the agent writes at the
+  // workspace root, so the human can read the plan + backlog beside the run.
+  if (url === '/api/docs') {
+    void serveDocs(res, cwd)
+    return
+  }
   if (url === '/stop') {
     // The Stop button. Idempotent: a stop after the run has ended just aborts an
     // already-aborted signal (a no-op). 405 for a non-POST so a stray GET can't
@@ -199,6 +206,13 @@ async function serveRun(res: ServerResponse, cwd: string | undefined, id: string
   const meta = cwd ? (await listRuns(cwd).catch(() => [])).find(r => r.id === id) : undefined
   res.writeHead(200, { 'content-type': 'application/json' })
   res.end(JSON.stringify({ id, meta, events }))
+}
+
+/** `GET /api/docs` — the surfaced workspace documents (PLAN.md, TODO.md), or `[]`. */
+async function serveDocs(res: ServerResponse, cwd: string | undefined): Promise<void> {
+  const docs = cwd ? await readDocs(cwd).catch(() => []) : []
+  res.writeHead(200, { 'content-type': 'application/json' })
+  res.end(JSON.stringify({ docs }))
 }
 
 function closeServer(


### PR DESCRIPTION
## What

Part of the MVP UI (#309): *"Sidebar for showing documents (e.g. markdown like PLAN.md)."* Also the third-sidebar idea in #314 (sticky top nav to jump between PLAN.md and TODO.md).

The anti-lazy-pill (#301) already has the agent write `PLAN.md` / `TODO.md` at the workspace root. This surfaces them on the dashboard so you can read the plan + backlog beside the run.

## How

- **`GET /api/docs`** reads the surfaced docs (`PLAN.md`, `TODO.md`) from the run's workspace. Fixed filenames (no traversal), gated on `cwd` like `/api/runs`; blank/missing files are skipped, a runaway file is truncated.
- A **right sidebar** renders each doc as markdown with a **sticky tab nav** to switch between them. It polls `/api/docs` (and refreshes right after a choice gate / run end) so a plan written mid-run appears, and stays hidden when there are no docs.
- The markdown renderer is **minimal and dependency-free** (headings, ordered/unordered lists, task checkboxes, fenced + inline code, bold/italic, http/relative links) so the page stays one self-contained file. Input is HTML-escaped first, so agent-authored docs can't inject markup.

## Test

- `readDocs` unit tests: order, skip-blank/missing, never-throws, fixed-filename guard.
- `/api/docs` integration test: serves PLAN.md, `[]` without a cwd.
- Page test: the sidebar + renderer + poll ship in the page.
- Exercised the markdown renderer directly in Node (headings/bold/code/tasks/links/ordered-list/fence-escaping/XSS-escaping all pass) and live-smoked a running dashboard serving a real PLAN.md + TODO.md.

Full suite: 186 pass, 1 skip (docker). MVP scope is PLAN.md + TODO.md; the AI-callable `showMarkdown()` / arbitrary views from #314 are out of scope here.

Closes #319