### PR TITLE
feat(framework): thread Global options through the run engine (#370)

### DIFF
--- a/.changeset/global-options-engine-314.md
+++ b/.changeset/global-options-engine-314.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Thread the #314 Global options through the run engine (#370). `POST /api/start` now carries an `options` object which the daemon turns into CLI flags: `--vanilla` removes the built-in #326 system prompt entirely (raw Claude Code), and `--eco-auto-planning` / `--eco-auto-research` / `--eco-auto-maintenance` drop the matching #326 sections to save tokens (Autopilot and Technical keep mapping to modes). `system-prompt.ts` drops the Eco sections at render, so the #343 Prompts panel reflects the toggles live; the #326 template stays byte-identical. The dashboard panel that drives these lands separately (#371); all fields default off, so today's behavior is unchanged.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -8,11 +8,13 @@ import { daemonStatePath } from './daemon.js'
 import { EVENTS_FILE, FRAMEWORK_DIR } from './store/index.js'
 import {
   activeModes,
+  antiLazyPillOff,
   autoSelectPreset,
   buildDeployTarget,
   chooseSessionLink,
   claudeDriverOptions,
   CLAUDE_CODE_SESSION_LIST,
+  ecoOptions,
   mergeRunConfig,
   parseArgs,
   resolveDomainPreset,
@@ -43,6 +45,30 @@ test('parseArgs reads the backlog-loop flags (#323)', () => {
   assert.equal(parseArgs(['--no-todo-loop', 'x']).todoLoop, false)
   assert.equal(parseArgs(['--max-todo-items', '5', 'x']).todoMaxItems, 5)
   assert.match(parseArgs(['--max-todo-items', '0', 'x']).error!, /max-todo-items/)
+})
+
+test('parseArgs reads the Global options flags: vanilla + eco (#314)', () => {
+  const dflt = parseArgs(['x'])
+  assert.equal(dflt.vanilla, false)
+  assert.deepEqual(dflt.eco, { autoPlanning: false, autoResearch: false, autoMaintenance: false })
+  const on = parseArgs(['--vanilla', '--eco-auto-planning', '--eco-auto-maintenance', 'x'])
+  assert.equal(on.vanilla, true)
+  assert.deepEqual(on.eco, { autoPlanning: true, autoResearch: false, autoMaintenance: true })
+})
+
+test('ecoOptions returns undefined when nothing is set, else only the enabled drops (#314)', () => {
+  assert.equal(ecoOptions(parseArgs(['x'])), undefined)
+  assert.deepEqual(ecoOptions(parseArgs(['--eco-auto-research', 'x'])), {
+    autoPlanning: false,
+    autoResearch: true,
+    autoMaintenance: false,
+  })
+})
+
+test('antiLazyPillOff is true for --vanilla or the-framework.yml antiLazyPill:false (#314)', () => {
+  assert.equal(antiLazyPillOff(parseArgs(['x']), {}), false)
+  assert.equal(antiLazyPillOff(parseArgs(['--vanilla', 'x']), {}), true)
+  assert.equal(antiLazyPillOff(parseArgs(['x']), { antiLazyPill: false }), true)
 })
 
 test('parseArgs reads the research subcommand with its optional what (#331)', () => {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -35,7 +35,7 @@ import {
 import { isWorkspaceEmpty } from './steps.js'
 import { loadFrameworkConfig, type FrameworkFileConfig } from './config.js'
 import { loadRepoMemory } from './memory.js'
-import { loadUserSystemPrompt, SYSTEM_PROMPT_FILE } from './system-prompt.js'
+import { loadUserSystemPrompt, SYSTEM_PROMPT_FILE, type EcoOptions } from './system-prompt.js'
 import { preflight } from './preflight.js'
 import { RunStore } from './store/index.js'
 import { daemonStatus, ensureDaemon, runDaemon, stopDaemon, DEFAULT_DAEMON_PORT } from './daemon.js'
@@ -106,6 +106,13 @@ Options:
   --technical            Activate the preset's Technical mode variants.
                          (--preset / --autopilot / --technical / --kind can also be
                           set per repo in the-framework.yml; these flags override it.)
+  --vanilla              Remove the built-in system prompt entirely, so the agent
+                         runs as raw Claude Code (fully transparent). Overrides the
+                         Eco flags below (there is no built-in prompt left to trim).
+  --eco-auto-planning    Drop the built-in prompt's "Large scope" (planning) section.
+  --eco-auto-research    Drop the built-in prompt's "Alternatives" (research) section.
+  --eco-auto-maintenance Drop the built-in prompt's "Maintenance" section.
+                         (The --eco-* flags trim the #326 prompt to save tokens.)
   --kind <name>          Build event kind the preset's review loop fires for, e.g.
                          bug-fix or major-change (default: the-framework.yml's event,
                          else the preset's own, else major-change). Selects which
@@ -173,6 +180,10 @@ export interface CliOptions {
   autoPreset: boolean
   autopilot: boolean
   technical: boolean
+  /** `--vanilla`: remove the built-in #326 system prompt entirely (antiLazyPill off, #314). */
+  vanilla: boolean
+  /** `--eco-*`: fine-grained #326 section drops to save tokens (#314). */
+  eco: Required<EcoOptions>
   buildEvent?: string | undefined
   maxPasses?: number
   maxCost?: number
@@ -222,6 +233,8 @@ export function parseArgs(argv: string[]): CliOptions {
     autoPreset: true,
     autopilot: false,
     technical: false,
+    vanilla: false,
+    eco: { autoPlanning: false, autoResearch: false, autoMaintenance: false },
     dashboard: true,
     relayServe: false,
     composeExtensions: false,
@@ -267,6 +280,18 @@ export function parseArgs(argv: string[]): CliOptions {
         break
       case '--technical':
         opts.technical = true
+        break
+      case '--vanilla':
+        opts.vanilla = true
+        break
+      case '--eco-auto-planning':
+        opts.eco.autoPlanning = true
+        break
+      case '--eco-auto-research':
+        opts.eco.autoResearch = true
+        break
+      case '--eco-auto-maintenance':
+        opts.eco.autoMaintenance = true
         break
       case '--kind':
         opts.buildEvent = argv[++i]
@@ -423,6 +448,21 @@ export function activeModes(opts: Pick<CliOptions, 'autopilot' | 'technical'>): 
   if (opts.autopilot) modes.push('autopilot')
   if (opts.technical) modes.push('technical')
   return modes
+}
+
+/**
+ * Whether the built-in #326 system prompt is removed for this run (#314): the
+ * Vanilla toggle (`--vanilla`) or `the-framework.yml`'s `antiLazyPill: false`.
+ */
+export function antiLazyPillOff(opts: Pick<CliOptions, 'vanilla'>, file: FrameworkFileConfig): boolean {
+  return opts.vanilla || file.antiLazyPill === false
+}
+
+/** The Eco section drops in effect (#314), or `undefined` when none are set. */
+export function ecoOptions(opts: Pick<CliOptions, 'eco'>): EcoOptions | undefined {
+  const { autoPlanning, autoResearch, autoMaintenance } = opts.eco
+  if (!autoPlanning && !autoResearch && !autoMaintenance) return undefined
+  return { autoPlanning, autoResearch, autoMaintenance }
 }
 
 /**
@@ -802,8 +842,11 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   if (opts.research || opts.directPrompt) {
     const kindLabel = opts.directPrompt ? 'prompt run' : 'research'
     const userSystemPrompt = await loadUserSystemPrompt(cwd)
+    const noBuiltinPrompt = antiLazyPillOff(opts, fileConfig)
+    const eco = ecoOptions(opts)
     if (userSystemPrompt) io.out(`◆ system prompt: ${SYSTEM_PROMPT_FILE}`)
-    if (fileConfig.antiLazyPill === false) io.out('◆ anti-lazy-pill: off (the-framework.yml)')
+    if (noBuiltinPrompt) io.out(`◆ built-in system prompt: off (${opts.vanilla ? 'vanilla' : 'the-framework.yml'})`)
+    else if (eco) io.out(`◆ eco: dropping ${Object.keys(eco).filter(k => eco[k as keyof EcoOptions]).join(', ')}`)
     try {
       await runPrompt({
         prompt: opts.directPrompt ? intent : renderResearchPrompt(intent),
@@ -820,7 +863,8 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
         ...(opts.model ? { model: opts.model } : {}),
         ...(opts.maxCost ? { budgetUsd: opts.maxCost } : {}),
         ...(userSystemPrompt ? { systemPrompt: userSystemPrompt } : {}),
-        ...(fileConfig.antiLazyPill === false ? { antiLazyPill: false } : {}),
+        ...(noBuiltinPrompt ? { antiLazyPill: false } : {}),
+        ...(eco ? { eco } : {}),
         ...(modeList.includes('autopilot') ? { autopilot: true } : {}),
         ...((): { sessionLink?: string } => {
           const link = chooseSessionLink(opts, fake)
@@ -916,8 +960,11 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // A user SYSTEM.md and the-framework.yml's anti-lazy-pill toggle shape the system
   // prompt injected into every prompt (#301). The built-in pill is on unless removed.
   const userSystemPrompt = await loadUserSystemPrompt(cwd)
+  const noBuiltinPrompt = antiLazyPillOff(opts, fileConfig)
+  const eco = ecoOptions(opts)
   if (userSystemPrompt) io.out(`◆ system prompt: ${SYSTEM_PROMPT_FILE}`)
-  if (fileConfig.antiLazyPill === false) io.out('◆ anti-lazy-pill: off (the-framework.yml)')
+  if (noBuiltinPrompt) io.out(`◆ built-in system prompt: off (${opts.vanilla ? 'vanilla' : 'the-framework.yml'})`)
+  else if (eco) io.out(`◆ eco: dropping ${Object.keys(eco).filter(k => eco[k as keyof EcoOptions]).join(', ')}`)
 
   const runOpts: RunFrameworkOptions = {
     intent,
@@ -954,7 +1001,8 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     ...(buildEvent ? { buildEvent } : {}),
     ...(memory.length ? { memory } : {}),
     ...(userSystemPrompt ? { systemPrompt: userSystemPrompt } : {}),
-    ...(fileConfig.antiLazyPill === false ? { antiLazyPill: false } : {}),
+    ...(noBuiltinPrompt ? { antiLazyPill: false } : {}),
+    ...(eco ? { eco } : {}),
     ...((): { sessionLink?: string } => {
       const link = chooseSessionLink(opts, fake)
       return link ? { sessionLink: link } : {}

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -12,9 +12,23 @@ import {
   stopDaemon,
   runDaemon,
   daemonStatePath,
+  startOptionFlags,
 } from './daemon.js'
 import { EVENTS_FILE, FRAMEWORK_DIR } from './store/index.js'
 import { controlPath } from './control.js'
+
+test('startOptionFlags maps only enabled Global options to CLI flags (#314)', () => {
+  assert.deepEqual(startOptionFlags({}), [])
+  assert.deepEqual(startOptionFlags({ autopilot: true, technical: true, vanilla: true }), [
+    '--autopilot',
+    '--technical',
+    '--vanilla',
+  ])
+  assert.deepEqual(startOptionFlags({ eco: { autoPlanning: true, autoMaintenance: true } }), [
+    '--eco-auto-planning',
+    '--eco-auto-maintenance',
+  ])
+})
 
 const logEvent = (message: string): FrameworkEvent => ({ kind: 'log', message })
 const line = (message: string): string => JSON.stringify(logEvent(message)) + '\n'

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -4,7 +4,7 @@ import { mkdir, readFile, writeFile, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { FrameworkEvent } from './events.js'
 import { EVENTS_FILE, FRAMEWORK_DIR } from './store/index.js'
-import { startDashboard, type Dashboard, type StartRunKind, type StartRunResult } from './dashboard/index.js'
+import { startDashboard, type Dashboard, type StartRunKind, type StartRunOptions, type StartRunResult } from './dashboard/index.js'
 import { appendControl } from './control.js'
 import { JsonlTailer } from './jsonl-tail.js'
 
@@ -40,6 +40,22 @@ export interface DaemonState {
 /** The `.framework/` directory for a workspace. */
 export function daemonDir(cwd: string): string {
   return join(cwd, FRAMEWORK_DIR)
+}
+
+/**
+ * Translate the dashboard's Global options (#314) into CLI flags for the spawned
+ * run. Only enabled toggles emit a flag, so a default (all-off) start is
+ * byte-identical to before. `parseArgs` on the other side accepts every one.
+ */
+export function startOptionFlags(options: StartRunOptions): string[] {
+  const flags: string[] = []
+  if (options.autopilot) flags.push('--autopilot')
+  if (options.technical) flags.push('--technical')
+  if (options.vanilla) flags.push('--vanilla')
+  if (options.eco?.autoPlanning) flags.push('--eco-auto-planning')
+  if (options.eco?.autoResearch) flags.push('--eco-auto-research')
+  if (options.eco?.autoMaintenance) flags.push('--eco-auto-maintenance')
+  return flags
 }
 
 /** The daemon state file path for a workspace. */
@@ -214,7 +230,7 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
   // which the run wires whenever a daemon is live. One run at a time: while the
   // last child is alive, Start is refused (the #322 runaway concern).
   let activeRunPid: number | undefined
-  const startRun = (prompt: string, kind: StartRunKind): StartRunResult => {
+  const startRun = (prompt: string, kind: StartRunKind, options: StartRunOptions = {}): StartRunResult => {
     if (activeRunPid !== undefined && isProcessAlive(activeRunPid)) {
       return { ok: false, busy: true, error: 'a run is already active; stop it or wait for it to finish' }
     }
@@ -234,7 +250,7 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
         : kind === 'prompt'
           ? ['prompt', prompt]
           : [prompt]
-    const child = spawn(process.execPath, [binPath, ...runArgs, '--no-dashboard', '--cwd', cwd], {
+    const child = spawn(process.execPath, [binPath, ...runArgs, ...startOptionFlags(options), '--no-dashboard', '--cwd', cwd], {
       detached: true,
       stdio: 'ignore',
     })

--- a/packages/framework/src/dashboard/index.ts
+++ b/packages/framework/src/dashboard/index.ts
@@ -1,2 +1,2 @@
-export { startDashboard, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunResult } from './server.js'
+export { startDashboard, parseStartOptions, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunOptions, type StartRunResult } from './server.js'
 export { dashboardHtml } from './page.js'

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -4,7 +4,7 @@ import { get, request } from 'node:http'
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { startDashboard } from './server.js'
+import { startDashboard, parseStartOptions, type StartRunOptions } from './server.js'
 import type { FrameworkEvent } from '../events.js'
 
 function fetchText(url: string): Promise<{ status: number; body: string }> {
@@ -432,6 +432,40 @@ test('/api/start passes the run kind through; a research start may omit the prom
     assert.match(page.body, /id="start-maintainability-minimal"/)
     assert.match(page.body, /const MAINTAINABILITY_MINIMAL_PROMPT = /)
     assert.match(page.body, /wirePresetButton\('start-maintainability-minimal'/)
+  } finally {
+    await dash.close()
+  }
+})
+
+test('parseStartOptions keeps only known boolean fields (#314)', () => {
+  assert.deepEqual(parseStartOptions(undefined), {})
+  assert.deepEqual(parseStartOptions('nope'), {})
+  // Truthy-but-not-true values are ignored; only `=== true` survives.
+  assert.deepEqual(parseStartOptions({ autopilot: true, technical: 'yes', vanilla: 1, junk: true }), {
+    autopilot: true,
+  })
+  assert.deepEqual(
+    parseStartOptions({ eco: { autoPlanning: true, autoResearch: false, bogus: true } }),
+    { eco: { autoPlanning: true } },
+  )
+  // An eco object with nothing enabled drops out entirely.
+  assert.deepEqual(parseStartOptions({ eco: { autoResearch: false } }), {})
+})
+
+test('/api/start forwards the sanitized Global options to onStart (#314)', async () => {
+  const calls: StartRunOptions[] = []
+  const dash = await startDashboard({ port: 0, onStart: (_p, _k, options) => { calls.push(options); return { ok: true } } })
+  try {
+    await postJson(dash.url + '/api/start', {
+      prompt: 'a blog',
+      options: { autopilot: true, vanilla: true, eco: { autoMaintenance: true, junk: true }, junk: true },
+    })
+    // No options field at all -> the handler still gets an object (all-off).
+    await postJson(dash.url + '/api/start', { prompt: 'a blog' })
+    assert.deepEqual(calls, [
+      { autopilot: true, vanilla: true, eco: { autoMaintenance: true } },
+      {},
+    ])
   } finally {
     await dash.close()
   }

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -2,6 +2,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import type { AddressInfo } from 'node:net'
 import { EventStream } from '@gemstack/ai-autopilot'
 import type { ChoiceBy, FrameworkEvent } from '../events.js'
+import type { EcoOptions } from '../system-prompt.js'
 import { listRuns, loadRunEvents } from '../store/index.js'
 import { readDocs } from './docs.js'
 import { dashboardHtml } from './page.js'
@@ -37,11 +38,29 @@ export interface DashboardOptions {
   cwd?: string
   /**
    * Called when the browser posts a new-run prompt (#345): `POST /api/start`
-   * with a JSON `{ prompt, kind? }` body. Wire this to spawn the run (the
+   * with a JSON `{ prompt, kind?, options? }` body. Wire this to spawn the run (the
    * daemon does); return `busy: true` to refuse because a run is already active
-   * (409). Omit to disable starting; the page hides the prompt panel.
+   * (409). Omit to disable starting; the page hides the prompt panel. The Global
+   * options (#314) ride along in `options`.
    */
-  onStart?: (prompt: string, kind: StartRunKind) => StartRunResult
+  onStart?: (prompt: string, kind: StartRunKind, options: StartRunOptions) => StartRunResult
+}
+
+/**
+ * The dashboard's Global options (#314), posted alongside a Start. Each maps to a
+ * run flag: Autopilot + Technical to modes, Vanilla to removing the built-in
+ * system prompt, and Eco to the fine-grained #326 section drops. Absent fields
+ * default off, i.e. today's behavior.
+ */
+export interface StartRunOptions {
+  /** Auto-accept mode; also steers the #326 maintenance stance. */
+  autopilot?: boolean
+  /** Technical mode: expose technical detail (preset-scoped). */
+  technical?: boolean
+  /** Remove the built-in #326 system prompt entirely (raw Claude Code). */
+  vanilla?: boolean
+  /** Fine-grained #326 section drops to save tokens. */
+  eco?: EcoOptions
 }
 
 /**
@@ -117,7 +136,7 @@ function handle(
   title: string,
   onStop: (() => void) | undefined,
   onChoice: ((id: string, pick: string | string[], by: ChoiceBy) => void) | undefined,
-  onStart: ((prompt: string, kind: StartRunKind) => StartRunResult) | undefined,
+  onStart: ((prompt: string, kind: StartRunKind, options: StartRunOptions) => StartRunResult) | undefined,
   cwd: string | undefined,
 ): void {
   const url = req.url ?? '/'
@@ -235,7 +254,7 @@ function handle(
         res.end('{"error":"a non-empty prompt is required"}')
         return
       }
-      const result = onStart(prompt, kind)
+      const result = onStart(prompt, kind, parseStartOptions(body['options']))
       if (!result.ok) {
         res.writeHead(result.busy ? 409 : 500, { 'content-type': 'application/json' })
         res.end(JSON.stringify({ error: result.error }))
@@ -270,6 +289,27 @@ function isSameOriginRequest(req: IncomingMessage): boolean {
     return false // malformed Origin: treat as cross-origin
   }
   return hostname === 'localhost' || hostname === '::1' || hostname === '[::1]' || hostname.startsWith('127.')
+}
+
+/**
+ * Sanitize the posted Global options (#314) into a {@link StartRunOptions}. Only
+ * known boolean fields survive, so a malformed or hostile body can never smuggle
+ * anything into the run flags. An absent/non-object value yields all-off.
+ */
+export function parseStartOptions(raw: unknown): StartRunOptions {
+  const src = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {}
+  const ecoSrc = src['eco'] && typeof src['eco'] === 'object' ? (src['eco'] as Record<string, unknown>) : {}
+  const eco: EcoOptions = {
+    ...(ecoSrc['autoPlanning'] === true ? { autoPlanning: true } : {}),
+    ...(ecoSrc['autoResearch'] === true ? { autoResearch: true } : {}),
+    ...(ecoSrc['autoMaintenance'] === true ? { autoMaintenance: true } : {}),
+  }
+  return {
+    ...(src['autopilot'] === true ? { autopilot: true } : {}),
+    ...(src['technical'] === true ? { technical: true } : {}),
+    ...(src['vanilla'] === true ? { vanilla: true } : {}),
+    ...(Object.keys(eco).length ? { eco } : {}),
+  }
 }
 
 /** Read a small JSON request body, tolerant of malformed input (yields `{}`). */

--- a/packages/framework/src/prompt-run.test.ts
+++ b/packages/framework/src/prompt-run.test.ts
@@ -59,6 +59,42 @@ test('runPrompt surfaces the system prompt (#343); the user prompt rides a drive
   if (start.event.type === 'start') assert.match(start.event.prompt, /refactor the auth flow/)
 })
 
+test('runPrompt honors eco flags in the emitted system prompt (#314)', async () => {
+  const events: FrameworkEvent[] = []
+  const driver = new FakeDriver({ turns: [{ text: 'done' }] })
+  await runPrompt({
+    prompt: 'tidy the code',
+    driver,
+    cwd: '/ws',
+    onEvent: e => events.push(e),
+    eco: { autoResearch: true, autoMaintenance: true },
+  })
+  const sys = events.find(e => e.kind === 'system-prompt') as { text: string } | undefined
+  assert.ok(sys)
+  // The dropped sections are gone; the surviving one stays.
+  assert.ok(!sys.text.includes('## Alternatives'))
+  assert.ok(!sys.text.includes('## Maintenance'))
+  assert.ok(sys.text.includes('## Large scope'))
+})
+
+test('runPrompt with antiLazyPill false emits no built-in prompt even with eco set (#314)', async () => {
+  const events: FrameworkEvent[] = []
+  const driver = new FakeDriver({ turns: [{ text: 'done' }] })
+  await runPrompt({
+    prompt: 'raw run',
+    driver,
+    cwd: '/ws',
+    onEvent: e => events.push(e),
+    antiLazyPill: false,
+    eco: { autoPlanning: true },
+  })
+  const sys = events.find(e => e.kind === 'system-prompt') as { text: string } | undefined
+  assert.ok(sys)
+  // Vanilla: no #326 block at all, only the always-on await protocol.
+  assert.ok(!sys.text.includes('# System prompt'))
+  assert.ok(!sys.text.includes('## Unclear scope'))
+})
+
 test('runPrompt pauses on a multi-select gate and continues with the pick (#331)', async () => {
   const events: FrameworkEvent[] = []
   const picks: ChoiceRequest[] = []

--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -1,7 +1,7 @@
 import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { hasSessionIdPlaceholder, resolveSessionLink, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 import { resolveAwaitGate } from './run.js'
-import { renderSystemPrompt, systemPromptBlock, type TfContext } from './system-prompt.js'
+import { renderSystemPrompt, systemPromptBlock, type EcoOptions, type TfContext } from './system-prompt.js'
 import { AWAIT_PROTOCOL, PLAN_DECLINED_MESSAGE, isDeclinedConfirmation, parseAwaitGate } from './turn-gate.js'
 import { UsageMeter } from './usage.js'
 
@@ -40,6 +40,8 @@ export interface RunPromptOptions {
   antiLazyPill?: boolean
   /** Whether autopilot mode is on: steers the #326 prompt's maintenance stance (#325). Default false. */
   autopilot?: boolean
+  /** Eco fine-grained control (#314): drop the enabled #326 sections to save tokens. */
+  eco?: EcoOptions
   /** Stop the run once the agent has spent this much, in USD (#322). */
   budgetUsd?: number
   /** Session link template for the dashboard, `{sessionId}` resolved when known. */
@@ -74,7 +76,10 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
   // The built-in #326 prompt + any user SYSTEM.md frame the session (#301). The
   // await protocol is always on — honoring the prompt's gates is the whole point
   // of this path.
-  const tf: TfContext = { prompt: opts.prompt, params: { autopilot: opts.autopilot === true } }
+  const tf: TfContext = {
+    prompt: opts.prompt,
+    params: { autopilot: opts.autopilot === true, ...(opts.eco ? { eco: opts.eco } : {}) },
+  }
   const promptBlock = systemPromptBlock({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt, tf })
   const system = [...(promptBlock ? [promptBlock] : []), AWAIT_PROTOCOL].join('\n\n')
   // The template's `# User prompt` half carries the prompt (today it renders to

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -37,7 +37,7 @@ import {
 import { snapshotWorkspace } from './sandbox.js'
 import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { memoryFraming, type LoadedMemory } from './memory.js'
-import { systemPromptBlock, type TfContext } from './system-prompt.js'
+import { systemPromptBlock, type EcoOptions, type TfContext } from './system-prompt.js'
 import { AWAIT_PROTOCOL, CONFIRM_APPROVED, CONFIRM_DECLINED, PLAN_DECLINED_MESSAGE, isDeclinedConfirmation, parseAwaitGate, type ParsedAwaitGate } from './turn-gate.js'
 // Value import from todo-loop.js is a benign cycle: todo-loop.js only calls
 // run.js's hoisted function declarations (requestChoices / resolveAwaitGate).
@@ -121,6 +121,8 @@ export interface RunFrameworkOptions {
    * is the historical config key: #326 is the anti-lazy-pill's (#297) successor.
    */
   antiLazyPill?: boolean
+  /** Eco fine-grained control (#314): drop the enabled #326 sections to save tokens. */
+  eco?: EcoOptions
   /**
    * A user-picked Open Loop domain preset ({loops, prompts, skills}) to run the
    * build under (#251). Its skills (and their personas) frame every phase, and
@@ -339,7 +341,7 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
   // the steps. `tf.params.autopilot` reflects the run's autopilot mode (#325).
   const tf: TfContext = {
     prompt: opts.intent,
-    params: { autopilot: opts.modes?.includes('autopilot') ?? false },
+    params: { autopilot: opts.modes?.includes('autopilot') ?? false, ...(opts.eco ? { eco: opts.eco } : {}) },
   }
   const promptBlock = systemPromptBlock({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt, tf })
   // The await protocol (#337) concretizes the pill's showChoices()/AWAIT macros into a

--- a/packages/framework/src/system-prompt.test.ts
+++ b/packages/framework/src/system-prompt.test.ts
@@ -90,3 +90,56 @@ test('systemPromptBlock threads tf through to the template', () => {
   const block = systemPromptBlock({ tf: { prompt: 'x', params: { autopilot: true } } })
   assert.ok(block.includes('postpone a deep refactor'))
 })
+
+test('eco.autoPlanning drops only the Large scope section (#314)', () => {
+  const { system } = renderSystemPrompt({ prompt: 'x', params: { eco: { autoPlanning: true } } })
+  assert.ok(!system.includes('## Large scope'))
+  assert.ok(!system.includes('PLAN_<SESSION_NAME>'))
+  // The neighbours survive, and the block spacing is intact.
+  assert.ok(system.includes('## Unclear scope'))
+  assert.ok(system.includes('## Alternatives'))
+  assert.ok(system.includes('## Maintenance'))
+  assert.ok(!system.includes('\n\n\n'))
+})
+
+test('eco.autoResearch drops only the Alternatives section (#314)', () => {
+  const { system } = renderSystemPrompt({ prompt: 'x', params: { eco: { autoResearch: true } } })
+  assert.ok(!system.includes('## Alternatives'))
+  assert.ok(!system.includes('measure "variability"'))
+  assert.ok(system.includes('## Large scope'))
+  assert.ok(system.includes('## Maintenance'))
+})
+
+test('eco.autoMaintenance drops the trailing Maintenance section cleanly (#314)', () => {
+  const { system, user } = renderSystemPrompt({ prompt: 'ship it', params: { eco: { autoMaintenance: true } } })
+  assert.ok(!system.includes('## Maintenance'))
+  assert.ok(system.includes('## Alternatives'))
+  // The user half is untouched by eco, and no stray fragment survives the drop.
+  assert.equal(user, 'ship it')
+  assert.ok(!system.includes('${{'))
+})
+
+test('all three eco drops leave just the Unclear scope section (#314)', () => {
+  const { system } = renderSystemPrompt({
+    prompt: 'x',
+    params: { eco: { autoPlanning: true, autoResearch: true, autoMaintenance: true } },
+  })
+  assert.ok(system.includes('## Unclear scope'))
+  for (const gone of ['## Large scope', '## Alternatives', '## Maintenance']) {
+    assert.ok(!system.includes(gone), `${gone} should be dropped`)
+  }
+})
+
+test('no eco flags renders every section, and eco never touches the template', () => {
+  const { system } = renderSystemPrompt({ prompt: 'x', params: { eco: {} } })
+  for (const section of ['## Unclear scope', '## Large scope', '## Alternatives', '## Maintenance']) {
+    assert.ok(system.includes(section), `missing ${section}`)
+  }
+  // The living #326 doc stays byte-identical regardless of eco.
+  assert.ok(SYSTEM_PROMPT_TEMPLATE.includes('## Large scope'))
+})
+
+test('vanilla (antiLazyPill false) wins over eco: no built-in prompt at all (#314)', () => {
+  const block = systemPromptBlock({ antiLazyPill: false, tf: { prompt: 'x', params: { eco: { autoResearch: true } } } })
+  assert.equal(block, '')
+})

--- a/packages/framework/src/system-prompt.ts
+++ b/packages/framework/src/system-prompt.ts
@@ -59,12 +59,34 @@ Before starting to write code, measure "variability":
 
 \${{tf.prompt}}`
 
+/**
+ * Eco fine-grained control (#314): each flag drops one whole `##` section from the
+ * built-in #326 prompt to save tokens, letting the agent auto-handle that concern.
+ * The template itself stays byte-identical to Rom's #326 doc; the sections are
+ * removed after the split, so a dropped section never leaves a fragment behind.
+ */
+export interface EcoOptions {
+  /** Drop `## Large scope` (the PLAN-file planning section). */
+  autoPlanning?: boolean | undefined
+  /** Drop `## Alternatives` (the variability-rating research section). */
+  autoResearch?: boolean | undefined
+  /** Drop `## Maintenance` (the minimal-changes maintenance section). */
+  autoMaintenance?: boolean | undefined
+}
+
+/** Maps an {@link EcoOptions} flag to the `## ` heading it drops from the template. */
+const ECO_SECTION_HEADINGS: Record<keyof EcoOptions, string> = {
+  autoPlanning: '## Large scope',
+  autoResearch: '## Alternatives',
+  autoMaintenance: '## Maintenance',
+}
+
 /** The `tf` context the template's `${{...}}` fragments read (#326/#350). */
 export interface TfContext {
   /** The user's prompt (the run intent, or the typed prompt): fills `${{tf.prompt}}`. */
   prompt: string
-  /** Run parameters the template branches on (e.g. `autopilot`, #325's mode sense). */
-  params: { autopilot?: boolean } & Record<string, unknown>
+  /** Run parameters the template branches on (e.g. `autopilot`, #325's mode sense; `eco`, #314). */
+  params: { autopilot?: boolean; eco?: EcoOptions | undefined } & Record<string, unknown>
 }
 
 /** The neutral context used when a caller has none: empty prompt, no modes. */
@@ -81,14 +103,40 @@ export interface RenderedSystemPrompt {
 const USER_PROMPT_HEADING = '\n# User prompt\n'
 
 /**
+ * Drop a whole `## <heading>` section from a markdown block: everything from the
+ * heading up to (but not including) the next `## ` heading, or the end. The `\n\n`
+ * separator ahead of the section goes with it, so the surrounding blocks stay
+ * spaced exactly as before. A heading that isn't present is a no-op.
+ */
+function dropSection(md: string, heading: string): string {
+  const at = md.indexOf(`\n${heading}`)
+  if (at === -1) return md
+  const nextHeading = md.indexOf('\n## ', at + heading.length + 1)
+  const end = nextHeading === -1 ? md.length : nextHeading
+  return md.slice(0, at) + md.slice(end)
+}
+
+/** Remove each Eco-enabled section from the template's system half (#314). */
+function applyEco(systemHalf: string, eco: EcoOptions | undefined): string {
+  if (!eco) return systemHalf
+  let out = systemHalf
+  for (const key of Object.keys(ECO_SECTION_HEADINGS) as (keyof EcoOptions)[]) {
+    if (eco[key]) out = dropSection(out, ECO_SECTION_HEADINGS[key])
+  }
+  return out
+}
+
+/**
  * Render the built-in system prompt against a {@link TfContext} and split it at
  * the `# User prompt` heading. The split happens on the *template*, before
  * rendering, so a user prompt that itself contains the heading can never move
- * the boundary.
+ * the boundary. Eco flags (#314) drop their sections from the system half here,
+ * before rendering, so a dropped section's `${{...}}` fragments never evaluate.
  */
 export function renderSystemPrompt(tf: TfContext = DEFAULT_TF): RenderedSystemPrompt {
   const at = SYSTEM_PROMPT_TEMPLATE.indexOf(USER_PROMPT_HEADING)
-  const systemHalf = at === -1 ? SYSTEM_PROMPT_TEMPLATE : SYSTEM_PROMPT_TEMPLATE.slice(0, at)
+  const rawSystemHalf = at === -1 ? SYSTEM_PROMPT_TEMPLATE : SYSTEM_PROMPT_TEMPLATE.slice(0, at)
+  const systemHalf = applyEco(rawSystemHalf, tf.params.eco)
   const userHalf = at === -1 ? '${{tf.prompt}}' : SYSTEM_PROMPT_TEMPLATE.slice(at + USER_PROMPT_HEADING.length)
   return {
     system: renderTemplate(systemHalf, { tf }).trim(),


### PR DESCRIPTION
Wires the #314 "Global options" through the run engine so a dashboard Start can honor them. No UI here (that is #371); this is the plumbing plus the system-prompt honoring.

What it does:
- `POST /api/start` now carries an `options` object. The daemon turns it into CLI flags that `parseArgs` already accepts.
- `--vanilla` removes the built-in #326 system prompt entirely, so the agent runs as raw Claude Code.
- `--eco-auto-planning` / `--eco-auto-research` / `--eco-auto-maintenance` drop the matching #326 section (Large scope / Alternatives / Maintenance) to save tokens. `system-prompt.ts` strips the sections at render, so the #343 Prompts panel reflects the toggles live.
- Autopilot and Technical keep mapping to modes.

The #326 template stays byte-identical (sections are removed after the split, never edited in place). Every option defaults off, so behavior is unchanged until the panel lands. Verified end to end with `framework prompt "..." --fake --vanilla` and `--eco-*`.

The ask: review + merge. The dashboard panel is the sibling PR on #371.

`pnpm typecheck` and `pnpm test` green (347 tests).

Closes #370
