### PR TITLE
feat(framework): multi-project registry module

### DIFF
--- a/.changeset/multi-project-registry-module.md
+++ b/.changeset/multi-project-registry-module.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Add the multi-project registry module: reads and writes the list of projects The Framework is installed into, as a small `{id, path, addedAt}` JSON index under the user's config dir. Exposes `projectId`, `registryPath`, `listProjects`, `addProject`, `removeProject`, and an injectable `RegistryFs` seam with a `nodeRegistryFs()` adapter. No daemon or UI wiring yet.

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -131,6 +131,18 @@ export {
   type ProjectFs,
   type GitRunner,
 } from './project.js'
+export {
+  projectId,
+  registryPath,
+  nodeRegistryFs,
+  listProjects,
+  addProject,
+  removeProject,
+  REGISTRY_DIR,
+  REGISTRY_FILE,
+  type ProjectRecord,
+  type RegistryFs,
+} from './registry.js'
 export { runCli, parseArgs, buildDeployTarget, workspaceSummary, autoSelectPreset, type CliIO, type CliOptions } from './cli.js'
 export {
   metaSelect,

--- a/packages/framework/src/registry.test.ts
+++ b/packages/framework/src/registry.test.ts
@@ -1,0 +1,138 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { join } from 'node:path'
+import {
+  addProject,
+  listProjects,
+  projectId,
+  registryPath,
+  removeProject,
+  REGISTRY_DIR,
+  REGISTRY_FILE,
+  type ProjectRecord,
+  type RegistryFs,
+} from './registry.js'
+
+/** An in-memory {@link RegistryFs} so the registry logic is tested without touching disk. */
+function memFs(seed: Record<string, string> = {}): RegistryFs & { files: Map<string, string>; dirs: string[] } {
+  const files = new Map<string, string>(Object.entries(seed))
+  const dirs: string[] = []
+  return {
+    files,
+    dirs,
+    async read(path) {
+      const v = files.get(path)
+      if (v === undefined) throw new Error(`ENOENT: ${path}`)
+      return v
+    },
+    async write(path, contents) {
+      files.set(path, contents)
+    },
+    async mkdir(path) {
+      dirs.push(path) // no-op: the memory fs has no directories
+    },
+  }
+}
+
+const ENV = { HOME: '/home/u' }
+const FILE = registryPath(ENV)
+
+const APP_A: ProjectRecord = {
+  id: projectId('/repos/app-a'),
+  path: '/repos/app-a',
+  addedAt: '2026-07-10T09:00:00.000Z',
+}
+
+const APP_B: ProjectRecord = {
+  id: projectId('/repos/app-b'),
+  path: '/repos/app-b',
+  addedAt: '2026-07-10T10:00:00.000Z',
+}
+
+test('registryPath prefers XDG_CONFIG_HOME over HOME', () => {
+  assert.equal(registryPath({ XDG_CONFIG_HOME: '/cfg' }), join('/cfg', REGISTRY_DIR, REGISTRY_FILE))
+  assert.equal(registryPath({ XDG_CONFIG_HOME: '/cfg', HOME: '/home/u' }), join('/cfg', REGISTRY_DIR, REGISTRY_FILE))
+})
+
+test('registryPath falls back to a dot dir under HOME (empty XDG counts as unset)', () => {
+  assert.equal(registryPath(ENV), join('/home/u', '.' + REGISTRY_DIR, REGISTRY_FILE))
+  assert.equal(registryPath({ XDG_CONFIG_HOME: '', HOME: '/home/u' }), join('/home/u', '.' + REGISTRY_DIR, REGISTRY_FILE))
+})
+
+test('projectId is deterministic and distinct per path', () => {
+  assert.equal(projectId('/repos/app-a'), projectId('/repos/app-a'))
+  assert.notEqual(projectId('/repos/app-a'), projectId('/repos/app-b'))
+  assert.notEqual(projectId('/repos/app-a'), projectId('/other/app-a')) // same basename, different path
+})
+
+test('projectId is URL-safe, even for a messy basename', () => {
+  for (const path of ['/repos/app-a', '/repos/My App (v2)!', '/repos/ÜMLAUT.dir']) {
+    assert.match(projectId(path), /^[a-z0-9-]+$/)
+  }
+})
+
+test('listProjects on a missing file is []', async () => {
+  assert.deepEqual(await listProjects(memFs(), ENV), [])
+})
+
+test('listProjects on an empty / malformed / non-array file is []', async () => {
+  for (const raw of ['', 'not json', '{"id":"x"}', '42']) {
+    assert.deepEqual(await listProjects(memFs({ [FILE]: raw }), ENV), [])
+  }
+})
+
+test('listProjects round-trips a well-formed file and drops malformed records', async () => {
+  const raw = JSON.stringify([APP_A, { id: 'no-path' }, 'nope', APP_B])
+  assert.deepEqual(await listProjects(memFs({ [FILE]: raw }), ENV), [APP_A, APP_B])
+})
+
+test('listProjects dedupes by resolved path, first wins', async () => {
+  const dupe = { ...APP_B, path: '/repos/app-a/', addedAt: '2026-07-10T11:00:00.000Z' }
+  const raw = JSON.stringify([APP_A, dupe, APP_B])
+  assert.deepEqual(await listProjects(memFs({ [FILE]: raw }), ENV), [APP_A, APP_B])
+})
+
+test('addProject appends a record and writes pretty JSON that parses back', async () => {
+  const fs = memFs()
+  const record = await addProject('/repos/app-a', APP_A.addedAt, fs, ENV)
+  assert.deepEqual(record, APP_A)
+  assert.deepEqual(fs.dirs, [join('/home/u', '.' + REGISTRY_DIR)])
+  assert.deepEqual(JSON.parse(fs.files.get(FILE)!), [APP_A])
+
+  await addProject('/repos/app-b', APP_B.addedAt, fs, ENV)
+  assert.deepEqual(await listProjects(fs, ENV), [APP_A, APP_B])
+})
+
+test('addProject is idempotent by resolved path and keeps the original addedAt', async () => {
+  const fs = memFs()
+  await addProject('/repos/app-a', APP_A.addedAt, fs, ENV)
+  for (const variant of ['/repos/app-a', '/repos/app-a/', '/repos/other/../app-a']) {
+    const again = await addProject(variant, '2027-01-01T00:00:00.000Z', fs, ENV)
+    assert.deepEqual(again, APP_A) // existing record, addedAt untouched
+  }
+  assert.deepEqual(JSON.parse(fs.files.get(FILE)!), [APP_A])
+})
+
+test('addProject normalizes the stored path to an absolute one', async () => {
+  const fs = memFs()
+  const record = await addProject('/repos/app-a/', APP_A.addedAt, fs, ENV)
+  assert.equal(record.path, '/repos/app-a')
+})
+
+test('removeProject drops the matching record and returns true', async () => {
+  const fs = memFs({ [FILE]: JSON.stringify([APP_A, APP_B]) })
+  assert.equal(await removeProject(APP_A.id, fs, ENV), true)
+  assert.deepEqual(await listProjects(fs, ENV), [APP_B])
+})
+
+test('removeProject on an unknown id is false and does not write', async () => {
+  const raw = JSON.stringify([APP_A])
+  const fs = memFs({ [FILE]: raw })
+  assert.equal(await removeProject('nope-123', fs, ENV), false)
+  assert.equal(fs.files.get(FILE), raw) // untouched
+})
+
+test('removeProject on an empty / missing registry is false', async () => {
+  assert.equal(await removeProject(APP_A.id, memFs(), ENV), false)
+  assert.equal(await removeProject(APP_A.id, memFs({ [FILE]: '[]' }), ENV), false)
+})

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -1,0 +1,156 @@
+import { basename, dirname, join, resolve } from 'node:path'
+
+/**
+ * The multi-project registry (#390): the list of projects the user has
+ * installed The Framework into, kept as a small JSON index under the user's
+ * config dir. Stores only `{id, path, addedAt}` per project; the daemon and
+ * UI over it are separate concerns.
+ */
+
+/** One registered project. */
+export interface ProjectRecord {
+  /** Stable, URL-safe id derived from the path. */
+  id: string
+  /** Absolute repo path. */
+  path: string
+  /** ISO timestamp the project was added. */
+  addedAt: string
+}
+
+/** The directory name under `$XDG_CONFIG_HOME` (dotted under `$HOME`). */
+export const REGISTRY_DIR = 'the-framework'
+
+/** The registry file name. */
+export const REGISTRY_FILE = 'projects.json'
+
+/**
+ * Deterministic, URL-safe id for a project path: the sanitized basename plus a
+ * short hash of the full path, so two repos named alike still get distinct ids.
+ * Pure; same path always yields the same id.
+ */
+export function projectId(path: string): string {
+  // djb2, rendered as base36: short, stable, URL-safe. Not cryptographic.
+  let hash = 5381
+  for (let i = 0; i < path.length; i++) {
+    hash = ((hash * 33) ^ path.charCodeAt(i)) >>> 0
+  }
+  const name = basename(path)
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+  return `${name}-${hash.toString(36)}`
+}
+
+/**
+ * The registry file path, resolved from `env` (injectable so tests never touch
+ * the real home): `$XDG_CONFIG_HOME/the-framework/projects.json` when set,
+ * else `$HOME/.the-framework/projects.json`.
+ */
+export function registryPath(env: NodeJS.ProcessEnv): string {
+  if (env.XDG_CONFIG_HOME) return join(env.XDG_CONFIG_HOME, REGISTRY_DIR, REGISTRY_FILE)
+  return join(env.HOME ?? '', '.' + REGISTRY_DIR, REGISTRY_FILE)
+}
+
+/** Minimal fs seam so the registry is unit-testable without touching disk. */
+export interface RegistryFs {
+  /** Rejects when the file is absent. */
+  read(path: string): Promise<string>
+  write(path: string, contents: string): Promise<void>
+  /** Recursive; used on the registry file's parent dir. */
+  mkdir(path: string): Promise<void>
+}
+
+/**
+ * A {@link RegistryFs} backed by `node:fs/promises`. The import is dynamic so
+ * the module core stays free of a hard `node:fs` dependency, same convention
+ * as {@link nodeProjectFs}.
+ */
+export function nodeRegistryFs(): RegistryFs {
+  return {
+    async read(path) {
+      const { readFile } = await import('node:fs/promises')
+      return readFile(path, 'utf8')
+    },
+    async write(path, contents) {
+      const { writeFile } = await import('node:fs/promises')
+      await writeFile(path, contents, 'utf8')
+    },
+    async mkdir(path) {
+      const { mkdir } = await import('node:fs/promises')
+      await mkdir(path, { recursive: true })
+    },
+  }
+}
+
+/** True when `value` is a well-formed {@link ProjectRecord}. */
+function isRecord(value: unknown): value is ProjectRecord {
+  if (typeof value !== 'object' || value === null) return false
+  const record = value as Record<string, unknown>
+  return typeof record.id === 'string' && typeof record.path === 'string' && typeof record.addedAt === 'string'
+}
+
+/**
+ * Read the registry. Forgiving: a missing / unreadable / malformed / non-array
+ * file yields `[]`, never throws. Deduped by resolved path, first wins.
+ */
+export async function listProjects(
+  fs: RegistryFs = nodeRegistryFs(),
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ProjectRecord[]> {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(await fs.read(registryPath(env)))
+  } catch {
+    return []
+  }
+  if (!Array.isArray(parsed)) return []
+  const seen = new Set<string>()
+  const projects: ProjectRecord[] = []
+  for (const value of parsed) {
+    if (!isRecord(value)) continue
+    const key = resolve(value.path)
+    if (seen.has(key)) continue
+    seen.add(key)
+    projects.push(value)
+  }
+  return projects
+}
+
+/**
+ * Register a project. Idempotent by resolved path: when the path is already
+ * registered, the existing record is returned untouched (addedAt survives);
+ * otherwise the new record is appended and the file written back.
+ */
+export async function addProject(
+  path: string,
+  addedAt: string,
+  fs: RegistryFs = nodeRegistryFs(),
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ProjectRecord> {
+  const absolute = resolve(path)
+  const projects = await listProjects(fs, env)
+  const existing = projects.find(project => resolve(project.path) === absolute)
+  if (existing) return existing
+
+  const record: ProjectRecord = { id: projectId(absolute), path: absolute, addedAt }
+  projects.push(record)
+  const file = registryPath(env)
+  await fs.mkdir(dirname(file))
+  await fs.write(file, JSON.stringify(projects, null, 2))
+  return record
+}
+
+/**
+ * Drop the project whose id matches and write the list back. Returns whether a
+ * record was removed; an empty/missing registry is a no-write `false`.
+ */
+export async function removeProject(
+  id: string,
+  fs: RegistryFs = nodeRegistryFs(),
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+  const projects = await listProjects(fs, env)
+  const remaining = projects.filter(project => project.id !== id)
+  if (remaining.length === projects.length) return false
+  await fs.write(registryPath(env), JSON.stringify(remaining, null, 2))
+  return true
+}


### PR DESCRIPTION
Closes #390. Part of #314.

The smallest slice of the multi-project registry: a pure module that reads and writes the list of projects The Framework is installed into. Stores only an index of `{id, path, addedAt}` per project (an XDG/`$HOME` JSON file). No daemon or UI wiring here (those are #392+).

## API
- `projectId(path)` — deterministic, URL-safe id (sanitized basename + short djb2 hash).
- `registryPath(env)` — `$XDG_CONFIG_HOME/the-framework/projects.json`, else `$HOME/.the-framework/projects.json`. Injectable env so tests never touch the real home.
- `listProjects` / `addProject` / `removeProject` — forgiving read (missing/malformed yields `[]`), idempotent add deduped by resolved path, remove-by-id.
- `RegistryFs` seam + `nodeRegistryFs()` adapter (dynamic `node:fs/promises` import, same convention as `nodeProjectFs`).

Storage-agnostic on purpose: the local JSON file can later swap for Rom`\s `my-framework` user-DB behind `registryPath()` + the seam. See #390 for that open decision.

## Tests
`registry.test.ts`, node:test with an in-memory `RegistryFs` and a fixed fake env: path resolution (XDG vs HOME), id stability + URL-safety, forgiving parse, add/dedupe idempotency, remove. Package suite green (410 pass, 1 pre-existing skip), typecheck clean. No new deps.