### PR TITLE
feat(framework): presets only prefill the textarea; Start sends the edited text verbatim

### DIFF
--- a/.changeset/presets-prefill-textarea.md
+++ b/.changeset/presets-prefill-textarea.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Dashboard presets only prefill the textarea (#353): the [Research] button now loads the full rendered preset prompt for review and editing, and nothing runs until Start / Ctrl+Enter. The edited text is sent verbatim via a new `prompt` start kind and `framework prompt <text>` subcommand (the direct path: gates honored, no build pipeline). Clearing the box reverts Start to a normal build run.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -55,6 +55,27 @@ test('parseArgs reads the research subcommand with its optional what (#331)', ()
   assert.equal(parseArgs(['build', 'a', 'blog']).research, false)
 })
 
+test('parseArgs reads the prompt subcommand with its verbatim text (#353)', () => {
+  const p = parseArgs(['prompt', 'review', 'the', 'auth', 'flow'])
+  assert.equal(p.directPrompt, true)
+  assert.equal(p.intent, 'review the auth flow')
+  assert.equal(parseArgs(['build', 'a', 'blog']).directPrompt, false)
+})
+
+test('runCli errors on a bare `framework prompt` (nothing to run, #353)', async () => {
+  const { io, err } = capture()
+  const code = await runCli(['prompt'], io)
+  assert.equal(code, 2)
+  assert.ok(err.some(l => /needs the prompt text/.test(l)))
+})
+
+test('runCli prompt runs the text through the direct path (#353)', async () => {
+  const { io, out } = capture()
+  const code = await runCli(['prompt', 'say hi', '--fake', '--no-dashboard'], io)
+  assert.equal(code, 0)
+  assert.ok(out.some(l => /prompt run done/.test(l)))
+})
+
 test('parseArgs reads the stop subcommand and the internal --daemon flag', () => {
   const stop = parseArgs(['stop'])
   assert.equal(stop.stop, true)

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -84,6 +84,9 @@ Usage:
   framework research [what]      Rate the "problem variability" of <what> (default:
                                  this PR), then pick which problems to deep-dive.
                                  A direct review prompt on existing code — no build.
+  framework prompt <text>         Run one prompt verbatim through the agent, honoring
+                                 its await gates — no scaffold/build pipeline. This is
+                                 what a dashboard preset sends after you edit it.
   framework --fake                Run the offline demo (no CLI, no model, deterministic).
   framework doctor                Check prerequisites (Claude Code installed, etc.).
   framework relay                 Host a run relay so teammates can watch a run (#230).
@@ -201,6 +204,8 @@ export interface CliOptions {
   stop: boolean
   /** `framework research [what]`: run the Research preset as a direct prompt (#331). */
   research: boolean
+  /** `framework prompt <text>`: run one prompt verbatim through the direct path (#353). */
+  directPrompt: boolean
   error?: string
 }
 
@@ -226,6 +231,7 @@ export function parseArgs(argv: string[]): CliOptions {
     daemon: false,
     stop: false,
     research: false,
+    directPrompt: false,
     todoLoop: true,
   }
   const PERMISSION_MODES: PermissionMode[] = ['default', 'acceptEdits', 'bypassPermissions', 'plan']
@@ -388,6 +394,9 @@ export function parseArgs(argv: string[]): CliOptions {
   } else if (words[0] === 'research') {
     opts.research = true
     words.shift() // the remaining words are the "what" param (may be empty -> default)
+  } else if (words[0] === 'prompt') {
+    opts.directPrompt = true
+    words.shift() // the remaining words are the prompt text, run verbatim (#353)
   }
   opts.intent = words.join(' ').trim()
   return opts
@@ -571,6 +580,12 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   const intent = opts.intent || (fake ? FAKE_INTENT : '')
   // Bare `framework` (no prompt): ensure the persistent dashboard is running and
   // print the convenience commands + version (#299/#302). A prompt still builds.
+  // A bare `framework prompt` has nothing to run — verbatim text is required.
+  if (opts.directPrompt && !intent) {
+    io.err('framework prompt needs the prompt text, e.g. `framework prompt "review the auth flow"`.')
+    io.err('Run `framework --help` for usage.')
+    return 2
+  }
   // A bare `framework research` is a real run — its "what" defaults to `this PR`.
   if (!intent && !fake && !opts.research) return ensureDaemonCmd(opts, io)
 
@@ -746,7 +761,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // AI meta-select: with no preset chosen explicitly, infer the best fit (+ modes +
   // build event) from the intent + workspace, then resolve it with the active modes.
   // Narrates through onEvent so the routing turn is visible on the dashboard (#310).
-  if (!fake && opts.autoPreset && !presetName && !opts.research) {
+  if (!fake && opts.autoPreset && !presetName && !opts.research && !opts.directPrompt) {
     const selection = await autoSelectPreset({ intent, cwd, signals, claudeOpts, signal: controller.signal, io, onEvent })
     if (selection?.preset) {
       presetName = selection.preset
@@ -778,17 +793,20 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
 
   const driver: Driver = fake ? fakeDriver() : new ClaudeCodeDriver(claudeOpts)
 
-  // `framework research [what]` (#331): the direct prompt path — render the
-  // Research preset prompt and run it through runPrompt, which honors its gates
+  // `framework research [what]` (#331) and `framework prompt <text>` (#353): the
+  // direct prompt path — run one prompt through runPrompt, which honors its gates
   // (#337/#339) but skips the scope -> architect -> build scaffolding entirely.
+  // Research renders its preset template around the "what"; prompt runs the text
+  // verbatim (it may already BE an edited preset, so it must not be re-rendered).
   // Shares all the wiring above (dashboard, store, control channel, budget).
-  if (opts.research) {
+  if (opts.research || opts.directPrompt) {
+    const kindLabel = opts.directPrompt ? 'prompt run' : 'research'
     const userSystemPrompt = await loadUserSystemPrompt(cwd)
     if (userSystemPrompt) io.out(`◆ system prompt: ${SYSTEM_PROMPT_FILE}`)
     if (fileConfig.antiLazyPill === false) io.out('◆ anti-lazy-pill: off (the-framework.yml)')
     try {
       await runPrompt({
-        prompt: renderResearchPrompt(intent),
+        prompt: opts.directPrompt ? intent : renderResearchPrompt(intent),
         driver,
         cwd,
         onEvent,
@@ -810,7 +828,11 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
         })(),
       })
       clearInterrupt()
-      io.out('\n✓ research done: see the REVIEW-PROBLEMS / TODO files it wrote.')
+      io.out(
+        opts.directPrompt
+          ? '\n✓ prompt run done.'
+          : '\n✓ research done: see the REVIEW-PROBLEMS / TODO files it wrote.',
+      )
       await store?.close()
       if (dashboard) {
         io.out(`\nDashboard still live at ${dashboard.url}. Press Ctrl+C to exit.`)
@@ -830,7 +852,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
         }
         return 0
       }
-      io.err(`\n✗ research failed: ${err instanceof Error ? err.message : String(err)}`)
+      io.err(`\n✗ ${kindLabel} failed: ${err instanceof Error ? err.message : String(err)}`)
       await dashboard?.close()
       return 1
     } finally {

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -294,6 +294,21 @@ fs.appendFileSync(path.join(args[args.indexOf('--cwd') + 1], 'started.log'), JSO
     }
     assert.deepEqual(JSON.parse(lines[1]!), ['research', '--no-dashboard', '--cwd', cwd])
 
+    // kind=prompt (#353): a preset the user reviewed in the textarea runs verbatim
+    // through the `prompt` subcommand, never re-rendered.
+    const verbatim = 'Measure "problem variability" of this PR\n- List all high-level flows'
+    let third = await post({ prompt: verbatim, kind: 'prompt' })
+    for (let i = 0; i < 100 && third.status !== 202; i++) {
+      await new Promise(r => setTimeout(r, 50))
+      third = await post({ prompt: verbatim, kind: 'prompt' })
+    }
+    assert.equal(third.status, 202)
+    for (let i = 0; i < 100 && lines.length < 3; i++) {
+      await new Promise(r => setTimeout(r, 20))
+      lines = (await readFile(join(cwd, 'started.log'), 'utf8')).split('\n').filter(Boolean)
+    }
+    assert.deepEqual(JSON.parse(lines[2]!), ['prompt', verbatim, '--no-dashboard', '--cwd', cwd])
+
     ac.abort()
     await done
   } finally {

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -226,8 +226,14 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
       return { ok: false, error: 'refusing to spawn a run from a test entry; pass an explicit binPath' }
     }
     // [Research] (#331) runs the research subcommand; its empty prompt is fine
-    // (the "what" defaults to `this PR` in the CLI).
-    const runArgs = kind === 'research' ? ['research', ...(prompt ? [prompt] : [])] : [prompt]
+    // (the "what" defaults to `this PR` in the CLI). A `prompt` kind (#353) is a
+    // preset the user reviewed in the textarea: run it verbatim, never re-render.
+    const runArgs =
+      kind === 'research'
+        ? ['research', ...(prompt ? [prompt] : [])]
+        : kind === 'prompt'
+          ? ['prompt', prompt]
+          : [prompt]
     const child = spawn(process.execPath, [binPath, ...runArgs, '--no-dashboard', '--cwd', cwd], {
       detached: true,
       stdio: 'ignore',
@@ -244,9 +250,17 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
       if (code) dashboard.push({ kind: 'log', message: `✗ run exited with code ${code}` })
     })
     activeRunPid = child.pid
+    // A verbatim prompt can be a whole preset document: narrate its first line only.
+    const firstLine = prompt.split('\n', 1)[0] ?? ''
+    const brief = firstLine.length > 80 ? `${firstLine.slice(0, 80)}…` : firstLine
     dashboard.push({
       kind: 'log',
-      message: kind === 'research' ? `▶ research started: ${prompt || 'this PR'}` : `▶ run started: ${prompt}`,
+      message:
+        kind === 'research'
+          ? `▶ research started: ${prompt || 'this PR'}`
+          : kind === 'prompt'
+            ? `▶ prompt run started: ${brief}`
+            : `▶ run started: ${prompt}`,
     })
     return { ok: true }
   }

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -1,4 +1,5 @@
 import { CLAUDE_CODE_SESSION_LINK } from '../events.js'
+import { renderResearchPrompt } from '../research-preset.js'
 
 /**
  * The single self-contained dashboard page: HTML + inline CSS + inline JS, no
@@ -198,7 +199,7 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
     <textarea id="start-prompt" rows="3" placeholder="What should the agent build?"></textarea>
     <div id="start-actions">
       <button id="start-run">&#9654; Start<span class="kbd">Ctrl+Enter</span></button>
-      <button id="start-research" title="Rate the problem variability of the prompt above (default: this PR), then pick which problems to deep-dive">&#128269; Research</button>
+      <button id="start-research" title="Prefill the Research preset prompt (rates problem variability, picks deep-dives); review or edit it, then Start">&#128269; Research</button>
       <span id="start-note"></span>
     </div>
   </section>
@@ -259,6 +260,7 @@ function clientScript(stoppable: boolean, choiceable: boolean, startable: boolea
 const STOPPABLE = ${stoppable ? 'true' : 'false'};
 const CHOICEABLE = ${choiceable ? 'true' : 'false'};
 const STARTABLE = ${startable ? 'true' : 'false'};
+const RESEARCH_PROMPT = ${JSON.stringify(renderResearchPrompt())};
 const AUTO_ACCEPT_MS = 10000;
 const GENERIC_SESSION_LINK = ${JSON.stringify(CLAUDE_CODE_SESSION_LINK)};
 let ended = false;
@@ -698,32 +700,45 @@ syncNotifyBtn();
 
 // Start a run (#345): POST the prompt to /api/start; the daemon spawns the run
 // and its events stream in over the same SSE feed. A 409 means one is active.
-// kind 'research' (#331) runs the Research preset on the prompt instead of
-// building it; its empty prompt is fine (the "what" defaults to "this PR").
-function startNewRun(kind) {
+// Presets only PREFILL the textarea (#353): the [Research] button loads the full
+// preset prompt for review/editing and flips startKind to 'prompt' (run the text
+// verbatim); nothing is sent until Start / Ctrl+Enter. Clearing the box reverts
+// to a normal 'build' run.
+let startKind = 'build';
+function startNewRun() {
   if (!STARTABLE) return;
   const note = $('start-note');
   const prompt = $('start-prompt').value.trim();
-  if (!prompt && kind !== 'research') { note.textContent = 'type what to build first'; return; }
+  if (!prompt) { note.textContent = startKind === 'build' ? 'type what to build first' : 'the prompt is empty'; return; }
   const buttons = [$('start-run'), $('start-research')];
   for (const b of buttons) b.disabled = true;
   note.textContent = 'starting\\u2026';
   fetch('api/start', { method: 'POST', headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ prompt: prompt, kind: kind }) })
+    body: JSON.stringify({ prompt: prompt, kind: startKind }) })
     .then(async r => {
       for (const b of buttons) b.disabled = false;
-      if (r.ok) { note.textContent = ''; $('start-prompt').value = ''; showLive(); return; }
+      if (r.ok) { note.textContent = ''; $('start-prompt').value = ''; startKind = 'build'; showLive(); return; }
       let msg = 'could not start (' + r.status + ')';
       try { const b = await r.json(); if (b && b.error) msg = b.error; } catch {}
       note.textContent = msg;
     })
     .catch(() => { for (const b of buttons) b.disabled = false; note.textContent = 'could not reach the dashboard server'; });
 }
-$('start-run').addEventListener('click', () => startNewRun('build'));
-$('start-research').addEventListener('click', () => startNewRun('research'));
+$('start-run').addEventListener('click', startNewRun);
+$('start-research').addEventListener('click', () => {
+  const box = $('start-prompt');
+  box.value = RESEARCH_PROMPT;
+  startKind = 'prompt';
+  $('start-note').textContent = 'research preset loaded \\u2014 review or edit, then Start';
+  box.focus();
+});
+$('start-prompt').addEventListener('input', () => {
+  // An emptied box is a fresh start: back to a normal build run.
+  if (!$('start-prompt').value.trim() && startKind !== 'build') { startKind = 'build'; $('start-note').textContent = ''; }
+});
 $('start-prompt').addEventListener('keydown', ev => {
   // stopPropagation so the document-level Ctrl+Enter never accepts a choice too.
-  if ((ev.ctrlKey || ev.metaKey) && ev.key === 'Enter') { ev.preventDefault(); ev.stopPropagation(); startNewRun('build'); }
+  if ((ev.ctrlKey || ev.metaKey) && ev.key === 'Enter') { ev.preventDefault(); ev.stopPropagation(); startNewRun(); }
 });
 
 $('stop').addEventListener('click', stopRun);

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -371,10 +371,25 @@ test('/api/start passes the run kind through; a research start may omit the prom
       { prompt: 'the auth flow', kind: 'research' },
       { prompt: '', kind: 'research' },
     ])
-    // The page ships the [Research] button beside Start.
+    // The page ships the [Research] button beside Start, as a prefill (#353): the
+    // full preset text is baked in, and nothing is sent until Start / Ctrl+Enter.
     const page = await fetchText(dash.url + '/')
     assert.match(page.body, /id="start-research"/)
-    assert.match(page.body, /startNewRun\('research'\)/)
+    assert.match(page.body, /const RESEARCH_PROMPT = /)
+    assert.match(page.body, /research preset loaded/)
+  } finally {
+    await dash.close()
+  }
+})
+
+test('/api/start kind=prompt runs verbatim text and requires a prompt (#353)', async () => {
+  const calls: Array<{ prompt: string; kind: string }> = []
+  const dash = await startDashboard({ port: 0, onStart: (prompt, kind) => { calls.push({ prompt, kind }); return { ok: true } } })
+  try {
+    assert.equal((await postJson(dash.url + '/api/start', { prompt: 'Measure "problem variability" of the auth flow', kind: 'prompt' })).status, 202)
+    // A verbatim prompt run with no text has nothing to run.
+    assert.equal((await postJson(dash.url + '/api/start', { prompt: '   ', kind: 'prompt' })).status, 400)
+    assert.deepEqual(calls, [{ prompt: 'Measure "problem variability" of the auth flow', kind: 'prompt' }])
   } finally {
     await dash.close()
   }

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -45,11 +45,13 @@ export interface DashboardOptions {
 }
 
 /**
- * What a dashboard Start spawns (#345/#331): `build` is the normal framework
- * run; `research` is the [Research] preset as a direct prompt, whose empty
- * prompt is allowed (its "what" defaults to `this PR`).
+ * What a dashboard Start spawns (#345/#331/#353): `build` is the normal framework
+ * run; `prompt` runs the posted text verbatim through the direct path — what the
+ * page sends after a preset prefilled (and the user possibly edited) the textarea;
+ * `research` renders the [Research] preset around the posted "what" server-side
+ * (empty allowed, defaults to `this PR`) and remains for API callers.
  */
-export type StartRunKind = 'build' | 'research'
+export type StartRunKind = 'build' | 'research' | 'prompt'
 
 /** The outcome of an {@link DashboardOptions.onStart} attempt (#345). */
 export type StartRunResult =
@@ -209,9 +211,10 @@ function handle(
     }
     readJsonBody(req, body => {
       const prompt = typeof body['prompt'] === 'string' ? body['prompt'].trim() : ''
-      const kind: StartRunKind = body['kind'] === 'research' ? 'research' : 'build'
-      // A research run's "what" defaults server-side (`this PR`), so only a
-      // build needs a prompt.
+      const kind: StartRunKind =
+        body['kind'] === 'research' ? 'research' : body['kind'] === 'prompt' ? 'prompt' : 'build'
+      // A research run's "what" defaults server-side (`this PR`); a build or a
+      // verbatim prompt run has nothing to run without text.
       if (!prompt && kind !== 'research') {
         res.writeHead(400, { 'content-type': 'application/json' })
         res.end('{"error":"a non-empty prompt is required"}')

--- a/packages/framework/src/dashboard/start-prefill.test.ts
+++ b/packages/framework/src/dashboard/start-prefill.test.ts
@@ -1,0 +1,75 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { JSDOM } from 'jsdom'
+import { dashboardHtml } from './page.js'
+import { renderResearchPrompt } from '../research-preset.js'
+
+// Presets only prefill the textarea (#353): the [Research] button must load the
+// full preset prompt for review and send NOTHING; Start posts the (possibly
+// edited) text verbatim as kind 'prompt'. Like the autopilot smoke (#311), this
+// drives the real client JS in jsdom rather than asserting the code ships.
+
+interface StartPost {
+  prompt: string
+  kind: string
+}
+
+function boot() {
+  const posts: StartPost[] = []
+  const dom = new JSDOM(dashboardHtml('Test', true, true, true), {
+    runScripts: 'dangerously',
+    url: 'http://localhost/',
+    beforeParse(window) {
+      const w = window as unknown as Record<string, unknown>
+      // Neuter the page's polling timers so the test never leaves live handles.
+      w['setInterval'] = () => 0
+      w['setTimeout'] = () => 0
+      w['EventSource'] = class {
+        onmessage = null
+        onerror = null
+        close() {}
+      }
+      w['fetch'] = (url: string, opts?: { method?: string; body?: string }) => {
+        if (url === 'api/start' && opts?.method === 'POST' && opts.body) posts.push(JSON.parse(opts.body) as StartPost)
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ runs: [], docs: [] }) })
+      }
+    },
+  })
+  const doc = dom.window.document
+  const box = doc.getElementById('start-prompt') as HTMLTextAreaElement
+  return {
+    posts,
+    box,
+    note: () => doc.getElementById('start-note')?.textContent ?? '',
+    click: (id: string) => (doc.getElementById(id) as HTMLButtonElement).click(),
+    type: (value: string) => {
+      box.value = value
+      box.dispatchEvent(new dom.window.Event('input'))
+    },
+  }
+}
+
+test('[Research] only prefills the textarea; Start sends the edited text verbatim (#353)', async () => {
+  const h = boot()
+  h.click('start-research')
+  assert.equal(h.posts.length, 0) // prefill sends nothing
+  assert.equal(h.box.value, renderResearchPrompt())
+  assert.match(h.note(), /research preset loaded/)
+  // The user customizes the prompt, then presses Start.
+  h.type(h.box.value.replace('this PR', 'the auth flow'))
+  h.click('start-run')
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(h.posts.length, 1)
+  assert.equal(h.posts[0]!.kind, 'prompt')
+  assert.match(h.posts[0]!.prompt, /the auth flow/)
+})
+
+test('clearing a prefilled preset reverts Start to a normal build run (#353)', async () => {
+  const h = boot()
+  h.click('start-research')
+  h.type('')
+  h.type('a plain blog')
+  h.click('start-run')
+  await new Promise(resolve => setImmediate(resolve))
+  assert.deepEqual(h.posts, [{ prompt: 'a plain blog', kind: 'build' }])
+})


### PR DESCRIPTION
Closes #353

[Research] no longer starts a run. It prefills the textarea with the full rendered preset prompt (the "what" slot holds its `this PR` default, editable inline), notes "research preset loaded - review or edit, then Start", and nothing is sent until Start / Ctrl+Enter.

The key wrinkle: an edited preset must run VERBATIM. Re-sending it as kind `research` would nest the text back into the preset template, and kind `build` would drag a review prompt through the scaffold pipeline. So:

- New start kind `prompt` end to end: the page posts it after a prefill, `/api/start` requires non-empty text for it, and the daemon spawns the new `framework prompt <text>` subcommand, which shares the research branch (runPrompt: gates honored, no build pipeline) but skips the template render.
- Clearing the textarea reverts Start to a normal `build` run; the API `research` kind stays for existing callers.
- The daemon narrates a verbatim run by its first line (truncated), since the prompt can be a whole document.

Interpretation note: I read Rom's "users can customize the prompt" as the full prompt in the box, hence the verbatim path; commented on #353 so he can veto.

Tests: jsdom drive of the real client JS (prefill sends nothing, Start posts kind prompt with the edited text, cleared box reverts to build), /api/start kind matrix, daemon spawn argv, CLI parse + bare-`prompt` usage error + a fake-driver e2e. 306 green. Also live-drove `framework prompt "say hi" --fake` against dist.