### PR TITLE
fix(framework): countdown text says Auto accept, not autopilot (#325)

### DIFF
--- a/.changeset/auto-accept-naming-325.md
+++ b/.changeset/auto-accept-naming-325.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Untangle the two "autopilot" concepts in the dashboard (#325): the countdown text now reads "Auto accept in 10s" (and "Auto accept canceled" / "Auto accept off"), so "autopilot" is left to mean the mode preset. The checkbox that arms the countdown is labeled "Autopilot", per Rom's call on the issue.

--- a/packages/framework/src/dashboard/autopilot.test.ts
+++ b/packages/framework/src/dashboard/autopilot.test.ts
@@ -156,10 +156,10 @@ test('autopilot countdown auto-accepts the recommended pick after 10s (#311)', (
   h.fire(CHOICE)
   // The panel opens and the countdown is armed at 10s.
   assert.equal(h.el('choice-panel').hidden, false)
-  assert.match(h.el('choice-count').textContent, /accepting in 10s/)
+  assert.match(h.el('choice-count').textContent, /Auto accept in 10s/)
   // Nine seconds in: still counting, not yet accepted.
   h.tick(9000)
-  assert.match(h.el('choice-count').textContent, /accepting in 1s/)
+  assert.match(h.el('choice-count').textContent, /Auto accept in 1s/)
   assert.equal(h.picks.length, 0)
   // The tenth tick fires the autopilot accept of the recommended option.
   h.tick(1000)

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -222,7 +222,7 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
       <button id="choice-accept">Accept<span class="kbd">Ctrl+Enter</span></button>
       <button id="choice-approve" hidden>&#10003; Approve<span class="kbd">Ctrl+Enter</span></button>
       <button id="choice-decline" hidden>&#10007; Decline</button>
-      <label id="autopilot-row"><input type="checkbox" id="autopilot-toggle" /> autopilot</label>
+      <label id="autopilot-row"><input type="checkbox" id="autopilot-toggle" /> Autopilot</label>
       <span id="choice-count"></span>
     </div>
   </section>
@@ -482,7 +482,7 @@ function selectedChoice() {
   return el ? el.value : (activeChoice ? activeChoice.recommended : null);
 }
 function renderCount() {
-  $('choice-count').textContent = '\\u25cf autopilot accepting in ' + choiceLeft + 's \\u2014 move the mouse to cancel';
+  $('choice-count').textContent = '\\u25cf Auto accept in ' + choiceLeft + 's \\u2014 move the mouse to cancel';
 }
 function startCountdown() {
   stopCountdown();
@@ -497,7 +497,7 @@ function startCountdown() {
 }
 function stopCountdown() { if (choiceTimer) { clearInterval(choiceTimer); choiceTimer = null; } }
 function cancelAutopilot() {
-  if (choiceTimer) { stopCountdown(); $('choice-count').textContent = 'autopilot canceled \\u2014 pick manually'; }
+  if (choiceTimer) { stopCountdown(); $('choice-count').textContent = 'Auto accept canceled \\u2014 pick manually'; }
 }
 function acceptChoice(by, pickOverride) {
   if (!activeChoice) return;
@@ -772,7 +772,7 @@ $('choice-approve').addEventListener('click', () => acceptChoice('user', 'approv
 $('choice-decline').addEventListener('click', () => acceptChoice('user', 'decline'));
 $('autopilot-toggle').addEventListener('change', ev => {
   localStorage.setItem('framework:autopilot', ev.target.checked ? '1' : '0');
-  if (ev.target.checked) startCountdown(); else { stopCountdown(); $('choice-count').textContent = 'autopilot off'; }
+  if (ev.target.checked) startCountdown(); else { stopCountdown(); $('choice-count').textContent = 'Auto accept off'; }
 });
 // Any mouse movement cancels the running autopilot countdown (cheap no-op once cleared).
 document.addEventListener('mousemove', cancelAutopilot);


### PR DESCRIPTION
Closes #325

Per your suggestion on the issue:
- The checkbox stays **Autopilot** (capitalized).
- The countdown line is now "Auto accept in 10s / move the mouse to cancel", plus "Auto accept canceled" and "Auto accept off".

So "autopilot" in running text now only ever means the mode preset. Internal ids (localStorage key, `by: 'autopilot'`, CSS ids) are unchanged; they are not user-visible.