### PR TITLE
feat(framework-dashboard): Telefunc read model — runs, docs, project log (#405)

### DIFF
--- a/.changeset/dashboard-read-model.md
+++ b/.changeset/dashboard-read-model.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Export `readDocs` + the `WorkspaceDoc` type from the package root, so a separate dashboard can read the same surfaced PLAN/TODO docs the daemon serves (#405 phase 2).

--- a/packages/framework-dashboard/components/DocsPanel.tsx
+++ b/packages/framework-dashboard/components/DocsPanel.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react'
+import type { WorkspaceDoc } from '@gemstack/framework'
+import { onDocs } from '../server/reads.telefunc.js'
+import { Button } from './ui/button.js'
+import { Markdown } from './Markdown.js'
+import { cn } from '../lib/utils.js'
+
+// The surfaced documents (#319/#328): the PLAN/TODO the agent writes, rendered beside
+// the run. Telefunc RPC (server/reads.telefunc.ts), polled so edits mid-run show up.
+export function DocsPanel({ projectId }: { projectId: string | null }) {
+  const [docs, setDocs] = useState<WorkspaceDoc[]>([])
+  const [active, setActive] = useState(0)
+
+  useEffect(() => {
+    if (!projectId) {
+      setDocs([])
+      return
+    }
+    let live = true
+    const load = () => void onDocs(projectId).then(list => live && setDocs(list))
+    load()
+    const poll = setInterval(load, 4000)
+    return () => {
+      live = false
+      clearInterval(poll)
+    }
+  }, [projectId])
+
+  if (!projectId) return null
+  if (docs.length === 0) return <p className="p-4 text-sm text-muted-foreground">No PLAN/TODO docs yet.</p>
+
+  const current = docs[Math.min(active, docs.length - 1)]!
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex flex-wrap gap-1 border-b border-border p-2">
+        {docs.map((d, i) => (
+          <Button
+            key={d.name}
+            variant="ghost"
+            size="sm"
+            className={cn('h-7 text-xs', i === active && 'bg-accent text-accent-foreground')}
+            onClick={() => setActive(i)}
+          >
+            {d.name}
+          </Button>
+        ))}
+      </div>
+      <div className="flex-1 overflow-y-auto p-4">
+        <Markdown text={current.content} />
+      </div>
+    </div>
+  )
+}

--- a/packages/framework-dashboard/components/EventList.tsx
+++ b/packages/framework-dashboard/components/EventList.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react'
+import type { FrameworkEvent } from '@gemstack/framework'
+import { Badge } from './ui/badge.js'
+
+// Presentational event log, shared by the live SSE stream and past-run replay. Each
+// FrameworkEvent is a kind badge + a one-line summary; the pane sticks to the bottom
+// as events arrive (live) — replay renders the whole list at once.
+export function EventList({ events, stick = true }: { events: FrameworkEvent[]; stick?: boolean }) {
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (stick) bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [events.length, stick])
+
+  return (
+    <div className="flex-1 overflow-y-auto p-4">
+      <ol className="space-y-1 font-mono text-xs">
+        {events.map((e, i) => (
+          <li key={i} className="flex items-start gap-2">
+            <Badge className="mt-0.5 shrink-0 text-[10px] uppercase text-muted-foreground">{e.kind}</Badge>
+            <span className="whitespace-pre-wrap break-words text-foreground">{summarizeEvent(e)}</span>
+          </li>
+        ))}
+      </ol>
+      <div ref={bottomRef} />
+    </div>
+  )
+}
+
+/** A one-line human summary of an event: its message when it has one, else compact JSON. */
+export function summarizeEvent(event: FrameworkEvent): string {
+  const record = event as Record<string, unknown>
+  if (typeof record['message'] === 'string') return record['message']
+  if (typeof record['title'] === 'string') return record['title']
+  const { kind, ...rest } = record
+  return Object.keys(rest).length ? JSON.stringify(rest) : String(kind)
+}

--- a/packages/framework-dashboard/components/EventStream.tsx
+++ b/packages/framework-dashboard/components/EventStream.tsx
@@ -1,14 +1,12 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { FrameworkEvent } from '@gemstack/framework'
-import { Badge } from './ui/badge.js'
+import { EventList } from './EventList.js'
 
 // The live event stream (#406/#314): a projection of the selected project's
