### PR TITLE
feat(framework): Projects sidebar (Overview / Projects / Queue)

### DIFF
--- a/.changeset/projects-sidebar.md
+++ b/.changeset/projects-sidebar.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Add the Projects sidebar to the dashboard: a leftmost nav with Overview (project count plus the most recently active projects), Projects (every registered project with an activation dot and last-activity, from `/api/projects`), and Queue (the open TODO items aggregated across all projects). Selecting a project re-points the project log to `?project=<id>`. The per-project second sidebar and main view come next.

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -68,6 +68,28 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   #runs .st-running { color: #6ea8fe; }
   #runs .empty { color: #5c657a; font-size: 12px; padding: 6px; cursor: default; }
   #runs .empty:hover { background: none; }
+  /* Projects sidebar (#314/#394): the leftmost nav — Overview, Projects, Queue.
+     Selecting a project re-points the project log (and, later, the main view). */
+  #projects-sidebar { flex: 0 0 220px; width: 220px; border-right: 1px solid #1c2230; padding: 14px 10px;
+    overflow-y: auto; max-height: calc(100vh - 57px); position: sticky; top: 57px; }
+  #projects-sidebar h2 { margin: 16px 0 8px; padding: 0 6px; font-size: 12px; text-transform: uppercase;
+    letter-spacing: .8px; color: #7b8496; font-weight: 600; }
+  #projects-sidebar h2:first-child { margin-top: 0; }
+  #projects li, #overview .ov-item, #queue li { padding: 7px 8px; border-bottom: 1px solid #161b26;
+    cursor: pointer; border-radius: 6px; }
+  #projects li:hover, #overview .ov-item:hover, #queue li:hover { background: #141a24; }
+  #projects li.active { background: #17212f; }
+  #projects .p-name, #overview .ov-name { color: #d7dce5; font-size: 13px; display: flex; align-items: center;
+    gap: 6px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  #projects .p-meta, #overview .ov-meta { color: #7b8496; font-size: 11px; margin-top: 2px; }
+  #projects .adot { font-size: 9px; }
+  #projects .on { color: #67d98f; }
+  #projects .off { color: #5c657a; }
+  #overview .ov-count { color: #b7c0d0; font-size: 12px; padding: 2px 6px 8px; }
+  #queue .q-text { color: #cdd4e0; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  #queue .q-proj { color: #7b8496; font-size: 10px; text-transform: uppercase; letter-spacing: .5px; margin-top: 2px; }
+  #projects .empty, #overview .empty, #queue .empty { color: #5c657a; font-size: 12px; padding: 6px; cursor: default; }
+  #projects .empty:hover, #overview .empty:hover, #queue .empty:hover { background: none; }
   #viewing { display: none; align-items: center; gap: 8px; padding: 8px 20px; font-size: 12px;
     background: #16202e; border-bottom: 1px solid #24344a; color: #9db4d6; }
   #viewing.on { display: flex; }
@@ -224,6 +246,14 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   <button id="stop" hidden>■ Stop</button>
 </header>
 <div id="layout">
+<aside id="projects-sidebar">
+  <h2>Overview</h2>
+  <div id="overview"><div class="empty">loading…</div></div>
+  <h2>Projects</h2>
+  <ul id="projects"><li class="empty">loading…</li></ul>
+  <h2>Queue</h2>
+  <ul id="queue"><li class="empty">loading…</li></ul>
+</aside>
 <aside id="sidebar">
   <h2>Runs</h2>
   <ul id="runs"><li class="empty">loading…</li></ul>
