### PR TITLE
feat(framework): multi-select turn-boundary gate for showMultiSelect()

### DIFF
--- a/.changeset/multiselect-turn-boundary-gate.md
+++ b/.changeset/multiselect-turn-boundary-gate.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/framework': minor
+---
+
+feat(framework): turn an agent's showMultiSelect()+AWAIT into a live checklist gate (#339)
+
+The multi twin of the single-select turn-boundary gate (#337). When a build turn ends on an `await-multiselect` block, the framework shows a checklist on the dashboard (via `requestMultiSelect`, with the agent-marked defaults pre-checked), waits for the selection, and re-prompts the agent to continue from it. This is what the research preset needs to let the user pick which problems to deep-dive. Same safety as #337: a no-op when headless and when the agent just finishes.

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -762,6 +762,46 @@ test('a build turn that stops to ask fires a live gate and resumes on the pick (
   assert.equal(result.productionGrade, true)
 })
 
+test('a build turn that stops to showMultiSelect fires a checklist gate and resumes (#339)', async () => {
+  const plan = { stack: 'Vike', narration: 'p', decisions: [{ choice: 'x', why: 'y' }], alternatives: [] }
+  const awaitBlock =
+    'Rated the problems.\n```await-multiselect\n' +
+    '{ "title": "Which problems to deep-dive?", "options": [{ "id": "auth", "label": "auth", "default": true }, { "id": "routing", "label": "routing" }] }\n' +
+    '```'
+  const driver = new FakeDriver({
+    respond: (prompt: string): string => {
+      if (/You are the architect/.test(prompt)) return '```json\n' + JSON.stringify(plan) + '\n```'
+      if (/Build this app end to end/.test(prompt)) return awaitBlock
+      if (/You paused to ask/.test(prompt)) return 'Added the picks to TODO. Done.'
+      if (/production-grade checklist/.test(prompt)) return 'Reviewed.\n```json\n{ "blockers": [] }\n```'
+      return 'done'
+    },
+    sessionId: 'multi339',
+  })
+
+  const events: FrameworkEvent[] = []
+  const prompts: string[] = []
+  await runFramework({
+    intent: FAKE_INTENT,
+    driver,
+    cwd: '/tmp/ws',
+    signals: FAKE_SIGNALS,
+    onEvent: e => {
+      events.push(e)
+      if (e.kind === 'driver' && e.event.type === 'start') prompts.push(e.event.prompt)
+    },
+    // The user unchecks the default `auth` and keeps `routing`.
+    requestChoice: async req => (req.multi ? { picked: ['routing'], by: 'user' } : { picked: 'proceed', by: 'user' }),
+  })
+
+  const gate = events.find(e => e.kind === 'choice' && e.id === 'await-multiselect')
+  assert.ok(gate && gate.kind === 'choice' && gate.multi === true)
+  assert.ok(gate.options.some(o => o.id === 'auth' && o.default === true))
+  // Resumed with the user's selection (routing only), not the defaults.
+  assert.ok(events.some(e => e.kind === 'log' && /Continuing with your choice: routing/.test(e.message)))
+  assert.ok(prompts.some(p => /You paused to ask.*chose: routing/s.test(p)))
+})
+
 test('without a requestChoice handler a build that asks is not gated (#337 headless)', async () => {
   const plan = { stack: 'Vike', narration: 'p', decisions: [{ choice: 'x', why: 'y' }], alternatives: [] }
   const driver = new FakeDriver({

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -38,7 +38,7 @@ import { snapshotWorkspace } from './sandbox.js'
 import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { memoryFraming, type LoadedMemory } from './memory.js'
 import { systemPromptBlock } from './system-prompt.js'
-import { AWAIT_PROTOCOL, parseChoicesGate } from './turn-gate.js'
+import { AWAIT_PROTOCOL, parseAwaitGate } from './turn-gate.js'
 import { continueAfterChoice, decideDeploy, deployWith, domainLoopChecklist, driverArchitect, driverBuild, driverChecklist, driverImprove, driverLoopPrompts, reArchitect } from './steps.js'
 import { hasSessionIdPlaceholder, OPEN_LOOP_MODES, pickedIds, resolveSessionLink, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 import { UsageMeter } from './usage.js'
@@ -479,7 +479,7 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
           emit,
           signal: runSignal,
         }),
-        build: agentChoiceGate(driverBuild(session, workspaceOpt), session, {
+        build: agentAwaitGate(driverBuild(session, workspaceOpt), session, {
           ...(opts.requestChoice ? { requestChoice: opts.requestChoice } : {}),
           emit,
           signal: runSignal,
@@ -593,48 +593,58 @@ const MAX_PLAN_ROUNDS = 5
 const MAX_AWAIT_ROUNDS = 5
 
 /**
- * The agent-authored choice gate (#337): the turn-boundary counterpart to the
+ * The agent-authored await gate (#337 / #339): the turn-boundary counterpart to the
  * framework-emitted plan-approval gate (#304). When a build turn ends by asking the
- * user — an `await-choices` block per {@link AWAIT_PROTOCOL}, e.g. the #326 unclear-scope
- * or alternatives flow — rather than finishing, show the choice, wait for the pick, and
- * re-prompt the driver to continue from that decision. A no-op unless a
- * {@link RunFrameworkOptions.requestChoice} handler is wired (headless byte-identical),
- * and unless the agent actually stopped to ask (the common case returns straight through).
- * Bounded so an agent that keeps asking can't loop forever.
+ * user — an `await-choices` (pick one) or `await-multiselect` (pick any) block per
+ * {@link AWAIT_PROTOCOL}, e.g. the #326 alternatives flow or the [Research] preset (#331)
+ * — rather than finishing, show it, wait for the answer, and re-prompt the driver to
+ * continue from that decision. A no-op unless a {@link RunFrameworkOptions.requestChoice}
+ * handler is wired (headless byte-identical), and unless the agent actually stopped to
+ * ask (the common case returns straight through). Bounded so an agent that keeps asking
+ * can't loop forever.
  */
-function agentChoiceGate(
+function agentAwaitGate(
   base: (ctx: BuildContext) => Promise<SupervisorRun>,
   session: DriverSession,
   deps: {
     requestChoice?: (req: ChoiceRequest) => Promise<ChoicePick>
     emit: (event: FrameworkEvent) => void
-    /** The run signal; a gate parked for a pick unblocks (proceed) if the run aborts. */
+    /** The run signal; a gate parked for an answer unblocks (default) if the run aborts. */
     signal?: AbortSignal
   },
 ): (ctx: BuildContext) => Promise<SupervisorRun> {
   return async ctx => {
     const { requestChoice, emit } = deps
+    const signalOpt = deps.signal ? { signal: deps.signal } : {}
     let run = await base(ctx)
     if (!requestChoice) return run
 
     for (let round = 0; round < MAX_AWAIT_ROUNDS; round++) {
-      const gate = parseChoicesGate(run.text)
+      const gate = parseAwaitGate(run.text)
       if (!gate) return run // the agent finished instead of asking — the common case
-      // Round 0 keeps the stable `await-choices` id; later rounds get a unique one so a
-      // dashboard never confuses a re-ask with the pick it just resolved.
-      const id = round === 0 ? 'await-choices' : `await-choices-${round}`
-      const picked = await requestChoices({
-        id,
-        title: gate.title,
-        options: gate.options,
-        ...(gate.recommended ? { recommended: gate.recommended } : {}),
-        requestChoice,
-        emit,
-        ...(deps.signal ? { signal: deps.signal } : {}),
-      })
-      const chosen = gate.options.find(o => o.id === picked)
-      emit({ kind: 'log', message: `Continuing with your choice: ${chosen?.label ?? picked}` })
-      run = await continueAfterChoice(session, ctx, gate.title, chosen?.label ?? picked)
+      // Round 0 keeps a stable id; later rounds get a unique one so a dashboard never
+      // confuses a re-ask with the answer it just resolved.
+      const base = gate.kind === 'multi' ? 'await-multiselect' : 'await-choices'
+      const id = round === 0 ? base : `${base}-${round}`
+      let answer: string
+      if (gate.kind === 'multi') {
+        const picked = await requestMultiSelect({ id, title: gate.title, options: gate.options, requestChoice, emit, ...signalOpt })
+        const labels = gate.options.filter(o => picked.includes(o.id)).map(o => o.label)
+        answer = labels.length ? labels.join(', ') : '(none)'
+      } else {
+        const pickedId = await requestChoices({
+          id,
+          title: gate.title,
+          options: gate.options,
+          ...(gate.recommended ? { recommended: gate.recommended } : {}),
+          requestChoice,
+          emit,
+          ...signalOpt,
+        })
+        answer = gate.options.find(o => o.id === pickedId)?.label ?? pickedId
+      }
+      emit({ kind: 'log', message: `Continuing with your choice: ${answer}` })
+      run = await continueAfterChoice(session, ctx, gate.title, answer)
     }
     // The agent kept asking past the limit: proceed with the latest turn rather than loop.
     emit({ kind: 'log', message: 'Proceeding with the build (await limit reached).' })

--- a/packages/framework/src/steps.ts
+++ b/packages/framework/src/steps.ts
@@ -22,7 +22,7 @@ import type {
   Verdict,
 } from '@gemstack/ai-autopilot'
 import type { DriverSession } from './driver/index.js'
-import { parseChoicesGate } from './turn-gate.js'
+import { parseAwaitGate } from './turn-gate.js'
 
 /**
  * Driver-backed {@link https://github.com/gemstack-land/gemstack | Bootstrap} steps.
@@ -284,10 +284,10 @@ export function driverBuild(
     // #182: the build must actually produce an app. If nothing landed on disk,
     // the agent stalled (e.g. sanity-checking the stack) — re-prompt once with a
     // hard "create it from scratch" directive so an empty-dir run starts building.
-    // Exception (#337): an empty workspace plus an `await-choices` block means the
-    // agent stopped *on purpose* to ask; the choice gate handles it, so don't clobber
-    // the question with a scaffold directive.
-    if (opts.verifyWorkspace && isWorkspaceEmpty(session.cwd) && !parseChoicesGate(turn.text)) {
+    // Exception (#337 / #339): an empty workspace plus an await block means the agent
+    // stopped *on purpose* to ask; the await gate handles it, so don't clobber the
+    // question with a scaffold directive.
+    if (opts.verifyWorkspace && isWorkspaceEmpty(session.cwd) && !parseAwaitGate(turn.text)) {
       const retry: PlannedSubtask = { id: 'build-2', description: 'Scaffold the app from scratch (workspace was empty)' }
       ctx.onEvent({ type: 'dispatch-start', subtask: retry })
       turn = await session.prompt(scaffoldPrompt(ctx.plan, ctx.intent), { ...promptOpts, ...signalOpt })

--- a/packages/framework/src/turn-gate.test.ts
+++ b/packages/framework/src/turn-gate.test.ts
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { parseChoicesGate } from './turn-gate.js'
+import { parseAwaitGate, parseChoicesGate, parseMultiSelectGate } from './turn-gate.js'
 
 const block = (json: string): string => 'Here are the options.\n```await-choices\n' + json + '\n```'
+const multiBlock = (json: string): string => 'Pick some.\n```await-multiselect\n' + json + '\n```'
 
 test('parseChoicesGate returns undefined when the agent did not stop to ask (#337)', () => {
   assert.equal(parseChoicesGate('Built the whole app. Done.'), undefined)
@@ -48,4 +49,33 @@ test('parseChoicesGate ignores a malformed or empty block rather than throwing (
   assert.equal(parseChoicesGate(block('{ "options": [] }')), undefined)
   assert.equal(parseChoicesGate(block('{ "options": [{ "detail": "no label" }] }')), undefined)
   assert.equal(parseChoicesGate(block('{ "title": "x" }')), undefined) // no options array
+})
+
+test('parseMultiSelectGate parses a checklist and preserves default-checked entries (#339)', () => {
+  const gate = parseMultiSelectGate(
+    multiBlock('{ "title": "Which problems?", "options": [{ "label": "auth", "default": true }, { "label": "routing" }, { "label": "data", "detail": "rated 2/10", "default": true }] }'),
+  )
+  assert.ok(gate)
+  assert.equal(gate.title, 'Which problems?')
+  assert.deepEqual(gate.options, [
+    { id: 'opt:0', label: 'auth', default: true },
+    { id: 'opt:1', label: 'routing' },
+    { id: 'opt:2', label: 'data', detail: 'rated 2/10', default: true },
+  ])
+})
+
+test('parseMultiSelectGate returns undefined for no block / empty options (#339)', () => {
+  assert.equal(parseMultiSelectGate('no block here'), undefined)
+  assert.equal(parseMultiSelectGate(multiBlock('{ "options": [] }')), undefined)
+})
+
+test('parseAwaitGate discriminates choices vs multiselect, later block wins (#339)', () => {
+  const c = parseAwaitGate(block('{ "options": [{ "label": "one" }] }'))
+  assert.equal(c?.kind, 'choices')
+  const m = parseAwaitGate(multiBlock('{ "options": [{ "label": "a", "default": true }] }'))
+  assert.equal(m?.kind, 'multi')
+  assert.equal(parseAwaitGate('the agent just finished'), undefined)
+  // Both present: the one appearing later in the turn wins.
+  const both = parseAwaitGate(block('{ "options": [{ "label": "x" }] }') + '\n' + multiBlock('{ "options": [{ "label": "y" }] }'))
+  assert.equal(both?.kind, 'multi')
 })

--- a/packages/framework/src/turn-gate.ts
+++ b/packages/framework/src/turn-gate.ts
@@ -1,26 +1,32 @@
 import type { ChoicesOption } from './run.js'
+import type { MultiSelectOption } from './run.js'
 
 /**
- * The framework-owned "await" protocol (#337): the *code side* of the #326
- * `showChoices()` / `AWAIT` macros that Rom delegated. The driver runs each agent
- * turn as a black box to completion (#165), so the only way the framework can learn
- * the agent stopped to ask (rather than deciding for itself) is a signal in the
- * turn's final message. This appends one to the system prompt: it does not restate
- * the macros, it pins *how* to emit an awaited choice so the turn-boundary gate can
- * detect it. Kept minimal and self-contained so it survives the #326 wording still
- * being written.
+ * The framework-owned "await" protocol (#337 / #339): the *code side* of the
+ * `showChoices()` / `showMultiSelect()` + `AWAIT` macros that Rom delegated. The
+ * driver runs each agent turn as a black box to completion (#165), so the only way
+ * the framework can learn the agent stopped to ask (rather than deciding for itself)
+ * is a signal in the turn's final message. This appends one to the system prompt: it
+ * does not restate the macros, it pins *how* to emit an awaited choice so the
+ * turn-boundary gate can detect it. Kept minimal and self-contained so it survives the
+ * #326 wording still being written.
  */
 export const AWAIT_PROTOCOL = [
   '## Awaiting a choice',
-  'When these instructions tell you to showChoices() and then AWAIT, do not pick for the user.',
-  'End your turn with a fenced code block tagged `await-choices` holding JSON, then stop:',
+  'When these instructions tell you to showChoices() / showMultiSelect() and then AWAIT, do not decide for the user.',
+  'End your turn with one fenced code block, then stop.',
+  'For a single choice (showChoices, pick one), tag it `await-choices`:',
   '```await-choices',
   '{ "title": "<the question>", "options": [{ "label": "<option>", "detail": "<optional one-liner>" }], "recommended": "<the label to default to>" }',
   '```',
-  'The framework shows the choice, waits for the user, and re-prompts you with their pick. Do not continue past it on your own.',
+  'For a multi-select (showMultiSelect, pick any number), tag it `await-multiselect` and set `default` on the entries that start checked:',
+  '```await-multiselect',
+  '{ "title": "<the prompt>", "options": [{ "label": "<option>", "detail": "<optional one-liner>", "default": true }] }',
+  '```',
+  'The framework shows it, waits for the user, and re-prompts you with their answer. Do not continue past it on your own.',
 ].join('\n')
 
-/** A choice an agent stopped to ask, parsed from an `await-choices` block (#337). */
+/** A single-select choice an agent stopped to ask, parsed from an `await-choices` block (#337). */
 export interface ParsedChoicesGate {
   /** The question shown above the options. */
   title: string
@@ -30,22 +36,29 @@ export interface ParsedChoicesGate {
   recommended?: string
 }
 
-/** Matches every `await-choices` fenced block; the last one in the turn wins. */
-const AWAIT_CHOICES_BLOCK = /```await-choices\s+([\s\S]*?)```/g
+/** A multi-select an agent stopped to ask, parsed from an `await-multiselect` block (#339). */
+export interface ParsedMultiSelectGate {
+  /** The prompt shown above the checklist. */
+  title: string
+  /** The options (each may start checked via {@link MultiSelectOption.default}). */
+  options: MultiSelectOption[]
+}
 
-/**
- * Parse a trailing `await-choices` block (per {@link AWAIT_PROTOCOL}) from a turn's
- * final text (#337). Returns `undefined` when the agent did not stop to ask, which is
- * the common case, so a normal build turn flows straight through. Tolerant by design:
- * ids are synthesized from position, a blank title falls back, `recommended` may be
- * given as a label or an id, and a malformed block is ignored (no gate) rather than
- * throwing — a bad parse must never crash a build.
- */
-export function parseChoicesGate(text: string): ParsedChoicesGate | undefined {
-  let body: string | undefined
-  for (const match of text.matchAll(AWAIT_CHOICES_BLOCK)) body = match[1]
-  if (body === undefined) return undefined
+/** A parsed await gate: either kind, discriminated by `kind`. */
+export type ParsedAwaitGate =
+  | ({ kind: 'choices' } & ParsedChoicesGate)
+  | ({ kind: 'multi' } & ParsedMultiSelectGate)
 
+/** Find the body + start index of the last fenced block with `tag` in `text`. */
+function lastBlock(text: string, tag: string): { body: string; index: number } | undefined {
+  const re = new RegExp('```' + tag + '\\s+([\\s\\S]*?)```', 'g')
+  let found: { body: string; index: number } | undefined
+  for (const m of text.matchAll(re)) found = { body: m[1] ?? '', index: m.index ?? 0 }
+  return found
+}
+
+/** Parse the JSON body of an await block, returning its `options` array or undefined. */
+function parseBody(body: string): { record: Record<string, unknown>; options: Record<string, unknown>[] } | undefined {
   let raw: unknown
   try {
     raw = JSON.parse(body)
@@ -55,21 +68,81 @@ export function parseChoicesGate(text: string): ParsedChoicesGate | undefined {
   if (typeof raw !== 'object' || raw === null) return undefined
   const record = raw as Record<string, unknown>
   if (!Array.isArray(record.options)) return undefined
+  return { record, options: record.options as Record<string, unknown>[] }
+}
+
+/** Read a trimmed string field, or `''`. */
+const str = (v: unknown): string => (typeof v === 'string' ? v.trim() : '')
+
+/**
+ * Parse a trailing `await-choices` block (per {@link AWAIT_PROTOCOL}) from a turn's
+ * final text (#337). Returns `undefined` when the agent did not stop to ask (the common
+ * case). Tolerant by design: ids are synthesized from position, a blank title falls
+ * back, `recommended` may be a label or an id, and a malformed block is ignored rather
+ * than throwing — a bad parse must never crash a build.
+ */
+export function parseChoicesGate(text: string): ParsedChoicesGate | undefined {
+  const block = lastBlock(text, 'await-choices')
+  if (!block) return undefined
+  const parsed = parseBody(block.body)
+  if (!parsed) return undefined
 
   const options: ChoicesOption[] = []
-  record.options.forEach((entry, i) => {
-    const o = entry as Record<string, unknown> | null
-    const label = typeof o?.label === 'string' ? o.label.trim() : ''
+  parsed.options.forEach((o, i) => {
+    const label = str(o?.label)
     if (!label) return
-    const rawId = typeof o?.id === 'string' ? o.id.trim() : ''
-    const detail = typeof o?.detail === 'string' ? o.detail.trim() : ''
-    options.push({ id: rawId || `opt:${i}`, label, ...(detail ? { detail } : {}) })
+    const detail = str(o?.detail)
+    options.push({ id: str(o?.id) || `opt:${i}`, label, ...(detail ? { detail } : {}) })
   })
   if (options.length === 0) return undefined
 
-  const title = typeof record.title === 'string' && record.title.trim() ? record.title.trim() : 'Which option?'
-  const rec = typeof record.recommended === 'string' ? record.recommended.trim() : ''
+  const title = str(parsed.record.title) || 'Which option?'
+  const rec = str(parsed.record.recommended)
   const recommended = rec ? (options.find(o => o.id === rec) ?? options.find(o => o.label === rec))?.id : undefined
-
   return { title, options, ...(recommended ? { recommended } : {}) }
+}
+
+/**
+ * Parse a trailing `await-multiselect` block (#339), the multi twin of
+ * {@link parseChoicesGate}. Each option may start checked via `default`. Same
+ * tolerance: synthesized ids, blank-title fallback, malformed block ignored.
+ */
+export function parseMultiSelectGate(text: string): ParsedMultiSelectGate | undefined {
+  const block = lastBlock(text, 'await-multiselect')
+  if (!block) return undefined
+  const parsed = parseBody(block.body)
+  if (!parsed) return undefined
+
+  const options: MultiSelectOption[] = []
+  parsed.options.forEach((o, i) => {
+    const label = str(o?.label)
+    if (!label) return
+    const detail = str(o?.detail)
+    options.push({ id: str(o?.id) || `opt:${i}`, label, ...(detail ? { detail } : {}), ...(o?.default === true ? { default: true } : {}) })
+  })
+  if (options.length === 0) return undefined
+
+  return { title: str(parsed.record.title) || 'Select any that apply', options }
+}
+
+/**
+ * Parse whichever await gate a build turn ended on (#337 / #339). When both a
+ * single- and multi-select block are present (an agent shouldn't emit both), the one
+ * that appears later in the text wins. Returns `undefined` when the agent just
+ * finished — the common case, so a normal build flows straight through.
+ */
+export function parseAwaitGate(text: string): ParsedAwaitGate | undefined {
+  const choicesAt = lastBlock(text, 'await-choices')?.index ?? -1
+  const multiAt = lastBlock(text, 'await-multiselect')?.index ?? -1
+  if (choicesAt < 0 && multiAt < 0) return undefined
+  if (multiAt > choicesAt) {
+    const multi = parseMultiSelectGate(text)
+    if (multi) return { kind: 'multi', ...multi }
+    const choices = parseChoicesGate(text)
+    return choices ? { kind: 'choices', ...choices } : undefined
+  }
+  const choices = parseChoicesGate(text)
+  if (choices) return { kind: 'choices', ...choices }
+  const multi = parseMultiSelectGate(text)
+  return multi ? { kind: 'multi', ...multi } : undefined
 }


### PR DESCRIPTION
Closes #339. Builds on #337 (single-select turn-boundary gate) and #332 (`requestMultiSelect`).

The [Research] preset (#331, its text now finalized by Rom) instructs the agent to `showMultiSelect()` the rated problems and `AWAIT`. That needs a turn-boundary multi-select gate, the direct twin of the single-select one from #337.

## How

- `AWAIT_PROTOCOL` gains an `await-multiselect` block (options carry `default` for pre-checked entries).
- `parseMultiSelectGate` + a `parseAwaitGate` dispatcher that returns whichever block a build turn ended on (`{ kind: "choices" | "multi" }`; if both are present the later one wins).
- The build-step wrapper `agentChoiceGate` -> `agentAwaitGate`: dispatches on kind, firing `requestChoices` (#335) or `requestMultiSelect` (#332), then resumes the driver with the answer via `continueAfterChoice`.
- `driverBuild`s empty-workspace retry-skip now checks `parseAwaitGate`, so a multi-select await also survives.

## Safety

Single-select behavior (#337) is byte-identical (its `await-choices` id and tests unchanged). No-op when headless and when the agent just finishes. 4 new tests (multi parser, dispatch/later-wins, one e2e through `runFramework`: a build that stops to `showMultiSelect` fires the checklist gate with defaults and resumes on the user selection). 239 pass / 1 docker-skip, typecheck clean.

Next: compose the [Research] preset (#331) on this + `renderPresetPrompt` (#330).