### PR TITLE
feat(framework): registry-aware dashboard read endpoints

### DIFF
--- a/.changeset/multi-project-daemon-reads.md
+++ b/.changeset/multi-project-daemon-reads.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Make the dashboard multi-project on the read side: `GET /api/projects` lists the registered projects (from the registry) with a per-project summary (name, activated, last activity), and `?project=<id>` on `/api/logs`, `/api/runs`, `/api/runs/<id>`, and `/api/docs` reads that project's data (an absent id keeps the daemon's own workspace, single-project back-compat). The daemon auto-registers its own workspace on boot when it is activated, so the Projects list is populated for the common single-project case. Live event streaming and per-project run start/stop stay single-project for now. Adds `ProjectSummary` / `ProjectsProvider` / `summarizeProject` / `defaultProjectsProvider`.

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -6,6 +6,8 @@ import type { FrameworkEvent } from './events.js'
 import { EVENTS_FILE, FRAMEWORK_DIR } from './store/index.js'
 import { startDashboard, type Dashboard, type StartRunKind, type StartRunOptions, type StartRunResult } from './dashboard/index.js'
 import { appendControl } from './control.js'
+import { isActivated } from './project.js'
+import { addProject } from './registry.js'
 import { JsonlTailer } from './jsonl-tail.js'
 
 /**
@@ -222,6 +224,13 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
   // `.framework/` — create it up front so the daemon works as the very first
   // command in a fresh workspace (before any run made the dir).
   await mkdir(daemonDir(cwd), { recursive: true })
+
+  // Multi-project (#392): when the daemon starts in an activated repo, make sure
+  // it shows up in the Projects list. Best-effort and idempotent (addProject
+  // dedupes by path), so it never blocks the daemon coming up.
+  if (await isActivated(cwd).catch(() => false)) {
+    await addProject(cwd, new Date().toISOString()).catch(() => {})
+  }
 
   // Start-from-dashboard (#345): POST /api/start spawns `framework "<prompt>"
   // --no-dashboard` as a detached child — the same spawn pattern ensureDaemon

--- a/packages/framework/src/dashboard/index.ts
+++ b/packages/framework/src/dashboard/index.ts
@@ -1,2 +1,9 @@
 export { startDashboard, parseStartOptions, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunOptions, type StartRunResult } from './server.js'
+export {
+  summarizeProject,
+  defaultProjectsProvider,
+  type ProjectSummary,
+  type ProjectsProvider,
+  type SummarizeDeps,
+} from './projects.js'
 export { dashboardHtml } from './page.js'

--- a/packages/framework/src/dashboard/projects.test.ts
+++ b/packages/framework/src/dashboard/projects.test.ts
@@ -1,0 +1,53 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { summarizeProject, type SummarizeDeps } from './projects.js'
+import type { ProjectRecord } from '../registry.js'
+import type { LogEntry } from '../logs.js'
+
+const RECORD: ProjectRecord = { id: 'app-a-1', path: '/repos/app-a', addedAt: '2026-07-11T00:00:00.000Z' }
+
+function deps(over: SummarizeDeps): SummarizeDeps {
+  return { isActivated: async () => true, readLogs: async () => [], ...over }
+}
+
+test('summarizeProject derives name from the path basename', async () => {
+  const summary = await summarizeProject(RECORD, deps({}))
+  assert.equal(summary.name, 'app-a')
+  assert.equal(summary.id, 'app-a-1')
+  assert.equal(summary.path, '/repos/app-a')
+})
+
+test('lastActivityAt is the newest LOGS.md entry (readLogs is newest-first)', async () => {
+  const logs: LogEntry[] = [
+    { at: '2026-07-11T10:00:00.000Z', kind: 'build', title: 'newest', status: 'done' },
+    { at: '2026-07-10T09:00:00.000Z', kind: 'prompt', title: 'older', status: 'done' },
+  ]
+  const summary = await summarizeProject(RECORD, deps({ readLogs: async () => logs }))
+  assert.equal(summary.lastActivityAt, '2026-07-11T10:00:00.000Z')
+})
+
+test('no log entries means no lastActivityAt key at all', async () => {
+  const summary = await summarizeProject(RECORD, deps({ readLogs: async () => [] }))
+  assert.equal('lastActivityAt' in summary, false)
+})
+
+test('activation reflects the injected check', async () => {
+  const summary = await summarizeProject(RECORD, deps({ isActivated: async () => false }))
+  assert.equal(summary.activated, false)
+})
+
+test('a throwing reader is forgiving: inactive, no activity, never throws', async () => {
+  const summary = await summarizeProject(
+    RECORD,
+    deps({
+      isActivated: async () => {
+        throw new Error('stat failed')
+      },
+      readLogs: async () => {
+        throw new Error('read failed')
+      },
+    }),
+  )
+  assert.equal(summary.activated, false)
+  assert.equal('lastActivityAt' in summary, false)
+})

--- a/packages/framework/src/dashboard/projects.ts
+++ b/packages/framework/src/dashboard/projects.ts
@@ -1,0 +1,80 @@
+import { basename } from 'node:path'
+import { listProjects, type ProjectRecord } from '../registry.js'
+import { isActivated } from '../project.js'
+import { readLogs, type LogEntry } from '../logs.js'
+
+/**
+ * The multi-project read side (#392): projects the daemon serves come from the
+ * registry (#390), and each read endpoint (`/api/logs`, `/api/runs`, `/api/docs`)
+ * resolves a `?project=<id>` to that project's path before running the existing
+ * per-cwd reader. Live streaming + per-project run start/stop stay single-project
+ * for now (#393).
+ */
+
+/** One project's summary for the Projects sidebar (#314). */
+export interface ProjectSummary {
+  /** Registry id (stable, URL-safe). */
+  id: string
+  /** Absolute repo path. */
+  path: string
+  /** Display name (the path's basename). */
+  name: string
+  /** True when the repo still has its `.the-framework/` marker. */
+  activated: boolean
+  /** ISO timestamp of the newest `LOGS.md` entry, when any. */
+  lastActivityAt?: string
+}
+
+/** Injectable readers so {@link summarizeProject} is unit-testable off disk. */
+export interface SummarizeDeps {
+  isActivated?: (path: string) => Promise<boolean>
+  readLogs?: (path: string) => Promise<LogEntry[]>
+}
+
+/**
+ * Derive a {@link ProjectSummary} from a registry record: its display name, whether
+ * it is still activated, and its last activity (the newest `LOGS.md` entry, since
+ * {@link readLogs} returns newest-first). Forgiving: a failed read reads as an
+ * inactive project with no activity, never a throw.
+ */
+export async function summarizeProject(record: ProjectRecord, deps: SummarizeDeps = {}): Promise<ProjectSummary> {
+  const checkActivated = deps.isActivated ?? isActivated
+  const loadLogs = deps.readLogs ?? readLogs
+  const activated = await checkActivated(record.path).catch(() => false)
+  const logs = await loadLogs(record.path).catch(() => [] as LogEntry[])
+  const lastActivityAt = logs[0]?.at
+  const summary: ProjectSummary = {
+    id: record.id,
+    path: record.path,
+    name: basename(record.path),
+    activated,
+  }
+  if (lastActivityAt) summary.lastActivityAt = lastActivityAt
+  return summary
+}
+
+/**
+ * Reads the registry to serve the multi-project endpoints. The dashboard server
+ * holds one of these; the daemon uses the default (the real registry), tests pass
+ * a fake so the server is exercised without touching the user's registry.
+ */
+export interface ProjectsProvider {
+  /** Every registered project, summarized, for `GET /api/projects`. */
+  list(): Promise<ProjectSummary[]>
+  /** The absolute path for a registry id, or `undefined` when unknown. */
+  resolvePath(id: string): Promise<string | undefined>
+}
+
+/** A {@link ProjectsProvider} backed by the global registry (#390). */
+export function defaultProjectsProvider(): ProjectsProvider {
+  return {
+    async list() {
+      const records = await listProjects().catch(() => [])
+      return Promise.all(records.map(record => summarizeProject(record)))
+    },
+    async resolvePath(id) {
+      const records = await listProjects().catch(() => [])
+      return records.find(record => record.id === id)?.path
+    },
+  }
+}

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { startDashboard, parseStartOptions, type StartRunOptions } from './server.js'
 import type { FrameworkEvent } from '../events.js'
