### PR TITLE
feat(framework): start runs from the daemon dashboard (#345)

### DIFF
--- a/.changeset/dashboard-start-run.md
+++ b/.changeset/dashboard-start-run.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Start runs from the daemon dashboard (#345): a prompt textarea + `POST /api/start` that spawns `framework "<prompt>" --no-dashboard` as a detached child, with a one-run-at-a-time guard. The started run streams into the page via the tailed event log and is steerable (gates + Stop) through the control channel.

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -913,7 +913,7 @@ async function ensureDaemonCmd(opts: CliOptions, io: CliIO): Promise<number> {
   const { state, alreadyRunning } = result
   io.out(`◆ dashboard ${alreadyRunning ? 'already running' : 'started'}: ${state.url}`)
   io.out('')
-  io.out('Commands:')
+  io.out('Type a prompt on the dashboard to start a run, or use:')
   io.out('  framework "<what to build>"   Build (streams to the dashboard)')
   io.out('  framework stop                Stop the background dashboard')
   io.out('  framework --help              All options')

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -177,6 +177,99 @@ test('runDaemon comes up on a fresh workspace with no .framework yet', async () 
   }
 })
 
+test('POST /api/start spawns the run child (prompt, --no-dashboard, --cwd) one at a time (#345)', async () => {
+  const cwd = await tmpWorkspace()
+  // A stub CLI standing in for the framework bin: it records its argv, then
+  // stays alive briefly so the one-run-at-a-time guard has a window to trip.
+  const stub = join(cwd, 'stub-cli.cjs')
+  await writeFile(
+    stub,
+    `const fs = require('node:fs'), path = require('node:path')
+const args = process.argv.slice(2)
+fs.appendFileSync(path.join(args[args.indexOf('--cwd') + 1], 'started.log'), JSON.stringify(args) + '\\n')
+setTimeout(() => {}, 600)
+`,
+  )
+  const ac = new AbortController()
+  try {
+    const done = runDaemon(cwd, { port: 0, pollMs: 50, signal: ac.signal, binPath: stub })
+    let state = await readDaemonState(cwd)
+    for (let i = 0; i < 100 && !state; i++) {
+      await new Promise(r => setTimeout(r, 20))
+      state = await readDaemonState(cwd)
+    }
+    assert.ok(state, 'daemon wrote its state file')
+
+    const startUrl = `${state!.url}/api/start`
+    const post = (prompt: string) =>
+      fetch(startUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ prompt }),
+      })
+
+    const first = await post('a blog')
+    assert.equal(first.status, 202)
+
+    // The child got the prompt as one word plus the headless + workspace flags.
+    let lines: string[] = []
+    for (let i = 0; i < 100 && lines.length < 1; i++) {
+      await new Promise(r => setTimeout(r, 20))
+      lines = await readFile(join(cwd, 'started.log'), 'utf8').then(
+        s => s.split('\n').filter(Boolean),
+        () => [],
+      )
+    }
+    assert.deepEqual(JSON.parse(lines[0]!), ['a blog', '--no-dashboard', '--cwd', cwd])
+
+    // While that child is alive, a second Start is refused (#322 runaway concern).
+    const busy = await post('another app')
+    assert.equal(busy.status, 409)
+    assert.match(await busy.text(), /already active/)
+
+    // Once the child exits, the guard resets and Start works again.
+    let again = busy
+    for (let i = 0; i < 100 && again.status !== 202; i++) {
+      await new Promise(r => setTimeout(r, 50))
+      again = await post('a second run')
+    }
+    assert.equal(again.status, 202)
+
+    ac.abort()
+    await done
+  } finally {
+    ac.abort()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('/api/start refuses to re-exec a test entry as the run (#345)', async () => {
+  const cwd = await tmpWorkspace()
+  const ac = new AbortController()
+  try {
+    // No binPath: argv[1] here is this test file — the fork-bomb guard must trip.
+    const done = runDaemon(cwd, { port: 0, pollMs: 50, signal: ac.signal })
+    let state = await readDaemonState(cwd)
+    for (let i = 0; i < 100 && !state; i++) {
+      await new Promise(r => setTimeout(r, 20))
+      state = await readDaemonState(cwd)
+    }
+    assert.ok(state, 'daemon wrote its state file')
+    const res = await fetch(`${state!.url}/api/start`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ prompt: 'a blog' }),
+    })
+    assert.equal(res.status, 500)
+    assert.match(await res.text(), /test entry/)
+    ac.abort()
+    await done
+  } finally {
+    ac.abort()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
 test('runDaemon steers through the control log: /stop and /choice POSTs append entries (#344)', async () => {
   const cwd = await tmpWorkspace()
   const ac = new AbortController()

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -4,7 +4,7 @@ import { mkdir, readFile, writeFile, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { FrameworkEvent } from './events.js'
 import { EVENTS_FILE, FRAMEWORK_DIR } from './store/index.js'
-import { startDashboard, type Dashboard } from './dashboard/index.js'
+import { startDashboard, type Dashboard, type StartRunResult } from './dashboard/index.js'
 import { appendControl } from './control.js'
 import { JsonlTailer } from './jsonl-tail.js'
 
@@ -186,6 +186,8 @@ export interface RunDaemonOptions {
   pollMs?: number
   /** Shut the daemon down when this aborts (in addition to SIGINT/SIGTERM). For tests. */
   signal?: AbortSignal
+  /** The CLI entry script to re-invoke for a dashboard-started run (#345). Default `process.argv[1]`. */
+  binPath?: string
 }
 
 /**
@@ -204,11 +206,51 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
   // `.framework/` — create it up front so the daemon works as the very first
   // command in a fresh workspace (before any run made the dir).
   await mkdir(daemonDir(cwd), { recursive: true })
+
+  // Start-from-dashboard (#345): POST /api/start spawns `framework "<prompt>"
+  // --no-dashboard` as a detached child — the same spawn pattern ensureDaemon
+  // uses for the daemon itself. The run streams into this page via the tailed
+  // event log, and its gates + Stop steer through the control channel (#344),
+  // which the run wires whenever a daemon is live. One run at a time: while the
+  // last child is alive, Start is refused (the #322 runaway concern).
+  let activeRunPid: number | undefined
+  const startRun = (prompt: string): StartRunResult => {
+    if (activeRunPid !== undefined && isProcessAlive(activeRunPid)) {
+      return { ok: false, busy: true, error: 'a run is already active; stop it or wait for it to finish' }
+    }
+    activeRunPid = undefined
+    const binPath = opts.binPath ?? process.argv[1]
+    if (!binPath) return { ok: false, error: 'cannot locate the framework CLI entry to spawn a run' }
+    // Same fork-bomb guard as ensureDaemon: never re-exec a test file as a run.
+    if (!opts.binPath && (process.env.NODE_TEST_CONTEXT || /\.test\.[cm]?[jt]s$/.test(binPath))) {
+      return { ok: false, error: 'refusing to spawn a run from a test entry; pass an explicit binPath' }
+    }
+    const child = spawn(process.execPath, [binPath, prompt, '--no-dashboard', '--cwd', cwd], {
+      detached: true,
+      stdio: 'ignore',
+    })
+    child.unref()
+    child.once('error', err => {
+      activeRunPid = undefined
+      dashboard.push({ kind: 'log', message: `✗ run failed to start: ${err.message}` })
+    })
+    child.once('exit', code => {
+      activeRunPid = undefined
+      // The run narrates its own end through the event log; only a hard failure
+      // (nonzero exit with no run to tell the tale) needs the daemon's voice.
+      if (code) dashboard.push({ kind: 'log', message: `✗ run exited with code ${code}` })
+    })
+    activeRunPid = child.pid
+    dashboard.push({ kind: 'log', message: `▶ run started: ${prompt}` })
+    return { ok: true }
+  }
+
   const dashboard: Dashboard = await startDashboard({
     port,
     cwd,
     onStop: () => void appendControl(cwd, { kind: 'stop' }).catch(() => {}),
     onChoice: (id, pick, by) => void appendControl(cwd, { kind: 'choice', id, pick, by }).catch(() => {}),
+    onStart: startRun,
   })
   const eventsPath = join(daemonDir(cwd), EVENTS_FILE)
   const tailer = new EventTailer(eventsPath, event => dashboard.push(event))

--- a/packages/framework/src/dashboard/index.ts
+++ b/packages/framework/src/dashboard/index.ts
@@ -1,2 +1,2 @@
-export { startDashboard, type Dashboard, type DashboardOptions } from './server.js'
+export { startDashboard, type Dashboard, type DashboardOptions, type StartRunResult } from './server.js'
 export { dashboardHtml } from './page.js'

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -7,7 +7,7 @@ import { CLAUDE_CODE_SESSION_LINK } from '../events.js'
  * that foreground the orchestration (stack rationale, loop status, decisions)
  * beside a tail of the wrapped agent's own activity.
  */
-export function dashboardHtml(title: string, stoppable = false, choiceable = false): string {
+export function dashboardHtml(title: string, stoppable = false, choiceable = false, startable = false): string {
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -97,6 +97,19 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   #modes .box { color: #6ea8fe; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
   #modes li.off { color: #5c657a; }
   #modes li.off .box { color: #3a4256; }
+  /* Start-a-run panel (#345): only the daemon dashboard wires /api/start; the
+     per-run page and the relay render it hidden. */
+  #start-panel { grid-column: 1 / -1; }
+  #start-panel[hidden] { display: none; }
+  #start-prompt { width: 100%; min-height: 60px; resize: vertical; font: inherit; color: #e8ecf3;
+    background: #0d1119; border: 1px solid #24344a; border-radius: 8px; padding: 8px 10px; }
+  #start-prompt:focus { outline: none; border-color: #3d5a8a; }
+  #start-actions { display: flex; align-items: center; gap: 12px; margin-top: 10px; }
+  #start-run { font: inherit; font-size: 13px; font-weight: 600; cursor: pointer; color: #0b0e14;
+    background: #6ea8fe; border: 0; border-radius: 6px; padding: 6px 16px; }
+  #start-run:hover { background: #8bbaff; }
+  #start-run:disabled { opacity: .5; cursor: default; }
+  #start-note { color: #f0a35e; font-size: 12px; }
   /* Interactive plan-approval / choice panel (#304): full-width, accented so it
      reads as the one thing awaiting the human. */
   #choice-panel { grid-column: 1 / -1; background: #131a2a; border: 1px solid #2b3b5c;
@@ -176,6 +189,14 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   <span class="run">live until you stop the run</span>
 </div>
 <main>
+  <section id="start-panel"${startable ? '' : ' hidden'}>
+    <h2>Start a run</h2>
+    <textarea id="start-prompt" rows="3" placeholder="What should the agent build?"></textarea>
+    <div id="start-actions">
+      <button id="start-run">&#9654; Start<span class="kbd">Ctrl+Enter</span></button>
+      <span id="start-note"></span>
+    </div>
+  </section>
   <section id="choice-panel" hidden>
     <h2>Your call</h2>
     <div id="choice-title"></div>
@@ -221,17 +242,18 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
 </aside>
 </div>
 <script>
-${clientScript(stoppable, choiceable)}
+${clientScript(stoppable, choiceable, startable)}
 </script>
 </body>
 </html>`
 }
 
-function clientScript(stoppable: boolean, choiceable: boolean): string {
+function clientScript(stoppable: boolean, choiceable: boolean, startable: boolean): string {
   // Runs in the browser. Keep it dependency-free.
   return `
 const STOPPABLE = ${stoppable ? 'true' : 'false'};
 const CHOICEABLE = ${choiceable ? 'true' : 'false'};
+const STARTABLE = ${startable ? 'true' : 'false'};
 const AUTO_ACCEPT_MS = 10000;
 const GENERIC_SESSION_LINK = ${JSON.stringify(CLAUDE_CODE_SESSION_LINK)};
 let ended = false;
@@ -668,6 +690,33 @@ function notify(title, body) {
 }
 notifyBtn.addEventListener('click', toggleNotify);
 syncNotifyBtn();
+
+// Start a run (#345): POST the prompt to /api/start; the daemon spawns the run
+// and its events stream in over the same SSE feed. A 409 means one is active.
+function startNewRun() {
+  if (!STARTABLE) return;
+  const note = $('start-note');
+  const prompt = $('start-prompt').value.trim();
+  if (!prompt) { note.textContent = 'type what to build first'; return; }
+  const btn = $('start-run');
+  btn.disabled = true;
+  note.textContent = 'starting\\u2026';
+  fetch('api/start', { method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ prompt: prompt }) })
+    .then(async r => {
+      btn.disabled = false;
+      if (r.ok) { note.textContent = ''; $('start-prompt').value = ''; showLive(); return; }
+      let msg = 'could not start (' + r.status + ')';
+      try { const b = await r.json(); if (b && b.error) msg = b.error; } catch {}
+      note.textContent = msg;
+    })
+    .catch(() => { btn.disabled = false; note.textContent = 'could not reach the dashboard server'; });
+}
+$('start-run').addEventListener('click', startNewRun);
+$('start-prompt').addEventListener('keydown', ev => {
+  // stopPropagation so the document-level Ctrl+Enter never accepts a choice too.
+  if ((ev.ctrlKey || ev.metaKey) && ev.key === 'Enter') { ev.preventDefault(); ev.stopPropagation(); startNewRun(); }
+});
 
 $('stop').addEventListener('click', stopRun);
 $('back-live').addEventListener('click', showLive);

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -314,6 +314,65 @@ test('POST /choice forwards a multi-select subset (array pick), including an emp
   }
 })
 
+test('POST /api/start invokes onStart with the trimmed prompt and the page is startable (#345)', async () => {
+  const prompts: string[] = []
+  const dash = await startDashboard({ port: 0, onStart: prompt => { prompts.push(prompt); return { ok: true } } })
+  try {
+    const { status, body } = await postJson(dash.url + '/api/start', { prompt: '  a blog  ' })
+    assert.equal(status, 202)
+    assert.match(body, /"ok":true/)
+    assert.deepEqual(prompts, ['a blog'])
+    // The page ships the prompt panel visible and knows the server can start runs.
+    const page = await fetchText(dash.url + '/')
+    assert.match(page.body, /STARTABLE = true/)
+    assert.match(page.body, /<section id="start-panel">/)
+    assert.match(page.body, /id="start-prompt"/)
+  } finally {
+    await dash.close()
+  }
+})
+
+test('/api/start guards: 400 empty prompt, 409 busy, 500 spawn failure (#345)', async () => {
+  let calls = 0
+  let outcome: { ok: false; busy?: boolean; error: string } = { ok: false, busy: true, error: 'a run is already active' }
+  const dash = await startDashboard({ port: 0, onStart: () => { calls++; return outcome } })
+  try {
+    // An empty / missing prompt never reaches the handler.
+    assert.equal((await postJson(dash.url + '/api/start', { prompt: '   ' })).status, 400)
+    assert.equal((await postJson(dash.url + '/api/start', {})).status, 400)
+    assert.equal(calls, 0)
+    // Busy -> 409 with the reason; any other failure -> 500.
+    const busy = await postJson(dash.url + '/api/start', { prompt: 'a blog' })
+    assert.equal(busy.status, 409)
+    assert.match(busy.body, /already active/)
+    outcome = { ok: false, error: 'spawn failed' }
+    const failed = await postJson(dash.url + '/api/start', { prompt: 'a blog' })
+    assert.equal(failed.status, 500)
+    assert.match(failed.body, /spawn failed/)
+  } finally {
+    await dash.close()
+  }
+})
+
+test('/api/start is 405 for a non-POST and 404 when starting is not wired (#345)', async () => {
+  const withStart = await startDashboard({ port: 0, onStart: () => ({ ok: true }) })
+  try {
+    assert.equal((await send(withStart.url + '/api/start', 'GET')).status, 405)
+  } finally {
+    await withStart.close()
+  }
+  const noStart = await startDashboard({ port: 0 })
+  try {
+    assert.equal((await postJson(noStart.url + '/api/start', { prompt: 'a blog' })).status, 404)
+    // The panel renders hidden on a page that cannot start runs (per-run dashboard, relay).
+    const page = await fetchText(noStart.url + '/')
+    assert.match(page.body, /STARTABLE = false/)
+    assert.match(page.body, /<section id="start-panel" hidden>/)
+  } finally {
+    await noStart.close()
+  }
+})
+
 test('/choice is 405 for a non-POST and 404 when choices are not wired (#304)', async () => {
   const withChoice = await startDashboard({ port: 0, onChoice: () => {} })
   try {

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -35,7 +35,19 @@ export interface DashboardOptions {
    * to disable history (the endpoints report an empty list).
    */
   cwd?: string
+  /**
+   * Called when the browser posts a new-run prompt (#345): `POST /api/start`
+   * with a JSON `{ prompt }` body. Wire this to spawn the run (the daemon
+   * does); return `busy: true` to refuse because a run is already active (409).
+   * Omit to disable starting; the page hides the prompt panel.
+   */
+  onStart?: (prompt: string) => StartRunResult
 }
+
+/** The outcome of an {@link DashboardOptions.onStart} attempt (#345). */
+export type StartRunResult =
+  | { ok: true }
+  | { ok: false; busy?: boolean; error: string }
 
 /** A running localhost dashboard. Push {@link FrameworkEvent}s; it renders them live. */
 export interface Dashboard {
@@ -65,11 +77,12 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
   const title = opts.title ?? 'The Framework'
   const onStop = opts.onStop
   const onChoice = opts.onChoice
+  const onStart = opts.onStart
   const cwd = opts.cwd
   const stream = new EventStream<FrameworkEvent>()
   const clients = new Set<ServerResponse>()
 
-  const server = createServer((req, res) => handle(req, res, stream, clients, title, onStop, onChoice, cwd))
+  const server = createServer((req, res) => handle(req, res, stream, clients, title, onStop, onChoice, onStart, cwd))
 
   return new Promise<Dashboard>((resolvePromise, rejectPromise) => {
     server.once('error', rejectPromise)
@@ -95,12 +108,13 @@ function handle(
   title: string,
   onStop: (() => void) | undefined,
   onChoice: ((id: string, pick: string | string[], by: ChoiceBy) => void) | undefined,
+  onStart: ((prompt: string) => StartRunResult) | undefined,
   cwd: string | undefined,
 ): void {
   const url = req.url ?? '/'
   if (url === '/' || url.startsWith('/?')) {
     res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
-    res.end(dashboardHtml(title, Boolean(onStop), Boolean(onChoice)))
+    res.end(dashboardHtml(title, Boolean(onStop), Boolean(onChoice), Boolean(onStart)))
     return
   }
   if (url === '/events') {
@@ -167,6 +181,38 @@ function handle(
           : ''
       const by: ChoiceBy = body['by'] === 'autopilot' ? 'autopilot' : body['by'] === 'auto' ? 'auto' : 'user'
       if (id && (Array.isArray(pick) || pick)) onChoice(id, pick, by)
+      res.writeHead(202, { 'content-type': 'application/json' })
+      res.end('{"ok":true}')
+    })
+    return
+  }
+  if (url === '/api/start') {
+    // Start a new run from the dashboard (#345). Same guards as /stop: POST-only
+    // so a stray GET can never spawn a run, 404 when no handler is wired (the
+    // per-run dashboard and the relay never start runs). 409 = a run is active.
+    if (req.method !== 'POST') {
+      res.writeHead(405, { 'content-type': 'text/plain', allow: 'POST' })
+      res.end('method not allowed')
+      return
+    }
+    if (!onStart) {
+      res.writeHead(404, { 'content-type': 'text/plain' })
+      res.end('starting not enabled')
+      return
+    }
+    readJsonBody(req, body => {
+      const prompt = typeof body['prompt'] === 'string' ? body['prompt'].trim() : ''
+      if (!prompt) {
+        res.writeHead(400, { 'content-type': 'application/json' })
+        res.end('{"error":"a non-empty prompt is required"}')
+        return
+      }
+      const result = onStart(prompt)
+      if (!result.ok) {
+        res.writeHead(result.busy ? 409 : 500, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ error: result.error }))
+        return
+      }
       res.writeHead(202, { 'content-type': 'application/json' })
       res.end('{"ok":true}')
     })

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -91,7 +91,7 @@ export {
   SESSION_ID_PLACEHOLDER,
   OPEN_LOOP_MODES,
 } from './events.js'
-export { startDashboard, dashboardHtml, type Dashboard, type DashboardOptions } from './dashboard/index.js'
+export { startDashboard, dashboardHtml, type Dashboard, type DashboardOptions, type StartRunResult } from './dashboard/index.js'
 export {
   RunStore,
   nodeStoreFs,


### PR DESCRIPTION
Closes #345. The MVP DX from #331: run `framework`, open the dashboard, type a prompt.

- Prompt textarea + Start button on the daemon dashboard page (Ctrl+Enter submits). Hidden on pages that cannot start runs (per-run dashboard, relay).
- `POST /api/start` on the daemon: spawns `framework "<prompt>" --no-dashboard --cwd <ws>` as a detached child, the same spawn pattern `ensureDaemon` uses. Events stream into the page via the existing tailed event log; gates + Stop steer through the control channel (#344).
- One-run-at-a-time guard (the #322 runaway concern): while the last child is alive, Start returns 409 with the reason. The guard resets when the child exits; a nonzero exit is surfaced as a log line on the page.
- Route guards mirror /stop and /choice: POST-only (405), 404 when no handler is wired, 400 on an empty prompt. Same fork-bomb guard as `ensureDaemon` so a test entry is never re-exec'd as a run.

Verified live end to end: real daemon from the compiled bin, Start spawned a real run whose events streamed into the page, a second Start got 409, the daemon Stop button aborted the run through control.jsonl, and the guard reset after exit.