### PR TITLE
feat(framework): show the real prompts on the dashboard (#343)

### DIFF
--- a/.changeset/show-real-prompts-343.md
+++ b/.changeset/show-real-prompts-343.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Show the real prompts on the dashboard (#343). The framework now emits the exact system prompt it runs the agent under, the #326 block plus any persona / skill / memory framing, as a `system-prompt` event at session start (both the direct-prompt path and the full build path). A new "Prompts sent to Claude Code" panel renders it alongside each turn's user prompt (harvested from the `driver` `start` events already in the stream), so the normally-hidden prompt is fully visible for transparency. Prompt text renders as inert text, never markup. Read-only; nothing is gated on it.

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -101,6 +101,15 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   #modes .box { color: #6ea8fe; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
   #modes li.off { color: #5c657a; }
   #modes li.off .box { color: #3a4256; }
+  /* Prompts panel (#343): the actual system + per-turn prompts sent to the agent,
+     for full transparency. Collapsed <details> so the long text stays out of the way. */
+  #prompts-panel { grid-column: 1 / -1; }
+  #prompts-panel[hidden] { display: none; }
+  #prompts details { border: 1px solid #1c2230; border-radius: 8px; margin-bottom: 8px; background: #0d1119; }
+  #prompts summary { cursor: pointer; padding: 8px 12px; font-size: 12px; font-weight: 600;
+    color: #9db4d6; text-transform: uppercase; letter-spacing: .6px; }
+  #prompts pre { margin: 0; padding: 10px 12px; border-top: 1px solid #1c2230; white-space: pre-wrap;
+    word-break: break-word; font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; color: #c3ccdb; }
   /* Start-a-run panel (#345): only the daemon dashboard wires /api/start; the
      per-run page and the relay render it hidden. */
   #start-panel { grid-column: 1 / -1; }
@@ -259,6 +268,10 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
     <h2>Agent activity</h2>
     <div id="log"></div>
   </section>
+  <section id="prompts-panel" hidden>
+    <h2>Prompts sent to Claude Code</h2>
+    <div id="prompts"></div>
+  </section>
 </main>
 </div>
 <aside id="docs" hidden>
@@ -345,7 +358,18 @@ function driver(e) {
   if (e.type === 'text') log('  ' + e.text.replace(/\\s+/g, ' ').trim().slice(0, 160));
   else if (e.type === 'action') log('  \\u00b7 ' + e.label);
   else if (e.type === 'error') log('  ! ' + e.message);
-  else if (e.type === 'start') log('\\u203a prompt sent');
+  else if (e.type === 'start') { log('\\u203a prompt sent'); addPrompt('Turn ' + (++promptTurn), e.prompt); }
+}
+// Prompts panel (#343): every prompt sent to the agent, system + per turn. Uses
+// textContent (never innerHTML), so a prompt's contents can never inject markup.
+let promptTurn = 0;
+function addPrompt(label, text) {
+  const d = document.createElement('details');
+  const s = document.createElement('summary'); s.textContent = label;
+  const pre = document.createElement('pre'); pre.textContent = text;
+  d.appendChild(s); d.appendChild(pre);
+  $('prompts').appendChild(d);
+  $('prompts-panel').hidden = false;
 }
 function renderRationale(e) {
   const el = $('rationale'); el.innerHTML = '';
@@ -405,6 +429,7 @@ function render(fe) {
     log('\\u25b6 your app is running at ' + fe.url);
   }
   else if (fe.kind === 'bootstrap') bootstrap(fe.event);
+  else if (fe.kind === 'system-prompt') addPrompt('System prompt', fe.text);
   else if (fe.kind === 'driver') driver(fe.event);
   else if (fe.kind === 'modes') renderModes(fe.all, fe.active);
   else if (fe.kind === 'choice') showChoice(fe);
@@ -557,6 +582,7 @@ function resetPanels() {
   $('deploy').textContent = 'not decided yet'; $('deploy').classList.add('muted');
   $('ledger').innerHTML = '';
   $('log').textContent = '';
+  $('prompts-panel').hidden = true; $('prompts').innerHTML = ''; promptTurn = 0;
 }
 
 function project(events) {

--- a/packages/framework/src/dashboard/prompts-panel.test.ts
+++ b/packages/framework/src/dashboard/prompts-panel.test.ts
@@ -1,0 +1,77 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { JSDOM } from 'jsdom'
+import { dashboardHtml } from './page.js'
+
+// The Prompts panel (#343) shows every prompt sent to Claude Code: the system
+// prompt (a `system-prompt` event) plus each turn's user prompt (harvested from
+// the `driver` `start` events already in the stream). These drive the real
+// client JS in jsdom.
+
+interface Harness {
+  fire: (event: Record<string, unknown>) => void
+  query: (sel: string) => Element | null
+  queryAll: (sel: string) => Element[]
+  window: Record<string, unknown>
+}
+
+function boot(): Harness {
+  const dom = new JSDOM(dashboardHtml('Test', true, true), {
+    runScripts: 'dangerously',
+    url: 'http://localhost/',
+    beforeParse(window) {
+      const w = window as unknown as { [k: string]: unknown }
+      w['setInterval'] = () => 0
+      w['setTimeout'] = () => 0
+      w['EventSource'] = class {
+        onmessage: ((ev: { data: string }) => void) | null = null
+        onerror: (() => void) | null = null
+        constructor() {
+          w['__es'] = this
+        }
+        close() {}
+      }
+      w['fetch'] = () => Promise.resolve({ ok: true, json: () => Promise.resolve({ runs: [], docs: [] }) })
+    },
+  })
+  const window = dom.window as unknown as { [k: string]: unknown }
+  const doc = dom.window.document
+  return {
+    fire(event) {
+      const es = window['__es'] as { onmessage: ((ev: { data: string }) => void) | null }
+      es.onmessage?.({ data: JSON.stringify(event) })
+    },
+    query: sel => doc.querySelector(sel),
+    queryAll: sel => [...doc.querySelectorAll(sel)],
+    window,
+  }
+}
+
+test('the Prompts panel stays hidden until a prompt arrives', () => {
+  const h = boot()
+  assert.equal((h.query('#prompts-panel') as HTMLElement).hidden, true)
+})
+
+test('a system-prompt event and driver start events render one entry each, in order', () => {
+  const h = boot()
+  h.fire({ kind: 'system-prompt', text: '# System prompt\nBe transparent.' })
+  h.fire({ kind: 'driver', event: { type: 'start', prompt: 'refactor the auth flow' } })
+  h.fire({ kind: 'driver', event: { type: 'start', prompt: 'continue with the pick' } })
+
+  assert.equal((h.query('#prompts-panel') as HTMLElement).hidden, false)
+  const entries = h.queryAll('#prompts details')
+  assert.equal(entries.length, 3)
+  const summaries = h.queryAll('#prompts summary').map(s => s.textContent)
+  assert.deepEqual(summaries, ['System prompt', 'Turn 1', 'Turn 2'])
+  const bodies = h.queryAll('#prompts pre').map(p => p.textContent)
+  assert.deepEqual(bodies, ['# System prompt\nBe transparent.', 'refactor the auth flow', 'continue with the pick'])
+})
+
+test('prompt text is rendered as inert text, never markup (agent-controlled)', () => {
+  const h = boot()
+  h.fire({ kind: 'system-prompt', text: '<img src=x onerror="window.__pwned=1">' })
+  // The payload survives verbatim as text, and no <img> was ever created.
+  assert.equal(h.query('#prompts pre')!.textContent, '<img src=x onerror="window.__pwned=1">')
+  assert.equal(h.queryAll('#prompts img').length, 0)
+  assert.equal(h.window['__pwned'], undefined)
+})

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -91,6 +91,18 @@ test('page ships opt-in browser notifications for run-end and choice gates (#309
   }
 })
 
+test('page ships the Prompts transparency panel fed by system-prompt + driver events (#343)', async () => {
+  const dash = await startDashboard({ port: 0 })
+  try {
+    const { body } = await fetchText(dash.url + '/')
+    assert.match(body, /id="prompts-panel"/)
+    assert.match(body, /function addPrompt/)
+    assert.match(body, /fe\.kind === 'system-prompt'/)
+  } finally {
+    await dash.close()
+  }
+})
+
 test('page ships a live spend readout fed by usage events (#322)', async () => {
   const dash = await startDashboard({ port: 0 })
   try {

--- a/packages/framework/src/events.test.ts
+++ b/packages/framework/src/events.test.ts
@@ -80,6 +80,10 @@ test('formatFrameworkEvent renders a session-update line', () => {
   )
 })
 
+test('formatFrameworkEvent renders a system-prompt line by length (#343)', () => {
+  assert.equal(formatFrameworkEvent({ kind: 'system-prompt', text: 'abcde' }), '  system prompt sent (5 chars)')
+})
+
 test('formatFrameworkEvent renders a preview line', () => {
   assert.equal(
     formatFrameworkEvent({ kind: 'preview', url: 'http://localhost:3000', command: 'npm run dev' }),

--- a/packages/framework/src/events.ts
+++ b/packages/framework/src/events.ts
@@ -82,6 +82,15 @@ export type FrameworkEvent =
    * (each Claude Code prompt is a fresh session), keeping the link current.
    */
   | { kind: 'session-update'; sessionId: string; sessionLink?: string }
+  /**
+   * The full system prompt sent to the wrapped agent for this run (#343): the
+   * #326 block plus any personas / skills / memory framing, exactly as passed to
+   * the driver's system channel. Emitted once at session start so the dashboard
+   * can show the normally-hidden prompt (the per-turn user prompts arrive as
+   * `driver` `start` events, which already carry their text). Transparency, never
+   * gated on.
+   */
+  | { kind: 'system-prompt'; text: string }
   /** A bootstrap-phase narration event (scope / architect / checklist / deploy / ...). */
   | { kind: 'bootstrap'; event: BootstrapEvent }
   /** The wrapped agent's own progress, forwarded verbatim (never gated on). */
@@ -141,6 +150,8 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
       }`
     case 'session-update':
       return `  session ${event.sessionId}${event.sessionLink ? ` — ${event.sessionLink}` : ''}`
+    case 'system-prompt':
+      return `  system prompt sent (${event.text.length} chars)`
     case 'preview':
       return `▶ your app is running at ${event.url}`
     case 'log':

--- a/packages/framework/src/preset-run.test.ts
+++ b/packages/framework/src/preset-run.test.ts
@@ -46,6 +46,12 @@ test('a domain preset frames the run and is narrated', async () => {
   assert.match(system(), /Skill: Engineering Practices/)
   assert.match(system(), /google\.github\.io\/eng-practices/)
 
+  // That exact system prompt is surfaced for transparency (#343), not just handed
+  // to the driver.
+  const sys = events.find(e => e.kind === 'system-prompt')
+  assert.ok(sys, 'a system-prompt event is emitted')
+  assert.equal((sys as { text: string }).text, system())
+
   // It was narrated (title + active modes).
   const log = events.find(e => e.kind === 'log' && /Domain preset: Software Development/.test(e.message))
   assert.ok(log, 'domain preset is logged')

--- a/packages/framework/src/prompt-run.test.ts
+++ b/packages/framework/src/prompt-run.test.ts
@@ -34,6 +34,31 @@ test('runPrompt runs a gateless prompt straight through and emits session + end'
   assert.equal(events.some(e => e.kind === 'choice'), false)
 })
 
+test('runPrompt surfaces the system prompt (#343); the user prompt rides a driver start event', async () => {
+  const events: FrameworkEvent[] = []
+  const driver = new FakeDriver({ turns: [{ text: 'done' }] })
+  const startSpy = driver.start.bind(driver)
+  let captured = ''
+  driver.start = async opts => {
+    captured = opts.system ?? ''
+    return startSpy(opts)
+  }
+
+  await runPrompt({ prompt: 'refactor the auth flow', driver, cwd: '/ws', onEvent: e => events.push(e) })
+
+  // The system prompt is emitted verbatim: exactly what the driver was started with.
+  const sys = events.find(e => e.kind === 'system-prompt')
+  assert.ok(sys, 'a system-prompt event is emitted')
+  assert.equal((sys as { text: string }).text, captured)
+  assert.match((sys as { text: string }).text, /# System prompt/) // the built-in #326 block
+  // The user prompt is observable too, carried by the driver start event.
+  const start = events.find(
+    (e): e is Extract<FrameworkEvent, { kind: 'driver' }> => e.kind === 'driver' && e.event.type === 'start',
+  )
+  assert.ok(start, 'the driver start event carries the user prompt')
+  if (start.event.type === 'start') assert.match(start.event.prompt, /refactor the auth flow/)
+})
+
 test('runPrompt pauses on a multi-select gate and continues with the pick (#331)', async () => {
   const events: FrameworkEvent[] = []
   const picks: ChoiceRequest[] = []

--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -91,6 +91,9 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
     fake: opts.driver.name === 'fake',
     ...(literalLink ? { sessionLink: literalLink } : {}),
   })
+  // Surface the exact system prompt the agent runs under (#343). The user prompts
+  // ride along as `driver` `start` events, so the dashboard can show them all.
+  emit({ kind: 'system-prompt', text: system })
 
   // Usage accounting + the self-stopping budget cap, the same wiring as a build
   // run (#322): the run signal composes the caller's abort with the budget abort.

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -364,6 +364,10 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     fake: opts.driver.name === 'fake',
     ...(literalLink ? { sessionLink: literalLink } : {}),
   })
+  // Surface the exact system prompt the agent runs under (#343): the #326 block
+  // plus persona / skill / memory framing. The per-turn user prompts ride along
+  // as `driver` `start` events, so the dashboard can show every prompt sent.
+  if (system) emit({ kind: 'system-prompt', text: system })
   const extensionNote = activeExtensions.length ? `, ${activeExtensions.map(e => e.name).join(' + ')}` : ''
   const skillNote = skills.length ? `, ${skills.length} skill(s)` : ''
   emit({


### PR DESCRIPTION
MVP transparency: users can now see the actual prompts sent to Claude Code, including the normally-hidden system prompt. Closes #343.

## Approach
The per-turn user prompts were already in the event stream (the `driver` `start` event carries the full prompt text). The only missing piece was the **system prompt**, passed to the driver's system channel but never surfaced. So:

- **Backend (small):** emit a `system-prompt` event with the exact system text at session start, on both run paths (`prompt-run.ts` direct path + `run.ts` build path). It's the #326 block plus any persona / skill / memory framing, verbatim what the driver gets.
- **Dashboard:** a new "Prompts sent to Claude Code" panel renders the system prompt plus each turn's prompt (harvested from the existing `start` events) as collapsed `<details>`. Rendered via `textContent`, so agent-controlled prompt text is always inert.

## Why this UX
Rom left the UX open ("experiment and iterate once we have an MVP-esque dashboard"). This is a deliberately simple first cut: a full-width panel beside the activity log, easy to move into the right sidebar later (per #314). It's also the concrete building block for #314's "Vanilla" / "Technical control" transparency options.

## Tests
- `prompt-run.test.ts` / `preset-run.test.ts`: the `system-prompt` event is emitted equal to what the driver was started with, on both paths; the user prompt is observable via the driver start event.
- `prompts-panel.test.ts` (jsdom, real client JS): system + turn entries render in order; an `<img onerror>` payload stays inert text.
- `events.test.ts`: the format line. `server.test.ts`: the panel ships.

Full suite green (332), typecheck clean. Minor changeset included.