### PR TITLE
feat(framework): track agent spend and add a budget cap (#322)

### DIFF
--- a/.changeset/usage-accounting-budget-cap.md
+++ b/.changeset/usage-accounting-budget-cap.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/framework': minor
+---
+
+feat(framework): track agent spend and add a budget cap (#322)
+
+The framework now accumulates the token + cost usage the wrapped agent reports each turn, streams a running total as a `usage` event, and shows a live spend readout on the dashboard header. Pass `--max-cost <usd>` to stop a run once it has spent that much: the current turn finishes, then the run stops cleanly (not a failure). Useful for long autopilot runs where you only review the result at the end.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -47,7 +47,14 @@ test('parseArgs flags unknown options and bad values', () => {
   assert.match(parseArgs(['--nope']).error!, /unknown option/)
   assert.match(parseArgs(['--scope', 'huge']).error!, /invalid --scope/)
   assert.match(parseArgs(['--max-passes', '0']).error!, /max-passes/)
+  assert.match(parseArgs(['--max-cost', '0']).error!, /max-cost/)
+  assert.match(parseArgs(['--max-cost', 'abc']).error!, /max-cost/)
   assert.match(parseArgs(['--permission-mode', 'wat']).error!, /permission-mode/)
+})
+
+test('parseArgs reads --max-cost as a positive USD budget (#322)', () => {
+  assert.equal(parseArgs(['--max-cost', '2.5', 'x']).maxCost, 2.5)
+  assert.equal(parseArgs(['x']).maxCost, undefined)
 })
 
 test('parseArgs reads permission-mode and skip-permissions', () => {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -106,6 +106,7 @@ Options:
                          hand-rolling. Vike-only; installed framework-* extensions
                          auto-activate either way (default: off, hand-rolled + Prisma).
   --max-passes <n>       Full-fledged loop pass budget (default: 5).
+  --max-cost <usd>       Stop the run once it has spent this much (USD).
   --permission-mode <mode>   Claude Code permission mode: default | acceptEdits |
                              bypassPermissions | plan (default: bypassPermissions,
                              so the headless loop can run installs/builds/tests).
@@ -161,6 +162,7 @@ export interface CliOptions {
   technical: boolean
   buildEvent?: string | undefined
   maxPasses?: number
+  maxCost?: number
   deploy?: string | undefined
   cfProject?: string | undefined
   dokployUrl?: string | undefined
@@ -329,6 +331,12 @@ export function parseArgs(argv: string[]): CliOptions {
         const n = Number(argv[++i])
         if (!Number.isInteger(n) || n < 1) opts.error = `invalid --max-passes: must be a positive integer`
         else opts.maxPasses = n
+        break
+      }
+      case '--max-cost': {
+        const n = Number(argv[++i])
+        if (!Number.isFinite(n) || n <= 0) opts.error = `invalid --max-cost: must be a positive number (USD)`
+        else opts.maxCost = n
         break
       }
       case '--port': {
@@ -669,7 +677,12 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     io.out(`◆ shared run: ${publisher.url}`)
   }
 
+  // The framework's own verdict that the run stopped cleanly rather than failed —
+  // set by a user interrupt or a budget cap (#322). Trusted over which signal
+  // aborted, since a budget stop trips an internal signal the CLI never sees.
+  let stoppedCleanly = false
   const onEvent = (event: FrameworkEvent) => {
+    if (event.kind === 'end' && event.stopped) stoppedCleanly = true
     io.out(formatFrameworkEvent(event))
     dashboard?.push(event)
     void store?.append(event)
@@ -782,6 +795,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
       : {}),
     ...(opts.model ? { model: opts.model } : {}),
     ...(opts.maxPasses ? { maxPasses: opts.maxPasses } : {}),
+    ...(opts.maxCost ? { budgetUsd: opts.maxCost } : {}),
     ...(deploy ? { deploy } : {}),
     ...(deployTarget ? { deployTarget } : {}),
     ...(serve ? { serve } : {}),
@@ -825,10 +839,10 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   } catch (err) {
     clearInterrupt()
     await store?.close()
-    // A user stop (the dashboard Stop button aborted the signal) is not a failure:
-    // report it cleanly, keep the dashboard up so the stopped state is visible, and
-    // exit 0.
-    if (controller.signal.aborted) {
+    // A clean stop (dashboard Stop button, Ctrl+C, or a budget cap #322) is not a
+    // failure: report it cleanly, keep the dashboard up so the stopped state is
+    // visible, and exit 0.
+    if (controller.signal.aborted || stoppedCleanly) {
       io.out('\n■ Stopped.')
       if (dashboard) {
         io.out(`\nDashboard still live at ${dashboard.url}. Press Ctrl+C to exit.`)

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -155,6 +155,7 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   <h1>${escapeHtml(title)}</h1>
   <span class="sub" id="session">connecting…</span>
   <span id="session-link"></span>
+  <span class="sub" id="spend" title="Cumulative agent spend for this run" hidden></span>
   <span id="status">●</span>
   <button id="notify" title="Notify me when a run finishes or needs my input">🔕</button>
   <button id="stop" hidden>■ Stop</button>
@@ -358,6 +359,7 @@ function render(fe) {
   else if (fe.kind === 'choice') showChoice(fe);
   else if (fe.kind === 'choice-resolved') resolveChoice(fe);
   else if (fe.kind === 'log') log(fe.message);
+  else if (fe.kind === 'usage') updateSpend(fe);
   else if (fe.kind === 'end') {
     if (mode === 'live') { ended = true; $('stop').hidden = true; }
     closeChoice();
@@ -366,6 +368,13 @@ function render(fe) {
       fe.ok ? '\\u2713 Run finished' : fe.stopped ? '\\u25a0 Run stopped' : '\\u2717 Run failed',
       fe.ok ? 'Your build is ready on the dashboard.' : fe.detail || '');
   }
+}
+function updateSpend(fe) {
+  const el = $('spend');
+  let s = 'spend $' + fe.costUsd.toFixed(4);
+  if (fe.budgetUsd) s += ' / $' + fe.budgetUsd;
+  el.textContent = s;
+  el.hidden = false;
 }
 function stopRun() {
   const btn = $('stop');

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -91,6 +91,19 @@ test('page ships opt-in browser notifications for run-end and choice gates (#309
   }
 })
 
+test('page ships a live spend readout fed by usage events (#322)', async () => {
+  const dash = await startDashboard({ port: 0 })
+  try {
+    const { body } = await fetchText(dash.url + '/')
+    // Header element + its updater, dispatched from a usage event.
+    assert.match(body, /id="spend"/)
+    assert.match(body, /function updateSpend\(fe\)/)
+    assert.match(body, /fe\.kind === 'usage'/)
+  } finally {
+    await dash.close()
+  }
+})
+
 test('page ships the document sidebar with a dependency-free markdown renderer (#319)', async () => {
   const dash = await startDashboard({ port: 0 })
   try {

--- a/packages/framework/src/driver/claude-code.test.ts
+++ b/packages/framework/src/driver/claude-code.test.ts
@@ -22,6 +22,31 @@ test('StreamJsonParser surfaces assistant text + tool names, keeps the result', 
   assert.deepEqual(p.result(), { text: 'All done', sessionId: 'sess-1' })
 })
 
+test('StreamJsonParser pulls token + cost usage off the result line (#322)', () => {
+  const p = new StreamJsonParser()
+  p.push(
+    JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      result: 'done',
+      session_id: 's',
+      total_cost_usd: 0.1234,
+      usage: { input_tokens: 100, output_tokens: 40, cache_read_input_tokens: 900, cache_creation_input_tokens: 50 },
+    }),
+  )
+  assert.deepEqual(p.result(), {
+    text: 'done',
+    sessionId: 's',
+    usage: { costUsd: 0.1234, inputTokens: 100, outputTokens: 40, cacheReadTokens: 900, cacheCreationTokens: 50 },
+  })
+})
+
+test('StreamJsonParser leaves usage off when the result line reports none (#322)', () => {
+  const p = new StreamJsonParser()
+  p.push(JSON.stringify({ type: 'result', subtype: 'success', result: 'done', session_id: 's' }))
+  assert.deepEqual(p.result(), { text: 'done', sessionId: 's' })
+})
+
 test('StreamJsonParser ignores non-JSON noise and falls back to assistant text', () => {
   const p = new StreamJsonParser()
   assert.deepEqual(p.push('some banner line'), [])

--- a/packages/framework/src/driver/claude-code.ts
+++ b/packages/framework/src/driver/claude-code.ts
@@ -3,7 +3,7 @@ import { createInterface } from 'node:readline'
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { killTree, registerChild, unregisterChild } from './child-registry.js'
-import type { Driver, DriverEvent, DriverPromptOptions, DriverSession, DriverStartOptions, DriverTurn } from './types.js'
+import type { Driver, DriverEvent, DriverPromptOptions, DriverSession, DriverStartOptions, DriverTurn, DriverUsage } from './types.js'
 
 /** Grace between SIGTERM and the SIGKILL that forces a hung agent tree down. */
 const TERMINATE_GRACE_MS = 5000
@@ -227,7 +227,12 @@ export function runClaude(opts: RunClaudeOptions): Promise<DriverTurn> {
         finish(() => rejectPromise(new Error(`[framework] claude-code exited (${code ?? 'null'}): ${detail}`)))
         return
       }
-      opts.emit({ type: 'result', text: turn.text, ...(turn.sessionId ? { sessionId: turn.sessionId } : {}) })
+      opts.emit({
+        type: 'result',
+        text: turn.text,
+        ...(turn.sessionId ? { sessionId: turn.sessionId } : {}),
+        ...(turn.usage ? { usage: turn.usage } : {}),
+      })
       finish(() => resolvePromise(turn))
     })
 
@@ -249,6 +254,7 @@ export class StreamJsonParser {
   private finalText = ''
   private assistantText = ''
   private sessionId?: string
+  private usage?: DriverUsage
 
   /** Feed one line; returns the events it produced (may be empty). */
   push(line: string): DriverEvent[] {
@@ -268,6 +274,8 @@ export class StreamJsonParser {
     if (type === 'result') {
       const result = obj['result']
       if (typeof result === 'string') this.finalText = result
+      const usage = parseUsage(obj)
+      if (usage) this.usage = usage
       return [] // The `result` event is emitted by the runner after `close`.
     }
     return []
@@ -295,6 +303,31 @@ export class StreamJsonParser {
   /** The final turn: the `result` text, falling back to accumulated assistant text. */
   result(): DriverTurn {
     const text = this.finalText || this.assistantText
-    return { text, ...(this.sessionId ? { sessionId: this.sessionId } : {}) }
+    return {
+      text,
+      ...(this.sessionId ? { sessionId: this.sessionId } : {}),
+      ...(this.usage ? { usage: this.usage } : {}),
+    }
+  }
+}
+
+/**
+ * Pull token + cost accounting off Claude Code's `result` line (#322):
+ * `total_cost_usd` plus a `usage` object of token counts. Returns undefined when
+ * the line carries neither, so a driver/agent that omits usage stays usage-free.
+ */
+function parseUsage(obj: Record<string, unknown>): DriverUsage | undefined {
+  const cost = obj['total_cost_usd']
+  const raw = obj['usage']
+  const hasUsage = typeof raw === 'object' && raw !== null
+  if (typeof cost !== 'number' && !hasUsage) return undefined
+  const usage = (hasUsage ? raw : {}) as Record<string, unknown>
+  const num = (v: unknown): number => (typeof v === 'number' && Number.isFinite(v) ? v : 0)
+  return {
+    costUsd: typeof cost === 'number' && Number.isFinite(cost) ? cost : 0,
+    inputTokens: num(usage['input_tokens']),
+    outputTokens: num(usage['output_tokens']),
+    cacheReadTokens: num(usage['cache_read_input_tokens']),
+    cacheCreationTokens: num(usage['cache_creation_input_tokens']),
   }
 }

--- a/packages/framework/src/driver/fake.ts
+++ b/packages/framework/src/driver/fake.ts
@@ -1,4 +1,4 @@
-import type { Driver, DriverEvent, DriverPromptOptions, DriverSession, DriverStartOptions, DriverTurn } from './types.js'
+import type { Driver, DriverEvent, DriverPromptOptions, DriverSession, DriverStartOptions, DriverTurn, DriverUsage } from './types.js'
 
 /** One scripted turn the {@link FakeDriver} replays. */
 export interface FakeTurn {
@@ -6,6 +6,8 @@ export interface FakeTurn {
   text: string
   /** Tool names to emit as `action` events before the result (visual only). */
   actions?: string[]
+  /** Token + cost accounting to report for this turn (#322). Omitted = no usage. */
+  usage?: DriverUsage
 }
 
 /** Options for {@link FakeDriver}. */
@@ -71,9 +73,9 @@ export class FakeDriverSession implements DriverSession {
     this.emit({ type: 'start', prompt: text })
     for (const label of turn.actions ?? []) this.emit({ type: 'action', label })
     if (turn.text) this.emit({ type: 'text', text: turn.text })
-    this.emit({ type: 'result', text: turn.text, sessionId: this.id })
+    this.emit({ type: 'result', text: turn.text, sessionId: this.id, ...(turn.usage ? { usage: turn.usage } : {}) })
 
-    return Promise.resolve({ text: turn.text, sessionId: this.id })
+    return Promise.resolve({ text: turn.text, sessionId: this.id, ...(turn.usage ? { usage: turn.usage } : {}) })
   }
 
   readCode(path: string): Promise<string> {

--- a/packages/framework/src/driver/index.ts
+++ b/packages/framework/src/driver/index.ts
@@ -5,6 +5,7 @@ export type {
   DriverPromptOptions,
   DriverTurn,
   DriverEvent,
+  DriverUsage,
 } from './types.js'
 export { FakeDriver, FakeDriverSession, type FakeTurn, type FakeDriverOptions } from './fake.js'
 export {

--- a/packages/framework/src/driver/types.ts
+++ b/packages/framework/src/driver/types.ts
@@ -87,6 +87,26 @@ export interface DriverTurn {
    * keep our own store (#165), so this is the handle a UI links to.
    */
   sessionId?: string
+  /** Token + cost accounting for this turn, when the agent reports it (#322). */
+  usage?: DriverUsage
+}
+
+/**
+ * Token and cost accounting for one turn, as reported by the wrapped agent (#322).
+ * Claude Code emits this on its final `result` line; drivers that cannot report
+ * it simply omit it. Costs are whatever the agent computed, in USD.
+ */
+export interface DriverUsage {
+  /** Cost of the turn in USD, as reported by the agent. */
+  costUsd: number
+  /** Non-cached input tokens. */
+  inputTokens: number
+  /** Output tokens. */
+  outputTokens: number
+  /** Tokens read from the prompt cache. */
+  cacheReadTokens: number
+  /** Tokens written to the prompt cache. */
+  cacheCreationTokens: number
 }
 
 /**
@@ -102,6 +122,6 @@ export type DriverEvent =
   /** The agent used a tool. We surface the name only, not the arguments. */
   | { type: 'action'; label: string }
   /** The turn settled with this final text. */
-  | { type: 'result'; text: string; sessionId?: string }
+  | { type: 'result'; text: string; sessionId?: string; usage?: DriverUsage }
   /** The agent (or its transport) errored. */
   | { type: 'error'; message: string }

--- a/packages/framework/src/events.test.ts
+++ b/packages/framework/src/events.test.ts
@@ -52,3 +52,9 @@ test('formatFrameworkEvent distinguishes finished / stopped / failed (#218)', ()
   assert.equal(formatFrameworkEvent({ kind: 'end', ok: false, stopped: true }), '■ stopped')
   assert.equal(formatFrameworkEvent({ kind: 'end', ok: false, detail: 'boom' }), '✗ failed: boom')
 })
+
+test('formatFrameworkEvent renders a usage spend line, with the cap when set (#322)', () => {
+  const base = { kind: 'usage' as const, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 }
+  assert.equal(formatFrameworkEvent({ ...base, costUsd: 0.04, turns: 2 }), '  spend: $0.0400 over 2 turns')
+  assert.equal(formatFrameworkEvent({ ...base, costUsd: 0.02, turns: 1, budgetUsd: 5 }), '  spend: $0.0200 / $5 over 1 turn')
+})

--- a/packages/framework/src/events.ts
+++ b/packages/framework/src/events.ts
@@ -70,6 +70,22 @@ export type FrameworkEvent =
   /** A framework-level log line. */
   | { kind: 'log'; message: string }
   /**
+   * Cumulative token + cost usage for the run so far (#322). Emitted after each
+   * agent turn that reports usage; the dashboard renders a live spend readout and
+   * the run stops itself once `costUsd` reaches the budget cap, if one is set.
+   */
+  | {
+      kind: 'usage'
+      costUsd: number
+      inputTokens: number
+      outputTokens: number
+      cacheReadTokens: number
+      cacheCreationTokens: number
+      turns: number
+      /** The budget cap in USD this run is gated on, when one was set. */
+      budgetUsd?: number
+    }
+  /**
    * The run's active Open Loop modes (#272), emitted once when a domain preset is
    * in effect. `all` is every mode the run knows about (stable order); `active` is
    * the subset switched on for this run. The dashboard renders them as read-only
@@ -104,6 +120,10 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
       return `▶ your app is running at ${event.url}`
     case 'log':
       return `  ${event.message}`
+    case 'usage':
+      return `  spend: $${event.costUsd.toFixed(4)}${
+        event.budgetUsd ? ` / $${event.budgetUsd}` : ''
+      } over ${event.turns} turn${event.turns === 1 ? '' : 's'}`
     case 'modes': {
       const shown = event.all.map(m => `${event.active.includes(m) ? '[x]' : '[ ]'} ${m}`).join('  ')
       return `  modes: ${shown}`

--- a/packages/framework/src/fake-script.ts
+++ b/packages/framework/src/fake-script.ts
@@ -41,18 +41,23 @@ const ARCHITECT = {
   alternatives: [{ option: 'Next.js', whyNot: 'more constrained Cloudflare/edge deploy for the per-request data path' }],
 }
 
+// A small, plausible per-turn usage so the demo shows spend accumulating (#322).
+const FAKE_USAGE = { costUsd: 0.02, inputTokens: 1800, outputTokens: 600, cacheReadTokens: 12000, cacheCreationTokens: 800 }
+
 const TURNS: FakeTurn[] = [
-  { text: '```json\n' + JSON.stringify(ARCHITECT) + '\n```', actions: ['Read'] },
+  { text: '```json\n' + JSON.stringify(ARCHITECT) + '\n```', actions: ['Read'], usage: FAKE_USAGE },
   {
     text: 'Built the orders app: an orders schema and migration, a paginated /orders page, and a sign-in stub.',
     actions: ['Write', 'Write', 'Bash'],
+    usage: FAKE_USAGE,
   },
   {
     text: 'Reviewed the app.\n```json\n{ "blockers": ["No authentication on the orders page yet"] }\n```',
     actions: ['Read', 'Grep'],
+    usage: FAKE_USAGE,
   },
-  { text: 'Added a +guard to the orders page (vike-auth) so it requires a signed-in user.', actions: ['Edit'] },
-  { text: 'Reviewed again.\n```json\n{ "blockers": [] }\n```', actions: ['Read'] },
+  { text: 'Added a +guard to the orders page (vike-auth) so it requires a signed-in user.', actions: ['Edit'], usage: FAKE_USAGE },
+  { text: 'Reviewed again.\n```json\n{ "blockers": [] }\n```', actions: ['Read'], usage: FAKE_USAGE },
 ]
 
 /** Build the scripted {@link FakeDriver} for the demo. */

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -98,6 +98,81 @@ test('runFramework resolves a {sessionId} link template once the id is known', a
   assert.equal(update.sessionLink, 'https://code.example.com/s/fake-orders-app')
 })
 
+test('runFramework accumulates per-turn usage and emits a running total (#322)', async () => {
+  const events: FrameworkEvent[] = []
+  await runFramework({
+    intent: FAKE_INTENT,
+    driver: fakeDriver(), // every scripted turn reports $0.02 usage
+    cwd: '/tmp/ws',
+    signals: FAKE_SIGNALS,
+    onEvent: e => events.push(e),
+  })
+
+  const usage = events.filter(e => e.kind === 'usage')
+  assert.ok(usage.length >= 1)
+  const last = usage.at(-1)!
+  assert.equal(last.kind, 'usage')
+  if (last.kind !== 'usage') return
+  // One usage event per turn that reported usage; totals grow monotonically.
+  assert.equal(last.turns, usage.length)
+  assert.ok(Math.abs(last.costUsd - last.turns * 0.02) < 1e-9)
+  assert.ok(last.cacheReadTokens > 0)
+  // No cap was set, so the total carries no budget and the run finished cleanly.
+  assert.equal(last.budgetUsd, undefined)
+  const end = events.at(-1)!
+  assert.equal(end.kind === 'end' && end.ok, true)
+})
+
+test('runFramework stops itself once the budget cap is reached (#322)', async () => {
+  const events: FrameworkEvent[] = []
+  // $0.01 cap trips on the very first $0.02 turn (the architect).
+  await assert.rejects(
+    runFramework({
+      intent: FAKE_INTENT,
+      driver: fakeDriver(),
+      cwd: '/tmp/ws',
+      signals: FAKE_SIGNALS,
+      budgetUsd: 0.01,
+      onEvent: e => events.push(e),
+    }),
+  )
+
+  const usage = events.filter(e => e.kind === 'usage')
+  assert.ok(usage.length >= 1)
+  assert.equal(usage[0]!.kind === 'usage' && usage[0]!.budgetUsd, 0.01)
+  assert.ok(events.some(e => e.kind === 'log' && e.message.startsWith('Budget reached:')))
+
+  const end = events.at(-1)!
+  assert.equal(end.kind, 'end')
+  if (end.kind !== 'end') return
+  // A budget stop is a clean stop, not a failure.
+  assert.equal(end.ok, false)
+  assert.equal(end.stopped, true)
+  assert.match(end.detail ?? '', /budget reached/)
+  // The run stopped early: it never reached the deploy/production-grade tail.
+  assert.ok(!events.some(e => e.kind === 'bootstrap' && e.event.type === 'done'))
+})
+
+test('a plan-approval gate parked for a pick unblocks when the budget trips (#322)', async () => {
+  const events: FrameworkEvent[] = []
+  // The gate awaits a pick that never arrives; the budget cap trips on the first
+  // (architect) turn and must unblock it rather than hang the run.
+  await assert.rejects(
+    runFramework({
+      intent: FAKE_INTENT,
+      driver: fakeDriver(),
+      cwd: '/tmp/ws',
+      signals: FAKE_SIGNALS,
+      budgetUsd: 0.01,
+      requestChoice: () => new Promise<never>(() => {}),
+      onEvent: e => events.push(e),
+    }),
+  )
+  assert.ok(events.some(e => e.kind === 'choice'))
+  const end = events.at(-1)!
+  assert.equal(end.kind === 'end' && end.stopped, true)
+})
+
 test('runFramework shows a literal session link immediately (no template)', async () => {
   const events: FrameworkEvent[] = []
   await runFramework({

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -38,6 +38,7 @@ import { memoryFraming, type LoadedMemory } from './memory.js'
 import { systemPromptBlock } from './system-prompt.js'
 import { decideDeploy, deployWith, domainLoopChecklist, driverArchitect, driverBuild, driverChecklist, driverImprove, driverLoopPrompts, reArchitect } from './steps.js'
 import { hasSessionIdPlaceholder, OPEN_LOOP_MODES, resolveSessionLink, type ChoiceOption, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
+import { UsageMeter } from './usage.js'
 
 /**
  * The framework's default full-fledged pass budget. Higher than ai-autopilot's
@@ -200,6 +201,14 @@ export interface RunFrameworkOptions {
    * wires this to the dashboard's Accept button + autopilot countdown.
    */
   requestChoice?: (req: ChoiceRequest) => Promise<ChoicePick>
+  /**
+   * Stop the run once cumulative agent cost reaches this many USD (budget cap,
+   * #322). Checked after each turn that reports usage: the turn that crosses the
+   * cap finishes, then the run stops itself (a clean stop, not a failure). Omit
+   * for no cap. The framework infers spend from what the agent reports, since the
+   * account's usage *limit* is not retrievable under subscription auth.
+   */
+  budgetUsd?: number
   /** Observe the unified event stream. */
   onEvent?: (event: FrameworkEvent) => void
 }
@@ -343,17 +352,37 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     emit({ kind: 'modes', all: OPEN_LOOP_MODES, active: opts.modes ?? [] })
   }
 
+  // Compose the caller's signal with a budget-triggered abort (#322) so the run can
+  // stop *itself* once it has spent too much, without the caller having to watch
+  // usage. Everything downstream aborts on `runSignal`; only the budget path (or a
+  // caller abort) trips it. With no caller signal this is just the budget signal.
+  const budgetController = new AbortController()
+  const runSignal = opts.signal ? AbortSignal.any([opts.signal, budgetController.signal]) : budgetController.signal
+
   // Watch the black box for its real session id (the {type:'result'} event) and
   // surface it as `session-update` once known — that is the honest handle a UI
   // links to. Re-emit when it changes, since each Claude Code prompt is a fresh
-  // session; the dashboard just updates the link in place.
+  // session; the dashboard just updates the link in place. The same result event
+  // carries this turn's usage, which we fold into the run total and gate on (#322).
   let lastSessionId: string | undefined
+  const usage = new UsageMeter()
   const onDriverEvent = (event: DriverEvent) => {
     emit({ kind: 'driver', event })
-    if (event.type === 'result' && event.sessionId && event.sessionId !== lastSessionId) {
+    if (event.type !== 'result') return
+    if (event.sessionId && event.sessionId !== lastSessionId) {
       lastSessionId = event.sessionId
       const link = linkTemplate ? resolveSessionLink(linkTemplate, event.sessionId) : undefined
       emit({ kind: 'session-update', sessionId: event.sessionId, ...(link ? { sessionLink: link } : {}) })
+    }
+    if (!event.usage) return
+    usage.add(event.usage)
+    const totals = usage.totals()
+    emit({ kind: 'usage', ...totals, ...(opts.budgetUsd != null ? { budgetUsd: opts.budgetUsd } : {}) })
+    // The turn that crosses the cap has already run (its cost is spent); stop the
+    // run before the next one. Signalled once — the next phase's check ends it.
+    if (opts.budgetUsd != null && totals.costUsd >= opts.budgetUsd && !budgetController.signal.aborted) {
+      emit({ kind: 'log', message: `Budget reached: $${totals.costUsd.toFixed(4)} of $${opts.budgetUsd} — stopping the run.` })
+      budgetController.abort(new Error('[framework] budget reached'))
     }
   }
 
@@ -362,7 +391,7 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     cwd: opts.cwd,
     system,
     ...(opts.model ? { model: opts.model } : {}),
-    ...(opts.signal ? { signal: opts.signal } : {}),
+    signal: runSignal,
     onEvent: onDriverEvent,
   })
 
@@ -376,7 +405,7 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
         loops: [...domainPreset.loops],
         prompts: driverLoopPrompts(session, domainPreset.prompts, {
           ledger,
-          ...(opts.signal ? { signal: opts.signal } : {}),
+          signal: runSignal,
         }),
       })
     : undefined
@@ -436,13 +465,14 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     const bootstrap = new Bootstrap({
       ledger,
       maxPasses: opts.maxPasses ?? DEFAULT_MAX_PASSES,
-      ...(opts.signal ? { signal: opts.signal } : {}),
+      signal: runSignal,
       onEvent: (event: BootstrapEvent) => emit({ kind: 'bootstrap', event }),
       steps: {
         scope: () => ({ scope: opts.scope ?? 'full', intent: opts.intent }),
         architect: planApprovalGate(driverArchitect(session), session, {
           ...(opts.requestChoice ? { requestChoice: opts.requestChoice } : {}),
           emit,
+          signal: runSignal,
         }),
         build: driverBuild(session, workspaceOpt),
         checklist,
@@ -466,10 +496,13 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     emit({ kind: 'end', ok: true })
     return { result, detection, events, ledger, ...(preview ? { preview } : {}), ...(loop ? { loop } : {}) }
   } catch (err) {
-    // A user interrupt (the dashboard Stop button / Ctrl+C aborts the signal) is a
-    // clean stop, not a failure — mark it so surfaces show "stopped".
-    const stopped = opts.signal?.aborted === true
-    emit({ kind: 'end', ok: false, ...(stopped ? { stopped: true } : {}), detail: err instanceof Error ? err.message : String(err) })
+    // A user interrupt (the dashboard Stop button / Ctrl+C) or a budget cap (#322)
+    // is a clean stop, not a failure — mark it so surfaces show "stopped". Budget is
+    // its own signal, so it trips when the caller's signal did not.
+    const budgetStopped = budgetController.signal.aborted && opts.signal?.aborted !== true
+    const stopped = opts.signal?.aborted === true || budgetController.signal.aborted
+    const detail = budgetStopped ? `budget reached ($${opts.budgetUsd})` : err instanceof Error ? err.message : String(err)
+    emit({ kind: 'end', ok: false, ...(stopped ? { stopped: true } : {}), detail })
     throw err
   } finally {
     await session.dispose()
@@ -493,6 +526,8 @@ function planApprovalGate(
   deps: {
     requestChoice?: (req: ChoiceRequest) => Promise<ChoicePick>
     emit: (event: FrameworkEvent) => void
+    /** The run signal; a gate parked for a pick unblocks (proceed) if the run aborts. */
+    signal?: AbortSignal
   },
 ): (ctx: ArchitectContext) => Promise<ArchitectPlan> {
   return async ctx => {
@@ -512,14 +547,10 @@ function planApprovalGate(
     const req: ChoiceRequest = { id: 'plan-approval', title: 'Approve this plan?', options, recommended: 'proceed' }
     emit({ kind: 'choice', ...req })
 
-    // A handler that rejects (or a run aborted mid-await) must not hang the gate:
-    // fall back to the recommended option so the next phase's signal check ends it.
-    let pick: ChoicePick
-    try {
-      pick = await requestChoice(req)
-    } catch {
-      pick = { picked: 'proceed', by: 'auto' }
-    }
+    // A handler that rejects, or a run aborted mid-await (user stop / budget cap
+    // #322), must not hang the gate: fall back to the recommended option so the
+    // next phase's signal check ends the run.
+    const pick = await raceChoiceOrAbort(requestChoice(req), deps.signal)
     emit({ kind: 'choice-resolved', id: req.id, picked: pick.picked, by: pick.by ?? 'user' })
 
     const altMatch = /^alt:(\d+)$/.exec(pick.picked)
@@ -528,6 +559,28 @@ function planApprovalGate(
     emit({ kind: 'log', message: `Re-architecting around your choice: ${chosen.option}` })
     return reArchitect(session, ctx, plan.stack, chosen.option)
   }
+}
+
+/** The recommended fallback pick when a gate cannot get a real answer. */
+const PROCEED: ChoicePick = { picked: 'proceed', by: 'auto' }
+
+/**
+ * Resolve with the human's pick, or fall back to proceed if the pick rejects or
+ * the run aborts first (user stop / budget cap #322) — so a gate parked for input
+ * never hangs. Never rejects. Cleans up its abort listener either way.
+ */
+function raceChoiceOrAbort(pick: Promise<ChoicePick>, signal?: AbortSignal): Promise<ChoicePick> {
+  if (!signal) return pick.catch(() => PROCEED)
+  if (signal.aborted) return Promise.resolve(PROCEED)
+  return new Promise<ChoicePick>(resolve => {
+    const onAbort = () => resolve(PROCEED)
+    signal.addEventListener('abort', onAbort, { once: true })
+    const done = (value: ChoicePick) => {
+      signal.removeEventListener('abort', onAbort)
+      resolve(value)
+    }
+    pick.then(done, () => done(PROCEED))
+  })
 }
 
 /**

--- a/packages/framework/src/usage.test.ts
+++ b/packages/framework/src/usage.test.ts
@@ -1,0 +1,39 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { UsageMeter } from './usage.js'
+
+const turn = { costUsd: 0.02, inputTokens: 100, outputTokens: 40, cacheReadTokens: 900, cacheCreationTokens: 50 }
+
+test('UsageMeter starts at zero', () => {
+  assert.deepEqual(new UsageMeter().totals(), {
+    costUsd: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    turns: 0,
+  })
+})
+
+test('UsageMeter sums each field and counts turns (#322)', () => {
+  const m = new UsageMeter()
+  m.add(turn)
+  m.add(turn)
+  assert.deepEqual(m.totals(), {
+    costUsd: 0.04,
+    inputTokens: 200,
+    outputTokens: 80,
+    cacheReadTokens: 1800,
+    cacheCreationTokens: 100,
+    turns: 2,
+  })
+})
+
+test('UsageMeter.totals returns a snapshot, not the live state', () => {
+  const m = new UsageMeter()
+  m.add(turn)
+  const snap = m.totals()
+  m.add(turn)
+  assert.equal(snap.turns, 1)
+  assert.equal(m.totals().turns, 2)
+})

--- a/packages/framework/src/usage.ts
+++ b/packages/framework/src/usage.ts
@@ -1,0 +1,47 @@
+import type { DriverUsage } from './driver/index.js'
+
+/**
+ * Cumulative token + cost usage for a run (#322). Extends {@link DriverUsage}
+ * with a turn count so a surface can show both the spend and how many agent
+ * turns produced it.
+ */
+export interface UsageTotals extends DriverUsage {
+  /** Number of turns that reported usage. */
+  turns: number
+}
+
+const ZERO: UsageTotals = {
+  costUsd: 0,
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  turns: 0,
+}
+
+/**
+ * Accumulates per-turn {@link DriverUsage} into a running total for the whole
+ * run. The framework can't retrieve the account's usage *limit* under
+ * subscription auth, so it infers consumption from what the agent already
+ * reports each turn (the alternative from #322) and lets a budget cap gate on it.
+ */
+export class UsageMeter {
+  private totalsState: UsageTotals = { ...ZERO }
+
+  /** Fold one turn's usage into the running total. */
+  add(usage: DriverUsage): void {
+    this.totalsState = {
+      costUsd: this.totalsState.costUsd + usage.costUsd,
+      inputTokens: this.totalsState.inputTokens + usage.inputTokens,
+      outputTokens: this.totalsState.outputTokens + usage.outputTokens,
+      cacheReadTokens: this.totalsState.cacheReadTokens + usage.cacheReadTokens,
+      cacheCreationTokens: this.totalsState.cacheCreationTokens + usage.cacheCreationTokens,
+      turns: this.totalsState.turns + 1,
+    }
+  }
+
+  /** A snapshot of the cumulative totals. */
+  totals(): UsageTotals {
+    return { ...this.totalsState }
+  }
+}


### PR DESCRIPTION
Takes the "infer % from tokens/dollars" path in #322: we can't read the account's usage limit under subscription auth, so we track what the agent already reports each turn.

What you get:
- A live spend readout on the dashboard header, and a `spend: $x over n turns` line in the terminal.
- `--max-cost <usd>`: the run stops itself once it has spent that much. The current turn finishes, then it stops cleanly (marked stopped, exit 0, not a failure).

The cap is what you asked for on long autopilot runs where you only review at the end. The "% of weekly limit" framing is a follow-up: it needs the weekly limit, which we can revisit once #322's retrieve-the-limit half is possible (or the user just provides it).

Closes #322

Internals: usage rides the driver's `result` event (`total_cost_usd` + token counts), a `UsageMeter` sums it, and a budget-linked abort signal stops the run. A plan-approval gate parked for a pick now unblocks on that signal too, so it can't hang. 201 tests green.
