### PR TITLE
fix(framework): dashboard layout fills the viewport height (#376)

### DIFF
--- a/.changeset/dashboard-layout-fill-height.md
+++ b/.changeset/dashboard-layout-fill-height.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Make the dashboard layout fill the viewport height. `#layout` only grew to its content height, so on a short page the runs-sidebar right border stopped partway down instead of reaching the bottom. Give `#layout` a `min-height: calc(100vh - 57px)` (matching the sidebar's existing header-height key) so the stretched sidebar runs full-height.

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -48,7 +48,9 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   #app-banner .dot { color: #67d98f; }
   #app-banner a { color: #67d98f; font-weight: 600; }
   #app-banner .run { color: #6f8a79; font-size: 12px; }
-  #layout { display: flex; align-items: stretch; }
+  /* Fill the viewport below the 57px header so the sidebar border runs full-height
+     even when the content is short. */
+  #layout { display: flex; align-items: stretch; min-height: calc(100vh - 57px); }
   #sidebar { flex: 0 0 240px; width: 240px; border-right: 1px solid #1c2230; padding: 14px 10px;
     overflow-y: auto; max-height: calc(100vh - 57px); }
   #sidebar h2 { margin: 0 0 8px; padding: 0 6px; font-size: 12px; text-transform: uppercase;

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -70,6 +70,8 @@ test('dashboard serves the HTML page with the title', async () => {
     assert.match(body, /function renderModes/)
     // The main grid is capped and centered in the content column, not left-hugging.
     assert.match(body, /main \{[^}]*max-width: 1100px; margin: 0 auto;/)
+    // The layout fills the viewport below the header, so the sidebar border runs full-height.
+    assert.match(body, /#layout \{[^}]*min-height: calc\(100vh - 57px\);/)
   } finally {
     await dash.close()
   }


### PR DESCRIPTION
The runs-sidebar right border stopped partway down on a short page because `#layout` only grew to its content height. This gives `#layout` a `min-height: calc(100vh - 57px)` (the header-height key the sidebar already uses), so the stretched sidebar runs full-height.

Verified in the browser against a live daemon. `pnpm typecheck` and `pnpm test` green (356 tests).

Closes #376