@@ -703,7 +733,114 @@ function renderProjectLog(logs) {
 }
 
 function loadLogs() {
-  fetch('api/logs').then(r => r.ok ? r.json() : { logs: [] }).then(d => renderProjectLog(d.logs || [])).catch(() => {});
+  const q = selectedProjectId ? '?project=' + encodeURIComponent(selectedProjectId) : '';
+  fetch('api/logs' + q).then(r => r.ok ? r.json() : { logs: [] }).then(d => renderProjectLog(d.logs || [])).catch(() => {});
+}
+
+// Projects sidebar (#314/#394): the registered projects come from /api/projects
+// (#392). Selecting one re-points the project log to ?project=<id>; the per-project
+// second sidebar + main view land in #395. All fields are path/agent-controlled, so
+// every value is escaped.
+let allProjects = [];
+let selectedProjectId = null;
+
+function ago(iso) {
+  if (!iso) return 'no activity yet';
+  const then = new Date(iso).getTime();
+  if (!then) return 'no activity yet';
+  const secs = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (secs < 60) return 'just now';
+  const mins = Math.round(secs / 60); if (mins < 60) return mins + 'm ago';
+  const hrs = Math.round(mins / 60); if (hrs < 24) return hrs + 'h ago';
+  return Math.round(hrs / 24) + 'd ago';
+}
+
+// Newest activity first; projects that never ran sort last.
+function byRecency(a, b) {
+  return (b.lastActivityAt ? Date.parse(b.lastActivityAt) : 0) - (a.lastActivityAt ? Date.parse(a.lastActivityAt) : 0);
+}
+
+function selectProject(id) {
+  selectedProjectId = selectedProjectId === id ? null : id;
+  markProjectActive();
+  loadLogs();
+}
+
+function markProjectActive() {
+  for (const li of $('projects').children) {
+    if (li.dataset) li.classList.toggle('active', li.dataset.id === selectedProjectId);
+  }
+}
+
+function renderProjects(projects) {
+  allProjects = projects.slice();
+  const ul = $('projects'); ul.innerHTML = '';
+  if (!projects.length) { ul.innerHTML = '<li class="empty">No projects yet.</li>'; return; }
+  for (const p of projects.slice().sort(byRecency)) {
+    const li = document.createElement('li');
+    li.dataset.id = p.id;
+    const dot = p.activated ? '<span class="adot on">\\u25cf</span>' : '<span class="adot off" title="marker missing">\\u25cb</span>';
+    li.innerHTML = '<div class="p-name">' + dot + '<span>' + esc(p.name || 'project') + '</span></div>' +
+      '<div class="p-meta">' + esc(ago(p.lastActivityAt)) + '</div>';
+    li.addEventListener('click', () => selectProject(p.id));
+    ul.appendChild(li);
+  }
+  markProjectActive();
+  renderOverview(projects);
+}
+
+function renderOverview(projects) {
+  const box = $('overview'); box.innerHTML = '';
+  if (!projects.length) { box.innerHTML = '<div class="empty">No projects yet.</div>'; return; }
+  const active = projects.filter(p => p.activated).length;
+  const count = document.createElement('div'); count.className = 'ov-count';
+  count.textContent = projects.length + ' project' + (projects.length === 1 ? '' : 's') + ' \\u00b7 ' + active + ' active';
+  box.appendChild(count);
+  for (const p of projects.slice().sort(byRecency).slice(0, 3)) {
+    const row = document.createElement('div'); row.className = 'ov-item'; row.dataset.id = p.id;
+    row.innerHTML = '<div class="ov-name"><span>' + esc(p.name || 'project') + '</span></div>' +
+      '<div class="ov-meta">' + esc(ago(p.lastActivityAt)) + '</div>';
+    row.addEventListener('click', () => selectProject(p.id));
+    box.appendChild(row);
+  }
+}
+
+function loadProjects() {
+  fetch('api/projects').then(r => r.ok ? r.json() : { projects: [] })
+    .then(d => { renderProjects(d.projects || []); loadQueue(); }).catch(() => {});
+}
+
+// Queue (#314): the open TODO items across all projects. Each project's TODO.md is
+// surfaced by /api/docs (#319); we pull the unchecked checklist lines and tag each
+// with its project, so the whole backlog is one glanceable list.
+function todoItems(content) {
+  const out = [];
+  for (const line of String(content).split('\\n')) {
+    const m = /^\\s*[-*]\\s+\\[ \\]\\s+(.+?)\\s*$/.exec(line);
+    if (m) out.push(m[1]);
+  }
+  return out;
+}
+
+function renderQueue(items) {
+  const ul = $('queue'); ul.innerHTML = '';
+  if (!items.length) { ul.innerHTML = '<li class="empty">Queue is empty.</li>'; return; }
+  for (const it of items.slice(0, 24)) {
+    const li = document.createElement('li'); li.dataset.id = it.projectId;
+    li.innerHTML = '<div class="q-text">' + esc(it.text) + '</div><div class="q-proj">' + esc(it.projectName) + '</div>';
+    li.addEventListener('click', () => selectProject(it.projectId));
+    ul.appendChild(li);
+  }
+}
+
+function loadQueue() {
+  const projects = allProjects.slice();
+  Promise.all(projects.map(p =>
+    fetch('api/docs?project=' + encodeURIComponent(p.id)).then(r => r.ok ? r.json() : { docs: [] })
+      .then(d => (d.docs || []).filter(doc => /todo/i.test(doc.name || ''))
+        .flatMap(doc => todoItems(doc.content).map(text => ({ projectId: p.id, projectName: p.name || 'project', text }))))
+      .catch(() => [])
+  )).then(perProject => renderQueue(perProject.flat())).catch(() => {});
 }
 
 // Document sidebar (#319): render the PLAN.md / TODO.md the agent writes at the
