### PR TITLE
feat(framework): plan-approval gate for showMarkdown() + AWAIT (#358)

### DIFF
--- a/.changeset/confirmation-gate-358.md
+++ b/.changeset/confirmation-gate-358.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Turn-boundary gate for plan approval (`showMarkdown()` + AWAIT): a build turn that ends with an `await-confirmation` block (the #326 large-scope PLAN flow) now pauses the run with a green Approve and a red Decline button on the dashboard. Approve resumes the build; Decline logs "Plan declined, awaiting user instructions." and stops the run cleanly (like the budget cap), so nothing reviews or improves work the user just declined. Headless runs auto-approve, keeping programmatic runs deterministic. Try it offline with `FRAMEWORK_FAKE_AWAIT=confirmation`.

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -236,7 +236,9 @@ A malformed file is a warning, never a failed run.
 
 Every prompt is framed with the built-in system prompt (#326, the successor of the
 validated "anti-lazy-pill" #297): unclear scope becomes a ranked `showChoices()`
-list, a large scope becomes a `PLAN_<session>.agent.md` to approve, a very large one
+list, a large scope becomes a `PLAN_<session>.agent.md` to approve (a live
+Approve/Decline gate on the dashboard; declining stops the run and hands control
+back to you), a very large one
 also spins off a `TODO_<session>.agent.md` backlog (consumed by the backlog loop),
 an alternatives pass rates problem "variability" before code is written, and edits
 to existing code stay minimal. The prompt is a template: `${{ ... }}` JS fragments

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -131,6 +131,16 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   #choice-accept { font: inherit; font-size: 13px; font-weight: 600; cursor: pointer; color: #0b0e14;
     background: #6ea8fe; border: 0; border-radius: 6px; padding: 6px 16px; }
   #choice-accept:hover { background: #8bbaff; }
+  /* Approve/Decline confirmation buttons (#358): shown instead of the option list. */
+  #choice-approve { font: inherit; font-size: 13px; font-weight: 600; cursor: pointer; color: #0b0e14;
+    background: #4cc38a; border: 0; border-radius: 6px; padding: 6px 16px; }
+  #choice-approve:hover { background: #6fd6a5; }
+  #choice-approve[hidden], #choice-decline[hidden], #choice-accept[hidden] { display: none; }
+  #choice-decline { font: inherit; font-size: 13px; font-weight: 600; cursor: pointer; color: #fff;
+    background: #e5484d; border: 0; border-radius: 6px; padding: 6px 16px; }
+  #choice-decline:hover { background: #f2555a; }
+  #choice-file { color: #8b93a3; font-size: 12px; margin: -4px 0 10px; }
+  #choice-file[hidden] { display: none; }
   #autopilot-row { display: flex; align-items: center; gap: 6px; color: #b7c0d0; font-size: 13px; cursor: pointer; }
   #choice-count { color: #6ea8fe; font-size: 12px; }
   .kbd { color: #26324a; background: #aebfe0; border-radius: 4px; padding: 0 5px; font-size: 10px;
@@ -206,9 +216,12 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   <section id="choice-panel" hidden>
     <h2>Your call</h2>
     <div id="choice-title"></div>
+    <div id="choice-file" hidden></div>
     <ul id="choice-options"></ul>
     <div id="choice-actions">
       <button id="choice-accept">Accept<span class="kbd">Ctrl+Enter</span></button>
+      <button id="choice-approve" hidden>&#10003; Approve<span class="kbd">Ctrl+Enter</span></button>
+      <button id="choice-decline" hidden>&#10007; Decline</button>
       <label id="autopilot-row"><input type="checkbox" id="autopilot-toggle" /> autopilot</label>
       <span id="choice-count"></span>
     </div>
@@ -432,10 +445,19 @@ function showChoice(req) {
   activeChoice = req;
   $('choice-title').textContent = req.title || 'Your call';
   const ul = $('choice-options'); ul.innerHTML = '';
+  // A confirmation (#358) renders Approve/Decline buttons instead of the option list,
+  // pointing at the plan file the doc sidebar shows.
+  const confirm = !!req.confirm;
+  $('choice-accept').hidden = confirm;
+  $('choice-approve').hidden = !confirm;
+  $('choice-decline').hidden = !confirm;
+  const fileEl = $('choice-file');
+  fileEl.hidden = !(confirm && req.file);
+  fileEl.textContent = confirm && req.file ? 'Review ' + req.file + ' in the doc panel.' : '';
   // A multi-select (#332) renders checkboxes pre-checked per option default; a
   // single-select renders radios with the recommended option pre-selected (#304).
   const multi = !!req.multi;
-  for (const o of (req.options || [])) {
+  for (const o of (confirm ? [] : (req.options || []))) {
     const li = document.createElement('li');
     const type = multi ? 'checkbox' : 'radio';
     const nameAttr = multi ? '' : ' name="choice-opt"';
@@ -477,10 +499,12 @@ function stopCountdown() { if (choiceTimer) { clearInterval(choiceTimer); choice
 function cancelAutopilot() {
   if (choiceTimer) { stopCountdown(); $('choice-count').textContent = 'autopilot canceled \\u2014 pick manually'; }
 }
-function acceptChoice(by) {
+function acceptChoice(by, pickOverride) {
   if (!activeChoice) return;
   const id = activeChoice.id;
-  const pick = selectedChoice();
+  // The Decline button (#358) posts its pick directly; everything else reads the form
+  // (a confirmation has no inputs, so selectedChoice falls back to recommended = approve).
+  const pick = pickOverride !== undefined ? pickOverride : selectedChoice();
   stopCountdown();
   activeChoice = null;
   $('choice-panel').hidden = true;
@@ -744,6 +768,8 @@ $('start-prompt').addEventListener('keydown', ev => {
 $('stop').addEventListener('click', stopRun);
 $('back-live').addEventListener('click', showLive);
 $('choice-accept').addEventListener('click', () => acceptChoice('user'));
+$('choice-approve').addEventListener('click', () => acceptChoice('user', 'approve'));
+$('choice-decline').addEventListener('click', () => acceptChoice('user', 'decline'));
 $('autopilot-toggle').addEventListener('change', ev => {
   localStorage.setItem('framework:autopilot', ev.target.checked ? '1' : '0');
   if (ev.target.checked) startCountdown(); else { stopCountdown(); $('choice-count').textContent = 'autopilot off'; }

--- a/packages/framework/src/events.ts
+++ b/packages/framework/src/events.ts
@@ -39,6 +39,14 @@ export interface ChoiceRequest {
   multi?: boolean
   /** Auto-accept the recommended option after this many ms when autopilot is on. Default 10000. */
   autoAcceptMs?: number
+  /**
+   * Render as an Approve/Decline confirmation (#358): the dashboard shows a green
+   * Approve and a red Decline button instead of the option list. The options still
+   * carry the two ids, so the pick machinery is unchanged.
+   */
+  confirm?: boolean
+  /** The markdown file under approval (e.g. `PLAN_<slug>.agent.md`); the doc sidebar renders it. */
+  file?: string
 }
 
 /** Who resolved a {@link ChoiceRequest}: a human, the autopilot countdown, or a headless auto-accept. */

--- a/packages/framework/src/fake-script.ts
+++ b/packages/framework/src/fake-script.ts
@@ -64,7 +64,7 @@ const TURNS: FakeTurn[] = [ARCHITECT_TURN, BUILD_TURN, CHECKLIST_BLOCKER, IMPROV
 // single-select / #339 multi-select checklist) can be seen offline. The build turn ends
 // with an await block; the framework shows the gate, waits, then re-prompts (RESUME_TURN),
 // and the run continues to review as usual. Needs the dashboard on (so requestChoice is
-// wired); selected via FRAMEWORK_FAKE_AWAIT=choices|multiselect.
+// wired); selected via FRAMEWORK_FAKE_AWAIT=choices|multiselect|confirmation.
 const AWAIT_CHOICES_TURN: FakeTurn = {
   text:
     'I need one decision before wiring auth.\n```await-choices\n' +
@@ -79,11 +79,22 @@ const AWAIT_MULTISELECT_TURN: FakeTurn = {
   actions: ['Read', 'Grep'],
   usage: FAKE_USAGE,
 }
+const AWAIT_CONFIRMATION_TURN: FakeTurn = {
+  text:
+    'The scope is large, so I wrote a plan first.\n```await-confirmation\n' +
+    '{ "title": "Approve the plan for the orders app?", "file": "PLAN_fake-orders-app.agent.md" }\n```',
+  actions: ['Write'],
+  usage: FAKE_USAGE,
+}
 const RESUME_TURN: FakeTurn = { text: 'Applied your answer and finished building the orders app.', actions: ['Write', 'Bash'], usage: FAKE_USAGE }
 
 /** Scripted turns for the demo, optionally routed through a turn-boundary gate. */
 export function demoTurns(awaitMode: string | undefined): FakeTurn[] {
-  const askTurn = awaitMode === 'choices' ? AWAIT_CHOICES_TURN : awaitMode === 'multiselect' ? AWAIT_MULTISELECT_TURN : undefined
+  const askTurn =
+    awaitMode === 'choices' ? AWAIT_CHOICES_TURN
+    : awaitMode === 'multiselect' ? AWAIT_MULTISELECT_TURN
+    : awaitMode === 'confirmation' ? AWAIT_CONFIRMATION_TURN
+    : undefined
   if (!askTurn) return TURNS
   // The build asks (askTurn), the gate resolves, the framework re-prompts (RESUME_TURN),
   // then the normal review turns follow.

--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -2,7 +2,7 @@ import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { hasSessionIdPlaceholder, resolveSessionLink, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 import { resolveAwaitGate } from './run.js'
 import { renderSystemPrompt, systemPromptBlock, type TfContext } from './system-prompt.js'
-import { AWAIT_PROTOCOL, parseAwaitGate } from './turn-gate.js'
+import { AWAIT_PROTOCOL, PLAN_DECLINED_MESSAGE, isDeclinedConfirmation, parseAwaitGate } from './turn-gate.js'
 import { UsageMeter } from './usage.js'
 
 /**
@@ -129,6 +129,12 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
     let gate = parseAwaitGate(turn.text)
     for (let round = 0; round < MAX_AWAIT_ROUNDS && gate; round++) {
       const answer = await resolveAwaitGate(gate, round, { requestChoice: opts.requestChoice, emit, signal: runSignal })
+      if (isDeclinedConfirmation(gate, answer)) {
+        // A declined plan (#358) ends the run cleanly: the user takes over with fresh instructions.
+        emit({ kind: 'log', message: PLAN_DECLINED_MESSAGE })
+        gate = undefined
+        break
+      }
       emit({ kind: 'log', message: `Continuing with your choice: ${answer}` })
       turn = await session.prompt(
         `You paused to ask: "${gate.title}". The user chose: ${answer}. Continue with that decision, and do not ask again unless a genuinely new choice comes up.`,

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -802,6 +802,86 @@ test('a build turn that stops to showMultiSelect fires a checklist gate and resu
   assert.ok(prompts.some(p => /You paused to ask.*chose: routing/s.test(p)))
 })
 
+test('a build turn that stops for plan approval resumes on Approve (#358)', async () => {
+  const plan = { stack: 'Vike', narration: 'p', decisions: [{ choice: 'x', why: 'y' }], alternatives: [] }
+  const awaitBlock =
+    'The scope is large, so I wrote a plan.\n```await-confirmation\n' +
+    '{ "title": "Approve the orders plan?", "file": "PLAN_orders.agent.md" }\n' +
+    '```'
+  const driver = new FakeDriver({
+    respond: (prompt: string): string => {
+      if (/You are the architect/.test(prompt)) return '```json\n' + JSON.stringify(plan) + '\n```'
+      if (/Build this app end to end/.test(prompt)) return awaitBlock
+      if (/You paused to ask/.test(prompt)) return 'Built the plan out. Done.'
+      if (/production-grade checklist/.test(prompt)) return 'Reviewed.\n```json\n{ "blockers": [] }\n```'
+      return 'done'
+    },
+    sessionId: 'confirm358',
+  })
+
+  const events: FrameworkEvent[] = []
+  const prompts: string[] = []
+  const { result } = await runFramework({
+    intent: FAKE_INTENT,
+    driver,
+    cwd: '/tmp/ws',
+    signals: FAKE_SIGNALS,
+    onEvent: e => {
+      events.push(e)
+      if (e.kind === 'driver' && e.event.type === 'start') prompts.push(e.event.prompt)
+    },
+    requestChoice: async () => ({ picked: 'approve', by: 'user' }),
+  })
+
+  // The approval surfaced as a confirmation gate carrying the plan file.
+  const gate = events.find(e => e.kind === 'choice' && e.id === 'await-confirmation')
+  assert.ok(gate && gate.kind === 'choice')
+  assert.equal(gate.confirm, true)
+  assert.equal(gate.file, 'PLAN_orders.agent.md')
+  assert.equal(gate.recommended, 'approve')
+  assert.deepEqual(gate.options.map(o => o.id), ['approve', 'decline'])
+  // Approved: the driver was re-prompted to continue and the run finished.
+  assert.ok(events.some(e => e.kind === 'log' && /Continuing with your choice: Approve/.test(e.message)))
+  assert.ok(prompts.some(p => /You paused to ask.*Approve the orders plan.*chose: Approve/s.test(p)))
+  assert.equal(result.productionGrade, true)
+})
+
+test('a declined plan stops the run cleanly instead of building on (#358)', async () => {
+  const plan = { stack: 'Vike', narration: 'p', decisions: [{ choice: 'x', why: 'y' }], alternatives: [] }
+  const awaitBlock = 'Plan written.\n```await-confirmation\n{ "title": "Approve?", "file": "PLAN_x.agent.md" }\n```'
+  let resumed = false
+  const driver = new FakeDriver({
+    respond: (prompt: string): string => {
+      if (/You are the architect/.test(prompt)) return '```json\n' + JSON.stringify(plan) + '\n```'
+      if (/Build this app end to end/.test(prompt)) return awaitBlock
+      if (/You paused to ask/.test(prompt)) resumed = true
+      if (/production-grade checklist/.test(prompt)) resumed = true // a declined plan must not be reviewed either
+      return 'done'
+    },
+    sessionId: 'decline358',
+  })
+
+  const events: FrameworkEvent[] = []
+  await assert.rejects(
+    runFramework({
+      intent: FAKE_INTENT,
+      driver,
+      cwd: '/tmp/ws',
+      signals: FAKE_SIGNALS,
+      onEvent: e => events.push(e),
+      requestChoice: async req => ({ picked: req.confirm ? 'decline' : 'proceed', by: 'user' }),
+    }),
+  )
+  assert.equal(resumed, false)
+  assert.ok(events.some(e => e.kind === 'log' && /Plan declined, awaiting user instructions/.test(e.message)))
+  // A decline is a clean stop, not a failure.
+  const end = events.find(e => e.kind === 'end')
+  assert.ok(end && end.kind === 'end')
+  assert.equal(end.ok, false)
+  assert.equal(end.stopped, true)
+  assert.equal(end.detail, 'plan declined')
+})
+
 test('a re-architect turn that stops to ask fires a live gate instead of a stub plan (#356)', async () => {
   const first = {
     stack: 'Vike + Prisma',

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -38,7 +38,7 @@ import { snapshotWorkspace } from './sandbox.js'
 import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { memoryFraming, type LoadedMemory } from './memory.js'
 import { systemPromptBlock, type TfContext } from './system-prompt.js'
-import { AWAIT_PROTOCOL, parseAwaitGate, type ParsedAwaitGate } from './turn-gate.js'
+import { AWAIT_PROTOCOL, CONFIRM_APPROVED, CONFIRM_DECLINED, PLAN_DECLINED_MESSAGE, isDeclinedConfirmation, parseAwaitGate, type ParsedAwaitGate } from './turn-gate.js'
 // Value import from todo-loop.js is a benign cycle: todo-loop.js only calls
 // run.js's hoisted function declarations (requestChoices / resolveAwaitGate).
 import { runTodoLoop, type TodoLoopResult } from './todo-loop.js'
@@ -385,7 +385,14 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
   // usage. Everything downstream aborts on `runSignal`; only the budget path (or a
   // caller abort) trips it. With no caller signal this is just the budget signal.
   const budgetController = new AbortController()
-  const runSignal = opts.signal ? AbortSignal.any([opts.signal, budgetController.signal]) : budgetController.signal
+  // A declined plan (#358) also stops the run cleanly, like the budget cap: nothing
+  // downstream should review or improve work the user just declined.
+  const declineController = new AbortController()
+  const runSignal = AbortSignal.any([
+    ...(opts.signal ? [opts.signal] : []),
+    budgetController.signal,
+    declineController.signal,
+  ])
 
   // Watch the black box for its real session id (the {type:'result'} event) and
   // surface it as `session-update` once known — that is the honest handle a UI
@@ -494,11 +501,17 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     ...(opts.requestChoice ? { requestChoice: opts.requestChoice } : {}),
     emit,
     signal: runSignal,
+    onDecline: () => declineController.abort(new Error('[framework] plan declined')),
   }
   const architectAwait: { resolveAwait?: AwaitResolver } = opts.requestChoice
     ? {
         resolveAwait: async (gate, round) => {
           const answer = await resolveAwaitGate(gate, round, gateDeps)
+          if (isDeclinedConfirmation(gate, answer)) {
+            emit({ kind: 'log', message: PLAN_DECLINED_MESSAGE })
+            gateDeps.onDecline()
+            return answer
+          }
           emit({ kind: 'log', message: `Continuing with your choice: ${answer}` })
           return answer
         },
@@ -564,8 +577,15 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     // is a clean stop, not a failure — mark it so surfaces show "stopped". Budget is
     // its own signal, so it trips when the caller's signal did not.
     const budgetStopped = budgetController.signal.aborted && opts.signal?.aborted !== true
-    const stopped = opts.signal?.aborted === true || budgetController.signal.aborted
-    const detail = budgetStopped ? `budget reached ($${opts.budgetUsd})` : err instanceof Error ? err.message : String(err)
+    const declined = declineController.signal.aborted
+    const stopped = opts.signal?.aborted === true || budgetController.signal.aborted || declined
+    const detail = declined
+      ? 'plan declined'
+      : budgetStopped
+        ? `budget reached ($${opts.budgetUsd})`
+        : err instanceof Error
+          ? err.message
+          : String(err)
     emit({ kind: 'end', ok: false, ...(stopped ? { stopped: true } : {}), detail })
     throw err
   } finally {
@@ -652,7 +672,8 @@ const MAX_AWAIT_ROUNDS = 5
 /**
  * The agent-authored await gate (#337 / #339): the turn-boundary counterpart to the
  * framework-emitted plan-approval gate (#304). When a build turn ends by asking the
- * user — an `await-choices` (pick one) or `await-multiselect` (pick any) block per
+ * user — an `await-choices` (pick one), `await-multiselect` (pick any), or
+ * `await-confirmation` (approve/decline a plan, #358) block per
  * {@link AWAIT_PROTOCOL}, e.g. the #326 alternatives flow or the [Research] preset (#331)
  * — rather than finishing, show it, wait for the answer, and re-prompt the driver to
  * continue from that decision. A no-op unless a {@link RunFrameworkOptions.requestChoice}
@@ -668,6 +689,8 @@ function agentAwaitGate(
     emit: (event: FrameworkEvent) => void
     /** The run signal; a gate parked for an answer unblocks (default) if the run aborts. */
     signal?: AbortSignal
+    /** Called when a confirmation gate is declined (#358): the run stops instead of building on. */
+    onDecline?: () => void
   },
 ): (ctx: BuildContext) => Promise<SupervisorRun> {
   return async ctx => {
@@ -679,6 +702,13 @@ function agentAwaitGate(
       const gate = parseAwaitGate(run.text)
       if (!gate) return run // the agent finished instead of asking — the common case
       const answer = await resolveAwaitGate(gate, round, deps)
+      if (isDeclinedConfirmation(gate, answer)) {
+        // A declined plan (#358) ends the build here rather than re-prompting: the
+        // user takes over with fresh instructions (e.g. a new run from the dashboard).
+        emit({ kind: 'log', message: PLAN_DECLINED_MESSAGE })
+        deps.onDecline?.()
+        return run
+      }
       emit({ kind: 'log', message: `Continuing with your choice: ${answer}` })
       run = await continueAfterChoice(session, ctx, gate.title, answer)
     }
@@ -707,8 +737,27 @@ export async function resolveAwaitGate(
 ): Promise<string> {
   const signalOpt = deps.signal ? { signal: deps.signal } : {}
   const choiceOpt = deps.requestChoice ? { requestChoice: deps.requestChoice } : {}
-  const baseId = gate.kind === 'multi' ? 'await-multiselect' : 'await-choices'
+  const baseId = gate.kind === 'multi' ? 'await-multiselect' : gate.kind === 'confirm' ? 'await-confirmation' : 'await-choices'
   const id = round === 0 ? baseId : `${baseId}-${round}`
+  if (gate.kind === 'confirm') {
+    // The plan-approval confirmation (#358): a fixed Approve / Decline pair, recommended
+    // Approve so a headless (or aborted) run proceeds — the same semantics as the other gates.
+    const picked = await requestChoices({
+      id,
+      title: gate.title,
+      options: [
+        { id: 'approve', label: CONFIRM_APPROVED },
+        { id: 'decline', label: CONFIRM_DECLINED },
+      ],
+      recommended: 'approve',
+      confirm: true,
+      ...(gate.file ? { file: gate.file } : {}),
+      emit: deps.emit,
+      ...choiceOpt,
+      ...signalOpt,
+    })
+    return picked === 'decline' ? CONFIRM_DECLINED : CONFIRM_APPROVED
+  }
   if (gate.kind === 'multi') {
     const picked = await requestMultiSelect({ id, title: gate.title, options: gate.options, emit: deps.emit, ...choiceOpt, ...signalOpt })
     const labels = gate.options.filter(o => picked.includes(o.id)).map(o => o.label)
@@ -773,6 +822,10 @@ export interface ChoicesDeps {
   options: readonly ChoicesOption[]
   /** The option id pre-selected (autopilot auto-accepts it) and used as the headless/abort fallback. Default = the first option. */
   recommended?: string
+  /** Render as an Approve/Decline confirmation (#358): buttons instead of an option list. */
+  confirm?: boolean
+  /** The markdown file under approval; the dashboard's doc sidebar renders it. */
+  file?: string
   /** The interactive handler (the CLI wires it to the dashboard); omit for a headless run. */
   requestChoice?: (req: ChoiceRequest) => Promise<ChoicePick>
   /** Emit the `choice` / `choice-resolved` events onto the run stream. */
@@ -797,6 +850,8 @@ export async function requestChoices(deps: ChoicesDeps): Promise<string> {
     title: deps.title,
     options: options.map(o => ({ id: o.id, label: o.label, ...(o.detail ? { detail: o.detail } : {}) })),
     ...(recommended ? { recommended } : {}),
+    ...(deps.confirm ? { confirm: true } : {}),
+    ...(deps.file ? { file: deps.file } : {}),
   }
   emit({ kind: 'choice', ...req })
 

--- a/packages/framework/src/todo-loop.ts
+++ b/packages/framework/src/todo-loop.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 import type { DriverSession } from './driver/index.js'
 import type { ChoicePick, ChoiceRequest, FrameworkEvent } from './events.js'
 import { requestChoices, resolveAwaitGate } from './run.js'
-import { parseAwaitGate } from './turn-gate.js'
+import { PLAN_DECLINED_MESSAGE, isDeclinedConfirmation, parseAwaitGate } from './turn-gate.js'
 
 /**
  * The backlog loop (#323): once the main work settles, consume the agent's own
@@ -243,6 +243,11 @@ async function promptItem(
   let gate = parseAwaitGate(turn.text)
   for (let round = 0; round < MAX_AWAIT_ROUNDS && gate; round++) {
     const answer = await resolveAwaitGate(gate, round, deps)
+    if (isDeclinedConfirmation(gate, answer)) {
+      // A declined plan (#358) ends the item turn; the loop's stall check takes it from there.
+      deps.emit({ kind: 'log', message: PLAN_DECLINED_MESSAGE })
+      return
+    }
     deps.emit({ kind: 'log', message: `Continuing with your choice: ${answer}` })
     turn = await session.prompt(
       `You paused to ask: "${gate.title}". The user chose: ${answer}. Continue the backlog entry with that decision, and do not ask again unless a genuinely new choice comes up.`,

--- a/packages/framework/src/turn-gate.test.ts
+++ b/packages/framework/src/turn-gate.test.ts
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { parseAwaitGate, parseChoicesGate, parseMultiSelectGate } from './turn-gate.js'
+import { isDeclinedConfirmation, parseAwaitGate, parseChoicesGate, parseConfirmationGate, parseMultiSelectGate } from './turn-gate.js'
 
 const block = (json: string): string => 'Here are the options.\n```await-choices\n' + json + '\n```'
 const multiBlock = (json: string): string => 'Pick some.\n```await-multiselect\n' + json + '\n```'
+const confirmBlock = (json: string): string => 'Wrote the plan.\n```await-confirmation\n' + json + '\n```'
 
 test('parseChoicesGate returns undefined when the agent did not stop to ask (#337)', () => {
   assert.equal(parseChoicesGate('Built the whole app. Done.'), undefined)
@@ -67,6 +68,46 @@ test('parseMultiSelectGate parses a checklist and preserves default-checked entr
 test('parseMultiSelectGate returns undefined for no block / empty options (#339)', () => {
   assert.equal(parseMultiSelectGate('no block here'), undefined)
   assert.equal(parseMultiSelectGate(multiBlock('{ "options": [] }')), undefined)
+})
+
+test('parseConfirmationGate parses a plan approval with its file (#358)', () => {
+  const gate = parseConfirmationGate(confirmBlock('{ "title": "Approve the plan?", "file": "PLAN_orders.agent.md" }'))
+  assert.ok(gate)
+  assert.equal(gate.title, 'Approve the plan?')
+  assert.equal(gate.file, 'PLAN_orders.agent.md')
+})
+
+test('parseConfirmationGate defaults a blank title and omits a missing file (#358)', () => {
+  const gate = parseConfirmationGate(confirmBlock('{}'))
+  assert.ok(gate)
+  assert.equal(gate.title, 'Approve this plan?')
+  assert.equal(gate.file, undefined)
+})
+
+test('parseConfirmationGate ignores a malformed block rather than throwing (#358)', () => {
+  assert.equal(parseConfirmationGate(confirmBlock('{ not json')), undefined)
+  assert.equal(parseConfirmationGate(confirmBlock('"just a string"')), undefined)
+  assert.equal(parseConfirmationGate('no block here'), undefined)
+})
+
+test('parseAwaitGate discriminates a confirmation, later block wins (#358)', () => {
+  const c = parseAwaitGate(confirmBlock('{ "title": "Approve?", "file": "PLAN_x.agent.md" }'))
+  assert.equal(c?.kind, 'confirm')
+  const both = parseAwaitGate(block('{ "options": [{ "label": "x" }] }') + '\n' + confirmBlock('{ "title": "Approve?" }'))
+  assert.equal(both?.kind, 'confirm')
+  // A malformed later confirmation falls back to the earlier choices block.
+  const broken = parseAwaitGate(block('{ "options": [{ "label": "x" }] }') + '\n' + confirmBlock('{ not json'))
+  assert.equal(broken?.kind, 'choices')
+})
+
+test('isDeclinedConfirmation flags only a declined confirmation (#358)', () => {
+  const confirm = parseAwaitGate(confirmBlock('{ "title": "Approve?" }'))
+  assert.ok(confirm)
+  assert.equal(isDeclinedConfirmation(confirm, 'Decline'), true)
+  assert.equal(isDeclinedConfirmation(confirm, 'Approve'), false)
+  const choices = parseAwaitGate(block('{ "options": [{ "label": "Decline" }] }'))
+  assert.ok(choices)
+  assert.equal(isDeclinedConfirmation(choices, 'Decline'), false)
 })
 
 test('parseAwaitGate discriminates choices vs multiselect, later block wins (#339)', () => {

--- a/packages/framework/src/turn-gate.ts
+++ b/packages/framework/src/turn-gate.ts
@@ -13,7 +13,7 @@ import type { MultiSelectOption } from './run.js'
  */
 export const AWAIT_PROTOCOL = [
   '## Awaiting a choice',
-  'When these instructions tell you to showChoices() / showMultiSelect() and then AWAIT, do not decide for the user.',
+  'When these instructions tell you to showChoices() / showMultiSelect() / showMarkdown() and then AWAIT, do not decide for the user.',
   'End your turn with one fenced code block, then stop.',
   'For a single choice (showChoices, pick one), tag it `await-choices`:',
   '```await-choices',
@@ -22,6 +22,10 @@ export const AWAIT_PROTOCOL = [
   'For a multi-select (showMultiSelect, pick any number), tag it `await-multiselect` and set `default` on the entries that start checked:',
   '```await-multiselect',
   '{ "title": "<the prompt>", "options": [{ "label": "<option>", "detail": "<optional one-liner>", "default": true }] }',
+  '```',
+  'For a plan/document approval (showMarkdown of a file you wrote, then AWAIT), tag it `await-confirmation` and name the file:',
+  '```await-confirmation',
+  '{ "title": "<what to approve>", "file": "PLAN_<slug>.agent.md" }',
   '```',
   'The framework shows it, waits for the user, and re-prompts you with their answer. Do not continue past it on your own.',
 ].join('\n')
@@ -44,10 +48,31 @@ export interface ParsedMultiSelectGate {
   options: MultiSelectOption[]
 }
 
-/** A parsed await gate: either kind, discriminated by `kind`. */
+/** A plan/document approval an agent stopped to ask, parsed from an `await-confirmation` block (#358). */
+export interface ParsedConfirmationGate {
+  /** The question shown above the Approve / Decline buttons. */
+  title: string
+  /** The markdown file under approval (the doc sidebar renders it), when the agent named one. */
+  file?: string
+}
+
+/** A parsed await gate: any kind, discriminated by `kind`. */
 export type ParsedAwaitGate =
   | ({ kind: 'choices' } & ParsedChoicesGate)
   | ({ kind: 'multi' } & ParsedMultiSelectGate)
+  | ({ kind: 'confirm' } & ParsedConfirmationGate)
+
+/** The answer a resolved confirmation gate (#358) yields: the picked button's label. */
+export const CONFIRM_APPROVED = 'Approve'
+export const CONFIRM_DECLINED = 'Decline'
+
+/** The log line printed when a confirmation gate is declined (#358). */
+export const PLAN_DECLINED_MESSAGE = 'Plan declined, awaiting user instructions.'
+
+/** Whether a resolved gate was a declined confirmation (#358): the caller stops instead of re-prompting. */
+export function isDeclinedConfirmation(gate: ParsedAwaitGate, answer: string): boolean {
+  return gate.kind === 'confirm' && answer === CONFIRM_DECLINED
+}
 
 /** Find the body + start index of the last fenced block with `tag` in `text`. */
 function lastBlock(text: string, tag: string): { body: string; index: number } | undefined {
@@ -126,23 +151,60 @@ export function parseMultiSelectGate(text: string): ParsedMultiSelectGate | unde
 }
 
 /**
- * Parse whichever await gate a build turn ended on (#337 / #339). When both a
- * single- and multi-select block are present (an agent shouldn't emit both), the one
- * that appears later in the text wins. Returns `undefined` when the agent just
- * finished — the common case, so a normal build flows straight through.
+ * Parse a trailing `await-confirmation` block (#358): a plan/document approval,
+ * e.g. the #326 large-scope flow's PLAN file (`showMarkdown()` + AWAIT). No
+ * options — the gate is a fixed Approve / Decline. Same tolerance as the other
+ * parsers: blank-title fallback, malformed block ignored.
+ */
+export function parseConfirmationGate(text: string): ParsedConfirmationGate | undefined {
+  const block = lastBlock(text, 'await-confirmation')
+  if (!block) return undefined
+  let raw: unknown
+  try {
+    raw = JSON.parse(block.body)
+  } catch {
+    return undefined
+  }
+  if (typeof raw !== 'object' || raw === null) return undefined
+  const record = raw as Record<string, unknown>
+  const file = str(record.file)
+  return { title: str(record.title) || 'Approve this plan?', ...(file ? { file } : {}) }
+}
+
+/**
+ * Parse whichever await gate a build turn ended on (#337 / #339 / #358). When more
+ * than one block kind is present (an agent shouldn't emit several), the one that
+ * appears latest in the text wins; a malformed later block falls back to an earlier
+ * one. Returns `undefined` when the agent just finished — the common case, so a
+ * normal build flows straight through.
  */
 export function parseAwaitGate(text: string): ParsedAwaitGate | undefined {
-  const choicesAt = lastBlock(text, 'await-choices')?.index ?? -1
-  const multiAt = lastBlock(text, 'await-multiselect')?.index ?? -1
-  if (choicesAt < 0 && multiAt < 0) return undefined
-  if (multiAt > choicesAt) {
-    const multi = parseMultiSelectGate(text)
-    if (multi) return { kind: 'multi', ...multi }
-    const choices = parseChoicesGate(text)
-    return choices ? { kind: 'choices', ...choices } : undefined
+  const kinds: { at: number; parse: () => ParsedAwaitGate | undefined }[] = [
+    {
+      at: lastBlock(text, 'await-choices')?.index ?? -1,
+      parse: () => {
+        const g = parseChoicesGate(text)
+        return g ? { kind: 'choices', ...g } : undefined
+      },
+    },
+    {
+      at: lastBlock(text, 'await-multiselect')?.index ?? -1,
+      parse: () => {
+        const g = parseMultiSelectGate(text)
+        return g ? { kind: 'multi', ...g } : undefined
+      },
+    },
+    {
+      at: lastBlock(text, 'await-confirmation')?.index ?? -1,
+      parse: () => {
+        const g = parseConfirmationGate(text)
+        return g ? { kind: 'confirm', ...g } : undefined
+      },
+    },
+  ]
+  for (const kind of kinds.filter(k => k.at >= 0).sort((a, b) => b.at - a.at)) {
+    const gate = kind.parse()
+    if (gate) return gate
   }
-  const choices = parseChoicesGate(text)
-  if (choices) return { kind: 'choices', ...choices }
-  const multi = parseMultiSelectGate(text)
-  return multi ? { kind: 'multi', ...multi } : undefined
+  return undefined
 }


### PR DESCRIPTION
Closes #358

The #326 large-scope flow (write PLAN file, showMarkdown, AWAIT) now actually gates. A build turn ending with an `await-confirmation` block (`{ "title", "file" }`, taught by the await protocol appendix; the #326 template is untouched) pauses the run.

Per Rom's call on the issue:
- Green **Approve** resumes the build.
- Red **Decline** logs "Plan declined, awaiting user instructions." and stops the run cleanly (same mechanism as the budget cap), so the checklist/improve loop never builds on a declined plan.

Details:
- The gate panel shows the buttons instead of an option list, plus a pointer to the PLAN file the doc sidebar already renders.
- Autopilot countdown auto-accepts Approve (it is the recommended option); headless runs auto-approve, so programmatic runs are unchanged.
- Decline handling is wired in all await consumers: the build gate, the direct prompt path, the backlog loop, and the architect resolver.
- Offline demo: `FRAMEWORK_FAKE_AWAIT=confirmation`.
- Kept the `show*` naming for now (all agent-facing APIs stay one family: showChoices / showMultiSelect / showMarkdown); the `request*` rename you okayed can be a follow-up polish if we still want it.

Tests: parser + approve-resumes + decline-stops-cleanly (313 pass).