### PR TITLE
feat(framework): record finished runs in .the-framework/LOGS.md (#379)

### DIFF
--- a/.changeset/the-framework-log-run-completion.md
+++ b/.changeset/the-framework-log-run-completion.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Record every finished run in the project log `.the-framework/LOGS.md` (#379). When a run ends, the CLI appends an entry with the intent/prompt title, the kind (build or prompt), the final status (done/stopped/failed), and the Claude Code session id and link. Best-effort, so a log write can never break a run. This is what makes the project DB (#378) fill itself; the run-history sidebar in #314 reads from it.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -19,9 +19,12 @@ import {
   parseArgs,
   resolveDomainPreset,
   runCli,
+  runLogEntry,
+  runLogKind,
   workspaceSummary,
   type CliIO,
 } from './cli.js'
+import { readLogs } from './logs.js'
 import { FakeDriver } from './driver/index.js'
 import type { FrameworkEvent } from './events.js'
 
@@ -69,6 +72,41 @@ test('antiLazyPillOff is true for --vanilla or the-framework.yml antiLazyPill:fa
   assert.equal(antiLazyPillOff(parseArgs(['x']), {}), false)
   assert.equal(antiLazyPillOff(parseArgs(['--vanilla', 'x']), {}), true)
   assert.equal(antiLazyPillOff(parseArgs(['x']), { antiLazyPill: false }), true)
+})
+
+test('runLogKind maps the run path to a project-log kind (#379)', () => {
+  assert.equal(runLogKind({ directPrompt: false, research: false }), 'build')
+  assert.equal(runLogKind({ directPrompt: true, research: false }), 'prompt')
+  assert.equal(runLogKind({ directPrompt: false, research: true }), 'prompt')
+})
+
+test('runLogEntry maps the end event to a status and carries the session (#379)', () => {
+  const base = { at: '2026-07-11T00:00:00.000Z', kind: 'build' as const, title: 'a blog' }
+  assert.equal(runLogEntry({ ...base, end: { kind: 'end', ok: true } }).status, 'done')
+  assert.equal(runLogEntry({ ...base, end: { kind: 'end', ok: false, stopped: true } }).status, 'stopped')
+  assert.equal(runLogEntry({ ...base, end: { kind: 'end', ok: false } }).status, 'failed')
+  const withSession = runLogEntry({ ...base, end: { kind: 'end', ok: true }, sessionId: 's1', sessionLink: 'http://x/s1' })
+  assert.equal(withSession.sessionId, 's1')
+  assert.equal(withSession.sessionLink, 'http://x/s1')
+  // No session captured -> the fields are omitted, not set to undefined.
+  assert.equal('sessionId' in runLogEntry({ ...base, end: { kind: 'end', ok: true } }), false)
+})
+
+test('a finished run records itself in .the-framework/LOGS.md (#379)', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'framework-logs-'))
+  try {
+    const { io } = capture()
+    const code = await runCli(['prompt', 'review the auth flow', '--fake', '--no-dashboard', '--cwd', dir], io)
+    assert.equal(code, 0)
+    const logs = await readLogs(dir)
+    assert.equal(logs.length, 1)
+    assert.equal(logs[0]!.kind, 'prompt')
+    assert.equal(logs[0]!.title, 'review the auth flow')
+    assert.equal(logs[0]!.status, 'done')
+    assert.match(logs[0]!.at, /^\d{4}-\d{2}-\d{2}T/) // a real ISO timestamp
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
 })
 
 test('parseArgs reads the research subcommand with its optional what (#331)', () => {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -36,6 +36,7 @@ import { isWorkspaceEmpty } from './steps.js'
 import { loadFrameworkConfig, type FrameworkFileConfig } from './config.js'
 import { loadRepoMemory } from './memory.js'
 import { loadUserSystemPrompt, SYSTEM_PROMPT_FILE, type EcoOptions } from './system-prompt.js'
+import { appendLog, type LogEntry } from './logs.js'
 import { preflight } from './preflight.js'
 import { RunStore } from './store/index.js'
 import { daemonStatus, ensureDaemon, runDaemon, stopDaemon, DEFAULT_DAEMON_PORT } from './daemon.js'
@@ -465,6 +466,35 @@ export function ecoOptions(opts: Pick<CliOptions, 'eco'>): EcoOptions | undefine
   return { autoPlanning, autoResearch, autoMaintenance }
 }
 
+/** The log kind a run records in `.the-framework/LOGS.md` (#379): the direct paths are prompts, a build run is a build. */
+export function runLogKind(opts: Pick<CliOptions, 'directPrompt' | 'research'>): LogEntry['kind'] {
+  return opts.directPrompt || opts.research ? 'prompt' : 'build'
+}
+
+/**
+ * Build the project-log entry (#379) for a finished run from its `end` event and
+ * the session captured along the way. Pure, so the status mapping is unit-testable
+ * without a live run.
+ */
+export function runLogEntry(input: {
+  at: string
+  kind: LogEntry['kind']
+  title: string
+  end: Extract<FrameworkEvent, { kind: 'end' }>
+  sessionId?: string | undefined
+  sessionLink?: string | undefined
+}): LogEntry {
+  const status: LogEntry['status'] = input.end.ok ? 'done' : input.end.stopped ? 'stopped' : 'failed'
+  return {
+    at: input.at,
+    kind: input.kind,
+    title: input.title,
+    status,
+    ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+    ...(input.sessionLink ? { sessionLink: input.sessionLink } : {}),
+  }
+}
+
 /**
  * Merge CLI flags over a project's `the-framework.yml` defaults (#258). A `--preset`
  * flag wins over the file's `preset`; the mode flags OR with the file's booleans
@@ -790,8 +820,32 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // set by a user interrupt or a budget cap (#322). Trusted over which signal
   // aborted, since a budget stop trips an internal signal the CLI never sees.
   let stoppedCleanly = false
+  // Record the finished run in the project log `.the-framework/LOGS.md` (#379). The
+  // kind + title are known up front; the session id/link arrive mid-run, and the
+  // `end` event (fired once by both run paths) closes the entry. Best-effort: the
+  // project DB is committed history, so it must never break a run.
+  const logKind = runLogKind(opts)
+  const logTitle = intent || (opts.research ? 'this PR' : '')
+  let logSessionId: string | undefined
+  let logSessionLink: string | undefined
   const onEvent = (event: FrameworkEvent) => {
-    if (event.kind === 'end' && event.stopped) stoppedCleanly = true
+    if (event.kind === 'session' && event.sessionLink) logSessionLink = event.sessionLink
+    else if (event.kind === 'session-update') {
+      logSessionId = event.sessionId
+      if (event.sessionLink) logSessionLink = event.sessionLink
+    }
+    if (event.kind === 'end') {
+      if (event.stopped) stoppedCleanly = true
+      const entry = runLogEntry({
+        at: new Date().toISOString(),
+        kind: logKind,
+        title: logTitle,
+        end: event,
+        sessionId: logSessionId,
+        sessionLink: logSessionLink,
+      })
+      void appendLog(cwd, entry).catch(() => {})
+    }
     io.out(formatFrameworkEvent(event))
     dashboard?.push(event)
     void store?.append(event)


### PR DESCRIPTION
Makes the project DB (#378) fill itself. When a run finishes, the CLI appends an entry to `.the-framework/LOGS.md`: the intent/prompt title, the kind (build or prompt), the final status (done/stopped/failed), and the Claude session id + link.

Hooked off the single `end` event, so both the build path and the direct-prompt/research path are covered by one code path. Best-effort, like the existing run archival: a log-write failure can never break a run.

Verified end to end (a fake prompt run and a build run both append; header written once). `pnpm typecheck` and `pnpm test` green (371 tests).

Next in #313: repo activation marker + `git ls-files` crawl (#380), which together with this unblock the #314 run-history sidebar.

Closes #379