### PR TITLE
feat(framework): default dashboard port 4200

### DIFF
--- a/.changeset/dashboard-port-4200.md
+++ b/.changeset/dashboard-port-4200.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Default dashboard port is now 4200 (was 4477): easier to remember. Pass `--port` to override.

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -101,7 +101,7 @@ framework relay                Host a run relay so teammates can watch a run (se
   --cf-project <name>    Cloudflare Pages project name (for a Pages deploy).
   --dokploy-url <url>    Dokploy instance URL (required for --deploy dokploy).
   --dokploy-app <id>     Dokploy application id (required for --deploy dokploy).
-  --port <n>             Dashboard port (default: 4477); with `relay`, the relay port (4488).
+  --port <n>             Dashboard port (default: 4200); with `relay`, the relay port (4488).
   --no-dashboard         Run headless.
   --share <relay-url>    Publish this run to a relay (see below) so teammates can watch it.
   --resume               Reopen the last run's dashboard from .framework/ (see below).

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -123,7 +123,7 @@ Options:
   --cf-project <name>    Cloudflare Pages project name (for a Pages deploy).
   --dokploy-url <url>    Dokploy instance URL (required for --deploy dokploy).
   --dokploy-app <id>     Dokploy application id (required for --deploy dokploy).
-  --port <n>             Dashboard port (default: 4477); with the relay, the relay port (4488).
+  --port <n>             Dashboard port (default: 4200); with the relay, the relay port (4488).
   --no-dashboard         Do not start the localhost dashboard.
   --share <relay-url>    Publish this run to a relay (from "framework relay") so
                          teammates can watch it live; prints the shareable URL.

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -20,7 +20,7 @@ import { startDashboard, type Dashboard } from './dashboard/index.js'
 export const DAEMON_STATE_FILE = 'daemon.json'
 
 /** The default dashboard port the daemon binds. Matches the per-run dashboard. */
-export const DEFAULT_DAEMON_PORT = 4477
+export const DEFAULT_DAEMON_PORT = 4200
 
 /** What a running daemon writes so a later `framework` invocation can find it. */
 export interface DaemonState {

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -9,7 +9,7 @@ import { serveSSE } from './sse.js'
 
 /** Options for {@link startDashboard}. */
 export interface DashboardOptions {
-  /** Port to bind. Default `4477`; pass `0` for an ephemeral port. */
+  /** Port to bind. Default `4200`; pass `0` for an ephemeral port. */
   port?: number
   /** Host to bind. Default `127.0.0.1` (localhost only). */
   host?: string
@@ -61,7 +61,7 @@ export interface Dashboard {
  */
 export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> {
   const host = opts.host ?? '127.0.0.1'
-  const port = opts.port ?? 4477
+  const port = opts.port ?? 4200
   const title = opts.title ?? 'The Framework'
   const onStop = opts.onStop
   const onChoice = opts.onChoice


### PR DESCRIPTION
Closes #346.

Rom's call in #331: 4200 is easier to remember than 4477. Changed the default in the daemon, the per-run dashboard, the CLI help, and the README. Explicit `--port` still overrides; the two remaining 4477s in tests are explicit values, not defaults.

MVP scope only: no 4201 fallback when 4200 is busy (post-MVP per #346).

243 tests pass, typecheck clean, minor changeset.