### PR TITLE
feat(framework): wire the #326 system prompt verbatim via a ${{...}} template layer

### DIFF
--- a/.changeset/system-prompt-326.md
+++ b/.changeset/system-prompt-326.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+The built-in system prompt is now Rom's #326 text, verbatim, replacing the anti-lazy-pill it grew out of: unclear scope becomes a ranked `showChoices()` list, a large scope a `PLAN_<session>.agent.md` to approve, a very large one also a `TODO_<session>.agent.md` backlog, an alternatives pass rates problem "variability" before code is written, and edits to existing code stay minimal. The prompt is a template (#350): `${{ ... }}` JS fragments render against the run context, so `tf.params.autopilot` relaxes the maintenance stance on autopilot runs and `${{tf.prompt}}` carries the user prompt slot. New exports: `SYSTEM_PROMPT_TEMPLATE`, `renderSystemPrompt`, `renderTemplate`; the `ANTI_LAZY_PILL` export is gone (the `antiLazyPill` config key still toggles the built-in prompt). `--autopilot` now has an effect without a preset.

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -220,7 +220,7 @@ preset: software-development
 autopilot: true      # activate the preset's Autopilot mode variants
 technical: false
 event: bug-fix        # the build event kind its review loop fires for
-antiLazyPill: false   # remove the built-in anti-lazy-pill system prompt (default: on)
+antiLazyPill: false   # remove the built-in system prompt (default: on)
 ```
 
 Every field is optional. CLI flags override the file, so the precedence is:
@@ -232,17 +232,21 @@ Every field is optional. CLI flags override the file, so the precedence is:
 When the file contributes anything, the run narrates it (`◆ the-framework.yml: ...`).
 A malformed file is a warning, never a failed run.
 
-### System prompt: the anti-lazy-pill + `SYSTEM.md`
+### System prompt: the built-in working agreement + `SYSTEM.md`
 
-Every prompt is framed with a built-in system prompt (the validated "anti-lazy-pill",
-#297): unclear scope becomes a ranked list to approve, a large scope becomes a
-`PLAN.md`, a very large one also spins off a `TODO.md` backlog. It turns a mock UI
-shell into a real backend and declares what it descopes instead of faking it.
+Every prompt is framed with the built-in system prompt (#326, the successor of the
+validated "anti-lazy-pill" #297): unclear scope becomes a ranked `showChoices()`
+list, a large scope becomes a `PLAN_<session>.agent.md` to approve, a very large one
+also spins off a `TODO_<session>.agent.md` backlog (consumed by the backlog loop),
+an alternatives pass rates problem "variability" before code is written, and edits
+to existing code stay minimal. The prompt is a template: `${{ ... }}` JS fragments
+render against the run context (e.g. `tf.params.autopilot` relaxes the maintenance
+stance on autopilot runs).
 
 Drop a `SYSTEM.md` at the workspace root to add your own instructions on top (it
-travels with the repo, like the memory files). To remove the built-in pill and keep
-only your own, set `antiLazyPill: false` in `the-framework.yml`. The run narrates
-what it picked up (`◆ system prompt: SYSTEM.md`).
+travels with the repo, like the memory files). To remove the built-in prompt and keep
+only your own, set `antiLazyPill: false` in `the-framework.yml` (the key keeps its
+historical name). The run narrates what it picked up (`◆ system prompt: SYSTEM.md`).
 
 ## Extensions (#190)
 

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -258,9 +258,16 @@ test('runCli rejects an unknown --preset with a usage error (exit 2)', async () 
 test('runCli notes mode flags given without a preset', async () => {
   const { io, err } = capture()
   // --fake so the note fires before any real run; unknown-preset path is not hit.
+  const code = await runCli(['--fake', '--no-dashboard', '--technical'], io)
+  assert.equal(code, 0)
+  assert.ok(err.some(l => /technical mode\(s\) have no effect without a preset/.test(l)))
+})
+
+test('runCli does not note --autopilot without a preset (it steers the #326 prompt)', async () => {
+  const { io, err } = capture()
   const code = await runCli(['--fake', '--no-dashboard', '--autopilot'], io)
   assert.equal(code, 0)
-  assert.ok(err.some(l => /have no effect without a preset/.test(l)))
+  assert.ok(!err.some(l => /have no effect without a preset/.test(l)))
 })
 
 test('runCli notes --kind given without a preset (#265)', async () => {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -762,8 +762,11 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   }
 
   // A mode/kind given with no preset in effect has nothing to act on: note it.
-  if (modeList.length && !domainPreset) {
-    io.err(`note: ${modeList.join(' + ')} mode(s) have no effect without a preset.`)
+  // Autopilot is the exception — it also steers the #326 system prompt's
+  // maintenance stance, so it works preset or not.
+  const presetOnlyModes = modeList.filter(m => m !== 'autopilot')
+  if (presetOnlyModes.length && !domainPreset) {
+    io.err(`note: ${presetOnlyModes.join(' + ')} mode(s) have no effect without a preset.`)
   }
   if (buildEvent && !domainPreset) {
     io.err(`note: build event "${buildEvent}" has no effect without a preset.`)
@@ -800,6 +803,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
         ...(opts.maxCost ? { budgetUsd: opts.maxCost } : {}),
         ...(userSystemPrompt ? { systemPrompt: userSystemPrompt } : {}),
         ...(fileConfig.antiLazyPill === false ? { antiLazyPill: false } : {}),
+        ...(modeList.includes('autopilot') ? { autopilot: true } : {}),
         ...((): { sessionLink?: string } => {
           const link = chooseSessionLink(opts, fake)
           return link ? { sessionLink: link } : {}
@@ -921,7 +925,10 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     ...(serve && opts.sandbox ? { sandbox: opts.sandbox } : {}),
     ...(discovered ? { extensions: discovered } : {}),
     ...(opts.composeExtensions ? { composeExtensions: true } : {}),
-    ...(domainPreset ? { preset: domainPreset, ...(modeList.length ? { modes: modeList } : {}) } : {}),
+    // Modes ride along even without a domain preset: autopilot also steers the
+    // #326 system prompt's maintenance stance.
+    ...(domainPreset ? { preset: domainPreset } : {}),
+    ...(modeList.length ? { modes: modeList } : {}),
     ...(buildEvent ? { buildEvent } : {}),
     ...(memory.length ? { memory } : {}),
     ...(userSystemPrompt ? { systemPrompt: userSystemPrompt } : {}),

--- a/packages/framework/src/config.ts
+++ b/packages/framework/src/config.ts
@@ -16,7 +16,7 @@ export interface FrameworkFileConfig {
   technical?: boolean
   /** Build event kind the preset's review loop fires for, e.g. `bug-fix` (#265). */
   event?: string
-  /** Inject the built-in anti-lazy-pill system prompt (#301). Default `true`; set false to remove it. */
+  /** Inject the built-in system prompt (#326, via #301). Default `true`; set false to remove it. */
   antiLazyPill?: boolean
 }
 

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -139,10 +139,14 @@ export {
 export {
   loadUserSystemPrompt,
   systemPromptBlock,
-  ANTI_LAZY_PILL,
+  renderSystemPrompt,
+  SYSTEM_PROMPT_TEMPLATE,
   SYSTEM_PROMPT_FILE,
   type SystemPromptOptions,
+  type TfContext,
+  type RenderedSystemPrompt,
 } from './system-prompt.js'
+export { renderTemplate, TemplateFragmentError } from './prompt-template.js'
 export {
   extractParamNames,
   renderPresetPrompt,

--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -1,7 +1,7 @@
 import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { hasSessionIdPlaceholder, resolveSessionLink, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 import { resolveAwaitGate } from './run.js'
-import { systemPromptBlock } from './system-prompt.js'
+import { renderSystemPrompt, systemPromptBlock, type TfContext } from './system-prompt.js'
 import { AWAIT_PROTOCOL, parseAwaitGate } from './turn-gate.js'
 import { UsageMeter } from './usage.js'
 
@@ -36,8 +36,10 @@ export interface RunPromptOptions {
   model?: string
   /** A user SYSTEM.md to append to the built-in system prompt (#301). */
   systemPrompt?: string
-  /** Include the anti-lazy working agreement. Default true (#301). */
+  /** Include the built-in #326 system prompt. Default true (#301; the name is the historical config key). */
   antiLazyPill?: boolean
+  /** Whether autopilot mode is on: steers the #326 prompt's maintenance stance (#325). Default false. */
+  autopilot?: boolean
   /** Stop the run once the agent has spent this much, in USD (#322). */
   budgetUsd?: number
   /** Session link template for the dashboard, `{sessionId}` resolved when known. */
@@ -69,10 +71,16 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
     opts.onEvent?.(event)
   }
 
-  // The pill + any user SYSTEM.md frame the session (#301). The await protocol is
-  // always on — honoring the prompt's gates is the whole point of this path.
-  const promptBlock = systemPromptBlock({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt })
+  // The built-in #326 prompt + any user SYSTEM.md frame the session (#301). The
+  // await protocol is always on — honoring the prompt's gates is the whole point
+  // of this path.
+  const tf: TfContext = { prompt: opts.prompt, params: { autopilot: opts.autopilot === true } }
+  const promptBlock = systemPromptBlock({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt, tf })
   const system = [...(promptBlock ? [promptBlock] : []), AWAIT_PROTOCOL].join('\n\n')
+  // The template's `# User prompt` half carries the prompt (today it renders to
+  // exactly `opts.prompt`; any framing Rom adds around the slot rides along). With
+  // the built-in prompt off, the raw prompt is sent as-is.
+  const firstPrompt = opts.antiLazyPill === false ? opts.prompt : renderSystemPrompt(tf).user
 
   const linkTemplate = opts.sessionLink
   const literalLink = linkTemplate && !hasSessionIdPlaceholder(linkTemplate) ? linkTemplate : undefined
