### PR TITLE
feat(framework): Add project(s) install flow

### DIFF
--- a/.changeset/add-project-flow.md
+++ b/.changeset/add-project-flow.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Add the "Add project(s)" install flow to the dashboard. A `POST /api/projects` (guarded like the other state-changing routes) installs The Framework into a repo, or every git repo directly under a folder, then registers each so it shows up in the Projects list; the daemon wires it to install-core. The Projects sidebar gains an "Add" control with a small path form (single repo or "folder of repos"), shown only when the server enables adding. Also fixes `enumerateGitRepos` to detect repo roots via `git rev-parse --show-prefix` instead of comparing `--show-toplevel` to the path, which failed across a symlink (e.g. macOS `/var` -> `/private/var`) and returned no repos.

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -4,10 +4,11 @@ import { mkdir, readFile, writeFile, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { FrameworkEvent } from './events.js'
 import { EVENTS_FILE, FRAMEWORK_DIR } from './store/index.js'
-import { startDashboard, type Dashboard, type StartRunKind, type StartRunOptions, type StartRunResult } from './dashboard/index.js'
+import { startDashboard, type Dashboard, type StartRunKind, type StartRunOptions, type StartRunResult, type AddProjectResult } from './dashboard/index.js'
 import { appendControl } from './control.js'
 import { isActivated } from './project.js'
 import { addProject } from './registry.js'
+import { installProject, enumerateGitRepos } from './install.js'
 import { JsonlTailer } from './jsonl-tail.js'
 
 /**
@@ -290,12 +291,32 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     return { ok: true }
   }
 
+  // Add project(s) (#396): install a single repo, or every git repo directly under
+  // a directory, then register each so it appears in the Projects list. installProject
+  // is idempotent (an already-activated repo is a no-op success); a git failure on any
+  // target aborts and surfaces as an error the dialog shows.
+  const addProjects = async (path: string, directory: boolean): Promise<AddProjectResult> => {
+    const targets = directory ? await enumerateGitRepos(path) : [path]
+    if (!targets.length) return { ok: false, error: `no git repositories found under ${path}` }
+    let added = 0
+    let alreadyActivated = 0
+    for (const repo of targets) {
+      const result = await installProject(repo)
+      if (!result.ok) return { ok: false, error: result.error }
+      if (result.alreadyActivated) alreadyActivated++
+      else added++
+      await addProject(repo, new Date().toISOString()).catch(() => {})
+    }
+    return { ok: true, added, alreadyActivated }
+  }
+
   const dashboard: Dashboard = await startDashboard({
     port,
     cwd,
     onStop: () => void appendControl(cwd, { kind: 'stop' }).catch(() => {}),
     onChoice: (id, pick, by) => void appendControl(cwd, { kind: 'choice', id, pick, by }).catch(() => {}),
     onStart: startRun,
+    onAddProject: addProjects,
   })
   const eventsPath = join(daemonDir(cwd), EVENTS_FILE)
   const tailer = new EventTailer(eventsPath, event => dashboard.push(event))

--- a/packages/framework/src/dashboard/add-project.test.ts
+++ b/packages/framework/src/dashboard/add-project.test.ts
@@ -1,0 +1,88 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { JSDOM } from 'jsdom'
+import { dashboardHtml } from './page.js'
+
+// The Add project(s) control (#396) POSTs a path to /api/projects and reloads the
+// list on success. Drives the real client JS in jsdom, recording each fetch.
+
+interface Call { url: string; method: string; body: string | undefined }
+
+function boot(addable: boolean): {
+  query: (sel: string) => Element | null
+  calls: Call[]
+  window: Window & typeof globalThis
+} {
+  const calls: Call[] = []
+  const dom = new JSDOM(dashboardHtml('Test', true, true, true, addable), {
+    runScripts: 'dangerously',
+    url: 'http://localhost/',
+    beforeParse(window) {
+      const w = window as unknown as { [k: string]: unknown }
+      w['setInterval'] = () => 0
+      w['setTimeout'] = () => 0
+      w['EventSource'] = class {
+        onmessage: ((ev: { data: string }) => void) | null = null
+        onerror: (() => void) | null = null
+        close() {}
+      }
+      w['fetch'] = (url: string, opts?: { method?: string; body?: string }) => {
+        const method = (opts && opts.method) || 'GET'
+        calls.push({ url, method, body: opts && opts.body })
+        let body: unknown = {}
+        if (url === 'api/projects' && method === 'POST') body = { ok: true, added: 1, alreadyActivated: 0 }
+        else if (url === 'api/projects') body = { projects: [] }
+        else if (url.indexOf('api/logs') === 0) body = { logs: [] }
+        else if (url.indexOf('api/docs') === 0) body = { docs: [] }
+        else if (url.indexOf('api/runs') === 0) body = { runs: [] }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(body) })
+      }
+    },
+  })
+  return {
+    query: sel => dom.window.document.querySelector(sel),
+    calls,
+    window: dom.window as unknown as Window & typeof globalThis,
+  }
+}
+
+const tick = async () => { for (let i = 0; i < 5; i++) await new Promise(r => setImmediate(r)) }
+
+test('the Add control is hidden unless the server enables adding', async () => {
+  assert.equal(boot(false).query('#add-project')!.hasAttribute('hidden'), true)
+  assert.equal(boot(true).query('#add-project')!.hasAttribute('hidden'), false)
+})
+
+test('adding a project POSTs the path, shows a result, and reloads the list', async () => {
+  const h = boot(true)
+  await tick()
+  // The form starts hidden; the Add button reveals it.
+  assert.equal(h.query('#add-project-form')!.hasAttribute('hidden'), true)
+  ;(h.query('#add-project') as unknown as { click: () => void }).click()
+  assert.equal(h.query('#add-project-form')!.hasAttribute('hidden'), false)
+
+  const input = h.query('#add-project-path') as HTMLInputElement
+  input.value = '/repos/app-a'
+  ;(h.query('#add-project-dir') as HTMLInputElement).checked = true
+  h.query('#add-project-form')!.dispatchEvent(new h.window.Event('submit', { cancelable: true, bubbles: true }))
+  await tick()
+
+  const post = h.calls.find(c => c.url === 'api/projects' && c.method === 'POST')
+  assert.ok(post, 'a POST to /api/projects was made')
+  assert.deepEqual(JSON.parse(post!.body ?? '{}'), { path: '/repos/app-a', directory: true })
+  assert.match(h.query('#add-project-note')!.textContent ?? '', /added 1 project/)
+  // The list is reloaded (a GET after the POST) and the path input is cleared.
+  assert.ok(h.calls.some(c => c.url === 'api/projects' && c.method === 'GET'))
+  assert.equal(input.value, '')
+})
+
+test('an empty path is rejected client-side without a POST', async () => {
+  const h = boot(true)
+  await tick()
+  ;(h.query('#add-project') as unknown as { click: () => void }).click()
+  const before = h.calls.filter(c => c.method === 'POST').length
+  h.query('#add-project-form')!.dispatchEvent(new h.window.Event('submit', { cancelable: true, bubbles: true }))
+  await tick()
+  assert.equal(h.calls.filter(c => c.method === 'POST').length, before, 'no POST for an empty path')
+  assert.match(h.query('#add-project-note')!.textContent ?? '', /enter a path/)
+})

--- a/packages/framework/src/dashboard/index.ts
+++ b/packages/framework/src/dashboard/index.ts
@@ -1,4 +1,4 @@
-export { startDashboard, parseStartOptions, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunOptions, type StartRunResult } from './server.js'
+export { startDashboard, parseStartOptions, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunOptions, type StartRunResult, type AddProjectResult } from './server.js'
 export {
   summarizeProject,
   defaultProjectsProvider,

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -11,7 +11,7 @@ import { renderMaintainabilityMinimalPrompt } from '../maintainability-minimal-p
  * that foreground the orchestration (stack rationale, loop status, decisions)
  * beside a tail of the wrapped agent's own activity.
  */
-export function dashboardHtml(title: string, stoppable = false, choiceable = false, startable = false): string {
+export function dashboardHtml(title: string, stoppable = false, choiceable = false, startable = false, addable = false): string {
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -90,6 +90,25 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   #queue .q-proj { color: #7b8496; font-size: 10px; text-transform: uppercase; letter-spacing: .5px; margin-top: 2px; }
   #projects .empty, #overview .empty, #queue .empty { color: #5c657a; font-size: 12px; padding: 6px; cursor: default; }
   #projects .empty:hover, #overview .empty:hover, #queue .empty:hover { background: none; }
+  /* Add project(s) (#396): a small install form under the Projects heading. */
+  #projects-head { display: flex; align-items: center; justify-content: space-between; margin: 16px 0 8px; }
+  #projects-head h2 { margin: 0; }
+  #add-project { font: inherit; font-size: 12px; cursor: pointer; color: #9db4d6; background: #131a2a;
+    border: 1px solid #24344a; border-radius: 6px; padding: 2px 8px; }
+  #add-project:hover { background: #17212f; }
+  #add-project[hidden] { display: none; }
+  #add-project-form { padding: 8px 6px 10px; display: flex; flex-direction: column; gap: 6px; }
+  #add-project-form[hidden] { display: none; }
+  #add-project-form input[type=text] { font: inherit; font-size: 12px; color: #d7dce5; background: #0d1119;
+    border: 1px solid #24344a; border-radius: 6px; padding: 6px 8px; width: 100%; box-sizing: border-box; }
+  #add-project-form label { color: #8b93a3; font-size: 12px; display: flex; align-items: center; gap: 6px; }
+  #add-project-actions { display: flex; gap: 6px; }
+  #add-project-actions button { font: inherit; font-size: 12px; cursor: pointer; border-radius: 6px; padding: 4px 10px; }
+  #add-project-submit { color: #cfe6d6; background: #12241a; border: 1px solid #2f6f4a; }
+  #add-project-cancel { color: #b7c0d0; background: #141a24; border: 1px solid #24344a; }
+  #add-project-note { font-size: 11px; color: #7b8496; }
+  #add-project-note.err { color: #e2686a; }
+  #add-project-note.ok { color: #67d98f; }
   #viewing { display: none; align-items: center; gap: 8px; padding: 8px 20px; font-size: 12px;
     background: #16202e; border-bottom: 1px solid #24344a; color: #9db4d6; }
   #viewing.on { display: flex; }
@@ -269,7 +288,19 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
 <aside id="projects-sidebar">
   <h2>Overview</h2>
   <div id="overview"><div class="empty">loading…</div></div>
-  <h2>Projects</h2>
+  <div id="projects-head">
+    <h2>Projects</h2>
+    <button id="add-project"${addable ? '' : ' hidden'} title="Install The Framework into a repo (or every repo in a folder)">+ Add</button>
+  </div>
+  <form id="add-project-form" hidden>
+    <input id="add-project-path" type="text" placeholder="/absolute/path/to/repo" autocomplete="off" />
+    <label><input type="checkbox" id="add-project-dir" /> It&#39;s a folder of repos</label>
+    <div id="add-project-actions">
+      <button type="submit" id="add-project-submit">Add</button>
+      <button type="button" id="add-project-cancel">Cancel</button>
+    </div>
+    <span id="add-project-note"></span>
+  </form>
   <ul id="projects"><li class="empty">loading…</li></ul>
   <h2>Queue</h2>
   <ul id="queue"><li class="empty">loading…</li></ul>
@@ -371,18 +402,19 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
 </aside>
 </div>
 <script>
-${clientScript(stoppable, choiceable, startable)}
+${clientScript(stoppable, choiceable, startable, addable)}
 </script>
 </body>
 </html>`
 }
 
-function clientScript(stoppable: boolean, choiceable: boolean, startable: boolean): string {
+function clientScript(stoppable: boolean, choiceable: boolean, startable: boolean, addable: boolean): string {
   // Runs in the browser. Keep it dependency-free.
   return `
 const STOPPABLE = ${stoppable ? 'true' : 'false'};
 const CHOICEABLE = ${choiceable ? 'true' : 'false'};
 const STARTABLE = ${startable ? 'true' : 'false'};
+const ADDABLE = ${addable ? 'true' : 'false'};
 const RESEARCH_PROMPT = ${JSON.stringify(renderResearchPrompt())};
 const READABILITY_PROMPT = ${JSON.stringify(renderReadabilityPrompt())};
 const MAINTAINABILITY_PROMPT = ${JSON.stringify(renderMaintainabilityPrompt())};
@@ -938,6 +970,53 @@ function loadQueue() {
         .flatMap(doc => todoItems(doc.content).map(text => ({ projectId: p.id, projectName: p.name || 'project', text }))))
       .catch(() => [])
   )).then(perProject => renderQueue(perProject.flat())).catch(() => {});
+}
+
+// Add project(s) (#396): install The Framework into a repo (or every git repo in a
+// folder) and register it. The install + commit happen server-side; on success we
+// just reload the Projects list.
+function toggleAddProject(show) {
+  const form = $('add-project-form');
+  form.hidden = !show;
+  $('add-project-note').textContent = '';
+  if (show) $('add-project-path').focus();
+}
+
+function submitAddProject(ev) {
+  ev.preventDefault();
+  if (!ADDABLE) return;
+  const note = $('add-project-note');
+  note.className = '';
+  const path = $('add-project-path').value.trim();
+  if (!path) { note.className = 'err'; note.textContent = 'enter a path first'; return; }
+  const directory = $('add-project-dir').checked;
+  $('add-project-submit').disabled = true;
+  note.textContent = 'installing\\u2026';
+  fetch('api/projects', { method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ path: path, directory: directory }) })
+    .then(async r => {
+      $('add-project-submit').disabled = false;
+      let body = {}; try { body = await r.json(); } catch {}
+      if (r.ok && body.ok) {
+        const n = (body.added || 0) + (body.alreadyActivated || 0);
+        note.className = 'ok';
+        note.textContent = 'added ' + n + ' project' + (n === 1 ? '' : 's');
+        $('add-project-path').value = '';
+        $('add-project-dir').checked = false;
+        loadProjects();
+        return;
+      }
+      note.className = 'err';
+      note.textContent = (body && body.error) ? body.error : 'could not add (' + r.status + ')';
+    })
+    .catch(() => { $('add-project-submit').disabled = false; note.className = 'err';
+      note.textContent = 'could not reach the dashboard server'; });
+}
+
+if (ADDABLE) {
+  $('add-project').addEventListener('click', () => toggleAddProject($('add-project-form').hidden));
+  $('add-project-cancel').addEventListener('click', () => toggleAddProject(false));
+  $('add-project-form').addEventListener('submit', submitAddProject);
 }
 
 // Document sidebar (#319): render the PLAN.md / TODO.md the agent writes at the

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -362,6 +362,54 @@ test('/stop is 405 for a non-POST and 404 when stopping is not wired (#218)', as
   }
 })
 
