### PR TITLE
feat(framework): [Research] preset via a direct prompt path (#331)

### DIFF
--- a/.changeset/research-preset-button.md
+++ b/.changeset/research-preset-button.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+The [Research] preset (#331): `framework research [what]` and a [Research] button on the daemon dashboard run Rom's problem-variability review as a direct prompt via the new `runPrompt()` path, which honors await gates (showChoices/showMultiSelect) but skips the scope/architect/build scaffolding. The "what" defaults to `this PR`.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -36,6 +36,16 @@ test('parseArgs reads flags and the intent words', () => {
   assert.equal(opts.intent, 'a blog app')
 })
 
+test('parseArgs reads the research subcommand with its optional what (#331)', () => {
+  const bare = parseArgs(['research'])
+  assert.equal(bare.research, true)
+  assert.equal(bare.intent, '') // the "what" defaults downstream (this PR)
+  const withWhat = parseArgs(['research', 'the', 'auth', 'flow'])
+  assert.equal(withWhat.research, true)
+  assert.equal(withWhat.intent, 'the auth flow')
+  assert.equal(parseArgs(['build', 'a', 'blog']).research, false)
+})
+
 test('parseArgs reads the stop subcommand and the internal --daemon flag', () => {
   const stop = parseArgs(['stop'])
   assert.equal(stop.stop, true)

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -40,6 +40,8 @@ import { preflight } from './preflight.js'
 import { RunStore } from './store/index.js'
 import { daemonStatus, ensureDaemon, runDaemon, stopDaemon, DEFAULT_DAEMON_PORT } from './daemon.js'
 import { resetControl, watchControl, type ControlWatcher } from './control.js'
+import { runPrompt } from './prompt-run.js'
+import { renderResearchPrompt } from './research-preset.js'
 
 /**
  * The default link shown for a live run: the generic Claude Code entry point,
@@ -79,6 +81,9 @@ Usage:
   framework                       Ensure the background dashboard is running; print commands.
   framework [intent...]           Build what you describe, from scratch.
   framework stop                  Stop the background dashboard for this workspace.
+  framework research [what]      Rate the "problem variability" of <what> (default:
+                                 this PR), then pick which problems to deep-dive.
+                                 A direct review prompt on existing code — no build.
   framework --fake                Run the offline demo (no CLI, no model, deterministic).
   framework doctor                Check prerequisites (Claude Code installed, etc.).
   framework relay                 Host a run relay so teammates can watch a run (#230).
@@ -188,6 +193,8 @@ export interface CliOptions {
   daemon: boolean
   /** `framework stop`: stop the background daemon for this workspace. */
   stop: boolean
+  /** `framework research [what]`: run the Research preset as a direct prompt (#331). */
+  research: boolean
   error?: string
 }
 
@@ -212,6 +219,7 @@ export function parseArgs(argv: string[]): CliOptions {
     persist: true,
     daemon: false,
     stop: false,
+    research: false,
   }
   const PERMISSION_MODES: PermissionMode[] = ['default', 'acceptEdits', 'bypassPermissions', 'plan']
   const words: string[] = []
@@ -361,6 +369,9 @@ export function parseArgs(argv: string[]): CliOptions {
   } else if (words[0] === 'stop') {
     opts.stop = true
     words.shift()
+  } else if (words[0] === 'research') {
+    opts.research = true
+    words.shift() // the remaining words are the "what" param (may be empty -> default)
   }
   opts.intent = words.join(' ').trim()
   return opts
@@ -544,7 +555,8 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   const intent = opts.intent || (fake ? FAKE_INTENT : '')
   // Bare `framework` (no prompt): ensure the persistent dashboard is running and
   // print the convenience commands + version (#299/#302). A prompt still builds.
-  if (!intent && !fake) return ensureDaemonCmd(opts, io)
+  // A bare `framework research` is a real run — its "what" defaults to `this PR`.
+  if (!intent && !fake && !opts.research) return ensureDaemonCmd(opts, io)
 
   const cwd = opts.cwd ?? (fake ? join(tmpdir(), 'framework-fake-workspace') : process.cwd())
 
@@ -718,7 +730,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // AI meta-select: with no preset chosen explicitly, infer the best fit (+ modes +
   // build event) from the intent + workspace, then resolve it with the active modes.
   // Narrates through onEvent so the routing turn is visible on the dashboard (#310).
-  if (!fake && opts.autoPreset && !presetName) {
+  if (!fake && opts.autoPreset && !presetName && !opts.research) {
     const selection = await autoSelectPreset({ intent, cwd, signals, claudeOpts, signal: controller.signal, io, onEvent })
     if (selection?.preset) {
       presetName = selection.preset
@@ -746,6 +758,68 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   }
 
   const driver: Driver = fake ? fakeDriver() : new ClaudeCodeDriver(claudeOpts)
+
+  // `framework research [what]` (#331): the direct prompt path — render the
+  // Research preset prompt and run it through runPrompt, which honors its gates
+  // (#337/#339) but skips the scope -> architect -> build scaffolding entirely.
+  // Shares all the wiring above (dashboard, store, control channel, budget).
+  if (opts.research) {
+    const userSystemPrompt = await loadUserSystemPrompt(cwd)
+    if (userSystemPrompt) io.out(`◆ system prompt: ${SYSTEM_PROMPT_FILE}`)
+    if (fileConfig.antiLazyPill === false) io.out('◆ anti-lazy-pill: off (the-framework.yml)')
+    try {
+      await runPrompt({
+        prompt: renderResearchPrompt(intent),
+        driver,
+        cwd,
+        onEvent,
+        signal: controller.signal,
+        ...(dashboard || control
+          ? {
+              requestChoice: (req: ChoiceRequest) =>
+                new Promise<ChoicePick>(resolve => pendingChoices.set(req.id, resolve)),
+            }
+          : {}),
+        ...(opts.model ? { model: opts.model } : {}),
+        ...(opts.maxCost ? { budgetUsd: opts.maxCost } : {}),
+        ...(userSystemPrompt ? { systemPrompt: userSystemPrompt } : {}),
+        ...(fileConfig.antiLazyPill === false ? { antiLazyPill: false } : {}),
+        ...((): { sessionLink?: string } => {
+          const link = chooseSessionLink(opts, fake)
+          return link ? { sessionLink: link } : {}
+        })(),
+      })
+      clearInterrupt()
+      io.out('\n✓ research done: see the REVIEW-PROBLEMS / TODO files it wrote.')
+      await store?.close()
+      if (dashboard) {
+        io.out(`\nDashboard still live at ${dashboard.url}. Press Ctrl+C to exit.`)
+        await waitForInterrupt()
+        await dashboard.close()
+      }
+      return 0
+    } catch (err) {
+      clearInterrupt()
+      await store?.close()
+      if (controller.signal.aborted || stoppedCleanly) {
+        io.out('\n■ Stopped.')
+        if (dashboard) {
+          io.out(`\nDashboard still live at ${dashboard.url}. Press Ctrl+C to exit.`)
+          await waitForInterrupt()
+          await dashboard.close()
+        }
+        return 0
+      }
+      io.err(`\n✗ research failed: ${err instanceof Error ? err.message : String(err)}`)
+      await dashboard?.close()
+      return 1
+    } finally {
+      clearInterrupt()
+      control?.close()
+      if (publisher) await publisher.flush()
+    }
+  }
+
   // The fake demo defaults to a Cloudflare deploy decision so the flow ends with
   // a deploy phase; a live run only narrates deploy when asked.
   const deploy: DeployDecision | undefined = opts.deploy

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -243,6 +243,65 @@ setTimeout(() => {}, 600)
   }
 })
 
