### PR TITLE
feat(framework): dashboard control channel: the daemon dashboard steers any run

### DIFF
--- a/.changeset/dashboard-control-channel.md
+++ b/.changeset/dashboard-control-channel.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Dashboard control channel: the persistent daemon dashboard can now steer any run in its workspace. Its Stop button and choice picks append to `.framework/control.jsonl`; the run tails the file and aborts or resolves its parked gate. Gates now pause whenever a workspace daemon is live, not only when the run owns its own dashboard; headless behavior without a daemon is unchanged. Also fixes the fresh-workspace daemon startup: bare `framework` in a project with no `.framework/` yet used to fail and leave a zombie server on the port.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -1,8 +1,11 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { appendControl } from './control.js'
+import { daemonStatePath } from './daemon.js'
+import { EVENTS_FILE, FRAMEWORK_DIR } from './store/index.js'
 import {
   activeModes,
   autoSelectPreset,
@@ -345,4 +348,60 @@ test('runCli --fake --no-dashboard runs the whole flow offline to production-gra
   assert.match(text, /checklist pass 1/)
   assert.match(text, /production-grade/)
   assert.match(text, /deploy: SSR/)
+})
+
+test('a live daemon steers a dashboard-less run through its gates via control.jsonl (#344)', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'framework-ws-'))
+  const prevAwait = process.env.FRAMEWORK_FAKE_AWAIT
+  process.env.FRAMEWORK_FAKE_AWAIT = 'choices' // the fake build stops to ask (#341)
+  try {
+    // Fake a live daemon for this workspace: our own pid always reads as alive.
+    await mkdir(join(cwd, FRAMEWORK_DIR), { recursive: true })
+    await writeFile(
+      daemonStatePath(cwd),
+      JSON.stringify({ pid: process.pid, port: 1, url: 'http://127.0.0.1:1', startedAt: '' }),
+    )
+
+    const { io, out } = capture()
+    let settled = false
+    const done = runCli(['--fake', '--no-dashboard', '--cwd', cwd], io).finally(() => (settled = true))
+
+    // Play the daemon: tail events.jsonl for parked gates (plan-approval, then the
+    // build's await-choices) and answer each with its recommended pick, exactly as
+    // the daemon page's Accept button would.
+    const answered = new Set<string>()
+    const eventsPath = join(cwd, FRAMEWORK_DIR, EVENTS_FILE)
+    for (let i = 0; i < 500 && !settled; i++) {
+      const lines = await readFile(eventsPath, 'utf8').then(s => s.split('\n').filter(Boolean), () => [])
+      for (const l of lines) {
+        let e: { kind?: string; id?: string; recommended?: string; options?: { id: string }[] }
+        try {
+          e = JSON.parse(l)
+        } catch {
+          continue
+        }
+        if (e.kind !== 'choice' || !e.id || answered.has(e.id)) continue
+        answered.add(e.id)
+        await appendControl(cwd, { kind: 'choice', id: e.id, pick: e.recommended ?? e.options?.[0]?.id ?? '', by: 'user' })
+      }
+      await new Promise(r => setTimeout(r, 20))
+    }
+
+    assert.equal(await done, 0)
+    assert.ok(answered.has('plan-approval'), 'the plan gate parked and was steered')
+    assert.ok(answered.has('await-choices'), 'the build await gate parked and was steered')
+    assert.match(out.join('\n'), /production-grade/)
+    // Both resolutions were attributed to the steering user, not a headless auto-accept.
+    const resolved = (await readFile(eventsPath, 'utf8'))
+      .split('\n')
+      .filter(Boolean)
+      .map(l => JSON.parse(l))
+      .filter((e: { kind: string }) => e.kind === 'choice-resolved')
+    assert.equal(resolved.length, 2)
+    assert.ok(resolved.every((e: { by: string }) => e.by === 'user'))
+  } finally {
+    if (prevAwait === undefined) delete process.env.FRAMEWORK_FAKE_AWAIT
+    else process.env.FRAMEWORK_FAKE_AWAIT = prevAwait
+    await rm(cwd, { recursive: true, force: true })
+  }
 })

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -38,7 +38,8 @@ import { loadRepoMemory } from './memory.js'
 import { loadUserSystemPrompt, SYSTEM_PROMPT_FILE } from './system-prompt.js'
 import { preflight } from './preflight.js'
 import { RunStore } from './store/index.js'
