### PR TITLE
test(framework): let the --fake demo exercise the turn-boundary gates offline

### DIFF
--- a/packages/framework/src/fake-script.test.ts
+++ b/packages/framework/src/fake-script.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { demoTurns } from './fake-script.js'
+import { parseChoicesGate, parseMultiSelectGate } from './turn-gate.js'
+
+test('demoTurns default: the plain scripted run, no await gate', () => {
+  const turns = demoTurns(undefined)
+  assert.equal(turns.length, 5) // architect, build, checklist-blocker, improve, clean
+  assert.ok(turns.every(t => parseChoicesGate(t.text) === undefined && parseMultiSelectGate(t.text) === undefined))
+})
+
+test('demoTurns choices: the build stops to ask a single-select the gate can parse (#337)', () => {
+  const turns = demoTurns('choices')
+  assert.equal(turns.length, 6) // + a resume turn after the ask
+  const gate = parseChoicesGate(turns[1]!.text) // the build turn asks
+  assert.ok(gate)
+  assert.equal(gate.recommended, 'opt:0')
+  assert.ok(gate.options.some(o => /Session cookies/.test(o.label)))
+  // The turn right after the ask is the resume (no gate), so the run continues.
+  assert.equal(parseChoicesGate(turns[2]!.text), undefined)
+})
+
+test('demoTurns multiselect: the build stops to ask a checklist with defaults (#339)', () => {
+  const turns = demoTurns('multiselect')
+  assert.equal(turns.length, 6)
+  const gate = parseMultiSelectGate(turns[1]!.text)
+  assert.ok(gate)
+  const defaults = gate.options.filter(o => o.default).map(o => o.label)
+  assert.deepEqual(defaults, ['auth model', 'orders schema'])
+})
+
+test('demoTurns ignores an unknown await mode and falls back to the default run', () => {
+  assert.deepEqual(demoTurns('bogus'), demoTurns(undefined))
+})

