### PR TITLE
feat(framework): [Readability] preset button (#360)

### DIFF
--- a/.changeset/readability-preset-360.md
+++ b/.changeset/readability-preset-360.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+New [Readability] preset button on the dashboard (#360): prefills Rom's refactor-for-human-readers prompt (architectural seams, linearity/altitude pass, exhaustive per-function rating lists, one commit per refactor) into the start textarea for review or editing; Start runs the text verbatim as a direct prompt run. The one blank, `<PARAM:what>`, defaults to `this PR`.

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -1,5 +1,6 @@
 import { CLAUDE_CODE_SESSION_LINK } from '../events.js'
 import { renderResearchPrompt } from '../research-preset.js'
+import { renderReadabilityPrompt } from '../readability-preset.js'
 
 /**
  * The single self-contained dashboard page: HTML + inline CSS + inline JS, no
@@ -110,10 +111,10 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
     background: #6ea8fe; border: 0; border-radius: 6px; padding: 6px 16px; }
   #start-run:hover { background: #8bbaff; }
   #start-run:disabled { opacity: .5; cursor: default; }
-  #start-research { font: inherit; font-size: 13px; font-weight: 600; cursor: pointer; color: #b7c0d0;
+  .start-preset { font: inherit; font-size: 13px; font-weight: 600; cursor: pointer; color: #b7c0d0;
     background: #141a24; border: 1px solid #24344a; border-radius: 6px; padding: 6px 14px; }
-  #start-research:hover { background: #17212f; }
-  #start-research:disabled { opacity: .5; cursor: default; }
+  .start-preset:hover { background: #17212f; }
+  .start-preset:disabled { opacity: .5; cursor: default; }
   #start-note { color: #f0a35e; font-size: 12px; }
   /* Interactive plan-approval / choice panel (#304): full-width, accented so it
      reads as the one thing awaiting the human. */
@@ -209,7 +210,8 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
     <textarea id="start-prompt" rows="3" placeholder="What should the agent build?"></textarea>
     <div id="start-actions">
       <button id="start-run">&#9654; Start<span class="kbd">Ctrl+Enter</span></button>
-      <button id="start-research" title="Prefill the Research preset prompt (rates problem variability, picks deep-dives); review or edit it, then Start">&#128269; Research</button>
+      <button id="start-research" class="start-preset" title="Prefill the Research preset prompt (rates problem variability, picks deep-dives); review or edit it, then Start">&#128269; Research</button>
+      <button id="start-readability" class="start-preset" title="Prefill the Readability preset prompt (refactor code to make it easier for humans to read); review or edit it, then Start">&#128200; Readability</button>
       <span id="start-note"></span>
     </div>
   </section>
@@ -274,6 +276,7 @@ const STOPPABLE = ${stoppable ? 'true' : 'false'};
 const CHOICEABLE = ${choiceable ? 'true' : 'false'};
 const STARTABLE = ${startable ? 'true' : 'false'};
 const RESEARCH_PROMPT = ${JSON.stringify(renderResearchPrompt())};
+const READABILITY_PROMPT = ${JSON.stringify(renderReadabilityPrompt())};
 const AUTO_ACCEPT_MS = 10000;
 const GENERIC_SESSION_LINK = ${JSON.stringify(CLAUDE_CODE_SESSION_LINK)};
 let ended = false;
@@ -724,8 +727,8 @@ syncNotifyBtn();
 
 // Start a run (#345): POST the prompt to /api/start; the daemon spawns the run
 // and its events stream in over the same SSE feed. A 409 means one is active.
-// Presets only PREFILL the textarea (#353): the [Research] button loads the full
-// preset prompt for review/editing and flips startKind to 'prompt' (run the text
+// Presets only PREFILL the textarea (#353): a preset button loads its full
+// prompt for review/editing and flips startKind to 'prompt' (run the text
 // verbatim); nothing is sent until Start / Ctrl+Enter. Clearing the box reverts
 // to a normal 'build' run.
 let startKind = 'build';
@@ -734,7 +737,7 @@ function startNewRun() {
   const note = $('start-note');
   const prompt = $('start-prompt').value.trim();
   if (!prompt) { note.textContent = startKind === 'build' ? 'type what to build first' : 'the prompt is empty'; return; }
-  const buttons = [$('start-run'), $('start-research')];
+  const buttons = [$('start-run'), ...document.querySelectorAll('.start-preset')];
   for (const b of buttons) b.disabled = true;
   note.textContent = 'starting\\u2026';
   fetch('api/start', { method: 'POST', headers: { 'content-type': 'application/json' },
@@ -749,13 +752,17 @@ function startNewRun() {
     .catch(() => { for (const b of buttons) b.disabled = false; note.textContent = 'could not reach the dashboard server'; });
 }
 $('start-run').addEventListener('click', startNewRun);
-$('start-research').addEventListener('click', () => {
-  const box = $('start-prompt');
-  box.value = RESEARCH_PROMPT;
-  startKind = 'prompt';
-  $('start-note').textContent = 'research preset loaded \\u2014 review or edit, then Start';
-  box.focus();
-});
+function wirePresetButton(id, name, prompt) {
+  $(id).addEventListener('click', () => {
+    const box = $('start-prompt');
+    box.value = prompt;
+    startKind = 'prompt';
+    $('start-note').textContent = name + ' preset loaded \\u2014 review or edit, then Start';
+    box.focus();
+  });
+}
+wirePresetButton('start-research', 'research', RESEARCH_PROMPT);
+wirePresetButton('start-readability', 'readability', READABILITY_PROMPT);
 $('start-prompt').addEventListener('input', () => {
   // An emptied box is a fresh start: back to a normal build run.
   if (!$('start-prompt').value.trim() && startKind !== 'build') { startKind = 'build'; $('start-note').textContent = ''; }

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -376,7 +376,11 @@ test('/api/start passes the run kind through; a research start may omit the prom
     const page = await fetchText(dash.url + '/')
     assert.match(page.body, /id="start-research"/)
     assert.match(page.body, /const RESEARCH_PROMPT = /)
-    assert.match(page.body, /research preset loaded/)
+    assert.match(page.body, /wirePresetButton\('start-research'/)
+    // Same prefill contract for [Readability] (#360).
+    assert.match(page.body, /id="start-readability"/)
+    assert.match(page.body, /const READABILITY_PROMPT = /)
+    assert.match(page.body, /wirePresetButton\('start-readability'/)
   } finally {
     await dash.close()
   }

--- a/packages/framework/src/dashboard/start-prefill.test.ts
+++ b/packages/framework/src/dashboard/start-prefill.test.ts
@@ -3,6 +3,7 @@ import { test } from 'node:test'
 import { JSDOM } from 'jsdom'
 import { dashboardHtml } from './page.js'
 import { renderResearchPrompt } from '../research-preset.js'
+import { renderReadabilityPrompt } from '../readability-preset.js'
 
 // Presets only prefill the textarea (#353): the [Research] button must load the
 // full preset prompt for review and send NOTHING; Start posts the (possibly
@@ -62,6 +63,18 @@ test('[Research] only prefills the textarea; Start sends the edited text verbati
   assert.equal(h.posts.length, 1)
   assert.equal(h.posts[0]!.kind, 'prompt')
   assert.match(h.posts[0]!.prompt, /the auth flow/)
+})
+
+test('[Readability] prefills its #360 prompt the same way', async () => {
+  const h = boot()
+  h.click('start-readability')
+  assert.equal(h.posts.length, 0) // prefill sends nothing
+  assert.equal(h.box.value, renderReadabilityPrompt())
+  assert.match(h.note(), /readability preset loaded/)
+  h.click('start-run')
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(h.posts.length, 1)
+  assert.equal(h.posts[0]!.kind, 'prompt')
 })
 
 test('clearing a prefilled preset reverts Start to a normal build run (#353)', async () => {

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -207,6 +207,12 @@ export {
   RESEARCH_PARAMS,
 } from './research-preset.js'
 export {
+  renderReadabilityPrompt,
+  READABILITY_PRESET_NAME,
+  READABILITY_PROMPT_TEMPLATE,
+  READABILITY_PARAMS,
+} from './readability-preset.js'
+export {
   fakeDriver,
   FAKE_INTENT,
   FAKE_SIGNALS,

--- a/packages/framework/src/readability-preset.test.ts
+++ b/packages/framework/src/readability-preset.test.ts
@@ -1,0 +1,29 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { PARAM_PATTERN } from './preset-params.js'
+import { renderReadabilityPrompt, READABILITY_PARAMS, READABILITY_PROMPT_TEMPLATE } from './readability-preset.js'
+
+test('the Readability template carries the #360 flow: seams, altitude pass, rating lists', () => {
+  assert.match(READABILITY_PROMPT_TEMPLATE, /easy as possible for humans to read/)
+  assert.match(READABILITY_PROMPT_TEMPLATE, /Rate the \*seams\*/)
+  assert.match(READABILITY_PROMPT_TEMPLATE, /Altitude pass/)
+  assert.match(READABILITY_PROMPT_TEMPLATE, /Separate commit for each refactor/)
+  // The agent-facing macro is defined at the bottom of the prompt itself.
+  assert.match(READABILITY_PROMPT_TEMPLATE, /<FUNCTION>/)
+  assert.match(READABILITY_PROMPT_TEMPLATE, /^FUNCTION: /m)
+  // The one user blank, declared with its default.
+  assert.match(READABILITY_PROMPT_TEMPLATE, /<PARAM:what>/)
+  assert.deepEqual(READABILITY_PARAMS.map(p => p.name), ['what'])
+})
+
+test('renderReadabilityPrompt defaults the blank to "this PR" and takes an override', () => {
+  const byDefault = renderReadabilityPrompt()
+  assert.match(byDefault, /^Refactor this PR to make it/)
+  const blank = renderReadabilityPrompt('   ')
+  assert.match(blank, /^Refactor this PR to make it/) // blank falls back, not erased
+  const custom = renderReadabilityPrompt('the dashboard package')
+  assert.match(custom, /^Refactor the dashboard package to make it/)
+  // No raw placeholder survives a render; <FUNCTION> is not a param and stays.
+  assert.equal(PARAM_PATTERN.test(custom), false)
+  assert.match(custom, /<FUNCTION>/)
+})

--- a/packages/framework/src/readability-preset.ts
+++ b/packages/framework/src/readability-preset.ts
@@ -1,0 +1,47 @@
+import { renderPresetPrompt, type PresetParam } from './preset-params.js'
+
+/**
+ * The [Readability] preset (#360): Rom's refactor-for-human-readers pass, shipped
+ * as a direct prompt like [Research] (#331) — it reworks existing code, so it
+ * skips the scope -> architect -> build scaffolding. `<PARAM:what>` is the
+ * user-facing blank (#330); `<FUNCTION>` is an agent-facing macro defined at the
+ * bottom of the prompt itself, like the Research preset's CAPS tokens.
+ */
+
+/** The preset's name, as the dashboard button uses it. */
+export const READABILITY_PRESET_NAME = 'readability'
+
+/** The one user param: what to refactor. Defaults to `this PR`, like Research. */
+export const READABILITY_PARAMS: readonly PresetParam[] = [
+  { name: 'what', default: 'this PR', description: 'What to refactor for readability' },
+]
+
+/** The prompt template, verbatim from #360 (with `<PARAM:what>` as the blank). */
+export const READABILITY_PROMPT_TEMPLATE = `Refactor <PARAM:what> to make it as easy as possible for humans to read:
+- Pinnacle architectural split
+  - Does each file and each <FUNCTION> represent a sensible and natural abstraction?
+  - Rate the *seams*, not just the boxes: for each call site, ask whether the responsibility sits on the right side of the boundary — should a caller's wrapper move down into the callee (or vice versa)? A <FUNCTION> can be clean, DRY and well-tested in isolation yet still be in the wrong place. "Well-factored" is not "well-located".
+- Linearity (for humans)
+  - Put yourself in the shoes of a human reader who reads everything in a linear fashion
+  - Top to bottom: place callers above callees so readers encounter high-level logic before implementation details (humans think high-level first)
+  - Altitude pass: for each entry-point / orchestration <FUNCTION>, read it top-to-bottom as prose. Flag any line that drops the reader into lower-level mechanism (a flag, a thunk, a log verb, error plumbing) in the middle of what should be a high-level narrative. For each, ask: can that mechanism move down into the callee so the caller reads at one consistent altitude? Prioritize the reading path of all the <FUNCTION> a reader hits first.
+- Before starting to work: list *ALL* files and *ALL* <FUNCTION> in this chat, rate them all (0: convoluted abstraction, hard to read, wrong place — 10: perfect), and give a reason for your rating
+  - DON'T skip any file nor any <FUNCTION> in your rating list — write an extra separated list in this chat of all files and all <FUNCTION> and put a ✅ tick to each entry to double check whether you forgot to rate something. So two lists: one list of ratings & explanation, and a second confirmation list.
+- Separate commit for each refactor
+- Work until it's exceptionally good. We as an expert team will check against every little detail.
+  - If we see that you gave mostly a 10/10 rating, that's a sign you've been lazy... so make sure you scrutinize everything and spend a substantial amount of time. We don't want to prompt you again and again to achieve quality — autonomously strive for quality on your own without us pushing you.
+- Give summary of what you worked on: print the lists again with old rating => new rating with link to commit(s)
+
+FUNCTION: an actual function or a class, procedure, etc. (anything that represents a unit of logic)`
+
+/**
+ * Render the Readability prompt for a target. A blank / omitted `what` falls
+ * back to the declared default (`this PR`), so the dashboard button runs with
+ * zero input.
+ */
+export function renderReadabilityPrompt(what?: string): string {
+  return renderPresetPrompt(READABILITY_PROMPT_TEMPLATE, {
+    params: READABILITY_PARAMS,
+    values: { what },
+  })
+}


### PR DESCRIPTION
Adds the [Readability] button next to [Research] on the dashboard. It prefills the #360 prompt verbatim into the start textarea (prefill model from #353): review or edit, then Start runs it as a direct prompt run.

- `$PARAM:what` from the issue is the `<PARAM:what>` blank, defaulting to `this PR` like Research
- `<FUNCTION>` stays agent-interpreted, defined at the bottom of the prompt itself
- button styling factored into a shared `.start-preset` class and a `wirePresetButton()` helper, so [Maintainability] (#361) lands as a follow-up on top of this
- jsdom prefill test + page-shipping assertions

Closes #360