### PR TITLE
feat(framework): Global options panel on the dashboard (#371)

### DIFF
--- a/.changeset/global-options-panel-314.md
+++ b/.changeset/global-options-panel-314.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Add the #314 Global options panel to the dashboard (#371). Beside the Start box the daemon dashboard now shows persistent toggles: Autopilot (auto-accept, sharing its key with the choice-panel toggle so the two stay in lockstep), Technical control, Vanilla (remove all system prompts, fully transparent), and Eco with Auto planning / Auto research / Auto maintenance to trim the built-in prompt. Each persists in localStorage and rides along in the `POST /api/start` body, so flipping a toggle changes what the run gets (and, with the engine plumbing in #370, what the #343 Prompts panel shows). Vanilla disables Eco, since a removed prompt has nothing left to trim.

--- a/packages/framework/src/dashboard/global-options.test.ts
+++ b/packages/framework/src/dashboard/global-options.test.ts
@@ -1,0 +1,161 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { JSDOM } from 'jsdom'
+import { dashboardHtml } from './page.js'
+
+// The Global options panel (#314) is client-side JS baked into the page: a set of
+// persistent run toggles (Autopilot / Technical / Vanilla / Eco + sub-toggles)
+// saved in localStorage and sent with each Start. These drive the real page in
+// jsdom, so we assert behavior, not just that the code ships.
+
+interface Started {
+  prompt: string
+  kind: string
+  options: Record<string, unknown>
+}
+
+interface Harness {
+  doc: Document
+  window: Record<string, unknown>
+  started: Started[]
+  check: (id: string) => void
+  isChecked: (id: string) => boolean
+  el: (id: string) => HTMLElement
+}
+
+// Boot the startable dashboard page in jsdom, seeding localStorage first so
+// init-from-storage is observable. `fetch` to api/start records the posted body.
+function boot(seed: Record<string, string> = {}): Harness {
+  const started: Started[] = []
+  const dom = new JSDOM(dashboardHtml('Test', true, true, true), {
+    runScripts: 'dangerously',
+    url: 'http://localhost/',
+    beforeParse(window) {
+      const w = window as unknown as { [k: string]: unknown }
+      for (const [k, v] of Object.entries(seed)) window.localStorage.setItem(k, v)
+      w['setInterval'] = () => 0
+      w['setTimeout'] = () => 0
+      w['EventSource'] = class {
+        onmessage: ((ev: { data: string }) => void) | null = null
+        onerror: (() => void) | null = null
+        close() {}
+      }
+      w['fetch'] = (url: string, opts?: { method?: string; body?: string }) => {
+        if (url === 'api/start' && opts?.body) started.push(JSON.parse(opts.body) as Started)
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ runs: [], docs: [] }) })
+      }
+    },
+  })
+  const window = dom.window as unknown as { [k: string]: unknown }
+  const doc = dom.window.document
+  const el = (id: string): HTMLElement => {
+    const node = doc.getElementById(id)
+    assert.ok(node, `#${id} exists`)
+    return node as HTMLElement
+  }
+  return {
+    doc,
+    window,
+    started,
+    el,
+    isChecked: id => (el(id) as HTMLInputElement).checked,
+    check(id) {
+      const input = el(id) as HTMLInputElement
+      input.checked = !input.checked
+      input.dispatchEvent(new dom.window.Event('change'))
+    },
+  }
+}
+
+// Type a prompt and press Start, returning the options that would be POSTed.
+function start(h: Harness, prompt = 'build a blog'): Record<string, unknown> {
+  ;(h.el('start-prompt') as HTMLTextAreaElement).value = prompt
+  ;(h.el('start-run') as unknown as { click: () => void }).click()
+  assert.equal(h.started.length, 1, 'one start was posted')
+  return h.started[0]!.options
+}
+
+test('the panel ships in the startable page with all Global option toggles (#314)', () => {
+  const h = boot()
+  for (const id of ['opt-autopilot', 'opt-technical', 'opt-vanilla', 'opt-eco', 'opt-eco-planning', 'opt-eco-research', 'opt-eco-maintenance'])
+    assert.ok(h.doc.getElementById(id), `#${id} exists`)
+})
+
+test('defaults: Autopilot on, the rest off, Eco sub-toggles hidden (#314)', () => {
+  const h = boot()
+  assert.equal(h.isChecked('opt-autopilot'), true) // framework:autopilot defaults on
+  assert.equal(h.isChecked('opt-technical'), false)
+  assert.equal(h.isChecked('opt-vanilla'), false)
+  assert.equal(h.isChecked('opt-eco'), false)
+  assert.equal(h.el('eco-subs').hidden, true)
+})
+
+test('toggles initialize from localStorage (#314)', () => {
+  const h = boot({
+    'framework:autopilot': '0',
+    'framework:opt:technical': '1',
+    'framework:opt:eco': '1',
+    'framework:opt:eco-research': '1',
+  })
+  assert.equal(h.isChecked('opt-autopilot'), false)
+  assert.equal(h.isChecked('opt-technical'), true)
+  assert.equal(h.isChecked('opt-eco'), true)
+  assert.equal(h.isChecked('opt-eco-research'), true)
+  // Eco is on, so the sub-toggles are revealed.
+  assert.equal(h.el('eco-subs').hidden, false)
+})
+
+test('toggling a Global option persists it to localStorage (#314)', () => {
+  const h = boot()
+  h.check('opt-technical')
+  assert.equal(h.window['localStorage'] && (h.el('opt-technical') as HTMLInputElement).checked, true)
+  assert.equal((h.window as { localStorage: Storage }).localStorage.getItem('framework:opt:technical'), '1')
+})
+
+test('Eco reveals its sub-toggles; Vanilla disables Eco entirely (#314)', () => {
+  const h = boot()
+  h.check('opt-eco')
+  assert.equal(h.el('eco-subs').hidden, false)
+  // Turning Vanilla on removes the whole built-in prompt: Eco is disabled and its
+  // sub-toggles hidden (nothing left to trim).
+  h.check('opt-vanilla')
+  assert.equal((h.el('opt-eco') as HTMLInputElement).disabled, true)
+  assert.equal(h.el('eco-subs').hidden, true)
+})
+
+test('Start posts the enabled options; a plain default start sends autopilot only (#314)', () => {
+  const h = boot()
+  const options = start(h)
+  assert.deepEqual(options, { autopilot: true }) // autopilot default-on, nothing else
+})
+
+test('Start posts vanilla + technical + the enabled Eco drops (#314)', () => {
+  const h = boot()
+  h.check('opt-autopilot') // turn the default-on autopilot off
+  h.check('opt-technical')
+  h.check('opt-eco')
+  h.check('opt-eco-planning')
+  h.check('opt-eco-maintenance')
+  const options = start(h)
+  assert.deepEqual(options, {
+    technical: true,
+    eco: { autoPlanning: true, autoMaintenance: true },
+  })
+})
+
+test('Eco off drops the eco object even when sub-toggles were checked (#314)', () => {
+  const h = boot({ 'framework:opt:eco': '1', 'framework:opt:eco-research': '1' })
+  h.check('opt-eco') // turn Eco off; the sub-toggle stays stored but is not sent
+  const options = start(h)
+  assert.equal('eco' in options, false)
+})
+
+test('Autopilot stays in lockstep with the choice-panel toggle (#314)', () => {
+  const h = boot()
+  // The global Autopilot and the choice-panel Autopilot share framework:autopilot.
+  h.check('opt-autopilot') // -> off
+  assert.equal((h.window as { localStorage: Storage }).localStorage.getItem('framework:autopilot'), '0')
+  assert.equal(h.isChecked('autopilot-toggle'), false)
+  h.check('opt-autopilot') // -> on
+  assert.equal(h.isChecked('autopilot-toggle'), true)
+})

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -127,6 +127,17 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   .start-preset:hover { background: #17212f; }
   .start-preset:disabled { opacity: .5; cursor: default; }
   #start-note { color: #f0a35e; font-size: 12px; }
+  /* Global options (#314): persistent run toggles beside the Start box. */
+  #global-options { display: flex; flex-wrap: wrap; align-items: center; gap: 6px 16px; margin-top: 12px;
+    padding-top: 10px; border-top: 1px solid #1c2230; }
+  #global-options .go-title { color: #7b8496; font-size: 11px; text-transform: uppercase; letter-spacing: .6px;
+    font-weight: 600; margin-right: 4px; }
+  #global-options label { display: flex; align-items: center; gap: 5px; color: #b7c0d0; font-size: 13px; cursor: pointer; }
+  #global-options label.disabled { color: #4a5266; cursor: default; }
+  #eco-subs { display: flex; flex-wrap: wrap; gap: 6px 14px; width: 100%; margin: 2px 0 0 4px;
+    padding-left: 12px; border-left: 2px solid #1c2230; }
+  #eco-subs[hidden] { display: none; }
+  #eco-subs label { font-size: 12px; color: #96a0b3; }
   /* Interactive plan-approval / choice panel (#304): full-width, accented so it
      reads as the one thing awaiting the human. */
   #choice-panel { grid-column: 1 / -1; background: #131a2a; border: 1px solid #2b3b5c;