+test('POST /api/start kind=research spawns the research subcommand, defaulting the what (#331)', async () => {
+  const cwd = await tmpWorkspace()
+  const stub = join(cwd, 'stub-cli.cjs')
+  await writeFile(
+    stub,
+    `const fs = require('node:fs'), path = require('node:path')
+const args = process.argv.slice(2)
+fs.appendFileSync(path.join(args[args.indexOf('--cwd') + 1], 'started.log'), JSON.stringify(args) + '\\n')
+`,
+  )
+  const ac = new AbortController()
+  try {
+    const done = runDaemon(cwd, { port: 0, pollMs: 50, signal: ac.signal, binPath: stub })
+    let state = await readDaemonState(cwd)
+    for (let i = 0; i < 100 && !state; i++) {
+      await new Promise(r => setTimeout(r, 20))
+      state = await readDaemonState(cwd)
+    }
+    assert.ok(state, 'daemon wrote its state file')
+
+    const post = (body: object) =>
+      fetch(`${state!.url}/api/start`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+
+    // With a what -> it is passed through; without -> omitted so the CLI defaults it.
+    assert.equal((await post({ prompt: 'the auth flow', kind: 'research' })).status, 202)
+    let lines: string[] = []
+    for (let i = 0; i < 100 && lines.length < 1; i++) {
+      await new Promise(r => setTimeout(r, 20))
+      lines = await readFile(join(cwd, 'started.log'), 'utf8').then(
+        s => s.split('\n').filter(Boolean),
+        () => [],
+      )
+    }
+    assert.deepEqual(JSON.parse(lines[0]!), ['research', 'the auth flow', '--no-dashboard', '--cwd', cwd])
+
+    let second = await post({ kind: 'research' })
+    for (let i = 0; i < 100 && second.status !== 202; i++) {
+      await new Promise(r => setTimeout(r, 50))
+      second = await post({ kind: 'research' })
+    }
+    assert.equal(second.status, 202)
+    for (let i = 0; i < 100 && lines.length < 2; i++) {
+      await new Promise(r => setTimeout(r, 20))
+      lines = (await readFile(join(cwd, 'started.log'), 'utf8')).split('\n').filter(Boolean)
+    }
+    assert.deepEqual(JSON.parse(lines[1]!), ['research', '--no-dashboard', '--cwd', cwd])
+
+    ac.abort()
+    await done
+  } finally {
+    ac.abort()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
 test('/api/start refuses to re-exec a test entry as the run (#345)', async () => {
   const cwd = await tmpWorkspace()
   const ac = new AbortController()

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -4,7 +4,7 @@ import { mkdir, readFile, writeFile, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { FrameworkEvent } from './events.js'
 import { EVENTS_FILE, FRAMEWORK_DIR } from './store/index.js'
-import { startDashboard, type Dashboard, type StartRunResult } from './dashboard/index.js'
+import { startDashboard, type Dashboard, type StartRunKind, type StartRunResult } from './dashboard/index.js'
 import { appendControl } from './control.js'
 import { JsonlTailer } from './jsonl-tail.js'
 
@@ -214,7 +214,7 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
   // which the run wires whenever a daemon is live. One run at a time: while the
   // last child is alive, Start is refused (the #322 runaway concern).
   let activeRunPid: number | undefined
-  const startRun = (prompt: string): StartRunResult => {
+  const startRun = (prompt: string, kind: StartRunKind): StartRunResult => {
     if (activeRunPid !== undefined && isProcessAlive(activeRunPid)) {
       return { ok: false, busy: true, error: 'a run is already active; stop it or wait for it to finish' }
     }
@@ -225,7 +225,10 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     if (!opts.binPath && (process.env.NODE_TEST_CONTEXT || /\.test\.[cm]?[jt]s$/.test(binPath))) {
       return { ok: false, error: 'refusing to spawn a run from a test entry; pass an explicit binPath' }
     }
-    const child = spawn(process.execPath, [binPath, prompt, '--no-dashboard', '--cwd', cwd], {
+    // [Research] (#331) runs the research subcommand; its empty prompt is fine
+    // (the "what" defaults to `this PR` in the CLI).
+    const runArgs = kind === 'research' ? ['research', ...(prompt ? [prompt] : [])] : [prompt]
+    const child = spawn(process.execPath, [binPath, ...runArgs, '--no-dashboard', '--cwd', cwd], {
       detached: true,
       stdio: 'ignore',
     })
@@ -241,7 +244,10 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
       if (code) dashboard.push({ kind: 'log', message: `✗ run exited with code ${code}` })
     })
     activeRunPid = child.pid
-    dashboard.push({ kind: 'log', message: `▶ run started: ${prompt}` })
+    dashboard.push({
+      kind: 'log',
+      message: kind === 'research' ? `▶ research started: ${prompt || 'this PR'}` : `▶ run started: ${prompt}`,
+    })
     return { ok: true }
   }
 

--- a/packages/framework/src/dashboard/index.ts
+++ b/packages/framework/src/dashboard/index.ts
@@ -1,2 +1,2 @@
-export { startDashboard, type Dashboard, type DashboardOptions, type StartRunResult } from './server.js'
+export { startDashboard, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunResult } from './server.js'
 export { dashboardHtml } from './page.js'

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -109,6 +109,10 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
     background: #6ea8fe; border: 0; border-radius: 6px; padding: 6px 16px; }
   #start-run:hover { background: #8bbaff; }
   #start-run:disabled { opacity: .5; cursor: default; }
+  #start-research { font: inherit; font-size: 13px; font-weight: 600; cursor: pointer; color: #b7c0d0;
+    background: #141a24; border: 1px solid #24344a; border-radius: 6px; padding: 6px 14px; }
+  #start-research:hover { background: #17212f; }
+  #start-research:disabled { opacity: .5; cursor: default; }
   #start-note { color: #f0a35e; font-size: 12px; }
   /* Interactive plan-approval / choice panel (#304): full-width, accented so it
      reads as the one thing awaiting the human. */
@@ -194,6 +198,7 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
     <textarea id="start-prompt" rows="3" placeholder="What should the agent build?"></textarea>
     <div id="start-actions">
       <button id="start-run">&#9654; Start<span class="kbd">Ctrl+Enter</span></button>
+      <button id="start-research" title="Rate the problem variability of the prompt above (default: this PR), then pick which problems to deep-dive">&#128269; Research</button>
       <span id="start-note"></span>
     </div>
   </section>
@@ -693,29 +698,32 @@ syncNotifyBtn();
 
 // Start a run (#345): POST the prompt to /api/start; the daemon spawns the run
 // and its events stream in over the same SSE feed. A 409 means one is active.
-function startNewRun() {
+// kind 'research' (#331) runs the Research preset on the prompt instead of
+// building it; its empty prompt is fine (the "what" defaults to "this PR").
+function startNewRun(kind) {
   if (!STARTABLE) return;
   const note = $('start-note');
   const prompt = $('start-prompt').value.trim();
-  if (!prompt) { note.textContent = 'type what to build first'; return; }
-  const btn = $('start-run');
-  btn.disabled = true;
+  if (!prompt && kind !== 'research') { note.textContent = 'type what to build first'; return; }
+  const buttons = [$('start-run'), $('start-research')];
+  for (const b of buttons) b.disabled = true;
   note.textContent = 'starting\\u2026';
   fetch('api/start', { method: 'POST', headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ prompt: prompt }) })
+    body: JSON.stringify({ prompt: prompt, kind: kind }) })
     .then(async r => {
-      btn.disabled = false;
+      for (const b of buttons) b.disabled = false;
       if (r.ok) { note.textContent = ''; $('start-prompt').value = ''; showLive(); return; }
       let msg = 'could not start (' + r.status + ')';
       try { const b = await r.json(); if (b && b.error) msg = b.error; } catch {}
       note.textContent = msg;
     })
-    .catch(() => { btn.disabled = false; note.textContent = 'could not reach the dashboard server'; });
+    .catch(() => { for (const b of buttons) b.disabled = false; note.textContent = 'could not reach the dashboard server'; });
 }
-$('start-run').addEventListener('click', startNewRun);
+$('start-run').addEventListener('click', () => startNewRun('build'));
+$('start-research').addEventListener('click', () => startNewRun('research'));
 $('start-prompt').addEventListener('keydown', ev => {
   // stopPropagation so the document-level Ctrl+Enter never accepts a choice too.
-  if ((ev.ctrlKey || ev.metaKey) && ev.key === 'Enter') { ev.preventDefault(); ev.stopPropagation(); startNewRun(); }
+  if ((ev.ctrlKey || ev.metaKey) && ev.key === 'Enter') { ev.preventDefault(); ev.stopPropagation(); startNewRun('build'); }
 });
 
 $('stop').addEventListener('click', stopRun);

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -354,6 +354,32 @@ test('/api/start guards: 400 empty prompt, 409 busy, 500 spawn failure (#345)', 
   }
 })
 
+test('/api/start passes the run kind through; a research start may omit the prompt (#331)', async () => {
+  const calls: Array<{ prompt: string; kind: string }> = []
+  const dash = await startDashboard({ port: 0, onStart: (prompt, kind) => { calls.push({ prompt, kind }); return { ok: true } } })
+  try {
+    // No kind -> build; unknown kind -> build.
+    await postJson(dash.url + '/api/start', { prompt: 'a blog' })
+    await postJson(dash.url + '/api/start', { prompt: 'a blog', kind: 'nonsense' })
+    // Research: kind passes through, and an empty prompt is allowed (defaults to
+    // "this PR" downstream) where a build's would 400.
+    assert.equal((await postJson(dash.url + '/api/start', { prompt: 'the auth flow', kind: 'research' })).status, 202)
+    assert.equal((await postJson(dash.url + '/api/start', { kind: 'research' })).status, 202)
+    assert.deepEqual(calls, [
+      { prompt: 'a blog', kind: 'build' },
+      { prompt: 'a blog', kind: 'build' },
+      { prompt: 'the auth flow', kind: 'research' },
+      { prompt: '', kind: 'research' },
+    ])
+    // The page ships the [Research] button beside Start.
+    const page = await fetchText(dash.url + '/')
+    assert.match(page.body, /id="start-research"/)
+    assert.match(page.body, /startNewRun\('research'\)/)
+  } finally {
+    await dash.close()
+  }
+})
+
 test('/api/start is 405 for a non-POST and 404 when starting is not wired (#345)', async () => {
   const withStart = await startDashboard({ port: 0, onStart: () => ({ ok: true }) })
   try {

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -37,12 +37,19 @@ export interface DashboardOptions {
   cwd?: string
   /**
    * Called when the browser posts a new-run prompt (#345): `POST /api/start`
-   * with a JSON `{ prompt }` body. Wire this to spawn the run (the daemon
-   * does); return `busy: true` to refuse because a run is already active (409).
-   * Omit to disable starting; the page hides the prompt panel.
+   * with a JSON `{ prompt, kind? }` body. Wire this to spawn the run (the
+   * daemon does); return `busy: true` to refuse because a run is already active
+   * (409). Omit to disable starting; the page hides the prompt panel.
    */
-  onStart?: (prompt: string) => StartRunResult
+  onStart?: (prompt: string, kind: StartRunKind) => StartRunResult
 }
+
+/**
+ * What a dashboard Start spawns (#345/#331): `build` is the normal framework
+ * run; `research` is the [Research] preset as a direct prompt, whose empty
+ * prompt is allowed (its "what" defaults to `this PR`).
+ */
+export type StartRunKind = 'build' | 'research'
 
 /** The outcome of an {@link DashboardOptions.onStart} attempt (#345). */
 export type StartRunResult =
@@ -108,7 +115,7 @@ function handle(
   title: string,
   onStop: (() => void) | undefined,
   onChoice: ((id: string, pick: string | string[], by: ChoiceBy) => void) | undefined,
-  onStart: ((prompt: string) => StartRunResult) | undefined,
+  onStart: ((prompt: string, kind: StartRunKind) => StartRunResult) | undefined,
   cwd: string | undefined,
 ): void {
   const url = req.url ?? '/'
@@ -202,12 +209,15 @@ function handle(
     }
     readJsonBody(req, body => {
       const prompt = typeof body['prompt'] === 'string' ? body['prompt'].trim() : ''
-      if (!prompt) {
+      const kind: StartRunKind = body['kind'] === 'research' ? 'research' : 'build'
+      // A research run's "what" defaults server-side (`this PR`), so only a
+      // build needs a prompt.
+      if (!prompt && kind !== 'research') {
         res.writeHead(400, { 'content-type': 'application/json' })
         res.end('{"error":"a non-empty prompt is required"}')
         return
       }
-      const result = onStart(prompt)
+      const result = onStart(prompt, kind)
       if (!result.ok) {
         res.writeHead(result.busy ? 409 : 500, { 'content-type': 'application/json' })
         res.end(JSON.stringify({ error: result.error }))

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -91,7 +91,7 @@ export {
   SESSION_ID_PLACEHOLDER,
   OPEN_LOOP_MODES,
 } from './events.js'
-export { startDashboard, dashboardHtml, type Dashboard, type DashboardOptions, type StartRunResult } from './dashboard/index.js'
+export { startDashboard, dashboardHtml, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunResult } from './dashboard/index.js'
 export {
   RunStore,
   nodeStoreFs,
@@ -182,6 +182,13 @@ export {
   type ControlEntry,
   type ControlWatcher,
 } from './control.js'
+export { runPrompt, type RunPromptOptions, type RunPromptResult } from './prompt-run.js'
+export {
+  renderResearchPrompt,
+  RESEARCH_PRESET_NAME,
+  RESEARCH_PROMPT_TEMPLATE,
+  RESEARCH_PARAMS,
+} from './research-preset.js'
 export {
   fakeDriver,
   FAKE_INTENT,

--- a/packages/framework/src/prompt-run.test.ts
+++ b/packages/framework/src/prompt-run.test.ts
@@ -1,0 +1,156 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { FakeDriver } from './driver/fake.js'
+import type { ChoicePick, ChoiceRequest, FrameworkEvent } from './events.js'
+import { runPrompt } from './prompt-run.js'
+
+const multiGateTurn = [
+  'I rated the problems and wrote REVIEW-PROBLEMS_feat-x.agent.md.',
+  '```await-multiselect',
+  JSON.stringify({
+    title: 'Which problems should get a deep-dive?',
+    options: [
+      { label: 'Auth session refresh', detail: 'rated 2/10', default: true },
+      { label: 'CSV export', detail: 'rated 9/10' },
+    ],
+  }),
+  '```',
+].join('\n')
+
+test('runPrompt runs a gateless prompt straight through and emits session + end', async () => {
+  const events: FrameworkEvent[] = []
+  const driver = new FakeDriver({ turns: [{ text: 'all done' }] })
+  const { text } = await runPrompt({
+    prompt: 'do the thing',
+    driver,
+    cwd: '/ws',
+    onEvent: e => events.push(e),
+  })
+  assert.equal(text, 'all done')
+  assert.equal(events[0]!.kind, 'session')
+  assert.equal(events.at(-1)!.kind, 'end')
+  assert.deepEqual(events.at(-1), { kind: 'end', ok: true })
+  // No gate, so nothing paused.
+  assert.equal(events.some(e => e.kind === 'choice'), false)
+})
+
+test('runPrompt pauses on a multi-select gate and continues with the pick (#331)', async () => {
+  const events: FrameworkEvent[] = []
+  const picks: ChoiceRequest[] = []
+  const requestChoice = (req: ChoiceRequest): Promise<ChoicePick> => {
+    picks.push(req)
+    return Promise.resolve({ picked: ['opt:0'], by: 'user' })
+  }
+
+  const driver = new FakeDriver({ turns: [{ text: multiGateTurn }, { text: 'TODO entries written.' }] })
+  const startSpy = driver.start.bind(driver)
+  let prompts: string[] = []
+  driver.start = async opts => {
+    const s = await startSpy(opts)
+    prompts = s.prompts
+    return s
+  }
+
+  const { text } = await runPrompt({
+    prompt: 'measure problem variability of this PR',
+    driver,
+    cwd: '/ws',
+    onEvent: e => events.push(e),
+    requestChoice,
+  })
+
+  // The gate was shown with the low-rated problem pre-checked, and resolved.
+  assert.equal(picks.length, 1)
+  assert.equal(picks[0]!.multi, true)
+  assert.equal(picks[0]!.id, 'await-multiselect')
+  assert.equal(picks[0]!.options[0]!.default, true)
+  const choice = events.find(e => e.kind === 'choice')
+  assert.ok(choice, 'choice event emitted for the dashboard')
+  const resolved = events.find(e => e.kind === 'choice-resolved')
+  assert.deepEqual(resolved, { kind: 'choice-resolved', id: 'await-multiselect', picked: ['opt:0'], by: 'user' })
+
+  // The driver was re-prompted with the answer and finished on the second turn.
+  assert.equal(prompts.length, 2)
+  assert.match(prompts[1]!, /The user chose: Auth session refresh/)
+  assert.equal(text, 'TODO entries written.')
+  assert.deepEqual(events.at(-1), { kind: 'end', ok: true })
+})
+
+test('a headless runPrompt still resolves the gate to its defaults and continues', async () => {
+  // Unlike a build's agentAwaitGate (which returns as-is headless), the direct
+  // path must complete the prompt's post-gate steps, so it auto-accepts defaults.
+  const events: FrameworkEvent[] = []
+  let prompts: string[] = []
+  const driver = new FakeDriver({ turns: [{ text: multiGateTurn }, { text: 'done' }] })
+  const startSpy = driver.start.bind(driver)
+  driver.start = async opts => {
+    const s = await startSpy(opts)
+    prompts = s.prompts
+    return s
+  }
+  const { text } = await runPrompt({ prompt: 'research', driver, cwd: '/ws', onEvent: e => events.push(e) })
+  assert.equal(prompts.length, 2)
+  assert.match(prompts[1]!, /The user chose: Auth session refresh/) // the default-checked option
+  assert.equal(text, 'done')
+  const resolved = events.find(e => e.kind === 'choice-resolved')
+  assert.deepEqual(resolved, { kind: 'choice-resolved', id: 'await-multiselect', picked: ['opt:0'], by: 'auto' })
+})
+
+test('runPrompt honors a single-select gate with the recommended fallback id scheme', async () => {
+  const singleGateTurn = [
+    'Question first.',
+    '```await-choices',
+    JSON.stringify({ title: 'Proceed how?', options: [{ label: 'Fast' }, { label: 'Careful' }], recommended: 'Careful' }),
+    '```',
+  ].join('\n')
+  const events: FrameworkEvent[] = []
+  const driver = new FakeDriver({ turns: [{ text: singleGateTurn }, { text: 'ok' }] })
+  const requestChoice = (req: ChoiceRequest): Promise<ChoicePick> =>
+    Promise.resolve({ picked: req.recommended ?? '', by: 'user' })
+  const { text } = await runPrompt({ prompt: 'go', driver, cwd: '/ws', onEvent: e => events.push(e), requestChoice })
+  assert.equal(text, 'ok')
+  const resolved = events.find(e => e.kind === 'choice-resolved')
+  assert.deepEqual(resolved, { kind: 'choice-resolved', id: 'await-choices', picked: 'opt:1', by: 'user' })
+})
+
+test('runPrompt stops re-asking after the await limit instead of looping forever', async () => {
+  const events: FrameworkEvent[] = []
+  // Every turn ends on a gate; the run must finish after the bounded rounds.
+  const driver = new FakeDriver({ respond: () => multiGateTurn })
+  const { text } = await runPrompt({ prompt: 'ask forever', driver, cwd: '/ws', onEvent: e => events.push(e) })
+  assert.equal(text, multiGateTurn)
+  const limit = events.find(e => e.kind === 'log' && /await limit reached/.test(e.message))
+  assert.ok(limit, 'the limit is narrated')
+  assert.deepEqual(events.at(-1), { kind: 'end', ok: true })
+  // Rounds after the first get unique gate ids.
+  const ids = events.filter(e => e.kind === 'choice').map(e => (e as { id: string }).id)
+  assert.deepEqual(ids.slice(0, 2), ['await-multiselect', 'await-multiselect-1'])
+})
+
+test('an aborted runPrompt emits a stopped end and rethrows', async () => {
+  const events: FrameworkEvent[] = []
+  const controller = new AbortController()
+  controller.abort()
+  const driver = new FakeDriver({ turns: [{ text: 'never' }] })
+  await assert.rejects(() =>
+    runPrompt({ prompt: 'go', driver, cwd: '/ws', signal: controller.signal, onEvent: e => events.push(e) }),
+  )
+  const end = events.at(-1)
+  assert.equal(end!.kind, 'end')
+  assert.deepEqual(end, { kind: 'end', ok: false, stopped: true, detail: '[framework] fake prompt aborted' })
+})
+
+test('runPrompt stops itself at the budget cap and reports a clean stop (#322)', async () => {
+  const events: FrameworkEvent[] = []
+  const usage = { inputTokens: 10, outputTokens: 10, cacheReadTokens: 0, cacheCreationTokens: 0, costUsd: 1 }
+  // Turn 1 spends past the cap and ends on a gate, so the run tries a turn 2.
+  const driver = new FakeDriver({ turns: [{ text: multiGateTurn, usage }, { text: 'never', usage }] })
+  await assert.rejects(() =>
+    runPrompt({ prompt: 'go', driver, cwd: '/ws', budgetUsd: 0.5, onEvent: e => events.push(e) }),
+  )
+  const end = events.at(-1) as { kind: string; ok: boolean; stopped?: boolean; detail?: string }
+  assert.equal(end.kind, 'end')
+  assert.equal(end.ok, false)
+  assert.equal(end.stopped, true)
+  assert.match(end.detail ?? '', /budget reached/)
+})

--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -1,0 +1,172 @@
+import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
+import { hasSessionIdPlaceholder, resolveSessionLink, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
+import { requestChoices, requestMultiSelect } from './run.js'
+import { systemPromptBlock } from './system-prompt.js'
+import { AWAIT_PROTOCOL, parseAwaitGate } from './turn-gate.js'
+import { UsageMeter } from './usage.js'
+
+/**
+ * The direct prompt path (#331): run *one prompt* through the driver and honor
+ * its await gates — no scope/architect/build scaffolding, no review loop. This
+ * is what a review-shaped preset like [Research] needs: the prompt operates on
+ * existing code, stops at `showChoices()` / `showMultiSelect()` + AWAIT, and
+ * continues from the user's answer. Plumbing, not babysitting — the framework
+ * adds nothing but the gate protocol and the usage/budget accounting.
+ */
+
+/** Options for {@link runPrompt}. */
+export interface RunPromptOptions {
+  /** The fully rendered prompt to run (see e.g. `renderResearchPrompt`). */
+  prompt: string
+  /** The driver wrapping the coding agent. */
+  driver: Driver
+  /** Workspace the agent works in. */
+  cwd: string
+  /** Receives every {@link FrameworkEvent} as it happens (dashboard, terminal, store). */
+  onEvent?: (event: FrameworkEvent) => void
+  /**
+   * The interactive gate handler, exactly as in `RunFrameworkOptions` (#304).
+   * Unlike a build run, a *headless* direct run still resolves each gate to its
+   * defaults and continues — the prompt's post-gate steps must run either way.
+   */
+  requestChoice?: (req: ChoiceRequest) => Promise<ChoicePick>
+  /** Abort to stop the run (Stop button / Ctrl+C / control channel). */
+  signal?: AbortSignal
+  /** Model override passed through to the driver. */
+  model?: string
+  /** A user SYSTEM.md to append to the built-in system prompt (#301). */
+  systemPrompt?: string
+  /** Include the anti-lazy working agreement. Default true (#301). */
+  antiLazyPill?: boolean
+  /** Stop the run once the agent has spent this much, in USD (#322). */
+  budgetUsd?: number
+  /** Session link template for the dashboard, `{sessionId}` resolved when known. */
+  sessionLink?: string
+}
+
+/** What {@link runPrompt} resolves with. */
+export interface RunPromptResult {
+  /** The final turn's text. */
+  text: string
+  /** Every event emitted, in order. */
+  events: FrameworkEvent[]
+}
+
+/** How many times the prompt may stop to ask (and be resumed) before it just finishes. */
+const MAX_AWAIT_ROUNDS = 5
+
+/**
+ * Run one prompt to completion through the driver, pausing on each await gate
+ * (#337/#339) and re-prompting with the user's answer. Emits the same
+ * {@link FrameworkEvent} stream a build run does (`session`, `driver`, `choice`,
+ * `usage`, `end`), so the dashboard, the store, and the control channel (#344)
+ * all work unchanged.
+ */
+export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult> {
+  const events: FrameworkEvent[] = []
+  const emit = (event: FrameworkEvent): void => {
+    events.push(event)
+    opts.onEvent?.(event)
+  }
+
+  // The pill + any user SYSTEM.md frame the session (#301). The await protocol is
+  // always on — honoring the prompt's gates is the whole point of this path.
+  const promptBlock = systemPromptBlock({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt })
+  const system = [...(promptBlock ? [promptBlock] : []), AWAIT_PROTOCOL].join('\n\n')
+
+  const linkTemplate = opts.sessionLink
+  const literalLink = linkTemplate && !hasSessionIdPlaceholder(linkTemplate) ? linkTemplate : undefined
+  emit({
+    kind: 'session',
+    driver: opts.driver.name,
+    workspace: opts.cwd,
+    fake: opts.driver.name === 'fake',
+    ...(literalLink ? { sessionLink: literalLink } : {}),
+  })
+
+  // Usage accounting + the self-stopping budget cap, the same wiring as a build
+  // run (#322): the run signal composes the caller's abort with the budget abort.
+  const budgetController = new AbortController()
+  const runSignal = opts.signal ? AbortSignal.any([opts.signal, budgetController.signal]) : budgetController.signal
+  let lastSessionId: string | undefined
+  const usage = new UsageMeter()
+  const onDriverEvent = (event: DriverEvent): void => {
+    emit({ kind: 'driver', event })
+    if (event.type !== 'result') return
+    if (event.sessionId && event.sessionId !== lastSessionId) {
+      lastSessionId = event.sessionId
+      const link = linkTemplate ? resolveSessionLink(linkTemplate, event.sessionId) : undefined
+      emit({ kind: 'session-update', sessionId: event.sessionId, ...(link ? { sessionLink: link } : {}) })
+    }
+    if (!event.usage) return
+    usage.add(event.usage)
+    const totals = usage.totals()
+    emit({ kind: 'usage', ...totals, ...(opts.budgetUsd != null ? { budgetUsd: opts.budgetUsd } : {}) })
+    if (opts.budgetUsd != null && totals.costUsd >= opts.budgetUsd && !budgetController.signal.aborted) {
+      emit({ kind: 'log', message: `Budget reached: $${totals.costUsd.toFixed(4)} of $${opts.budgetUsd} — stopping the run.` })
+      budgetController.abort(new Error('[framework] budget reached'))
+    }
+  }
+
+  const session: DriverSession = await opts.driver.start({
+    cwd: opts.cwd,
+    system,
+    ...(opts.model ? { model: opts.model } : {}),
+    signal: runSignal,
+    onEvent: onDriverEvent,
+  })
+
+  try {
+    let turn = await session.prompt(opts.prompt, { signal: runSignal })
+    let gate = parseAwaitGate(turn.text)
+    for (let round = 0; round < MAX_AWAIT_ROUNDS && gate; round++) {
+      // Round 0 keeps a stable id; later rounds get a unique one so a dashboard never
+      // confuses a re-ask with the answer it just resolved (same scheme as #337).
+      const baseId = gate.kind === 'multi' ? 'await-multiselect' : 'await-choices'
+      const id = round === 0 ? baseId : `${baseId}-${round}`
+      let answer: string
+      if (gate.kind === 'multi') {
+        const picked = await requestMultiSelect({
+          id,
+          title: gate.title,
+          options: gate.options,
+          ...(opts.requestChoice ? { requestChoice: opts.requestChoice } : {}),
+          emit,
+          signal: runSignal,
+        })
+        const labels = gate.options.filter(o => picked.includes(o.id)).map(o => o.label)
+        answer = labels.length ? labels.join(', ') : '(none)'
+      } else {
+        const pickedId = await requestChoices({
+          id,
+          title: gate.title,
+          options: gate.options,
+          ...(gate.recommended ? { recommended: gate.recommended } : {}),
+          ...(opts.requestChoice ? { requestChoice: opts.requestChoice } : {}),
+          emit,
+          signal: runSignal,
+        })
+        answer = gate.options.find(o => o.id === pickedId)?.label ?? pickedId
+      }
+      emit({ kind: 'log', message: `Continuing with your choice: ${answer}` })
+      turn = await session.prompt(
+        `You paused to ask: "${gate.title}". The user chose: ${answer}. Continue with that decision, and do not ask again unless a genuinely new choice comes up.`,
+        { signal: runSignal },
+      )
+      gate = parseAwaitGate(turn.text)
+    }
+    // The agent kept asking past the limit: finish with the latest turn rather than loop.
+    if (gate) emit({ kind: 'log', message: 'Finishing the run (await limit reached).' })
+    emit({ kind: 'end', ok: true })
+    return { text: turn.text, events }
+  } catch (err) {
+    // A user interrupt or the budget cap is a clean stop, not a failure (#322).
+    const budgetStopped = budgetController.signal.aborted && opts.signal?.aborted !== true
+    const stopped = opts.signal?.aborted === true || budgetController.signal.aborted
+    const detail = budgetStopped ? `budget reached ($${opts.budgetUsd})` : err instanceof Error ? err.message : String(err)
+    emit({ kind: 'end', ok: false, ...(stopped ? { stopped: true } : {}), detail })
+    throw err
+  } finally {
+    await session.dispose()
+  }
+}

--- a/packages/framework/src/research-preset.test.ts
+++ b/packages/framework/src/research-preset.test.ts
@@ -1,0 +1,26 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { PARAM_PATTERN } from './preset-params.js'
+import { renderResearchPrompt, RESEARCH_PARAMS, RESEARCH_PROMPT_TEMPLATE } from './research-preset.js'
+
+test('the Research template carries the #331 flow: rating, multi-select gate, TODO entries', () => {
+  assert.match(RESEARCH_PROMPT_TEMPLATE, /problem variability/)
+  assert.match(RESEARCH_PROMPT_TEMPLATE, /showMultiSelect\(\)/)
+  assert.match(RESEARCH_PROMPT_TEMPLATE, /<AWAIT>/)
+  assert.match(RESEARCH_PROMPT_TEMPLATE, /<REVIEW_FILE>/)
+  assert.match(RESEARCH_PROMPT_TEMPLATE, /<TODO_FILE>/)
+  // The one user blank, declared with its default.
+  assert.match(RESEARCH_PROMPT_TEMPLATE, /<PARAM:what>/)
+  assert.deepEqual(RESEARCH_PARAMS.map(p => p.name), ['what'])
+})
+
+test('renderResearchPrompt defaults the blank to "this PR" and takes an override', () => {
+  const byDefault = renderResearchPrompt()
+  assert.match(byDefault, /problem variability" of this PR/)
+  const blank = renderResearchPrompt('   ')
+  assert.match(blank, /problem variability" of this PR/) // blank falls back, not erased
+  const custom = renderResearchPrompt('the auth flow')
+  assert.match(custom, /problem variability" of the auth flow/)
+  // No raw placeholder survives a render.
+  assert.equal(PARAM_PATTERN.test(custom), false)
+})

--- a/packages/framework/src/research-preset.ts
+++ b/packages/framework/src/research-preset.ts
@@ -1,0 +1,46 @@
+import { renderPresetPrompt, type PresetParam } from './preset-params.js'
+
+/**
+ * The [Research] preset (#331): Rom's problem-variability review, shipped as a
+ * direct prompt (see `runPrompt`) rather than a build run — research reviews
+ * existing code, so it skips the scope -> architect -> build scaffolding. The
+ * `<PARAM:what>` placeholder is the user-facing blank (#330); the CAPS tokens
+ * (`<AWAIT>`, `<REVIEW_FILE>`, …) are agent-facing macros defined at the bottom
+ * of the prompt itself, and `showMultiSelect()` + `<AWAIT>` becomes a live
+ * turn-boundary gate (#339/#340) the dashboard resolves.
+ */
+
+/** The preset's name, as the CLI subcommand and the dashboard button use it. */
+export const RESEARCH_PRESET_NAME = 'research'
+
+/** The one user param: what to measure. Defaults to `this PR`, per the issue. */
+export const RESEARCH_PARAMS: readonly PresetParam[] = [
+  { name: 'what', default: 'this PR', description: 'What to measure problem variability of' },
+]
+
+/** The prompt template, verbatim from #331 (with `<PARAM:what>` as the blank). */
+export const RESEARCH_PROMPT_TEMPLATE = `Measure "problem variability" of <PARAM:what>
+- List all high-level flows the code implements, i.e. the list of all "problems" the code solves
+- Give a rating for each problem (from 0 to 10) following this criteria: does the code solves the problem in an obviously optimal way (10), or is it highly unclear whether the problem can be solved in a better way (0)?
+- Write down the ratings in a new file <REVIEW_FILE>
+- Show the list to the user and enable him to select problems via \`showMultiSelect()\`, <AWAIT>
+  - Set default to \`true\` for entries with low rating
+- For all problems the user selected, add a new entry to <TODO_FILE>
+  - The entry: "Deep-dive research for alternative solutions, see <REVIEW_FILE>"
+
+AWAIT: Stop, await user answer before resuming
+REVIEW_FILE: \`REVIEW-PROBLEMS_<SESSION_NAME>.agent.md\`
+TODO_FILE: \`TODO_<SESSION_NAME>.agent.md\`
+SESSION_NAME: the name of the current Git branch — sanitize it to be a SLUG, if name is generic (e.g. \`main\`) then create a succinct SLUG`
+
+/**
+ * Render the Research prompt for a target. A blank / omitted `what` falls back
+ * to the declared default (`this PR`), so the dashboard button and a bare
+ * `framework research` both run with zero input.
+ */
+export function renderResearchPrompt(what?: string): string {
+  return renderPresetPrompt(RESEARCH_PROMPT_TEMPLATE, {
+    params: RESEARCH_PARAMS,
+    values: { what },
+  })
+}


### PR DESCRIPTION
Closes #331. Stacked on #351 (needs /api/start); merge that first, then this.

- `runPrompt()`: the thin direct path — run one prompt through the driver, honor its await gates (#337/#339), skip the scope/architect/build scaffolding. Emits the same event stream a build run does, so the dashboard, store, and control channel (#344) work unchanged. One deliberate difference from a build run: a headless direct run still resolves gates to their defaults and continues, because the prompt's post-gate steps (writing the TODO entries) must run either way.
- Research preset: your prompt text from this issue, verbatim, with `<PARAM:what>` as the one blank (#330) defaulting to `this PR`.
- `framework research [what]`: the CLI entry. Shares all the run wiring (dashboard, persistence, control channel, budget cap).
- [Research] button on the daemon dashboard: POSTs `kind: "research"` to /api/start; an empty textarea is fine (defaults to `this PR`). One-run-at-a-time guard applies.

Verified live: the button spawned `framework research`, the rendered problem-variability prompt reached the agent with no scaffold steps, its multi-select gate machinery is the merged #340 path, and the daemon Stop aborted it through control.jsonl.