### PR TITLE
feat(framework): [Maintainability] preset button (#361)

### DIFF
--- a/.changeset/maintainability-preset-361.md
+++ b/.changeset/maintainability-preset-361.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+New [Maintainability] preset button on the dashboard (#361): prefills the deliberately minimal refactor-for-future-changes prompt ("look for maintainability red flags, and fix them") into the start textarea for review or editing; Start runs the text verbatim as a direct prompt run. The one blank, `<PARAM:what>`, defaults to `this PR`.

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -1,6 +1,7 @@
 import { CLAUDE_CODE_SESSION_LINK } from '../events.js'
 import { renderResearchPrompt } from '../research-preset.js'
 import { renderReadabilityPrompt } from '../readability-preset.js'
+import { renderMaintainabilityPrompt } from '../maintainability-preset.js'
 
 /**
  * The single self-contained dashboard page: HTML + inline CSS + inline JS, no
@@ -212,6 +213,7 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
       <button id="start-run">&#9654; Start<span class="kbd">Ctrl+Enter</span></button>
       <button id="start-research" class="start-preset" title="Prefill the Research preset prompt (rates problem variability, picks deep-dives); review or edit it, then Start">&#128269; Research</button>
       <button id="start-readability" class="start-preset" title="Prefill the Readability preset prompt (refactor code to make it easier for humans to read); review or edit it, then Start">&#128200; Readability</button>
+      <button id="start-maintainability" class="start-preset" title="Prefill the Maintainability preset prompt (refactor code to make it easier to adapt for future changes); review or edit it, then Start">&#128200; Maintainability</button>
       <span id="start-note"></span>
     </div>
   </section>
@@ -277,6 +279,7 @@ const CHOICEABLE = ${choiceable ? 'true' : 'false'};
 const STARTABLE = ${startable ? 'true' : 'false'};
 const RESEARCH_PROMPT = ${JSON.stringify(renderResearchPrompt())};
 const READABILITY_PROMPT = ${JSON.stringify(renderReadabilityPrompt())};
+const MAINTAINABILITY_PROMPT = ${JSON.stringify(renderMaintainabilityPrompt())};
 const AUTO_ACCEPT_MS = 10000;
 const GENERIC_SESSION_LINK = ${JSON.stringify(CLAUDE_CODE_SESSION_LINK)};
 let ended = false;
@@ -763,6 +766,7 @@ function wirePresetButton(id, name, prompt) {
 }
 wirePresetButton('start-research', 'research', RESEARCH_PROMPT);
 wirePresetButton('start-readability', 'readability', READABILITY_PROMPT);
+wirePresetButton('start-maintainability', 'maintainability', MAINTAINABILITY_PROMPT);
 $('start-prompt').addEventListener('input', () => {
   // An emptied box is a fresh start: back to a normal build run.
   if (!$('start-prompt').value.trim() && startKind !== 'build') { startKind = 'build'; $('start-note').textContent = ''; }

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -381,6 +381,10 @@ test('/api/start passes the run kind through; a research start may omit the prom
     assert.match(page.body, /id="start-readability"/)
     assert.match(page.body, /const READABILITY_PROMPT = /)
     assert.match(page.body, /wirePresetButton\('start-readability'/)
+    // Same prefill contract for [Maintainability] (#361).
+    assert.match(page.body, /id="start-maintainability"/)
+    assert.match(page.body, /const MAINTAINABILITY_PROMPT = /)
+    assert.match(page.body, /wirePresetButton\('start-maintainability'/)
   } finally {
     await dash.close()
   }

--- a/packages/framework/src/dashboard/start-prefill.test.ts
+++ b/packages/framework/src/dashboard/start-prefill.test.ts
@@ -4,6 +4,7 @@ import { JSDOM } from 'jsdom'
 import { dashboardHtml } from './page.js'
 import { renderResearchPrompt } from '../research-preset.js'
 import { renderReadabilityPrompt } from '../readability-preset.js'
+import { renderMaintainabilityPrompt } from '../maintainability-preset.js'
 
 // Presets only prefill the textarea (#353): the [Research] button must load the
 // full preset prompt for review and send NOTHING; Start posts the (possibly
@@ -71,6 +72,18 @@ test('[Readability] prefills its #360 prompt the same way', async () => {
   assert.equal(h.posts.length, 0) // prefill sends nothing
   assert.equal(h.box.value, renderReadabilityPrompt())
   assert.match(h.note(), /readability preset loaded/)
+  h.click('start-run')
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(h.posts.length, 1)
+  assert.equal(h.posts[0]!.kind, 'prompt')
+})
+
+test('[Maintainability] prefills its #361 prompt the same way', async () => {
+  const h = boot()
+  h.click('start-maintainability')
+  assert.equal(h.posts.length, 0) // prefill sends nothing
+  assert.equal(h.box.value, renderMaintainabilityPrompt())
+  assert.match(h.note(), /maintainability preset loaded/)
   h.click('start-run')
   await new Promise(resolve => setImmediate(resolve))
   assert.equal(h.posts.length, 1)

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -213,6 +213,12 @@ export {
   READABILITY_PARAMS,
 } from './readability-preset.js'
 export {
+  renderMaintainabilityPrompt,
+  MAINTAINABILITY_PRESET_NAME,
+  MAINTAINABILITY_PROMPT_TEMPLATE,
+  MAINTAINABILITY_PARAMS,
+} from './maintainability-preset.js'
+export {
   fakeDriver,
   FAKE_INTENT,
   FAKE_SIGNALS,

--- a/packages/framework/src/maintainability-preset.test.ts
+++ b/packages/framework/src/maintainability-preset.test.ts
@@ -1,0 +1,27 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { PARAM_PATTERN } from './preset-params.js'
+import {
+  renderMaintainabilityPrompt,
+  MAINTAINABILITY_PARAMS,
+  MAINTAINABILITY_PROMPT_TEMPLATE,
+} from './maintainability-preset.js'
+
+test('the Maintainability template carries the #361 prompt: deliberately minimal', () => {
+  assert.match(MAINTAINABILITY_PROMPT_TEMPLATE, /as maintainable as possible/)
+  assert.match(MAINTAINABILITY_PROMPT_TEMPLATE, /maintainability red flags/)
+  // The one user blank, declared with its default.
+  assert.match(MAINTAINABILITY_PROMPT_TEMPLATE, /<PARAM:what>/)
+  assert.deepEqual(MAINTAINABILITY_PARAMS.map(p => p.name), ['what'])
+})
+
+test('renderMaintainabilityPrompt defaults the blank to "this PR" and takes an override', () => {
+  const byDefault = renderMaintainabilityPrompt()
+  assert.match(byDefault, /^Refactor this PR to make it/)
+  const blank = renderMaintainabilityPrompt('   ')
+  assert.match(blank, /^Refactor this PR to make it/) // blank falls back, not erased
+  const custom = renderMaintainabilityPrompt('the queue package')
+  assert.match(custom, /^Refactor the queue package to make it/)
+  // No raw placeholder survives a render.
+  assert.equal(PARAM_PATTERN.test(custom), false)
+})

--- a/packages/framework/src/maintainability-preset.ts
+++ b/packages/framework/src/maintainability-preset.ts
@@ -1,0 +1,31 @@
+import { renderPresetPrompt, type PresetParam } from './preset-params.js'
+
+/**
+ * The [Maintainability] preset (#361): Rom's refactor-for-future-changes pass,
+ * shipped as a direct prompt like [Readability] (#360). The prompt is
+ * deliberately minimal — Rom wants to see how it performs before developing a
+ * more explicit one, so keep it in sync with the issue rather than growing it here.
+ */
+
+/** The preset's name, as the dashboard button uses it. */
+export const MAINTAINABILITY_PRESET_NAME = 'maintainability'
+
+/** The one user param: what to refactor. Defaults to `this PR`, like the others. */
+export const MAINTAINABILITY_PARAMS: readonly PresetParam[] = [
+  { name: 'what', default: 'this PR', description: 'What to refactor for maintainability' },
+]
+
+/** The prompt template, verbatim from #361 (with `<PARAM:what>` as the blank). */
+export const MAINTAINABILITY_PROMPT_TEMPLATE = `Refactor <PARAM:what> to make it as maintainable as possible:
+- Look for maintainability red flags, and fix them.`
+
+/**
+ * Render the Maintainability prompt for a target. A blank / omitted `what`
+ * falls back to the declared default (`this PR`).
+ */
+export function renderMaintainabilityPrompt(what?: string): string {
+  return renderPresetPrompt(MAINTAINABILITY_PROMPT_TEMPLATE, {
+    params: MAINTAINABILITY_PARAMS,
+    values: { what },
+  })
+}


### PR DESCRIPTION
Adds the [Maintainability] button next to [Readability], on the same prefill model: the #361 prompt loads into the start textarea verbatim, Start runs it as a direct prompt run. Kept deliberately minimal per your note; the code carries it as one template constant, so syncing a revision is a copy-paste.

`$PARAM:what` is the `<PARAM:what>` blank, defaulting to `this PR`.

Stacked on #365 (merge that first; this one then retargets to main automatically).

Closes #361