### PR TITLE
fix(framework): center the dashboard main grid (#374)

### DIFF
--- a/.changeset/dashboard-center-main.md
+++ b/.changeset/dashboard-center-main.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Center the dashboard's main grid in the content column. `main` had a `max-width: 1100px` cap but no horizontal centering, so on a wide window the panels hugged the left edge next to the runs sidebar. Add `margin: 0 auto` so the capped grid sits centered.

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -72,7 +72,7 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   #viewing button { font: inherit; font-size: 12px; font-weight: 600; cursor: pointer; color: #6ea8fe;
     background: #0f1722; border: 1px solid #24344a; border-radius: 6px; padding: 3px 10px; }
   #content { flex: 1; min-width: 0; }
-  main { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; padding: 18px 20px; max-width: 1100px; }
+  main { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; padding: 18px 20px; max-width: 1100px; margin: 0 auto; }
   section { background: #10141d; border: 1px solid #1c2230; border-radius: 10px; padding: 14px 16px; }
   section h2 { margin: 0 0 10px; font-size: 12px; text-transform: uppercase;
     letter-spacing: .8px; color: #7b8496; font-weight: 600; }

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -68,6 +68,8 @@ test('dashboard serves the HTML page with the title', async () => {
     // The Modes panel + its renderer ship in the page (#272), hidden until a modes event.
     assert.match(body, /id="modes-panel" hidden/)
     assert.match(body, /function renderModes/)
+    // The main grid is capped and centered in the content column, not left-hugging.
+    assert.match(body, /main \{[^}]*max-width: 1100px; margin: 0 auto;/)
   } finally {
     await dash.close()
   }


### PR DESCRIPTION
The dashboard `main` had `max-width: 1100px` but no `margin: 0 auto`, so on a wide window the panels hugged the left edge next to the runs sidebar. This adds `margin: 0 auto` so the capped grid centers.

Verified in the browser against a live daemon. `pnpm typecheck` and `pnpm test` green (356 tests).

Closes #374