### PR TITLE
feat(framework): add the .the-framework/LOGS.md log module (#378)

### DIFF
--- a/.changeset/the-framework-logs-module.md
+++ b/.changeset/the-framework-logs-module.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+New `.the-framework/LOGS.md` project-log module (#378): `appendLog`/`readLogs` keep a human-readable markdown log of every loop, prompt, and build in a project, with `renderLogEntry`/`parseLogs` as the pure core over the same StoreFs seam as the run store. Parsing is forgiving: a malformed entry is skipped, never thrown. Standalone for now; the run-lifecycle wiring and dashboard UI land in follow-up issues.

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -112,6 +112,16 @@ export {
   type RunStatus,
   type OpenStoreOptions,
 } from './store/index.js'
+export {
+  logsPath,
+  renderLogEntry,
+  parseLogs,
+  appendLog,
+  readLogs,
+  THE_FRAMEWORK_DIR,
+  LOGS_FILE,
+  type LogEntry,
+} from './logs.js'
 export { runCli, parseArgs, buildDeployTarget, workspaceSummary, autoSelectPreset, type CliIO, type CliOptions } from './cli.js'
 export {
   metaSelect,

--- a/packages/framework/src/logs.test.ts
+++ b/packages/framework/src/logs.test.ts
@@ -1,0 +1,191 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { join } from 'node:path'
+import {
+  appendLog,
+  logsPath,
+  parseLogs,
+  readLogs,
+  renderLogEntry,
+  LOGS_FILE,
+  THE_FRAMEWORK_DIR,
+  type LogEntry,
+} from './logs.js'
+import type { StoreFs } from './store/index.js'
+
+/** An in-memory {@link StoreFs} so the log logic is tested without touching disk. */
+function memFs(seed: Record<string, string> = {}): StoreFs & { files: Map<string, string> } {
+  const files = new Map<string, string>(Object.entries(seed))
+  return {
+    files,
+    async read(path) {
+      const v = files.get(path)
+      if (v === undefined) throw new Error(`ENOENT: ${path}`)
+      return v
+    },
+    async write(path, contents) {
+      files.set(path, contents)
+    },
+    async append(path, contents) {
+      files.set(path, (files.get(path) ?? '') + contents)
+    },
+    async exists(path) {
+      return files.has(path)
+    },
+    async mkdir() {
+      // no-op: the memory fs has no directories
+    },
+    async readdir(dir) {
+      const prefix = dir.endsWith('/') ? dir : dir + '/'
+      const names = new Set<string>()
+      for (const p of files.keys()) {
+        if (!p.startsWith(prefix)) continue
+        const rest = p.slice(prefix.length)
+        if (!rest.includes('/')) names.add(rest)
+      }
+      return [...names]
+    },
+  }
+}
+
+const CWD = '/proj'
+const LOGS = join(CWD, THE_FRAMEWORK_DIR, LOGS_FILE)
+
+const PROMPT: LogEntry = {
+  at: '2026-07-10T09:00:00.000Z',
+  kind: 'prompt',
+  title: 'Add a login page',
+  status: 'done',
+  sessionId: 'sess-1',
+  sessionLink: 'https://claude.ai/code/sess-1',
+}
+
+const LOOP: LogEntry = {
+  at: '2026-07-10T10:00:00.000Z',
+  kind: 'loop',
+  title: 'Polish the dashboard',
+  status: 'stopped',
+  prompts: ['Fix the header layout', 'Tighten empty states'],
+}
+
+const BARE_SESSION: LogEntry = {
+  at: '2026-07-10T11:00:00.000Z',
+  kind: 'build',
+  title: 'A todo app',
+  status: 'running',
+  sessionId: 'sess-2',
+}
+
+const MINIMAL: LogEntry = {
+  at: '2026-07-10T12:00:00.000Z',
+  kind: 'build',
+  title: 'A blog',
+  status: 'failed',
+}
+
+test('logsPath joins cwd, dir, and file', () => {
+  assert.equal(logsPath(CWD), LOGS)
+})
+
+test('renderLogEntry renders a prompt with a session link', () => {
+  assert.equal(
+    renderLogEntry(PROMPT),
+    [
+      '## 2026-07-10T09:00:00.000Z · prompt · Add a login page',
+      '',
+      '- status: done',
+      '- session: [sess-1](https://claude.ai/code/sess-1)',
+    ].join('\n'),
+  )
+})
+
+test('renderLogEntry renders a loop with its prompts', () => {
+  assert.equal(
+    renderLogEntry(LOOP),
+    [
+      '## 2026-07-10T10:00:00.000Z · loop · Polish the dashboard',
+      '',
+      '- status: stopped',
+      '- prompts:',
+      '  - Fix the header layout',
+      '  - Tighten empty states',
+    ].join('\n'),
+  )
+})
+
+test('renderLogEntry renders a bare session id when there is no link', () => {
+  assert.equal(
+    renderLogEntry(BARE_SESSION),
+    ['## 2026-07-10T11:00:00.000Z · build · A todo app', '', '- status: running', '- session: sess-2'].join('\n'),
+  )
+})
+
+test('renderLogEntry omits session and prompts lines when absent', () => {
+  assert.equal(
+    renderLogEntry(MINIMAL),
+    ['## 2026-07-10T12:00:00.000Z · build · A blog', '', '- status: failed'].join('\n'),
+  )
+})
+
+test('parseLogs(renderLogEntry(e)) round-trips every entry shape', () => {
+  for (const entry of [PROMPT, LOOP, BARE_SESSION, MINIMAL]) {
+    assert.deepEqual(parseLogs(renderLogEntry(entry)), [entry])
+  }
+})
+
+test('a title containing the separator round-trips intact', () => {
+  const entry: LogEntry = { ...MINIMAL, title: 'A blog · with comments · and tags' }
+  assert.deepEqual(parseLogs(renderLogEntry(entry)), [entry])
+})
+
+test('parseLogs on empty input is []', () => {
+  assert.deepEqual(parseLogs(''), [])
+})
+
+test('parseLogs skips malformed entries but keeps the good ones around them', () => {
+  const md = [
+    '# The Framework logs',
+    '',
+    renderLogEntry(PROMPT),
+    '',
+    '## 2026-07-10T10:30:00.000Z · deploy · Not a real kind',
+    '',
+    '- status: done',
+    '',
+    '## 2026-07-10T10:45:00.000Z · build · Missing its status',
+    '',
+    renderLogEntry(LOOP),
+  ].join('\n')
+  assert.deepEqual(parseLogs(md), [PROMPT, LOOP])
+})
+
+test('appendLog writes the header once and readLogs returns entries newest-first', async () => {
+  const fs = memFs()
+  await appendLog(CWD, PROMPT, fs)
+  await appendLog(CWD, LOOP, fs)
+
+  const raw = fs.files.get(LOGS)!
+  assert.ok(raw.startsWith('# The Framework logs\n'))
+  assert.equal(raw.split('# The Framework logs').length, 2) // header written exactly once
+  assert.equal(parseLogs(raw).length, 2)
+
+  assert.deepEqual(await readLogs(CWD, fs), [LOOP, PROMPT])
+})
+
+test('readLogs on a missing file is []', async () => {
+  assert.deepEqual(await readLogs(CWD, memFs()), [])
+})
+
+test('appendLog creates the .the-framework dir and only writes the header when absent', async () => {
+  const fs = memFs()
+  const dirs: string[] = []
+  const spied: StoreFs = { ...fs, mkdir: async path => void dirs.push(path) }
+  await appendLog(CWD, PROMPT, spied)
+  assert.deepEqual(dirs, [join(CWD, THE_FRAMEWORK_DIR)])
+
+  const afterFirst = fs.files.get(LOGS)!
+  await appendLog(CWD, LOOP, spied)
+  const afterSecond = fs.files.get(LOGS)!
+  assert.ok(afterSecond.startsWith(afterFirst)) // second append did not rewrite the header
+  assert.equal(afterSecond.split('# The Framework logs').length, 2)
+})

--- a/packages/framework/src/logs.ts
+++ b/packages/framework/src/logs.ts
@@ -1,0 +1,161 @@
+import { join } from 'node:path'
+import { nodeStoreFs, type StoreFs } from './store/index.js'
+
+/**
+ * The `.the-framework/LOGS.md` project log (#378): a human-readable markdown
+ * record of every loop, prompt, and build run in a project. Pure core over the
+ * same {@link StoreFs} seam as the run store; the run-lifecycle wiring and UI
+ * land in later issues (#379/#380).
+ */
+
+/** The directory, under the project root, that holds the log. */
+export const THE_FRAMEWORK_DIR = '.the-framework'
+
+/** The markdown log file name. */
+export const LOGS_FILE = 'LOGS.md'
+
+/** One project-log entry: a loop, or a standalone prompt/build. */
+export interface LogEntry {
+  /** ISO timestamp. */
+  at: string
+  kind: 'loop' | 'prompt' | 'build'
+  /** Single-line intent/prompt summary. */
+  title: string
+  status: 'done' | 'stopped' | 'failed' | 'running'
+  /** Claude Code session id. */
+  sessionId?: string
+  /** e.g. `https://claude.ai/code/<id>` */
+  sessionLink?: string
+  /** For a loop: constituent prompt summaries. */
+  prompts?: string[]
+}
+
+const KINDS: readonly string[] = ['loop', 'prompt', 'build']
+const STATUSES: readonly string[] = ['done', 'stopped', 'failed', 'running']
+
+/** Heading field separator: a middle dot (U+00B7) with a space on each side. */
+const SEP = ' · '
+
+/** The one-time first line of the file, written on the first append. */
+const HEADER = '# The Framework logs\n'
+
+/** The log path under `cwd`. */
+export function logsPath(cwd: string): string {
+  return join(cwd, THE_FRAMEWORK_DIR, LOGS_FILE)
+}
+
+/** Markdown for one entry, starting at `## ` (no file header, no blank lines around it). */
+export function renderLogEntry(entry: LogEntry): string {
+  const lines = [
+    `## ${entry.at}${SEP}${entry.kind}${SEP}${entry.title}`,
+    '',
+    `- status: ${entry.status}`,
+  ]
+  if (entry.sessionId) {
+    lines.push(
+      entry.sessionLink
+        ? `- session: [${entry.sessionId}](${entry.sessionLink})`
+        : `- session: ${entry.sessionId}`,
+    )
+  }
+  if (entry.prompts && entry.prompts.length > 0) {
+    lines.push('- prompts:')
+    for (const prompt of entry.prompts) lines.push(`  - ${prompt}`)
+  }
+  return lines.join('\n')
+}
+
+/**
+ * Parse every entry out of the markdown, in file order (append order, so
+ * oldest-first). Forgiving: a malformed or torn entry is skipped, never thrown.
+ */
+export function parseLogs(md: string): LogEntry[] {
+  const entries: LogEntry[] = []
+  let block: string[] | undefined
+  const flush = () => {
+    const entry = block && parseEntry(block)
+    if (entry) entries.push(entry)
+    block = undefined
+  }
+  for (const line of md.split('\n')) {
+    if (line.startsWith('## ')) {
+      flush()
+      block = [line]
+    } else if (block) {
+      block.push(line)
+    }
+    // Anything before the first `## ` (the file header) is ignored.
+  }
+  flush()
+  return entries
+}
+
+/** Parse one `## `-headed block; `undefined` when a required field is missing/invalid. */
+function parseEntry(lines: string[]): LogEntry | undefined {
+  const heading = lines[0]?.slice('## '.length) ?? ''
+  const parts = heading.split(SEP)
+  const at = parts[0]
+  const kind = parts[1]
+  // Re-join the rest so a title containing the separator survives.
+  const title = parts.slice(2).join(SEP)
+  if (!at || !kind || !title || !KINDS.includes(kind)) return undefined
+
+  let status: string | undefined
+  let sessionId: string | undefined
+  let sessionLink: string | undefined
+  let prompts: string[] | undefined
+  let inPrompts = false
+  for (const line of lines.slice(1)) {
+    if (inPrompts && line.startsWith('  - ')) {
+      prompts!.push(line.slice('  - '.length))
+      continue
+    }
+    inPrompts = false
+    if (line.startsWith('- status: ')) {
+      status = line.slice('- status: '.length).trim()
+    } else if (line.startsWith('- session: ')) {
+      const value = line.slice('- session: '.length).trim()
+      const linked = /^\[(.+)\]\((.+)\)$/.exec(value)
+      if (linked) {
+        sessionId = linked[1]
+        sessionLink = linked[2]
+      } else {
+        sessionId = value
+      }
+    } else if (line.trim() === '- prompts:') {
+      prompts = []
+      inPrompts = true
+    }
+  }
+  if (!status || !STATUSES.includes(status)) return undefined
+
+  const entry: LogEntry = {
+    at,
+    kind: kind as LogEntry['kind'],
+    title,
+    status: status as LogEntry['status'],
+  }
+  if (sessionId) entry.sessionId = sessionId
+  if (sessionLink) entry.sessionLink = sessionLink
+  if (prompts && prompts.length > 0) entry.prompts = prompts
+  return entry
+}
+
+/**
+ * Append one entry to `.the-framework/LOGS.md`, creating the dir and the
+ * one-time file header when absent. A raw write (may reject); the caller
+ * decides best-effort.
+ */
+export async function appendLog(cwd: string, entry: LogEntry, fs: StoreFs = nodeStoreFs()): Promise<void> {
+  await fs.mkdir(join(cwd, THE_FRAMEWORK_DIR))
+  const path = logsPath(cwd)
+  if (!(await fs.exists(path))) await fs.write(path, HEADER)
+  await fs.append(path, '\n' + renderLogEntry(entry) + '\n')
+}
+
+/** Read the project log, newest-first (append order reversed). Missing file yields `[]`. */
+export async function readLogs(cwd: string, fs: StoreFs = nodeStoreFs()): Promise<LogEntry[]> {
+  const path = logsPath(cwd)
+  if (!(await fs.exists(path))) return []
+  return parseLogs(await fs.read(path)).reverse()
+}


### PR DESCRIPTION
Adds the project-log module: a human-readable `.the-framework/LOGS.md` recording every loop, prompt, and build.

- `renderLogEntry` / `parseLogs`: pure markdown core; forgiving parse skips a malformed entry instead of throwing
- `appendLog` / `readLogs`: on top of the existing `StoreFs` seam (same conventions as `store/run-store.ts`); readLogs is newest-first, missing file yields `[]`
- 12 unit tests over an in-memory fs; typecheck + full suite green

Standalone by design: no run-lifecycle wiring, no UI (those are #379/#380). Please review the markdown format and the parse rules.

Closes #378