### PR TITLE
feat(framework): unify run state into a single .the-framework/ directory (#313)

### DIFF
--- a/.changeset/unify-the-framework-dir.md
+++ b/.changeset/unify-the-framework-dir.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Keep everything in a single `.the-framework/` directory (#313). The transient run state (`events.jsonl`, `run.json`, `runs/`, `control.jsonl`, `daemon.json`) now lives in `.the-framework/` alongside the committed project log `LOGS.md`, instead of a separate `.framework/` directory. `install` seeds a `.the-framework/.gitignore` that ignores everything except `LOGS.md`, so the run state stays transient and only the log is committed.

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -104,8 +104,8 @@ framework relay                Host a run relay so teammates can watch a run (se
   --port <n>             Dashboard port (default: 4200); with `relay`, the relay port (4488).
   --no-dashboard         Run headless.
   --share <relay-url>    Publish this run to a relay (see below) so teammates can watch it.
-  --resume               Reopen the last run's dashboard from .framework/ (see below).
-  --no-persist           Do not write the orchestration state to .framework/.
+  --resume               Reopen the last run's dashboard from .the-framework/ (see below).
+  --no-persist           Do not write the orchestration state to .the-framework/.
   --skip-preflight       Skip the prerequisite checks before a live run.
   --session-link <url>   Link to the live agent session (shown on the dashboard).
 ```
@@ -117,7 +117,7 @@ The live path needs the Claude Code CLI installed (`claude` on `PATH`). The
 
 The orchestration state (the stack rationale, loop status, and decisions ledger)
 is our part of the run, not the agent's chat transcript, so we persist it. Each
-run appends its event stream to `.framework/events.jsonl` in the workspace, with a
+run appends its event stream to `.the-framework/events.jsonl` in the workspace, with a
 small `run.json` snapshot beside it and a human-readable `DECISIONS.md` at the
 root. Because the dashboard is a pure projection of that stream, a restart can
 replay it: `framework --resume` reopens the last run's dashboard read-only, exactly
@@ -125,10 +125,15 @@ as it looked, without running the agent again. Add `--cwd <dir>` to resume a run
 from another workspace. Pass `--no-persist` to skip writing state. We do not
 persist the agent's transcript; Claude Code owns that.
 
+The `.the-framework/` directory holds both the transient run state (`events.jsonl`,
+`run.json`, `runs/`) and the committed project log `LOGS.md`. `install` seeds a
+`.the-framework/.gitignore` that keeps the run state out of git so only `LOGS.md`
+is tracked.
+
 ### Run history
 
-Each finished run is archived under `.framework/runs/<id>.jsonl` (its log) and
-`.framework/runs/<id>.json` (its snapshot). The dashboard's left sidebar lists a
+Each finished run is archived under `.the-framework/runs/<id>.jsonl` (its log) and
+`.the-framework/runs/<id>.json` (its snapshot). The dashboard's left sidebar lists a
 project's past runs (intent, status, session link); clicking one replays that
 run's projection in the main view, and **Back to live** returns to the current
 run. The list is served by `GET /api/runs`, a single run by `GET /api/runs/<id>`

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -168,9 +168,9 @@ Options:
   --no-dashboard         Do not start the localhost dashboard.
   --share <relay-url>    Publish this run to a relay (from "framework relay") so
                          teammates can watch it live; prints the shareable URL.
-  --resume               Reopen the last run's dashboard from .framework/ in --cwd
+  --resume               Reopen the last run's dashboard from .the-framework/ in --cwd
                          (read-only replay; no new agent run). Survives a restart.
-  --no-persist           Do not write the orchestration state to .framework/.
+  --no-persist           Do not write the orchestration state to .the-framework/.
   --skip-preflight       Skip the prerequisite checks before a live run.
   --session-link <url>   A real per-session link to the live agent session, shown
                          on the dashboard. Our runs are headless (not Remote-
@@ -657,7 +657,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   if (opts.resume) return resumeRun(opts, io)
 
   // `--daemon` is the detached child's own entry: it *is* the persistent dashboard,
-  // tailing .framework/ until signalled. Never invoked by hand (#302).
+  // tailing .the-framework/ until signalled. Never invoked by hand (#302).
   if (opts.daemon) {
     await runDaemon(opts.cwd ?? process.cwd(), opts.port !== undefined ? { port: opts.port } : {})
     return 0
@@ -789,7 +789,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   }
 
   // Persist the orchestration state so a restart can --resume it (#211). The log
-  // is the dashboard's own event stream, appended to .framework/ in the workspace.
+  // is the dashboard's own event stream, appended to .the-framework/ in the workspace.
   // Best-effort: a store that fails to open just means no persistence, never a
   // failed run. --no-persist opts out entirely.
   let store: RunStore | undefined
@@ -801,7 +801,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     }
   }
 
-  // The persistent daemon dashboard steers this run through .framework/control.jsonl
+  // The persistent daemon dashboard steers this run through .the-framework/control.jsonl
   // (#344): its Stop button and choice picks append entries, we tail the file and
   // abort / resolve the parked gate. Reset first so a previous run's picks can never
   // fire into this one (gate ids repeat across runs). Only wired when a daemon is
@@ -1187,7 +1187,7 @@ async function runRelayServer(opts: CliOptions, io: CliIO): Promise<number> {
 }
 
 /**
- * Reopen the last run from its persisted `.framework/` log and replay it into a
+ * Reopen the last run from its persisted `.the-framework/` log and replay it into a
  * fresh dashboard (#211). No agent runs; the dashboard rehydrates from the saved
  * event stream and stays up read-only until Ctrl+C.
  */
@@ -1197,7 +1197,7 @@ async function resumeRun(opts: CliOptions, io: CliIO): Promise<number> {
   try {
     store = await RunStore.open(cwd, { fresh: false })
   } catch (err) {
-    io.err(`could not open .framework/ in ${cwd} (${err instanceof Error ? err.message : String(err)})`)
+    io.err(`could not open .the-framework/ in ${cwd} (${err instanceof Error ? err.message : String(err)})`)
     return 1
   }
   const events = await store.loadEvents()

--- a/packages/framework/src/control.ts
+++ b/packages/framework/src/control.ts
@@ -7,14 +7,14 @@ import { JsonlTailer } from './jsonl-tail.js'
 
 /**
  * The dashboard-to-run control channel (#344): the reverse of the event log.
- * Events flow run -> `.framework/events.jsonl` -> daemon -> browser; steering
- * flows browser -> daemon -> `.framework/control.jsonl` -> run. The daemon
+ * Events flow run -> `.the-framework/events.jsonl` -> daemon -> browser; steering
+ * flows browser -> daemon -> `.the-framework/control.jsonl` -> run. The daemon
  * appends a {@link ControlEntry} per Stop click / choice pick, and the run tails
  * the file, aborting or resolving its parked gate. Same file-is-the-seam design
  * as the forward direction — no run<->daemon IPC.
  */
 
-/** The control log filename under `.framework/`. */
+/** The control log filename under `.the-framework/`. */
 export const CONTROL_FILE = 'control.jsonl'
 
 /** One steering instruction from the dashboard to the live run. */
@@ -51,7 +51,7 @@ export interface ControlWatcher {
 
 /**
  * Tail the workspace's control log, dispatching each well-formed entry as it is
- * appended. An `fs.watch` on `.framework/` plus a poll backstop, mirroring the
+ * appended. An `fs.watch` on `.the-framework/` plus a poll backstop, mirroring the
  * daemon's event tail (`fs.watch` is unreliable across platforms). Malformed or
  * unknown lines are skipped so a bad write can never crash a run.
  */

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -171,7 +171,7 @@ test('runDaemon serves the dashboard, records its state, and cleans up on shutdo
   }
 })
 
-test('runDaemon comes up on a fresh workspace with no .framework yet', async () => {
+test('runDaemon comes up on a fresh workspace with no .the-framework yet', async () => {
   const cwd = await mkdtemp(join(tmpdir(), 'framework-daemon-')) // deliberately no mkdir
   const ac = new AbortController()
   try {
@@ -181,7 +181,7 @@ test('runDaemon comes up on a fresh workspace with no .framework yet', async () 
       await new Promise(r => setTimeout(r, 20))
       state = await readDaemonState(cwd)
     }
-    assert.ok(state, 'the daemon created .framework/ itself and wrote its state file')
+    assert.ok(state, 'the daemon created .the-framework/ itself and wrote its state file')
     assert.equal((await fetch(state!.url)).status, 200)
     ac.abort()
     await done

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -15,14 +15,14 @@ import { JsonlTailer } from './jsonl-tail.js'
  * The persistent background dashboard (#302). Today the dashboard dies with the
  * foreground `framework "<prompt>"` run; this makes it a long-lived local process
  * that outlives any single run. It is a pure projection of the store: the run
- * appends its events to `.framework/events.jsonl` (unchanged), and the daemon
+ * appends its events to `.the-framework/events.jsonl` (unchanged), and the daemon
  * *tails* that file, pushing each new event to connected browsers. No run<->daemon
  * IPC — the file is the seam, matching "the dashboard is a projection of the event
- * stream". Steering goes the other way through `.framework/control.jsonl` (#344).
+ * stream". Steering goes the other way through `.the-framework/control.jsonl` (#344).
  * MVP: one project = the workspace `cwd`; multi-project is deferred (#299).
  */
 
-/** The daemon's liveness record under `.framework/`. */
+/** The daemon's liveness record under `.the-framework/`. */
 export const DAEMON_STATE_FILE = 'daemon.json'
 
 /** The default dashboard port the daemon binds. Matches the per-run dashboard. */
@@ -40,7 +40,7 @@ export interface DaemonState {
   startedAt: string
 }
 
-/** The `.framework/` directory for a workspace. */
+/** The `.the-framework/` directory for a workspace. */
 export function daemonDir(cwd: string): string {
   return join(cwd, FRAMEWORK_DIR)
 }
@@ -191,7 +191,7 @@ export async function stopDaemon(cwd: string): Promise<boolean> {
 }
 
 /**
- * Tails the append-only `.framework/events.jsonl` run log. The generic tailing
+ * Tails the append-only `.the-framework/events.jsonl` run log. The generic tailing
  * lives in {@link JsonlTailer}; this keeps the event-typed name the daemon (and
  * public API) always had.
  */
@@ -211,7 +211,7 @@ export interface RunDaemonOptions {
 
 /**
  * The daemon body — run in the detached child. Starts the dashboard, seeds it
- * from the existing log, then tails `.framework/events.jsonl` (an `fs.watch` plus
+ * from the existing log, then tails `.the-framework/events.jsonl` (an `fs.watch` plus
  * a poll backstop, since `fs.watch` is unreliable across platforms), pushing each
  * new event to browsers. Resolves on SIGINT/SIGTERM after tearing the dashboard
  * down and removing its state file.
@@ -219,10 +219,10 @@ export interface RunDaemonOptions {
 export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promise<void> {
   const port = opts.port ?? DEFAULT_DAEMON_PORT
   // Steering (#344): the daemon owns no run, so its Stop button and choice picks
-  // append to `.framework/control.jsonl`; the live run tails that file. Appends
+  // append to `.the-framework/control.jsonl`; the live run tails that file. Appends
   // are best-effort — a full disk must not take the dashboard down with it.
   // The state file, the event/control logs, and the fs.watch all live under
-  // `.framework/` — create it up front so the daemon works as the very first
+  // `.the-framework/` — create it up front so the daemon works as the very first
   // command in a fresh workspace (before any run made the dir).
   await mkdir(daemonDir(cwd), { recursive: true })
 

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -296,7 +296,7 @@ test('POST /stop invokes onStop and the page renders the Stop button (#218)', as
 
 test('/api/runs lists the workspace archive and /api/runs/<id> replays a run (#303)', async () => {
   const cwd = await mkdtemp(join(tmpdir(), 'fw-hist-'))
-  const runs = join(cwd, '.framework', 'runs')
+  const runs = join(cwd, '.the-framework', 'runs')
   await mkdir(runs, { recursive: true })
   const events: FrameworkEvent[] = [
     { kind: 'session', driver: 'fake', workspace: cwd, fake: true },

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -33,7 +33,7 @@ export interface DashboardOptions {
    */
   onChoice?: (id: string, pick: string | string[], by: ChoiceBy) => void
   /**
-   * The workspace whose `.framework/runs/` archive backs the run-history sidebar
+   * The workspace whose `.the-framework/runs/` archive backs the run-history sidebar
    * (#303): `GET /api/runs` lists it, `GET /api/runs/<id>` replays one run. Omit
    * to disable history (the endpoints report an empty list).
    */

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -114,12 +114,14 @@ export {
 } from './store/index.js'
 export {
   logsPath,
+  gitignorePath,
   renderLogEntry,
   parseLogs,
   appendLog,
   readLogs,
   THE_FRAMEWORK_DIR,
   LOGS_FILE,
+  LOGS_GITIGNORE,
   type LogEntry,
 } from './logs.js'
 export {

--- a/packages/framework/src/install.test.ts
+++ b/packages/framework/src/install.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { join } from 'node:path'
 import { enumerateGitRepos, installProject, type DirLister } from './install.js'
-import { logsPath, readLogs, LOGS_HEADER } from './logs.js'
+import { logsPath, readLogs, LOGS_HEADER, gitignorePath, LOGS_GITIGNORE } from './logs.js'
 import type { GitRunner } from './project.js'
 import type { StoreFs } from './store/index.js'
 
@@ -62,6 +62,17 @@ test('installProject on a clean repo seeds the log and makes exactly one install
 
   const commits = calls.filter(args => args[0] === 'commit')
   assert.deepEqual(commits, [['commit', '-m', '[The Framework] install The Framework']])
+})
+
+test('installProject seeds .the-framework/.gitignore so only LOGS.md is committed (#313)', async () => {
+  const fs = memFs()
+  const { git } = fakeGit(() => '')
+
+  await installProject(CWD, { git, fs })
+  assert.equal(fs.files.get(gitignorePath(CWD)), LOGS_GITIGNORE)
+  // The ignore keeps run state (events.jsonl / run.json / runs/) untracked while committing LOGS.md.
+  assert.match(LOGS_GITIGNORE, /^\*$/m)
+  assert.match(LOGS_GITIGNORE, /^!LOGS\.md$/m)
 })
 
 test('installProject on a dirty repo commits the pre-existing changes first', async () => {

--- a/packages/framework/src/install.ts
+++ b/packages/framework/src/install.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path'
 import { nodeGitRunner, type GitRunner } from './project.js'
-import { logsPath, LOGS_HEADER, THE_FRAMEWORK_DIR } from './logs.js'
+import { logsPath, LOGS_HEADER, THE_FRAMEWORK_DIR, gitignorePath, LOGS_GITIGNORE } from './logs.js'
 import { nodeStoreFs, type StoreFs } from './store/index.js'
 
 /**
@@ -45,6 +45,10 @@ export async function installProject(cwd: string, deps: InstallDeps = {}): Promi
     await fs.mkdir(join(cwd, THE_FRAMEWORK_DIR))
     const path = logsPath(cwd)
     if (!(await fs.exists(path))) await fs.write(path, LOGS_HEADER)
+    // Keep the transient run state (events.jsonl / run.json / runs/) out of git;
+    // only LOGS.md is the committed DB (#313).
+    const ignore = gitignorePath(cwd)
+    if (!(await fs.exists(ignore))) await fs.write(ignore, LOGS_GITIGNORE)
 
     await git(['add', '-A'], cwd)
     await git(['commit', '-m', '[The Framework] install The Framework'], cwd)

--- a/packages/framework/src/logs.ts
+++ b/packages/framework/src/logs.ts
@@ -14,6 +14,14 @@ export const THE_FRAMEWORK_DIR = '.the-framework'
 /** The markdown log file name. */
 export const LOGS_FILE = 'LOGS.md'
 
+/**
+ * The `.the-framework/.gitignore` that keeps run state transient (#313): the dir
+ * holds both the committed DB (LOGS.md) and the transient run logs, so this
+ * ignores everything except LOGS.md and itself.
+ */
+export const LOGS_GITIGNORE =
+  '# The Framework: only LOGS.md is the committed project DB; run state is transient.\n*\n!.gitignore\n!LOGS.md\n'
+
 /** One project-log entry: a loop, or a standalone prompt/build. */
 export interface LogEntry {
   /** ISO timestamp. */
@@ -42,6 +50,11 @@ export const LOGS_HEADER = '# The Framework logs\n'
 /** The log path under `cwd`. */
 export function logsPath(cwd: string): string {
   return join(cwd, THE_FRAMEWORK_DIR, LOGS_FILE)
+}
+
+/** The `.gitignore` path under `cwd`'s `.the-framework/`. */
+export function gitignorePath(cwd: string): string {
+  return join(cwd, THE_FRAMEWORK_DIR, '.gitignore')
 }
 
 /** Markdown for one entry, starting at `## ` (no file header, no blank lines around it). */

--- a/packages/framework/src/sandbox.test.ts
+++ b/packages/framework/src/sandbox.test.ts
@@ -42,7 +42,7 @@ test('snapshotWorkspace skips binary files and oversized files', async () => {
 })
 
 test('SANDBOX_IGNORE lists the build/VCS/cache dirs', () => {
-  for (const name of ['node_modules', '.git', 'dist', '.framework']) {
+  for (const name of ['node_modules', '.git', 'dist', '.the-framework']) {
     assert.ok(SANDBOX_IGNORE.has(name), `${name} is ignored`)
   }
 })

--- a/packages/framework/src/sandbox.ts
+++ b/packages/framework/src/sandbox.ts
@@ -18,7 +18,7 @@ export const SANDBOX_IGNORE: ReadonlySet<string> = new Set([
   '.vite',
   '.cache',
   'coverage',
-  '.framework',
+  '.the-framework',
 ])
 
 /** Options for {@link snapshotWorkspace}. */

--- a/packages/framework/src/store/run-store.test.ts
+++ b/packages/framework/src/store/run-store.test.ts
@@ -51,8 +51,8 @@ function memFs(seed: Record<string, string> = {}): StoreFs & { files: Map<string
 
 const AT = '2026-07-04T00:00:00.000Z'
 const CWD = '/ws'
-const EVENTS = join(CWD, '.framework', 'events.jsonl')
-const META = join(CWD, '.framework', 'run.json')
+const EVENTS = join(CWD, '.the-framework', 'events.jsonl')
+const META = join(CWD, '.the-framework', 'run.json')
 
 const RUN: FrameworkEvent[] = [
   { kind: 'session', driver: 'fake', workspace: CWD, fake: true, sessionLink: 'https://claude.ai/code' },
@@ -150,8 +150,8 @@ test('close archives the run into runs/<id>.json + .jsonl for history (#303)', a
   await store.close()
 
   const id = store.snapshot().id
-  const archivedMeta = fs.files.get(join(CWD, '.framework', 'runs', `${id}.json`))
-  const archivedLog = fs.files.get(join(CWD, '.framework', 'runs', `${id}.jsonl`))
+  const archivedMeta = fs.files.get(join(CWD, '.the-framework', 'runs', `${id}.json`))
+  const archivedLog = fs.files.get(join(CWD, '.the-framework', 'runs', `${id}.jsonl`))
   assert.ok(archivedMeta, 'meta archived')
   assert.ok(archivedLog, 'log archived')
   assert.equal((JSON.parse(archivedMeta!) as RunMeta).intent, 'a blog with comments')

--- a/packages/framework/src/store/run-store.ts
+++ b/packages/framework/src/store/run-store.ts
@@ -11,8 +11,13 @@ import type { FrameworkEvent } from '../events.js'
  * transcript (Claude Code owns that); only our own orchestration events.
  */
 
-/** The directory, under the workspace root, that holds the persisted run. */
-export const FRAMEWORK_DIR = '.framework'
+/**
+ * The directory, under the workspace root, that holds the persisted run. Same
+ * `.the-framework/` directory as the committed project log (#313): one dir holds
+ * both the transient run state (events.jsonl / run.json / runs/) and the DB
+ * (LOGS.md); a seeded `.the-framework/.gitignore` keeps the run state untracked.
+ */
+export const FRAMEWORK_DIR = '.the-framework'
 
 /** The append-only event log: one {@link FrameworkEvent} per line (JSONL). */
 export const EVENTS_FILE = 'events.jsonl'
@@ -184,7 +189,7 @@ export class RunStore {
   }
 
   /**
-   * Open (creating `.framework/` if needed) under the workspace `cwd`. `fresh`
+   * Open (creating `.the-framework/` if needed) under the workspace `cwd`. `fresh`
    * truncates any prior log for a new run; the default preserves it so a resume
    * can {@link loadEvents}.
    */
@@ -283,7 +288,7 @@ export class RunStore {
   }
 }
 
-/** Paths of a run's archived log + meta under `.framework/runs/`. */
+/** Paths of a run's archived log + meta under `.the-framework/runs/`. */
 function archivePaths(dir: string, id: string): { events: string; meta: string } {
   const runs = join(dir, RUNS_DIR)
   return { events: join(runs, `${id}.jsonl`), meta: join(runs, `${id}.json`) }


### PR DESCRIPTION
Part of #313.

Per your two calls on #313: everything in one directory, named `.the-framework`.

Today there are two dirs. The transient run state (`events.jsonl`, `run.json`, `runs/`, `control.jsonl`, `daemon.json`) lived in `.framework/`, and the committed project log `LOGS.md` in `.the-framework/`. This folds the first into the second, so there is one `.the-framework/` dir.

The one reason-against you asked us to check: once run state shares the dir with the committed `LOGS.md`, git would sweep it in. `install` now seeds a `.the-framework/.gitignore`:

```
*
!.gitignore
!LOGS.md
```

so only `LOGS.md` (the DB) is tracked; run state stays transient.

Also renames the doc comments, the sandbox ignore entry, and the README. Full suite green (449 tests).