### PR TITLE
feat(framework): Project log panel on the dashboard (#384)

### DIFF
--- a/.changeset/dashboard-project-log-panel.md
+++ b/.changeset/dashboard-project-log-panel.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Add a Project log panel to the dashboard (#384). It surfaces the committed `.the-framework/LOGS.md` history (#378/#379) for the workspace: every loop/prompt/build run with its title, status, kind, session link, and a loop's constituent prompts, newest-first. Served by a new `GET /api/logs` endpoint and refreshed on load, on run-end, and on an interval. All fields are escaped and the session link is passed through the page's safe-URL guard, since the log is agent-authored.

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -112,6 +112,16 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
     color: #9db4d6; text-transform: uppercase; letter-spacing: .6px; }
   #prompts pre { margin: 0; padding: 10px 12px; border-top: 1px solid #1c2230; white-space: pre-wrap;
     word-break: break-word; font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; color: #c3ccdb; }
+  /* Project log (#314): the committed .the-framework/LOGS.md history, newest-first. */
+  #projectlog-panel { grid-column: 1 / -1; }
+  #projectlog .pl-title { color: #e8ecf3; font-size: 13px; }
+  #projectlog .pl-meta { color: #7b8496; font-size: 11px; margin-top: 3px; display: flex;
+    align-items: center; gap: 6px; flex-wrap: wrap; }
+  #projectlog .kind { color: #9db4d6; text-transform: uppercase; letter-spacing: .5px; font-size: 10px; }
+  #projectlog .pl-prompts { margin: 6px 0 0; padding-left: 16px; list-style: disc; }
+  #projectlog .pl-prompts li { padding: 1px 0; border-bottom: 0; color: #8b93a3; font-size: 12px; }
+  #projectlog .dot { font-size: 9px; }
+  #projectlog .empty { color: #5c657a; font-size: 12px; }
   /* Start-a-run panel (#345): only the daemon dashboard wires /api/start; the
      per-run page and the relay render it hidden. */
   #start-panel { grid-column: 1 / -1; }
@@ -296,6 +306,10 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   <section id="prompts-panel" hidden>
     <h2>Prompts sent to Claude Code</h2>
     <div id="prompts"></div>
+  </section>
+  <section id="projectlog-panel">
+    <h2>Project log</h2>
+    <ul id="projectlog"><li class="empty">loading…</li></ul>
   </section>
 </main>
 </div>
@@ -665,6 +679,33 @@ function loadRuns() {
   fetch('api/runs').then(r => r.ok ? r.json() : { runs: [] }).then(d => renderRuns(d.runs || [])).catch(() => {});
 }
 
+// Project log (#314): the committed .the-framework/LOGS.md history (#378/#379),
+// newest-first. All fields are agent/user-controlled, so every value is escaped
+// and the session link is passed through safeUrl.
+function renderProjectLog(logs) {
+  const ul = $('projectlog'); ul.innerHTML = '';
+  if (!logs.length) { ul.innerHTML = '<li class="empty">No runs logged yet.</li>'; return; }
+  for (const e of logs) {
+    const li = document.createElement('li');
+    const when = e.at ? new Date(e.at).toLocaleString() : '';
+    const link = e.sessionLink
+      ? ' \\u00b7 <a href="' + esc(safeUrl(e.sessionLink)) + '" target="_blank" rel="noopener">session</a>'
+      : (e.sessionId ? ' \\u00b7 session ' + esc(e.sessionId) : '');
+    const prompts = (e.prompts && e.prompts.length)
+      ? '<ul class="pl-prompts">' + e.prompts.map(p => '<li>' + esc(p) + '</li>').join('') + '</ul>'
+      : '';
+    li.innerHTML = '<div class="pl-title">' + esc(e.title || 'untitled') + '</div>' +
+      '<div class="pl-meta"><span class="dot ' + statusClass(e.status) + '">\\u25cf</span>' +
+      '<span>' + esc(e.status) + '</span><span class="kind">' + esc(e.kind) + '</span>' +
+      '<span>\\u00b7 ' + esc(when) + '</span>' + link + '</div>' + prompts;
+    ul.appendChild(li);
+  }
+}
+
+function loadLogs() {
+  fetch('api/logs').then(r => r.ok ? r.json() : { logs: [] }).then(d => renderProjectLog(d.logs || [])).catch(() => {});
+}
+
 // Document sidebar (#319): render the PLAN.md / TODO.md the agent writes at the
 // workspace root, with a sticky tab nav to jump between them. Minimal, dependency-
 // free markdown so the page stays a single self-contained file.
@@ -904,6 +945,8 @@ src.onmessage = ev => {
   if (mode === 'live') render(fe);
   // A finished run has just been archived; refresh the list so it appears.
   if (fe.kind === 'end') setTimeout(loadRuns, 1500);
+  // A finished run also appends to .the-framework/LOGS.md (#379); refresh the log.
+  if (fe.kind === 'end') setTimeout(loadLogs, 1500);
   // A plan/backlog is usually written right before a choice gate or at run end;
   // refresh the doc sidebar promptly so PLAN.md / TODO.md appear without waiting.
   if (fe.kind === 'choice' || fe.kind === 'end') setTimeout(loadDocs, 500);
@@ -913,6 +956,8 @@ loadRuns();
 setInterval(loadRuns, 10000);
 loadDocs();
 setInterval(loadDocs, 4000);
+loadLogs();
+setInterval(loadLogs, 10000);
 `
 }
 

--- a/packages/framework/src/dashboard/projectlog.test.ts
+++ b/packages/framework/src/dashboard/projectlog.test.ts
@@ -1,0 +1,88 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { JSDOM } from 'jsdom'
+import { dashboardHtml } from './page.js'
+
+// The Project log panel (#314) renders the committed .the-framework/LOGS.md
+// entries the server returns from GET /api/logs. It drives the real client JS in
+// jsdom, answering the page's own `fetch('api/logs')` with a canned payload.
+
+interface Harness {
+  query: (sel: string) => Element | null
+  queryAll: (sel: string) => Element[]
+  window: Record<string, unknown>
+}
+
+function boot(logs: unknown[]): Harness {
+  const dom = new JSDOM(dashboardHtml('Test', true, true, true), {
+    runScripts: 'dangerously',
+    url: 'http://localhost/',
+    beforeParse(window) {
+      const w = window as unknown as { [k: string]: unknown }
+      w['setInterval'] = () => 0
+      w['setTimeout'] = () => 0
+      w['EventSource'] = class {
+        onmessage: ((ev: { data: string }) => void) | null = null
+        onerror: (() => void) | null = null
+        close() {}
+      }
+      w['fetch'] = (url: string) => {
+        const body = url === 'api/logs' ? { logs } : { runs: [], docs: [] }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(body) })
+      }
+    },
+  })
+  const window = dom.window as unknown as { [k: string]: unknown }
+  const doc = dom.window.document
+  return {
+    query: sel => doc.querySelector(sel),
+    queryAll: sel => [...doc.querySelectorAll(sel)],
+    window,
+  }
+}
+
+// The page fetches on load; give the microtasks a tick to settle.
+const tick = () => new Promise(resolve => setImmediate(resolve))
+
+test('an empty log shows the empty state', async () => {
+  const h = boot([])
+  await tick()
+  assert.match(h.query('#projectlog')!.textContent ?? '', /No runs logged yet/)
+})
+
+test('log entries render title, status, kind, and a safe session link', async () => {
+  const h = boot([
+    { at: '2026-07-10T10:00:00.000Z', kind: 'build', title: 'a blog', status: 'done', sessionId: 's1', sessionLink: 'https://claude.ai/code/s1' },
+    { at: '2026-07-10T09:00:00.000Z', kind: 'loop', title: 'polish', status: 'stopped', prompts: ['fix header', 'tidy states'] },
+  ])
+  await tick()
+  const items = h.queryAll('#projectlog > li')
+  assert.equal(items.length, 2)
+  assert.match(items[0]!.textContent ?? '', /a blog/)
+  assert.match(items[0]!.textContent ?? '', /done/)
+  const link = h.query('#projectlog a') as HTMLAnchorElement | null
+  assert.ok(link, 'a session link renders')
+  assert.equal(link!.getAttribute('href'), 'https://claude.ai/code/s1')
+  // A loop's constituent prompts render as a nested list.
+  assert.equal(h.queryAll('#projectlog .pl-prompts li').length, 2)
+})
+
+test('agent-controlled fields are rendered as inert text, never markup', async () => {
+  const h = boot([
+    {
+      at: '2026-07-10T10:00:00.000Z',
+      kind: 'prompt',
+      title: '<img src=x onerror="window.__pwned=1">',
+      status: 'done',
+      sessionLink: 'javascript:alert(1)',
+    },
+  ])
+  await tick()
+  // The title survives as text, no <img> was created, and the payload never ran.
+  assert.match(h.query('#projectlog .pl-title')!.textContent ?? '', /<img src=x/)
+  assert.equal(h.queryAll('#projectlog img').length, 0)
+  assert.equal(h.window['__pwned'], undefined)
+  // The unsafe session link is neutralized to '#', not a javascript: URL.
+  const link = h.query('#projectlog a') as HTMLAnchorElement | null
+  assert.equal(link!.getAttribute('href'), '#')
+})

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { startDashboard, parseStartOptions, type StartRunOptions } from './server.js'
 import type { FrameworkEvent } from '../events.js'
+import { appendLog } from '../logs.js'
 
 function fetchText(url: string): Promise<{ status: number; body: string }> {
   return new Promise((resolvePromise, rejectPromise) => {
@@ -152,6 +153,34 @@ test('GET /api/docs serves the workspace PLAN.md / TODO.md, or [] without a cwd 
     const noCwd = await startDashboard({ port: 0 })
     try {
       assert.deepEqual(JSON.parse((await fetchText(noCwd.url + '/api/docs')).body), { docs: [] })
+    } finally {
+      await noCwd.close()
+    }
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('GET /api/logs serves the .the-framework/LOGS.md entries newest-first, or [] without a cwd (#314)', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'framework-projectlog-'))
+  try {
+    await appendLog(cwd, { at: '2026-07-10T09:00:00.000Z', kind: 'prompt', title: 'first run', status: 'done' })
+    await appendLog(cwd, { at: '2026-07-10T10:00:00.000Z', kind: 'build', title: 'second run', status: 'failed' })
+    const withCwd = await startDashboard({ port: 0, cwd })
+    try {
+      const { status, body } = await fetchText(withCwd.url + '/api/logs')
+      assert.equal(status, 200)
+      const parsed = JSON.parse(body)
+      assert.equal(parsed.logs.length, 2)
+      assert.equal(parsed.logs[0].title, 'second run') // newest-first
+      assert.equal(parsed.logs[1].title, 'first run')
+    } finally {
+      await withCwd.close()
+    }
+    // No cwd wired -> empty list, never an error.
+    const noCwd = await startDashboard({ port: 0 })
+    try {
+      assert.deepEqual(JSON.parse((await fetchText(noCwd.url + '/api/logs')).body), { logs: [] })
     } finally {
       await noCwd.close()
     }

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -4,6 +4,7 @@ import { EventStream } from '@gemstack/ai-autopilot'
 import type { ChoiceBy, FrameworkEvent } from '../events.js'
 import type { EcoOptions } from '../system-prompt.js'
 import { listRuns, loadRunEvents } from '../store/index.js'
+import { readLogs } from '../logs.js'
 import { readDocs } from './docs.js'
 import { dashboardHtml } from './page.js'
 import { serveSSE } from './sse.js'
@@ -163,6 +164,12 @@ function handle(
   // workspace root, so the human can read the plan + backlog beside the run.
   if (url === '/api/docs') {
     void serveDocs(res, cwd)
+    return
+  }
+  // Project log (#314): the committed `.the-framework/LOGS.md` history of every
+  // loop/prompt/build run in this workspace (#378/#379), newest-first.
+  if (url === '/api/logs') {
+    void serveLogs(res, cwd)
     return
   }
   if (url === '/stop') {
@@ -356,6 +363,13 @@ async function serveDocs(res: ServerResponse, cwd: string | undefined): Promise<
   const docs = cwd ? await readDocs(cwd).catch(() => []) : []
   res.writeHead(200, { 'content-type': 'application/json' })
   res.end(JSON.stringify({ docs }))
+}
+
+/** `GET /api/logs` — the workspace's committed `.the-framework/LOGS.md` entries, newest-first, or `[]`. */
+async function serveLogs(res: ServerResponse, cwd: string | undefined): Promise<void> {
+  const logs = cwd ? await readLogs(cwd).catch(() => []) : []
+  res.writeHead(200, { 'content-type': 'application/json' })
+  res.end(JSON.stringify({ logs }))
 }
 
 function closeServer(


### PR DESCRIPTION
Surfaces the project DB (#378/#379) on the dashboard. A new Project log panel lists this workspace's committed `.the-framework/LOGS.md` history: each run's title, status, kind, session link, and (for a loop) its constituent prompts, newest-first.

- Server: `GET /api/logs` -> `readLogs(cwd)`, mirroring `/api/docs`.
- Page: the panel fetches on load, on run-end, and on a 10s interval. Every field is agent-authored, so all values are escaped and the session link goes through the page's safeUrl guard (an XSS test covers a hostile title + a javascript: link).

Single-workspace for now; the multi-project Projects list stays deferred until there's a project registry.

Verified live: a run appended to LOGS.md, /api/logs returned it, the panel rendered it. `pnpm typecheck` and `pnpm test` green (382 tests, 4 new).

Closes #384