### PR TITLE
feat(framework): preset-prompt param substitution (#330)

### DIFF
--- a/.changeset/preset-params-330.md
+++ b/.changeset/preset-params-330.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Add preset-prompt param substitution (`<PARAM:name>`), the foundation for prompt-preset buttons. A preset prompt template can carry `<PARAM:name>` placeholders substituted from supplied values or declared defaults; unfilled params are surfaced so a caller can ask the user to fill the blanks.

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -136,6 +136,15 @@ export {
   type SystemPromptOptions,
 } from './system-prompt.js'
 export {
+  extractParamNames,
+  renderPresetPrompt,
+  unfilledParams,
+  PresetParamError,
+  PARAM_PATTERN,
+  type PresetParam,
+  type PresetParamOptions,
+} from './preset-params.js'
+export {
   preflight,
   type PreflightResult,
   type PreflightCheck,

--- a/packages/framework/src/preset-params.test.ts
+++ b/packages/framework/src/preset-params.test.ts
@@ -1,0 +1,83 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import {
+  extractParamNames,
+  renderPresetPrompt,
+  unfilledParams,
+  PresetParamError,
+} from './preset-params.js'
+
+const RESEARCH = 'Measure "problem variability" of `<PARAM:what>`.'
+
+test('extractParamNames returns distinct names in first-seen order', () => {
+  assert.deepEqual(extractParamNames('<PARAM:a> then <PARAM:b> then <PARAM:a>'), ['a', 'b'])
+  assert.deepEqual(extractParamNames('no params here'), [])
+})
+
+test('renderPresetPrompt substitutes a supplied value', () => {
+  assert.equal(
+    renderPresetPrompt(RESEARCH, { values: { what: 'the auth module' } }),
+    'Measure "problem variability" of `the auth module`.',
+  )
+})
+
+test('renderPresetPrompt falls back to a declared default', () => {
+  assert.equal(
+    renderPresetPrompt(RESEARCH, { params: [{ name: 'what', default: 'this PR' }] }),
+    'Measure "problem variability" of `this PR`.',
+  )
+})
+
+test('a supplied value overrides the default', () => {
+  assert.equal(
+    renderPresetPrompt(RESEARCH, {
+      params: [{ name: 'what', default: 'this PR' }],
+      values: { what: 'the router' },
+    }),
+    'Measure "problem variability" of `the router`.',
+  )
+})
+
+test('a blank value falls back to the default (cleared field keeps the default)', () => {
+  assert.equal(
+    renderPresetPrompt(RESEARCH, {
+      params: [{ name: 'what', default: 'this PR' }],
+      values: { what: '   ' },
+    }),
+    'Measure "problem variability" of `this PR`.',
+  )
+})
+
+test('every occurrence of a repeated placeholder is replaced', () => {
+  assert.equal(
+    renderPresetPrompt('<PARAM:x> and again <PARAM:x>', { values: { x: 'y' } }),
+    'y and again y',
+  )
+})
+
+test('renderPresetPrompt throws PresetParamError listing unfilled params', () => {
+  assert.throws(
+    () => renderPresetPrompt('<PARAM:what> in <PARAM:where>', { values: { what: 'x' } }),
+    (err: unknown) => {
+      assert.ok(err instanceof PresetParamError)
+      assert.deepEqual(err.missing, ['where'])
+      return true
+    },
+  )
+})
+
+test('unfilledParams returns descriptors for blanks the user must fill', () => {
+  const template = 'do <PARAM:what> in <PARAM:where>'
+  const filled = unfilledParams(template, {
+    params: [
+      { name: 'what', default: 'this PR' },
+      { name: 'where', description: 'target directory' },
+    ],
+    values: {},
+  })
+  assert.deepEqual(filled, [{ name: 'where', description: 'target directory' }])
+})
+
+test('unfilledParams falls back to a bare descriptor for an undeclared param', () => {
+  assert.deepEqual(unfilledParams('<PARAM:foo>'), [{ name: 'foo' }])
+})

--- a/packages/framework/src/preset-params.ts
+++ b/packages/framework/src/preset-params.ts
@@ -1,0 +1,91 @@
+/**
+ * Preset params (#330): the substitution primitive behind preset prompts. A preset
+ * prompt is a markdown template that carries `<PARAM:name>` placeholders — e.g. the
+ * [Research] preset (#331) opens with:
+ *
+ *   Measure "problem variability" of `<PARAM:what>`.
+ *
+ * `<PARAM:what>` is replaced with the value of the param named `what`. A param can
+ * declare a default (here, `this PR`), so a preset button runs with zero input yet
+ * still lets the user override it. A placeholder with neither a supplied value nor a
+ * default is *unfilled* — the caller either asks the user to fill the blank (the
+ * issue's alternative) or renders with a default.
+ *
+ * This is only the `<PARAM:name>` layer. The framework's own tokens (`SESSION_NAME`,
+ * `AWAIT`, `REVIEW_FILE`, `SHOW_IT`) in #326/#331 are a separate expansion resolved
+ * elsewhere, not user params.
+ */
+
+/** Matches a `<PARAM:name>` placeholder; the name is a letter-led slug. */
+export const PARAM_PATTERN = /<PARAM:([A-Za-z][A-Za-z0-9_-]*)>/g
+
+/** One declared param of a preset prompt: its name, optional default, optional label. */
+export interface PresetParam {
+  /** The name referenced as `<PARAM:name>` in the template. */
+  name: string
+  /** Value substituted when the caller supplies none. Absent = the caller must fill it. */
+  default?: string
+  /** Human label shown when prompting the user to fill this blank. */
+  description?: string
+}
+
+/** Inputs shared by the render/inspect helpers. */
+export interface PresetParamOptions {
+  /** Declared params (defaults + labels), keyed by {@link PresetParam.name}. */
+  params?: readonly PresetParam[]
+  /** Caller-supplied values, keyed by param name. A non-blank value overrides the default. */
+  values?: Record<string, string | undefined>
+}
+
+/**
+ * Thrown by {@link renderPresetPrompt} when the template references params that have
+ * neither a supplied value nor a default. {@link missing} lists their names so the
+ * caller can prompt for exactly those blanks.
+ */
+export class PresetParamError extends Error {
+  constructor(public readonly missing: readonly string[]) {
+    super(`preset prompt has unfilled params: ${missing.join(', ')}`)
+    this.name = 'PresetParamError'
+  }
+}
+
+/** The distinct param names a template references, in first-seen order. */
+export function extractParamNames(template: string): string[] {
+  const seen = new Set<string>()
+  for (const m of template.matchAll(PARAM_PATTERN)) seen.add(m[1]!)
+  return [...seen]
+}
+
+/**
+ * Resolve one param's value: a non-blank supplied value wins, else the declared
+ * default. A blank supplied value (empty/whitespace) is treated as unset, so a
+ * cleared fill-in-the-blank field falls back to the default rather than erasing it.
+ * Returns `undefined` when the param is unfilled.
+ */
+function resolveValue(name: string, opts: PresetParamOptions): string | undefined {
+  const supplied = opts.values?.[name]
+  if (typeof supplied === 'string' && supplied.trim() !== '') return supplied
+  return opts.params?.find(p => p.name === name)?.default
+}
+
+/**
+ * The params a template references that are still unfilled (no value, no default),
+ * as their {@link PresetParam} descriptors (name + label). This is what a
+ * "fill in the blanks" UI asks the user before rendering.
+ */
+export function unfilledParams(template: string, opts: PresetParamOptions = {}): PresetParam[] {
+  return extractParamNames(template)
+    .filter(name => resolveValue(name, opts) === undefined)
+    .map(name => opts.params?.find(p => p.name === name) ?? { name })
+}
+
+/**
+ * Substitute every `<PARAM:name>` in the template from the supplied values, falling
+ * back to declared defaults. Throws {@link PresetParamError} listing the names that
+ * are unfilled, so a preset never runs with a raw placeholder left in the prompt.
+ */
+export function renderPresetPrompt(template: string, opts: PresetParamOptions = {}): string {
+  const missing = unfilledParams(template, opts).map(p => p.name)
+  if (missing.length) throw new PresetParamError(missing)
+  return template.replace(PARAM_PATTERN, (_, name: string) => resolveValue(name, opts)!)
+}


### PR DESCRIPTION
Closes #330.

Foundation for the prompt-preset buttons: preset prompts are markdown templates with `<PARAM:name>` placeholders.

- `renderPresetPrompt(template, {params, values})` substitutes each `<PARAM:name>` from a supplied value, falling back to a declared default.
- A blank supplied value falls back to the default (a cleared field keeps the default).
- `unfilledParams()` lists placeholders with neither a value nor a default, so the "let the user fill in the blanks" path can prompt for exactly those.
- `renderPresetPrompt` throws `PresetParamError{missing}` rather than run with a raw placeholder left in the prompt.

Only the `<PARAM:name>` layer here. The framework tokens (`SESSION_NAME`, `AWAIT`, `REVIEW_FILE`) from #326/#331 are a separate expansion.

9 tests, 212 pass/1 docker-skip, typecheck clean. Changeset (minor).

Next in the chain: #332 `showMultiSelect()`, then compose #331.