### PR TITLE
feat(framework): multi-project install-core

### DIFF
--- a/.changeset/multi-project-install-core.md
+++ b/.changeset/multi-project-install-core.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Add the install-core module: `installProject(cwd)` activates a repo for The Framework by creating the `.the-framework/` marker with a seeded `LOGS.md`, committing any pre-existing dirty changes first (`[The Framework] uncommitted changes`) so the install commit (`[The Framework] install The Framework`) is clean; an already-activated repo is a no-op. Also `enumerateGitRepos(dir)` lists the immediate child directories that are their own git repo roots (for the "add a directory of repos" flow). Pure core over the existing `GitRunner` + `StoreFs` seams; any git failure surfaces as a value, never a throw. No daemon or UI wiring yet.

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -144,6 +144,15 @@ export {
   type RegistryFs,
 } from './registry.js'
 export {
+  installProject,
+  enumerateGitRepos,
+  nodeDirLister,
+  type InstallResult,
+  type InstallDeps,
+  type DirLister,
+  type EnumerateDeps,
+} from './install.js'
+export {
   PACKAGE_NAME,
   nodeVersionFetcher,
   compareVersions,

--- a/packages/framework/src/install.test.ts
+++ b/packages/framework/src/install.test.ts
@@ -1,0 +1,123 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { join } from 'node:path'
+import { enumerateGitRepos, installProject, type DirLister } from './install.js'
+import { logsPath, readLogs, LOGS_HEADER } from './logs.js'
+import type { GitRunner } from './project.js'
+import type { StoreFs } from './store/index.js'
+
+/** An in-memory {@link StoreFs} so the install logic is tested without touching disk. */
+function memFs(seed: Record<string, string> = {}): StoreFs & { files: Map<string, string> } {
+  const files = new Map<string, string>(Object.entries(seed))
+  return {
+    files,
+    async read(path) {
+      const v = files.get(path)
+      if (v === undefined) throw new Error(`ENOENT: ${path}`)
+      return v
+    },
+    async write(path, contents) {
+      files.set(path, contents)
+    },
+    async append(path, contents) {
+      files.set(path, (files.get(path) ?? '') + contents)
+    },
+    async exists(path) {
+      return files.has(path)
+    },
+    async mkdir() {
+      // no-op: the memory fs has no directories
+    },
+    async readdir(dir) {
+      const prefix = dir.endsWith('/') ? dir : dir + '/'
+      const names = new Set<string>()
+      for (const p of files.keys()) {
+        if (!p.startsWith(prefix)) continue
+        const rest = p.slice(prefix.length)
+        if (!rest.includes('/')) names.add(rest)
+      }
+      return [...names]
+    },
+  }
+}
+
+/** A scriptable {@link GitRunner} that records every call's args. */
+function fakeGit(script: (args: string[], cwd: string) => Promise<string> | string) {
+  const calls: string[][] = []
+  const git: GitRunner = async (args, cwd) => {
+    calls.push(args)
+    return script(args, cwd)
+  }
+  return { git, calls }
+}
+
+const CWD = '/proj'
+
+test('installProject on a clean repo seeds the log and makes exactly one install commit', async () => {
+  const fs = memFs()
+  const { git, calls } = fakeGit(args => (args[0] === 'status' ? '' : ''))
+
+  assert.deepEqual(await installProject(CWD, { git, fs }), { ok: true })
+  assert.equal(fs.files.get(logsPath(CWD)), LOGS_HEADER)
+
+  const commits = calls.filter(args => args[0] === 'commit')
+  assert.deepEqual(commits, [['commit', '-m', '[The Framework] install The Framework']])
+})
+
+test('installProject on a dirty repo commits the pre-existing changes first', async () => {
+  const fs = memFs()
+  const { git, calls } = fakeGit(args => (args[0] === 'status' ? ' M file.ts\n' : ''))
+
+  assert.deepEqual(await installProject(CWD, { git, fs }), { ok: true })
+
+  const commits = calls.filter(args => args[0] === 'commit').map(args => args[2])
+  assert.deepEqual(commits, ['[The Framework] uncommitted changes', '[The Framework] install The Framework'])
+})
+
+test('installProject on an already-activated repo is a no-op that never calls git', async () => {
+  const fs = memFs({ [logsPath(CWD)]: LOGS_HEADER })
+  const { git, calls } = fakeGit(() => '')
+
+  assert.deepEqual(await installProject(CWD, { git, fs }), { ok: true, alreadyActivated: true })
+  assert.deepEqual(calls, [])
+})
+
+test('installProject surfaces a git failure as { ok: false }, never throws', async () => {
+  const fs = memFs()
+  const { git } = fakeGit(args => {
+    if (args[0] === 'commit') throw new Error('nothing to commit')
+    return ''
+  })
+
+  assert.deepEqual(await installProject(CWD, { git, fs }), { ok: false, error: 'nothing to commit' })
+})
+
+test('the seeded LOGS.md is a valid empty log', async () => {
+  const fs = memFs()
+  const { git } = fakeGit(() => '')
+
+  await installProject(CWD, { git, fs })
+  assert.equal(fs.files.get(logsPath(CWD)), LOGS_HEADER)
+  assert.deepEqual(await readLogs(CWD, fs), [])
+})
+
+test('enumerateGitRepos keeps only children that are their own repo roots, sorted', async () => {
+  const dir = '/repos'
+  const children = [join(dir, 'b'), join(dir, 'a'), join(dir, 'nested'), join(dir, 'plain')]
+  const dirs: DirLister = { childDirs: async () => children }
+  const { git } = fakeGit((_args, cwd) => {
+    if (cwd === join(dir, 'nested')) return dir + '\n' // subdir of an outer repo
+    if (cwd === join(dir, 'plain')) throw new Error('not a git repository')
+    return cwd + '\n'
+  })
+
+  assert.deepEqual(await enumerateGitRepos(dir, { git, dirs }), [join(dir, 'a'), join(dir, 'b')])
+})
+
+test('enumerateGitRepos on an empty or missing dir is []', async () => {
+  const dirs: DirLister = { childDirs: async () => [] }
+  const { git, calls } = fakeGit(() => '')
+
+  assert.deepEqual(await enumerateGitRepos('/nowhere', { git, dirs }), [])
+  assert.deepEqual(calls, [])
+})

--- a/packages/framework/src/install.ts
+++ b/packages/framework/src/install.ts
@@ -1,0 +1,108 @@
+import { join, resolve } from 'node:path'
+import { nodeGitRunner, type GitRunner } from './project.js'
+import { logsPath, LOGS_HEADER, THE_FRAMEWORK_DIR } from './logs.js'
+import { nodeStoreFs, type StoreFs } from './store/index.js'
+
+/**
+ * Install/activate a repo for The Framework (#391): create the
+ * `.the-framework/` marker + seeded `LOGS.md`, committing pre-existing dirty
+ * changes first so the install commit is clean. Pure core over the same
+ * {@link GitRunner} + {@link StoreFs} seams as project.ts/logs.ts; the
+ * endpoint/UI wiring lands in later #314 slices.
+ */
+
+/** The outcome of {@link installProject}. Failures are values, never throws. */
+export type InstallResult =
+  | { ok: true; alreadyActivated?: boolean }
+  | { ok: false; error: string }
+
+/** Injectable seams for {@link installProject}. */
+export interface InstallDeps {
+  git?: GitRunner
+  fs?: StoreFs
+}
+
+/**
+ * Activate the repo at `cwd`: commit any pre-existing dirty changes, create
+ * `.the-framework/` with a seeded `LOGS.md`, and commit the install. A repo
+ * with the log file already present is a no-op (`alreadyActivated`).
+ * Forgiving: any git/fs failure surfaces as `{ ok: false, error }`.
+ */
+export async function installProject(cwd: string, deps: InstallDeps = {}): Promise<InstallResult> {
+  const git = deps.git ?? nodeGitRunner()
+  const fs = deps.fs ?? nodeStoreFs()
+
+  if (await fs.exists(logsPath(cwd))) return { ok: true, alreadyActivated: true }
+
+  try {
+    // Commit pre-existing changes first so the install commit is clean.
+    const status = await git(['status', '--porcelain'], cwd)
+    if (status.trim()) {
+      await git(['add', '-A'], cwd)
+      await git(['commit', '-m', '[The Framework] uncommitted changes'], cwd)
+    }
+
+    await fs.mkdir(join(cwd, THE_FRAMEWORK_DIR))
+    const path = logsPath(cwd)
+    if (!(await fs.exists(path))) await fs.write(path, LOGS_HEADER)
+
+    await git(['add', '-A'], cwd)
+    await git(['commit', '-m', '[The Framework] install The Framework'], cwd)
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+/** Minimal directory-listing seam so {@link enumerateGitRepos} is unit-testable. */
+export interface DirLister {
+  /** Absolute paths of the immediate subdirectories of `dir`. Missing/non-dir/error yields `[]`. */
+  childDirs(dir: string): Promise<string[]>
+}
+
+/**
+ * A {@link DirLister} backed by `node:fs/promises`. The import is dynamic so
+ * the module core stays free of a hard `node:fs` dependency, same convention
+ * as {@link nodeStoreFs}; any error reads as `[]`.
+ */
+export function nodeDirLister(): DirLister {
+  return {
+    async childDirs(dir) {
+      try {
+        const { readdir } = await import('node:fs/promises')
+        const entries = await readdir(dir, { withFileTypes: true })
+        return entries.filter(entry => entry.isDirectory()).map(entry => join(dir, entry.name))
+      } catch {
+        return []
+      }
+    },
+  }
+}
+
+/** Injectable seams for {@link enumerateGitRepos}. */
+export interface EnumerateDeps {
+  git?: GitRunner
+  dirs?: DirLister
+}
+
+/**
+ * The immediate child directories of `dir` that are their own git repo roots
+ * (`git rev-parse --show-toplevel` resolves to the child itself). A child that
+ * is not a repo, or merely a subdir of an outer repo, is skipped. Returns the
+ * surviving paths, deduped and sorted. Forgiving: never throws.
+ */
+export async function enumerateGitRepos(dir: string, deps: EnumerateDeps = {}): Promise<string[]> {
+  const git = deps.git ?? nodeGitRunner()
+  const dirs = deps.dirs ?? nodeDirLister()
+
+  const repos = new Set<string>()
+  for (const child of await dirs.childDirs(dir)) {
+    try {
+      const toplevel = await git(['rev-parse', '--show-toplevel'], child)
+      if (resolve(toplevel.trim()) === resolve(child)) repos.add(child)
+    } catch {
+      // Not a repo (or git failed): skip.
+    }
+  }
+  return [...repos].sort()
+}

--- a/packages/framework/src/logs.ts
+++ b/packages/framework/src/logs.ts
@@ -37,7 +37,7 @@ const STATUSES: readonly string[] = ['done', 'stopped', 'failed', 'running']
 const SEP = ' · '
 
 /** The one-time first line of the file, written on the first append. */
-const HEADER = '# The Framework logs\n'
+export const LOGS_HEADER = '# The Framework logs\n'
 
 /** The log path under `cwd`. */
 export function logsPath(cwd: string): string {
@@ -149,7 +149,7 @@ function parseEntry(lines: string[]): LogEntry | undefined {
 export async function appendLog(cwd: string, entry: LogEntry, fs: StoreFs = nodeStoreFs()): Promise<void> {
   await fs.mkdir(join(cwd, THE_FRAMEWORK_DIR))
   const path = logsPath(cwd)
-  if (!(await fs.exists(path))) await fs.write(path, HEADER)
+  if (!(await fs.exists(path))) await fs.write(path, LOGS_HEADER)
   await fs.append(path, '\n' + renderLogEntry(entry) + '\n')
 }
 


### PR DESCRIPTION
Closes #391. Part of #314.

The second Fable-ready slice of the multi-project registry: a pure module that activates a repo for The Framework. No endpoint or UI here (that is #396).

## API
- `installProject(cwd, { git?, fs? })`:
  1. Already-activated (LOGS.md present) -> no-op `{ ok: true, alreadyActivated: true }`, zero git calls.
  2. If the repo is dirty (`git status --porcelain`), commit the pre-existing changes first: `[The Framework] uncommitted changes`.
  3. Create `.the-framework/` + seed `LOGS.md` with the shared log header.
  4. Commit the install: `[The Framework] install The Framework`.
  - Forgiving: any git/fs failure is returned as `{ ok: false, error }`, never thrown.
- `enumerateGitRepos(dir, { git?, dirs? })` — the immediate child dirs that are their own git repo roots (`git rev-parse --show-toplevel` resolves to the child). For the "add a directory of repos" flow. Deduped, sorted, never throws.
- `DirLister` seam + `nodeDirLister()` adapter (dynamic `node:fs/promises` readdir with `withFileTypes`).

Reuses the existing `GitRunner` (project.ts) and `StoreFs` (store/) seams, nothing redefined. One small DRY change: the log header in `logs.ts` is now exported as `LOGS_HEADER` and reused for the seed.

## Tests
`install.test.ts`, node:test with the in-memory `memFs` and a call-recording fake git: clean vs dirty (asserts commit order), already-activated no-op (git never called), git-failure-as-value, the seed is a valid empty log (`readLogs` -> `[]`), and repo-root filtering for `enumerateGitRepos`. Package suite green (417 pass, 1 pre-existing skip), typecheck clean. No new deps.