-// `.the-framework/events.jsonl`, streamed over SSE (server/events-sse.ts). Each
-// FrameworkEvent renders as a kind badge + a one-line summary; the pane sticks to the
-// bottom as new events land, like a run log.
+// `.the-framework/events.jsonl`, streamed over SSE (server/events-sse.ts). The row
+// rendering is shared with run replay via EventList.
 export function EventStream({ projectId }: { projectId: string | null }) {
   const [events, setEvents] = useState<FrameworkEvent[]>([])
-  const bottomRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     setEvents([])
@@ -24,37 +22,15 @@ export function EventStream({ projectId }: { projectId: string | null }) {
     return () => source.close()
   }, [projectId])
 
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [events.length])
-
   if (!projectId) {
     return <div className="grid flex-1 place-items-center text-sm text-muted-foreground">Select a project to watch its live run.</div>
   }
-
-  return (
-    <div className="flex-1 overflow-y-auto p-4">
-      {events.length === 0 && (
-        <p className="text-sm text-muted-foreground">Waiting for events… (start a run in this project)</p>
-      )}
-      <ol className="space-y-1 font-mono text-xs">
-        {events.map((e, i) => (
-          <li key={i} className="flex items-start gap-2">
-            <Badge className="mt-0.5 shrink-0 text-[10px] uppercase text-muted-foreground">{e.kind}</Badge>
-            <span className="whitespace-pre-wrap break-words text-foreground">{summarize(e)}</span>
-          </li>
-        ))}
-      </ol>
-      <div ref={bottomRef} />
-    </div>
-  )
-}
-
-/** A one-line human summary of an event: its message when it has one, else compact JSON. */
-function summarize(event: FrameworkEvent): string {
-  const record = event as Record<string, unknown>
-  if (typeof record['message'] === 'string') return record['message']
-  if (typeof record['title'] === 'string') return record['title']
-  const { kind, ...rest } = record
-  return Object.keys(rest).length ? JSON.stringify(rest) : String(kind)
+  if (events.length === 0) {
+    return (
+      <div className="grid flex-1 place-items-center text-sm text-muted-foreground">
+        Waiting for events… (start a run in this project)
+      </div>
+    )
+  }
+  return <EventList events={events} />
 }

