### PR TITLE
fix(framework): sticky dashboard header, banner, and sidebar (#386)

### DIFF
--- a/.changeset/dashboard-sticky-header-sidebar.md
+++ b/.changeset/dashboard-sticky-header-sidebar.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Keep the dashboard header and sidebar in view while scrolling. The header is now sticky at the top (with a background and z-index so content scrolls under it), and the app-running banner and the runs sidebar stick just below it. On a long page you no longer lose the title, stop button, and run list when you scroll down.

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -24,7 +24,7 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   body { margin: 0; font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, sans-serif;
     background: #0b0e14; color: #d7dce5; }
   header { display: flex; align-items: baseline; gap: 12px; padding: 16px 20px;
-    border-bottom: 1px solid #1c2230; }
+    border-bottom: 1px solid #1c2230; position: sticky; top: 0; z-index: 10; background: #0b0e14; }
   header h1 { margin: 0; font-size: 16px; font-weight: 600; letter-spacing: .2px; }
   header .sub { color: #7b8496; font-size: 12px; }
   header a { color: #6ea8fe; text-decoration: none; }
@@ -44,7 +44,7 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   #notify.on { border-color: #2f6f4a; background: #12241a; }
   #notify.denied { opacity: .5; cursor: not-allowed; }
   #app-banner { display: flex; align-items: center; gap: 8px; padding: 10px 20px;
-    background: #0f2417; border-bottom: 1px solid #1c3a28; font-size: 13px; }
+    background: #0f2417; border-bottom: 1px solid #1c3a28; font-size: 13px; position: sticky; top: 57px; }
   #app-banner .dot { color: #67d98f; }
   #app-banner a { color: #67d98f; font-weight: 600; }
   #app-banner .run { color: #6f8a79; font-size: 12px; }
@@ -52,7 +52,7 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
      even when the content is short. */
   #layout { display: flex; align-items: stretch; min-height: calc(100vh - 57px); }
   #sidebar { flex: 0 0 240px; width: 240px; border-right: 1px solid #1c2230; padding: 14px 10px;
-    overflow-y: auto; max-height: calc(100vh - 57px); }
+    overflow-y: auto; max-height: calc(100vh - 57px); position: sticky; top: 57px; }
   #sidebar h2 { margin: 0 0 8px; padding: 0 6px; font-size: 12px; text-transform: uppercase;
     letter-spacing: .8px; color: #7b8496; font-weight: 600; }
   #runs li { padding: 8px; border-bottom: 1px solid #161b26; cursor: pointer; border-radius: 6px; }

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -73,6 +73,10 @@ test('dashboard serves the HTML page with the title', async () => {
     assert.match(body, /main \{[^}]*max-width: 1100px; margin: 0 auto;/)
     // The layout fills the viewport below the header, so the sidebar border runs full-height.
     assert.match(body, /#layout \{[^}]*min-height: calc\(100vh - 57px\);/)
+    // The header and sidebar stay in view while the content scrolls (sticky).
+    assert.match(body, /header \{[^}]*position: sticky; top: 0;[^}]*background: #0b0e14;/)
+    assert.match(body, /#sidebar \{[^}]*position: sticky; top: 57px;/)
+    assert.match(body, /#app-banner \{[^}]*position: sticky; top: 57px;/)
   } finally {
     await dash.close()
   }


### PR DESCRIPTION
On a long page the header, the app-running banner, and the runs sidebar scrolled away. This pins them: the header sticks to the top (with a background and z-index so content scrolls under it), and the app-banner and sidebar stick just below it at 57px.

Verified live against a running daemon. `pnpm typecheck` and `pnpm test` green (382 tests).

Closes #386