### PR TITLE
feat(framework): `framework maintain` background maintenance sweep (#298)

### DIFF
--- a/.changeset/framework-maintain-sweep.md
+++ b/.changeset/framework-maintain-sweep.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Add `framework maintain` (#298): a background maintenance sweep. It walks the registered repos, and for each that has grown commits since its last review it runs the maintainability loop on them (`framework prompt`, budget-capped by `--max-cost`, bounded by `--max-repos`). A first-seen repo is baselined (recorded, not reviewed retroactively); per-repo review state lives in `.the-framework/maintenance.json`. `--dry-run` previews the plan. Also exports the maintenance API (`assessRepo`, `planMaintenanceSweep`, `maintainSweep`, review state helpers).

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -51,6 +51,20 @@ test('parseArgs reads the backlog-loop flags (#323)', () => {
   assert.match(parseArgs(['--max-todo-items', '0', 'x']).error!, /max-todo-items/)
 })
 
+test('parseArgs reads the maintain subcommand + its bounds (#298)', () => {
+  const dflt = parseArgs(['x'])
+  assert.equal(dflt.maintain, false)
+  assert.equal(dflt.dryRun, false)
+
+  const m = parseArgs(['maintain', '--dry-run'])
+  assert.equal(m.maintain, true)
+  assert.equal(m.dryRun, true)
+  assert.equal(m.intent, '') // maintain takes no positional args
+
+  assert.equal(parseArgs(['maintain', '--max-repos', '3']).maxRepos, 3)
+  assert.match(parseArgs(['maintain', '--max-repos', '0']).error!, /max-repos/)
+})
+
 test('parseArgs reads the Global options flags: vanilla + eco (#314)', () => {
   const dflt = parseArgs(['x'])
   assert.equal(dflt.vanilla, false)

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
+import { spawn } from 'node:child_process'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
   builtinDomainPresets,
@@ -44,8 +45,16 @@ import { preflight } from './preflight.js'
 import { RunStore } from './store/index.js'
 import { daemonStatus, ensureDaemon, runDaemon, stopDaemon, DEFAULT_DAEMON_PORT } from './daemon.js'
 import { resetControl, watchControl, type ControlWatcher } from './control.js'
-import { isActivated } from './project.js'
-import { addProject } from './registry.js'
+import { isActivated, nodeGitRunner } from './project.js'
+import { addProject, listProjects } from './registry.js'
+import {
+  planMaintenanceSweep,
+  maintainSweep,
+  writeMaintenanceState,
+  short,
+  type RepoReview,
+} from './maintenance.js'
+import { renderMaintainabilityPrompt } from './maintainability-preset.js'
 import { runPrompt } from './prompt-run.js'
 import { renderResearchPrompt } from './research-preset.js'
 
@@ -110,6 +119,9 @@ Usage:
   framework prompt <text>         Run one prompt verbatim through the agent, honoring
                                  its await gates — no scaffold/build pipeline. This is
                                  what a dashboard preset sends after you edit it.
+  framework maintain              Sweep the registered repos: run the maintainability
+                                 loop on any that grew un-reviewed commits (#298).
+                                 --dry-run to preview; --max-repos / --max-cost to bound.
   framework --fake                Run the offline demo (no CLI, no model, deterministic).
   framework doctor                Check prerequisites (Claude Code installed, etc.).
   framework relay                 Host a run relay so teammates can watch a run (#230).
@@ -240,6 +252,12 @@ export interface CliOptions {
   research: boolean
   /** `framework prompt <text>`: run one prompt verbatim through the direct path (#353). */
   directPrompt: boolean
+  /** `framework maintain`: sweep the registered repos, running the maintenance loop on un-reviewed commits (#298). */
+  maintain: boolean
+  /** `--dry-run`: for `maintain`, list what would be reviewed without running anything. */
+  dryRun: boolean
+  /** `--max-repos <n>`: cap how many repos one maintenance sweep reviews. */
+  maxRepos?: number
   error?: string
 }
 
@@ -268,6 +286,8 @@ export function parseArgs(argv: string[]): CliOptions {
     stop: false,
     research: false,
     directPrompt: false,
+    maintain: false,
+    dryRun: false,
     todoLoop: true,
   }
   const PERMISSION_MODES: PermissionMode[] = ['default', 'acceptEdits', 'bypassPermissions', 'plan']
@@ -412,6 +432,15 @@ export function parseArgs(argv: string[]): CliOptions {
       case '--no-todo-loop':
         opts.todoLoop = false
         break
+      case '--dry-run':
+        opts.dryRun = true
+        break
+      case '--max-repos': {
+        const n = Number(argv[++i])
+        if (!Number.isInteger(n) || n < 1) opts.error = `invalid --max-repos: must be a positive integer`
+        else opts.maxRepos = n
+        break
+      }
       case '--max-todo-items': {
         const n = Number(argv[++i])
         if (!Number.isInteger(n) || n < 1) opts.error = `invalid --max-todo-items: must be a positive integer`
@@ -445,6 +474,9 @@ export function parseArgs(argv: string[]): CliOptions {
   } else if (words[0] === 'prompt') {
     opts.directPrompt = true
     words.shift() // the remaining words are the prompt text, run verbatim (#353)
+  } else if (words[0] === 'maintain') {
+    opts.maintain = true
+    words.shift() // maintain takes no positional args; the target is the registry
   }
   opts.intent = words.join(' ').trim()
   return opts
@@ -667,6 +699,10 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
 
   // `framework stop` stops this workspace's background dashboard.
   if (opts.stop) return stopDaemonCmd(opts, io)
+
+  // `framework maintain` sweeps the registered repos, running the maintenance loop on
+  // any that grew un-reviewed commits (#298). No dashboard, no intent.
+  if (opts.maintain) return maintainCmd(opts, io)
 
   const fake = opts.fake
   const intent = opts.intent || (fake ? FAKE_INTENT : '')
@@ -1184,6 +1220,88 @@ async function stopDaemonCmd(_opts: CliOptions, io: CliIO): Promise<number> {
   const stopped = await stopDaemon()
   io.out(stopped ? '◆ dashboard stopped.' : 'No background dashboard was running.')
   return 0
+}
+
+/**
+ * `framework maintain`: the background maintenance sweep (#298). Walks the registered
+ * repos, and for each with new commits since its last review runs the maintainability
+ * loop (`framework prompt "<maintainability prompt>"`), budget-capped by `--max-cost`
+ * and bounded by `--max-repos`. A first-seen repo is baselined (recorded, not reviewed
+ * retroactively). `--dry-run` prints the plan without running anything.
+ */
+async function maintainCmd(opts: CliOptions, io: CliIO): Promise<number> {
+  const projects = await listProjects()
+  if (projects.length === 0) {
+    io.out('No registered projects. Run `framework` in a repo to add one.')
+    return 0
+  }
+
+  const reviews = await planMaintenanceSweep(
+    projects.map(p => ({ id: p.id, path: p.path })),
+    nodeGitRunner(),
+  )
+
+  if (opts.dryRun) {
+    io.out(`Maintenance sweep (dry run) — ${reviews.length} registered repo${reviews.length === 1 ? '' : 's'}:`)
+    for (const r of reviews) io.out(`  ${describeReview(r)}`)
+    return 0
+  }
+
+  const binPath = process.argv[1]
+  if (!binPath) {
+    io.err('cannot locate the framework CLI entry to run the maintenance loop.')
+    return 1
+  }
+
+  const summary = await maintainSweep(reviews, {
+    run: review => spawnMaintenanceRun(review, binPath, opts.maxCost),
+    record: (path, state) => writeMaintenanceState(path, state),
+    log: message => io.out(message),
+    now: () => new Date().toISOString(),
+    ...(opts.maxRepos !== undefined ? { maxRepos: opts.maxRepos } : {}),
+  })
+
+  io.out(
+    `Sweep done: ${summary.reviewed} reviewed, ${summary.baselined} baselined, ${summary.skipped} up-to-date, ` +
+      `${summary.failed} failed${summary.pending ? `, ${summary.pending} pending (--max-repos)` : ''}.`,
+  )
+  return summary.failed ? 1 : 0
+}
+
+/** One line describing a repo's assessed maintenance status, for the dry-run plan. */
+function describeReview(r: RepoReview): string {
+  const name = basename(r.path)
+  switch (r.action) {
+    case 'baseline':
+      return `${name} — baseline at ${short(r.headSha)} (first seen; nothing reviewed retroactively)`
+    case 'review':
+      return `${name} — review ${r.newCommits} new commit${r.newCommits === 1 ? '' : 's'} (${short(r.reviewedSha)}..${short(r.headSha)})${r.note ? ` [${r.note}]` : ''}`
+    case 'skip':
+      return `${name} — up to date`
+    case 'error':
+      return `${name} — skipped (${r.note ?? 'could not assess'})`
+  }
+}
+
+/**
+ * Run the maintainability loop on one repo by spawning `framework prompt "<prompt>"
+ * --cwd <repo> --no-dashboard`, reusing the whole run path (preflight, driver, budget
+ * cap, LOGS.md). The child inherits stdio so its run streams to the terminal.
+ * Resolves true on a clean exit (0). Never re-execs a test entry (fork-bomb guard).
+ */
+function spawnMaintenanceRun(review: RepoReview, binPath: string, maxCost?: number): Promise<boolean> {
+  if (process.env.NODE_TEST_CONTEXT || /\.test\.[cm]?[jt]s$/.test(binPath)) {
+    return Promise.resolve(false) // refuse to spawn from a test entry
+  }
+  // Scope the maintainability pass to the un-reviewed range so the agent knows what to look at.
+  const what = review.reviewedSha ? `the changes in ${short(review.reviewedSha)}..${short(review.headSha)}` : 'the recent changes'
+  const args = [binPath, 'prompt', renderMaintainabilityPrompt(what), '--no-dashboard', '--cwd', review.path]
+  if (maxCost !== undefined) args.push('--max-cost', String(maxCost))
+  return new Promise<boolean>(resolvePromise => {
+    const child = spawn(process.execPath, args, { stdio: 'inherit' })
+    child.once('error', () => resolvePromise(false))
+    child.once('exit', code => resolvePromise(code === 0))
+  })
 }
 
 async function runRelayServer(opts: CliOptions, io: CliIO): Promise<number> {

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -92,6 +92,21 @@ export {
   SESSION_ID_PLACEHOLDER,
   OPEN_LOOP_MODES,
 } from './events.js'
+export {
+  assessRepo,
+  planMaintenanceSweep,
+  maintainSweep,
+  readMaintenanceState,
+  writeMaintenanceState,
+  maintenanceStatePath,
+  MAINTENANCE_FILE,
+  type MaintenanceState,
+  type RepoReview,
+  type MaintenanceAction,
+  type SweepSummary,
+  type SweepDeps,
+  type MaintenanceFs,
+} from './maintenance.js'
 export { startDashboard, dashboardHtml, summarizeProject, defaultProjectsProvider, readDocs, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunResult, type AddProjectResult, type ProjectSummary, type ProjectsProvider, type SummarizeDeps, type WorkspaceDoc } from './dashboard/index.js'
 export {
   RunStore,

--- a/packages/framework/src/maintenance.test.ts
+++ b/packages/framework/src/maintenance.test.ts
@@ -1,0 +1,158 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import type { GitRunner } from './project.js'
+import {
+  assessRepo,
+  planMaintenanceSweep,
+  maintainSweep,
+  readMaintenanceState,
+  writeMaintenanceState,
+  type MaintenanceFs,
+  type RepoReview,
+  type SweepDeps,
+} from './maintenance.js'
+
+/** In-memory {@link MaintenanceFs}. */
+function memFs(): { fs: MaintenanceFs; files: Map<string, string> } {
+  const files = new Map<string, string>()
+  return {
+    files,
+    fs: {
+      async read(path) {
+        const v = files.get(path)
+        if (v === undefined) throw new Error('ENOENT')
+        return v
+      },
+      async write(path, contents) {
+        files.set(path, contents)
+      },
+      async mkdir() {},
+    },
+  }
+}
+
+/** A fake GitRunner keyed by repo path: HEAD + a rev-list count (or a throw). */
+function fakeGit(repos: Record<string, { head: string; newCommits?: number; revListThrows?: boolean } | undefined>): GitRunner {
+  return async (args, cwd) => {
+    const repo = repos[cwd]
+    if (!repo) throw new Error('not a git repo')
+    if (args[0] === 'rev-parse') return repo.head + '\n'
+    if (args[0] === 'rev-list') {
+      if (repo.revListThrows) throw new Error('bad revision')
+      return String(repo.newCommits ?? 0) + '\n'
+    }
+    throw new Error('unexpected git args: ' + args.join(' '))
+  }
+}
+
+test('assessRepo baselines a first-seen repo (records nothing retroactively)', async () => {
+  const { fs } = memFs()
+  const git = fakeGit({ '/a': { head: 'aaaaaaaa' } })
+  const r = await assessRepo('/a', git, fs)
+  assert.equal(r.action, 'baseline')
+  assert.equal(r.headSha, 'aaaaaaaa')
+  assert.equal(r.newCommits, 0)
+})
+
+test('assessRepo skips an up-to-date repo and reviews one with new commits', async () => {
+  const { fs } = memFs()
+  await writeMaintenanceState('/a', { reviewedSha: 'aaaaaaaa' }, fs)
+  await writeMaintenanceState('/b', { reviewedSha: 'old00000' }, fs)
+  const git = fakeGit({ '/a': { head: 'aaaaaaaa' }, '/b': { head: 'bbbbbbbb', newCommits: 3 } })
+
+  const a = await assessRepo('/a', git, fs)
+  assert.equal(a.action, 'skip')
+  assert.equal(a.newCommits, 0)
+
+  const b = await assessRepo('/b', git, fs)
+  assert.equal(b.action, 'review')
+  assert.equal(b.newCommits, 3)
+  assert.equal(b.reviewedSha, 'old00000')
+})
+
+test('assessRepo errors on a non-repo and re-reviews when history was rewritten', async () => {
+  const { fs } = memFs()
+  await writeMaintenanceState('/gone', { reviewedSha: 'deadbeef' }, fs)
+  const git = fakeGit({ '/gone': { head: 'cccccccc', revListThrows: true } })
+
+  const missing = await assessRepo('/missing', git, fs) // not in the fake -> git throws
+  assert.equal(missing.action, 'error')
+
+  const rewritten = await assessRepo('/gone', git, fs)
+  assert.equal(rewritten.action, 'review')
+  assert.match(rewritten.note ?? '', /history changed/)
+})
+
+test('readMaintenanceState is forgiving; write/read round-trips', async () => {
+  const { fs, files } = memFs()
+  assert.deepEqual(await readMaintenanceState('/a', fs), {}) // absent
+  files.set((await import('./maintenance.js')).maintenanceStatePath('/a'), 'not json')
+  assert.deepEqual(await readMaintenanceState('/a', fs), {}) // malformed
+
+  await writeMaintenanceState('/a', { reviewedSha: 'abc', reviewedAt: '2026-01-01T00:00:00Z' }, fs)
+  assert.deepEqual(await readMaintenanceState('/a', fs), { reviewedSha: 'abc', reviewedAt: '2026-01-01T00:00:00Z' })
+})
+
+test('planMaintenanceSweep tags each review with its registry id', async () => {
+  const { fs } = memFs()
+  const git = fakeGit({ '/a': { head: 'aaaaaaaa' }, '/b': { head: 'bbbbbbbb' } })
+  const plan = await planMaintenanceSweep([{ id: 'a-1', path: '/a' }, { id: 'b-1', path: '/b' }], git, fs)
+  assert.deepEqual(plan.map(r => r.id), ['a-1', 'b-1'])
+})
+
+/** A SweepDeps that records calls, with a run() outcome per path. */
+function recordingDeps(outcome: (path: string) => boolean): {
+  deps: SweepDeps
+  ran: string[]
+  recorded: { path: string; sha: string | undefined }[]
+} {
+  const ran: string[] = []
+  const recorded: { path: string; sha: string | undefined }[] = []
+  return {
+    ran,
+    recorded,
+    deps: {
+      run: async (review: RepoReview) => {
+        ran.push(review.path)
+        return outcome(review.path)
+      },
+      record: async (path, state) => {
+        recorded.push({ path, sha: state.reviewedSha })
+      },
+      log: () => {},
+      now: () => '2026-02-02T00:00:00Z',
+    },
+  }
+}
+
+test('maintainSweep baselines without running, records a successful review, retries a failure', async () => {
+  const reviews: RepoReview[] = [
+    { path: '/base', headSha: 'h0', newCommits: 0, action: 'baseline' },
+    { path: '/ok', headSha: 'h1', reviewedSha: 'r1', newCommits: 2, action: 'review' },
+    { path: '/fail', headSha: 'h2', reviewedSha: 'r2', newCommits: 1, action: 'review' },
+    { path: '/clean', headSha: 'h3', newCommits: 0, action: 'skip' },
+  ]
+  const { deps, ran, recorded } = recordingDeps(path => path === '/ok') // only /ok succeeds
+  const summary = await maintainSweep(reviews, deps)
+
+  assert.deepEqual(ran, ['/ok', '/fail']) // baseline + skip never run
+  assert.deepEqual(recorded, [
+    { path: '/base', sha: 'h0' }, // baseline records HEAD
+    { path: '/ok', sha: 'h1' }, // success records HEAD
+    // /fail is NOT recorded -> retried next sweep
+  ])
+  assert.deepEqual(summary, { reviewed: 1, baselined: 1, skipped: 1, failed: 1, pending: 0 })
+})
+
+test('maintainSweep honors maxRepos, leaving the rest pending', async () => {
+  const reviews: RepoReview[] = [
+    { path: '/a', headSha: 'a', reviewedSha: 'x', newCommits: 1, action: 'review' },
+    { path: '/b', headSha: 'b', reviewedSha: 'y', newCommits: 1, action: 'review' },
+    { path: '/c', headSha: 'c', reviewedSha: 'z', newCommits: 1, action: 'review' },
+  ]
+  const { deps, ran } = recordingDeps(() => true)
+  const summary = await maintainSweep(reviews, { ...deps, maxRepos: 2 })
+  assert.deepEqual(ran, ['/a', '/b'])
+  assert.equal(summary.reviewed, 2)
+  assert.equal(summary.pending, 1)
+})

--- a/packages/framework/src/maintenance.ts
+++ b/packages/framework/src/maintenance.ts
@@ -1,0 +1,217 @@
+import { join } from 'node:path'
+import { nodeGitRunner, type GitRunner } from './project.js'
+import { FRAMEWORK_DIR } from './store/index.js'
+
+/**
+ * The maintenance sweep (#298): a background job that walks the registered repos,
+ * finds the commits each repo has grown since its last maintenance review, and runs
+ * the maintainability loop on them. Per-repo review state is a small local file
+ * (`.the-framework/maintenance.json`, gitignored) recording the last-reviewed commit,
+ * so a sweep only ever acts on new work. The capacity gate is the existing budget cap
+ * (`--max-cost`) — the account's usage *limit* isn't retrievable under subscription
+ * auth (see usage.ts), so #298's "check the limit" half is out of reach for now.
+ */
+
+/** The per-repo review-state filename under `.the-framework/`. */
+export const MAINTENANCE_FILE = 'maintenance.json'
+
+/** What a repo's last maintenance review recorded. */
+export interface MaintenanceState {
+  /** The HEAD commit the maintenance loop last reviewed (a full SHA). */
+  reviewedSha?: string
+  /** ISO timestamp of that review. */
+  reviewedAt?: string
+}
+
+/** Minimal fs seam so the state IO is unit-testable without touching disk. */
+export interface MaintenanceFs {
+  read(path: string): Promise<string>
+  write(path: string, contents: string): Promise<void>
+  mkdir(path: string): Promise<void>
+}
+
+/** A {@link MaintenanceFs} backed by `node:fs/promises` (dynamic import, same convention as the registry). */
+export function nodeMaintenanceFs(): MaintenanceFs {
+  return {
+    async read(path) {
+      const { readFile } = await import('node:fs/promises')
+      return readFile(path, 'utf8')
+    },
+    async write(path, contents) {
+      const { writeFile } = await import('node:fs/promises')
+      await writeFile(path, contents, 'utf8')
+    },
+    async mkdir(path) {
+      const { mkdir } = await import('node:fs/promises')
+      await mkdir(path, { recursive: true })
+    },
+  }
+}
+
+/** The review-state file path for a repo. */
+export function maintenanceStatePath(cwd: string): string {
+  return join(cwd, FRAMEWORK_DIR, MAINTENANCE_FILE)
+}
+
+/** Read a repo's review state. Forgiving: a missing/unreadable/malformed file yields `{}`. */
+export async function readMaintenanceState(cwd: string, fs: MaintenanceFs = nodeMaintenanceFs()): Promise<MaintenanceState> {
+  try {
+    const parsed = JSON.parse(await fs.read(maintenanceStatePath(cwd))) as unknown
+    if (parsed && typeof parsed === 'object') {
+      const record = parsed as Record<string, unknown>
+      const state: MaintenanceState = {}
+      if (typeof record['reviewedSha'] === 'string') state.reviewedSha = record['reviewedSha']
+      if (typeof record['reviewedAt'] === 'string') state.reviewedAt = record['reviewedAt']
+      return state
+    }
+  } catch {
+    // absent / unreadable / malformed -> no prior review
+  }
+  return {}
+}
+
+/** Record a repo's review state, creating `.the-framework/` as needed. */
+export async function writeMaintenanceState(
+  cwd: string,
+  state: MaintenanceState,
+  fs: MaintenanceFs = nodeMaintenanceFs(),
+): Promise<void> {
+  await fs.mkdir(join(cwd, FRAMEWORK_DIR))
+  await fs.write(maintenanceStatePath(cwd), JSON.stringify(state, null, 2))
+}
+
+/** What the sweep decided for one repo. */
+export type MaintenanceAction = 'baseline' | 'review' | 'skip' | 'error'
+
+/** A repo's assessed maintenance status. */
+export interface RepoReview {
+  /** Registry id, when assessed from the registry. */
+  id?: string
+  /** Absolute repo path. */
+  path: string
+  /** Current HEAD SHA, when resolvable. */
+  headSha?: string
+  /** The last-reviewed SHA, when the repo has been reviewed before. */
+  reviewedSha?: string
+  /** Commits in `reviewedSha..HEAD` (0 for a first-seen or up-to-date repo). */
+  newCommits: number
+  /** What to do: baseline a first-seen repo, review new commits, skip an up-to-date one, or an error. */
+  action: MaintenanceAction
+  /** Context for an `error` or an unusual `review` (e.g. rewritten history). */
+  note?: string
+}
+
+/**
+ * Assess one repo: resolve HEAD, read its review state, and count the commits since
+ * the last review. A never-reviewed repo is `baseline` (we record HEAD without
+ * reviewing history retroactively); an unchanged repo is `skip`; new commits are
+ * `review`. A non-repo / missing git is `error` (skipped, never throws). A reviewed
+ * SHA git no longer knows (rebased away) falls back to `review`.
+ */
+export async function assessRepo(
+  path: string,
+  git: GitRunner = nodeGitRunner(),
+  fs: MaintenanceFs = nodeMaintenanceFs(),
+): Promise<RepoReview> {
+  let headSha: string
+  try {
+    headSha = (await git(['rev-parse', 'HEAD'], path)).trim()
+  } catch {
+    return { path, newCommits: 0, action: 'error', note: 'not a git repo, or it has no commits' }
+  }
+
+  const { reviewedSha } = await readMaintenanceState(path, fs)
+  if (!reviewedSha) return { path, headSha, newCommits: 0, action: 'baseline' }
+  if (reviewedSha === headSha) return { path, headSha, reviewedSha, newCommits: 0, action: 'skip' }
+
+  try {
+    const count = Number.parseInt((await git(['rev-list', '--count', `${reviewedSha}..HEAD`], path)).trim(), 10)
+    const newCommits = Number.isFinite(count) ? count : 0
+    return { path, headSha, reviewedSha, newCommits, action: newCommits > 0 ? 'review' : 'skip' }
+  } catch {
+    // The reviewed commit is unknown to git (history was rewritten): re-review to be safe.
+    return { path, headSha, reviewedSha, newCommits: 0, action: 'review', note: 'reviewed commit not found (history changed); re-reviewing' }
+  }
+}
+
+/** Assess every registered repo, tagging each review with its registry id. */
+export async function planMaintenanceSweep(
+  repos: readonly { id?: string; path: string }[],
+  git: GitRunner = nodeGitRunner(),
+  fs: MaintenanceFs = nodeMaintenanceFs(),
+): Promise<RepoReview[]> {
+  return Promise.all(repos.map(async repo => ({ ...(await assessRepo(repo.path, git, fs)), ...(repo.id ? { id: repo.id } : {}) })))
+}
+
+/** The tally a sweep returns. */
+export interface SweepSummary {
+  reviewed: number
+  baselined: number
+  skipped: number
+  failed: number
+  /** Repos not reached because `maxRepos` was hit. */
+  pending: number
+}
+
+/** Injected effects for {@link maintainSweep}, so the orchestration is testable off disk/process. */
+export interface SweepDeps {
+  /** Run the maintenance loop on a repo; resolves true on success. */
+  run(review: RepoReview): Promise<boolean>
+  /** Persist a repo's review state (called after a baseline or a successful review). */
+  record(path: string, state: MaintenanceState): Promise<void>
+  /** Progress line. */
+  log(message: string): void
+  /** ISO timestamp for a recorded review (injected so runs are deterministic in tests). */
+  now(): string
+  /** Stop after reviewing this many repos in one sweep (baselines/skips don't count). */
+  maxRepos?: number
+}
+
+/**
+ * Orchestrate a sweep over pre-assessed reviews: baseline first-seen repos (record
+ * HEAD, no run), skip up-to-date ones, and run the maintenance loop on the rest —
+ * recording the reviewed SHA only when the run succeeds, so a failure is retried next
+ * sweep. Honors `maxRepos`; the remainder is reported as `pending`.
+ */
+export async function maintainSweep(reviews: readonly RepoReview[], deps: SweepDeps): Promise<SweepSummary> {
+  const summary: SweepSummary = { reviewed: 0, baselined: 0, skipped: 0, failed: 0, pending: 0 }
+  const limit = deps.maxRepos ?? Infinity
+  for (const review of reviews) {
+    if (review.action === 'skip') {
+      summary.skipped++
+      continue
+    }
+    if (review.action === 'error') {
+      summary.failed++
+      deps.log(`✗ ${review.path}: ${review.note ?? 'could not assess'}`)
+      continue
+    }
+    if (review.action === 'baseline') {
+      if (review.headSha) await deps.record(review.path, { reviewedSha: review.headSha, reviewedAt: deps.now() })
+      summary.baselined++
+      deps.log(`◆ baselined ${review.path} at ${short(review.headSha)}`)
+      continue
+    }
+    // action === 'review'
+    if (summary.reviewed >= limit) {
+      summary.pending++
+      continue
+    }
+    deps.log(`▶ maintaining ${review.path} (${review.newCommits} new commit${review.newCommits === 1 ? '' : 's'})…`)
+    const ok = await deps.run(review)
+    if (ok && review.headSha) {
+      await deps.record(review.path, { reviewedSha: review.headSha, reviewedAt: deps.now() })
+      summary.reviewed++
+      deps.log(`✓ ${review.path} reviewed`)
+    } else {
+      summary.failed++
+      deps.log(`✗ ${review.path} maintenance run failed; will retry next sweep`)
+    }
+  }
+  return summary
+}
+
+/** Short SHA for logs. */
+export function short(sha: string | undefined): string {
+  return sha ? sha.slice(0, 7) : '(unknown)'
+}


### PR DESCRIPTION
The first buildable, infra-free slice of #298 (Background jobs): a maintenance sweep.

`framework maintain` walks the registered repos, and for each that grew commits since its last review runs the maintainability loop on them (`framework prompt`, budget-capped by `--max-cost`, bounded by `--max-repos`). A first-seen repo is **baselined** (its HEAD recorded, history not reviewed retroactively); per-repo review state is `.the-framework/maintenance.json`. `--dry-run` previews the plan without running anything.

Composes what already exists: the registry (list repos), git (HEAD + `rev-list` for un-reviewed commits), the maintainability preset, the run path, and the #327 budget cap.

**Scope note (posted on #298):** the capacity gate is the budget cap, not usage-limit retrieval — the account's usage *limit*/reset isn't retrievable under subscription auth (`usage.ts` documents this), so #298's "check the limit / fallback model when maxed" half is out of reach for now. The **listeners** (Sentry/CI → agent) and **full autopilot** halves are later, infra-gated/design work.

**Design:** the assess/plan/sweep logic + review-state IO live in `maintenance.ts` behind git/fs seams (pure, unit-tested); the CLI wires the registry + a child-spawn runner (reuses the whole `framework prompt` run path, so budget cap + LOGS.md come for free).

**Verified:**
- 456 tests pass (7 new for baseline/skip/review/error/history-rewritten/maxRepos/round-trip); root `turbo typecheck` 22/22.
- Drove it end to end against two real git repos: dry-run previews (baseline → "review 2 new commits `a..b`" → "up to date"); the real sweep baselines first-seen repos without spawning any run; state recorded in `maintenance.json`. (The actual maintenance run spawn costs tokens, so it's exercised via the injected runner in tests, not live.)

Follow-ups if we keep going: a total sweep budget (needs spend aggregation), whether review state should be committed (cross-machine) vs local, and the infra-gated listeners.