+import type { ProjectsProvider, ProjectSummary } from './projects.js'
 import { appendLog } from '../logs.js'
 
 function fetchText(url: string): Promise<{ status: number; body: string }> {
@@ -187,6 +188,53 @@ test('GET /api/logs serves the .the-framework/LOGS.md entries newest-first, or [
       assert.deepEqual(JSON.parse((await fetchText(noCwd.url + '/api/logs')).body), { logs: [] })
     } finally {
       await noCwd.close()
+    }
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+/** A fake provider so the multi-project routes are exercised without the real registry. */
+function fakeProjects(summaries: ProjectSummary[], paths: Record<string, string> = {}): ProjectsProvider {
+  return {
+    async list() {
+      return summaries
+    },
+    async resolvePath(id) {
+      return paths[id]
+    },
+  }
+}
+
+test('GET /api/projects lists the registered projects (#392)', async () => {
+  const summaries: ProjectSummary[] = [
+    { id: 'app-a-1', path: '/repos/app-a', name: 'app-a', activated: true, lastActivityAt: '2026-07-11T10:00:00.000Z' },
+    { id: 'app-b-2', path: '/repos/app-b', name: 'app-b', activated: false },
+  ]
+  const dash = await startDashboard({ port: 0, projects: fakeProjects(summaries) })
+  try {
+    const { status, body } = await fetchText(dash.url + '/api/projects')
+    assert.equal(status, 200)
+    assert.deepEqual(JSON.parse(body), { projects: summaries })
+  } finally {
+    await dash.close()
+  }
+})
+
+test('?project=<id> reads that project, an unknown id reads [] (#392)', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'framework-proj-'))
+  try {
+    await appendLog(cwd, { at: '2026-07-10T10:00:00.000Z', kind: 'build', title: 'in project a', status: 'done' })
+    const dash = await startDashboard({ port: 0, projects: fakeProjects([], { 'a-1': cwd }) })
+    try {
+      // Known id resolves to the seeded workspace.
+      const known = JSON.parse((await fetchText(dash.url + '/api/logs?project=a-1')).body)
+      assert.equal(known.logs.length, 1)
+      assert.equal(known.logs[0].title, 'in project a')
+      // Unknown id resolves to nothing -> empty, never an error.
+      assert.deepEqual(JSON.parse((await fetchText(dash.url + '/api/logs?project=nope')).body), { logs: [] })
+    } finally {
+      await dash.close()
     }
   } finally {
     await rm(cwd, { recursive: true, force: true })

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -6,6 +6,7 @@ import type { EcoOptions } from '../system-prompt.js'
 import { listRuns, loadRunEvents } from '../store/index.js'
 import { readLogs } from '../logs.js'
 import { readDocs } from './docs.js'
+import { defaultProjectsProvider, type ProjectsProvider } from './projects.js'
 import { dashboardHtml } from './page.js'
 import { serveSSE } from './sse.js'
 
@@ -45,6 +46,14 @@ export interface DashboardOptions {
    * options (#314) ride along in `options`.
    */
   onStart?: (prompt: string, kind: StartRunKind, options: StartRunOptions) => StartRunResult
+  /**
+   * The multi-project registry read side (#392): `GET /api/projects` lists it, and
+   * `?project=<id>` on the read endpoints resolves to that project's path. Omit to
+   * use the real registry (the daemon does); tests pass a fake. The `cwd` above
+   * stays the default project when no `?project=` is given (single-project
+   * back-compat) and the target the live stream + run start/stop still follow (#393).
+   */
+  projects?: ProjectsProvider
 }
 
 /**
@@ -108,10 +117,11 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
   const onChoice = opts.onChoice
   const onStart = opts.onStart
   const cwd = opts.cwd
+  const projects = opts.projects ?? defaultProjectsProvider()
   const stream = new EventStream<FrameworkEvent>()
   const clients = new Set<ServerResponse>()
 
-  const server = createServer((req, res) => handle(req, res, stream, clients, title, onStop, onChoice, onStart, cwd))
+  const server = createServer((req, res) => handle(req, res, stream, clients, title, onStop, onChoice, onStart, cwd, projects))
 
   return new Promise<Dashboard>((resolvePromise, rejectPromise) => {
     server.once('error', rejectPromise)
@@ -139,40 +149,53 @@ function handle(
   onChoice: ((id: string, pick: string | string[], by: ChoiceBy) => void) | undefined,
   onStart: ((prompt: string, kind: StartRunKind, options: StartRunOptions) => StartRunResult) | undefined,
   cwd: string | undefined,
+  projects: ProjectsProvider,
 ): void {
   const url = req.url ?? '/'
-  if (url === '/' || url.startsWith('/?')) {
+  // Parse once so a `?project=<id>` query never bleeds into the pathname match
+  // (and a run id in `/api/runs/<id>` is read from the pathname, not the query).
+  const { pathname, searchParams } = new URL(url, 'http://localhost')
+  const projectId = searchParams.get('project')
+  if (pathname === '/') {
     res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
     res.end(dashboardHtml(title, Boolean(onStop), Boolean(onChoice), Boolean(onStart)))
     return
   }
-  if (url === '/events') {
+  if (pathname === '/events') {
     serveSSE(req, res, stream, clients)
     return
   }
-  // Run history (#303). The list feeds the second sidebar; a single run's log is
-  // replayed client-side into the same projection the live stream drives.
-  if (url === '/api/runs') {
-    void serveRunList(res, cwd)
+  // The registered projects (#392): the Projects sidebar lists these, then reads
+  // one via `?project=<id>` on the endpoints below.
+  if (pathname === '/api/projects') {
+    void serveProjects(res, projects)
     return
   }
-  if (url.startsWith('/api/runs/')) {
-    void serveRun(res, cwd, decodeURIComponent(url.slice('/api/runs/'.length)))
+  // Run history (#303). The list feeds the second sidebar; a single run's log is
+  // replayed client-side into the same projection the live stream drives. A
+  // `?project=<id>` reads that project's archive; absent, the daemon's own cwd.
+  if (pathname === '/api/runs') {
+    void resolveCwd(projects, projectId, cwd).then(target => serveRunList(res, target))
+    return
+  }
+  if (pathname.startsWith('/api/runs/')) {
+    const runId = decodeURIComponent(pathname.slice('/api/runs/'.length))
+    void resolveCwd(projects, projectId, cwd).then(target => serveRun(res, target, runId))
     return
   }
   // Document sidebar (#319): the PLAN.md / TODO.md the agent writes at the
   // workspace root, so the human can read the plan + backlog beside the run.
-  if (url === '/api/docs') {
-    void serveDocs(res, cwd)
+  if (pathname === '/api/docs') {
+    void resolveCwd(projects, projectId, cwd).then(target => serveDocs(res, target))
     return
   }
   // Project log (#314): the committed `.the-framework/LOGS.md` history of every
-  // loop/prompt/build run in this workspace (#378/#379), newest-first.
-  if (url === '/api/logs') {
-    void serveLogs(res, cwd)
+  // loop/prompt/build run in a project (#378/#379), newest-first.
+  if (pathname === '/api/logs') {
+    void resolveCwd(projects, projectId, cwd).then(target => serveLogs(res, target))
     return
   }
-  if (url === '/stop') {
+  if (pathname === '/stop') {
     // The Stop button. Idempotent: a stop after the run has ended just aborts an
     // already-aborted signal (a no-op). 405 for a non-POST so a stray GET can't
     // interrupt a run. 404 when no handler was wired (stopping disabled).
@@ -196,7 +219,7 @@ function handle(
     res.end('{"ok":true}')
     return
   }
-  if (url === '/choice') {
+  if (pathname === '/choice') {
     // An interactive-choice pick (#304). Same guards as /stop: 405 for a non-POST
     // so a stray GET can't resolve a choice, 404 when no handler is wired.
     if (req.method !== 'POST') {
@@ -231,7 +254,7 @@ function handle(
     })
     return
   }
-  if (url === '/api/start') {
+  if (pathname === '/api/start') {
     // Start a new run from the dashboard (#345). Same guards as /stop: POST-only
     // so a stray GET can never spawn a run, 404 when no handler is wired (the
     // per-run dashboard and the relay never start runs). 409 = a run is active.
@@ -336,6 +359,27 @@ function readJsonBody(req: IncomingMessage, cb: (body: Record<string, unknown>) 
     cb(body && typeof body === 'object' ? (body as Record<string, unknown>) : {})
   })
   req.on('error', () => cb({}))
+}
+
+/** `GET /api/projects` — every registered project, summarized (or `[]`). */
+async function serveProjects(res: ServerResponse, projects: ProjectsProvider): Promise<void> {
+  const list = await projects.list().catch(() => [])
+  res.writeHead(200, { 'content-type': 'application/json' })
+  res.end(JSON.stringify({ projects: list }))
+}
+
+/**
+ * The workspace a read endpoint should serve: the project named by `?project=<id>`
+ * when present (its registry path, or `undefined` when the id is unknown, which
+ * the readers surface as empty), else the server's default `cwd`.
+ */
+async function resolveCwd(
+  projects: ProjectsProvider,
+  projectId: string | null,
+  fallback: string | undefined,
+): Promise<string | undefined> {
+  if (!projectId) return fallback
+  return projects.resolvePath(projectId)
 }
 
 /** `GET /api/runs` — the project's archived runs, most-recent first (or `[]`). */

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -92,7 +92,7 @@ export {
   SESSION_ID_PLACEHOLDER,
   OPEN_LOOP_MODES,
 } from './events.js'
-export { startDashboard, dashboardHtml, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunResult } from './dashboard/index.js'
+export { startDashboard, dashboardHtml, summarizeProject, defaultProjectsProvider, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunResult, type ProjectSummary, type ProjectsProvider, type SummarizeDeps } from './dashboard/index.js'
 export {
   RunStore,
   nodeStoreFs,


### PR DESCRIPTION
Closes #392. Part of #314.

Makes the dashboard multi-project on the READ side, which is what unblocks the Projects sidebar (#394). Live streaming + per-project run start/stop stay single-project (that is #393).

## What changed
- `GET /api/projects` lists the registered projects (from the #390 registry) with a per-project summary: `{ id, path, name, activated, lastActivityAt? }` (last activity = newest `LOGS.md` entry).
- `?project=<id>` on `/api/logs`, `/api/runs`, `/api/runs/<id>`, `/api/docs`: resolves the id to that project`\s path via the registry, then runs the existing per-cwd reader unchanged. An absent id keeps the daemon`\s own workspace (single-project back-compat); an unknown id reads empty, never an error.
- The daemon auto-registers its own workspace on boot when it is activated (idempotent, best-effort), so the Projects list is populated for the common single-project case before the Add-project UI (#396) lands.
- New `ProjectsProvider` seam (default = the real registry; tests inject a fake), `ProjectSummary`, and a `summarizeProject` helper.

Routing now parses the URL once (`pathname` + `searchParams`) so a `?project=` query never bleeds into the pathname match and a run id is read from the path, not the query.

## Design note (the open point the issue flagged)
The issue listed "daemon-state relocation vs back-compat" as a design point to settle here. I settled it by DEFERRING the liveness relocation (global `daemon.json`, one-daemon-for-the-machine) to #393: it is coupled to the run-side steering check (`cli.ts` `daemonStatus(cwd)`) and per-project run start/stop, which are #393`\s scope. A per-workspace daemon already lists every registered project and reads any project by path, so the sidebar is fully unblocked without it.

## Tests
- `projects.test.ts`: `summarizeProject` with injected readers (name, newest-first last activity, no-logs -> no key, activation, forgiving on throw).
- `server.test.ts`: `/api/projects` over real HTTP with a fake provider; `?project=<id>` reading a real seeded temp workspace, and an unknown id reading `[]`.
Package suite green (424 pass, 1 pre-existing skip), typecheck clean. No new deps.