-import { ensureDaemon, runDaemon, stopDaemon, DEFAULT_DAEMON_PORT } from './daemon.js'
+import { daemonStatus, ensureDaemon, runDaemon, stopDaemon, DEFAULT_DAEMON_PORT } from './daemon.js'
+import { resetControl, watchControl, type ControlWatcher } from './control.js'
 
 /**
  * The default link shown for a live run: the generic Claude Code entry point,
@@ -667,6 +668,31 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     }
   }
 
+  // The persistent daemon dashboard steers this run through .framework/control.jsonl
+  // (#344): its Stop button and choice picks append entries, we tail the file and
+  // abort / resolve the parked gate. Reset first so a previous run's picks can never
+  // fire into this one (gate ids repeat across runs). Only wired when a daemon is
+  // live for this workspace — without one, headless behavior is byte-identical.
+  let control: ControlWatcher | undefined
+  if (opts.persist && (await daemonStatus(cwd))) {
+    try {
+      await resetControl(cwd)
+      control = watchControl(cwd, entry => {
+        if (entry.kind === 'stop') {
+          controller.abort()
+          return
+        }
+        const resolve = pendingChoices.get(entry.id)
+        if (resolve) {
+          pendingChoices.delete(entry.id)
+          resolve({ picked: entry.pick, by: entry.by })
+        }
+      })
+    } catch (err) {
+      io.err(`control channel unavailable (${err instanceof Error ? err.message : String(err)}); daemon steering disabled`)
+    }
+  }
+
   // Publish the run to a relay (#230) so teammates can watch it live. Best-effort:
   // a relay that is down never fails the run (relayPublisher swallows POST errors).
   let publisher: RelayPublisher | undefined
@@ -785,9 +811,10 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     onEvent,
     signals,
     signal: controller.signal,
-    // Pause the plan-approval gate on the dashboard when one is live to accept the
-    // pick; without a dashboard the gate auto-accepts the recommended plan (#304).
-    ...(dashboard
+    // Pause the choice gates when someone can answer: this run's own dashboard, or
+    // the workspace daemon's via the control channel (#344). With neither, the gates
+    // auto-accept the recommended option as before (#304).
+    ...(dashboard || control
       ? {
           requestChoice: (req: ChoiceRequest) =>
             new Promise<ChoicePick>(resolve => pendingChoices.set(req.id, resolve)),
@@ -856,6 +883,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     return 1
   } finally {
     clearInterrupt()
+    control?.close()
     // Make sure every event (including the final `end`) reached the relay before exit.
     if (publisher) await publisher.flush()
   }

--- a/packages/framework/src/control.test.ts
+++ b/packages/framework/src/control.test.ts
@@ -1,0 +1,88 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { appendFile, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  appendControl,
+  controlPath,
+  resetControl,
+  watchControl,
+  type ControlEntry,
+} from './control.js'
+
+async function tmpWorkspace(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'framework-control-'))
+}
+
+/** Poll until the predicate holds or the timeout passes. */
+async function until(check: () => boolean, timeoutMs = 3000): Promise<boolean> {
+  for (let waited = 0; waited < timeoutMs; waited += 20) {
+    if (check()) return true
+    await new Promise(r => setTimeout(r, 20))
+  }
+  return check()
+}
+
+test('appendControl + watchControl deliver entries in order', async () => {
+  const cwd = await tmpWorkspace()
+  const seen: ControlEntry[] = []
+  const watcher = watchControl(cwd, e => seen.push(e), 20)
+  try {
+    await appendControl(cwd, { kind: 'stop' })
+    await appendControl(cwd, { kind: 'choice', id: 'plan-approval', pick: 'proceed', by: 'user' })
+    await appendControl(cwd, { kind: 'choice', id: 'await-multiselect', pick: ['opt:0', 'opt:2'], by: 'autopilot' })
+
+    assert.ok(await until(() => seen.length === 3), `saw ${seen.length} of 3 entries`)
+    assert.deepEqual(seen[0], { kind: 'stop' })
+    assert.deepEqual(seen[1], { kind: 'choice', id: 'plan-approval', pick: 'proceed', by: 'user' })
+    assert.deepEqual(seen[2], { kind: 'choice', id: 'await-multiselect', pick: ['opt:0', 'opt:2'], by: 'autopilot' })
+  } finally {
+    watcher.close()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('resetControl truncates so a previous run\'s picks never replay', async () => {
+  const cwd = await tmpWorkspace()
+  try {
+    await appendControl(cwd, { kind: 'choice', id: 'plan-approval', pick: 'alt:0', by: 'user' })
+    await resetControl(cwd)
+    assert.equal(await readFile(controlPath(cwd), 'utf8'), '')
+
+    // A watcher started after the reset (a fresh run) only sees new entries.
+    const seen: ControlEntry[] = []
+    const watcher = watchControl(cwd, e => seen.push(e), 20)
+    try {
+      await appendControl(cwd, { kind: 'stop' })
+      assert.ok(await until(() => seen.length === 1))
+      assert.deepEqual(seen, [{ kind: 'stop' }])
+    } finally {
+      watcher.close()
+    }
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('watchControl skips malformed and unknown lines', async () => {
+  const cwd = await tmpWorkspace()
+  const seen: ControlEntry[] = []
+  const watcher = watchControl(cwd, e => seen.push(e), 20)
+  try {
+    await resetControl(cwd)
+    await appendFile(
+      controlPath(cwd),
+      'not json\n' +
+        JSON.stringify({ kind: 'reboot' }) + '\n' +
+        JSON.stringify({ kind: 'choice', id: '', pick: 'x' }) + '\n' + // empty id -> dropped
+        JSON.stringify({ kind: 'choice', id: 'g', pick: 42 }) + '\n' + // bad pick -> dropped
+        JSON.stringify({ kind: 'choice', id: 'g', pick: [], by: 'user' }) + '\n', // empty multi pick is legit
+    )
+    assert.ok(await until(() => seen.length === 1), `saw ${seen.length}`)
+    assert.deepEqual(seen, [{ kind: 'choice', id: 'g', pick: [], by: 'user' }])
+  } finally {
+    watcher.close()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})

--- a/packages/framework/src/control.ts
+++ b/packages/framework/src/control.ts
@@ -1,0 +1,103 @@
+import { watch, type FSWatcher } from 'node:fs'
+import { appendFile, mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { ChoiceBy } from './events.js'
+import { FRAMEWORK_DIR } from './store/index.js'
+import { JsonlTailer } from './jsonl-tail.js'
+
+/**
+ * The dashboard-to-run control channel (#344): the reverse of the event log.
+ * Events flow run -> `.framework/events.jsonl` -> daemon -> browser; steering
+ * flows browser -> daemon -> `.framework/control.jsonl` -> run. The daemon
+ * appends a {@link ControlEntry} per Stop click / choice pick, and the run tails
+ * the file, aborting or resolving its parked gate. Same file-is-the-seam design
+ * as the forward direction — no run<->daemon IPC.
+ */
+
+/** The control log filename under `.framework/`. */
+export const CONTROL_FILE = 'control.jsonl'
+
+/** One steering instruction from the dashboard to the live run. */
+export type ControlEntry =
+  /** Stop the run (the daemon dashboard's Stop button). */
+  | { kind: 'stop' }
+  /** Resolve a parked choice gate: the pick for the pending {@link ChoiceRequest} id. */
+  | { kind: 'choice'; id: string; pick: string | string[]; by: ChoiceBy }
+
+/** The control log path for a workspace. */
+export function controlPath(cwd: string): string {
+  return join(cwd, FRAMEWORK_DIR, CONTROL_FILE)
+}
+
+/** Append one entry to the workspace's control log, creating it as needed. */
+export async function appendControl(cwd: string, entry: ControlEntry): Promise<void> {
+  await mkdir(join(cwd, FRAMEWORK_DIR), { recursive: true })
+  await appendFile(controlPath(cwd), JSON.stringify(entry) + '\n')
+}
+
+/**
+ * Truncate the control log. A run calls this at start so a previous run's picks
+ * can never fire into this one (gate ids like `plan-approval` repeat across runs).
+ */
+export async function resetControl(cwd: string): Promise<void> {
+  await mkdir(join(cwd, FRAMEWORK_DIR), { recursive: true })
+  await writeFile(controlPath(cwd), '')
+}
+
+/** A live control tail. {@link close} stops watching (idempotent). */
+export interface ControlWatcher {
+  close(): void
+}
+
+/**
+ * Tail the workspace's control log, dispatching each well-formed entry as it is
+ * appended. An `fs.watch` on `.framework/` plus a poll backstop, mirroring the
+ * daemon's event tail (`fs.watch` is unreliable across platforms). Malformed or
+ * unknown lines are skipped so a bad write can never crash a run.
+ */
+export function watchControl(
+  cwd: string,
+  onEntry: (entry: ControlEntry) => void,
+  pollMs = 300,
+): ControlWatcher {
+  const tailer = new JsonlTailer<ControlEntry>(controlPath(cwd), entry => {
+    if (isControlEntry(entry)) onEntry(entry)
+  })
+  let pulling = false
+  const pump = async (): Promise<void> => {
+    if (pulling) return
+    pulling = true
+    try {
+      await tailer.pull()
+    } finally {
+      pulling = false
+    }
+  }
+  let watcher: FSWatcher | undefined
+  try {
+    watcher = watch(join(cwd, FRAMEWORK_DIR), () => void pump())
+  } catch {
+    // dir may not be watchable everywhere; the poll backstop still covers it
+  }
+  const poll = setInterval(() => void pump(), pollMs)
+  poll.unref() // never keep the process alive just for steering
+  void pump()
+  return {
+    close: () => {
+      clearInterval(poll)
+      watcher?.close()
+      watcher = undefined
+    },
+  }
+}
+
+/** Shape-check a parsed line. A multi-select pick may legitimately be `[]`. */
+function isControlEntry(value: unknown): value is ControlEntry {
+  if (!value || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+  if (v['kind'] === 'stop') return true
+  if (v['kind'] !== 'choice') return false
+  if (typeof v['id'] !== 'string' || !v['id']) return false
+  const pick = v['pick']
+  return typeof pick === 'string' || (Array.isArray(pick) && pick.every(p => typeof p === 'string'))
+}

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -14,6 +14,7 @@ import {
   daemonStatePath,
 } from './daemon.js'
 import { EVENTS_FILE, FRAMEWORK_DIR } from './store/index.js'
+import { controlPath } from './control.js'
 
 const logEvent = (message: string): FrameworkEvent => ({ kind: 'log', message })
 const line = (message: string): string => JSON.stringify(logEvent(message)) + '\n'
@@ -150,6 +151,70 @@ test('runDaemon serves the dashboard, records its state, and cleans up on shutdo
     ac.abort()
     await done
     assert.equal(await readDaemonState(cwd), undefined) // state file removed on exit
+  } finally {
+    ac.abort()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('runDaemon comes up on a fresh workspace with no .framework yet', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'framework-daemon-')) // deliberately no mkdir
+  const ac = new AbortController()
+  try {
+    const done = runDaemon(cwd, { port: 0, pollMs: 50, signal: ac.signal })
+    let state = await readDaemonState(cwd)
+    for (let i = 0; i < 100 && !state; i++) {
+      await new Promise(r => setTimeout(r, 20))
+      state = await readDaemonState(cwd)
+    }
+    assert.ok(state, 'the daemon created .framework/ itself and wrote its state file')
+    assert.equal((await fetch(state!.url)).status, 200)
+    ac.abort()
+    await done
+  } finally {
+    ac.abort()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('runDaemon steers through the control log: /stop and /choice POSTs append entries (#344)', async () => {
+  const cwd = await tmpWorkspace()
+  const ac = new AbortController()
+  try {
+    const done = runDaemon(cwd, { port: 0, pollMs: 50, signal: ac.signal })
+    let state = await readDaemonState(cwd)
+    for (let i = 0; i < 100 && !state; i++) {
+      await new Promise(r => setTimeout(r, 20))
+      state = await readDaemonState(cwd)
+    }
+    assert.ok(state, 'daemon wrote its state file')
+
+    // The daemon page has steering wired: the Stop button shows and /choice accepts.
+    const stop = await fetch(`${state!.url}/stop`, { method: 'POST' })
+    assert.equal(stop.status, 202)
+    const choice = await fetch(`${state!.url}/choice`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: 'plan-approval', pick: 'alt:0', by: 'user' }),
+    })
+    assert.equal(choice.status, 202)
+
+    // Both landed in the control log (appends are async fire-and-forget: poll).
+    let lines: string[] = []
+    for (let i = 0; i < 100 && lines.length < 2; i++) {
+      await new Promise(r => setTimeout(r, 20))
+      lines = await readFile(controlPath(cwd), 'utf8').then(
+        s => s.split('\n').filter(Boolean),
+        () => [],
+      )
+    }
+    assert.deepEqual(lines.map(l => JSON.parse(l)), [
+      { kind: 'stop' },
+      { kind: 'choice', id: 'plan-approval', pick: 'alt:0', by: 'user' },
+    ])
+
+    ac.abort()
+    await done
   } finally {
     ac.abort()
     await rm(cwd, { recursive: true, force: true })

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -1,10 +1,12 @@
 import { spawn } from 'node:child_process'
 import { watch, type FSWatcher } from 'node:fs'
-import { open, readFile, writeFile, rm } from 'node:fs/promises'
+import { mkdir, readFile, writeFile, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { FrameworkEvent } from './events.js'
 import { EVENTS_FILE, FRAMEWORK_DIR } from './store/index.js'
 import { startDashboard, type Dashboard } from './dashboard/index.js'
+import { appendControl } from './control.js'
+import { JsonlTailer } from './jsonl-tail.js'
 
 /**
  * The persistent background dashboard (#302). Today the dashboard dies with the
@@ -13,7 +15,8 @@ import { startDashboard, type Dashboard } from './dashboard/index.js'
  * appends its events to `.framework/events.jsonl` (unchanged), and the daemon
  * *tails* that file, pushing each new event to connected browsers. No run<->daemon
  * IPC — the file is the seam, matching "the dashboard is a projection of the event
- * stream". MVP: one project = the workspace `cwd`; multi-project is deferred (#299).
+ * stream". Steering goes the other way through `.framework/control.jsonl` (#344).
+ * MVP: one project = the workspace `cwd`; multi-project is deferred (#299).
  */
 
 /** The daemon's liveness record under `.framework/`. */
@@ -169,61 +172,11 @@ export async function stopDaemon(cwd: string): Promise<boolean> {
 }
 
 /**
- * Tails an append-only JSONL event log, calling `onEvent` for each complete line
- * as it is written. Reads only the bytes appended since the last {@link pull},
- * buffering a torn trailing line until its newline arrives. A file that shrinks
- * (a fresh run truncated the log) resets to the start so the new run is picked up.
+ * Tails the append-only `.framework/events.jsonl` run log. The generic tailing
+ * lives in {@link JsonlTailer}; this keeps the event-typed name the daemon (and
+ * public API) always had.
  */
-export class EventTailer {
-  private offset = 0
-  private partial = ''
-  private lastMtimeMs = 0
-
-  constructor(
-    private readonly path: string,
-    private readonly onEvent: (event: FrameworkEvent) => void,
-  ) {}
-
-  /** Read and dispatch any events appended since the previous call. */
-  async pull(): Promise<void> {
-    let fd
-    try {
-      fd = await open(this.path, 'r')
-    } catch {
-      return // not created yet (no run has started)
-    }
-    try {
-      const { size, mtimeMs } = await fd.stat()
-      // A fresh run truncates the log in place (same inode). Detect it two ways: the
-      // file shrank below what we consumed, or it was rewritten to the same length
-      // (size unchanged but mtime advanced). Either way, re-read from the top.
-      const rewritten = size === this.offset && this.offset > 0 && mtimeMs > this.lastMtimeMs
-      if (size < this.offset || rewritten) {
-        this.offset = 0
-        this.partial = ''
-      }
-      this.lastMtimeMs = mtimeMs
-      if (size === this.offset) return
-      const buf = Buffer.alloc(size - this.offset)
-      await fd.read(buf, 0, buf.length, this.offset)
-      this.offset = size
-      this.partial += buf.toString('utf8')
-      const lines = this.partial.split('\n')
-      this.partial = lines.pop() ?? '' // trailing fragment with no newline yet
-      for (const line of lines) {
-        const trimmed = line.trim()
-        if (!trimmed) continue
-        try {
-          this.onEvent(JSON.parse(trimmed) as FrameworkEvent)
-        } catch {
-          // a torn/half-written line — skip it; the store never rewrites history
-        }
-      }
-    } finally {
-      await fd.close()
-    }
-  }
-}
+export class EventTailer extends JsonlTailer<FrameworkEvent> {}
 
 /** Options for {@link runDaemon}. */
 export interface RunDaemonOptions {
@@ -244,34 +197,57 @@ export interface RunDaemonOptions {
  */
 export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promise<void> {
   const port = opts.port ?? DEFAULT_DAEMON_PORT
-  const dashboard: Dashboard = await startDashboard({ port, cwd })
+  // Steering (#344): the daemon owns no run, so its Stop button and choice picks
+  // append to `.framework/control.jsonl`; the live run tails that file. Appends
+  // are best-effort — a full disk must not take the dashboard down with it.
+  // The state file, the event/control logs, and the fs.watch all live under
+  // `.framework/` — create it up front so the daemon works as the very first
+  // command in a fresh workspace (before any run made the dir).
+  await mkdir(daemonDir(cwd), { recursive: true })
+  const dashboard: Dashboard = await startDashboard({
+    port,
+    cwd,
+    onStop: () => void appendControl(cwd, { kind: 'stop' }).catch(() => {}),
+    onChoice: (id, pick, by) => void appendControl(cwd, { kind: 'choice', id, pick, by }).catch(() => {}),
+  })
   const eventsPath = join(daemonDir(cwd), EVENTS_FILE)
   const tailer = new EventTailer(eventsPath, event => dashboard.push(event))
 
-  // Seed from whatever is already logged, then keep up with appends.
-  await tailer.pull()
-  let pulling = false
-  const pump = async (): Promise<void> => {
-    if (pulling) return
-    pulling = true
-    try {
-      await tailer.pull()
-    } finally {
-      pulling = false
-    }
-  }
-
   let watcher: FSWatcher | undefined
+  let poll: NodeJS.Timeout | undefined
   try {
-    watcher = watch(daemonDir(cwd), () => void pump())
-  } catch {
-    // dir may not be watchable everywhere; the poll backstop still covers it
-  }
-  const poll = setInterval(() => void pump(), opts.pollMs ?? 1000)
+    // Seed from whatever is already logged, then keep up with appends.
+    await tailer.pull()
+    let pulling = false
+    const pump = async (): Promise<void> => {
+      if (pulling) return
+      pulling = true
+      try {
+        await tailer.pull()
+      } finally {
+        pulling = false
+      }
+    }
 
-  const actualPort = Number(new URL(dashboard.url).port) || port
-  const state: DaemonState = { pid: process.pid, port: actualPort, url: dashboard.url, startedAt: new Date().toISOString() }
-  await writeFile(daemonStatePath(cwd), JSON.stringify(state, null, 2))
+    try {
+      watcher = watch(daemonDir(cwd), () => void pump())
+    } catch {
+      // dir may not be watchable everywhere; the poll backstop still covers it
+    }
+    poll = setInterval(() => void pump(), opts.pollMs ?? 1000)
+
+    const actualPort = Number(new URL(dashboard.url).port) || port
+    const state: DaemonState = { pid: process.pid, port: actualPort, url: dashboard.url, startedAt: new Date().toISOString() }
+    await writeFile(daemonStatePath(cwd), JSON.stringify(state, null, 2))
+  } catch (err) {
+    // Startup failed after the port was bound. Tear everything down, or the live
+    // server + interval keep the event loop alive: a zombie daemon squatting the
+    // port with no state file, which also wedges every later `framework` start.
+    clearInterval(poll)
+    watcher?.close()
+    await dashboard.close()
+    throw err
+  }
 
   await waitForShutdown(opts.signal)
 

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -174,6 +174,15 @@ export {
   type RunDaemonOptions,
 } from './daemon.js'
 export {
+  appendControl,
+  resetControl,
+  watchControl,
+  controlPath,
+  CONTROL_FILE,
+  type ControlEntry,
+  type ControlWatcher,
+} from './control.js'
+export {
   fakeDriver,
   FAKE_INTENT,
   FAKE_SIGNALS,

--- a/packages/framework/src/jsonl-tail.ts
+++ b/packages/framework/src/jsonl-tail.ts
@@ -1,0 +1,60 @@
+import { open } from 'node:fs/promises'
+
+/**
+ * Tails an append-only JSONL log, calling `onLine` for each complete line as it
+ * is written. Reads only the bytes appended since the last {@link pull},
+ * buffering a torn trailing line until its newline arrives. A file that shrinks
+ * (a fresh run truncated the log) resets to the start so the new content is
+ * picked up. The generic base behind the daemon's event tail and the run's
+ * control tail (#344) — one tailer, two directions.
+ */
+export class JsonlTailer<T> {
+  private offset = 0
+  private partial = ''
+  private lastMtimeMs = 0
+
+  constructor(
+    private readonly path: string,
+    private readonly onLine: (value: T) => void,
+  ) {}
+
+  /** Read and dispatch any lines appended since the previous call. */
+  async pull(): Promise<void> {
+    let fd
+    try {
+      fd = await open(this.path, 'r')
+    } catch {
+      return // not created yet (nothing has written)
+    }
+    try {
+      const { size, mtimeMs } = await fd.stat()
+      // A fresh run truncates the log in place (same inode). Detect it two ways: the
+      // file shrank below what we consumed, or it was rewritten to the same length
+      // (size unchanged but mtime advanced). Either way, re-read from the top.
+      const rewritten = size === this.offset && this.offset > 0 && mtimeMs > this.lastMtimeMs
+      if (size < this.offset || rewritten) {
+        this.offset = 0
+        this.partial = ''
+      }
+      this.lastMtimeMs = mtimeMs
+      if (size === this.offset) return
+      const buf = Buffer.alloc(size - this.offset)
+      await fd.read(buf, 0, buf.length, this.offset)
+      this.offset = size
+      this.partial += buf.toString('utf8')
+      const lines = this.partial.split('\n')
+      this.partial = lines.pop() ?? '' // trailing fragment with no newline yet
+      for (const line of lines) {
+        const trimmed = line.trim()
+        if (!trimmed) continue
+        try {
+          this.onLine(JSON.parse(trimmed) as T)
+        } catch {
+          // a torn/half-written line — skip it; the log never rewrites history
+        }
+      }
+    } finally {
+      await fd.close()
+    }
+  }
+}


### PR DESCRIPTION
Closes #344. Also fixes #348 (found while live-verifying this; same lines).

The daemon dashboard was a pure projection: it rendered gates but could not answer them, and its Stop button was hidden. Now steering flows back through a file, mirroring the event log: browser -> daemon -> `.framework/control.jsonl` -> run.

- `control.ts` (new): `appendControl` / `resetControl` / `watchControl` over `.framework/control.jsonl`. Malformed lines are skipped; a run resets the file at start so a previous run's picks can never fire into it.
- `jsonl-tail.ts` (new): the generic tailer extracted from the daemon's `EventTailer` (which stays, as a typed subclass) so both directions share the truncation-safe tailing.
- `daemon.ts`: the daemon dashboard wires `onStop`/`onChoice` to control-log appends. Plus the #348 fix: `runDaemon` mkdirs `.framework/` up front and tears the server down if startup throws, so a fresh workspace can never end up with a zombie daemon squatting the port.
- `cli.ts`: when a workspace daemon is live, the run tails the control log (stop -> abort, pick -> resolve the parked gate) and `requestChoice` is wired even without an own dashboard, so daemon-steered runs pause at gates. Without a daemon, headless runs stay byte-identical (gates auto-accept as before, #304).

This is the prerequisite for #345 (start runs from the dashboard): a daemon-started run has no dashboard of its own, so this channel is what makes its gates and Stop work.

Live-verified end to end: real daemon + `FRAMEWORK_FAKE_AWAIT=choices` run steered entirely by POSTs to the daemon (alt pick -> re-architect -> re-fired gate -> approve -> production-grade, exit 0); Stop mid-gate -> clean "Stopped.", exit 0; stale picks truncated on the next run's start; malformed/wrong-method POSTs rejected without effect.

249 tests pass (3 control, 2 daemon incl. a fresh-workspace regression, 1 e2e driving a run through both gates via the control file), typecheck clean, minor changeset.