@@ -117,7 +125,7 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
   })
 
   try {
-    let turn = await session.prompt(opts.prompt, { signal: runSignal })
+    let turn = await session.prompt(firstPrompt, { signal: runSignal })
     let gate = parseAwaitGate(turn.text)
     for (let round = 0; round < MAX_AWAIT_ROUNDS && gate; round++) {
       const answer = await resolveAwaitGate(gate, round, { requestChoice: opts.requestChoice, emit, signal: runSignal })

--- a/packages/framework/src/prompt-template.test.ts
+++ b/packages/framework/src/prompt-template.test.ts
@@ -1,0 +1,57 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { renderTemplate, TemplateFragmentError } from './prompt-template.js'
+
+test('renderTemplate passes fragment-free text through byte-identical', () => {
+  const text = '# Title\n\nPlain `md` with ${single-brace} and $ signs.\n'
+  assert.equal(renderTemplate(text, {}), text)
+})
+
+test('renderTemplate substitutes a simple context read', () => {
+  const out = renderTemplate('User: ${{tf.prompt}}', { tf: { prompt: 'build a todo app' } })
+  assert.equal(out, 'User: build a todo app')
+})
+
+test('renderTemplate evaluates the #326 maintenance ternary both ways', () => {
+  const template = '${{ tf.params.autopilot ? "minimal ok" : "minimal for humans" }}'
+  assert.equal(renderTemplate(template, { tf: { params: { autopilot: true } } }), 'minimal ok')
+  assert.equal(renderTemplate(template, { tf: { params: { autopilot: false } } }), 'minimal for humans')
+  assert.equal(renderTemplate(template, { tf: { params: {} } }), 'minimal for humans') // absent = off
+})
+
+test('renderTemplate renders several fragments in one template', () => {
+  const out = renderTemplate('${{a}} + ${{b}} = ${{a + b}}', { a: 1, b: 2 })
+  assert.equal(out, '1 + 2 = 3')
+})
+
+test('renderTemplate stringifies non-string results', () => {
+  assert.equal(renderTemplate('n=${{40 + 2}}', {}), 'n=42')
+  assert.equal(renderTemplate('b=${{false}}', {}), 'b=false')
+})
+
+test('renderTemplate keeps special replacement patterns in results literal', () => {
+  // String.replace's `$&`-style patterns must not fire on the evaluated value.
+  const out = renderTemplate('x ${{tf.prompt}} y', { tf: { prompt: 'give me $& and $1' } })
+  assert.equal(out, 'x give me $& and $1 y')
+})
+
+test('renderTemplate throws a TemplateFragmentError on invalid JS', () => {
+  assert.throws(() => renderTemplate('${{ this is not js }}', {}), TemplateFragmentError)
+})
+
+test('renderTemplate throws on a fragment that evaluates to undefined (typo guard)', () => {
+  assert.throws(
+    () => renderTemplate('${{tf.promt}}', { tf: { prompt: 'x' } }),
+    (err: unknown) => err instanceof TemplateFragmentError && err.fragment === 'tf.promt',
+  )
+})
+
+test('renderTemplate names the failing fragment in the error message', () => {
+  try {
+    renderTemplate('${{ nope( }}', {})
+    assert.fail('expected a throw')
+  } catch (err) {
+    assert.ok(err instanceof TemplateFragmentError)
+    assert.match(err.message, /nope\(/)
+  }
+})

--- a/packages/framework/src/prompt-template.ts
+++ b/packages/framework/src/prompt-template.ts
@@ -1,0 +1,44 @@
+/**
+ * The `${{ ... }}` markdown-fragment layer (#350): the #326 system prompt embeds
+ * JS expressions (e.g. a ternary on `tf.params.autopilot`), so the verbatim
+ * template renders against a context at run time. Each fragment is a real JS
+ * expression evaluated with `new Function` — that is arbitrary code execution,
+ * so only ever render trusted templates (the built-in system prompt), never
+ * user- or repo-supplied text.
+ */
+
+const FRAGMENT = /\$\{\{([\s\S]*?)\}\}/g
+
+/** Thrown when a `${{ ... }}` fragment fails to evaluate or evaluates to `undefined`. */
+export class TemplateFragmentError extends Error {
+  /** The fragment's expression, as written in the template. */
+  readonly fragment: string
+  constructor(fragment: string, detail: string) {
+    super(`[framework] template fragment \${{${fragment}}} ${detail}`)
+    this.name = 'TemplateFragmentError'
+    this.fragment = fragment
+  }
+}
+
+/**
+ * Render a template by evaluating every `${{ <expression> }}` fragment against
+ * `context` (each key becomes a variable the expression can read, e.g. `tf`).
+ * The result is stringified in place; text outside fragments passes through
+ * byte-identical. A fragment that throws or evaluates to `undefined` (almost
+ * always a typo) throws a {@link TemplateFragmentError} rather than silently
+ * degrading the prompt.
+ */
+export function renderTemplate(template: string, context: Record<string, unknown>): string {
+  const names = Object.keys(context)
+  const values = names.map(name => context[name])
+  return template.replace(FRAGMENT, (_, expression: string) => {
+    let result: unknown
+    try {
+      result = new Function(...names, `'use strict'; return (${expression});`)(...values)
+    } catch (err) {
+      throw new TemplateFragmentError(expression, `failed to evaluate: ${err instanceof Error ? err.message : String(err)}`)
+    }
+    if (result === undefined) throw new TemplateFragmentError(expression, 'evaluated to undefined (typo in the expression?)')
+    return String(result)
+  })
+}

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -37,7 +37,7 @@ import {
 import { snapshotWorkspace } from './sandbox.js'
 import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { memoryFraming, type LoadedMemory } from './memory.js'
-import { systemPromptBlock } from './system-prompt.js'
+import { systemPromptBlock, type TfContext } from './system-prompt.js'
 import { AWAIT_PROTOCOL, parseAwaitGate, type ParsedAwaitGate } from './turn-gate.js'
 // Value import from todo-loop.js is a benign cycle: todo-loop.js only calls
 // run.js's hoisted function declarations (requestChoices / resolveAwaitGate).
@@ -112,12 +112,13 @@ export interface RunFrameworkOptions {
   /**
    * A user-authored system prompt (from `SYSTEM.md`) injected into every prompt
    * (#301). Load with `loadUserSystemPrompt(cwd)`. Composed after the built-in
-   * anti-lazy-pill, so a repo can add its own instructions on top of the default.
+   * #326 system prompt, so a repo can add its own instructions on top of the default.
    */
   systemPrompt?: string
   /**
-   * Inject the built-in anti-lazy-pill (#297) into every prompt (#301). Default
-   * `true`; pass `false` (e.g. from `the-framework.yml`) to remove it.
+   * Inject the built-in #326 system prompt into every prompt (#301). Default
+   * `true`; pass `false` (e.g. from `the-framework.yml`) to remove it. The name
+   * is the historical config key: #326 is the anti-lazy-pill's (#297) successor.
    */
   antiLazyPill?: boolean
   /**
@@ -130,9 +131,9 @@ export interface RunFrameworkOptions {
    */
   preset?: DomainPreset
   /**
-   * The active modes for {@link preset} (e.g. `['autopilot']`), for narration.
-   * The preset is expected to be loaded with these already applied; this is the
-   * label shown to the user.
+   * The active modes for the run (e.g. `['autopilot']`). Narrated with the
+   * {@link preset} (which is expected to be loaded with them already applied),
+   * and `autopilot` also steers the #326 system prompt's maintenance stance.
    */
   modes?: readonly string[]
   /**
@@ -331,9 +332,16 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
   // The repo's own memory files (#260) frame the agent alongside personas + skills:
   // their contents give context, and the agent is told to keep the ones it owns current.
   const memoryBlock = opts.memory && opts.memory.length ? memoryFraming(opts.memory) : ''
-  // The anti-lazy-pill + any user SYSTEM.md lead the system prompt so its working
-  // agreement frames every prompt before the role/skill/memory context (#301).
-  const promptBlock = systemPromptBlock({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt })
+  // The built-in #326 system prompt + any user SYSTEM.md lead the system prompt so
+  // its working agreement frames every prompt before the role/skill/memory context
+  // (#301). Only the template's system half is used here: each Bootstrap step
+  // composes its own prompt around the intent, so the user-prompt slot stays with
+  // the steps. `tf.params.autopilot` reflects the run's autopilot mode (#325).
+  const tf: TfContext = {
+    prompt: opts.intent,
+    params: { autopilot: opts.modes?.includes('autopilot') ?? false },
+  }
+  const promptBlock = systemPromptBlock({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt, tf })
   // The await protocol (#337) concretizes the pill's showChoices()/AWAIT macros into a
   // signal the turn-boundary gate can detect, so it rides along with the pill.
   const system = [

--- a/packages/framework/src/system-prompt.test.ts
+++ b/packages/framework/src/system-prompt.test.ts
@@ -4,10 +4,11 @@ import { mkdtemp, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
-  ANTI_LAZY_PILL,
   loadUserSystemPrompt,
+  renderSystemPrompt,
   systemPromptBlock,
   SYSTEM_PROMPT_FILE,
+  SYSTEM_PROMPT_TEMPLATE,
 } from './system-prompt.js'
 
 test('loadUserSystemPrompt reads and trims SYSTEM.md', async () => {
@@ -31,23 +32,61 @@ test('loadUserSystemPrompt is undefined when the file is absent or empty', async
   }
 })
 
-test('systemPromptBlock defaults to the anti-lazy-pill alone', () => {
-  assert.equal(systemPromptBlock(), ANTI_LAZY_PILL)
+test('SYSTEM_PROMPT_TEMPLATE carries the #326 sections verbatim', () => {
+  for (const section of ['## Unclear scope', '## Large scope', '## Alternatives', '## Maintenance', '# User prompt']) {
+    assert.ok(SYSTEM_PROMPT_TEMPLATE.includes(section), `missing ${section}`)
+  }
+  assert.ok(SYSTEM_PROMPT_TEMPLATE.includes('TODO_FILE: `TODO_<SESSION_NAME>.agent.md`'))
+  assert.ok(SYSTEM_PROMPT_TEMPLATE.includes('${{tf.prompt}}'))
+  assert.ok(SYSTEM_PROMPT_TEMPLATE.includes('${{ tf.params.autopilot ?'))
 })
 
-test('systemPromptBlock appends the user prompt after the pill', () => {
+test('renderSystemPrompt splits the system and user halves', () => {
+  const { system, user } = renderSystemPrompt({ prompt: 'build a todo app', params: {} })
+  assert.ok(system.startsWith('# System prompt'))
+  assert.ok(system.includes('## Maintenance'))
+  assert.ok(!system.includes('# User prompt'))
+  assert.ok(!system.includes('${{'), 'system half fully rendered')
+  assert.equal(user, 'build a todo app')
+})
+
+test('renderSystemPrompt branches the maintenance line on tf.params.autopilot', () => {
+  const attended = renderSystemPrompt({ prompt: 'x', params: { autopilot: false } }).system
+  const autopilot = renderSystemPrompt({ prompt: 'x', params: { autopilot: true } }).system
+  assert.ok(attended.includes('prefer minimal changes to make it easier for humans to read the changes'))
+  assert.ok(autopilot.includes('you can prefer minimal changes (e.g. to postpone a deep refactor)'))
+  assert.ok(!autopilot.includes('easier for humans'))
+})
+
+test('renderSystemPrompt is not confused by a user prompt containing the heading', () => {
+  const sneaky = 'do X\n# User prompt\ndo Y'
+  const { system, user } = renderSystemPrompt({ prompt: sneaky, params: {} })
+  assert.ok(system.startsWith('# System prompt'))
+  assert.equal(user, sneaky)
+})
+
+test('systemPromptBlock defaults to the built-in #326 prompt alone', () => {
+  assert.equal(systemPromptBlock(), renderSystemPrompt().system)
+})
+
+test('systemPromptBlock appends the user prompt after the built-in one', () => {
   const block = systemPromptBlock({ user: 'Ship small PRs.' })
-  assert.ok(block.startsWith(ANTI_LAZY_PILL))
+  assert.ok(block.startsWith('# System prompt'))
   assert.ok(block.endsWith('Ship small PRs.'))
-  assert.match(block, /AWAIT[\s\S]*Ship small PRs\./) // pill first, then user
+  assert.match(block, /AWAIT[\s\S]*Ship small PRs\./) // built-in first, then user
 })
 
-test('systemPromptBlock removes the pill when antiLazyPill is false', () => {
+test('systemPromptBlock removes the built-in prompt when antiLazyPill is false', () => {
   assert.equal(systemPromptBlock({ antiLazyPill: false }), '')
   assert.equal(systemPromptBlock({ antiLazyPill: false, user: 'Only mine.' }), 'Only mine.')
 })
 
 test('systemPromptBlock ignores a whitespace-only user prompt', () => {
-  assert.equal(systemPromptBlock({ user: '   ' }), ANTI_LAZY_PILL)
+  assert.equal(systemPromptBlock({ user: '   ' }), renderSystemPrompt().system)
   assert.equal(systemPromptBlock({ antiLazyPill: false, user: '  \n ' }), '')
+})
+
+test('systemPromptBlock threads tf through to the template', () => {
+  const block = systemPromptBlock({ tf: { prompt: 'x', params: { autopilot: true } } })
+  assert.ok(block.includes('postpone a deep refactor'))
 })

--- a/packages/framework/src/system-prompt.ts
+++ b/packages/framework/src/system-prompt.ts
@@ -1,26 +1,100 @@
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { renderTemplate } from './prompt-template.js'
 
 /**
- * The built-in system prompt injected into every run (#301): Rom's validated
- * "anti-lazy-pill" (#297). It decouples what the agent *thinks* it should build
- * from what we actually build next: unclear scope becomes a ranked list to show,
- * a large scope becomes a `PLAN.md` to approve, a very large one also spins off a
- * `TODO.md` backlog. In our Instagram-clone test this turned a mock UI shell
- * (0/7 real) into a real persisted backend (~4.5/7), and it declares what it
- * descopes instead of silently faking it.
+ * Rom's system prompt (#326), verbatim, as a template. It supersedes the
+ * anti-lazy-pill (#297/#301) it grew out of: unclear scope becomes a ranked
+ * `showChoices()` list, a large scope becomes a PLAN file to approve, a very
+ * large one also spins off a TODO backlog (consumed by the backlog loop, #323),
+ * the alternatives flow rates problem "variability" before code is written, and
+ * the maintenance section keeps edits minimal.
  *
- * `SHOW_IT` / `AWAIT` fully wire up with the interactive `<Choices>` panel (#304);
- * until then a headless run still writes the `PLAN.md` / `TODO.md`, which is the
- * ambition lever we want.
+ * Two layers make it executable:
+ * - `${{ ... }}` fragments are JS evaluated against a {@link TfContext} (#350).
+ * - The trailing `# User prompt` section is the user-prompt slot; use
+ *   {@link renderSystemPrompt} to render and split the two halves.
+ *
+ * The `<SHOW_*>` / `<AWAIT>` macros are interpreted by the agent itself (Rom's
+ * call on #326); the await protocol (#337/#339) pins how the stop-signal is
+ * emitted so the turn-boundary gates can detect it.
+ *
+ * Keep this byte-identical to the #326 issue text (it is Rom's living doc);
+ * change it there first.
  */
-export const ANTI_LAZY_PILL = `## How to work
-- If it isn't clear what you should do (e.g. unclear scope, unclear user prompt), make a list of interpretations sorted by plausibility, SHOW_IT, AWAIT.
-- If the scope of what you'll work on is large, create a \`PLAN.md\` of what you'll work on, SHOW_IT, AWAIT.
-  - If the scope is potentially very large (e.g. spans over many hours of work), also create a \`TODO.md\` (backlog of follow-up tasks) and SHOW_IT
+export const SYSTEM_PROMPT_TEMPLATE = `# System prompt
 
-SHOW_IT: Show it to the user
-AWAIT: Stop, await user answer before resuming`
+SHOW_MD: Show it to the user via \`showMarkdown()\`
+SHOW_CHOICES: Show it to the user via \`showChoices()\`
+AWAIT: Stop, await user answer before resuming
+SESSION_NAME: the name of the current Git branch — sanitize it to be a SLUG, if name is generic (e.g. \`main\`) then create a succinct SLUG
+SLUG: [a-z0-9-]+
+TODO_FILE: \`TODO_<SESSION_NAME>.agent.md\`
+
+## Unclear scope
+
+If it isn't clear what you should do (e.g. unclear scope, unclear user prompt), make a list of interpretations sorted by plausibility, <SHOW_CHOICES>, <AWAIT>
+
+## Large scope
+
+- If the scope of what you'll work on is *large*, create a \`PLAN_<SESSION_NAME>.agent.md\` of what you'll work on, <SHOW_MD>, <AWAIT>
+- If the scope is potentially *very large* (e.g. spans over many hours/days of work), also create a <TODO_FILE> (backlog of follow-up tasks) and <SHOW_MD>
+
+## Alternatives
+
+Before starting to write code, measure "variability":
+- List all high-level problems that need to be implemented
+- Give a rating for each problem (from 0 to 10) following this criteria: is there an obviously optimal way to solve the problem (10), or is it highly unclear whether the problem can be solved in a better way (0)?
+- Explore and suggest alternatives for problems with a low rating
+- For each problem that has alternatives: list all alternatives sorted in a sensible order, <SHOW_CHOICES>, <AWAIT>
+
+## Maintenance
+
+- When making changes to existing code, \${{ tf.params.autopilot ? "you can prefer minimal changes (e.g. to postpone a deep refactor)" : "prefer minimal changes to make it easier for humans to read the changes" }}
+- But your changes should still be the correct solution on a high-level, don't implement a bad solution for the sake of making minimal changes
+- If your changes aren't trivial and leads to refactor potential, add a new entry to <TODO_FILE>
+  - The entry: "Look for refactoring opportunities arising from the <SESSION_NAME> merge"
+
+# User prompt
+
+\${{tf.prompt}}`
+
+/** The `tf` context the template's `${{...}}` fragments read (#326/#350). */
+export interface TfContext {
+  /** The user's prompt (the run intent, or the typed prompt): fills `${{tf.prompt}}`. */
+  prompt: string
+  /** Run parameters the template branches on (e.g. `autopilot`, #325's mode sense). */
+  params: { autopilot?: boolean } & Record<string, unknown>
+}
+
+/** The neutral context used when a caller has none: empty prompt, no modes. */
+const DEFAULT_TF: TfContext = { prompt: '', params: {} }
+
+/** The two halves of the rendered {@link SYSTEM_PROMPT_TEMPLATE}. */
+export interface RenderedSystemPrompt {
+  /** The `# System prompt` half: frames the session's system channel. */
+  system: string
+  /** The `# User prompt` half: the rendered user-prompt slot (`${{tf.prompt}}` plus any framing Rom adds around it). */
+  user: string
+}
+
+const USER_PROMPT_HEADING = '\n# User prompt\n'
+
+/**
+ * Render the built-in system prompt against a {@link TfContext} and split it at
+ * the `# User prompt` heading. The split happens on the *template*, before
+ * rendering, so a user prompt that itself contains the heading can never move
+ * the boundary.
+ */
+export function renderSystemPrompt(tf: TfContext = DEFAULT_TF): RenderedSystemPrompt {
+  const at = SYSTEM_PROMPT_TEMPLATE.indexOf(USER_PROMPT_HEADING)
+  const systemHalf = at === -1 ? SYSTEM_PROMPT_TEMPLATE : SYSTEM_PROMPT_TEMPLATE.slice(0, at)
+  const userHalf = at === -1 ? '${{tf.prompt}}' : SYSTEM_PROMPT_TEMPLATE.slice(at + USER_PROMPT_HEADING.length)
+  return {
+    system: renderTemplate(systemHalf, { tf }).trim(),
+    user: renderTemplate(userHalf, { tf }).trim(),
+  }
+}
 
 /**
  * The canonical user system-prompt file at the workspace root. Its contents are
@@ -48,21 +122,29 @@ export async function loadUserSystemPrompt(
 
 /** Inputs to {@link systemPromptBlock}. */
 export interface SystemPromptOptions {
-  /** Include the built-in {@link ANTI_LAZY_PILL}. Default `true`; set false per repo to remove it. */
+  /**
+   * Include the built-in #326 system prompt. Default `true`; set false per repo
+   * to remove it. The name is the historical `the-framework.yml` key (#301): the
+   * #326 prompt is the anti-lazy-pill's successor and answers to the same toggle.
+   */
   antiLazyPill?: boolean | undefined
-  /** The user's own system prompt (e.g. from `SYSTEM.md`), injected after the pill. */
+  /** The user's own system prompt (e.g. from `SYSTEM.md`), injected after the built-in one. */
   user?: string | undefined
+  /** Context for the template's `${{...}}` fragments. Default: {@link DEFAULT_TF}. */
+  tf?: TfContext | undefined
 }
 
 /**
- * Compose the system-prompt block injected into every prompt: the built-in
- * anti-lazy-pill (unless removed) followed by the user's own prompt. Additive, so
- * a repo can keep the pill *and* add its instructions, remove the pill and keep
- * only its own, or leave both off. Returns `''` when there is nothing to inject.
+ * Compose the system-prompt block injected into every prompt: the built-in #326
+ * prompt (unless removed) followed by the user's own prompt. Additive, so a repo
+ * can keep the built-in *and* add its instructions, remove it and keep only its
+ * own, or leave both off. Returns `''` when there is nothing to inject. Only the
+ * template's system half lands here; the user-prompt half is the caller's to
+ * deliver (see {@link renderSystemPrompt}).
  */
 export function systemPromptBlock(opts: SystemPromptOptions = {}): string {
   const parts: string[] = []
-  if (opts.antiLazyPill !== false) parts.push(ANTI_LAZY_PILL)
+  if (opts.antiLazyPill !== false) parts.push(renderSystemPrompt(opts.tf).system)
   const user = opts.user?.trim()
   if (user) parts.push(user)
   return parts.join('\n\n')


### PR DESCRIPTION
Closes #350

The built-in system prompt is now the #326 text, byte-identical (verified by rendering and diffing against the issue). It replaces the anti-lazy-pill it grew out of.

What makes it executable:

- A tiny template layer (`prompt-template.ts`, #350): `${{ ... }}` fragments are real JS evaluated against a context, so the `tf.params.autopilot` ternary in `## Maintenance` and `${{tf.prompt}}` work as written. A fragment that throws or evaluates to `undefined` fails loudly instead of silently degrading the prompt. `new Function` based, so only trusted (built-in) templates are ever rendered.
- The template splits at the `# User prompt` heading (on the template, before rendering, so a user prompt containing that heading cannot move the boundary). The system half frames the session; the user half is the prompt slot. The build flow keeps composing per-step prompts (the steps own the intent); the direct prompt path (#331) sends the rendered user half as its first turn, which today is exactly the raw prompt.
- `tf.params.autopilot` comes from the run's modes: `--autopilot` now also steers the maintenance stance, so it has an effect even without a preset (the "no effect without a preset" note now only fires for `technical`).
- The `<SHOW_*>`/`<AWAIT>` macros stay agent-interpreted per Rom's call; the await protocol (#337/#339) still pins the stop-signal format so the turn-boundary gates fire.

The `antiLazyPill` config key keeps its name and still toggles the built-in prompt. `ANTI_LAZY_PILL` export is gone; new exports `SYSTEM_PROMPT_TEMPLATE` / `renderSystemPrompt` / `renderTemplate`.

#326 stays open as Rom's living doc; the constant carries a "keep byte-identical, edit the issue first" note.