### PR TITLE
feat(framework): turn-boundary choice gate for agent-authored showChoices()

### DIFF
--- a/.changeset/turn-boundary-choice-gate.md
+++ b/.changeset/turn-boundary-choice-gate.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/framework': minor
+---
+
+feat(framework): turn an agent's showChoices()+AWAIT into a live gate at the turn boundary (#337)
+
+The system prompt tells the agent to `showChoices()` and `AWAIT` at unclear-scope / alternatives points, but until now only framework-emitted gates (the plan-approval gate, multi-select) could pause a run. Now when a build turn ends by asking the user, an `await-choices` block, the framework shows the choice on the dashboard, waits for the pick, and re-prompts the agent to continue from that decision. It is the agent-authored counterpart to the plan-approval gate: a no-op when headless and when the agent just finishes instead of asking, so existing runs are unchanged.

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -714,6 +714,71 @@ test('requestMultiSelect can resolve to an empty set when the user checks nothin
   assert.deepEqual(selected, [])
 })
 
+test('a build turn that stops to ask fires a live gate and resumes on the pick (#337)', async () => {
+  const plan = {
+    stack: 'Vike + Prisma',
+    narration: 'a plan',
+    decisions: [{ choice: 'SSR', why: 'per-request data' }],
+    alternatives: [],
+  }
+  const awaitBlock =
+    'I need a decision first.\n```await-choices\n' +
+    '{ "title": "Which data store?", "options": [{ "id": "sqlite", "label": "SQLite" }, { "id": "pg", "label": "Postgres" }], "recommended": "sqlite" }\n' +
+    '```'
+  const driver = new FakeDriver({
+    respond: (prompt: string): string => {
+      if (/You are the architect/.test(prompt)) return '```json\n' + JSON.stringify(plan) + '\n```'
+      if (/Build this app end to end/.test(prompt)) return awaitBlock // the build stops to ask
+      if (/You paused to ask/.test(prompt)) return 'Built it with Postgres. Done.' // the resume
+      if (/production-grade checklist/.test(prompt)) return 'Reviewed.\n```json\n{ "blockers": [] }\n```'
+      return 'done'
+    },
+    sessionId: 'gate337',
+  })
+
+  const events: FrameworkEvent[] = []
+  const prompts: string[] = []
+  const { result } = await runFramework({
+    intent: FAKE_INTENT,
+    driver,
+    cwd: '/tmp/ws',
+    signals: FAKE_SIGNALS,
+    onEvent: e => {
+      events.push(e)
+      if (e.kind === 'driver' && e.event.type === 'start') prompts.push(e.event.prompt)
+    },
+    requestChoice: async () => ({ picked: 'pg', by: 'user' }),
+  })
+
+  // The agent-authored choice surfaced as a live gate with the offered options.
+  // (The architect plan-approval gate #304 also fires first; find ours by id.)
+  const choice = events.find(e => e.kind === 'choice' && e.id === 'await-choices')
+  assert.ok(choice && choice.kind === 'choice')
+  assert.equal(choice.title, 'Which data store?')
+  assert.ok(choice.options.some(o => o.id === 'pg' && o.label === 'Postgres'))
+  // The pick was narrated and the driver was re-prompted to continue from it.
+  assert.ok(events.some(e => e.kind === 'log' && /Continuing with your choice: Postgres/.test(e.message)))
+  assert.ok(prompts.some(p => /You paused to ask.*Which data store.*chose: Postgres/s.test(p)))
+  assert.equal(result.productionGrade, true)
+})
+
+test('without a requestChoice handler a build that asks is not gated (#337 headless)', async () => {
+  const plan = { stack: 'Vike', narration: 'p', decisions: [{ choice: 'x', why: 'y' }], alternatives: [] }
+  const driver = new FakeDriver({
+    respond: (prompt: string): string => {
+      if (/You are the architect/.test(prompt)) return '```json\n' + JSON.stringify(plan) + '\n```'
+      if (/Build this app end to end/.test(prompt)) return 'built it\n```await-choices\n{ "options": [{ "label": "A" }] }\n```'
+      if (/production-grade checklist/.test(prompt)) return 'Reviewed.\n```json\n{ "blockers": [] }\n```'
+      return 'done'
+    },
+    sessionId: 'headless337',
+  })
+  const events: FrameworkEvent[] = []
+  await runFramework({ intent: FAKE_INTENT, driver, cwd: '/tmp/ws', signals: FAKE_SIGNALS, onEvent: e => events.push(e) })
+  assert.equal(events.some(e => e.kind === 'choice'), false)
+  assert.equal(events.some(e => e.kind === 'choice-resolved'), false)
+})
+
 const CH_OPTS: ChoicesOption[] = [
   { id: 'a', label: 'Interpretation A' },
   { id: 'b', label: 'Interpretation B', detail: 'less likely' },

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -23,6 +23,7 @@ import {
   type BootstrapResult,
   type BootstrapScope,
   type BootstrapSteps,
+  type BuildContext,
   type DeployTarget,
   type DomainPreset,
   type FrameworkDetection,
@@ -30,13 +31,15 @@ import {
   type FrameworkSignals,
   type LoopPassContext,
   type RunnerSession,
+  type SupervisorRun,
   type Verdict,
 } from '@gemstack/ai-autopilot'
 import { snapshotWorkspace } from './sandbox.js'
 import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { memoryFraming, type LoadedMemory } from './memory.js'
 import { systemPromptBlock } from './system-prompt.js'
-import { decideDeploy, deployWith, domainLoopChecklist, driverArchitect, driverBuild, driverChecklist, driverImprove, driverLoopPrompts, reArchitect } from './steps.js'
+import { AWAIT_PROTOCOL, parseChoicesGate } from './turn-gate.js'
+import { continueAfterChoice, decideDeploy, deployWith, domainLoopChecklist, driverArchitect, driverBuild, driverChecklist, driverImprove, driverLoopPrompts, reArchitect } from './steps.js'
 import { hasSessionIdPlaceholder, OPEN_LOOP_MODES, pickedIds, resolveSessionLink, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 import { UsageMeter } from './usage.js'
 
@@ -316,8 +319,10 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
   // The anti-lazy-pill + any user SYSTEM.md lead the system prompt so its working
   // agreement frames every prompt before the role/skill/memory context (#301).
   const promptBlock = systemPromptBlock({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt })
+  // The await protocol (#337) concretizes the pill's showChoices()/AWAIT macros into a
+  // signal the turn-boundary gate can detect, so it rides along with the pill.
   const system = [
-    ...(promptBlock ? [promptBlock] : []),
+    ...(promptBlock ? [promptBlock, AWAIT_PROTOCOL] : []),
     ...personas.map(personaInstructions),
     ...skills.map(skillInstructions),
     ...(memoryBlock ? [memoryBlock] : []),
@@ -474,7 +479,11 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
           emit,
           signal: runSignal,
         }),
-        build: driverBuild(session, workspaceOpt),
+        build: agentChoiceGate(driverBuild(session, workspaceOpt), session, {
+          ...(opts.requestChoice ? { requestChoice: opts.requestChoice } : {}),
+          emit,
+          signal: runSignal,
+        }),
         checklist,
         improve: driverImprove(session, workspaceOpt),
         ...(opts.deploy
@@ -579,6 +588,59 @@ function planApprovalGate(
 
 /** How many times a run may re-architect at the plan-approval gate before proceeding (#324). */
 const MAX_PLAN_ROUNDS = 5
+
+/** How many times a build may stop to ask (and be resumed) before it just proceeds (#337). */
+const MAX_AWAIT_ROUNDS = 5
+
+/**
+ * The agent-authored choice gate (#337): the turn-boundary counterpart to the
+ * framework-emitted plan-approval gate (#304). When a build turn ends by asking the
+ * user — an `await-choices` block per {@link AWAIT_PROTOCOL}, e.g. the #326 unclear-scope
+ * or alternatives flow — rather than finishing, show the choice, wait for the pick, and
+ * re-prompt the driver to continue from that decision. A no-op unless a
+ * {@link RunFrameworkOptions.requestChoice} handler is wired (headless byte-identical),
+ * and unless the agent actually stopped to ask (the common case returns straight through).
+ * Bounded so an agent that keeps asking can't loop forever.
+ */
+function agentChoiceGate(
+  base: (ctx: BuildContext) => Promise<SupervisorRun>,
+  session: DriverSession,
+  deps: {
+    requestChoice?: (req: ChoiceRequest) => Promise<ChoicePick>
+    emit: (event: FrameworkEvent) => void
+    /** The run signal; a gate parked for a pick unblocks (proceed) if the run aborts. */
+    signal?: AbortSignal
+  },
+): (ctx: BuildContext) => Promise<SupervisorRun> {
+  return async ctx => {
+    const { requestChoice, emit } = deps
+    let run = await base(ctx)
+    if (!requestChoice) return run
+
+    for (let round = 0; round < MAX_AWAIT_ROUNDS; round++) {
+      const gate = parseChoicesGate(run.text)
+      if (!gate) return run // the agent finished instead of asking — the common case
+      // Round 0 keeps the stable `await-choices` id; later rounds get a unique one so a
+      // dashboard never confuses a re-ask with the pick it just resolved.
+      const id = round === 0 ? 'await-choices' : `await-choices-${round}`
+      const picked = await requestChoices({
+        id,
+        title: gate.title,
+        options: gate.options,
+        ...(gate.recommended ? { recommended: gate.recommended } : {}),
+        requestChoice,
+        emit,
+        ...(deps.signal ? { signal: deps.signal } : {}),
+      })
+      const chosen = gate.options.find(o => o.id === picked)
+      emit({ kind: 'log', message: `Continuing with your choice: ${chosen?.label ?? picked}` })
+      run = await continueAfterChoice(session, ctx, gate.title, chosen?.label ?? picked)
+    }
+    // The agent kept asking past the limit: proceed with the latest turn rather than loop.
+    emit({ kind: 'log', message: 'Proceeding with the build (await limit reached).' })
+    return run
+  }
+}
 
 /** The recommended fallback pick when a single-select gate cannot get a real answer. */
 const PROCEED: ChoicePick = { picked: 'proceed', by: 'auto' }

--- a/packages/framework/src/steps.ts
+++ b/packages/framework/src/steps.ts
@@ -22,6 +22,7 @@ import type {
   Verdict,
 } from '@gemstack/ai-autopilot'
 import type { DriverSession } from './driver/index.js'
+import { parseChoicesGate } from './turn-gate.js'
 
 /**
  * Driver-backed {@link https://github.com/gemstack-land/gemstack | Bootstrap} steps.
@@ -212,6 +213,29 @@ export function reArchitect(
 }
 
 /**
+ * Resume the build after the agent stopped to ask (#337): the turn-boundary choice
+ * gate re-prompts the driver with the user's pick so it continues from the decision
+ * rather than deciding for itself. A fresh turn (option A), so the agent re-reads the
+ * workspace and the pick frames what to do next. Returns a {@link SupervisorRun} in
+ * the same shape as {@link driverBuild} so the gate can hand it straight back.
+ */
+export function continueAfterChoice(
+  session: DriverSession,
+  ctx: BuildContext,
+  question: string,
+  answer: string,
+): Promise<SupervisorRun> {
+  const prompt = `You paused to ask: "${question}". The user chose: ${answer}. Continue building "${ctx.intent}" with that decision, and do not ask again unless a genuinely new choice comes up.`
+  return session
+    .prompt(prompt, { ...(ctx.signal ? { signal: ctx.signal } : {}) })
+    .then(turn => {
+      const subtask: PlannedSubtask = { id: 'build-resume', description: 'Continue after the user picked' }
+      const result: SubtaskResult = { subtask, text: turn.text, ok: true, usage: ZERO_USAGE }
+      return { text: turn.text, plan: [subtask], results: [result], usage: ZERO_USAGE, stoppedEarly: false }
+    })
+}
+
+/**
  * The build step: prompt the driver to build the app and let its own loop run.
  * Emits synthetic Supervisor events so the bootstrap narration still shows a
  * build phase, and returns a {@link SupervisorRun} carrying the driver's summary.
@@ -260,7 +284,10 @@ export function driverBuild(
     // #182: the build must actually produce an app. If nothing landed on disk,
     // the agent stalled (e.g. sanity-checking the stack) — re-prompt once with a
     // hard "create it from scratch" directive so an empty-dir run starts building.
-    if (opts.verifyWorkspace && isWorkspaceEmpty(session.cwd)) {
+    // Exception (#337): an empty workspace plus an `await-choices` block means the
+    // agent stopped *on purpose* to ask; the choice gate handles it, so don't clobber
+    // the question with a scaffold directive.
+    if (opts.verifyWorkspace && isWorkspaceEmpty(session.cwd) && !parseChoicesGate(turn.text)) {
       const retry: PlannedSubtask = { id: 'build-2', description: 'Scaffold the app from scratch (workspace was empty)' }
       ctx.onEvent({ type: 'dispatch-start', subtask: retry })
       turn = await session.prompt(scaffoldPrompt(ctx.plan, ctx.intent), { ...promptOpts, ...signalOpt })

--- a/packages/framework/src/turn-gate.test.ts
+++ b/packages/framework/src/turn-gate.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { parseChoicesGate } from './turn-gate.js'
+
+const block = (json: string): string => 'Here are the options.\n```await-choices\n' + json + '\n```'
+
+test('parseChoicesGate returns undefined when the agent did not stop to ask (#337)', () => {
+  assert.equal(parseChoicesGate('Built the whole app. Done.'), undefined)
+})
+
+test('parseChoicesGate parses a well-formed await-choices block (#337)', () => {
+  const gate = parseChoicesGate(
+    block('{ "title": "Which auth?", "options": [{ "id": "sessions", "label": "Sessions" }, { "id": "jwt", "label": "JWT", "detail": "stateless" }], "recommended": "sessions" }'),
+  )
+  assert.ok(gate)
+  assert.equal(gate.title, 'Which auth?')
+  assert.equal(gate.recommended, 'sessions')
+  assert.deepEqual(gate.options, [
+    { id: 'sessions', label: 'Sessions' },
+    { id: 'jwt', label: 'JWT', detail: 'stateless' },
+  ])
+})
+
+test('parseChoicesGate synthesizes ids and defaults a blank title (#337)', () => {
+  const gate = parseChoicesGate(block('{ "options": [{ "label": "A" }, { "label": "B" }] }'))
+  assert.ok(gate)
+  assert.equal(gate.title, 'Which option?')
+  assert.deepEqual(gate.options.map(o => o.id), ['opt:0', 'opt:1'])
+  assert.equal(gate.recommended, undefined)
+})
+
+test('parseChoicesGate maps a recommended label to its option id (#337)', () => {
+  const gate = parseChoicesGate(block('{ "title": "Pick", "options": [{ "label": "First" }, { "label": "Second" }], "recommended": "Second" }'))
+  assert.ok(gate)
+  assert.equal(gate.recommended, 'opt:1')
+})
+
+test('parseChoicesGate takes the last block when a turn has more than one (#337)', () => {
+  const text = block('{ "options": [{ "label": "old" }] }') + '\n' + block('{ "title": "final", "options": [{ "label": "new" }] }')
+  const gate = parseChoicesGate(text)
+  assert.ok(gate)
+  assert.equal(gate.title, 'final')
+  assert.deepEqual(gate.options.map(o => o.label), ['new'])
+})
+
+test('parseChoicesGate ignores a malformed or empty block rather than throwing (#337)', () => {
+  assert.equal(parseChoicesGate(block('{ not json')), undefined)
+  assert.equal(parseChoicesGate(block('{ "options": [] }')), undefined)
+  assert.equal(parseChoicesGate(block('{ "options": [{ "detail": "no label" }] }')), undefined)
+  assert.equal(parseChoicesGate(block('{ "title": "x" }')), undefined) // no options array
+})

--- a/packages/framework/src/turn-gate.ts
+++ b/packages/framework/src/turn-gate.ts
@@ -1,0 +1,75 @@
+import type { ChoicesOption } from './run.js'
+
+/**
+ * The framework-owned "await" protocol (#337): the *code side* of the #326
+ * `showChoices()` / `AWAIT` macros that Rom delegated. The driver runs each agent
+ * turn as a black box to completion (#165), so the only way the framework can learn
+ * the agent stopped to ask (rather than deciding for itself) is a signal in the
+ * turn's final message. This appends one to the system prompt: it does not restate
+ * the macros, it pins *how* to emit an awaited choice so the turn-boundary gate can
+ * detect it. Kept minimal and self-contained so it survives the #326 wording still
+ * being written.
+ */
+export const AWAIT_PROTOCOL = [
+  '## Awaiting a choice',
+  'When these instructions tell you to showChoices() and then AWAIT, do not pick for the user.',
+  'End your turn with a fenced code block tagged `await-choices` holding JSON, then stop:',
+  '```await-choices',
+  '{ "title": "<the question>", "options": [{ "label": "<option>", "detail": "<optional one-liner>" }], "recommended": "<the label to default to>" }',
+  '```',
+  'The framework shows the choice, waits for the user, and re-prompts you with their pick. Do not continue past it on your own.',
+].join('\n')
+
+/** A choice an agent stopped to ask, parsed from an `await-choices` block (#337). */
+export interface ParsedChoicesGate {
+  /** The question shown above the options. */
+  title: string
+  /** The options to choose between (at least one). */
+  options: ChoicesOption[]
+  /** The option id to default to, when the agent named one. */
+  recommended?: string
+}
+
+/** Matches every `await-choices` fenced block; the last one in the turn wins. */
+const AWAIT_CHOICES_BLOCK = /```await-choices\s+([\s\S]*?)```/g
+
+/**
+ * Parse a trailing `await-choices` block (per {@link AWAIT_PROTOCOL}) from a turn's
+ * final text (#337). Returns `undefined` when the agent did not stop to ask, which is
+ * the common case, so a normal build turn flows straight through. Tolerant by design:
+ * ids are synthesized from position, a blank title falls back, `recommended` may be
+ * given as a label or an id, and a malformed block is ignored (no gate) rather than
+ * throwing — a bad parse must never crash a build.
+ */
+export function parseChoicesGate(text: string): ParsedChoicesGate | undefined {
+  let body: string | undefined
+  for (const match of text.matchAll(AWAIT_CHOICES_BLOCK)) body = match[1]
+  if (body === undefined) return undefined
+
+  let raw: unknown
+  try {
+    raw = JSON.parse(body)
+  } catch {
+    return undefined
+  }
+  if (typeof raw !== 'object' || raw === null) return undefined
+  const record = raw as Record<string, unknown>
+  if (!Array.isArray(record.options)) return undefined
+
+  const options: ChoicesOption[] = []
+  record.options.forEach((entry, i) => {
+    const o = entry as Record<string, unknown> | null
+    const label = typeof o?.label === 'string' ? o.label.trim() : ''
+    if (!label) return
+    const rawId = typeof o?.id === 'string' ? o.id.trim() : ''
+    const detail = typeof o?.detail === 'string' ? o.detail.trim() : ''
+    options.push({ id: rawId || `opt:${i}`, label, ...(detail ? { detail } : {}) })
+  })
+  if (options.length === 0) return undefined
+
+  const title = typeof record.title === 'string' && record.title.trim() ? record.title.trim() : 'Which option?'
+  const rec = typeof record.recommended === 'string' ? record.recommended.trim() : ''
+  const recommended = rec ? (options.find(o => o.id === rec) ?? options.find(o => o.label === rec))?.id : undefined
+
+  return { title, options, ...(recommended ? { recommended } : {}) }
+}


### PR DESCRIPTION
Closes #337. Builds on #335 (`requestChoices`).

The system prompt tells the agent to `showChoices()` and `AWAIT`, but until now only framework-*emitted* gates (plan-approval #304, multi-select #332) could pause a run. There was no path from an agent stopping mid-run to a live dashboard gate. This wires it for the single-select case (turn-boundary approach, greenlit by Rom on #326).

## How

Because the driver runs each agent turn as a black box to completion (#165), the only way the framework can learn the agent *stopped to ask* is a signal in the turn's final message. So there is a thin, framework-owned convention (the "code side" of the macros Rom delegated, not a change to the verbatim prompt):

- **`AWAIT_PROTOCOL`** (`turn-gate.ts`): appended to the system prompt alongside the anti-lazy pill. When told to `showChoices()` + `AWAIT`, the agent ends its turn with a fenced `await-choices` block and stops.
- **`parseChoicesGate`**: pulls that block off the turn text. Tolerant (synthesizes ids, maps a `recommended` label to its id, ignores malformed blocks) so a bad parse never crashes a build. Returns `undefined` when the agent just finished, which is the common case.
- **`agentChoiceGate`** (`run.ts`): wraps the build step, mirroring `planApprovalGate`. On an `await-choices` block it fires the gate via `requestChoices` (#335), then re-prompts the driver to continue from the pick (`continueAfterChoice`). Bounded loop so an agent that keeps asking can't spin.
- `driverBuild` skips its empty-workspace retry (#182) when the agent stopped to ask, so the question is not clobbered by a scaffold directive.

## Safety

No-op unless a `requestChoice` handler is wired (headless byte-identical) **and** unless the agent actually stopped to ask. Existing #304/#332 behavior is unchanged. 8 new tests (parser unit + two e2e through `runFramework`: a build that asks fires the gate and resumes on the pick; headless does not gate). 235 pass / 1 docker-skip, typecheck clean.

## Note for review

The `await-choices` convention is framework-owned and swappable (isolated in `turn-gate.ts`). It is the reliable-signal reading of your "AI will interpret macros correctly": the AI emits the stop-signal, the framework recognizes it. Follow-ups (separate PRs): the `showMarkdown()` PLAN-approval gate, the unclear-scope gate on a driver-backed scope step, and wiring #326 verbatim into `system-prompt.ts` once the text is final.