### PR TITLE
feat(framework): backlog loop consumes the agent's TODO file (#323)

### DIFF
--- a/.changeset/todo-backlog-loop.md
+++ b/.changeset/todo-backlog-loop.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+The backlog loop (#323): after the build settles, the run consumes the agent's own TODO backlog (`TODO_<slug>.agent.md`, or the flat `TODO.md`) one entry per turn until it is empty. When a dashboard can answer, the loop gates before each entry ("start the next item?"), so autopilot consumes the backlog unattended and autopilot-off pauses per item. Caps make it safe overnight: the budget/Stop signal ends any turn, `--max-todo-items` bounds the run (default 25), and two no-progress items stop the loop. `--no-todo-loop` opts out.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -36,6 +36,15 @@ test('parseArgs reads flags and the intent words', () => {
   assert.equal(opts.intent, 'a blog app')
 })
 
+test('parseArgs reads the backlog-loop flags (#323)', () => {
+  const dflt = parseArgs(['x'])
+  assert.equal(dflt.todoLoop, true)
+  assert.equal(dflt.todoMaxItems, undefined)
+  assert.equal(parseArgs(['--no-todo-loop', 'x']).todoLoop, false)
+  assert.equal(parseArgs(['--max-todo-items', '5', 'x']).todoMaxItems, 5)
+  assert.match(parseArgs(['--max-todo-items', '0', 'x']).error!, /max-todo-items/)
+})
+
 test('parseArgs reads the research subcommand with its optional what (#331)', () => {
   const bare = parseArgs(['research'])
   assert.equal(bare.research, true)

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -113,6 +113,10 @@ Options:
                          auto-activate either way (default: off, hand-rolled + Prisma).
   --max-passes <n>       Full-fledged loop pass budget (default: 5).
   --max-cost <usd>       Stop the run once it has spent this much (USD).
+  --no-todo-loop         Do not consume the agent's TODO backlog after the build
+                         (the loop is on by default; it gates per item on the
+                         dashboard and stops when the backlog is empty).
+  --max-todo-items <n>   Backlog entries worked per run (default: 25).
   --permission-mode <mode>   Claude Code permission mode: default | acceptEdits |
                              bypassPermissions | plan (default: bypassPermissions,
                              so the headless loop can run installs/builds/tests).
@@ -169,6 +173,8 @@ export interface CliOptions {
   buildEvent?: string | undefined
   maxPasses?: number
   maxCost?: number
+  todoLoop: boolean
+  todoMaxItems?: number
   deploy?: string | undefined
   cfProject?: string | undefined
   dokployUrl?: string | undefined
@@ -220,6 +226,7 @@ export function parseArgs(argv: string[]): CliOptions {
     daemon: false,
     stop: false,
     research: false,
+    todoLoop: true,
   }
   const PERMISSION_MODES: PermissionMode[] = ['default', 'acceptEdits', 'bypassPermissions', 'plan']
   const words: string[] = []
@@ -346,6 +353,15 @@ export function parseArgs(argv: string[]): CliOptions {
         const n = Number(argv[++i])
         if (!Number.isFinite(n) || n <= 0) opts.error = `invalid --max-cost: must be a positive number (USD)`
         else opts.maxCost = n
+        break
+      }
+      case '--no-todo-loop':
+        opts.todoLoop = false
+        break
+      case '--max-todo-items': {
+        const n = Number(argv[++i])
+        if (!Number.isInteger(n) || n < 1) opts.error = `invalid --max-todo-items: must be a positive integer`
+        else opts.todoMaxItems = n
         break
       }
       case '--port': {
@@ -897,6 +913,8 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     ...(opts.model ? { model: opts.model } : {}),
     ...(opts.maxPasses ? { maxPasses: opts.maxPasses } : {}),
     ...(opts.maxCost ? { budgetUsd: opts.maxCost } : {}),
+    ...(opts.todoLoop ? {} : { todoLoop: false }),
+    ...(opts.todoMaxItems ? { todoMaxItems: opts.todoMaxItems } : {}),
     ...(deploy ? { deploy } : {}),
     ...(deployTarget ? { deployTarget } : {}),
     ...(serve ? { serve } : {}),

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -54,6 +54,7 @@ export {
   runFramework,
   requestChoices,
   requestMultiSelect,
+  resolveAwaitGate,
   type RunFrameworkOptions,
   type RunFrameworkResult,
   type DeployDecision,
@@ -183,6 +184,18 @@ export {
   type ControlWatcher,
 } from './control.js'
 export { runPrompt, type RunPromptOptions, type RunPromptResult } from './prompt-run.js'
+export {
+  runTodoLoop,
+  findTodoBacklog,
+  parseTodoEntries,
+  TODO_FILE_PATTERN,
+  FLAT_TODO_FILE,
+  DEFAULT_MAX_TODO_ITEMS,
+  type TodoBacklog,
+  type TodoLoopOptions,
+  type TodoLoopResult,
+  type TodoLoopReason,
+} from './todo-loop.js'
 export {
   renderResearchPrompt,
   RESEARCH_PRESET_NAME,

--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -1,6 +1,6 @@
 import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { hasSessionIdPlaceholder, resolveSessionLink, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
-import { requestChoices, requestMultiSelect } from './run.js'
+import { resolveAwaitGate } from './run.js'
 import { systemPromptBlock } from './system-prompt.js'
 import { AWAIT_PROTOCOL, parseAwaitGate } from './turn-gate.js'
 import { UsageMeter } from './usage.js'
@@ -120,34 +120,7 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
     let turn = await session.prompt(opts.prompt, { signal: runSignal })
     let gate = parseAwaitGate(turn.text)
     for (let round = 0; round < MAX_AWAIT_ROUNDS && gate; round++) {
-      // Round 0 keeps a stable id; later rounds get a unique one so a dashboard never
-      // confuses a re-ask with the answer it just resolved (same scheme as #337).
-      const baseId = gate.kind === 'multi' ? 'await-multiselect' : 'await-choices'
-      const id = round === 0 ? baseId : `${baseId}-${round}`
-      let answer: string
-      if (gate.kind === 'multi') {
-        const picked = await requestMultiSelect({
-          id,
-          title: gate.title,
-          options: gate.options,
-          ...(opts.requestChoice ? { requestChoice: opts.requestChoice } : {}),
-          emit,
-          signal: runSignal,
-        })
-        const labels = gate.options.filter(o => picked.includes(o.id)).map(o => o.label)
-        answer = labels.length ? labels.join(', ') : '(none)'
-      } else {
-        const pickedId = await requestChoices({
-          id,
-          title: gate.title,
-          options: gate.options,
-          ...(gate.recommended ? { recommended: gate.recommended } : {}),
-          ...(opts.requestChoice ? { requestChoice: opts.requestChoice } : {}),
-          emit,
-          signal: runSignal,
-        })
-        answer = gate.options.find(o => o.id === pickedId)?.label ?? pickedId
-      }
+      const answer = await resolveAwaitGate(gate, round, { requestChoice: opts.requestChoice, emit, signal: runSignal })
       emit({ kind: 'log', message: `Continuing with your choice: ${answer}` })
       turn = await session.prompt(
         `You paused to ask: "${gate.title}". The user chose: ${answer}. Continue with that decision, and do not ask again unless a genuinely new choice comes up.`,

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -888,3 +888,45 @@ test('requestChoices resolves to the recommended option if the run aborts while 
   })
   assert.equal(picked, 'b') // fell back to the recommended option, not a hang
 })
+
+test('a fake run skips the backlog loop by default; the demo stays deterministic (#323)', async () => {
+  const events: FrameworkEvent[] = []
+  const result = await runFramework({
+    intent: FAKE_INTENT,
+    driver: fakeDriver(),
+    cwd: '/tmp/ws',
+    signals: FAKE_SIGNALS,
+    onEvent: e => events.push(e),
+  })
+  assert.equal(result.todo, undefined)
+  assert.equal(events.some(e => e.kind === 'log' && /Backlog/.test(e.message)), false)
+})
+
+test('runFramework runs the backlog loop after the build when opted in (#323)', async () => {
+  const { mkdtemp, rm, writeFile } = await import('node:fs/promises')
+  const { tmpdir } = await import('node:os')
+  const { join } = await import('node:path')
+  const cwd = await mkdtemp(join(tmpdir(), 'framework-run-todo-'))
+  await writeFile(join(cwd, 'TODO.md'), '- [ ] leftover task\n')
+  try {
+    const events: FrameworkEvent[] = []
+    // The fake script never edits the backlog, so the loop stall-stops after two
+    // attempts — proving the wiring runs post-build with the run's own session.
+    const result = await runFramework({
+      intent: FAKE_INTENT,
+      driver: fakeDriver(),
+      cwd,
+      signals: FAKE_SIGNALS,
+      todoLoop: true,
+      onEvent: e => events.push(e),
+    })
+    assert.deepEqual(result.todo, { completed: 2, reason: 'stalled', file: 'TODO.md' })
+    assert.ok(events.some(e => e.kind === 'log' && /Backlog: TODO\.md has 1 open item\(s\)/.test(e.message)))
+    // The loop runs before the run's end event.
+    const endIndex = events.findIndex(e => e.kind === 'end')
+    const stallIndex = events.findIndex(e => e.kind === 'log' && /no progress/.test(e.message))
+    assert.ok(stallIndex !== -1 && stallIndex < endIndex)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -38,7 +38,10 @@ import { snapshotWorkspace } from './sandbox.js'
 import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { memoryFraming, type LoadedMemory } from './memory.js'
 import { systemPromptBlock } from './system-prompt.js'
-import { AWAIT_PROTOCOL, parseAwaitGate } from './turn-gate.js'
+import { AWAIT_PROTOCOL, parseAwaitGate, type ParsedAwaitGate } from './turn-gate.js'
+// Value import from todo-loop.js is a benign cycle: todo-loop.js only calls
+// run.js's hoisted function declarations (requestChoices / resolveAwaitGate).
+import { runTodoLoop, type TodoLoopResult } from './todo-loop.js'
 import { continueAfterChoice, decideDeploy, deployWith, domainLoopChecklist, driverArchitect, driverBuild, driverChecklist, driverImprove, driverLoopPrompts, reArchitect } from './steps.js'
 import { hasSessionIdPlaceholder, OPEN_LOOP_MODES, pickedIds, resolveSessionLink, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 import { UsageMeter } from './usage.js'
@@ -212,6 +215,16 @@ export interface RunFrameworkOptions {
    * account's usage *limit* is not retrievable under subscription auth.
    */
   budgetUsd?: number
+  /**
+   * Run the backlog loop (#323) after the build settles: consume the agent's own
+   * `TODO_<slug>.agent.md` / `TODO.md` one entry per turn until empty, gating
+   * before each entry when {@link requestChoice} is wired. Default: on for real
+   * drivers, off for the fake one (its scripted demo writes no backlog and must
+   * stay deterministic). Set explicitly to force either way.
+   */
+  todoLoop?: boolean
+  /** Per-run cap on backlog entries worked (#323). Default 25. */
+  todoMaxItems?: number
   /** Observe the unified event stream. */
   onEvent?: (event: FrameworkEvent) => void
 }
@@ -250,6 +263,8 @@ export interface RunFrameworkResult {
    * `major-change` event through it, so its chain replaces the built-in checklist.
    */
   loop?: LoopEngine
+  /** How the backlog loop (#323) ended, when it ran. */
+  todo?: TodoLoopResult
 }
 
 /**
@@ -496,6 +511,22 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
       },
     })
     const result = await bootstrap.run()
+    // The backlog loop (#323): with the build settled, consume the agent's own
+    // TODO backlog one gated entry per turn until it is empty. Default on for
+    // real drivers (the fake demo writes no backlog and must stay deterministic;
+    // its reused tmp workspace could also carry stale files). The run signal
+    // (Stop / budget cap #322) and the item cap bound it for unattended runs.
+    let todo: TodoLoopResult | undefined
+    if (opts.todoLoop ?? opts.driver.name !== 'fake') {
+      todo = await runTodoLoop({
+        session,
+        cwd: opts.cwd,
+        emit,
+        requestChoice: opts.requestChoice,
+        signal: runSignal,
+        maxItems: opts.todoMaxItems,
+      })
+    }
     // The serve gate boots the app only to check it, then stops it. When the
     // caller opts in (keepAlive), boot it once more after success and leave it up
     // so the user can open it; the caller owns tearing it down (Ctrl+C). Failure
@@ -503,7 +534,7 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     // process a caller that ignores `preview` would never stop.
     if (runner && s?.keepAlive) preview = await startAppPreview(runner, s, emit)
     emit({ kind: 'end', ok: true })
-    return { result, detection, events, ledger, ...(preview ? { preview } : {}), ...(loop ? { loop } : {}) }
+    return { result, detection, events, ledger, ...(preview ? { preview } : {}), ...(loop ? { loop } : {}), ...(todo ? { todo } : {}) }
   } catch (err) {
     // A user interrupt (the dashboard Stop button / Ctrl+C) or a budget cap (#322)
     // is a clean stop, not a failure — mark it so surfaces show "stopped". Budget is
@@ -615,34 +646,13 @@ function agentAwaitGate(
 ): (ctx: BuildContext) => Promise<SupervisorRun> {
   return async ctx => {
     const { requestChoice, emit } = deps
-    const signalOpt = deps.signal ? { signal: deps.signal } : {}
     let run = await base(ctx)
     if (!requestChoice) return run
 
     for (let round = 0; round < MAX_AWAIT_ROUNDS; round++) {
       const gate = parseAwaitGate(run.text)
       if (!gate) return run // the agent finished instead of asking — the common case
-      // Round 0 keeps a stable id; later rounds get a unique one so a dashboard never
-      // confuses a re-ask with the answer it just resolved.
-      const base = gate.kind === 'multi' ? 'await-multiselect' : 'await-choices'
-      const id = round === 0 ? base : `${base}-${round}`
-      let answer: string
-      if (gate.kind === 'multi') {
-        const picked = await requestMultiSelect({ id, title: gate.title, options: gate.options, requestChoice, emit, ...signalOpt })
-        const labels = gate.options.filter(o => picked.includes(o.id)).map(o => o.label)
-        answer = labels.length ? labels.join(', ') : '(none)'
-      } else {
-        const pickedId = await requestChoices({
-          id,
-          title: gate.title,
-          options: gate.options,
-          ...(gate.recommended ? { recommended: gate.recommended } : {}),
-          requestChoice,
-          emit,
-          ...signalOpt,
-        })
-        answer = gate.options.find(o => o.id === pickedId)?.label ?? pickedId
-      }
+      const answer = await resolveAwaitGate(gate, round, deps)
       emit({ kind: 'log', message: `Continuing with your choice: ${answer}` })
       run = await continueAfterChoice(session, ctx, gate.title, answer)
     }
@@ -650,6 +660,44 @@ function agentAwaitGate(
     emit({ kind: 'log', message: 'Proceeding with the build (await limit reached).' })
     return run
   }
+}
+
+/**
+ * Resolve one parsed await gate (#337/#339) to the user's answer text, ready to
+ * seed the continuation prompt: emits the `choice`, parks for the pick (or the
+ * headless/abort fallback), and maps the picked id(s) back to label(s). Round 0
+ * keeps a stable gate id; later rounds get a unique one so a dashboard never
+ * confuses a re-ask with the answer it just resolved. Shared by the build's
+ * {@link agentAwaitGate}, the direct prompt path, and the backlog loop (#323).
+ */
+export async function resolveAwaitGate(
+  gate: ParsedAwaitGate,
+  round: number,
+  deps: {
+    requestChoice?: ((req: ChoiceRequest) => Promise<ChoicePick>) | undefined
+    emit: (event: FrameworkEvent) => void
+    signal?: AbortSignal | undefined
+  },
+): Promise<string> {
+  const signalOpt = deps.signal ? { signal: deps.signal } : {}
+  const choiceOpt = deps.requestChoice ? { requestChoice: deps.requestChoice } : {}
+  const baseId = gate.kind === 'multi' ? 'await-multiselect' : 'await-choices'
+  const id = round === 0 ? baseId : `${baseId}-${round}`
+  if (gate.kind === 'multi') {
+    const picked = await requestMultiSelect({ id, title: gate.title, options: gate.options, emit: deps.emit, ...choiceOpt, ...signalOpt })
+    const labels = gate.options.filter(o => picked.includes(o.id)).map(o => o.label)
+    return labels.length ? labels.join(', ') : '(none)'
+  }
+  const pickedId = await requestChoices({
+    id,
+    title: gate.title,
+    options: gate.options,
+    ...(gate.recommended ? { recommended: gate.recommended } : {}),
+    emit: deps.emit,
+    ...choiceOpt,
+    ...signalOpt,
+  })
+  return gate.options.find(o => o.id === pickedId)?.label ?? pickedId
 }
 
 /** The recommended fallback pick when a single-select gate cannot get a real answer. */

--- a/packages/framework/src/todo-loop.test.ts
+++ b/packages/framework/src/todo-loop.test.ts
@@ -1,0 +1,251 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { writeFileSync } from 'node:fs'
+import { mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { FakeDriver } from './driver/fake.js'
+import type { ChoicePick, ChoiceRequest, FrameworkEvent } from './events.js'
+import { findTodoBacklog, parseTodoEntries, runTodoLoop } from './todo-loop.js'
+
+async function tmpWorkspace(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'framework-todo-'))
+}
+
+test('parseTodoEntries reads open list items and skips checked/blank/prose lines', () => {
+  const md = [
+    '# Backlog',
+    '',
+    'Some prose about the backlog.',
+    '- [ ] fix the login redirect',
+    '- [x] already done',
+    '- [X] also done',
+    '- plain bullet entry',
+    '* star bullet entry',
+    '2. numbered entry',
+    '- [ ]   ', // open checkbox with no text
+    '-    ', // empty bullet
+  ].join('\n')
+  assert.deepEqual(parseTodoEntries(md), [
+    'fix the login redirect',
+    'plain bullet entry',
+    'star bullet entry',
+    'numbered entry',
+  ])
+})
+
+test('findTodoBacklog prefers the newest session-scoped file, falls back to flat TODO.md', async () => {
+  const cwd = await tmpWorkspace()
+  try {
+    assert.equal(await findTodoBacklog(cwd), undefined) // nothing yet
+
+    await writeFile(join(cwd, 'TODO.md'), '- flat entry\n')
+    assert.equal((await findTodoBacklog(cwd))?.name, 'TODO.md')
+
+    // A session-scoped backlog wins over the flat one.
+    await writeFile(join(cwd, 'TODO_feat-x.agent.md'), '- [ ] scoped entry\n')
+    assert.deepEqual(await findTodoBacklog(cwd), { name: 'TODO_feat-x.agent.md', entries: ['scoped entry'] })
+
+    // Two sessions: the most recently modified wins.
+    await writeFile(join(cwd, 'TODO_feat-y.agent.md'), '- newer entry\n')
+    const past = new Date(Date.now() - 60_000)
+    await utimes(join(cwd, 'TODO_feat-x.agent.md'), past, past)
+    assert.equal((await findTodoBacklog(cwd))?.name, 'TODO_feat-y.agent.md')
+
+    // A fully checked-off scoped backlog is skipped in favor of the next candidate.
+    await writeFile(join(cwd, 'TODO_feat-y.agent.md'), '- [x] all done\n')
+    await writeFile(join(cwd, 'TODO_feat-x.agent.md'), '- [x] all done\n')
+    assert.equal((await findTodoBacklog(cwd))?.name, 'TODO.md')
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('runTodoLoop works the backlog to empty, one entry per turn (#323)', async () => {
+  const cwd = await tmpWorkspace()
+  const file = join(cwd, 'TODO_feat-x.agent.md')
+  await writeFile(file, '- [ ] first task\n- [ ] second task\n')
+  try {
+    const events: FrameworkEvent[] = []
+    const prompts: string[] = []
+    // The fake driver writes no files, so the test plays the agent's side: each
+    // item turn checks its entry off before the loop re-reads the backlog.
+    const driver = new FakeDriver({
+      respond: (prompt, i) => {
+        prompts.push(prompt)
+        writeFileSync(file, i === 0 ? '- [x] first task\n- [ ] second task\n' : '- [x] first task\n- [x] second task\n')
+        return `completed item ${i + 1}`
+      },
+    })
+    const session = await driver.start({ cwd })
+    const result = await runTodoLoop({ session, cwd, emit: e => events.push(e) })
+
+    assert.deepEqual(result, { completed: 2, reason: 'empty', file: 'TODO_feat-x.agent.md' })
+    assert.equal(prompts.length, 2)
+    assert.match(prompts[0]!, /TODO_feat-x\.agent\.md/)
+    assert.match(prompts[0]!, /FIRST open entry only/)
+    // Narrated: the opening count, each item, and the completion line.
+    assert.ok(events.some(e => e.kind === 'log' && /has 2 open item\(s\)/.test(e.message)))
+    assert.ok(events.some(e => e.kind === 'log' && /Backlog item 1: first task/.test(e.message)))
+    assert.ok(events.some(e => e.kind === 'log' && /Backlog item 2: second task/.test(e.message)))
+    assert.ok(events.some(e => e.kind === 'log' && /Backlog done/.test(e.message)))
+    // Headless: no per-item gate events.
+    assert.equal(events.some(e => e.kind === 'choice'), false)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('runTodoLoop returns empty without a backlog and emits nothing', async () => {
+  const cwd = await tmpWorkspace()
+  try {
+    const events: FrameworkEvent[] = []
+    const session = await new FakeDriver({ turns: [{ text: 'never prompted' }] }).start({ cwd })
+    const result = await runTodoLoop({ session, cwd, emit: e => events.push(e) })
+    assert.deepEqual(result, { completed: 0, reason: 'empty' })
+    assert.deepEqual(events, [])
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('an interactive loop gates before each entry; picking stop ends it (#323)', async () => {
+  const cwd = await tmpWorkspace()
+  const file = join(cwd, 'TODO.md')
+  await writeFile(file, '- [ ] task a\n- [ ] task b\n')
+  try {
+    const events: FrameworkEvent[] = []
+    const gates: ChoiceRequest[] = []
+    // Accept the first gate, stop at the second.
+    const requestChoice = (req: ChoiceRequest): Promise<ChoicePick> => {
+      gates.push(req)
+      return Promise.resolve({ picked: gates.length === 1 ? 'proceed' : 'stop', by: 'user' })
+    }
+    const driver = new FakeDriver({
+      respond: () => {
+        writeFileSync(file, '- [x] task a\n- [ ] task b\n')
+        return 'did task a'
+      },
+    })
+    const session = await driver.start({ cwd })
+    const result = await runTodoLoop({ session, cwd, emit: e => events.push(e), requestChoice })
+
+    assert.deepEqual(result, { completed: 1, reason: 'stopped', file: 'TODO.md' })
+    assert.equal(gates.length, 2)
+    assert.equal(gates[0]!.id, 'todo-next')
+    assert.equal(gates[1]!.id, 'todo-next-1')
+    assert.match(gates[0]!.options[0]!.label, /Work on: task a/)
+    assert.equal(gates[0]!.recommended, 'proceed')
+    assert.ok(events.some(e => e.kind === 'log' && /stopped by you/.test(e.message)))
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('runTodoLoop stops after two items with no progress instead of spinning', async () => {
+  const cwd = await tmpWorkspace()
+  await writeFile(join(cwd, 'TODO.md'), '- [ ] stubborn task\n')
+  try {
+    const events: FrameworkEvent[] = []
+    // The agent never touches the file, so the next entry never changes.
+    const session = await new FakeDriver({ respond: () => 'did nothing' }).start({ cwd })
+    const result = await runTodoLoop({ session, cwd, emit: e => events.push(e) })
+    assert.deepEqual(result, { completed: 2, reason: 'stalled', file: 'TODO.md' })
+    assert.ok(events.some(e => e.kind === 'log' && /no progress on "stubborn task"/.test(e.message)))
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('appended follow-up entries do not count as a stall (Maintenance pattern)', async () => {
+  const cwd = await tmpWorkspace()
+  const file = join(cwd, 'TODO.md')
+  await writeFile(file, '- [ ] task a\n')
+  try {
+    let turn = 0
+    // Turn 1 retires task a but appends a follow-up; turn 2 retires the follow-up.
+    const session = await new FakeDriver({
+      respond: () => {
+        turn++
+        writeFileSync(file, turn === 1 ? '- [x] task a\n- [ ] refactor follow-up\n' : '- [x] task a\n- [x] refactor follow-up\n')
+        return `turn ${turn}`
+      },
+    }).start({ cwd })
+    const result = await runTodoLoop({ session, cwd, emit: () => {} })
+    assert.deepEqual(result, { completed: 2, reason: 'empty', file: 'TODO.md' })
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('runTodoLoop honors the item cap and reports what is left', async () => {
+  const cwd = await tmpWorkspace()
+  const file = join(cwd, 'TODO.md')
+  await writeFile(file, '- [ ] a\n- [ ] b\n- [ ] c\n')
+  try {
+    let turn = 0
+    const events: FrameworkEvent[] = []
+    const session = await new FakeDriver({
+      respond: () => {
+        turn++
+        writeFileSync(file, ['- [x] a', turn >= 2 ? '- [x] b' : '- [ ] b', '- [ ] c'].join('\n') + '\n')
+        return `turn ${turn}`
+      },
+    }).start({ cwd })
+    const result = await runTodoLoop({ session, cwd, emit: e => events.push(e), maxItems: 2 })
+    assert.deepEqual(result, { completed: 2, reason: 'max-items', file: 'TODO.md' })
+    assert.ok(events.some(e => e.kind === 'log' && /2-item cap.*1 item\(s\) left/.test(e.message)))
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('an item turn that stops to ask is gated and resumed like any await gate (#337)', async () => {
+  const cwd = await tmpWorkspace()
+  const file = join(cwd, 'TODO.md')
+  await writeFile(file, '- [ ] pick a database\n')
+  const gateTurn = [
+    'Which database?',
+    '```await-choices',
+    JSON.stringify({ title: 'Which database?', options: [{ label: 'SQLite' }, { label: 'Postgres' }], recommended: 'SQLite' }),
+    '```',
+  ].join('\n')
+  try {
+    const events: FrameworkEvent[] = []
+    const prompts: string[] = []
+    const session = await new FakeDriver({
+      respond: (prompt, i) => {
+        prompts.push(prompt)
+        if (i === 0) return gateTurn // the item turn stops to ask
+        writeFileSync(file, '- [x] pick a database\n')
+        return 'picked and done'
+      },
+    }).start({ cwd })
+    const requestChoice = (req: ChoiceRequest): Promise<ChoicePick> =>
+      Promise.resolve({ picked: req.id.startsWith('todo-next') ? 'proceed' : 'opt:1', by: 'user' })
+    const result = await runTodoLoop({ session, cwd, emit: e => events.push(e), requestChoice })
+
+    assert.deepEqual(result, { completed: 1, reason: 'empty', file: 'TODO.md' })
+    assert.equal(prompts.length, 2)
+    assert.match(prompts[1]!, /The user chose: Postgres/)
+    const ids = events.filter(e => e.kind === 'choice').map(e => (e as { id: string }).id)
+    assert.deepEqual(ids, ['todo-next', 'await-choices'])
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('an aborted signal ends the loop before starting another entry', async () => {
+  const cwd = await tmpWorkspace()
+  await writeFile(join(cwd, 'TODO.md'), '- [ ] a\n')
+  try {
+    const controller = new AbortController()
+    controller.abort()
+    const session = await new FakeDriver({ respond: () => 'never' }).start({ cwd })
+    const result = await runTodoLoop({ session, cwd, emit: () => {}, signal: controller.signal })
+    // Aborted before item 1: nothing worked, reported as a clean stop.
+    assert.deepEqual(result, { completed: 0, reason: 'stopped' })
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})

--- a/packages/framework/src/todo-loop.ts
+++ b/packages/framework/src/todo-loop.ts
@@ -1,0 +1,253 @@
+import { readdir, readFile, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { DriverSession } from './driver/index.js'
+import type { ChoicePick, ChoiceRequest, FrameworkEvent } from './events.js'
+import { requestChoices, resolveAwaitGate } from './run.js'
+import { parseAwaitGate } from './turn-gate.js'
+
+/**
+ * The backlog loop (#323): once the main work settles, consume the agent's own
+ * TODO backlog one entry per turn until it is empty. The agent writes the
+ * backlog itself (a very large scope, the Maintenance follow-ups, or the
+ * [Research] preset's deep-dive picks all append entries); the framework only
+ * drives: read the file, gate ("start the next item?") when someone can answer,
+ * prompt the agent to complete exactly one entry and check it off, repeat.
+ * Termination is Rom's call on the issue: stop when the backlog is empty. The
+ * dashboard's autopilot auto-accepts the per-item gate, so `[x] autopilot`
+ * consumes the whole backlog unattended; autopilot off pauses before each entry.
+ */
+
+/** The session-scoped backlog filename the #326 prompt writes. */
+export const TODO_FILE_PATTERN = /^TODO_[a-z0-9-]+\.agent\.md$/
+
+/** The flat fallback the current pill (#301) still writes. */
+export const FLAT_TODO_FILE = 'TODO.md'
+
+/** A located backlog: its filename and the entries still open. */
+export interface TodoBacklog {
+  /** The backlog filename (workspace-root relative, e.g. `TODO_feat-x.agent.md`). */
+  name: string
+  /** The open (unchecked) entries, in file order. */
+  entries: string[]
+}
+
+/**
+ * The open entries of a backlog document: markdown list items (`-`, `*`, or
+ * `1.`), where a task checkbox counts only while unchecked (`- [ ]`); a checked
+ * `- [x]` entry is done. Headings, prose, and blank lines are not entries.
+ */
+export function parseTodoEntries(md: string): string[] {
+  const entries: string[] = []
+  for (const line of md.split('\n')) {
+    const item = /^\s*(?:[-*]|\d+\.)\s+(.*)$/.exec(line)
+    if (!item) continue
+    const text = item[1]!.trim()
+    if (!text) continue
+    const task = /^\[([ xX])\]\s*(.*)$/.exec(text)
+    if (task) {
+      if (task[1] !== ' ') continue // checked off = done
+      if (task[2]!.trim()) entries.push(task[2]!.trim())
+    } else {
+      entries.push(text)
+    }
+  }
+  return entries
+}
+
+/**
+ * Locate the workspace's backlog: the most recently modified session-scoped
+ * `TODO_<slug>.agent.md` (#323/#326), falling back to the flat `TODO.md` the
+ * current pill writes (#301) — the same dual convention as the doc sidebar.
+ * Returns `undefined` when no backlog exists or none has open entries.
+ */
+export async function findTodoBacklog(cwd: string): Promise<TodoBacklog | undefined> {
+  let names: string[]
+  try {
+    names = (await readdir(cwd, { withFileTypes: true })).filter(e => e.isFile()).map(e => e.name)
+  } catch {
+    return undefined
+  }
+  const scoped = names.filter(name => TODO_FILE_PATTERN.test(name))
+  const candidates: string[] = []
+  if (scoped.length > 1) {
+    // More than one session's backlog: the newest is this run's.
+    const withTimes = await Promise.all(
+      scoped.map(async name => ({ name, mtime: (await stat(join(cwd, name)).catch(() => undefined))?.mtimeMs ?? 0 })),
+    )
+    candidates.push(...withTimes.sort((a, b) => b.mtime - a.mtime).map(e => e.name))
+  } else {
+    candidates.push(...scoped)
+  }
+  if (names.includes(FLAT_TODO_FILE)) candidates.push(FLAT_TODO_FILE)
+
+  for (const name of candidates) {
+    const md = await readFile(join(cwd, name), 'utf8').catch(() => undefined)
+    if (md === undefined) continue
+    const entries = parseTodoEntries(md)
+    if (entries.length) return { name, entries }
+  }
+  return undefined
+}
+
+/** Why the loop ended. */
+export type TodoLoopReason =
+  /** The backlog is empty (or was never written) — the success case. */
+  | 'empty'
+  /** The user picked "stop" at a per-item gate. */
+  | 'stopped'
+  /** Two items in a row left the backlog's next entry untouched. */
+  | 'stalled'
+  /** The item cap was reached with entries still open. */
+  | 'max-items'
+
+/** What {@link runTodoLoop} resolves with. */
+export interface TodoLoopResult {
+  /** Backlog entries worked (turns taken), regardless of outcome. */
+  completed: number
+  /** Why the loop ended. */
+  reason: TodoLoopReason
+  /** The backlog filename, when one was found. */
+  file?: string
+}
+
+/** Options for {@link runTodoLoop}. */
+export interface TodoLoopOptions {
+  /** The live driver session the run already owns. */
+  session: DriverSession
+  /** The workspace the backlog lives in. */
+  cwd: string
+  /** Emit the loop's events onto the run stream. */
+  emit: (event: FrameworkEvent) => void
+  /**
+   * The interactive gate handler (#304). When wired, the loop pauses before each
+   * entry ("start the next item?") — the dashboard's autopilot auto-accepts, so
+   * autopilot off means a human gate per item (#323). Headless runs don't pause.
+   */
+  requestChoice?: ((req: ChoiceRequest) => Promise<ChoicePick>) | undefined
+  /** The run signal; aborting (Stop button / budget cap #322) ends the loop. */
+  signal?: AbortSignal | undefined
+  /** Hard cap on entries worked in one run. Default {@link DEFAULT_MAX_TODO_ITEMS}. */
+  maxItems?: number | undefined
+}
+
+/** The default per-run cap on backlog entries — a backstop beside the budget cap (#322). */
+export const DEFAULT_MAX_TODO_ITEMS = 25
+
+/** How many consecutive no-progress items before the loop stops rather than spins. */
+const MAX_STALLS = 2
+
+/**
+ * Drive the backlog to empty: read the next open entry, gate, prompt the agent
+ * to complete exactly that entry and check it off, and repeat. Caps make it safe
+ * to leave unattended (#322's concern): the run's budget/abort signal ends any
+ * turn, a hard item cap bounds the run, and two consecutive items that leave the
+ * next entry untouched stop the loop instead of spinning. Await gates inside an
+ * item turn (`showChoices()` / `showMultiSelect()`) are honored like anywhere else.
+ */
+export async function runTodoLoop(opts: TodoLoopOptions): Promise<TodoLoopResult> {
+  const { session, cwd, emit } = opts
+  const maxItems = opts.maxItems ?? DEFAULT_MAX_TODO_ITEMS
+  const gateDeps = { requestChoice: opts.requestChoice, emit, signal: opts.signal }
+
+  let completed = 0
+  let stalls = 0
+  let file: string | undefined
+
+  for (let item = 0; item < maxItems; item++) {
+    if (opts.signal?.aborted) break
+    const backlog = await findTodoBacklog(cwd)
+    if (!backlog) {
+      if (completed > 0) emit({ kind: 'log', message: `Backlog done: ${file ?? 'TODO'} is empty after ${completed} item(s).` })
+      return { completed, reason: 'empty', ...(file ? { file } : {}) }
+    }
+    file = backlog.name
+    const next = backlog.entries[0]!
+    const preview = next.length > 100 ? `${next.slice(0, 100)}…` : next
+
+    if (item === 0) emit({ kind: 'log', message: `Backlog: ${backlog.name} has ${backlog.entries.length} open item(s).` })
+
+    // The per-item gate (#323): pause before starting a new entry when someone
+    // can answer. Interactive-only, like the plan-approval gate — a headless run
+    // emits no gate and just proceeds (autopilot semantics, budget-capped).
+    if (opts.requestChoice) {
+      const picked = await requestChoices({
+        id: item === 0 ? 'todo-next' : `todo-next-${item}`,
+        title: `Start the next backlog item? (${backlog.entries.length} open)`,
+        options: [
+          { id: 'proceed', label: `Work on: ${preview}` },
+          { id: 'stop', label: 'Stop the backlog loop' },
+        ],
+        recommended: 'proceed',
+        requestChoice: opts.requestChoice,
+        emit,
+        ...(opts.signal ? { signal: opts.signal } : {}),
+      })
+      if (picked === 'stop') {
+        emit({ kind: 'log', message: `Backlog loop stopped by you (${backlog.entries.length} item(s) left in ${backlog.name}).` })
+        return { completed, reason: 'stopped', file }
+      }
+    }
+
+    emit({ kind: 'log', message: `Backlog item ${completed + 1}: ${preview}` })
+    await promptItem(session, backlog.name, gateDeps)
+    completed++
+
+    // Progress check: the item turn must have retired the entry it was given
+    // (checked off, removed, or reworded). New entries appended by the work
+    // (e.g. Maintenance follow-ups) are fine — only the *next* entry standing
+    // still counts as a stall.
+    const after = await findTodoBacklog(cwd)
+    if (after && after.name === backlog.name && after.entries[0] === next) {
+      stalls++
+      if (stalls >= MAX_STALLS) {
+        emit({ kind: 'log', message: `Backlog loop stopped: no progress on "${preview}" after ${MAX_STALLS} attempt(s).` })
+        return { completed, reason: 'stalled', file }
+      }
+    } else {
+      stalls = 0
+    }
+  }
+
+  // Aborted mid-loop (Stop button / budget cap #322): the run is ending anyway,
+  // so report a clean stop without extra narration.
+  if (opts.signal?.aborted) return { completed, reason: 'stopped', ...(file ? { file } : {}) }
+
+  const remaining = await findTodoBacklog(cwd)
+  if (!remaining) {
+    if (completed > 0) emit({ kind: 'log', message: `Backlog done: ${file ?? 'TODO'} is empty after ${completed} item(s).` })
+    return { completed, reason: 'empty', ...(file ? { file } : {}) }
+  }
+  emit({
+    kind: 'log',
+    message: `Backlog loop stopped at the ${maxItems}-item cap; ${remaining.entries.length} item(s) left in ${remaining.name}.`,
+  })
+  return { completed, reason: 'max-items', ...(file ? { file } : {}) }
+}
+
+/** How many times one backlog item may stop to ask before the turn just finishes. */
+const MAX_AWAIT_ROUNDS = 5
+
+/** One backlog item's turn: complete the first open entry, honoring await gates. */
+async function promptItem(
+  session: DriverSession,
+  fileName: string,
+  deps: {
+    requestChoice?: ((req: ChoiceRequest) => Promise<ChoicePick>) | undefined
+    emit: (event: FrameworkEvent) => void
+    signal?: AbortSignal | undefined
+  },
+): Promise<void> {
+  const signalOpt = deps.signal ? { signal: deps.signal } : {}
+  const prompt = `Open \`${fileName}\` at the workspace root and work on the FIRST open entry only. Complete it fully and verify your work. Then update \`${fileName}\`: check the entry off (or remove it). Do not start any other entry.`
+  let turn = await session.prompt(prompt, signalOpt)
+  let gate = parseAwaitGate(turn.text)
+  for (let round = 0; round < MAX_AWAIT_ROUNDS && gate; round++) {
+    const answer = await resolveAwaitGate(gate, round, deps)
+    deps.emit({ kind: 'log', message: `Continuing with your choice: ${answer}` })
+    turn = await session.prompt(
+      `You paused to ask: "${gate.title}". The user chose: ${answer}. Continue the backlog entry with that decision, and do not ask again unless a genuinely new choice comes up.`,
+      signalOpt,
+    )
+    gate = parseAwaitGate(turn.text)
+  }
+}


### PR DESCRIPTION
Closes #323 (the loop half; the prompts that generate PLAN/TODO are #326).

Built to your three answers on the issue:
- **Always session-scoped**: the loop consumes the newest `TODO_<slug>.agent.md`, falling back to the flat `TODO.md` the current pill still writes (same dual convention as the doc sidebar), so it works today and keeps working when #326 lands.
- **Terminate on empty**: one entry per turn ("work the FIRST open entry, then check it off"), re-reading the file between turns; done when no open entries remain.
- **Pause before each entry when autopilot is off**: a per-item gate ("Start the next backlog item?") fires on the dashboard before every entry. The dashboard autopilot auto-accepts it, so `[x] autopilot` consumes the whole backlog unattended; off means a human click per item. Headless runs do not gate (same as the plan-approval gate).

Caps, for the trust-it-overnight flow:
- The run's abort signal (Stop button, Ctrl+C, `--max-cost` budget cap) ends any turn.
- `--max-todo-items <n>` bounds entries per run (default 25); `--no-todo-loop` opts out.
- Two consecutive items that leave the next entry untouched stop the loop instead of spinning. Entries the work itself appends (the Maintenance follow-up pattern) do not count as stalls.

Await gates inside an item turn (`showChoices()`/`showMultiSelect()`) are honored like anywhere else; the gate resolution is now one shared `resolveAwaitGate()` used by the build gate, `runPrompt`, and the loop.

Skipped for the fake driver by default (deterministic demo, reused tmp workspace); `todoLoop: true` forces it for tests.

Verified live against real Claude Code: seeded a 2-entry backlog, the loop worked each entry in its own turn, the agent created both files and checked both entries off, and the loop terminated on empty. 280 tests green.