+test('POST /api/projects installs + registers via onAddProject (#396)', async () => {
+  const calls: Array<{ path: string; directory: boolean }> = []
+  const dash = await startDashboard({
+    port: 0,
+    onAddProject: (path, directory) => {
+      calls.push({ path, directory })
+      return { ok: true, added: directory ? 2 : 1, alreadyActivated: 0 }
+    },
+  })
+  try {
+    // A single repo.
+    const one = await postJson(dash.url + '/api/projects', { path: '/repos/app-a' })
+    assert.equal(one.status, 202)
+    assert.deepEqual(JSON.parse(one.body), { ok: true, added: 1, alreadyActivated: 0 })
+    // A folder of repos.
+    const many = await postJson(dash.url + '/api/projects', { path: '/repos', directory: true })
+    assert.equal(JSON.parse(many.body).added, 2)
+    assert.deepEqual(calls, [
+      { path: '/repos/app-a', directory: false },
+      { path: '/repos', directory: true },
+    ])
+    // A missing path is a 400 and never reaches the handler.
+    assert.equal((await postJson(dash.url + '/api/projects', {})).status, 400)
+    assert.equal(calls.length, 2)
+  } finally {
+    await dash.close()
+  }
+})
+
+test('POST /api/projects surfaces a failed install as 400, and is 404 when adding is disabled (#396)', async () => {
+  const failing = await startDashboard({ port: 0, onAddProject: () => ({ ok: false, error: 'not a git repo' }) })
+  try {
+    const res = await postJson(failing.url + '/api/projects', { path: '/nope' })
+    assert.equal(res.status, 400)
+    assert.deepEqual(JSON.parse(res.body), { ok: false, error: 'not a git repo' })
+  } finally {
+    await failing.close()
+  }
+  // No handler wired -> 404 (adding disabled), and a cross-origin POST is refused.
+  const noAdd = await startDashboard({ port: 0 })
+  try {
+    assert.equal((await postJson(noAdd.url + '/api/projects', { path: '/x' })).status, 404)
+    assert.equal((await postJson(noAdd.url + '/api/projects', { path: '/x' }, { origin: 'https://evil.example' })).status, 403)
+  } finally {
+    await noAdd.close()
+  }
+})
+
 function postJson(
   url: string,
   body: unknown,

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -54,7 +54,19 @@ export interface DashboardOptions {
    * back-compat) and the target the live stream + run start/stop still follow (#393).
    */
   projects?: ProjectsProvider
+  /**
+   * Install + register projects (#396): `POST /api/projects` with a JSON
+   * `{ path, directory? }` body. Wire this to install the repo (or every git repo
+   * under a directory) and add it to the registry (the daemon does). Omit to
+   * disable adding; the page hides the "Add project(s)" control.
+   */
+  onAddProject?: (path: string, directory: boolean) => Promise<AddProjectResult> | AddProjectResult
 }
+
+/** The outcome of an {@link DashboardOptions.onAddProject} attempt (#396). */
+export type AddProjectResult =
+  | { ok: true; added: number; alreadyActivated: number }
+  | { ok: false; error: string }
 
 /**
  * The dashboard's Global options (#314), posted alongside a Start. Each maps to a
@@ -118,10 +130,11 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
   const onStart = opts.onStart
   const cwd = opts.cwd
   const projects = opts.projects ?? defaultProjectsProvider()
+  const onAddProject = opts.onAddProject
   const stream = new EventStream<FrameworkEvent>()
   const clients = new Set<ServerResponse>()
 
-  const server = createServer((req, res) => handle(req, res, stream, clients, title, onStop, onChoice, onStart, cwd, projects))
+  const server = createServer((req, res) => handle(req, res, stream, clients, title, onStop, onChoice, onStart, cwd, projects, onAddProject))
 
   return new Promise<Dashboard>((resolvePromise, rejectPromise) => {
     server.once('error', rejectPromise)
@@ -150,6 +163,7 @@ function handle(
   onStart: ((prompt: string, kind: StartRunKind, options: StartRunOptions) => StartRunResult) | undefined,
   cwd: string | undefined,
   projects: ProjectsProvider,
+  onAddProject: ((path: string, directory: boolean) => Promise<AddProjectResult> | AddProjectResult) | undefined,
 ): void {
   const url = req.url ?? '/'
   // Parse once so a `?project=<id>` query never bleeds into the pathname match
@@ -158,16 +172,48 @@ function handle(
   const projectId = searchParams.get('project')
   if (pathname === '/') {
     res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
-    res.end(dashboardHtml(title, Boolean(onStop), Boolean(onChoice), Boolean(onStart)))
+    res.end(dashboardHtml(title, Boolean(onStop), Boolean(onChoice), Boolean(onStart), Boolean(onAddProject)))
     return
   }
   if (pathname === '/events') {
     serveSSE(req, res, stream, clients)
     return
   }
-  // The registered projects (#392): the Projects sidebar lists these, then reads
-  // one via `?project=<id>` on the endpoints below.
+  // The registered projects (#392): the Projects sidebar lists these (GET), then
+  // reads one via `?project=<id>` on the endpoints below. A POST installs + adds a
+  // project (#396) through the wired handler, guarded like the other POST routes.
   if (pathname === '/api/projects') {
+    if (req.method === 'POST') {
+      if (!isSameOriginRequest(req)) {
+        res.writeHead(403, { 'content-type': 'text/plain' })
+        res.end('cross-origin request forbidden')
+        return
+      }
+      if (!onAddProject) {
+        res.writeHead(404, { 'content-type': 'text/plain' })
+        res.end('adding projects not enabled')
+        return
+      }
+      readJsonBody(req, body => {
+        const path = typeof body['path'] === 'string' ? body['path'].trim() : ''
+        const directory = body['directory'] === true
+        if (!path) {
+          res.writeHead(400, { 'content-type': 'application/json' })
+          res.end('{"error":"a project path is required"}')
+          return
+        }
+        void Promise.resolve(onAddProject(path, directory))
+          .then(result => {
+            res.writeHead(result.ok ? 202 : 400, { 'content-type': 'application/json' })
+            res.end(JSON.stringify(result))
+          })
+          .catch(err => {
+            res.writeHead(500, { 'content-type': 'application/json' })
+            res.end(JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) }))
+          })
+      })
+      return
+    }
     void serveProjects(res, projects)
     return
   }

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -92,7 +92,7 @@ export {
   SESSION_ID_PLACEHOLDER,
   OPEN_LOOP_MODES,
 } from './events.js'
-export { startDashboard, dashboardHtml, summarizeProject, defaultProjectsProvider, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunResult, type ProjectSummary, type ProjectsProvider, type SummarizeDeps } from './dashboard/index.js'
+export { startDashboard, dashboardHtml, summarizeProject, defaultProjectsProvider, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunResult, type AddProjectResult, type ProjectSummary, type ProjectsProvider, type SummarizeDeps } from './dashboard/index.js'
 export {
   RunStore,
   nodeStoreFs,

--- a/packages/framework/src/install.test.ts
+++ b/packages/framework/src/install.test.ts
@@ -105,10 +105,12 @@ test('enumerateGitRepos keeps only children that are their own repo roots, sorte
   const dir = '/repos'
   const children = [join(dir, 'b'), join(dir, 'a'), join(dir, 'nested'), join(dir, 'plain')]
   const dirs: DirLister = { childDirs: async () => children }
+  // `git rev-parse --show-prefix`: '' at a repo root, a path inside an outer repo,
+  // and an error when the dir is not a repo at all.
   const { git } = fakeGit((_args, cwd) => {
-    if (cwd === join(dir, 'nested')) return dir + '\n' // subdir of an outer repo
+    if (cwd === join(dir, 'nested')) return 'nested/\n' // subdir of an outer repo
     if (cwd === join(dir, 'plain')) throw new Error('not a git repository')
-    return cwd + '\n'
+    return '\n'
   })
 
   assert.deepEqual(await enumerateGitRepos(dir, { git, dirs }), [join(dir, 'a'), join(dir, 'b')])

--- a/packages/framework/src/install.ts
+++ b/packages/framework/src/install.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'node:path'
+import { join } from 'node:path'
 import { nodeGitRunner, type GitRunner } from './project.js'
 import { logsPath, LOGS_HEADER, THE_FRAMEWORK_DIR } from './logs.js'
 import { nodeStoreFs, type StoreFs } from './store/index.js'
@@ -86,10 +86,12 @@ export interface EnumerateDeps {
 }
 
 /**
- * The immediate child directories of `dir` that are their own git repo roots
- * (`git rev-parse --show-toplevel` resolves to the child itself). A child that
- * is not a repo, or merely a subdir of an outer repo, is skipped. Returns the
- * surviving paths, deduped and sorted. Forgiving: never throws.
+ * The immediate child directories of `dir` that are their own git repo roots. A
+ * child is a root when `git rev-parse --show-prefix` (the path from the repo root
+ * down to the cwd) is empty; a subdir of an outer repo yields a non-empty prefix,
+ * and a non-repo makes git error. This beats comparing `--show-toplevel` to the
+ * child path, which breaks where the path crosses a symlink (e.g. macOS `/var` ->
+ * `/private/var`). Returns the surviving paths, deduped and sorted; never throws.
  */
 export async function enumerateGitRepos(dir: string, deps: EnumerateDeps = {}): Promise<string[]> {
   const git = deps.git ?? nodeGitRunner()
@@ -98,8 +100,8 @@ export async function enumerateGitRepos(dir: string, deps: EnumerateDeps = {}): 
   const repos = new Set<string>()
   for (const child of await dirs.childDirs(dir)) {
     try {
-      const toplevel = await git(['rev-parse', '--show-toplevel'], child)
-      if (resolve(toplevel.trim()) === resolve(child)) repos.add(child)
+      const prefix = await git(['rev-parse', '--show-prefix'], child)
+      if (prefix.trim() === '') repos.add(child)
     } catch {
       // Not a repo (or git failed): skip.
     }


### PR DESCRIPTION
Closes #396. Part of #314. Depends on the merged install-core (#391) and registry (#390).

Completes the multi-project loop: you can now add projects from the dashboard, not just have the daemon auto-register its own.

## Server (`POST /api/projects`)
Guarded exactly like `/stop` `/choice` `/api/start` (POST-only, same-origin). Body `{ path, directory? }`. Delegates to a wired `onAddProject` handler (default off; the page hides the control when unwired, tests inject a fake), returning `{ ok, added, alreadyActivated }` or `{ ok:false, error }`. `GET /api/projects` is unchanged (the two split on method).

## Daemon
Wires `onAddProject`: installs a single repo, or every git repo directly under a folder (`enumerateGitRepos`), via the merged install-core (`installProject` is idempotent), then `addProject`s each. A git failure on any target aborts with the error.

## UI
The Projects sidebar gains an **Add** button + a small form (path input, "folder of repos" checkbox), shown only when the server enables adding. Submit POSTs, shows the result inline, and reloads the list.

## Bug fixed along the way
Verifying against real git surfaced that `enumerateGitRepos` returned `[]` on macOS: it compared `git rev-parse --show-toplevel` (symlink-resolved, `/private/var/...`) to the dir path (`/var/...`), which never matched. Switched to `--show-prefix` (empty = repo root), which is symlink-proof. The "folder of repos" add would otherwise silently find nothing.

## Tests + verification
- `server.test.ts`: POST installs+registers via `onAddProject` (single + folder), 400 on missing path, 400 on failed install, 404 when disabled, 403 cross-origin.
- `add-project.test.ts` (jsdom): the Add control is gated by the server flag; submitting POSTs the path, shows the result, reloads the list; an empty path is refused with no POST.
- `install.test.ts`: updated to the `--show-prefix` semantics.
- Verified the real-git path by hand: dirty repo -> two commits in order + clean tree + LOGS.md tracked; clean repo -> one commit; re-install idempotent; `enumerateGitRepos` finds the child repo and skips the plain dir.

Suite green (440 pass, 1 pre-existing skip), typecheck clean. No new deps.