### PR TITLE
fix(framework): report the real CLI version (#312)

### DIFF
--- a/.changeset/cli-real-version.md
+++ b/.changeset/cli-real-version.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Fix `framework --version` (and the bare-`framework` footer) reporting `0.0.0` instead of the real package version (#312). The version is now read from the package's own `package.json` at runtime, so it always matches what is installed.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -15,6 +15,7 @@ import {
   claudeDriverOptions,
   CLAUDE_CODE_SESSION_LIST,
   ecoOptions,
+  frameworkVersion,
   mergeRunConfig,
   parseArgs,
   resolveDomainPreset,
@@ -124,6 +125,20 @@ test('parseArgs reads the prompt subcommand with its verbatim text (#353)', () =
   assert.equal(p.directPrompt, true)
   assert.equal(p.intent, 'review the auth flow')
   assert.equal(parseArgs(['build', 'a', 'blog']).directPrompt, false)
+})
+
+test('frameworkVersion reports the real package version, not the 0.0.0 placeholder (#312)', async () => {
+  const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8')) as { version: string }
+  assert.equal(frameworkVersion(), pkg.version)
+  assert.notEqual(frameworkVersion(), '0.0.0')
+})
+
+test('runCli --version prints the real version (#312)', async () => {
+  const { io, out } = capture()
+  const code = await runCli(['--version'], io)
+  assert.equal(code, 0)
+  const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8')) as { version: string }
+  assert.deepEqual(out, [pkg.version])
 })
 
 test('runCli errors on a bare `framework prompt` (nothing to run, #353)', async () => {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -1,5 +1,7 @@
+import { readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import {
   builtinDomainPresets,
   cloudflareTarget,
@@ -74,7 +76,24 @@ const defaultIO: CliIO = {
   err: line => process.stderr.write(line + '\n'),
 }
 
-const VERSION = '0.0.0'
+/**
+ * The CLI version, read from the package's own `package.json` at runtime (#312).
+ * The compiled entry lives one level under the package root (`dist/` or
+ * `dist-test/`), so its `package.json` is always `../package.json`. Cached after
+ * the first read; falls back to `0.0.0` if the file is somehow unreadable.
+ */
+let cachedVersion: string | undefined
+export function frameworkVersion(): string {
+  if (cachedVersion !== undefined) return cachedVersion
+  try {
+    const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json')
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: string }
+    cachedVersion = pkg.version ?? '0.0.0'
+  } catch {
+    cachedVersion = '0.0.0'
+  }
+  return cachedVersion
+}
 
 const HELP = `The Framework — turnkey AI orchestration that wraps a coding agent (Claude Code).
 
@@ -617,7 +636,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     return 0
   }
   if (opts.version) {
-    io.out(VERSION)
+    io.out(frameworkVersion())
     return 0
   }
   if (opts.doctor) {
@@ -1141,7 +1160,7 @@ async function ensureDaemonCmd(opts: CliOptions, io: CliIO): Promise<number> {
   io.out('  framework stop                Stop the background dashboard')
   io.out('  framework --help              All options')
   io.out('')
-  io.out(`The Framework v${VERSION}`)
+  io.out(`The Framework v${frameworkVersion()}`)
   return 0
 }
 


### PR DESCRIPTION
`framework --version` and the bare-`framework` footer both printed `v0.0.0` because the CLI hardcoded it, while the package is at 0.8.0. This reads the version from the package's own `package.json` at runtime, so it always matches what's installed.

Verified: `framework --version` now prints `0.8.0`, and so does the footer. `pnpm typecheck` and `pnpm test` green (384 tests, 2 new).

Addresses the "Prints the CLI version" item of #312 (the epic stays open; the async `npm info` up-to-date check and background jobs remain).