### PR TITLE
feat(framework): per-project daemon runs + machine-global liveness (#393)

### DIFF
--- a/.changeset/per-project-daemon-393.md
+++ b/.changeset/per-project-daemon-393.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Per-project daemon runs + one daemon per machine (#393). Dashboard-started runs, Stop, and choice picks now carry the viewed project id, so the daemon spawns each run with that project's `--cwd`, steers it through that project's own control log, and guards one run per project. Daemon liveness moved from a per-workspace `.the-framework/daemon.json` to a single global file beside the registry (`$XDG_CONFIG_HOME/the-framework-daemon.json`), so `framework` and `framework stop` in any repo find the same daemon. Per-project live event streaming is folded in with the dashboard rebuild (#405).

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -478,13 +478,17 @@ test('runCli --fake --no-dashboard runs the whole flow offline to production-gra
 
 test('a live daemon steers a dashboard-less run through its gates via control.jsonl (#344)', async () => {
   const cwd = await mkdtemp(join(tmpdir(), 'framework-ws-'))
+  const cfg = await mkdtemp(join(tmpdir(), 'framework-cfg-'))
   const prevAwait = process.env.FRAMEWORK_FAKE_AWAIT
+  const prevXdg = process.env.XDG_CONFIG_HOME
   process.env.FRAMEWORK_FAKE_AWAIT = 'choices' // the fake build stops to ask (#341)
+  process.env.XDG_CONFIG_HOME = cfg // the run reads the global daemon liveness from here (#393)
   try {
-    // Fake a live daemon for this workspace: our own pid always reads as alive.
+    // Fake the machine's live daemon (#393): our own pid always reads as alive. The
+    // run's steering check is now global, so the liveness goes in the config dir.
     await mkdir(join(cwd, FRAMEWORK_DIR), { recursive: true })
     await writeFile(
-      daemonStatePath(cwd),
+      daemonStatePath(),
       JSON.stringify({ pid: process.pid, port: 1, url: 'http://127.0.0.1:1', startedAt: '' }),
     )
 
@@ -528,6 +532,9 @@ test('a live daemon steers a dashboard-less run through its gates via control.js
   } finally {
     if (prevAwait === undefined) delete process.env.FRAMEWORK_FAKE_AWAIT
     else process.env.FRAMEWORK_FAKE_AWAIT = prevAwait
+    if (prevXdg === undefined) delete process.env.XDG_CONFIG_HOME
+    else process.env.XDG_CONFIG_HOME = prevXdg
     await rm(cwd, { recursive: true, force: true })
+    await rm(cfg, { recursive: true, force: true })
   }
 })

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -44,6 +44,8 @@ import { preflight } from './preflight.js'
 import { RunStore } from './store/index.js'
 import { daemonStatus, ensureDaemon, runDaemon, stopDaemon, DEFAULT_DAEMON_PORT } from './daemon.js'
 import { resetControl, watchControl, type ControlWatcher } from './control.js'
+import { isActivated } from './project.js'
+import { addProject } from './registry.js'
 import { runPrompt } from './prompt-run.js'
 import { renderResearchPrompt } from './research-preset.js'
 
@@ -804,10 +806,11 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // The persistent daemon dashboard steers this run through .the-framework/control.jsonl
   // (#344): its Stop button and choice picks append entries, we tail the file and
   // abort / resolve the parked gate. Reset first so a previous run's picks can never
-  // fire into this one (gate ids repeat across runs). Only wired when a daemon is
-  // live for this workspace — without one, headless behavior is byte-identical.
+  // fire into this one (gate ids repeat across runs). Only wired when the machine's
+  // daemon is live (#393): the one daemon steers runs in any project, and it writes
+  // to this run's own control.jsonl. Without a daemon, headless behavior is identical.
   let control: ControlWatcher | undefined
-  if (opts.persist && (await daemonStatus(cwd))) {
+  if (opts.persist && (await daemonStatus())) {
     try {
       await resetControl(cwd)
       control = watchControl(cwd, entry => {
@@ -1153,6 +1156,14 @@ async function ensureDaemonCmd(opts: CliOptions, io: CliIO): Promise<number> {
     io.err(`could not start the dashboard daemon (${err instanceof Error ? err.message : String(err)}).`)
     return 1
   }
+  // One daemon per machine (#393): when it is already running, `framework` in a new
+  // repo would not otherwise register that repo (only the daemon's own cwd is added
+  // on startup). Register it here too, best-effort, so it shows up in the Projects
+  // list either way. Idempotent (addProject dedupes by path).
+  if (await isActivated(cwd).catch(() => false)) {
+    await addProject(cwd, new Date().toISOString()).catch(() => {})
+  }
+
   const { state, alreadyRunning } = result
   io.out(`◆ dashboard ${alreadyRunning ? 'already running' : 'started'}: ${state.url}`)
   io.out('')
@@ -1168,10 +1179,9 @@ async function ensureDaemonCmd(opts: CliOptions, io: CliIO): Promise<number> {
   return 0
 }
 
-/** `framework stop`: stop this workspace's background dashboard, if any. */
-async function stopDaemonCmd(opts: CliOptions, io: CliIO): Promise<number> {
-  const cwd = opts.cwd ?? process.cwd()
-  const stopped = await stopDaemon(cwd)
+/** `framework stop`: stop the machine's background dashboard, if any (#393). */
+async function stopDaemonCmd(_opts: CliOptions, io: CliIO): Promise<number> {
+  const stopped = await stopDaemon()
   io.out(stopped ? '◆ dashboard stopped.' : 'No background dashboard was running.')
   return 0
 }

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -39,6 +39,15 @@ async function tmpWorkspace(): Promise<string> {
   return cwd
 }
 
+// The global daemon liveness now lives beside the registry (#393). Point it at a
+// throwaway config dir under the workspace so tests never touch the real $HOME and
+// clean up with the workspace. Returns the env the daemon fns resolve the path from.
+async function configEnv(cwd: string): Promise<NodeJS.ProcessEnv> {
+  const dir = join(cwd, 'cfg')
+  await mkdir(dir, { recursive: true })
+  return { XDG_CONFIG_HOME: dir }
+}
+
 test('EventTailer dispatches only events appended since the last pull', async () => {
   const cwd = await tmpWorkspace()
   const path = join(cwd, FRAMEWORK_DIR, EVENTS_FILE)
@@ -107,12 +116,13 @@ test('isProcessAlive is true for this process and false for a dead pid', () => {
 
 test('readDaemonState returns undefined when absent or malformed', async () => {
   const cwd = await tmpWorkspace()
+  const env = await configEnv(cwd)
   try {
-    assert.equal(await readDaemonState(cwd), undefined) // absent
-    await writeFile(daemonStatePath(cwd), 'not json')
-    assert.equal(await readDaemonState(cwd), undefined) // malformed
-    await writeFile(daemonStatePath(cwd), JSON.stringify({ pid: 1 })) // missing fields
-    assert.equal(await readDaemonState(cwd), undefined)
+    assert.equal(await readDaemonState(env), undefined) // absent
+    await writeFile(daemonStatePath(env), 'not json')
+    assert.equal(await readDaemonState(env), undefined) // malformed
+    await writeFile(daemonStatePath(env), JSON.stringify({ pid: 1 })) // missing fields
+    assert.equal(await readDaemonState(env), undefined)
   } finally {
     await rm(cwd, { recursive: true, force: true })
   }
@@ -120,13 +130,14 @@ test('readDaemonState returns undefined when absent or malformed', async () => {
 
 test('daemonStatus removes a stale state file whose process is gone', async () => {
   const cwd = await tmpWorkspace()
+  const env = await configEnv(cwd)
   try {
     await writeFile(
-      daemonStatePath(cwd),
+      daemonStatePath(env),
       JSON.stringify({ pid: 2 ** 31 - 1, port: 4477, url: 'http://127.0.0.1:4477', startedAt: '' }),
     )
-    assert.equal(await daemonStatus(cwd), undefined) // dead pid -> not running
-    assert.equal(await readDaemonState(cwd), undefined) // ...and the stale file is cleaned up
+    assert.equal(await daemonStatus(env), undefined) // dead pid -> not running
+    assert.equal(await readDaemonState(env), undefined) // ...and the stale file is cleaned up
   } finally {
     await rm(cwd, { recursive: true, force: true })
   }
@@ -134,8 +145,9 @@ test('daemonStatus removes a stale state file whose process is gone', async () =
 
 test('stopDaemon reports false when nothing is running', async () => {
   const cwd = await tmpWorkspace()
+  const env = await configEnv(cwd)
   try {
-    assert.equal(await stopDaemon(cwd), false)
+    assert.equal(await stopDaemon(env), false)
   } finally {
     await rm(cwd, { recursive: true, force: true })
   }
@@ -143,15 +155,16 @@ test('stopDaemon reports false when nothing is running', async () => {
 
 test('runDaemon serves the dashboard, records its state, and cleans up on shutdown', async () => {
   const cwd = await tmpWorkspace()
+  const env = await configEnv(cwd)
   const ac = new AbortController()
   try {
-    const done = runDaemon(cwd, { port: 0, pollMs: 50, signal: ac.signal })
+    const done = runDaemon(cwd, { port: 0, pollMs: 50, signal: ac.signal, env })
 
     // Wait for the daemon to bind and report itself.
-    let state = await readDaemonState(cwd)
+    let state = await readDaemonState(env)
     for (let i = 0; i < 100 && !state; i++) {
       await new Promise(r => setTimeout(r, 20))
-      state = await readDaemonState(cwd)
+      state = await readDaemonState(env)
     }
     assert.ok(state, 'daemon wrote its state file')
     assert.equal(state!.pid, process.pid)
@@ -164,7 +177,7 @@ test('runDaemon serves the dashboard, records its state, and cleans up on shutdo
 
     ac.abort()
     await done
-    assert.equal(await readDaemonState(cwd), undefined) // state file removed on exit
+    assert.equal(await readDaemonState(env), undefined) // state file removed on exit
   } finally {
     ac.abort()
     await rm(cwd, { recursive: true, force: true })
@@ -173,13 +186,14 @@ test('runDaemon serves the dashboard, records its state, and cleans up on shutdo
 
 test('runDaemon comes up on a fresh workspace with no .the-framework yet', async () => {
   const cwd = await mkdtemp(join(tmpdir(), 'framework-daemon-')) // deliberately no mkdir
+  const env = await configEnv(cwd)
   const ac = new AbortController()
   try {
-    const done = runDaemon(cwd, { port: 0, pollMs: 50, signal: ac.signal })
-    let state = await readDaemonState(cwd)
+    const done = runDaemon(cwd, { port: 0, pollMs: 50, signal: ac.signal, env })
+    let state = await readDaemonState(env)
     for (let i = 0; i < 100 && !state; i++) {
       await new Promise(r => setTimeout(r, 20))
-      state = await readDaemonState(cwd)
+      state = await readDaemonState(env)
     }
     assert.ok(state, 'the daemon created .the-framework/ itself and wrote its state file')
     assert.equal((await fetch(state!.url)).status, 200)
@@ -204,13 +218,14 @@ fs.appendFileSync(path.join(args[args.indexOf('--cwd') + 1], 'started.log'), JSO
 setTimeout(() => {}, 600)
 `,
   )
+  const env = await configEnv(cwd)
   const ac = new AbortController()
   try {
-    const done = runDaemon(cwd, { port: 0, pollMs: 50, signal: ac.signal, binPath: stub })
-    let state = await readDaemonState(cwd)
+    const done = runDaemon(cwd, { port: 0, pollMs: 50, signal: ac.signal, binPath: stub, env })
+    let state = await readDaemonState(env)
     for (let i = 0; i < 100 && !state; i++) {
       await new Promise(r => setTimeout(r, 20))
-      state = await readDaemonState(cwd)
+      state = await readDaemonState(env)
     }
     assert.ok(state, 'daemon wrote its state file')
 
@@ -267,13 +282,14 @@ const args = process.argv.slice(2)
 fs.appendFileSync(path.join(args[args.indexOf('--cwd') + 1], 'started.log'), JSON.stringify(args) + '\\n')
 `,
   )
+  const env = await configEnv(cwd)
   const ac = new AbortController()
   try {
-    const done = runDaemon(cwd, { port: 0, pollMs: 50, signal: ac.signal, binPath: stub })
-    let state = await readDaemonState(cwd)
+    const done = runDaemon(cwd, { port: 0, pollMs: 50, signal: ac.signal, binPath: stub, env })
+    let state = await readDaemonState(env)
     for (let i = 0; i < 100 && !state; i++) {
       await new Promise(r => setTimeout(r, 20))
-      state = await readDaemonState(cwd)
+      state = await readDaemonState(env)
     }
     assert.ok(state, 'daemon wrote its state file')
 
@@ -333,14 +349,15 @@ fs.appendFileSync(path.join(args[args.indexOf('--cwd') + 1], 'started.log'), JSO
 
 test('/api/start refuses to re-exec a test entry as the run (#345)', async () => {
   const cwd = await tmpWorkspace()
+  const env = await configEnv(cwd)
   const ac = new AbortController()
   try {
     // No binPath: argv[1] here is this test file — the fork-bomb guard must trip.
-    const done = runDaemon(cwd, { port: 0, pollMs: 50, signal: ac.signal })
-    let state = await readDaemonState(cwd)
+    const done = runDaemon(cwd, { port: 0, pollMs: 50, signal: ac.signal, env })
+    let state = await readDaemonState(env)
     for (let i = 0; i < 100 && !state; i++) {
       await new Promise(r => setTimeout(r, 20))
-      state = await readDaemonState(cwd)
+      state = await readDaemonState(env)
     }
     assert.ok(state, 'daemon wrote its state file')
     const res = await fetch(`${state!.url}/api/start`, {
@@ -360,13 +377,14 @@ test('/api/start refuses to re-exec a test entry as the run (#345)', async () =>
 
 test('runDaemon steers through the control log: /stop and /choice POSTs append entries (#344)', async () => {
   const cwd = await tmpWorkspace()
+  const env = await configEnv(cwd)
   const ac = new AbortController()
   try {
-    const done = runDaemon(cwd, { port: 0, pollMs: 50, signal: ac.signal })
-    let state = await readDaemonState(cwd)
+    const done = runDaemon(cwd, { port: 0, pollMs: 50, signal: ac.signal, env })
+    let state = await readDaemonState(env)
     for (let i = 0; i < 100 && !state; i++) {
       await new Promise(r => setTimeout(r, 20))
-      state = await readDaemonState(cwd)
+      state = await readDaemonState(env)
     }
     assert.ok(state, 'daemon wrote its state file')
 

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -1,13 +1,13 @@
 import { spawn } from 'node:child_process'
 import { watch, type FSWatcher } from 'node:fs'
 import { mkdir, readFile, writeFile, rm, stat } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import type { FrameworkEvent } from './events.js'
 import { EVENTS_FILE, FRAMEWORK_DIR } from './store/index.js'
 import { startDashboard, type Dashboard, type StartRunKind, type StartRunOptions, type StartRunResult, type AddProjectResult } from './dashboard/index.js'
 import { appendControl } from './control.js'
 import { isActivated } from './project.js'
-import { addProject } from './registry.js'
+import { addProject, listProjects, projectId } from './registry.js'
 import { installProject, enumerateGitRepos } from './install.js'
 import { JsonlTailer } from './jsonl-tail.js'
 
@@ -19,11 +19,20 @@ import { JsonlTailer } from './jsonl-tail.js'
  * *tails* that file, pushing each new event to connected browsers. No run<->daemon
  * IPC — the file is the seam, matching "the dashboard is a projection of the event
  * stream". Steering goes the other way through `.the-framework/control.jsonl` (#344).
- * MVP: one project = the workspace `cwd`; multi-project is deferred (#299).
+ *
+ * One daemon per machine (#393): liveness lives in a single global file next to the
+ * registry ({@link daemonStatePath}), not per-workspace, so `framework` in any repo
+ * finds the same daemon. Runs and steering are keyed per project: the daemon spawns
+ * each run with `--cwd <project path>` and appends its control entries to that
+ * project's own `control.jsonl`. Its own `cwd` is just the home project it streams by
+ * default (per-project live streaming is folded in with the dashboard rebuild, #405).
  */
 
-/** The daemon's liveness record under `.the-framework/`. */
-export const DAEMON_STATE_FILE = 'daemon.json'
+/**
+ * The daemon's liveness record filename. A single global file (one daemon per
+ * machine, #393), resolved by {@link daemonStatePath} beside the registry.
+ */
+export const DAEMON_STATE_FILE = 'the-framework-daemon.json'
 
 /** The default dashboard port the daemon binds. Matches the per-run dashboard. */
 export const DEFAULT_DAEMON_PORT = 4200
@@ -61,15 +70,21 @@ export function startOptionFlags(options: StartRunOptions): string[] {
   return flags
 }
 
-/** The daemon state file path for a workspace. */
-export function daemonStatePath(cwd: string): string {
-  return join(daemonDir(cwd), DAEMON_STATE_FILE)
+/**
+ * The global daemon state file path (#393): a single file beside the registry, so
+ * there is one daemon per machine. `$XDG_CONFIG_HOME/the-framework-daemon.json` when
+ * set, else the dotted `$HOME/.the-framework-daemon.json` — mirroring `registryPath`.
+ * `env` is injectable so tests never touch the real home.
+ */
+export function daemonStatePath(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.XDG_CONFIG_HOME) return join(env.XDG_CONFIG_HOME, DAEMON_STATE_FILE)
+  return join(env.HOME ?? '', '.' + DAEMON_STATE_FILE)
 }
 
 /** Read the daemon state, or `undefined` when absent or unreadable/corrupt. */
-export async function readDaemonState(cwd: string): Promise<DaemonState | undefined> {
+export async function readDaemonState(env: NodeJS.ProcessEnv = process.env): Promise<DaemonState | undefined> {
   try {
-    const raw = await readFile(daemonStatePath(cwd), 'utf8')
+    const raw = await readFile(daemonStatePath(env), 'utf8')
     const data = JSON.parse(raw) as Partial<DaemonState>
     if (typeof data.pid === 'number' && typeof data.port === 'number' && typeof data.url === 'string') {
       return { pid: data.pid, port: data.port, url: data.url, startedAt: data.startedAt ?? '' }
@@ -92,15 +107,15 @@ export function isProcessAlive(pid: number): boolean {
 }
 
 /**
- * The live daemon for a workspace, or `undefined` when none is running. A state
+ * The live daemon for this machine, or `undefined` when none is running. A state
  * file whose process is gone is stale — it is removed so the next `ensureDaemon`
  * starts fresh.
  */
-export async function daemonStatus(cwd: string): Promise<DaemonState | undefined> {
-  const state = await readDaemonState(cwd)
+export async function daemonStatus(env: NodeJS.ProcessEnv = process.env): Promise<DaemonState | undefined> {
+  const state = await readDaemonState(env)
   if (!state) return undefined
   if (isProcessAlive(state.pid)) return state
-  await rm(daemonStatePath(cwd), { force: true }).catch(() => {})
+  await rm(daemonStatePath(env), { force: true }).catch(() => {})
   return undefined
 }
 
@@ -119,16 +134,19 @@ export interface EnsureDaemonOptions {
   timeoutMs?: number
   /** The CLI entry script to re-invoke for the child. Default `process.argv[1]`. */
   binPath?: string
+  /** Env for the global liveness path (#393). Default `process.env`; injectable for tests. */
+  env?: NodeJS.ProcessEnv
 }
 
 /**
- * Ensure a background dashboard daemon is running for `cwd`, starting one if not.
- * Idempotent: a second call while one is live just returns it. The child is
- * detached and unref'd, so it outlives this process; it reports itself by writing
- * {@link DAEMON_STATE_FILE}, which this call polls for before returning.
+ * Ensure the machine's background dashboard daemon is running, starting one (homed
+ * at `cwd`) if not. Idempotent and machine-global (#393): a second call from any
+ * repo while one is live just returns it. The child is detached and unref'd, so it
+ * outlives this process; it reports itself by writing {@link DAEMON_STATE_FILE},
+ * which this call polls for before returning.
  */
 export async function ensureDaemon(cwd: string, opts: EnsureDaemonOptions = {}): Promise<EnsureResult> {
-  const existing = await daemonStatus(cwd)
+  const existing = await daemonStatus(opts.env)
   if (existing) return { state: existing, alreadyRunning: true }
 
   const port = opts.port ?? DEFAULT_DAEMON_PORT
@@ -150,16 +168,16 @@ export async function ensureDaemon(cwd: string, opts: EnsureDaemonOptions = {}):
   })
   child.unref()
 
-  const state = await waitForDaemon(cwd, opts.timeoutMs ?? 5000)
+  const state = await waitForDaemon(opts.env, opts.timeoutMs ?? 5000)
   if (!state) throw new Error('the daemon did not come up in time')
   return { state, alreadyRunning: false }
 }
 
-/** Poll for the daemon's state file to appear and its process to be alive. */
-async function waitForDaemon(cwd: string, timeoutMs: number): Promise<DaemonState | undefined> {
+/** Poll for the daemon's global state file to appear and its process to be alive. */
+async function waitForDaemon(env: NodeJS.ProcessEnv | undefined, timeoutMs: number): Promise<DaemonState | undefined> {
   const step = 100
   for (let waited = 0; waited <= timeoutMs; waited += step) {
-    const state = await daemonStatus(cwd)
+    const state = await daemonStatus(env)
     if (state) return state
     await delay(step)
   }
@@ -171,12 +189,12 @@ function delay(ms: number): Promise<void> {
 }
 
 /**
- * Stop the workspace's daemon, if any. Returns true when one was running and got
- * a termination signal. The daemon removes its own state file on exit; a stale
+ * Stop the machine's daemon, if any (#393). Returns true when one was running and
+ * got a termination signal. The daemon removes its own state file on exit; a stale
  * file (dead process) is cleaned up here.
  */
-export async function stopDaemon(cwd: string): Promise<boolean> {
-  const state = await readDaemonState(cwd)
+export async function stopDaemon(env: NodeJS.ProcessEnv = process.env): Promise<boolean> {
+  const state = await readDaemonState(env)
   if (!state) return false
   const alive = isProcessAlive(state.pid)
   if (alive) {
@@ -186,7 +204,7 @@ export async function stopDaemon(cwd: string): Promise<boolean> {
       // already gone between the check and the signal
     }
   }
-  await rm(daemonStatePath(cwd), { force: true }).catch(() => {})
+  await rm(daemonStatePath(env), { force: true }).catch(() => {})
   return alive
 }
 
@@ -207,6 +225,8 @@ export interface RunDaemonOptions {
   signal?: AbortSignal
   /** The CLI entry script to re-invoke for a dashboard-started run (#345). Default `process.argv[1]`. */
   binPath?: string
+  /** Env for the global liveness path (#393). Default `process.env`; injectable for tests. */
+  env?: NodeJS.ProcessEnv
 }
 
 /**
@@ -218,6 +238,7 @@ export interface RunDaemonOptions {
  */
 export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promise<void> {
   const port = opts.port ?? DEFAULT_DAEMON_PORT
+  const env = opts.env ?? process.env
   // Steering (#344): the daemon owns no run, so its Stop button and choice picks
   // append to `.the-framework/control.jsonl`; the live run tails that file. Appends
   // are best-effort — a full disk must not take the dashboard down with it.
@@ -230,65 +251,93 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
   // it shows up in the Projects list. Best-effort and idempotent (addProject
   // dedupes by path), so it never blocks the daemon coming up.
   if (await isActivated(cwd).catch(() => false)) {
-    await addProject(cwd, new Date().toISOString()).catch(() => {})
+    await addProject(cwd, new Date().toISOString(), undefined, env).catch(() => {})
+  }
+
+  // Per-project run state (#393). The one global run became a map keyed by project
+  // id, so each project runs at most one run at a time independently. The daemon's
+  // own `cwd` is the home project; a run started without a project id targets it, and
+  // the browser passes the home project's id or omits it (both resolve to `homeId`).
+  const homeId = projectId(resolve(cwd))
+  const activeRuns = new Map<string, number>()
+  const starting = new Set<string>() // reserved keys mid-spawn, to close the async gap
+  // A project id resolves to its repo path via the registry; the home id (or none)
+  // resolves to the daemon's own `cwd` without a lookup.
+  const resolveProject = async (id: string | undefined): Promise<string | undefined> => {
+    if (!id || id === homeId) return cwd
+    const records = await listProjects(undefined, env).catch(() => [])
+    return records.find(record => record.id === id)?.path
   }
 
   // Start-from-dashboard (#345): POST /api/start spawns `framework "<prompt>"
-  // --no-dashboard` as a detached child — the same spawn pattern ensureDaemon
-  // uses for the daemon itself. The run streams into this page via the tailed
-  // event log, and its gates + Stop steer through the control channel (#344),
-  // which the run wires whenever a daemon is live. One run at a time: while the
-  // last child is alive, Start is refused (the #322 runaway concern).
-  let activeRunPid: number | undefined
-  const startRun = (prompt: string, kind: StartRunKind, options: StartRunOptions = {}): StartRunResult => {
-    if (activeRunPid !== undefined && isProcessAlive(activeRunPid)) {
-      return { ok: false, busy: true, error: 'a run is already active; stop it or wait for it to finish' }
+  // --no-dashboard --cwd <project>` as a detached child — the same spawn pattern
+  // ensureDaemon uses for the daemon itself. The run streams into this page via the
+  // tailed event log, and its gates + Stop steer through the control channel (#344),
+  // which the run wires whenever a daemon is live. One run per project (#393): while
+  // that project's child is alive, Start for it is refused (the #322 runaway concern).
+  const startRun = async (
+    prompt: string,
+    kind: StartRunKind,
+    options: StartRunOptions = {},
+    targetProjectId?: string,
+  ): Promise<StartRunResult> => {
+    const key = targetProjectId ?? homeId
+    const active = activeRuns.get(key)
+    if (starting.has(key) || (active !== undefined && isProcessAlive(active))) {
+      return { ok: false, busy: true, error: 'a run is already active for this project; stop it or wait for it to finish' }
     }
-    activeRunPid = undefined
-    const binPath = opts.binPath ?? process.argv[1]
-    if (!binPath) return { ok: false, error: 'cannot locate the framework CLI entry to spawn a run' }
-    // Same fork-bomb guard as ensureDaemon: never re-exec a test file as a run.
-    if (!opts.binPath && (process.env.NODE_TEST_CONTEXT || /\.test\.[cm]?[jt]s$/.test(binPath))) {
-      return { ok: false, error: 'refusing to spawn a run from a test entry; pass an explicit binPath' }
-    }
-    // [Research] (#331) runs the research subcommand; its empty prompt is fine
-    // (the "what" defaults to `this PR` in the CLI). A `prompt` kind (#353) is a
-    // preset the user reviewed in the textarea: run it verbatim, never re-render.
-    const runArgs =
-      kind === 'research'
-        ? ['research', ...(prompt ? [prompt] : [])]
-        : kind === 'prompt'
-          ? ['prompt', prompt]
-          : [prompt]
-    const child = spawn(process.execPath, [binPath, ...runArgs, ...startOptionFlags(options), '--no-dashboard', '--cwd', cwd], {
-      detached: true,
-      stdio: 'ignore',
-    })
-    child.unref()
-    child.once('error', err => {
-      activeRunPid = undefined
-      dashboard.push({ kind: 'log', message: `✗ run failed to start: ${err.message}` })
-    })
-    child.once('exit', code => {
-      activeRunPid = undefined
-      // The run narrates its own end through the event log; only a hard failure
-      // (nonzero exit with no run to tell the tale) needs the daemon's voice.
-      if (code) dashboard.push({ kind: 'log', message: `✗ run exited with code ${code}` })
-    })
-    activeRunPid = child.pid
-    // A verbatim prompt can be a whole preset document: narrate its first line only.
-    const firstLine = prompt.split('\n', 1)[0] ?? ''
-    const brief = firstLine.length > 80 ? `${firstLine.slice(0, 80)}…` : firstLine
-    dashboard.push({
-      kind: 'log',
-      message:
+    activeRuns.delete(key)
+    starting.add(key)
+    try {
+      const projectCwd = await resolveProject(targetProjectId)
+      if (!projectCwd) return { ok: false, error: `unknown project: ${targetProjectId}` }
+      const binPath = opts.binPath ?? process.argv[1]
+      if (!binPath) return { ok: false, error: 'cannot locate the framework CLI entry to spawn a run' }
+      // Same fork-bomb guard as ensureDaemon: never re-exec a test file as a run.
+      if (!opts.binPath && (process.env.NODE_TEST_CONTEXT || /\.test\.[cm]?[jt]s$/.test(binPath))) {
+        return { ok: false, error: 'refusing to spawn a run from a test entry; pass an explicit binPath' }
+      }
+      // [Research] (#331) runs the research subcommand; its empty prompt is fine
+      // (the "what" defaults to `this PR` in the CLI). A `prompt` kind (#353) is a
+      // preset the user reviewed in the textarea: run it verbatim, never re-render.
+      const runArgs =
         kind === 'research'
-          ? `▶ research started: ${prompt || 'this PR'}`
+          ? ['research', ...(prompt ? [prompt] : [])]
           : kind === 'prompt'
-            ? `▶ prompt run started: ${brief}`
-            : `▶ run started: ${prompt}`,
-    })
-    return { ok: true }
+            ? ['prompt', prompt]
+            : [prompt]
+      const child = spawn(process.execPath, [binPath, ...runArgs, ...startOptionFlags(options), '--no-dashboard', '--cwd', projectCwd], {
+        detached: true,
+        stdio: 'ignore',
+      })
+      child.unref()
+      child.once('error', err => {
+        activeRuns.delete(key)
+        dashboard.push({ kind: 'log', message: `✗ run failed to start: ${err.message}` })
+      })
+      child.once('exit', code => {
+        activeRuns.delete(key)
+        // The run narrates its own end through the event log; only a hard failure
+        // (nonzero exit with no run to tell the tale) needs the daemon's voice.
+        if (code) dashboard.push({ kind: 'log', message: `✗ run exited with code ${code}` })
+      })
+      if (child.pid !== undefined) activeRuns.set(key, child.pid)
+      // A verbatim prompt can be a whole preset document: narrate its first line only.
+      const firstLine = prompt.split('\n', 1)[0] ?? ''
+      const brief = firstLine.length > 80 ? `${firstLine.slice(0, 80)}…` : firstLine
+      dashboard.push({
+        kind: 'log',
+        message:
+          kind === 'research'
+            ? `▶ research started: ${prompt || 'this PR'}`
+            : kind === 'prompt'
+              ? `▶ prompt run started: ${brief}`
+              : `▶ run started: ${prompt}`,
+      })
+      return { ok: true }
+    } finally {
+      starting.delete(key)
+    }
   }
 
   // Add project(s) (#396): install a single repo, or every git repo directly under
@@ -316,11 +365,16 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     return { ok: true, added, alreadyActivated }
   }
 
+  // Steering is keyed per project (#393): a Stop / choice pick carries the project id
+  // the browser is viewing, and we append it to that project's own control.jsonl (its
+  // live run tails that file). No project id targets the home project, as before.
+  const steer = (id: string | undefined, entry: Parameters<typeof appendControl>[1]): void =>
+    void resolveProject(id).then(path => (path ? appendControl(path, entry) : undefined)).catch(() => {})
   const dashboard: Dashboard = await startDashboard({
     port,
     cwd,
-    onStop: () => void appendControl(cwd, { kind: 'stop' }).catch(() => {}),
-    onChoice: (id, pick, by) => void appendControl(cwd, { kind: 'choice', id, pick, by }).catch(() => {}),
+    onStop: projectId => steer(projectId, { kind: 'stop' }),
+    onChoice: (id, pick, by, projectId) => steer(projectId, { kind: 'choice', id, pick, by }),
     onStart: startRun,
     onAddProject: addProjects,
   })
@@ -352,7 +406,8 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
 
     const actualPort = Number(new URL(dashboard.url).port) || port
     const state: DaemonState = { pid: process.pid, port: actualPort, url: dashboard.url, startedAt: new Date().toISOString() }
-    await writeFile(daemonStatePath(cwd), JSON.stringify(state, null, 2))
+    await mkdir(dirname(daemonStatePath(env)), { recursive: true })
+    await writeFile(daemonStatePath(env), JSON.stringify(state, null, 2))
   } catch (err) {
     // Startup failed after the port was bound. Tear everything down, or the live
     // server + interval keep the event loop alive: a zombie daemon squatting the
@@ -368,7 +423,7 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
   clearInterval(poll)
   watcher?.close()
   await dashboard.close()
-  await rm(daemonStatePath(cwd), { force: true }).catch(() => {})
+  await rm(daemonStatePath(env), { force: true }).catch(() => {})
 }
 
 /** Resolve on SIGINT/SIGTERM, or when the optional abort signal fires. */

--- a/packages/framework/src/dashboard/page.ts
+++ b/packages/framework/src/dashboard/page.ts
@@ -591,7 +591,7 @@ function stopRun() {
   const btn = $('stop');
   btn.disabled = true;
   btn.textContent = 'stopping\\u2026';
-  fetch('stop', { method: 'POST' }).catch(() => {});
+  fetch('stop' + projectQuery(), { method: 'POST' }).catch(() => {});
 }
 // Attribute-safe: textContent->innerHTML escapes < > &, but NOT quotes, so we also
 // escape " and ' to stay safe inside quoted HTML attributes, not just text nodes.
@@ -683,7 +683,7 @@ function acceptChoice(by, pickOverride) {
   stopCountdown();
   activeChoice = null;
   $('choice-panel').hidden = true;
-  fetch('choice', { method: 'POST', headers: { 'content-type': 'application/json' },
+  fetch('choice' + projectQuery(), { method: 'POST', headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ id: id, pick: pick, by: by }) }).catch(() => {});
 }
 function resolveChoice(fe) {
@@ -858,6 +858,9 @@ function loadLogs() {
 let allProjects = [];
 let selectedProjectId = null;
 let selectedProjectName = '';
+// The ?project=<id> the read endpoints and the write POSTs (start/stop/choice)
+// carry, so the daemon steers and starts runs in the viewed project (#393).
+function projectQuery() { return selectedProjectId ? '?project=' + encodeURIComponent(selectedProjectId) : ''; }
 let didAutoSelect = false;
 let currentLogs = [];
 let selectedLogAt = null;
@@ -1220,7 +1223,7 @@ function startNewRun() {
   const buttons = [$('start-run'), ...document.querySelectorAll('.start-preset')];
   for (const b of buttons) b.disabled = true;
   note.textContent = 'starting\\u2026';
-  fetch('api/start', { method: 'POST', headers: { 'content-type': 'application/json' },
+  fetch('api/start' + projectQuery(), { method: 'POST', headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ prompt: prompt, kind: startKind, options: collectStartOptions() }) })
     .then(async r => {
       for (const b of buttons) b.disabled = false;

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -20,18 +20,21 @@ export interface DashboardOptions {
   title?: string
   /**
    * Called when the browser hits the Stop button (`POST /stop`). Wire this to
-   * abort the run (e.g. an `AbortController.abort()`). Omit to disable stopping;
-   * the page hides the button when the server reports no stop handler.
+   * abort the run (e.g. an `AbortController.abort()`). The optional `projectId` is
+   * the `?project=<id>` the page is viewing (#393), so the daemon steers the right
+   * project; absent means the default project. Omit to disable stopping; the page
+   * hides the button when the server reports no stop handler.
    */
-  onStop?: () => void
+  onStop?: (projectId?: string) => void
   /**
    * Called when the browser posts an interactive-choice pick (#304): `POST /choice`
    * with a JSON `{ id, pick, by }` body. Wire this to resolve the run's pending
-   * choice (e.g. settle the promise a `requestChoice` handler returned). Omit to
-   * disable interactive choices; the page still renders them but the route reports
-   * no handler (404).
+   * choice (e.g. settle the promise a `requestChoice` handler returned). The optional
+   * `projectId` routes the pick to the viewed project (#393). Omit to disable
+   * interactive choices; the page still renders them but the route reports no handler
+   * (404).
    */
-  onChoice?: (id: string, pick: string | string[], by: ChoiceBy) => void
+  onChoice?: (id: string, pick: string | string[], by: ChoiceBy, projectId?: string) => void
   /**
    * The workspace whose `.the-framework/runs/` archive backs the run-history sidebar
    * (#303): `GET /api/runs` lists it, `GET /api/runs/<id>` replays one run. Omit
@@ -43,9 +46,15 @@ export interface DashboardOptions {
    * with a JSON `{ prompt, kind?, options? }` body. Wire this to spawn the run (the
    * daemon does); return `busy: true` to refuse because a run is already active
    * (409). Omit to disable starting; the page hides the prompt panel. The Global
-   * options (#314) ride along in `options`.
+   * options (#314) ride along in `options`; the optional `projectId` targets the
+   * viewed project (#393), spawning the run with that project's `--cwd`.
    */
-  onStart?: (prompt: string, kind: StartRunKind, options: StartRunOptions) => StartRunResult
+  onStart?: (
+    prompt: string,
+    kind: StartRunKind,
+    options: StartRunOptions,
+    projectId?: string,
+  ) => StartRunResult | Promise<StartRunResult>
   /**
    * The multi-project registry read side (#392): `GET /api/projects` lists it, and
    * `?project=<id>` on the read endpoints resolves to that project's path. Omit to
@@ -158,9 +167,11 @@ function handle(
   stream: EventStream<FrameworkEvent>,
   clients: Set<ServerResponse>,
   title: string,
-  onStop: (() => void) | undefined,
-  onChoice: ((id: string, pick: string | string[], by: ChoiceBy) => void) | undefined,
-  onStart: ((prompt: string, kind: StartRunKind, options: StartRunOptions) => StartRunResult) | undefined,
+  onStop: ((projectId?: string) => void) | undefined,
+  onChoice: ((id: string, pick: string | string[], by: ChoiceBy, projectId?: string) => void) | undefined,
+  onStart:
+    | ((prompt: string, kind: StartRunKind, options: StartRunOptions, projectId?: string) => StartRunResult | Promise<StartRunResult>)
+    | undefined,
   cwd: string | undefined,
   projects: ProjectsProvider,
   onAddProject: ((path: string, directory: boolean) => Promise<AddProjectResult> | AddProjectResult) | undefined,
@@ -260,7 +271,7 @@ function handle(
       res.end('stopping not enabled')
       return
     }
-    onStop()
+    onStop(projectId ?? undefined)
     res.writeHead(202, { 'content-type': 'application/json' })
     res.end('{"ok":true}')
     return
@@ -294,7 +305,7 @@ function handle(
           ? raw.filter((x): x is string => typeof x === 'string')
           : ''
       const by: ChoiceBy = body['by'] === 'autopilot' ? 'autopilot' : body['by'] === 'auto' ? 'auto' : 'user'
-      if (id && (Array.isArray(pick) || pick)) onChoice(id, pick, by)
+      if (id && (Array.isArray(pick) || pick)) onChoice(id, pick, by, projectId ?? undefined)
       res.writeHead(202, { 'content-type': 'application/json' })
       res.end('{"ok":true}')
     })
@@ -330,14 +341,22 @@ function handle(
         res.end('{"error":"a non-empty prompt is required"}')
         return
       }
-      const result = onStart(prompt, kind, parseStartOptions(body['options']))
-      if (!result.ok) {
-        res.writeHead(result.busy ? 409 : 500, { 'content-type': 'application/json' })
-        res.end(JSON.stringify({ error: result.error }))
-        return
-      }
-      res.writeHead(202, { 'content-type': 'application/json' })
-      res.end('{"ok":true}')
+      // onStart may resolve the target project's path from the registry (#393), so
+      // it can be async; await it before answering. A thrown handler is a 500.
+      void Promise.resolve(onStart(prompt, kind, parseStartOptions(body['options']), projectId ?? undefined))
+        .then(result => {
+          if (!result.ok) {
+            res.writeHead(result.busy ? 409 : 500, { 'content-type': 'application/json' })
+            res.end(JSON.stringify({ error: result.error }))
+            return
+          }
+          res.writeHead(202, { 'content-type': 'application/json' })
+          res.end('{"ok":true}')
+        })
+        .catch(err => {
+          res.writeHead(500, { 'content-type': 'application/json' })
+          res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }))
+        })
     })
     return
   }


### PR DESCRIPTION
Part of #393 (the rebuild-safe backend; live event streaming stays deferred to the dashboard rebuild #405).

Today the daemon is single-project throughout: one global `activeRunPid`, one control target, and a per-workspace liveness file. This keys all of that per project.

**What changed**
- Start / Stop / choice from the dashboard carry the viewed project id (`?project=<id>`, same param the read endpoints already use). The daemon spawns each run with that project's `--cwd`, steers it through that project's own `control.jsonl`, and keeps a one-run-per-project guard (a `Map` keyed by project id).
- Daemon liveness moved from `<repo>/.the-framework/daemon.json` to one global file beside the registry: `$XDG_CONFIG_HOME/the-framework-daemon.json` (dotted under `$HOME`). One daemon per machine, so `framework` / `framework stop` in any repo find the same one. The run-side steering check is now global to match, which is what makes cross-project Start/Stop actually steer.
- `framework` in a repo registers it even when the daemon is already running (otherwise the one-daemon model would skip registration).

**Deferred** (folded into #405): tagging streamed events with a project id + per-project tailers. The live stream still reflects the daemon's home project for now.

**Verify**
- Full framework suite green (448 pass, 1 skip).
- Drove the lifecycle end to end: `framework` writes the global liveness + registry entry and serves (HTTP 200); `framework stop` from another cwd finds and stops it and cleans the file up.

Note: a daemon already running from before this change uses the old per-workspace file and will be orphaned on upgrade (just `kill` it once); new daemons use the global file.