@@ -226,6 +237,18 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
       <button id="start-maintainability" class="start-preset" title="Prefill the Maintainability preset prompt (refactor code to make it easier to adapt for future changes); review or edit it, then Start">&#128200; Maintainability</button>
       <button id="start-maintainability-minimal" class="start-preset" title="Prefill the minimal Maintainability preset prompt (#362: the bare red-flags line, no target scope); review or edit it, then Start">&#128200; Maintainability (minimal)</button>
       <span id="start-note"></span>
+    </div>
+    <div id="global-options">
+      <span class="go-title">Global options</span>
+      <label id="opt-autopilot-label" title="Auto-accept the recommended choice after a countdown; also relaxes the maintenance stance"><input type="checkbox" id="opt-autopilot"> Autopilot</label>
+      <label title="Expose technical detail (e.g. tech-stack choices) — the 'technical' mode"><input type="checkbox" id="opt-technical"> Technical control</label>
+      <label title="Remove all system prompts: fully transparent, same as raw Claude Code"><input type="checkbox" id="opt-vanilla"> Vanilla</label>
+      <label id="opt-eco-label" title="Trim the built-in system prompt to save tokens"><input type="checkbox" id="opt-eco"> Eco</label>
+      <div id="eco-subs" hidden>
+        <label title="Drop the planning section, letting the agent plan on its own"><input type="checkbox" id="opt-eco-planning"> Auto planning</label>
+        <label title="Drop the alternatives/variability section"><input type="checkbox" id="opt-eco-research"> Auto research</label>
+        <label title="Drop the maintenance section"><input type="checkbox" id="opt-eco-maintenance"> Auto maintenance</label>
+      </div>
     </div>
   </section>
   <section id="choice-panel" hidden>
