### PR TITLE
feat(framework): show whether the CLI is up to date (#312)

### DIFF
--- a/.changeset/cli-update-check.md
+++ b/.changeset/cli-update-check.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Bare `framework` now tells you whether the CLI is up to date (#312): after the version footer it checks npm's `dist-tags.latest` (2.5s cap) and prints "Up to date" or "Update available: vX (you have vY). Run: npm i -g @gemstack/framework". Offline or on any fetch failure it prints nothing. Display only; no auto-update.

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -38,6 +38,7 @@ import { isWorkspaceEmpty } from './steps.js'
 import { loadFrameworkConfig, type FrameworkFileConfig } from './config.js'
 import { loadRepoMemory } from './memory.js'
 import { loadUserSystemPrompt, SYSTEM_PROMPT_FILE, type EcoOptions } from './system-prompt.js'
+import { checkForUpdate, formatUpdateStatus, nodeVersionFetcher } from './update-check.js'
 import { appendLog, type LogEntry } from './logs.js'
 import { preflight } from './preflight.js'
 import { RunStore } from './store/index.js'
@@ -1161,6 +1162,9 @@ async function ensureDaemonCmd(opts: CliOptions, io: CliIO): Promise<number> {
   io.out('  framework --help              All options')
   io.out('')
   io.out(`The Framework v${frameworkVersion()}`)
+  const status = await checkForUpdate(frameworkVersion(), nodeVersionFetcher())
+  const line = formatUpdateStatus(status)
+  if (line) io.out(line)
   return 0
 }
 

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -131,6 +131,15 @@ export {
   type ProjectFs,
   type GitRunner,
 } from './project.js'
+export {
+  PACKAGE_NAME,
+  nodeVersionFetcher,
+  compareVersions,
+  checkForUpdate,
+  formatUpdateStatus,
+  type VersionFetcher,
+  type UpdateStatus,
+} from './update-check.js'
 export { runCli, parseArgs, buildDeployTarget, workspaceSummary, autoSelectPreset, type CliIO, type CliOptions } from './cli.js'
 export {
   metaSelect,

--- a/packages/framework/src/update-check.test.ts
+++ b/packages/framework/src/update-check.test.ts
@@ -1,0 +1,83 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import {
+  PACKAGE_NAME,
+  checkForUpdate,
+  compareVersions,
+  formatUpdateStatus,
+  type VersionFetcher,
+} from './update-check.js'
+
+/** A {@link VersionFetcher} that always resolves `latest`, never hitting the network. */
+function fakeFetcher(latest: string | undefined): VersionFetcher {
+  return async () => latest
+}
+
+test('compareVersions: equal versions -> 0', () => {
+  assert.equal(compareVersions('1.2.3', '1.2.3'), 0)
+})
+
+test('compareVersions: 1.9.0 vs 1.10.0 compares numerically, not as strings', () => {
+  assert.ok(compareVersions('1.9.0', '1.10.0') < 0)
+  assert.ok(compareVersions('1.10.0', '1.9.0') > 0)
+})
+
+test('compareVersions: 2.0.0 vs 1.9.9 -> positive', () => {
+  assert.ok(compareVersions('2.0.0', '1.9.9') > 0)
+})
+
+test('compareVersions: prerelease/build suffix is stripped', () => {
+  assert.equal(compareVersions('1.2.3-beta.1', '1.2.3'), 0)
+  assert.equal(compareVersions('1.2.3+build.5', '1.2.3'), 0)
+})
+
+test('compareVersions: missing parts read as 0', () => {
+  assert.equal(compareVersions('1.2', '1.2.0'), 0)
+  assert.ok(compareVersions('1.2', '1.2.1') < 0)
+})
+
+test('checkForUpdate: same version -> up-to-date', async () => {
+  const status = await checkForUpdate('1.2.3', fakeFetcher('1.2.3'))
+  assert.deepEqual(status, { kind: 'up-to-date', current: '1.2.3' })
+})
+
+test('checkForUpdate: higher latest -> update-available with latest', async () => {
+  const status = await checkForUpdate('1.2.3', fakeFetcher('1.3.0'))
+  assert.deepEqual(status, { kind: 'update-available', current: '1.2.3', latest: '1.3.0' })
+})
+
+test('checkForUpdate: lower latest (local build ahead) -> up-to-date', async () => {
+  const status = await checkForUpdate('2.0.0', fakeFetcher('1.9.9'))
+  assert.deepEqual(status, { kind: 'up-to-date', current: '2.0.0' })
+})
+
+test('checkForUpdate: fetcher returns undefined -> unknown', async () => {
+  const status = await checkForUpdate('1.2.3', fakeFetcher(undefined))
+  assert.deepEqual(status, { kind: 'unknown', current: '1.2.3' })
+})
+
+test('checkForUpdate: passes the package name to the fetcher (default + override)', async () => {
+  const seen: string[] = []
+  const spy: VersionFetcher = async pkg => {
+    seen.push(pkg)
+    return '1.0.0'
+  }
+  await checkForUpdate('1.0.0', spy)
+  await checkForUpdate('1.0.0', spy, 'some-other-pkg')
+  assert.deepEqual(seen, [PACKAGE_NAME, 'some-other-pkg'])
+})
+
+test('formatUpdateStatus: up-to-date line', () => {
+  assert.equal(formatUpdateStatus({ kind: 'up-to-date', current: '1.2.3' }), '✅ Up to date (v1.2.3)')
+})
+
+test('formatUpdateStatus: update-available line', () => {
+  assert.equal(
+    formatUpdateStatus({ kind: 'update-available', current: '1.2.3', latest: '1.3.0' }),
+    `⬆️  Update available: v1.3.0 (you have v1.2.3). Run: npm i -g ${PACKAGE_NAME}`,
+  )
+})
+
+test('formatUpdateStatus: unknown -> undefined (print nothing)', () => {
+  assert.equal(formatUpdateStatus({ kind: 'unknown', current: '1.2.3' }), undefined)
+})

--- a/packages/framework/src/update-check.ts
+++ b/packages/framework/src/update-check.ts
@@ -1,0 +1,85 @@
+/**
+ * CLI "up-to-date?" check (#312): after the bare-`framework` version footer,
+ * tell the user whether a newer version is published on npm. Display only;
+ * auto-update is a separate, deferred concern. Same seam + node-adapter +
+ * forgiving-on-error convention as `project.ts` (#380).
+ */
+
+/** The npm package this CLI ships as; the registry key for the version check. */
+export const PACKAGE_NAME = '@gemstack/framework'
+
+/** Fetches the latest published version of `pkg`, or undefined on any failure. Injectable for tests. */
+export type VersionFetcher = (pkg: string) => Promise<string | undefined>
+
+/**
+ * A {@link VersionFetcher} backed by the npm registry. GETs the packument and
+ * reads `dist-tags.latest`. A 2.5s AbortSignal.timeout caps it; any error /
+ * non-ok / offline yields undefined (the check silently degrades to "unknown").
+ */
+export function nodeVersionFetcher(): VersionFetcher {
+  return async pkg => {
+    try {
+      const res = await fetch(`https://registry.npmjs.org/${pkg}`, { signal: AbortSignal.timeout(2500) })
+      if (!res.ok) return undefined
+      const data = (await res.json()) as { 'dist-tags'?: { latest?: unknown } } | undefined
+      const latest = data?.['dist-tags']?.latest
+      return typeof latest === 'string' ? latest : undefined
+    } catch {
+      return undefined
+    }
+  }
+}
+
+/** The result of an update check. */
+export type UpdateStatus =
+  | { kind: 'up-to-date'; current: string }
+  | { kind: 'update-available'; current: string; latest: string }
+  | { kind: 'unknown'; current: string } // offline / fetch failed
+
+/**
+ * Compare two `major.minor.patch` versions numerically (a prerelease/build
+ * suffix after `-` or `+` is stripped, missing parts read as 0). Returns
+ * -1 / 0 / 1. No semver dependency.
+ */
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string): number[] =>
+    (v.split(/[-+]/)[0] ?? '').split('.').map(n => parseInt(n, 10) || 0)
+  const pa = parse(a)
+  const pb = parse(b)
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const na = pa[i] ?? 0
+    const nb = pb[i] ?? 0
+    if (na !== nb) return na < nb ? -1 : 1
+  }
+  return 0
+}
+
+/**
+ * Check whether `current` is behind the latest published version. Uses the
+ * injected fetcher; a missing/failed fetch is 'unknown'. `current` >= latest is
+ * 'up-to-date' (so running a local build ahead of the registry never reads as
+ * "update available").
+ */
+export async function checkForUpdate(
+  current: string,
+  fetchLatest: VersionFetcher,
+  pkg: string = PACKAGE_NAME,
+): Promise<UpdateStatus> {
+  const latest = await fetchLatest(pkg)
+  if (!latest) return { kind: 'unknown', current }
+  return compareVersions(latest, current) > 0
+    ? { kind: 'update-available', current, latest }
+    : { kind: 'up-to-date', current }
+}
+
+/** The one-line message to print for a status, or undefined for 'unknown' (print nothing). */
+export function formatUpdateStatus(status: UpdateStatus): string | undefined {
+  switch (status.kind) {
+    case 'up-to-date':
+      return `✅ Up to date (v${status.current})`
+    case 'update-available':
+      return `⬆️  Update available: v${status.latest} (you have v${status.current}). Run: npm i -g ${PACKAGE_NAME}`
+    case 'unknown':
+      return undefined
+  }
+}


### PR DESCRIPTION
Bare `framework` now prints an update line right after the version footer: "Up to date (vX)" or "Update available: vY (you have vX). Run: npm i -g @gemstack/framework". It reads npm's `dist-tags.latest` with a 2.5s timeout; offline or any fetch failure prints nothing. Display only, no auto-update (deferred follow-up; no "auto-update enabled" messaging until it exists).

Addresses the up-to-date-check item of #312 (the epic stays open; auto-update messaging and background jobs remain).

- New `src/update-check.ts`: injectable `VersionFetcher` seam + `nodeVersionFetcher()` npm-registry default (same convention as `project.ts`), tiny numeric `compareVersions` (no semver dep), `checkForUpdate`, `formatUpdateStatus`. A local build ahead of the registry reads as up to date.
- Wired into `ensureDaemonCmd` on the success path; barrel-exported from `index.ts`.
- Tests inject the fetcher, no network. Changeset: minor.

Ask: review + merge when happy.