### PR TITLE
feat(framework): add repo activation + git ls-files crawl helpers (#380)

### DIFF
--- a/.changeset/the-framework-project-helpers.md
+++ b/.changeset/the-framework-project-helpers.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Add project repo helpers (#380): `isActivated()` checks the `.the-framework/` activation marker via an injectable `ProjectFs`, and `crawlRepoFiles()` lists every tracked + untracked (gitignore-honoring) file via `git ls-files -z` behind an injectable `GitRunner`. Both forgiving: any failure reads as not-activated / an empty list. Building blocks for the #314 sidebars.

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -122,6 +122,15 @@ export {
   LOGS_FILE,
   type LogEntry,
 } from './logs.js'
+export {
+  theFrameworkDir,
+  isActivated,
+  nodeProjectFs,
+  crawlRepoFiles,
+  nodeGitRunner,
+  type ProjectFs,
+  type GitRunner,
+} from './project.js'
 export { runCli, parseArgs, buildDeployTarget, workspaceSummary, autoSelectPreset, type CliIO, type CliOptions } from './cli.js'
 export {
   metaSelect,

--- a/packages/framework/src/project.test.ts
+++ b/packages/framework/src/project.test.ts
@@ -1,0 +1,65 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { join } from 'node:path'
+import { THE_FRAMEWORK_DIR } from './logs.js'
+import {
+  crawlRepoFiles,
+  isActivated,
+  theFrameworkDir,
+  type GitRunner,
+  type ProjectFs,
+} from './project.js'
+
+const CWD = '/proj'
+
+/** A {@link ProjectFs} that reports exactly one set of paths as directories. */
+function fakeFs(dirs: string[]): ProjectFs {
+  return {
+    async isDirectory(path) {
+      return dirs.includes(path)
+    },
+  }
+}
+
+test('theFrameworkDir joins cwd + .the-framework', () => {
+  assert.equal(theFrameworkDir(CWD), join(CWD, THE_FRAMEWORK_DIR))
+})
+
+test('isActivated is true when .the-framework/ is a directory', async () => {
+  assert.equal(await isActivated(CWD, fakeFs([join(CWD, THE_FRAMEWORK_DIR)])), true)
+})
+
+test('isActivated is false when the marker dir is absent', async () => {
+  assert.equal(await isActivated(CWD, fakeFs([])), false)
+})
+
+test('crawlRepoFiles parses NUL-separated output, deduped + sorted', async () => {
+  const calls: { args: string[]; cwd: string }[] = []
+  const run: GitRunner = async (args, cwd) => {
+    calls.push({ args, cwd })
+    // git -z output ends with a trailing NUL.
+    return 'src/b.ts\0README.md\0src/a.ts\0'
+  }
+  const files = await crawlRepoFiles(CWD, run)
+  assert.deepEqual(files, ['README.md', 'src/a.ts', 'src/b.ts'])
+  assert.deepEqual(calls, [
+    { args: ['ls-files', '-z', '--cached', '--others', '--exclude-standard'], cwd: CWD },
+  ])
+})
+
+test('crawlRepoFiles drops the trailing empty entry from the final NUL', async () => {
+  const files = await crawlRepoFiles(CWD, async () => 'only.ts\0')
+  assert.deepEqual(files, ['only.ts'])
+})
+
+test('crawlRepoFiles de-dupes a path that appears twice', async () => {
+  const files = await crawlRepoFiles(CWD, async () => 'dup.ts\0dup.ts\0other.ts\0')
+  assert.deepEqual(files, ['dup.ts', 'other.ts'])
+})
+
+test('crawlRepoFiles yields [] when git fails', async () => {
+  const files = await crawlRepoFiles(CWD, async () => {
+    throw new Error('not a git repository')
+  })
+  assert.deepEqual(files, [])
+})

--- a/packages/framework/src/project.ts
+++ b/packages/framework/src/project.ts
@@ -1,0 +1,84 @@
+import { join } from 'node:path'
+import { THE_FRAMEWORK_DIR } from './logs.js'
+
+/**
+ * Project-level repo helpers (#380): the `.the-framework/` activation marker
+ * check and a `git ls-files` crawl. Read-only building blocks for the #314
+ * sidebars; activation/install (creating the dir, the install commit) is a
+ * separate, deferred concern.
+ */
+
+/** The `.the-framework/` path under a project root. */
+export function theFrameworkDir(cwd: string): string {
+  return join(cwd, THE_FRAMEWORK_DIR)
+}
+
+/** Minimal fs seam so activation is unit-testable without touching disk. */
+export interface ProjectFs {
+  /** True when `path` exists AND is a directory. */
+  isDirectory(path: string): Promise<boolean>
+}
+
+/**
+ * A {@link ProjectFs} backed by `node:fs/promises`. The import is dynamic so
+ * the module core stays free of a hard `node:fs` dependency, same convention
+ * as {@link nodeStoreFs}; any stat error reads as `false`.
+ */
+export function nodeProjectFs(): ProjectFs {
+  return {
+    async isDirectory(path) {
+      const { stat } = await import('node:fs/promises')
+      try {
+        return (await stat(path)).isDirectory()
+      } catch {
+        return false
+      }
+    },
+  }
+}
+
+/**
+ * A repo is "activated"/installed for The Framework when it has a
+ * `.the-framework/` directory (#314: the dir is the activation marker).
+ * Read-only check; creating the dir + the install commit is a separate,
+ * deferred concern.
+ */
+export async function isActivated(cwd: string, fs: ProjectFs = nodeProjectFs()): Promise<boolean> {
+  return fs.isDirectory(theFrameworkDir(cwd))
+}
+
+/** Runs `git` in `cwd` and resolves stdout. Injectable so the crawl is testable. */
+export type GitRunner = (args: string[], cwd: string) => Promise<string>
+
+/** A {@link GitRunner} backed by `execFile('git', ...)`. Rejects on any git error. */
+export function nodeGitRunner(): GitRunner {
+  return async (args, cwd) => {
+    const { execFile } = await import('node:child_process')
+    return new Promise((resolvePromise, rejectPromise) => {
+      execFile('git', args, { cwd, timeout: 10_000, maxBuffer: 16 * 1024 * 1024 }, (err, stdout) => {
+        if (err) rejectPromise(err)
+        else resolvePromise(String(stdout))
+      })
+    })
+  }
+}
+
+/**
+ * List every file git sees in the repo at `cwd`: tracked + untracked, honoring
+ * .gitignore. Uses `git ls-files -z --cached --others --exclude-standard` (the
+ * same approach Vike uses). Returns repo-relative paths, deduped and sorted.
+ * Forgiving: a non-repo / missing git / any failure yields `[]`, never throws.
+ */
+export async function crawlRepoFiles(cwd: string, run: GitRunner = nodeGitRunner()): Promise<string[]> {
+  try {
+    const out = await run(['ls-files', '-z', '--cached', '--others', '--exclude-standard'], cwd)
+    const files = new Set<string>()
+    for (const entry of out.split('\0')) {
+      const trimmed = entry.trim()
+      if (trimmed) files.add(trimmed)
+    }
+    return [...files].sort()
+  } catch {
+    return []
+  }
+}


### PR DESCRIPTION
Two read-only project helpers for the #314 sidebars:

- `isActivated(cwd)`: a repo is activated for The Framework when it has a `.the-framework/` directory. Checked through an injectable `ProjectFs` seam (node adapter uses a dynamic `node:fs/promises` import, any error reads as false).
- `crawlRepoFiles(cwd)`: every file git sees (tracked + untracked, honoring .gitignore) via `git ls-files -z --cached --others --exclude-standard`, behind an injectable `GitRunner`. Deduped, sorted, and forgiving: any failure yields `[]`.

No UI, no run wiring; activation/install (creating the dir + commit) is deferred. Tests inject both seams, no real git. Please review the seam shapes.

Closes #380