--- a/packages/framework-dashboard/components/Markdown.tsx
+++ b/packages/framework-dashboard/components/Markdown.tsx
@@ -1,0 +1,104 @@
+import { Fragment, type ReactNode } from 'react'
+
+// A tiny, dependency-free Markdown renderer for the surfaced PLAN/TODO docs. Builds
+// React nodes (never injects HTML), so agent-written content can't smuggle markup.
+// Handles what those docs use: headings, bullet + task lists, fenced/inline code,
+// bold/italic. Anything else falls through as a paragraph.
+export function Markdown({ text }: { text: string }) {
+  return <div className="space-y-2 text-sm leading-relaxed">{renderBlocks(text)}</div>
+}
+
+function renderBlocks(text: string): ReactNode[] {
+  const lines = text.replace(/\r\n/g, '\n').split('\n')
+  const blocks: ReactNode[] = []
+  let list: ReactNode[] = []
+  let code: string[] | null = null
+  let key = 0
+
+  const flushList = () => {
+    if (list.length) {
+      blocks.push(
+        <ul key={key++} className="ml-4 list-disc space-y-1 marker:text-muted-foreground">
+          {list}
+        </ul>,
+      )
+      list = []
+    }
+  }
+
+  for (const line of lines) {
+    if (line.trim().startsWith('```')) {
+      if (code === null) {
+        flushList()
+        code = []
+      } else {
+        blocks.push(
+          <pre key={key++} className="overflow-x-auto rounded bg-muted p-2 text-xs">
+            <code>{code.join('\n')}</code>
+          </pre>,
+        )
+        code = null
+      }
+      continue
+    }
+    if (code !== null) {
+      code.push(line)
+      continue
+    }
+
+    const heading = /^(#{1,6})\s+(.*)$/.exec(line)
+    if (heading) {
+      flushList()
+      const level = heading[1]!.length
+      const sizes = ['text-lg', 'text-base', 'text-sm', 'text-sm', 'text-sm', 'text-sm']
+      blocks.push(
+        <p key={key++} className={`font-semibold ${sizes[level - 1]}`}>
+          {inline(heading[2]!)}
+        </p>,
+      )
+      continue
+    }
+
+    const task = /^\s*[-*]\s+\[([ xX])\]\s+(.*)$/.exec(line)
+    if (task) {
+      list.push(
+        <li key={key++} className="list-none -ml-4 flex items-start gap-2">
+          <input type="checkbox" checked={task[1]!.toLowerCase() === 'x'} readOnly className="mt-1" />
+          <span>{inline(task[2]!)}</span>
+        </li>,
+      )
+      continue
+    }
+
+    const bullet = /^\s*[-*]\s+(.*)$/.exec(line)
+    if (bullet) {
+      list.push(<li key={key++}>{inline(bullet[1]!)}</li>)
+      continue
+    }
+
+    flushList()
+    if (line.trim()) blocks.push(<p key={key++}>{inline(line)}</p>)
+  }
+  flushList()
+  if (code !== null) blocks.push(<pre key={key++} className="overflow-x-auto rounded bg-muted p-2 text-xs"><code>{code.join('\n')}</code></pre>)
+  return blocks
+}
+
+// Inline spans: `code`, **bold**, *italic*. Applied left-to-right, non-overlapping.
+function inline(text: string): ReactNode {
+  const parts: ReactNode[] = []
+  const re = /(`[^`]+`|\*\*[^*]+\*\*|\*[^*]+\*)/g
+  let last = 0
+  let m: RegExpExecArray | null
+  let key = 0
+  while ((m = re.exec(text))) {
+    if (m.index > last) parts.push(<Fragment key={key++}>{text.slice(last, m.index)}</Fragment>)
+    const token = m[0]
+    if (token.startsWith('`')) parts.push(<code key={key++} className="rounded bg-muted px-1 text-xs">{token.slice(1, -1)}</code>)
+    else if (token.startsWith('**')) parts.push(<strong key={key++}>{token.slice(2, -2)}</strong>)
+    else parts.push(<em key={key++}>{token.slice(1, -1)}</em>)
+    last = m.index + token.length
+  }
+  if (last < text.length) parts.push(<Fragment key={key++}>{text.slice(last)}</Fragment>)
+  return parts
+}

