### PR TITLE
feat(framework): multi-select gate (showMultiSelect) (#332)

### DIFF
--- a/.changeset/multi-select-gate-332.md
+++ b/.changeset/multi-select-gate-332.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Add a multi-select gate (`showMultiSelect()`): a dashboard checklist with pre-checked defaults that pauses the run and resolves to the selected subset. Built on the existing single-select choice gate (same panel and POST-back resolver), exposed as `requestMultiSelect()`; a headless run auto-accepts the default set. This is the primitive the [Research] preset uses to let the user pick which problems to deep-dive.

--- a/packages/framework/src/dashboard/autopilot.test.ts
+++ b/packages/framework/src/dashboard/autopilot.test.ts
@@ -59,7 +59,7 @@ function installClock(window: { [k: string]: unknown }) {
 
 interface Pick {
   id: string
-  pick: string
+  pick: string | string[]
   by: string
 }
 
@@ -70,6 +70,10 @@ interface Harness {
   el: (id: string) => { hidden: boolean; textContent: string }
   dispatch: (type: 'mousemove' | 'keydown', init?: Record<string, unknown>) => void
   window: Record<string, unknown>
+  /** Toggle a rendered option checkbox/radio by its value (multi-select interaction). */
+  setChecked: (value: string, checked: boolean) => void
+  /** Click a button by id (e.g. the Accept button). */
+  click: (id: string) => void
 }
 
 // Boot the real dashboard page in jsdom with stubbed EventSource/fetch and the
@@ -120,6 +124,16 @@ function boot(): Harness {
     dispatch(type, init) {
       const Ctor = type === 'mousemove' ? dom.window.MouseEvent : dom.window.KeyboardEvent
       doc.dispatchEvent(new Ctor(type, init as never))
+    },
+    setChecked(value, checked) {
+      const input = doc.querySelector(`#choice-options input[value="${value}"]`) as HTMLInputElement | null
+      assert.ok(input, `option ${value} exists`)
+      input.checked = checked
+    },
+    click(id) {
+      const node = doc.getElementById(id)
+      assert.ok(node, `#${id} exists`)
+      ;(node as unknown as { click: () => void }).click()
     },
     window,
   }
@@ -175,4 +189,47 @@ test('Ctrl+Enter accepts the choice as the user and stops the countdown (#311)',
   // The countdown was cleared, so no stray autopilot accept follows.
   h.tick(30000)
   assert.equal(h.picks.length, 1)
+})
+
+const MULTI = {
+  kind: 'choice',
+  id: 'ms',
+  title: 'Pick problems to deep-dive',
+  multi: true,
+  options: [
+    { id: 'p0', label: 'auth flow', default: true },
+    { id: 'p1', label: 'routing' },
+    { id: 'p2', label: 'data layer', default: true },
+  ],
+  autoAcceptMs: 10000,
+}
+
+test('a multi-select renders checkboxes and Accept posts the checked subset (#332)', () => {
+  const h = boot()
+  h.fire(MULTI)
+  assert.equal(h.el('choice-panel').hidden, false)
+  // The user unchecks a pre-checked default and checks a non-default one, so the
+  // posted subset differs from the defaults ['p0','p2'].
+  h.setChecked('p0', false)
+  h.setChecked('p1', true)
+  h.click('choice-accept')
+  assert.deepEqual(h.picks, [{ id: 'ms', pick: ['p1', 'p2'], by: 'user' }])
+  assert.equal(h.el('choice-panel').hidden, true)
+})
+
+test('a multi-select autopilot accept posts the default-checked subset (#332)', () => {
+  const h = boot()
+  h.fire(MULTI)
+  // Leave the pre-checked defaults; the countdown auto-accepts them.
+  h.tick(10000)
+  assert.deepEqual(h.picks, [{ id: 'ms', pick: ['p0', 'p2'], by: 'autopilot' }])
+})
+
+test('a multi-select can post an empty subset when the user unchecks everything (#332)', () => {
+  const h = boot()
+  h.fire(MULTI)
+  h.setChecked('p0', false)
+  h.setChecked('p2', false)
+  h.click('choice-accept')
+  assert.deepEqual(h.picks, [{ id: 'ms', pick: [], by: 'user' }])
 })

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -403,10 +403,15 @@ function showChoice(req) {
   activeChoice = req;
   $('choice-title').textContent = req.title || 'Your call';
   const ul = $('choice-options'); ul.innerHTML = '';
+  // A multi-select (#332) renders checkboxes pre-checked per option default; a
+  // single-select renders radios with the recommended option pre-selected (#304).
+  const multi = !!req.multi;
   for (const o of (req.options || [])) {
     const li = document.createElement('li');
-    const checked = o.id === req.recommended ? ' checked' : '';
-    li.innerHTML = '<label><input type="radio" name="choice-opt" value="' + esc(o.id) + '"' + checked + '>' +
+    const type = multi ? 'checkbox' : 'radio';
+    const nameAttr = multi ? '' : ' name="choice-opt"';
+    const checked = (multi ? o.default : o.id === req.recommended) ? ' checked' : '';
+    li.innerHTML = '<label><input type="' + type + '"' + nameAttr + ' class="choice-opt" value="' + esc(o.id) + '"' + checked + '>' +
       '<span class="opt-label">' + esc(o.label) + '</span>' +
       (o.detail ? '<span class="opt-detail">' + esc(o.detail) + '</span>' : '') + '</label>';
     ul.appendChild(li);
@@ -417,6 +422,11 @@ function showChoice(req) {
   notify('The run needs your input', req.title || 'A choice is waiting for you.');
 }
 function selectedChoice() {
+  // Multi-select: the picked SUBSET (may be empty). Single-select: one id, falling
+  // back to the recommended default if somehow nothing is checked.
+  if (activeChoice && activeChoice.multi) {
+    return [].slice.call(document.querySelectorAll('#choice-options input:checked')).map(function (e) { return e.value; });
+  }
   const el = document.querySelector('input[name="choice-opt"]:checked');
   return el ? el.value : (activeChoice ? activeChoice.recommended : null);
 }
@@ -452,7 +462,8 @@ function resolveChoice(fe) {
   if (activeChoice && activeChoice.id === fe.id) {
     stopCountdown(); activeChoice = null; $('choice-panel').hidden = true;
   }
-  log('\\u2713 chose ' + fe.picked + ' (' + fe.by + ')');
+  const picked = Array.isArray(fe.picked) ? (fe.picked.join(', ') || '(none)') : fe.picked;
+  log('\\u2713 chose ' + picked + ' (' + fe.by + ')');
 }
 function closeChoice() { stopCountdown(); activeChoice = null; $('choice-panel').hidden = true; }
 

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -279,7 +279,7 @@ function postJson(url: string, body: unknown): Promise<{ status: number; body: s
 }
 
 test('POST /choice invokes onChoice with the pick and the page reports it is choiceable (#304)', async () => {
-  const picks: Array<{ id: string; pick: string; by: string }> = []
+  const picks: Array<{ id: string; pick: string | string[]; by: string }> = []
   const dash = await startDashboard({ port: 0, onChoice: (id, pick, by) => picks.push({ id, pick, by }) })
   try {
     const { status } = await postJson(dash.url + '/choice', { id: 'plan-approval', pick: 'alt:0', by: 'autopilot' })
@@ -290,6 +290,25 @@ test('POST /choice invokes onChoice with the pick and the page reports it is cho
     assert.equal(picks[1]!.by, 'user')
     const page = await fetchText(dash.url + '/')
     assert.match(page.body, /CHOICEABLE = true/)
+  } finally {
+    await dash.close()
+  }
+})
+
+test('POST /choice forwards a multi-select subset (array pick), including an empty set (#332)', async () => {
+  const picks: Array<{ id: string; pick: string | string[] }> = []
+  const dash = await startDashboard({ port: 0, onChoice: (id, pick) => picks.push({ id, pick }) })
+  try {
+    await postJson(dash.url + '/choice', { id: 'ms', pick: ['p0', 'p2'], by: 'user' })
+    // An empty subset (nothing checked) is still a valid resolution, not dropped.
+    await postJson(dash.url + '/choice', { id: 'ms', pick: [], by: 'user' })
+    // Non-string array members are filtered out.
+    await postJson(dash.url + '/choice', { id: 'ms', pick: ['p1', 3, null], by: 'user' })
+    assert.deepEqual(picks, [
+      { id: 'ms', pick: ['p0', 'p2'] },
+      { id: 'ms', pick: [] },
+      { id: 'ms', pick: ['p1'] },
+    ])
   } finally {
     await dash.close()
   }

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -28,7 +28,7 @@ export interface DashboardOptions {
    * disable interactive choices; the page still renders them but the route reports
    * no handler (404).
    */
-  onChoice?: (id: string, pick: string, by: ChoiceBy) => void
+  onChoice?: (id: string, pick: string | string[], by: ChoiceBy) => void
   /**
    * The workspace whose `.framework/runs/` archive backs the run-history sidebar
    * (#303): `GET /api/runs` lists it, `GET /api/runs/<id>` replays one run. Omit
@@ -94,7 +94,7 @@ function handle(
   clients: Set<ServerResponse>,
   title: string,
   onStop: (() => void) | undefined,
-  onChoice: ((id: string, pick: string, by: ChoiceBy) => void) | undefined,
+  onChoice: ((id: string, pick: string | string[], by: ChoiceBy) => void) | undefined,
   cwd: string | undefined,
 ): void {
   const url = req.url ?? '/'
@@ -157,9 +157,16 @@ function handle(
     }
     readJsonBody(req, body => {
       const id = typeof body['id'] === 'string' ? body['id'] : ''
-      const pick = typeof body['pick'] === 'string' ? body['pick'] : ''
+      const raw = body['pick']
+      // A single-select posts one id (string); a multi-select (#332) posts the
+      // selected subset (array), which may legitimately be empty (nothing checked).
+      const pick: string | string[] = typeof raw === 'string'
+        ? raw
+        : Array.isArray(raw)
+          ? raw.filter((x): x is string => typeof x === 'string')
+          : ''
       const by: ChoiceBy = body['by'] === 'autopilot' ? 'autopilot' : body['by'] === 'auto' ? 'auto' : 'user'
-      if (id && pick) onChoice(id, pick, by)
+      if (id && (Array.isArray(pick) || pick)) onChoice(id, pick, by)
       res.writeHead(202, { 'content-type': 'application/json' })
       res.end('{"ok":true}')
     })

--- a/packages/framework/src/events.test.ts
+++ b/packages/framework/src/events.test.ts
@@ -5,12 +5,63 @@ import {
   SESSION_ID_PLACEHOLDER,
   formatFrameworkEvent,
   hasSessionIdPlaceholder,
+  pickedIds,
   resolveSessionLink,
 } from './events.js'
 
 test('hasSessionIdPlaceholder distinguishes templates from literal URLs', () => {
   assert.equal(hasSessionIdPlaceholder(`https://x.dev/s/${SESSION_ID_PLACEHOLDER}`), true)
   assert.equal(hasSessionIdPlaceholder('https://x.dev/live'), false)
+})
+
+test('pickedIds normalizes a single id or a subset to a list (#332)', () => {
+  assert.deepEqual(pickedIds('proceed'), ['proceed'])
+  assert.deepEqual(pickedIds(['p0', 'p2']), ['p0', 'p2'])
+  assert.deepEqual(pickedIds([]), [])
+  assert.deepEqual(pickedIds(''), [])
+})
+
+test('formatFrameworkEvent renders a multi-select choice as a checklist (#332)', () => {
+  const line = formatFrameworkEvent({
+    kind: 'choice',
+    id: 'ms',
+    title: 'Pick problems to deep-dive',
+    multi: true,
+    options: [
+      { id: 'p0', label: 'auth flow', default: true },
+      { id: 'p1', label: 'routing' },
+    ],
+  })
+  assert.equal(line, '? Pick problems to deep-dive\n    [x] auth flow\n    [ ] routing')
+})
+
+test('formatFrameworkEvent renders a single-select choice with the recommended mark (#304)', () => {
+  const line = formatFrameworkEvent({
+    kind: 'choice',
+    id: 'plan',
+    title: 'Approve this plan?',
+    recommended: 'proceed',
+    options: [
+      { id: 'proceed', label: 'Proceed: Vike' },
+      { id: 'alt:0', label: 'Use Next.js instead' },
+    ],
+  })
+  assert.equal(line, '? Approve this plan?\n    ● Proceed: Vike\n    ○ Use Next.js instead')
+})
+
+test('formatFrameworkEvent renders a resolved subset, and (none) when empty (#332)', () => {
+  assert.equal(
+    formatFrameworkEvent({ kind: 'choice-resolved', id: 'ms', picked: ['p0', 'p2'], by: 'user' }),
+    '  ✓ chose p0, p2 (user)',
+  )
+  assert.equal(
+    formatFrameworkEvent({ kind: 'choice-resolved', id: 'ms', picked: [], by: 'auto' }),
+    '  ✓ chose (none) (auto)',
+  )
+  assert.equal(
+    formatFrameworkEvent({ kind: 'choice-resolved', id: 'plan', picked: 'proceed', by: 'user' }),
+    '  ✓ chose proceed (user)',
+  )
 })
 
 test('resolveSessionLink fills the placeholder and is a no-op for a literal', () => {

--- a/packages/framework/src/events.ts
+++ b/packages/framework/src/events.ts
@@ -9,6 +9,8 @@ export interface ChoiceOption {
   label: string
   /** Optional one-line detail under the label (e.g. why an alternative lost). */
   detail?: string
+  /** In a multi-select ({@link ChoiceRequest.multi}), whether this option starts checked. Ignored for single-select. */
+  default?: boolean
 }
 
 /**
@@ -23,8 +25,18 @@ export interface ChoiceRequest {
   title: string
   /** The options to choose between (at least one). */
   options: readonly ChoiceOption[]
-  /** The option id pre-selected as the default (autopilot auto-accepts it). */
-  recommended: string
+  /**
+   * The option id pre-selected as the default (autopilot auto-accepts it). Required
+   * for a single-select; omitted for a {@link multi} select, where each option's own
+   * {@link ChoiceOption.default} drives the pre-checked set instead.
+   */
+  recommended?: string
+  /**
+   * Render as a multi-select checklist (#332): each option is a checkbox pre-checked
+   * per its {@link ChoiceOption.default}, and the pick resolves to the selected
+   * *subset* of ids rather than one. Absent = the single-select gate (#304).
+   */
+  multi?: boolean
   /** Auto-accept the recommended option after this many ms when autopilot is on. Default 10000. */
   autoAcceptMs?: number
 }
@@ -34,10 +46,15 @@ export type ChoiceBy = 'user' | 'autopilot' | 'auto'
 
 /** What a {@link import('./run.js').RunFrameworkOptions.requestChoice} handler resolves with. */
 export interface ChoicePick {
-  /** The picked option id. */
-  picked: string
+  /** The picked option id, or (for a {@link ChoiceRequest.multi} select) the selected subset of ids. */
+  picked: string | readonly string[]
   /** Who picked it. Default `'user'`. */
   by?: ChoiceBy
+}
+
+/** Normalize a {@link ChoicePick} (single id or subset) to a list of picked ids. */
+export function pickedIds(picked: string | readonly string[]): string[] {
+  return Array.isArray(picked) ? [...picked] : picked ? [picked as string] : []
 }
 
 /**
@@ -98,8 +115,8 @@ export type FrameworkEvent =
    * posts the pick back; a headless run auto-accepts the recommended option.
    */
   | ({ kind: 'choice' } & ChoiceRequest)
-  /** A pending {@link ChoiceRequest} was resolved — the run continues on `picked`. */
-  | { kind: 'choice-resolved'; id: string; picked: string; by: ChoiceBy }
+  /** A pending {@link ChoiceRequest} was resolved — the run continues on `picked` (one id, or the selected subset). */
+  | { kind: 'choice-resolved'; id: string; picked: string | readonly string[]; by: ChoiceBy }
   /**
    * The run finished. `ok` is false when it threw. `stopped` marks the common,
    * non-error case where the user interrupted it (the dashboard Stop button /
@@ -129,13 +146,13 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
       return `  modes: ${shown}`
     }
     case 'choice': {
-      const opts = event.options
-        .map(o => `    ${o.id === event.recommended ? '●' : '○'} ${o.label}`)
-        .join('\n')
+      const mark = (o: ChoiceOption) =>
+        event.multi ? (o.default ? '[x]' : '[ ]') : o.id === event.recommended ? '●' : '○'
+      const opts = event.options.map(o => `    ${mark(o)} ${o.label}`).join('\n')
       return `? ${event.title}\n${opts}`
     }
     case 'choice-resolved':
-      return `  ✓ chose ${event.picked} (${event.by})`
+      return `  ✓ chose ${pickedIds(event.picked).join(', ') || '(none)'} (${event.by})`
     case 'driver':
       return formatDriverEvent(event.event)
     case 'bootstrap':

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -52,11 +52,14 @@ export {
 } from './steps.js'
 export {
   runFramework,
+  requestMultiSelect,
   type RunFrameworkOptions,
   type RunFrameworkResult,
   type DeployDecision,
   type ServeConfig,
   type AppPreview,
+  type MultiSelectOption,
+  type MultiSelectDeps,
 } from './run.js'
 export { snapshotWorkspace, SANDBOX_IGNORE, type SnapshotOptions } from './sandbox.js'
 export {
@@ -78,6 +81,7 @@ export {
   type ChoiceRequest,
   type ChoicePick,
   type ChoiceBy,
+  pickedIds,
   formatFrameworkEvent,
   resolveSessionLink,
   hasSessionIdPlaceholder,

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { defineDomainPreset, defineFrameworkExtension, defineLoop, definePersona, defineSkill } from '@gemstack/ai-autopilot'
 import type { Prompt } from '@gemstack/ai-autopilot'
-import { DEFAULT_MAX_PASSES, runFramework } from './run.js'
+import { DEFAULT_MAX_PASSES, requestMultiSelect, runFramework, type MultiSelectOption } from './run.js'
 import { FAKE_DEPLOY, FAKE_INTENT, FAKE_SIGNALS, fakeDriver } from './fake-script.js'
 import { FakeDriver, type Driver, type DriverSession } from './driver/index.js'
 import type { ChoiceRequest, FrameworkEvent } from './events.js'
@@ -647,4 +647,69 @@ test('the gate re-fires to approve the re-architected plan (#324)', async () => 
   assert.ok(choices[1]!.kind === 'choice' && /Next\.js \+ Postgres/.test(choices[1]!.options[0]!.label))
   assert.ok(events.some(e => e.kind === 'log' && /Re-architecting around your choice: Next\.js/.test(e.message)))
   assert.equal(result.productionGrade, true)
+})
+
+const MS_OPTS: MultiSelectOption[] = [
+  { id: 'p0', label: 'auth flow', default: true },
+  { id: 'p1', label: 'routing' },
+  { id: 'p2', label: 'data layer', detail: 'rated 2/10', default: true },
+]
+
+test('requestMultiSelect headless: auto-accepts the default-checked set (#332)', async () => {
+  const events: FrameworkEvent[] = []
+  const selected = await requestMultiSelect({
+    id: 'ms',
+    title: 'Pick problems',
+    options: MS_OPTS,
+    emit: e => events.push(e),
+  })
+  assert.deepEqual(selected, ['p0', 'p2']) // the two defaults
+  const choice = events.find(e => e.kind === 'choice')
+  assert.ok(choice && choice.kind === 'choice' && choice.multi === true && choice.recommended === undefined)
+  const resolved = events.find(e => e.kind === 'choice-resolved')
+  assert.ok(resolved && resolved.kind === 'choice-resolved')
+  assert.deepEqual((resolved as { picked: unknown }).picked, ['p0', 'p2'])
+  assert.equal((resolved as { by: string }).by, 'auto')
+})
+
+test('requestMultiSelect returns the user-picked subset, filtered to valid ids (#332)', async () => {
+  const events: FrameworkEvent[] = []
+  const selected = await requestMultiSelect({
+    id: 'ms',
+    title: 'Pick problems',
+    options: MS_OPTS,
+    emit: e => events.push(e),
+    // The user unchecks a default (p0), keeps p1, and a stray id is dropped.
+    requestChoice: async () => ({ picked: ['p1', 'p2', 'bogus'], by: 'user' }),
+  })
+  assert.deepEqual(selected, ['p1', 'p2'])
+})
+
+test('requestMultiSelect resolves to the defaults if the run aborts while parked (#332)', async () => {
+  const events: FrameworkEvent[] = []
+  const ac = new AbortController()
+  const selected = await requestMultiSelect({
+    id: 'ms',
+    title: 'Pick problems',
+    options: MS_OPTS,
+    emit: e => events.push(e),
+    signal: ac.signal,
+    // Never resolves on its own; the abort must unblock it.
+    requestChoice: () => {
+      ac.abort()
+      return new Promise(() => {})
+    },
+  })
+  assert.deepEqual(selected, ['p0', 'p2']) // fell back to the defaults, not a hang
+})
+
+test('requestMultiSelect can resolve to an empty set when the user checks nothing (#332)', async () => {
+  const selected = await requestMultiSelect({
+    id: 'ms',
+    title: 'Pick problems',
+    options: MS_OPTS,
+    emit: () => {},
+    requestChoice: async () => ({ picked: [], by: 'user' }),
+  })
+  assert.deepEqual(selected, [])
 })

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -37,7 +37,7 @@ import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { memoryFraming, type LoadedMemory } from './memory.js'
 import { systemPromptBlock } from './system-prompt.js'
 import { decideDeploy, deployWith, domainLoopChecklist, driverArchitect, driverBuild, driverChecklist, driverImprove, driverLoopPrompts, reArchitect } from './steps.js'
-import { hasSessionIdPlaceholder, OPEN_LOOP_MODES, resolveSessionLink, type ChoiceOption, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
+import { hasSessionIdPlaceholder, OPEN_LOOP_MODES, pickedIds, resolveSessionLink, type ChoiceOption, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 import { UsageMeter } from './usage.js'
 
 /**
@@ -561,7 +561,9 @@ function planApprovalGate(
       const pick = await raceChoiceOrAbort(requestChoice(req), deps.signal)
       emit({ kind: 'choice-resolved', id: req.id, picked: pick.picked, by: pick.by ?? 'user' })
 
-      const altMatch = /^alt:(\d+)$/.exec(pick.picked)
+      // Single-select gate: the pick is one id.
+      const picked = typeof pick.picked === 'string' ? pick.picked : pick.picked[0] ?? ''
+      const altMatch = /^alt:(\d+)$/.exec(picked)
       const chosen = altMatch ? alternatives[Number(altMatch[1])] : undefined
       if (!chosen) return plan // proceed (or an unknown pick) approves the current plan
       emit({ kind: 'log', message: `Re-architecting around your choice: ${chosen.option}` })
@@ -577,26 +579,95 @@ function planApprovalGate(
 /** How many times a run may re-architect at the plan-approval gate before proceeding (#324). */
 const MAX_PLAN_ROUNDS = 5
 
-/** The recommended fallback pick when a gate cannot get a real answer. */
+/** The recommended fallback pick when a single-select gate cannot get a real answer. */
 const PROCEED: ChoicePick = { picked: 'proceed', by: 'auto' }
 
 /**
- * Resolve with the human's pick, or fall back to proceed if the pick rejects or
+ * Resolve with the human's pick, or fall back to `fallback` if the pick rejects or
  * the run aborts first (user stop / budget cap #322) — so a gate parked for input
- * never hangs. Never rejects. Cleans up its abort listener either way.
+ * never hangs. Never rejects. Cleans up its abort listener either way. The fallback
+ * is the single-select `proceed` by default; a multi-select passes its default set.
  */
-function raceChoiceOrAbort(pick: Promise<ChoicePick>, signal?: AbortSignal): Promise<ChoicePick> {
-  if (!signal) return pick.catch(() => PROCEED)
-  if (signal.aborted) return Promise.resolve(PROCEED)
+function raceChoiceOrAbort(
+  pick: Promise<ChoicePick>,
+  signal?: AbortSignal,
+  fallback: ChoicePick = PROCEED,
+): Promise<ChoicePick> {
+  if (!signal) return pick.catch(() => fallback)
+  if (signal.aborted) return Promise.resolve(fallback)
   return new Promise<ChoicePick>(resolve => {
-    const onAbort = () => resolve(PROCEED)
+    const onAbort = () => resolve(fallback)
     signal.addEventListener('abort', onAbort, { once: true })
     const done = (value: ChoicePick) => {
       signal.removeEventListener('abort', onAbort)
       resolve(value)
     }
-    pick.then(done, () => done(PROCEED))
+    pick.then(done, () => done(fallback))
   })
+}
+
+/** One option of a {@link requestMultiSelect} checklist (#332). */
+export interface MultiSelectOption {
+  /** Stable id returned when this option is checked. */
+  id: string
+  /** The label shown next to the checkbox. */
+  label: string
+  /** Optional one-line detail under the label. */
+  detail?: string
+  /** Whether this option starts checked (e.g. a low-rated problem in the [Research] preset #331). */
+  default?: boolean
+}
+
+/** Inputs to {@link requestMultiSelect}. */
+export interface MultiSelectDeps {
+  /** Stable id for the gate; the pick is posted back against it. */
+  id: string
+  /** The prompt shown above the checklist. */
+  title: string
+  /** The options to choose from (checkboxes). */
+  options: readonly MultiSelectOption[]
+  /** The interactive handler (the CLI wires it to the dashboard); omit for a headless run. */
+  requestChoice?: (req: ChoiceRequest) => Promise<ChoicePick>
+  /** Emit the `choice` / `choice-resolved` events onto the run stream. */
+  emit: (event: FrameworkEvent) => void
+  /** The run signal; a gate parked for a pick unblocks (to the defaults) if the run aborts. */
+  signal?: AbortSignal
+}
+
+/**
+ * The multi-select gate (#332): show a checklist with the default-checked options
+ * pre-selected, pause, and resolve to the *subset* of option ids the user kept
+ * checked. Built on the same `choice` gate + POST-back resolver as the single-select
+ * plan-approval gate (#304), just in checklist mode. A headless run (no
+ * `requestChoice`) auto-accepts the default set without pausing, so a programmatic
+ * run stays deterministic. This is the primitive the [Research] preset (#331) uses
+ * to let the user pick which problems to deep-dive.
+ */
+export async function requestMultiSelect(deps: MultiSelectDeps): Promise<string[]> {
+  const { options, requestChoice, emit } = deps
+  const defaults = options.filter(o => o.default).map(o => o.id)
+  const req: ChoiceRequest = {
+    id: deps.id,
+    title: deps.title,
+    multi: true,
+    options: options.map(o => ({
+      id: o.id,
+      label: o.label,
+      ...(o.detail ? { detail: o.detail } : {}),
+      ...(o.default ? { default: true } : {}),
+    })),
+  }
+  emit({ kind: 'choice', ...req })
+
+  const validIds = new Set(options.map(o => o.id))
+  const asDefaults: ChoicePick = { picked: defaults, by: 'auto' }
+  // Headless: no one to ask, so accept the defaults (the recommended set).
+  const pick = requestChoice
+    ? await raceChoiceOrAbort(requestChoice(req), deps.signal, asDefaults)
+    : asDefaults
+  const selected = pickedIds(pick.picked).filter(id => validIds.has(id))
+  emit({ kind: 'choice-resolved', id: req.id, picked: selected, by: pick.by ?? 'user' })
+  return selected
 }
 
 /**


### PR DESCRIPTION
Closes #332.

The multi-select checklist primitive, built by extending the single-select choice gate (per your confirm on the issue) rather than a separate gate.

- `requestMultiSelect({id, title, options})` shows a checklist, pauses, and returns the selected subset of option ids. Each option has a `default` (pre-checked); a headless run auto-accepts the default set; an abort while parked falls back to the defaults so it never hangs.
- `choice` event gains `multi` + per-option `default`; `ChoicePick.picked` / `choice-resolved.picked` now carry one id OR a subset; `pickedIds()` normalizes.
- `POST /choice` accepts an array pick, including an empty subset (unchecking everything is a valid answer).
- The panel renders checkboxes pre-checked per default; Accept posts the checked subset; the autopilot countdown auto-accepts the defaults.

Single-select (#304 plan-approval, #311 autopilot) is unchanged.

14 tests across events / run / server + the jsdom panel harness (renders checkboxes, Accept posts the subset, autopilot accepts the defaults, empty subset). 224 pass / 1 docker-skip, typecheck clean. Changeset (minor).

Naming note: exported as `requestMultiSelect` to mirror the existing `requestChoice` run option; the agent-facing verb in the prompts stays `showMultiSelect()`. Say if you would rather the export itself be `showMultiSelect`.

Next: compose #331 [Research] preset on top of this + #330 param substitution.