@@ -945,8 +1082,9 @@ src.onmessage = ev => {
   if (mode === 'live') render(fe);
   // A finished run has just been archived; refresh the list so it appears.
   if (fe.kind === 'end') setTimeout(loadRuns, 1500);
-  // A finished run also appends to .the-framework/LOGS.md (#379); refresh the log.
-  if (fe.kind === 'end') setTimeout(loadLogs, 1500);
+  // A finished run also appends to .the-framework/LOGS.md (#379); refresh the log
+  // and the projects sidebar so recency + the queue stay current.
+  if (fe.kind === 'end') { setTimeout(loadLogs, 1500); setTimeout(loadProjects, 1500); }
   // A plan/backlog is usually written right before a choice gate or at run end;
   // refresh the doc sidebar promptly so PLAN.md / TODO.md appear without waiting.
   if (fe.kind === 'choice' || fe.kind === 'end') setTimeout(loadDocs, 500);
@@ -958,6 +1096,8 @@ loadDocs();
 setInterval(loadDocs, 4000);
 loadLogs();
 setInterval(loadLogs, 10000);
+loadProjects();
+setInterval(loadProjects, 10000);
 `
 }
 

--- a/packages/framework/src/dashboard/projects-sidebar.test.ts
+++ b/packages/framework/src/dashboard/projects-sidebar.test.ts
@@ -1,0 +1,110 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { JSDOM } from 'jsdom'
+import { dashboardHtml } from './page.js'
+
+// The Projects sidebar (#394) renders /api/projects into Overview / Projects /
+// Queue, and selecting a project re-points the project log to ?project=<id>. This
+// drives the real client JS in jsdom, answering its fetches with canned payloads.
+
+interface Harness {
+  query: (sel: string) => Element | null
+  queryAll: (sel: string) => Element[]
+  calls: string[]
+}
+
+function boot(opts: {
+  projects: unknown[]
+  docsByProject?: Record<string, unknown[]>
+}): Harness {
+  const calls: string[] = []
+  const dom = new JSDOM(dashboardHtml('Test', true, true, true), {
+    runScripts: 'dangerously',
+    url: 'http://localhost/',
+    beforeParse(window) {
+      const w = window as unknown as { [k: string]: unknown }
+      w['setInterval'] = () => 0
+      w['setTimeout'] = () => 0
+      w['EventSource'] = class {
+        onmessage: ((ev: { data: string }) => void) | null = null
+        onerror: (() => void) | null = null
+        close() {}
+      }
+      w['fetch'] = (url: string) => {
+        calls.push(url)
+        let body: unknown = {}
+        if (url === 'api/projects') body = { projects: opts.projects }
+        else if (url.indexOf('api/logs') === 0) body = { logs: [] }
+        else if (url.indexOf('api/docs') === 0) {
+          const id = decodeURIComponent((url.split('project=')[1] || ''))
+          body = { docs: (opts.docsByProject || {})[id] || [] }
+        } else if (url.indexOf('api/runs') === 0) body = { runs: [] }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(body) })
+      }
+    },
+  })
+  const doc = dom.window.document
+  return {
+    query: sel => doc.querySelector(sel),
+    queryAll: sel => [...doc.querySelectorAll(sel)],
+    calls,
+  }
+}
+
+// The page fetches on load then chains (projects -> queue); give microtasks room.
+const tick = async () => { for (let i = 0; i < 5; i++) await new Promise(r => setImmediate(r)) }
+
+const PROJECTS = [
+  { id: 'a-1', path: '/repos/app-a', name: 'app-a', activated: true, lastActivityAt: '2026-07-11T10:00:00.000Z' },
+  { id: 'b-2', path: '/repos/app-b', name: 'app-b', activated: false },
+]
+
+test('the Projects list renders each project, newest activity first, with an activation dot', async () => {
+  const h = boot({ projects: PROJECTS })
+  await tick()
+  const items = h.queryAll('#projects > li')
+  assert.equal(items.length, 2)
+  assert.match(items[0]!.textContent ?? '', /app-a/) // most recent first
+  assert.match(items[1]!.textContent ?? '', /app-b/)
+  assert.ok(h.query('#projects .adot.on'), 'an activated project shows the filled dot')
+  assert.ok(h.query('#projects .adot.off'), 'a project whose marker is gone shows the hollow dot')
+})
+
+test('the Overview shows a project count and active tally', async () => {
+  const h = boot({ projects: PROJECTS })
+  await tick()
+  assert.match(h.query('#overview .ov-count')!.textContent ?? '', /2 projects.*1 active/)
+})
+
+test('selecting a project marks it active and re-points the project log to ?project=<id>', async () => {
+  const h = boot({ projects: PROJECTS })
+  await tick()
+  const first = h.query('#projects > li') as HTMLElement
+  ;(first as unknown as { click: () => void }).click()
+  await tick()
+  assert.ok(first.classList.contains('active'), 'the clicked project is highlighted')
+  assert.ok(h.calls.some(u => u === 'api/logs?project=a-1'), 'the log is refetched scoped to the project')
+})
+
+test('the Queue aggregates unchecked TODO items across projects, tagged by project', async () => {
+  const h = boot({
+    projects: PROJECTS,
+    docsByProject: {
+      'a-1': [{ name: 'TODO.md', content: '# Todo\n- [ ] ship the sidebar\n- [x] done already\n- [ ] write tests\n' }],
+      'b-2': [{ name: 'PLAN.md', content: 'no checklist here' }],
+    },
+  })
+  await tick()
+  const items = h.queryAll('#queue > li')
+  assert.equal(items.length, 2) // only the two unchecked items from app-a
+  assert.match(items[0]!.textContent ?? '', /ship the sidebar/)
+  assert.match(items[0]!.textContent ?? '', /app-a/)
+  assert.doesNotMatch(h.query('#queue')!.textContent ?? '', /done already/)
+})
+
+test('a project name is rendered as inert text, never markup (XSS)', async () => {
+  const h = boot({ projects: [{ id: 'x-1', path: '/x', name: '<img src=x onerror=alert(1)>', activated: true }] })
+  await tick()
+  assert.equal(h.queryAll('#projects img').length, 0, 'no element is injected from the name')
+  assert.match(h.query('#projects')!.innerHTML, /&lt;img/, 'the name is HTML-escaped')
+})


### PR DESCRIPTION
Closes #394. Part of #314.

Adds the leftmost dashboard nav, over the read endpoints from #392. Pure `page.ts` (self-contained HTML/CSS/JS, no build step, no deps).

## Sections
- **Overview**: project count + active tally, and the 3 most recently active projects (clickable).
- **Projects**: every registered project from `/api/projects` with an activation dot (filled = marker present, hollow = gone) and a relative last-activity, newest first.
- **Queue**: the open (`- [ ]`) TODO items aggregated across every project via `/api/docs?project=<id>`, each tagged with its project and clickable.

## Selection
Clicking a project (in Projects, Overview, or Queue) selects it, highlights it, and re-points the project log to `/api/logs?project=<id>`. Clicking it again clears the selection (back to the daemon`\s own workspace). The per-project second sidebar and the main view land in #395; this wires the selection state they build on.

All project/path/TODO fields are agent- or path-controlled, so every value goes through the existing `esc()` before it reaches the DOM.

## Tests
`projects-sidebar.test.ts`, jsdom driving the real client JS (same harness as `projectlog.test.ts`): list render + recency order + activation dots, the Overview tally, selection marking active and refetching `api/logs?project=`, Queue aggregation of unchecked TODO items tagged by project (skips checked/`[x]` and non-TODO docs), and an XSS case proving a project name is inert text. Suite green (429 pass, 1 pre-existing skip), typecheck clean.