--- a/packages/framework/src/fake-script.ts
+++ b/packages/framework/src/fake-script.ts
@@ -44,23 +44,53 @@ const ARCHITECT = {
 // A small, plausible per-turn usage so the demo shows spend accumulating (#322).
 const FAKE_USAGE = { costUsd: 0.02, inputTokens: 1800, outputTokens: 600, cacheReadTokens: 12000, cacheCreationTokens: 800 }
 
-const TURNS: FakeTurn[] = [
-  { text: '```json\n' + JSON.stringify(ARCHITECT) + '\n```', actions: ['Read'], usage: FAKE_USAGE },
-  {
-    text: 'Built the orders app: an orders schema and migration, a paginated /orders page, and a sign-in stub.',
-    actions: ['Write', 'Write', 'Bash'],
-    usage: FAKE_USAGE,
-  },
-  {
-    text: 'Reviewed the app.\n```json\n{ "blockers": ["No authentication on the orders page yet"] }\n```',
-    actions: ['Read', 'Grep'],
-    usage: FAKE_USAGE,
-  },
-  { text: 'Added a +guard to the orders page (vike-auth) so it requires a signed-in user.', actions: ['Edit'], usage: FAKE_USAGE },
-  { text: 'Reviewed again.\n```json\n{ "blockers": [] }\n```', actions: ['Read'], usage: FAKE_USAGE },
-]
+const ARCHITECT_TURN: FakeTurn = { text: '```json\n' + JSON.stringify(ARCHITECT) + '\n```', actions: ['Read'], usage: FAKE_USAGE }
+const BUILD_TURN: FakeTurn = {
+  text: 'Built the orders app: an orders schema and migration, a paginated /orders page, and a sign-in stub.',
+  actions: ['Write', 'Write', 'Bash'],
+  usage: FAKE_USAGE,
+}
+const CHECKLIST_BLOCKER: FakeTurn = {
+  text: 'Reviewed the app.\n```json\n{ "blockers": ["No authentication on the orders page yet"] }\n```',
+  actions: ['Read', 'Grep'],
+  usage: FAKE_USAGE,
+}
+const IMPROVE: FakeTurn = { text: 'Added a +guard to the orders page (vike-auth) so it requires a signed-in user.', actions: ['Edit'], usage: FAKE_USAGE }
+const CHECKLIST_CLEAN: FakeTurn = { text: 'Reviewed again.\n```json\n{ "blockers": [] }\n```', actions: ['Read'], usage: FAKE_USAGE }
+
+const TURNS: FakeTurn[] = [ARCHITECT_TURN, BUILD_TURN, CHECKLIST_BLOCKER, IMPROVE, CHECKLIST_CLEAN]
+
+// Demo variants that make the build stop to ask, so the turn-boundary gates (#337
+// single-select / #339 multi-select checklist) can be seen offline. The build turn ends
+// with an await block; the framework shows the gate, waits, then re-prompts (RESUME_TURN),
+// and the run continues to review as usual. Needs the dashboard on (so requestChoice is
+// wired); selected via FRAMEWORK_FAKE_AWAIT=choices|multiselect.
+const AWAIT_CHOICES_TURN: FakeTurn = {
+  text:
+    'I need one decision before wiring auth.\n```await-choices\n' +
+    '{ "title": "Which auth approach for the orders page?", "options": [{ "label": "Session cookies", "detail": "simple, server-side" }, { "label": "JWT", "detail": "stateless, more moving parts" }], "recommended": "Session cookies" }\n```',
+  actions: ['Read'],
+  usage: FAKE_USAGE,
+}
+const AWAIT_MULTISELECT_TURN: FakeTurn = {
+  text:
+    'Rated the problems by how clear the optimal solution is.\n```await-multiselect\n' +
+    '{ "title": "Which problems should I deep-dive for alternatives?", "options": [{ "label": "auth model", "detail": "rated 3/10", "default": true }, { "label": "pagination", "detail": "rated 7/10" }, { "label": "orders schema", "detail": "rated 2/10", "default": true }] }\n```',
+  actions: ['Read', 'Grep'],
+  usage: FAKE_USAGE,
+}
+const RESUME_TURN: FakeTurn = { text: 'Applied your answer and finished building the orders app.', actions: ['Write', 'Bash'], usage: FAKE_USAGE }
+
+/** Scripted turns for the demo, optionally routed through a turn-boundary gate. */
+export function demoTurns(awaitMode: string | undefined): FakeTurn[] {
+  const askTurn = awaitMode === 'choices' ? AWAIT_CHOICES_TURN : awaitMode === 'multiselect' ? AWAIT_MULTISELECT_TURN : undefined
+  if (!askTurn) return TURNS
+  // The build asks (askTurn), the gate resolves, the framework re-prompts (RESUME_TURN),
+  // then the normal review turns follow.
+  return [ARCHITECT_TURN, askTurn, RESUME_TURN, CHECKLIST_BLOCKER, IMPROVE, CHECKLIST_CLEAN]
+}
 
 /** Build the scripted {@link FakeDriver} for the demo. */
 export function fakeDriver(): FakeDriver {
-  return new FakeDriver({ turns: TURNS, sessionId: 'fake-orders-app' })
+  return new FakeDriver({ turns: demoTurns(process.env.FRAMEWORK_FAKE_AWAIT), sessionId: 'fake-orders-app' })
 }


### PR DESCRIPTION
Closes #341.

The turn-boundary gates (#337 single-select, #339 multi-select checklist) only fire when the agent stops mid-run to ask, which the scripted `--fake` demo never does. So today you can only see them in the dashboard via a real Claude run. This adds an offline trigger.

## What

- `FRAMEWORK_FAKE_AWAIT=choices` -> the fake build turn ends with an `await-choices` block ("Which auth approach?"), so the run pauses at the single-select "Your call" gate.
- `FRAMEWORK_FAKE_AWAIT=multiselect` -> an `await-multiselect` block ("Which problems to deep-dive?"), so it pauses at the checklist gate with two entries pre-checked.
- Either way the framework shows the gate, waits, re-prompts on the pick, and the run continues to production-grade. The default `--fake` run (no env var) is byte-identical.
- Refactored the scripted turns into named constants + an exported `demoTurns()` helper.

## Try it

```
pnpm build
FRAMEWORK_FAKE_AWAIT=multiselect node dist/bin.js --fake --cwd /tmp/fw-demo
# open http://localhost:4477 -> Proceed past the plan gate -> the checklist gate appears
```

## Tests

4 new tests assert each variant inserts a gate-parseable block (via the real `parseChoicesGate` / `parseMultiSelectGate`) plus a resume turn, and that an unknown mode falls back to the default run. 243 pass / 1 docker-skip, typecheck clean. Test/demo only, no changeset.