### PR TITLE
fix(framework): restore stranded add-project fixes + start-run feedback

### DIFF
--- a/.changeset/start-run-feedback.md
+++ b/.changeset/start-run-feedback.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Give the dashboard clear feedback when a run is started. A run is spawned detached, so there was a gap between clicking Start and the first event (and a failed launch produced nothing, so the page looked frozen). Now clicking Start shows an immediate "Starting your run..." banner; if no output arrives within ~8s it warns that the run may have failed to start; a run-launch/exit failure surfaces as an error banner; and a rejected Start (a run is already active) shows a clear "busy" banner instead of a tiny note.

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process'
 import { watch, type FSWatcher } from 'node:fs'
-import { mkdir, readFile, writeFile, rm } from 'node:fs/promises'
-import { join } from 'node:path'
+import { mkdir, readFile, writeFile, rm, stat } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
 import type { FrameworkEvent } from './events.js'
 import { EVENTS_FILE, FRAMEWORK_DIR } from './store/index.js'
 import { startDashboard, type Dashboard, type StartRunKind, type StartRunOptions, type StartRunResult, type AddProjectResult } from './dashboard/index.js'
@@ -296,8 +296,14 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
   // is idempotent (an already-activated repo is a no-op success); a git failure on any
   // target aborts and surfaces as an error the dialog shows.
   const addProjects = async (path: string, directory: boolean): Promise<AddProjectResult> => {
-    const targets = directory ? await enumerateGitRepos(path) : [path]
-    if (!targets.length) return { ok: false, error: `no git repositories found under ${path}` }
+    // Resolve relative input against the daemon cwd, and check the directory really
+    // exists first: without this a bad path reaches git as a missing cwd, which
+    // surfaces as the confusing "spawn git ENOENT" rather than a path error.
+    const abs = resolve(path)
+    const isDir = await stat(abs).then(s => s.isDirectory()).catch(() => false)
+    if (!isDir) return { ok: false, error: `path does not exist or is not a directory: ${abs}` }
+    const targets = directory ? await enumerateGitRepos(abs) : [abs]
+    if (!targets.length) return { ok: false, error: `no git repositories found under ${abs}` }
     let added = 0
     let alreadyActivated = 0
     for (const repo of targets) {

--- a/packages/framework/src/dashboard/add-project.test.ts
+++ b/packages/framework/src/dashboard/add-project.test.ts
@@ -86,3 +86,15 @@ test('an empty path is rejected client-side without a POST', async () => {
   assert.equal(h.calls.filter(c => c.method === 'POST').length, before, 'no POST for an empty path')
   assert.match(h.query('#add-project-note')!.textContent ?? '', /enter a path/)
 })
+
+test('a relative path is rejected client-side with an absolute-path hint, no POST', async () => {
+  const h = boot(true)
+  await tick()
+  ;(h.query('#add-project') as unknown as { click: () => void }).click()
+  ;(h.query('#add-project-path') as HTMLInputElement).value = 'first-project'
+  const before = h.calls.filter(c => c.method === 'POST').length
+  h.query('#add-project-form')!.dispatchEvent(new h.window.Event('submit', { cancelable: true, bubbles: true }))
+  await tick()
+  assert.equal(h.calls.filter(c => c.method === 'POST').length, before, 'no POST for a relative path')
+  assert.match(h.query('#add-project-note')!.textContent ?? '', /absolute path/)
+})

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -93,9 +93,9 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   /* Add project(s) (#396): a small install form under the Projects heading. */
   #projects-head { display: flex; align-items: center; justify-content: space-between; margin: 16px 0 8px; }
   #projects-head h2 { margin: 0; }
-  #add-project { font: inherit; font-size: 12px; cursor: pointer; color: #9db4d6; background: #131a2a;
-    border: 1px solid #24344a; border-radius: 6px; padding: 2px 8px; }
-  #add-project:hover { background: #17212f; }
+  #add-project { font: inherit; font-size: 12px; font-weight: 600; cursor: pointer; color: #cfe6d6;
+    background: #1c5233; border: 1px solid #3f8f5f; border-radius: 6px; padding: 3px 10px; }
+  #add-project:hover { background: #23653f; border-color: #4fa571; }
   #add-project[hidden] { display: none; }
   #add-project-form { padding: 8px 6px 10px; display: flex; flex-direction: column; gap: 6px; }
   #add-project-form[hidden] { display: none; }

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -989,6 +989,11 @@ function submitAddProject(ev) {
   note.className = '';
   const path = $('add-project-path').value.trim();
   if (!path) { note.className = 'err'; note.textContent = 'enter a path first'; return; }
+  // A relative path would resolve against the daemon's cwd (opaque here); require an
+  // absolute path (POSIX '/...' or Windows 'C:\\...') so there is no ambiguity.
+  if (!/^(\\/|[A-Za-z]:[\\\\/])/.test(path)) {
+    note.className = 'err'; note.textContent = 'use an absolute path (e.g. /Users/you/my-repo)'; return;
+  }
   const directory = $('add-project-dir').checked;
   $('add-project-submit').disabled = true;
   note.textContent = 'installing\\u2026';

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -48,6 +48,17 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   #app-banner .dot { color: #67d98f; }
   #app-banner a { color: #67d98f; font-weight: 600; }
   #app-banner .run { color: #6f8a79; font-size: 12px; }
+  /* Run-start feedback (#403): a banner that says a run is starting, warns when it
+     produces no output, reports a launch/exit failure, and shows the busy refusal. */
+  #run-notice { display: flex; align-items: center; gap: 8px; padding: 10px 20px; font-size: 13px;
+    position: sticky; top: 57px; border-bottom: 1px solid #1c2230; }
+  #run-notice[hidden] { display: none; }
+  #run-notice.rn-starting { background: #12233a; border-bottom-color: #24344a; color: #9db4d6; }
+  #run-notice.rn-starting .rn-icon { animation: rn-pulse 1.1s ease-in-out infinite; }
+  #run-notice.rn-warn { background: #2a2114; border-bottom-color: #4a3a1c; color: #f0a35e; }
+  #run-notice.rn-error { background: #2a1416; border-bottom-color: #4a1c1e; color: #e2686a; }
+  #run-notice.rn-busy { background: #131a2a; border-bottom-color: #2b3b5c; color: #9db4d6; }
+  @keyframes rn-pulse { 0%,100% { opacity: 1; } 50% { opacity: .3; } }
   /* Fill the viewport below the 57px header so the sidebar border runs full-height
      even when the content is short. */
   #layout { display: flex; align-items: stretch; min-height: calc(100vh - 57px); }
@@ -321,6 +332,7 @@ export function dashboardHtml(title: string, stoppable = false, choiceable = fal
   <span>Your app is running at <a id="app-link" href="#" target="_blank" rel="noopener">…</a></span>
   <span class="run">live until you stop the run</span>
 </div>
+<div id="run-notice" hidden></div>
 <main>
   <section id="project-view" hidden>
     <h2 id="pv-project">Project</h2>
@@ -1154,6 +1166,52 @@ syncNotifyBtn();
 // verbatim); nothing is sent until Start / Ctrl+Enter. Clearing the box reverts
 // to a normal 'build' run.
 let startKind = 'build';
+// Run-start feedback (#403). A run is spawned detached, so there is a gap between
+// the click and the first event (and a failed launch produces none). This little
+// state machine makes that gap and its failure modes visible.
+let runPhase = 'idle';       // idle | starting | stalled | live
+let runNoticeKind = '';      // which banner is showing
+let runWatchdog = null;
+const RUN_STALL_MS = 8000;
+
+function showRunNotice(kind, text) {
+  runNoticeKind = kind;
+  const el = $('run-notice');
+  el.className = 'rn-' + kind;
+  el.innerHTML = '<span class="rn-icon">' + esc(text.icon) + '</span><span>' + esc(text.msg) + '</span>';
+  el.hidden = false;
+}
+function clearRunNotice() { runNoticeKind = ''; $('run-notice').hidden = true; }
+function stopRunWatchdog() { if (runWatchdog) { clearTimeout(runWatchdog); runWatchdog = null; } }
+function armRunWatchdog() {
+  stopRunWatchdog();
+  runWatchdog = setTimeout(() => {
+    if (runPhase === 'starting') {
+      runPhase = 'stalled';
+      showRunNotice('warn', { icon: '\\u26a0', msg: 'No output yet \\u2014 the run may have failed to start. Is Claude Code installed?' });
+    }
+  }, RUN_STALL_MS);
+}
+
+// Drive the feedback state from the live event stream. The daemon's own lines are
+// kind 'log' (e.g. "\\u2717 run exited..."); the run's first real event is not, so a
+// non-log event means the run truly started.
+function runFeedbackOnEvent(fe) {
+  if (runPhase === 'starting' || runPhase === 'stalled') {
+    if (fe.kind === 'log' && /^\\u2717 run /.test(fe.message || '')) {
+      runPhase = 'idle'; stopRunWatchdog();
+      showRunNotice('error', { icon: '\\u2717', msg: fe.message });
+    } else if (fe.kind !== 'log') {
+      runPhase = 'live'; stopRunWatchdog(); clearRunNotice();
+    }
+  }
+  if (fe.kind === 'end') {
+    runPhase = 'idle'; stopRunWatchdog();
+    // Leave a failure banner up; clear the transient ones now the run is over.
+    if (runNoticeKind !== 'error') clearRunNotice();
+  }
+}
+
 function startNewRun() {
   if (!STARTABLE) return;
   const note = $('start-note');
@@ -1166,10 +1224,22 @@ function startNewRun() {
     body: JSON.stringify({ prompt: prompt, kind: startKind, options: collectStartOptions() }) })
     .then(async r => {
       for (const b of buttons) b.disabled = false;
-      if (r.ok) { note.textContent = ''; $('start-prompt').value = ''; startKind = 'build'; showLive(); return; }
+      if (r.ok) {
+        note.textContent = ''; $('start-prompt').value = ''; startKind = 'build';
+        runPhase = 'starting';
+        showRunNotice('starting', { icon: '\\u25cc', msg: 'Starting your run\\u2026' });
+        showLive();
+        armRunWatchdog();
+        return;
+      }
       let msg = 'could not start (' + r.status + ')';
       try { const b = await r.json(); if (b && b.error) msg = b.error; } catch {}
       note.textContent = msg;
+      // 409 = a run is already active. Make that refusal obvious, then auto-dismiss.
+      if (r.status === 409) {
+        showRunNotice('busy', { icon: '\\u25cf', msg: 'A run is already active \\u2014 stop it or wait for it to finish.' });
+        setTimeout(() => { if (runNoticeKind === 'busy') clearRunNotice(); }, 6000);
+      }
     })
     .catch(() => { for (const b of buttons) b.disabled = false; note.textContent = 'could not reach the dashboard server'; });
 }
@@ -1260,6 +1330,7 @@ const src = new EventSource('events');
 src.onmessage = ev => {
   let fe; try { fe = JSON.parse(ev.data); } catch { return; }
   liveEvents.push(fe);
+  runFeedbackOnEvent(fe);
   if (mode === 'live') render(fe);
   // A finished run has just been archived; refresh the list so it appears.
   if (fe.kind === 'end') setTimeout(loadRuns, 1500);

--- a/packages/framework/src/dashboard/start-feedback.test.ts
+++ b/packages/framework/src/dashboard/start-feedback.test.ts
@@ -1,0 +1,116 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { JSDOM } from 'jsdom'
+import { dashboardHtml } from './page.js'
+
+// Run-start feedback (#403): a run is spawned detached, so between the click and
+// the first event there must be a visible "starting" state, a watchdog for a run
+// that never produces output, a failure banner, and a "busy" refusal. Drives the
+// real client JS in jsdom, feeding the SSE handler and controlling the watchdog.
+
+function boot(startResp: { ok: boolean; status: number; body?: unknown }) {
+  const timers: Array<{ fn: () => void; ms: number } | null> = []
+  let es: { onmessage: ((ev: { data: string }) => void) | null } | null = null
+  const dom = new JSDOM(dashboardHtml('Test', true, true, true, true), {
+    runScripts: 'dangerously',
+    url: 'http://localhost/',
+    beforeParse(window) {
+      const w = window as unknown as { [k: string]: unknown }
+      w['setInterval'] = () => 0
+      w['setTimeout'] = (fn: () => void, ms: number) => { timers.push({ fn, ms }); return timers.length }
+      w['clearTimeout'] = (id: number) => { if (id) timers[id - 1] = null }
+      w['EventSource'] = class {
+        onmessage: ((ev: { data: string }) => void) | null = null
+        onerror: (() => void) | null = null
+        constructor() { es = this }
+        close() {}
+      }
+      w['fetch'] = (url: string, opts?: { method?: string }) => {
+        const method = (opts && opts.method) || 'GET'
+        if (url === 'api/start' && method === 'POST') {
+          return Promise.resolve({ ok: startResp.ok, status: startResp.status, json: () => Promise.resolve(startResp.body || {}) })
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+      }
+    },
+  })
+  const doc = dom.window.document
+  return {
+    query: (sel: string) => doc.querySelector(sel),
+    clickStart(prompt: string) {
+      ;(doc.getElementById('start-prompt') as HTMLTextAreaElement).value = prompt
+      ;(doc.getElementById('start-run') as unknown as { click: () => void }).click()
+    },
+    emit(fe: unknown) { es?.onmessage?.({ data: JSON.stringify(fe) }) },
+    fireTimers(ms: number) { for (const t of timers) if (t && t.ms === ms) t.fn() },
+  }
+}
+
+const tick = async () => { for (let i = 0; i < 5; i++) await new Promise(r => setImmediate(r)) }
+const ok202 = { ok: true, status: 202 }
+
+test('clicking Start shows a "starting" banner', async () => {
+  const h = boot(ok202)
+  await tick()
+  h.clickStart('build a blog')
+  await tick()
+  const notice = h.query('#run-notice')!
+  assert.equal(notice.hasAttribute('hidden'), false)
+  assert.ok(notice.classList.contains('rn-starting'))
+  assert.match(notice.textContent ?? '', /Starting your run/)
+})
+
+test('the first real (non-log) event clears the starting banner', async () => {
+  const h = boot(ok202)
+  await tick()
+  h.clickStart('build a blog')
+  await tick()
+  // The daemon's own "run started" log must NOT clear it...
+  h.emit({ kind: 'log', message: '▶ run started: build a blog' })
+  assert.equal(h.query('#run-notice')!.hasAttribute('hidden'), false)
+  // ...but the run's first real event does.
+  h.emit({ kind: 'session', sessionId: 's1' })
+  assert.equal(h.query('#run-notice')!.hasAttribute('hidden'), true)
+})
+
+test('the watchdog warns when a run produces no output', async () => {
+  const h = boot(ok202)
+  await tick()
+  h.clickStart('build a blog')
+  await tick()
+  h.fireTimers(8000) // the stall watchdog
+  const notice = h.query('#run-notice')!
+  assert.ok(notice.classList.contains('rn-warn'))
+  assert.match(notice.textContent ?? '', /No output yet/)
+})
+
+test('a real event before the watchdog cancels the warning', async () => {
+  const h = boot(ok202)
+  await tick()
+  h.clickStart('build a blog')
+  await tick()
+  h.emit({ kind: 'session', sessionId: 's1' }) // a real event arrives first -> watchdog cleared
+  h.fireTimers(8000)
+  assert.equal(h.query('#run-notice')!.hasAttribute('hidden'), true)
+})
+
+test('a run-exit failure shows an error banner', async () => {
+  const h = boot(ok202)
+  await tick()
+  h.clickStart('build a blog')
+  await tick()
+  h.emit({ kind: 'log', message: '✗ run exited with code 1' })
+  const notice = h.query('#run-notice')!
+  assert.ok(notice.classList.contains('rn-error'))
+  assert.match(notice.textContent ?? '', /run exited with code 1/)
+})
+
+test('a 409 busy response shows a "run already active" banner', async () => {
+  const h = boot({ ok: false, status: 409, body: { error: 'a run is already active' } })
+  await tick()
+  h.clickStart('build a blog')
+  await tick()
+  const notice = h.query('#run-notice')!
+  assert.ok(notice.classList.contains('rn-busy'))
+  assert.match(notice.textContent ?? '', /already active/)
+})


### PR DESCRIPTION
Recovery PR. Three commits landed on `feat/add-project-flow` **after** it was squash-merged to main (#402), plus the stacked #404 was merged into that branch instead of main - so they never reached `main` (that is the "recent pushes" banner GitHub was showing).

Brings the stranded work onto main (cherry-picked cleanly, no conflicts):
- Green Add button + add-project **path validation** (a bad/relative path returned a clear "path does not exist or is not a directory" instead of the misleading `spawn git ENOENT`) - from the #396 testing
- **Absolute-path guard** in the Add form (rejects a relative path up front with a clear hint)
- **Start-run feedback** (#404): "Starting your run…" state, an ~8s stall watchdog, a run-launch/exit error banner, and a clear "a run is already active" banner

All content was previously reviewed and green in #402/#404; this only re-lands it on main. After merge, `feat/add-project-flow` can be deleted to clear the banner.

Closes #403.