### PR TITLE
fix(framework): harden dashboard against CSRF and event-borne XSS

### DIFF
--- a/.changeset/framework-dashboard-csrf-xss.md
+++ b/.changeset/framework-dashboard-csrf-xss.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Harden the dashboard against cross-site abuse and event-borne XSS. The state-changing dashboard routes (`/stop`, `/choice`, `/api/start`) now reject any request whose `Origin` is a foreign site, so a page on another origin can no longer drive the localhost dashboard into spawning or steering a run (a non-browser caller that sends no `Origin` is unaffected). The client render pipeline no longer trusts event strings: link URLs (session link, preview URL, run-history link) are scheme-checked so a `javascript:` URL collapses to `#`, and the HTML escaper now escapes quotes so a relay-published event can't break out of an attribute (e.g. a choice option id like `x" autofocus onfocus=...`).

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -375,7 +375,7 @@ function setSessionLink(sessionId, sessionLink) {
     const generic = sessionLink === GENERIC_SESSION_LINK;
     const label = generic ? 'Open Claude Code' : 'live session';
     const idTail = sessionId ? ' <code>' + esc(sessionId) + '</code>' : '';
-    el.innerHTML = '\\u25b6 <a href="' + esc(sessionLink) + '" target="_blank" rel="noopener">' + label + '</a>' + idTail;
+    el.innerHTML = '\\u25b6 <a href="' + esc(safeUrl(sessionLink)) + '" target="_blank" rel="noopener">' + label + '</a>' + idTail;
     el.title = generic ? 'Generic Claude Code entry point, not a live session link' : (sessionId || '');
   } else if (sessionId) {
     el.innerHTML = 'session <code>' + esc(sessionId) + '</code>';
@@ -391,7 +391,7 @@ function render(fe) {
   } else if (fe.kind === 'session-update') setSessionLink(fe.sessionId, fe.sessionLink);
   else if (fe.kind === 'preview') {
     const a = $('app-link');
-    a.href = fe.url; a.textContent = fe.url;
+    a.href = safeUrl(fe.url); a.textContent = fe.url;
     $('app-banner').hidden = false;
     log('\\u25b6 your app is running at ' + fe.url);
   }
@@ -424,7 +424,13 @@ function stopRun() {
   btn.textContent = 'stopping\\u2026';
   fetch('stop', { method: 'POST' }).catch(() => {});
 }
-function esc(s) { const d = document.createElement('div'); d.textContent = String(s); return d.innerHTML; }
+// Attribute-safe: textContent->innerHTML escapes < > &, but NOT quotes, so we also
+// escape " and ' to stay safe inside quoted HTML attributes, not just text nodes.
+function esc(s) { const d = document.createElement('div'); d.textContent = String(s); return d.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;'); }
+// Neutralize a link before it reaches an href: only http(s)/mailto/relative/anchor
+// URLs pass; anything else (javascript:, data:) collapses to '#' so a published
+// event can't smuggle a script URL into a clickable link.
+function safeUrl(u) { return /^(https?:|mailto:|\\/|#)/i.test(String(u)) ? String(u) : '#'; }
 
 // Interactive plan-approval / choice panel (#304). The run pauses on a 'choice'
 // event; we render the options with the recommended one pre-selected, accept on
@@ -582,7 +588,7 @@ function renderRuns(runs) {
     const li = document.createElement('li');
     li.dataset.id = r.id;
     const when = new Date(r.startedAt).toLocaleString();
-    const link = r.sessionLink ? ' \\u00b7 <a href="' + esc(r.sessionLink) + '" target="_blank" rel="noopener">session</a>' : '';
+    const link = r.sessionLink ? ' \\u00b7 <a href="' + esc(safeUrl(r.sessionLink)) + '" target="_blank" rel="noopener">session</a>' : '';
     li.innerHTML = '<div class="r-intent">' + esc(r.intent || 'untitled run') + '</div>' +
       '<div class="r-meta"><span class="dot ' + statusClass(r.status) + '">\\u25cf</span>' +
       '<span>' + esc(r.status) + '</span><span>\\u00b7 ' + esc(when) + '</span>' + link + '</div>';

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -265,10 +265,14 @@ test('/stop is 405 for a non-POST and 404 when stopping is not wired (#218)', as
   }
 })
 
-function postJson(url: string, body: unknown): Promise<{ status: number; body: string }> {
+function postJson(
+  url: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: string }> {
   return new Promise((resolvePromise, rejectPromise) => {
     const payload = JSON.stringify(body)
-    const req = request(url, { method: 'POST', headers: { 'content-type': 'application/json' } }, res => {
+    const req = request(url, { method: 'POST', headers: { 'content-type': 'application/json', ...headers } }, res => {
       let out = ''
       res.on('data', c => (out += c))
       res.on('end', () => resolvePromise({ status: res.statusCode ?? 0, body: out }))
@@ -277,6 +281,33 @@ function postJson(url: string, body: unknown): Promise<{ status: number; body: s
     req.end(payload)
   })
 }
+
+test('state-changing POSTs reject a cross-origin Origin but allow same-origin / no-Origin (CSRF)', async () => {
+  const started: string[] = []
+  const dash = await startDashboard({
+    port: 0,
+    onStop: () => started.push('stop'),
+    onChoice: id => started.push('choice:' + id),
+    onStart: prompt => (started.push('start:' + prompt), { ok: true }),
+  })
+  try {
+    // A browser on another site attaches its Origin; every steering route must refuse it.
+    const evil = { origin: 'https://evil.example' }
+    assert.equal((await postJson(dash.url + '/stop', {}, evil)).status, 403)
+    assert.equal((await postJson(dash.url + '/choice', { id: 'x', pick: 'y' }, evil)).status, 403)
+    assert.equal((await postJson(dash.url + '/api/start', { prompt: 'a blog' }, evil)).status, 403)
+    assert.deepEqual(started, []) // none of the handlers fired
+
+    // The dashboard's own page (loopback Origin) is allowed, as is a non-browser
+    // caller that sends no Origin at all.
+    assert.equal((await postJson(dash.url + '/stop', {}, { origin: dash.url })).status, 202)
+    assert.equal((await postJson(dash.url + '/stop', {}, { origin: 'http://localhost:1234' })).status, 202)
+    assert.equal((await postJson(dash.url + '/api/start', { prompt: 'a blog' })).status, 202)
+    assert.deepEqual(started, ['stop', 'stop', 'start:a blog'])
+  } finally {
+    await dash.close()
+  }
+})
 
 test('POST /choice invokes onChoice with the pick and the page reports it is choiceable (#304)', async () => {
   const picks: Array<{ id: string; pick: string | string[]; by: string }> = []

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -155,6 +155,11 @@ function handle(
       res.end('method not allowed')
       return
     }
+    if (!isSameOriginRequest(req)) {
+      res.writeHead(403, { 'content-type': 'text/plain' })
+      res.end('cross-origin request forbidden')
+      return
+    }
     if (!onStop) {
       res.writeHead(404, { 'content-type': 'text/plain' })
       res.end('stopping not enabled')
@@ -171,6 +176,11 @@ function handle(
     if (req.method !== 'POST') {
       res.writeHead(405, { 'content-type': 'text/plain', allow: 'POST' })
       res.end('method not allowed')
+      return
+    }
+    if (!isSameOriginRequest(req)) {
+      res.writeHead(403, { 'content-type': 'text/plain' })
+      res.end('cross-origin request forbidden')
       return
     }
     if (!onChoice) {
@@ -204,6 +214,11 @@ function handle(
       res.end('method not allowed')
       return
     }
+    if (!isSameOriginRequest(req)) {
+      res.writeHead(403, { 'content-type': 'text/plain' })
+      res.end('cross-origin request forbidden')
+      return
+    }
     if (!onStart) {
       res.writeHead(404, { 'content-type': 'text/plain' })
       res.end('starting not enabled')
@@ -233,6 +248,28 @@ function handle(
   }
   res.writeHead(404, { 'content-type': 'text/plain' })
   res.end('not found')
+}
+
+/**
+ * CSRF guard for the state-changing POST routes. A browser attaches an `Origin`
+ * header to every cross-site request, so we reject any POST whose Origin is not
+ * this same server (or a loopback host) — otherwise a page on `evil.com` could
+ * `fetch()` the localhost dashboard and spawn/steer a run. An absent Origin means
+ * a non-browser caller (curl, the test suite) with no ambient session to abuse,
+ * so it passes.
+ */
+function isSameOriginRequest(req: IncomingMessage): boolean {
+  const origin = req.headers.origin
+  if (!origin) return true
+  const host = req.headers.host
+  if (host && (origin === `http://${host}` || origin === `https://${host}`)) return true
+  let hostname: string
+  try {
+    hostname = new URL(origin).hostname
+  } catch {
+    return false // malformed Origin: treat as cross-origin
+  }
+  return hostname === 'localhost' || hostname === '::1' || hostname === '[::1]' || hostname.startsWith('127.')
 }
 
 /** Read a small JSON request body, tolerant of malformed input (yields `{}`). */

--- a/packages/framework/src/dashboard/xss.test.ts
+++ b/packages/framework/src/dashboard/xss.test.ts
@@ -1,0 +1,100 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { JSDOM } from 'jsdom'
+import { dashboardHtml } from './page.js'
+
+// The relay ingests events from anywhere and re-serves them to every viewer, so
+// event-borne strings (session links, preview URLs, choice option ids) are
+// attacker-controlled. These drive the real client JS in jsdom and assert the
+// render pipeline neutralizes a `javascript:` link, a quote-breakout attribute,
+// and a script URL rather than trusting the payload.
+
+interface Harness {
+  fire: (event: Record<string, unknown>) => void
+  query: (sel: string) => Element | null
+  window: Record<string, unknown>
+}
+
+function boot(): Harness {
+  const dom = new JSDOM(dashboardHtml('Test', true, true), {
+    runScripts: 'dangerously',
+    url: 'http://localhost/',
+    beforeParse(window) {
+      const w = window as unknown as { [k: string]: unknown }
+      // Neuter the polling timers so the test leaves no live handles.
+      w['setInterval'] = () => 0
+      w['setTimeout'] = () => 0
+      w['EventSource'] = class {
+        onmessage: ((ev: { data: string }) => void) | null = null
+        onerror: (() => void) | null = null
+        constructor() {
+          w['__es'] = this
+        }
+        close() {}
+      }
+      w['fetch'] = () => Promise.resolve({ ok: true, json: () => Promise.resolve({ runs: [], docs: [] }) })
+    },
+  })
+  const window = dom.window as unknown as { [k: string]: unknown }
+  const doc = dom.window.document
+  return {
+    fire(event) {
+      const es = window['__es'] as { onmessage: ((ev: { data: string }) => void) | null }
+      es.onmessage?.({ data: JSON.stringify(event) })
+    },
+    query: sel => doc.querySelector(sel),
+    window,
+  }
+}
+
+test('a preview event with a javascript: URL is neutralized to # (no script href)', () => {
+  const h = boot()
+  h.fire({ kind: 'preview', url: 'javascript:window.__pwned=1' })
+  const a = h.query('#app-link') as HTMLAnchorElement | null
+  assert.ok(a, '#app-link exists')
+  // The href collapses to '#'; the raw URL survives only as inert text.
+  assert.equal(a!.getAttribute('href'), '#')
+  assert.equal(a!.textContent, 'javascript:window.__pwned=1')
+  assert.equal(h.window['__pwned'], undefined)
+})
+
+test('a preview event with a real http URL keeps its href', () => {
+  const h = boot()
+  h.fire({ kind: 'preview', url: 'http://localhost:3000/' })
+  const a = h.query('#app-link') as HTMLAnchorElement | null
+  assert.equal(a!.getAttribute('href'), 'http://localhost:3000/')
+})
+
+test('a session link with a quote-breakout injects no event-handler attribute', () => {
+  const h = boot()
+  h.fire({
+    kind: 'session',
+    driver: 'x',
+    workspace: 'y',
+    fake: false,
+    sessionLink: 'https://x" onmouseover="window.__pwned=1',
+  })
+  const a = h.query('#session-link a') as HTMLAnchorElement | null
+  assert.ok(a, 'the session anchor rendered')
+  // The `"` was escaped, so the payload stayed inside the href value instead of
+  // opening a new attribute.
+  assert.equal(a!.getAttribute('onmouseover'), null)
+  assert.equal(a!.getAttribute('href'), 'https://x" onmouseover="window.__pwned=1')
+})
+
+test('a choice option id with an autofocus/onfocus breakout stays inert', () => {
+  const h = boot()
+  h.fire({
+    kind: 'choice',
+    id: 'plan-approval',
+    title: 'Approve?',
+    recommended: 'proceed',
+    options: [{ id: 'x" autofocus onfocus="window.__pwned=1', label: 'Proceed' }],
+  })
+  const input = h.query('#choice-options input') as HTMLInputElement | null
+  assert.ok(input, 'the option input rendered')
+  assert.equal(input!.getAttribute('onfocus'), null)
+  assert.equal(input!.getAttribute('autofocus'), null)
+  assert.equal(input!.getAttribute('value'), 'x" autofocus onfocus="window.__pwned=1')
+  assert.equal(h.window['__pwned'], undefined)
+})


### PR DESCRIPTION
Hardens the dashboard/relay surface, from a code-quality review of `@gemstack/framework`.

## What changed
- **Origin check on state-changing routes** (`/stop`, `/choice`, `/api/start`): a request whose `Origin` is a foreign site is refused, so another origin can't drive the localhost dashboard into spawning or steering a run. Non-browser callers (no `Origin`: curl, tests) and the dashboard's own loopback origin are allowed.
- **Scheme-checked link URLs**: session link, preview URL, and run-history link now pass through `safeUrl()`; a non-http(s)/mailto/relative URL collapses to `#` (so a `javascript:` URL is inert).
- **Quote-safe HTML escaper**: `esc()` now escapes `"` and `'`, so an event-supplied string can't break out of a quoted attribute.

## Tests
- `server.test.ts`: cross-origin POSTs get 403; loopback/no-Origin still work.
- `xss.test.ts` (jsdom, drives the real client JS): `javascript:` preview URL neutralized, quote-breakout session link injects no handler attribute, choice-option-id breakout stays inert.

Full package suite green (326 tests), typecheck clean. Patch changeset included.