--- a/packages/framework-dashboard/components/ProjectLogPanel.tsx
+++ b/packages/framework-dashboard/components/ProjectLogPanel.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react'
+import type { LogEntry } from '@gemstack/framework'
+import { onProjectLog } from '../server/reads.telefunc.js'
+import { Badge } from './ui/badge.js'
+import { cn } from '../lib/utils.js'
+
+const STATUS_TONE: Record<string, string> = {
+  running: 'text-primary',
+  done: 'text-emerald-500',
+  stopped: 'text-amber-500',
+  failed: 'text-red-500',
+}
+
+// The committed project log (#378/#379): `.the-framework/LOGS.md`, every finished
+// loop/prompt/build run newest-first, over a Telefunc RPC (server/reads.telefunc.ts).
+export function ProjectLogPanel({ projectId }: { projectId: string | null }) {
+  const [logs, setLogs] = useState<LogEntry[]>([])
+
+  useEffect(() => {
+    if (!projectId) {
+      setLogs([])
+      return
+    }
+    let live = true
+    void onProjectLog(projectId).then(list => live && setLogs(list))
+    return () => {
+      live = false
+    }
+  }, [projectId])
+
+  if (!projectId) return null
+  if (logs.length === 0) return <p className="p-4 text-sm text-muted-foreground">No committed log entries yet.</p>
+
+  return (
+    <ul className="flex-1 divide-y divide-border overflow-y-auto">
+      {logs.map((log, i) => (
+        <li key={i} className="px-4 py-2">
+          <div className="flex items-center gap-2">
+            <Badge className="text-[10px] uppercase text-muted-foreground">{log.kind}</Badge>
+            <Badge className={cn('border-transparent px-0 text-[10px] uppercase', STATUS_TONE[log.status])}>{log.status}</Badge>
+            <span className="ml-auto text-xs text-muted-foreground">{new Date(log.at).toLocaleString()}</span>
+          </div>
+          <p className="mt-1 text-sm">{log.title}</p>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/packages/framework-dashboard/components/RightRail.tsx
+++ b/packages/framework-dashboard/components/RightRail.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react'
+import { DocsPanel } from './DocsPanel.js'
+import { ProjectLogPanel } from './ProjectLogPanel.js'
+import { Button } from './ui/button.js'
+import { cn } from '../lib/utils.js'
+
+// The right sidebar (#314 third rail): tabs between the surfaced docs (PLAN/TODO) and
+// the committed project log. Both are Telefunc-backed reads of the selected project.
+export function RightRail({ projectId }: { projectId: string | null }) {
+  const [tab, setTab] = useState<'docs' | 'log'>('docs')
+  if (!projectId) return null
+
+  return (
+    <aside className="flex w-80 shrink-0 flex-col border-l border-border">
+      <div className="flex gap-1 border-b border-border p-2">
+        {(['docs', 'log'] as const).map(t => (
+          <Button
+            key={t}
+            variant="ghost"
+            size="sm"
+            className={cn('h-7 text-xs capitalize', tab === t && 'bg-accent text-accent-foreground')}
+            onClick={() => setTab(t)}
+          >
+            {t === 'docs' ? 'Docs' : 'Project log'}
+          </Button>
+        ))}
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col">
+        {tab === 'docs' ? <DocsPanel projectId={projectId} /> : <ProjectLogPanel projectId={projectId} />}
+      </div>
+    </aside>
+  )
+}

--- a/packages/framework-dashboard/components/RunHistory.tsx
+++ b/packages/framework-dashboard/components/RunHistory.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react'
+import type { RunMeta } from '@gemstack/framework'
+import { onRuns } from '../server/reads.telefunc.js'
+import { Button } from './ui/button.js'
+import { Badge } from './ui/badge.js'
+import { cn } from '../lib/utils.js'
+
+const STATUS_TONE: Record<string, string> = {
+  running: 'text-primary',
+  done: 'text-emerald-500',
+  stopped: 'text-amber-500',
+  failed: 'text-red-500',
+}
+
+// The Runs rail (#314 second sidebar): the selected project's archived runs over a
+// Telefunc RPC (server/reads.telefunc.ts). "Live" returns to the SSE stream; picking a
+// run replays it in the main view. Polls so a run that just finished shows up.
+export function RunHistory({
+  projectId,
+  selectedRunId,
+  onSelect,
+}: {
+  projectId: string | null
+  selectedRunId: string | null
+  onSelect: (runId: string | null) => void
+}) {
+  const [runs, setRuns] = useState<RunMeta[]>([])
+
+  useEffect(() => {
+    if (!projectId) {
+      setRuns([])
+      return
+    }
+    let live = true
+    const load = () => void onRuns(projectId).then(list => live && setRuns(list))
+    load()
+    const poll = setInterval(load, 5000)
+    return () => {
+      live = false
+      clearInterval(poll)
+    }
+  }, [projectId])
+
+  if (!projectId) return null
+
+  return (
+    <aside className="flex w-60 shrink-0 flex-col border-r border-border">
+      <div className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Runs</div>
+      <div className="flex-1 overflow-y-auto px-2">
+        <Button
+          variant="ghost"
+          className={cn('mb-1 w-full justify-start', selectedRunId === null && 'bg-accent text-accent-foreground')}
+          onClick={() => onSelect(null)}
+        >
+          <span className="mr-2 inline-block h-2 w-2 animate-pulse rounded-full bg-primary" /> Live
+        </Button>
+        {runs.length === 0 && <p className="px-2 py-1 text-sm text-muted-foreground">No runs yet.</p>}
+        {runs.map(run => (
+          <Button
+            key={run.id}
+            variant="ghost"
+            className={cn(
+              'mb-0.5 h-auto w-full flex-col items-start gap-0.5 px-2 py-2 text-left',
+              run.id === selectedRunId && 'bg-accent text-accent-foreground',
+            )}
+            onClick={() => onSelect(run.id)}
+          >
+            <span className="flex w-full items-center gap-2">
+              <Badge className={cn('shrink-0 border-transparent px-0 text-[10px] uppercase', STATUS_TONE[run.status])}>
+                {run.status}
+              </Badge>
+              <span className="truncate text-xs font-normal text-muted-foreground">
+                {new Date(run.startedAt).toLocaleString()}
+              </span>
+            </span>
+            <span className="w-full truncate text-sm font-medium">{run.intent || '(no prompt)'}</span>
+          </Button>
+        ))}
+      </div>
+    </aside>
+  )
+}

--- a/packages/framework-dashboard/components/RunReplay.tsx
+++ b/packages/framework-dashboard/components/RunReplay.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react'
+import type { FrameworkEvent } from '@gemstack/framework'
+import { onRun } from '../server/reads.telefunc.js'
+import { EventList } from './EventList.js'
+
+// Replay one archived run: load its event log over a Telefunc RPC and render it in the
+// same EventList the live stream uses (no auto-scroll — it is a static log).
+export function RunReplay({ projectId, runId }: { projectId: string; runId: string }) {
+  const [events, setEvents] = useState<FrameworkEvent[] | null>(null)
+
+  useEffect(() => {
+    let live = true
+    setEvents(null)
+    void onRun(projectId, runId).then(list => live && setEvents(list))
+    return () => {
+      live = false
+    }
+  }, [projectId, runId])
+
+  if (events === null) return <div className="grid flex-1 place-items-center text-sm text-muted-foreground">Loading run…</div>
+  if (events.length === 0) return <div className="grid flex-1 place-items-center text-sm text-muted-foreground">This run has no events.</div>
+  return <EventList events={events} stick={false} />
+}

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -1,26 +1,39 @@
 import { useState } from 'react'
 import { ProjectsSidebar } from '../../components/ProjectsSidebar.js'
+import { RunHistory } from '../../components/RunHistory.js'
 import { EventStream } from '../../components/EventStream.js'
+import { RunReplay } from '../../components/RunReplay.js'
+import { RightRail } from '../../components/RightRail.js'
 import { Badge } from '../../components/ui/badge.js'
 
-// The spike's thin slice (#406): Projects sidebar (Telefunc RPC) on the left, the
-// selected project's live event stream (SSE) filling the rest. Enough real surface
-// to judge the component model + shadcn + Telefunc against the MVP page.ts dashboard.
+// The dashboard shell (#405 phase 2): Projects | Runs | main (live SSE stream or a
+// past-run replay) | Docs/Log rail. The Projects RPC, run history, run replay, docs
+// and log are all Telefunc; the live stream is SSE. A projection of the same
+// .the-framework files the daemon writes.
 export default function Page() {
-  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [projectId, setProjectId] = useState<string | null>(null)
+  // null = follow the live stream; a run id = replay that archived run.
+  const [runId, setRunId] = useState<string | null>(null)
+
+  const selectProject = (id: string) => {
+    setProjectId(id)
+    setRunId(null) // switching projects always returns to live
+  }
 
   return (
     <div className="flex h-screen flex-col">
       <header className="flex items-center gap-3 border-b border-border px-4 py-3">
         <span className="font-semibold">The Framework</span>
-        <Badge className="text-muted-foreground">dashboard spike</Badge>
+        <Badge className="text-muted-foreground">dashboard</Badge>
         <span className="ml-auto text-xs text-muted-foreground">Vike · React · shadcn · Telefunc</span>
       </header>
       <div className="flex min-h-0 flex-1">
-        <ProjectsSidebar selectedId={selectedId} onSelect={setSelectedId} />
+        <ProjectsSidebar selectedId={projectId} onSelect={selectProject} />
+        <RunHistory projectId={projectId} selectedRunId={runId} onSelect={setRunId} />
         <main className="flex min-w-0 flex-1 flex-col">
-          <EventStream projectId={selectedId} />
+          {projectId && runId ? <RunReplay projectId={projectId} runId={runId} /> : <EventStream projectId={projectId} />}
         </main>
+        <RightRail projectId={projectId} />
       </div>
     </div>
   )

--- a/packages/framework-dashboard/server/reads.telefunc.ts
+++ b/packages/framework-dashboard/server/reads.telefunc.ts
@@ -1,0 +1,46 @@
+import {
+  defaultProjectsProvider,
+  listRuns,
+  loadRunEvents,
+  readLogs,
+  readDocs,
+  type RunMeta,
+  type LogEntry,
+  type WorkspaceDoc,
+  type FrameworkEvent,
+} from '@gemstack/framework'
+
+// The read model over Telefunc (#405 phase 2): the run history, a run's replay, the
+// surfaced PLAN/TODO docs, and the committed LOGS.md — each keyed by project id and
+// backed by the same readers the daemon's /api/* endpoints use, so the new dashboard
+// stays a projection of the same files. A live run stream stays on SSE (events-sse.ts).
+
+/** The registry path for a project id, or undefined when unknown (readers then yield empty). */
+async function projectPath(projectId: string): Promise<string | undefined> {
+  return defaultProjectsProvider().resolvePath(projectId)
+}
+
+/** The project's archived runs, most-recent first (or `[]`). */
+export async function onRuns(projectId: string): Promise<RunMeta[]> {
+  const cwd = await projectPath(projectId)
+  return cwd ? listRuns(cwd).catch(() => []) : []
+}
+
+/** One archived run's event log for replay (or `[]` when the run or project is gone). */
+export async function onRun(projectId: string, runId: string): Promise<FrameworkEvent[]> {
+  const cwd = await projectPath(projectId)
+  if (!cwd) return []
+  return (await loadRunEvents(cwd, runId).catch(() => undefined)) ?? []
+}
+
+/** The surfaced PLAN/TODO docs at the workspace root, in sidebar order (or `[]`). */
+export async function onDocs(projectId: string): Promise<WorkspaceDoc[]> {
+  const cwd = await projectPath(projectId)
+  return cwd ? readDocs(cwd).catch(() => []) : []
+}
+
+/** The committed `.the-framework/LOGS.md` entries, newest-first (or `[]`). */
+export async function onProjectLog(projectId: string): Promise<LogEntry[]> {
+  const cwd = await projectPath(projectId)
+  return cwd ? readLogs(cwd).catch(() => []) : []
+}

--- a/packages/framework/src/dashboard/index.ts
+++ b/packages/framework/src/dashboard/index.ts
@@ -7,3 +7,4 @@ export {
   type SummarizeDeps,
 } from './projects.js'
 export { dashboardHtml } from './page.js'
+export { readDocs, DOC_CATEGORIES, type WorkspaceDoc } from './docs.js'

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -92,7 +92,7 @@ export {
   SESSION_ID_PLACEHOLDER,
   OPEN_LOOP_MODES,
 } from './events.js'
-export { startDashboard, dashboardHtml, summarizeProject, defaultProjectsProvider, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunResult, type AddProjectResult, type ProjectSummary, type ProjectsProvider, type SummarizeDeps } from './dashboard/index.js'
+export { startDashboard, dashboardHtml, summarizeProject, defaultProjectsProvider, readDocs, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunResult, type AddProjectResult, type ProjectSummary, type ProjectsProvider, type SummarizeDeps, type WorkspaceDoc } from './dashboard/index.js'
 export {
   RunStore,
   nodeStoreFs,


### PR DESCRIPTION
#405 phase 2, read side. Ports the rest of the dashboard's `/api/*` reads to **Telefunc RPCs** in the new dashboard, growing it toward parity. The current `page.ts` MVP page is still untouched.

**Telefunc RPCs** (`server/reads.telefunc.ts`), each keyed by project id and backed by the same `@gemstack/framework` readers the daemon uses, so the dashboard stays a projection of the same `.the-framework` files:
- `onRuns` → `listRuns` (run history)
- `onRun` → `loadRunEvents` (replay a past run)
- `onDocs` → `readDocs` (surfaced PLAN/TODO)
- `onProjectLog` → `readLogs` (committed `LOGS.md`)

**UI** grows to the 3-rail shell (#314): **Projects | Runs | main | Docs/Log**. The main view shows either the live SSE stream or a selected run's replay; event rows are shared via `EventList`. Docs render through a tiny dependency-free, XSS-safe `Markdown` component.

Exports `readDocs` + `WorkspaceDoc` from `@gemstack/framework` (minor) for reuse.

**Verified** (dev + prod):
- Root `turbo typecheck` 22/22; `vite build` clean — Telefunc auto-generated shields for all 5 telefunctions (`onProjects`, `onRuns`, `onRun`, `onDocs`, `onProjectLog`).
- Against a populated workspace (a real `--fake` run archives a run + writes `LOGS.md`, plus a `PLAN.md`): the readers behind the RPCs return real data (1 run `done`, 1 log entry, `PLAN.md`); `GET /` 200; SSE still streams; `/_telefunc` mounted with the new client transforms present.

**Not in scope** (later phases of #405): the write side (start/stop/choice RPCs), and the daemon serving the built bundle — the serve architecture question is on #405 awaiting your call. Telefunc-stream for events (vs SSE) is a separate evaluation.