### PR TITLE
feat(framework): store the project registry as a single .the-framework.json file (#390)

### DIFF
--- a/.changeset/registry-single-file.md
+++ b/.changeset/registry-single-file.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Store the multi-project registry as a single file, `.bashrc`-style: `$HOME/.the-framework.json` (or `$XDG_CONFIG_HOME/the-framework.json`) instead of a `projects.json` nested inside a `.the-framework/` directory (#390).

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -138,7 +138,6 @@ export {
   listProjects,
   addProject,
   removeProject,
-  REGISTRY_DIR,
   REGISTRY_FILE,
   type ProjectRecord,
   type RegistryFs,

--- a/packages/framework/src/registry.test.ts
+++ b/packages/framework/src/registry.test.ts
@@ -7,7 +7,6 @@ import {
   projectId,
   registryPath,
   removeProject,
-  REGISTRY_DIR,
   REGISTRY_FILE,
   type ProjectRecord,
   type RegistryFs,
@@ -50,13 +49,13 @@ const APP_B: ProjectRecord = {
 }
 
 test('registryPath prefers XDG_CONFIG_HOME over HOME', () => {
-  assert.equal(registryPath({ XDG_CONFIG_HOME: '/cfg' }), join('/cfg', REGISTRY_DIR, REGISTRY_FILE))
-  assert.equal(registryPath({ XDG_CONFIG_HOME: '/cfg', HOME: '/home/u' }), join('/cfg', REGISTRY_DIR, REGISTRY_FILE))
+  assert.equal(registryPath({ XDG_CONFIG_HOME: '/cfg' }), join('/cfg', REGISTRY_FILE))
+  assert.equal(registryPath({ XDG_CONFIG_HOME: '/cfg', HOME: '/home/u' }), join('/cfg', REGISTRY_FILE))
 })
 
-test('registryPath falls back to a dot dir under HOME (empty XDG counts as unset)', () => {
-  assert.equal(registryPath(ENV), join('/home/u', '.' + REGISTRY_DIR, REGISTRY_FILE))
-  assert.equal(registryPath({ XDG_CONFIG_HOME: '', HOME: '/home/u' }), join('/home/u', '.' + REGISTRY_DIR, REGISTRY_FILE))
+test('registryPath falls back to a single dotfile under HOME (empty XDG counts as unset)', () => {
+  assert.equal(registryPath(ENV), join('/home/u', '.' + REGISTRY_FILE))
+  assert.equal(registryPath({ XDG_CONFIG_HOME: '', HOME: '/home/u' }), join('/home/u', '.' + REGISTRY_FILE))
 })
 
 test('projectId is deterministic and distinct per path', () => {
@@ -96,7 +95,7 @@ test('addProject appends a record and writes pretty JSON that parses back', asyn
   const fs = memFs()
   const record = await addProject('/repos/app-a', APP_A.addedAt, fs, ENV)
   assert.deepEqual(record, APP_A)
-  assert.deepEqual(fs.dirs, [join('/home/u', '.' + REGISTRY_DIR)])
+  assert.deepEqual(fs.dirs, ['/home/u']) // the single dotfile's parent is $HOME itself
   assert.deepEqual(JSON.parse(fs.files.get(FILE)!), [APP_A])
 
   await addProject('/repos/app-b', APP_B.addedAt, fs, ENV)

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -2,8 +2,9 @@ import { basename, dirname, join, resolve } from 'node:path'
 
 /**
  * The multi-project registry (#390): the list of projects the user has
- * installed The Framework into, kept as a small JSON index under the user's
- * config dir. Stores only `{id, path, addedAt}` per project; the daemon and
+ * installed The Framework into, kept as a single JSON file `.bashrc`-style —
+ * `$HOME/.the-framework.json` — so it is the user's responsibility to re-create
+ * per machine. Stores only `{id, path, addedAt}` per project; the daemon and
  * UI over it are separate concerns.
  */
 
@@ -17,11 +18,8 @@ export interface ProjectRecord {
   addedAt: string
 }
 
-/** The directory name under `$XDG_CONFIG_HOME` (dotted under `$HOME`). */
-export const REGISTRY_DIR = 'the-framework'
-
-/** The registry file name. */
-export const REGISTRY_FILE = 'projects.json'
+/** The registry file name: a single file under `$XDG_CONFIG_HOME` (dotted under `$HOME`). */
+export const REGISTRY_FILE = 'the-framework.json'
 
 /**
  * Deterministic, URL-safe id for a project path: the sanitized basename plus a
@@ -42,12 +40,12 @@ export function projectId(path: string): string {
 
 /**
  * The registry file path, resolved from `env` (injectable so tests never touch
- * the real home): `$XDG_CONFIG_HOME/the-framework/projects.json` when set,
- * else `$HOME/.the-framework/projects.json`.
+ * the real home): `$XDG_CONFIG_HOME/the-framework.json` when set, else the
+ * dotted `$HOME/.the-framework.json`. A single file, not a directory (#390).
  */
 export function registryPath(env: NodeJS.ProcessEnv): string {
-  if (env.XDG_CONFIG_HOME) return join(env.XDG_CONFIG_HOME, REGISTRY_DIR, REGISTRY_FILE)
-  return join(env.HOME ?? '', '.' + REGISTRY_DIR, REGISTRY_FILE)
+  if (env.XDG_CONFIG_HOME) return join(env.XDG_CONFIG_HOME, REGISTRY_FILE)
+  return join(env.HOME ?? '', '.' + REGISTRY_FILE)
 }
 
 /** Minimal fs seam so the registry is unit-testable without touching disk. */


### PR DESCRIPTION
Follow-up to #390, doing your single-file idea.

The multi-project registry now lives in one file `$HOME/.the-framework.json` (or `$XDG_CONFIG_HOME/the-framework.json`) instead of a `projects.json` nested in a `.the-framework/` dir at $HOME. Fits the `.bashrc` framing better: one dotfile the user re-creates per machine.

Registry test paths updated; full suite green.