@@ -779,7 +802,7 @@ function startNewRun() {
   for (const b of buttons) b.disabled = true;
   note.textContent = 'starting\\u2026';
   fetch('api/start', { method: 'POST', headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ prompt: prompt, kind: startKind }) })
+    body: JSON.stringify({ prompt: prompt, kind: startKind, options: collectStartOptions() }) })
     .then(async r => {
       for (const b of buttons) b.disabled = false;
       if (r.ok) { note.textContent = ''; $('start-prompt').value = ''; startKind = 'build'; showLive(); return; }
@@ -812,13 +835,59 @@ $('start-prompt').addEventListener('keydown', ev => {
   if ((ev.ctrlKey || ev.metaKey) && ev.key === 'Enter') { ev.preventDefault(); ev.stopPropagation(); startNewRun(); }
 });
 
+// Global options (#314): persistent run toggles saved in localStorage and sent
+// with every Start. Autopilot keeps its historical key, shared with the choice
+// panel toggle so the two stay in lockstep; the rest map to run flags the daemon
+// forwards. Absent options default off, i.e. today's behavior.
+function optKey(name) { return 'framework:opt:' + name; }
+function optOn(name) { return localStorage.getItem(optKey(name)) === '1'; }
+function setOpt(name, on) { localStorage.setItem(optKey(name), on ? '1' : '0'); }
+function setAutopilot(on) {
+  localStorage.setItem('framework:autopilot', on ? '1' : '0');
+  const choiceToggle = $('autopilot-toggle'); if (choiceToggle) choiceToggle.checked = on;
+  const globalToggle = $('opt-autopilot'); if (globalToggle) globalToggle.checked = on;
+}
+const ECO_SUBS = ['eco-planning', 'eco-research', 'eco-maintenance'];
+function collectStartOptions() {
+  const options = {};
+  if (autopilotOn()) options.autopilot = true;
+  if (optOn('technical')) options.technical = true;
+  if (optOn('vanilla')) options.vanilla = true;
+  if (optOn('eco')) {
+    const eco = {};
+    if (optOn('eco-planning')) eco.autoPlanning = true;
+    if (optOn('eco-research')) eco.autoResearch = true;
+    if (optOn('eco-maintenance')) eco.autoMaintenance = true;
+    if (Object.keys(eco).length) options.eco = eco;
+  }
+  return options;
+}
+// Vanilla removes the whole built-in prompt, so Eco has nothing left to trim.
+function syncEcoUi() {
+  const vanilla = optOn('vanilla');
+  $('opt-eco').disabled = vanilla;
+  $('opt-eco-label').classList.toggle('disabled', vanilla);
+  $('eco-subs').hidden = !optOn('eco') || vanilla;
+}
+function initGlobalOptions() {
+  if (!STARTABLE) return;
+  $('opt-autopilot').checked = autopilotOn();
+  for (const name of ['technical', 'vanilla', 'eco', ...ECO_SUBS]) $('opt-' + name).checked = optOn(name);
+  syncEcoUi();
+  $('opt-autopilot').addEventListener('change', ev => setAutopilot(ev.target.checked));
+  for (const name of ['technical', 'vanilla', 'eco', ...ECO_SUBS]) {
+    $('opt-' + name).addEventListener('change', ev => { setOpt(name, ev.target.checked); syncEcoUi(); });
+  }
+}
+initGlobalOptions();
+
 $('stop').addEventListener('click', stopRun);
 $('back-live').addEventListener('click', showLive);
 $('choice-accept').addEventListener('click', () => acceptChoice('user'));
 $('choice-approve').addEventListener('click', () => acceptChoice('user', 'approve'));
 $('choice-decline').addEventListener('click', () => acceptChoice('user', 'decline'));
 $('autopilot-toggle').addEventListener('change', ev => {
-  localStorage.setItem('framework:autopilot', ev.target.checked ? '1' : '0');
+  setAutopilot(ev.target.checked);
   if (ev.target.checked) startCountdown(); else { stopCountdown(); $('choice-count').textContent = 'Auto accept off'; }
 });
 // Any mouse movement cancels the running autopilot countdown (cheap no-op once cleared).

--- a/packages/framework/src/dashboard/start-prefill.test.ts
+++ b/packages/framework/src/dashboard/start-prefill.test.ts
@@ -15,6 +15,7 @@ import { renderMaintainabilityMinimalPrompt } from '../maintainability-minimal-p
 interface StartPost {
   prompt: string
   kind: string
+  options?: Record<string, unknown>
 }
 
 function boot() {
@@ -110,5 +111,6 @@ test('clearing a prefilled preset reverts Start to a normal build run (#353)', a
   h.type('a plain blog')
   h.click('start-run')
   await new Promise(resolve => setImmediate(resolve))
-  assert.deepEqual(h.posts, [{ prompt: 'a plain blog', kind: 'build' }])
+  // The Global options (#314) ride along; autopilot defaults on, nothing else set.
+  assert.deepEqual(h.posts, [{ prompt: 'a plain blog', kind: 'build', options: { autopilot: true } }])
 })


### PR DESCRIPTION
Adds the #314 "Global options" panel to the daemon dashboard, on top of the engine plumbing in #370.

Beside the Start box:
- Autopilot: auto-accept choices. Shares the existing `framework:autopilot` key with the choice-panel toggle, so the two stay in lockstep.
- Technical control: expose technical detail (the `technical` mode).
- Vanilla: remove all system prompts, fully transparent, same as raw Claude Code. Turning it on disables Eco (nothing left to trim).
- Eco with Auto planning / Auto research / Auto maintenance: drop the matching built-in-prompt sections to save tokens.

Each toggle persists in localStorage and rides along in the `POST /api/start` body. With #370 merged, flipping a toggle changes what the run gets and what the #343 Prompts panel shows.

Independent of #370: an older server just ignores the extra body field, so this is safe to merge in either order.

The ask: review + merge.

`pnpm typecheck` and `pnpm test` green (342 tests; new jsdom test drives the real client JS for persistence, Eco/Vanilla interplay, and the posted options).

Closes #371
