### PR TITLE
feat(framework): [Maintainability (minimal)] preset button (#362)

### DIFF
--- a/.changeset/maintainability-minimal-preset-362.md
+++ b/.changeset/maintainability-minimal-preset-362.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Add a [Maintainability (minimal)] preset button on the dashboard (#362) beside the existing [Maintainability] one (#361), as a deliberate A/B. The minimal variant prefills the bare prompt "Look for maintainability red flags, and fix them." with no target scope and no goal framing, where #361 adds a `<PARAM:what>` target and a "make it as maintainable as possible" lead line. Both prefill the start textarea for review/editing and run verbatim as a direct prompt. Once the comparison settles, the losing variant will be removed.

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -2,6 +2,7 @@ import { CLAUDE_CODE_SESSION_LINK } from '../events.js'
 import { renderResearchPrompt } from '../research-preset.js'
 import { renderReadabilityPrompt } from '../readability-preset.js'
 import { renderMaintainabilityPrompt } from '../maintainability-preset.js'
+import { renderMaintainabilityMinimalPrompt } from '../maintainability-minimal-preset.js'
 
 /**
  * The single self-contained dashboard page: HTML + inline CSS + inline JS, no
@@ -214,6 +215,7 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
       <button id="start-research" class="start-preset" title="Prefill the Research preset prompt (rates problem variability, picks deep-dives); review or edit it, then Start">&#128269; Research</button>
       <button id="start-readability" class="start-preset" title="Prefill the Readability preset prompt (refactor code to make it easier for humans to read); review or edit it, then Start">&#128200; Readability</button>
       <button id="start-maintainability" class="start-preset" title="Prefill the Maintainability preset prompt (refactor code to make it easier to adapt for future changes); review or edit it, then Start">&#128200; Maintainability</button>
+      <button id="start-maintainability-minimal" class="start-preset" title="Prefill the minimal Maintainability preset prompt (#362: the bare red-flags line, no target scope); review or edit it, then Start">&#128200; Maintainability (minimal)</button>
       <span id="start-note"></span>
     </div>
   </section>
@@ -280,6 +282,7 @@ const STARTABLE = ${startable ? 'true' : 'false'};
 const RESEARCH_PROMPT = ${JSON.stringify(renderResearchPrompt())};
 const READABILITY_PROMPT = ${JSON.stringify(renderReadabilityPrompt())};
 const MAINTAINABILITY_PROMPT = ${JSON.stringify(renderMaintainabilityPrompt())};
+const MAINTAINABILITY_MINIMAL_PROMPT = ${JSON.stringify(renderMaintainabilityMinimalPrompt())};
 const AUTO_ACCEPT_MS = 10000;
 const GENERIC_SESSION_LINK = ${JSON.stringify(CLAUDE_CODE_SESSION_LINK)};
 let ended = false;
@@ -773,6 +776,7 @@ function wirePresetButton(id, name, prompt) {
 wirePresetButton('start-research', 'research', RESEARCH_PROMPT);
 wirePresetButton('start-readability', 'readability', READABILITY_PROMPT);
 wirePresetButton('start-maintainability', 'maintainability', MAINTAINABILITY_PROMPT);
+wirePresetButton('start-maintainability-minimal', 'maintainability (minimal)', MAINTAINABILITY_MINIMAL_PROMPT);
 $('start-prompt').addEventListener('input', () => {
   // An emptied box is a fresh start: back to a normal build run.
   if (!$('start-prompt').value.trim() && startKind !== 'build') { startKind = 'build'; $('start-note').textContent = ''; }

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -416,6 +416,10 @@ test('/api/start passes the run kind through; a research start may omit the prom
     assert.match(page.body, /id="start-maintainability"/)
     assert.match(page.body, /const MAINTAINABILITY_PROMPT = /)
     assert.match(page.body, /wirePresetButton\('start-maintainability'/)
+    // The minimal [Maintainability] variant (#362) ships beside the fuller one.
+    assert.match(page.body, /id="start-maintainability-minimal"/)
+    assert.match(page.body, /const MAINTAINABILITY_MINIMAL_PROMPT = /)
+    assert.match(page.body, /wirePresetButton\('start-maintainability-minimal'/)
   } finally {
     await dash.close()
   }

--- a/packages/framework/src/dashboard/start-prefill.test.ts
+++ b/packages/framework/src/dashboard/start-prefill.test.ts
@@ -5,6 +5,7 @@ import { dashboardHtml } from './page.js'
 import { renderResearchPrompt } from '../research-preset.js'
 import { renderReadabilityPrompt } from '../readability-preset.js'
 import { renderMaintainabilityPrompt } from '../maintainability-preset.js'
+import { renderMaintainabilityMinimalPrompt } from '../maintainability-minimal-preset.js'
 
 // Presets only prefill the textarea (#353): the [Research] button must load the
 // full preset prompt for review and send NOTHING; Start posts the (possibly
@@ -84,6 +85,18 @@ test('[Maintainability] prefills its #361 prompt the same way', async () => {
   assert.equal(h.posts.length, 0) // prefill sends nothing
   assert.equal(h.box.value, renderMaintainabilityPrompt())
   assert.match(h.note(), /maintainability preset loaded/)
+  h.click('start-run')
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(h.posts.length, 1)
+  assert.equal(h.posts[0]!.kind, 'prompt')
+})
+
+test('[Maintainability (minimal)] (#362) prefills the bare prompt the same way', async () => {
+  const h = boot()
+  h.click('start-maintainability-minimal')
+  assert.equal(h.posts.length, 0) // prefill sends nothing
+  assert.equal(h.box.value, renderMaintainabilityMinimalPrompt())
+  assert.match(h.note(), /maintainability \(minimal\) preset loaded/)
   h.click('start-run')
   await new Promise(resolve => setImmediate(resolve))
   assert.equal(h.posts.length, 1)

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -219,6 +219,12 @@ export {
   MAINTAINABILITY_PARAMS,
 } from './maintainability-preset.js'
 export {
+  renderMaintainabilityMinimalPrompt,
+  MAINTAINABILITY_MINIMAL_PRESET_NAME,
+  MAINTAINABILITY_MINIMAL_PROMPT_TEMPLATE,
+  MAINTAINABILITY_MINIMAL_PARAMS,
+} from './maintainability-minimal-preset.js'
+export {
   fakeDriver,
   FAKE_INTENT,
   FAKE_SIGNALS,

--- a/packages/framework/src/maintainability-minimal-preset.test.ts
+++ b/packages/framework/src/maintainability-minimal-preset.test.ts
@@ -1,0 +1,22 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { PARAM_PATTERN } from './preset-params.js'
+import {
+  renderMaintainabilityMinimalPrompt,
+  MAINTAINABILITY_MINIMAL_PARAMS,
+  MAINTAINABILITY_MINIMAL_PROMPT_TEMPLATE,
+} from './maintainability-minimal-preset.js'
+
+test('the minimal Maintainability template carries the bare #362 prompt, no framing or param', () => {
+  assert.equal(MAINTAINABILITY_MINIMAL_PROMPT_TEMPLATE, 'Look for maintainability red flags, and fix them.')
+  // The #362/#361 diff: no target scope and no "as maintainable as possible" framing.
+  assert.equal(MAINTAINABILITY_MINIMAL_PARAMS.length, 0)
+  assert.doesNotMatch(MAINTAINABILITY_MINIMAL_PROMPT_TEMPLATE, /<PARAM:/)
+  assert.doesNotMatch(MAINTAINABILITY_MINIMAL_PROMPT_TEMPLATE, /as maintainable as possible/)
+})
+
+test('renderMaintainabilityMinimalPrompt renders verbatim with no placeholder left', () => {
+  const rendered = renderMaintainabilityMinimalPrompt()
+  assert.equal(rendered, 'Look for maintainability red flags, and fix them.')
+  assert.equal(PARAM_PATTERN.test(rendered), false)
+})

--- a/packages/framework/src/maintainability-minimal-preset.ts
+++ b/packages/framework/src/maintainability-minimal-preset.ts
@@ -1,0 +1,27 @@
+import { renderPresetPrompt, type PresetParam } from './preset-params.js'
+
+/**
+ * The [Maintainability (minimal)] preset (#362): the barest form of Rom's
+ * maintainability pass, the red-flags line alone, with no target scope and no
+ * goal framing. It ships beside the fuller [Maintainability] (#361) as a
+ * deliberate A/B: #361 adds a `<PARAM:what>` target and a "make it as
+ * maintainable as possible" framing line, #362 drops both. Rom wants to see
+ * which performs better, so keep this verbatim from the issue. Once the
+ * comparison settles, the losing variant (this or #361) gets removed.
+ */
+
+/** The preset's name, as the dashboard note uses it. */
+export const MAINTAINABILITY_MINIMAL_PRESET_NAME = 'maintainability-minimal'
+
+/** No user params: #362 is deliberately unscoped (it acts on the session's work). */
+export const MAINTAINABILITY_MINIMAL_PARAMS: readonly PresetParam[] = []
+
+/** The prompt template, verbatim from #362: the red-flags line, nothing more. */
+export const MAINTAINABILITY_MINIMAL_PROMPT_TEMPLATE = `Look for maintainability red flags, and fix them.`
+
+/** Render the minimal Maintainability prompt. It has no blanks, so it renders as-is. */
+export function renderMaintainabilityMinimalPrompt(): string {
+  return renderPresetPrompt(MAINTAINABILITY_MINIMAL_PROMPT_TEMPLATE, {
+    params: MAINTAINABILITY_MINIMAL_PARAMS,
+  })
+}


### PR DESCRIPTION
Ships the #362 wording as a second Maintainability preset button beside the existing #361 one, so Rom can A/B both instead of us guessing which he meant.

## The difference being tested
- **Maintainability** (#361, shipped): `Refactor <what> to make it as maintainable as possible:` + `- Look for maintainability red flags, and fix them.` (target scope + goal framing)
- **Maintainability (minimal)** (#362, new): `Look for maintainability red flags, and fix them.` (bare line, no scope, no framing)

So #361 is a superset; this button isolates whether the extra target + framing actually helps.

## What changed (mirrors the #361 PR #366)
- `maintainability-minimal-preset.ts` — the bare template, no params, `renderMaintainabilityMinimalPrompt()`.
- `page.ts` — button `#start-maintainability-minimal`, prompt const, `wirePresetButton(...)`.
- `index.ts` — exports.
- Tests: unit (`maintainability-minimal-preset.test.ts`), the jsdom prefill behavioral test, and the page ships-check.

Prefill-only, runs verbatim as a direct `prompt` run like the other presets. Typecheck clean, full suite green (326).

Note: this is a deliberate temporary A/B. Once Rom picks a winner, we delete the losing variant's preset and close whichever of #361/#362 lost. Closes #362.