### PR TITLE
fix(framework): re-fire the plan-approval gate after picking an alternative (#324)

### DIFF
--- a/.changeset/gate-refire-after-realternative.md
+++ b/.changeset/gate-refire-after-realternative.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/framework': patch
+---
+
+fix(framework): re-fire the plan-approval gate after picking an alternative (#324)
+
+Picking an alternative at the plan-approval gate re-architects the plan, and that fresh plan can differ a lot from the one you rejected. The gate now re-fires on the re-architected plan so you approve the plan you will actually build, not just the first one. Bounded to a few re-architect rounds so a run of alternative-picks can't loop forever.

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -600,3 +600,51 @@ test('picking an alternative re-architects the run around it (#304)', async () =
   assert.match(architect.event.stack, /Next\.js \+ Postgres/)
   assert.equal(result.productionGrade, true)
 })
+
+test('the gate re-fires to approve the re-architected plan (#324)', async () => {
+  const first = {
+    stack: 'Vike + Prisma',
+    narration: 'first plan',
+    decisions: [{ choice: 'SSR', why: 'per-request data' }],
+    alternatives: [{ option: 'Next.js', whyNot: 'edge deploy is more constrained' }],
+  }
+  const second = {
+    stack: 'Next.js + Postgres',
+    narration: 'second plan',
+    decisions: [{ choice: 'App Router', why: 'the user chose it' }],
+    alternatives: [{ option: 'Remix', whyNot: 'smaller ecosystem' }],
+  }
+  const driver = new FakeDriver({
+    respond: (prompt: string): string => {
+      if (/You are the architect/.test(prompt) && /prefers Next\.js/.test(prompt))
+        return '```json\n' + JSON.stringify(second) + '\n```'
+      if (/You are the architect/.test(prompt)) return '```json\n' + JSON.stringify(first) + '\n```'
+      if (/production-grade checklist/.test(prompt)) return 'Reviewed.\n```json\n{ "blockers": [] }\n```'
+      return 'done'
+    },
+    sessionId: 'refire',
+  })
+
+  const events: FrameworkEvent[] = []
+  // Round 0: pick the alternative (Next.js). Round 1: approve the re-architected plan.
+  const picks = ['alt:0', 'proceed']
+  let round = 0
+  const { result } = await runFramework({
+    intent: FAKE_INTENT,
+    driver,
+    cwd: '/tmp/ws',
+    signals: FAKE_SIGNALS,
+    onEvent: e => events.push(e),
+    requestChoice: async () => ({ picked: picks[round++] ?? 'proceed', by: 'user' as const }),
+  })
+
+  // The gate fired twice: once on the initial plan, once on the re-architected one.
+  const choices = events.filter(e => e.kind === 'choice')
+  assert.equal(choices.length, 2)
+  assert.equal(choices[0]!.kind === 'choice' && choices[0]!.id, 'plan-approval')
+  assert.equal(choices[1]!.kind === 'choice' && choices[1]!.id, 'plan-approval-1')
+  // The second gate offered the re-architected (Next.js) plan for approval.
+  assert.ok(choices[1]!.kind === 'choice' && /Next\.js \+ Postgres/.test(choices[1]!.options[0]!.label))
+  assert.ok(events.some(e => e.kind === 'log' && /Re-architecting around your choice: Next\.js/.test(e.message)))
+  assert.equal(result.productionGrade, true)
+})

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -531,35 +531,51 @@ function planApprovalGate(
   },
 ): (ctx: ArchitectContext) => Promise<ArchitectPlan> {
   return async ctx => {
-    const plan = await base(ctx)
     const { requestChoice, emit } = deps
+    let plan = await base(ctx)
     if (!requestChoice) return plan
 
-    const alternatives = plan.alternatives ?? []
-    const options: ChoiceOption[] = [
-      { id: 'proceed', label: `Proceed: ${plan.stack}` },
-      ...alternatives.map((a, i) => ({
-        id: `alt:${i}`,
-        label: `Use ${a.option} instead`,
-        ...(a.whyNot ? { detail: a.whyNot } : {}),
-      })),
-    ]
-    const req: ChoiceRequest = { id: 'plan-approval', title: 'Approve this plan?', options, recommended: 'proceed' }
-    emit({ kind: 'choice', ...req })
+    // Re-fire the gate after each re-architect so the user approves the FINAL plan,
+    // not just the first (#324): a picked alternative can differ a lot from what was
+    // rejected, and an autopilot run should still get one look at it. Bounded so a
+    // run of alt-picks can't loop forever.
+    for (let round = 0; round < MAX_PLAN_ROUNDS; round++) {
+      const alternatives = plan.alternatives ?? []
+      const options: ChoiceOption[] = [
+        { id: 'proceed', label: `Proceed: ${plan.stack}` },
+        ...alternatives.map((a, i) => ({
+          id: `alt:${i}`,
+          label: `Use ${a.option} instead`,
+          ...(a.whyNot ? { detail: a.whyNot } : {}),
+        })),
+      ]
+      // Round 0 keeps the stable `plan-approval` id; later rounds get a unique id so
+      // a dashboard never confuses a re-approval with the pick it just resolved.
+      const id = round === 0 ? 'plan-approval' : `plan-approval-${round}`
+      const req: ChoiceRequest = { id, title: 'Approve this plan?', options, recommended: 'proceed' }
+      emit({ kind: 'choice', ...req })
 
-    // A handler that rejects, or a run aborted mid-await (user stop / budget cap
-    // #322), must not hang the gate: fall back to the recommended option so the
-    // next phase's signal check ends the run.
-    const pick = await raceChoiceOrAbort(requestChoice(req), deps.signal)
-    emit({ kind: 'choice-resolved', id: req.id, picked: pick.picked, by: pick.by ?? 'user' })
+      // A handler that rejects, or a run aborted mid-await (user stop / budget cap
+      // #322), must not hang the gate: fall back to the recommended option so the
+      // next phase's signal check ends the run.
+      const pick = await raceChoiceOrAbort(requestChoice(req), deps.signal)
+      emit({ kind: 'choice-resolved', id: req.id, picked: pick.picked, by: pick.by ?? 'user' })
 
-    const altMatch = /^alt:(\d+)$/.exec(pick.picked)
-    const chosen = altMatch ? alternatives[Number(altMatch[1])] : undefined
-    if (!chosen) return plan
-    emit({ kind: 'log', message: `Re-architecting around your choice: ${chosen.option}` })
-    return reArchitect(session, ctx, plan.stack, chosen.option)
+      const altMatch = /^alt:(\d+)$/.exec(pick.picked)
+      const chosen = altMatch ? alternatives[Number(altMatch[1])] : undefined
+      if (!chosen) return plan // proceed (or an unknown pick) approves the current plan
+      emit({ kind: 'log', message: `Re-architecting around your choice: ${chosen.option}` })
+      plan = await reArchitect(session, ctx, plan.stack, chosen.option)
+    }
+    // Ran out of rounds still picking alternatives: proceed with the latest plan
+    // rather than loop forever.
+    emit({ kind: 'log', message: 'Proceeding with the latest plan (re-architect limit reached).' })
+    return plan
   }
 }
+
+/** How many times a run may re-architect at the plan-approval gate before proceeding (#324). */
+const MAX_PLAN_ROUNDS = 5
 
 /** The recommended fallback pick when a gate cannot get a real answer. */
 const PROCEED: ChoicePick = { picked: 'proceed', by: 'auto' }


### PR DESCRIPTION
You agreed on re-firing, so: picking an alternative at the plan-approval gate now re-fires the gate on the re-architected plan, so you approve the plan you actually build (it can differ a lot from the one you rejected).

- The gate loops: pick an alternative -> re-architect -> approve (or pick again). Bounded to 5 re-architect rounds so a run of alt-picks can't loop forever, then it proceeds with the latest plan.
- Round 0 keeps the stable `plan-approval` id; later rounds get a unique id so the dashboard never confuses a re-approval with the pick it just resolved.

Closes #324
