### PR TITLE
fix(framework): architect turns honor agent await gates instead of swallowing the question

### DIFF
--- a/.changeset/architect-await-gate.md
+++ b/.changeset/architect-await-gate.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Architect turns now honor agent-authored await gates (#356): an architect (or re-architect) turn that stops to ask via `showChoices()` / `showMultiSelect()` resolves through the live dashboard gate and re-prompts with the answer, instead of the question being silently swallowed into a stub fallback plan at the plan-approval gate. Headless runs are unchanged. Bounded at 5 rounds, like the build gate.

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -802,6 +802,56 @@ test('a build turn that stops to showMultiSelect fires a checklist gate and resu
   assert.ok(prompts.some(p => /You paused to ask.*chose: routing/s.test(p)))
 })
 
+test('a re-architect turn that stops to ask fires a live gate instead of a stub plan (#356)', async () => {
+  const first = {
+    stack: 'Vike + Prisma',
+    narration: 'first plan',
+    decisions: [{ choice: 'SSR', why: 'data' }],
+    alternatives: [{ option: 'Next.js', whyNot: 'coupling' }],
+  }
+  const steered = { stack: 'Next.js + Postgres', narration: 'steered plan', decisions: [{ choice: 'RSC', why: 'fits' }], alternatives: [] }
+  const awaitBlock =
+    'One call before I re-decide.\n```await-choices\n' +
+    '{ "title": "Server components?", "options": [{ "id": "yes", "label": "Yes" }, { "id": "no", "label": "No" }], "recommended": "yes" }\n' +
+    '```'
+  const driver = new FakeDriver({
+    respond: (prompt: string): string => {
+      // Order matters: the re-architect prompt also matches "You are the architect".
+      if (/You paused to ask/.test(prompt)) return '```json\n' + JSON.stringify(steered) + '\n```'
+      if (/The user reviewed your first choice/.test(prompt)) return awaitBlock // re-architect stops to ask
+      if (/You are the architect/.test(prompt)) return '```json\n' + JSON.stringify(first) + '\n```'
+      if (/Build this app end to end/.test(prompt)) return 'built'
+      if (/production-grade checklist/.test(prompt)) return 'ok\n```json\n{ "blockers": [] }\n```'
+      return 'done'
+    },
+    sessionId: 'rearch356',
+  })
+
+  const events: FrameworkEvent[] = []
+  await runFramework({
+    intent: FAKE_INTENT,
+    driver,
+    cwd: '/tmp/ws',
+    signals: FAKE_SIGNALS,
+    onEvent: e => events.push(e),
+    requestChoice: async req => {
+      if (req.id === 'plan-approval') return { picked: 'alt:0', by: 'user' } // steer to Next.js -> reArchitect
+      if (req.id === 'await-choices') return { picked: 'no', by: 'user' } // answer the agent's question
+      return { picked: 'proceed', by: 'user' } // approve the re-architected plan
+    },
+  })
+
+  // The agent's mid-re-architect question surfaced as a live gate...
+  const gate = events.find(e => e.kind === 'choice' && e.id === 'await-choices')
+  assert.ok(gate && gate.kind === 'choice')
+  assert.equal(gate.title, 'Server components?')
+  assert.ok(events.some(e => e.kind === 'log' && /Continuing with your choice: No/.test(e.message)))
+  // ...and the re-approval gate (#324) offered the REAL steered plan, not the stub fallback.
+  const reApproval = events.find(e => e.kind === 'choice' && e.id === 'plan-approval-1')
+  assert.ok(reApproval && reApproval.kind === 'choice')
+  assert.ok(reApproval.options.some(o => o.label === 'Proceed: Next.js + Postgres'))
+})
+
 test('without a requestChoice handler a build that asks is not gated (#337 headless)', async () => {
   const plan = { stack: 'Vike', narration: 'p', decisions: [{ choice: 'x', why: 'y' }], alternatives: [] }
   const driver = new FakeDriver({

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -42,7 +42,7 @@ import { AWAIT_PROTOCOL, parseAwaitGate, type ParsedAwaitGate } from './turn-gat
 // Value import from todo-loop.js is a benign cycle: todo-loop.js only calls
 // run.js's hoisted function declarations (requestChoices / resolveAwaitGate).
 import { runTodoLoop, type TodoLoopResult } from './todo-loop.js'
-import { continueAfterChoice, decideDeploy, deployWith, domainLoopChecklist, driverArchitect, driverBuild, driverChecklist, driverImprove, driverLoopPrompts, reArchitect } from './steps.js'
+import { continueAfterChoice, decideDeploy, deployWith, domainLoopChecklist, driverArchitect, driverBuild, driverChecklist, driverImprove, driverLoopPrompts, reArchitect, type AwaitResolver } from './steps.js'
 import { hasSessionIdPlaceholder, OPEN_LOOP_MODES, pickedIds, resolveSessionLink, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 import { UsageMeter } from './usage.js'
 
@@ -488,6 +488,23 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
   const verifyWorkspace = opts.driver.name !== 'fake'
   const workspaceOpt = verifyWorkspace ? { verifyWorkspace: true } : {}
 
+  // The shared deps of every agent-facing gate, plus the architect-side await
+  // resolver (#356) built on them when an interactive handler is wired.
+  const gateDeps = {
+    ...(opts.requestChoice ? { requestChoice: opts.requestChoice } : {}),
+    emit,
+    signal: runSignal,
+  }
+  const architectAwait: { resolveAwait?: AwaitResolver } = opts.requestChoice
+    ? {
+        resolveAwait: async (gate, round) => {
+          const answer = await resolveAwaitGate(gate, round, gateDeps)
+          emit({ kind: 'log', message: `Continuing with your choice: ${answer}` })
+          return answer
+        },
+      }
+    : {}
+
   let preview: AppPreview | undefined
   try {
     const bootstrap = new Bootstrap({
@@ -497,16 +514,15 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
       onEvent: (event: BootstrapEvent) => emit({ kind: 'bootstrap', event }),
       steps: {
         scope: () => ({ scope: opts.scope ?? 'full', intent: opts.intent }),
-        architect: planApprovalGate(driverArchitect(session), session, {
-          ...(opts.requestChoice ? { requestChoice: opts.requestChoice } : {}),
-          emit,
-          signal: runSignal,
+        // An architect turn may itself stop to ask (#356, e.g. the #326
+        // unclear-scope flow): resolve it through the same gates instead of
+        // letting the stub-plan fallback swallow the question. Only when someone
+        // can answer, so a headless run stays byte-identical.
+        architect: planApprovalGate(driverArchitect(session, architectAwait), session, {
+          ...gateDeps,
+          ...architectAwait,
         }),
-        build: agentAwaitGate(driverBuild(session, workspaceOpt), session, {
-          ...(opts.requestChoice ? { requestChoice: opts.requestChoice } : {}),
-          emit,
-          signal: runSignal,
-        }),
+        build: agentAwaitGate(driverBuild(session, workspaceOpt), session, gateDeps),
         checklist,
         improve: driverImprove(session, workspaceOpt),
         ...(opts.deploy
@@ -576,6 +592,8 @@ function planApprovalGate(
     emit: (event: FrameworkEvent) => void
     /** The run signal; a gate parked for a pick unblocks (proceed) if the run aborts. */
     signal?: AbortSignal
+    /** Resolver for a re-architect turn that stops to ask (#356). */
+    resolveAwait?: AwaitResolver
   },
 ): (ctx: ArchitectContext) => Promise<ArchitectPlan> {
   return async ctx => {
@@ -616,7 +634,7 @@ function planApprovalGate(
       const chosen = altMatch ? alternatives[Number(altMatch[1])] : undefined
       if (!chosen) return plan // proceed (or an unknown pick) approves the current plan
       emit({ kind: 'log', message: `Re-architecting around your choice: ${chosen.option}` })
-      plan = await reArchitect(session, ctx, plan.stack, chosen.option)
+      plan = await reArchitect(session, ctx, plan.stack, chosen.option, deps.resolveAwait ? { resolveAwait: deps.resolveAwait } : {})
     }
     // Ran out of rounds still picking alternatives: proceed with the latest plan
     // rather than loop forever.

--- a/packages/framework/src/steps.test.ts
+++ b/packages/framework/src/steps.test.ts
@@ -17,6 +17,7 @@ import {
   isWorkspaceEmpty,
   MISSING_VERDICT_BLOCKER,
   parseArchitectPlan,
+  reArchitect,
   verdictFromLoopRun,
 } from './steps.js'
 
@@ -125,6 +126,69 @@ test('driverArchitect returns the parsed plan from the driver turn', async () =>
   }).start({ cwd: '/ws' })
   const plan = await driverArchitect(session)({ intent: 'x', scope: 'full', ledger: new DecisionLedger() })
   assert.equal(plan.stack, 'Next.js')
+})
+
+const ARCHITECT_AWAIT_BLOCK =
+  'I need to know what you meant.\n```await-choices\n' +
+  '{ "title": "Which did you mean?", "options": [{ "id": "blog", "label": "A blog" }, { "id": "shop", "label": "A shop" }] }\n' +
+  '```'
+
+test('driverArchitect resolves an await gate and re-prompts before parsing (#356)', async () => {
+  const session = await new FakeDriver({
+    respond: (prompt: string) =>
+      /You paused to ask/.test(prompt)
+        ? '```json\n' + JSON.stringify(PLAN) + '\n```'
+        : ARCHITECT_AWAIT_BLOCK, // the architect stops to ask first
+  }).start({ cwd: '/ws' })
+  const asked: string[] = []
+  const plan = await driverArchitect(session, {
+    resolveAwait: async gate => {
+      asked.push(gate.title)
+      return 'A shop'
+    },
+  })({ intent: 'x', scope: 'full', ledger: new DecisionLedger() })
+  assert.deepEqual(asked, ['Which did you mean?'])
+  assert.equal(plan.stack, PLAN.stack) // the real plan, not the stub fallback
+})
+
+test('driverArchitect without a resolver keeps the stub fallback (headless, #356)', async () => {
+  const session = await new FakeDriver({ turns: [{ text: ARCHITECT_AWAIT_BLOCK }] }).start({ cwd: '/ws' })
+  const plan = await driverArchitect(session)({ intent: 'a shop', scope: 'full', ledger: new DecisionLedger() })
+  assert.equal(plan.stack, 'A sensible stack for: a shop')
+})
+
+test('reArchitect resolves an await gate and re-prompts before parsing (#356)', async () => {
+  const steered = { stack: 'Next.js + Postgres', narration: 'steered', decisions: [] }
+  const prompts: string[] = []
+  const session = await new FakeDriver({
+    respond: (prompt: string) => {
+      prompts.push(prompt)
+      return /You paused to ask/.test(prompt) ? '```json\n' + JSON.stringify(steered) + '\n```' : ARCHITECT_AWAIT_BLOCK
+    },
+  }).start({ cwd: '/ws' })
+  const plan = await reArchitect(
+    session,
+    { intent: 'x', scope: 'full', ledger: new DecisionLedger() },
+    'Vike',
+    'Next.js',
+    { resolveAwait: async () => 'A shop' },
+  )
+  assert.equal(plan.stack, 'Next.js + Postgres')
+  // The continuation restates the answer contract so the reply is parseable.
+  assert.ok(prompts.some(p => /You paused to ask.*chose: A shop[\s\S]*ONLY a fenced/.test(p)))
+})
+
+test('an architect that keeps asking past the round limit falls back to the latest text (#356)', async () => {
+  const session = await new FakeDriver({ respond: () => ARCHITECT_AWAIT_BLOCK }).start({ cwd: '/ws' })
+  let rounds = 0
+  const plan = await driverArchitect(session, {
+    resolveAwait: async () => {
+      rounds++
+      return 'A shop'
+    },
+  })({ intent: 'a shop', scope: 'full', ledger: new DecisionLedger() })
+  assert.equal(rounds, 5) // bounded, no infinite loop
+  assert.equal(plan.stack, 'A sensible stack for: a shop')
 })
 
 test('driverBuild emits supervisor events and returns the driver summary', async () => {

--- a/packages/framework/src/steps.ts
+++ b/packages/framework/src/steps.ts
@@ -22,7 +22,7 @@ import type {
   Verdict,
 } from '@gemstack/ai-autopilot'
 import type { DriverSession } from './driver/index.js'
-import { parseAwaitGate } from './turn-gate.js'
+import { parseAwaitGate, type ParsedAwaitGate } from './turn-gate.js'
 
 /**
  * Driver-backed {@link https://github.com/gemstack-land/gemstack | Bootstrap} steps.
@@ -53,9 +53,57 @@ export function architectPrompt(intent: string, steer?: string): string {
     'Justify the stack honestly: give its real PROS and its CONS, and name the main',
     'alternative you rejected and why it lost. This is shown to the user as the rationale.',
     STACK_TRADEOFFS,
-    'Respond with ONLY a fenced ```json block of the shape:',
-    '{ "stack": "<one line>", "narration": "<what you are building and why>", "decisions": [{ "choice": "<one line>", "why": "<one line>" }], "pros": ["<upside>"], "cons": ["<downside>"], "alternatives": [{ "option": "<rejected stack>", "whyNot": "<one line>" }] }',
+    ARCHITECT_JSON_SHAPE,
   ].join('\n')
+}
+
+/** The architect's answer contract, restated on every architect (re-)prompt. */
+const ARCHITECT_JSON_SHAPE = [
+  'Respond with ONLY a fenced ```json block of the shape:',
+  '{ "stack": "<one line>", "narration": "<what you are building and why>", "decisions": [{ "choice": "<one line>", "why": "<one line>" }], "pros": ["<upside>"], "cons": ["<downside>"], "alternatives": [{ "option": "<rejected stack>", "whyNot": "<one line>" }] }',
+].join('\n')
+
+/**
+ * Resolve an agent-authored await gate (#337/#339) to the user's answer text.
+ * Wired by the run (see `resolveAwaitGate` there); absent on a headless run.
+ */
+export type AwaitResolver = (gate: ParsedAwaitGate, round: number) => Promise<string>
+
+/** How many times an architect turn may stop to ask before its latest text is parsed as-is. */
+const MAX_ARCHITECT_AWAIT_ROUNDS = 5
+
+/**
+ * Run an architect prompt, honoring agent-authored await gates (#356): an
+ * architect turn that stops to ask (e.g. the #326 unclear-scope flow) is resolved
+ * through `resolveAwait` and re-prompted with the answer, instead of the question
+ * being swallowed into a stub plan by {@link parseArchitectPlan}'s fallbacks.
+ * Without a resolver (headless) the first turn's text is returned unchanged.
+ */
+async function architectTurns(
+  session: DriverSession,
+  firstPrompt: string,
+  opts: { system?: string | undefined; signal?: AbortSignal | undefined; resolveAwait?: AwaitResolver | undefined },
+): Promise<string> {
+  const promptOpts = {
+    ...(opts.system ? { system: opts.system } : {}),
+    ...(opts.signal ? { signal: opts.signal } : {}),
+  }
+  let turn = await session.prompt(firstPrompt, promptOpts)
+  if (!opts.resolveAwait) return turn.text
+  for (let round = 0; round < MAX_ARCHITECT_AWAIT_ROUNDS; round++) {
+    const gate = parseAwaitGate(turn.text)
+    if (!gate) return turn.text
+    const answer = await opts.resolveAwait(gate, round)
+    turn = await session.prompt(
+      [
+        `You paused to ask: "${gate.title}". The user chose: ${answer}.`,
+        'Continue the architect decision with that answer, and do not ask again unless a genuinely new choice comes up.',
+        ARCHITECT_JSON_SHAPE,
+      ].join('\n'),
+      promptOpts,
+    )
+  }
+  return turn.text
 }
 
 /** Compose the build prompt from the architect's plan. */
@@ -183,15 +231,16 @@ export interface DriverStepOptions {
  */
 export function driverArchitect(
   session: DriverSession,
-  opts: { prompt?: (intent: string) => string } & DriverStepOptions = {},
+  opts: { prompt?: (intent: string) => string; resolveAwait?: AwaitResolver } & DriverStepOptions = {},
 ): (ctx: ArchitectContext) => Promise<ArchitectPlan> {
   const compose = opts.prompt ?? architectPrompt
   return async ctx => {
-    const turn = await session.prompt(compose(ctx.intent), {
-      ...(opts.system ? { system: opts.system } : {}),
-      ...(ctx.signal ? { signal: ctx.signal } : {}),
+    const text = await architectTurns(session, compose(ctx.intent), {
+      system: opts.system,
+      signal: ctx.signal,
+      resolveAwait: opts.resolveAwait,
     })
-    return parseArchitectPlan(turn.text, ctx.intent)
+    return parseArchitectPlan(text, ctx.intent)
   }
 }
 
@@ -200,16 +249,19 @@ export function driverArchitect(
  * (#304): same intent, same app goal, but steered to build around the alternative
  * they picked instead of the stack originally chosen. Returns a fresh plan.
  */
-export function reArchitect(
+export async function reArchitect(
   session: DriverSession,
   ctx: ArchitectContext,
   fromStack: string,
   toOption: string,
+  opts: { resolveAwait?: AwaitResolver } = {},
 ): Promise<ArchitectPlan> {
   const steer = `The user reviewed your first choice (${fromStack}) and prefers ${toOption}. Re-decide the stack around ${toOption}, keeping the same app goal.`
-  return session
-    .prompt(architectPrompt(ctx.intent, steer), { ...(ctx.signal ? { signal: ctx.signal } : {}) })
-    .then(turn => parseArchitectPlan(turn.text, ctx.intent))
+  const text = await architectTurns(session, architectPrompt(ctx.intent, steer), {
+    signal: ctx.signal,
+    resolveAwait: opts.resolveAwait,
+  })
+  return parseArchitectPlan(text, ctx.intent)
 }
 
 /**


### PR DESCRIPTION
Closes #356

An architect turn that ends by asking (an `await-choices` / `await-multiselect` block, which the #326 prompt now explicitly encourages on unclear scope) used to be piped straight into `parseArchitectPlan`, so the question was swallowed and a stub plan ("A sensible stack for: ...") reached the plan-approval gate. Sharpest in `reArchitect`, mid plan-approval loop.

Fix, same pattern as the build gate:

- `steps.ts`: `architectTurns()` runs the architect prompt, checks `parseAwaitGate` on each turn, resolves via an injected `AwaitResolver`, and re-prompts with the answer plus the JSON answer contract (extracted as `ARCHITECT_JSON_SHAPE` so the continuation stays parseable). Bounded at 5 rounds. `driverArchitect` and `reArchitect` take the optional resolver.
- `run.ts`: the resolver is built on the shared gate deps (`resolveAwaitGate`, so the dashboard sees the same `choice` events and "Continuing with your choice" narration) and is only wired when `requestChoice` exists. Headless runs are byte-identical: no resolver, old fallback.

5 new tests (4 unit incl the round bound + headless fallback, 1 e2e: pick alternative -> re-architect stops to ask -> gate -> re-approval gate offers the real steered plan). 300 tests green.