### PR TITLE
Steer live runs from the dashboard over Telefunc (stop + choice/multiselect)

### DIFF
--- a/packages/framework-dashboard/components/ChoicePanel.tsx
+++ b/packages/framework-dashboard/components/ChoicePanel.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react'
+import type { ChoiceRequest } from '@gemstack/framework'
+import { sendChoice } from '../server/control.telefunc.js'
+import { Button } from './ui/button.js'
+import { cn } from '../lib/utils.js'
+
+// "Your call" — the interactive gate the run parks on (#304/#332), rendered from the
+// live event stream and posted back over Telefunc (server/control.telefunc.ts) to the
+// project's control.jsonl. Three shapes: an Approve/Decline confirm (#358), a
+// multi-select checklist (#332), and the single-select list (#304). The panel clears
+// itself when the resulting `choice-resolved` event streams in (pendingChoice drops
+// it); mount it with `key={choice.id}` so a re-fired gate resets local state.
+export function ChoicePanel({ projectId, choice }: { projectId: string; choice: ChoiceRequest }) {
+  const [busy, setBusy] = useState(false)
+  const [checked, setChecked] = useState<Set<string>>(
+    () => new Set(choice.multi ? choice.options.filter(o => o.default).map(o => o.id) : []),
+  )
+
+  const post = (pick: string | string[]) => {
+    setBusy(true)
+    void sendChoice(projectId, choice.id, pick).catch(() => setBusy(false))
+  }
+
+  const toggle = (id: string) =>
+    setChecked(prev => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+
+  const approveId = choice.recommended ?? choice.options[0]?.id
+  const declineId = choice.options.find(o => o.id !== approveId)?.id ?? approveId
+
+  return (
+    <section className="border-b border-border bg-accent/40 p-4">
+      <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Your call</div>
+      <h2 className="mb-3 text-sm font-medium">{choice.title}</h2>
+
+      {choice.confirm ? (
+        <div className="flex gap-2">
+          <Button
+            className="bg-emerald-600 text-white hover:bg-emerald-600 hover:opacity-90"
+            disabled={busy || !approveId}
+            onClick={() => approveId && post(approveId)}
+          >
+            Approve
+          </Button>
+          <Button
+            variant="outline"
+            className="border-red-500/50 text-red-500 hover:bg-red-500/10 hover:text-red-500"
+            disabled={busy || !declineId}
+            onClick={() => declineId && post(declineId)}
+          >
+            Decline
+          </Button>
+        </div>
+      ) : choice.multi ? (
+        <>
+          <ul className="mb-3 space-y-1">
+            {choice.options.map(o => (
+              <li key={o.id}>
+                <label className="flex cursor-pointer items-start gap-2 text-sm">
+                  <input type="checkbox" className="mt-1" checked={checked.has(o.id)} onChange={() => toggle(o.id)} disabled={busy} />
+                  <span>
+                    {o.label}
+                    {o.detail && <span className="block text-xs text-muted-foreground">{o.detail}</span>}
+                  </span>
+                </label>
+              </li>
+            ))}
+          </ul>
+          <Button disabled={busy} onClick={() => post([...checked])}>
+            Accept
+          </Button>
+        </>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {choice.options.map(o => (
+            <Button
+              key={o.id}
+              variant={o.id === choice.recommended ? 'default' : 'outline'}
+              className={cn('h-auto flex-col items-start gap-0.5 py-2 text-left')}
+              disabled={busy}
+              onClick={() => post(o.id)}
+            >
+              <span className="font-medium">{o.label}</span>
+              {o.detail && <span className="text-xs font-normal opacity-80">{o.detail}</span>}
+            </Button>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/packages/framework-dashboard/components/EventStream.tsx
+++ b/packages/framework-dashboard/components/EventStream.tsx
@@ -2,12 +2,17 @@ import { useEffect, useState } from 'react'
 import type { FrameworkEvent } from '@gemstack/framework'
 import type { ClientChannel } from 'telefunc'
 import { onEvents } from '../server/events.telefunc.js'
+import { sendStop } from '../server/control.telefunc.js'
+import { pendingChoice, isRunActive } from '../lib/live-state.js'
 import { EventList } from './EventList.js'
+import { ChoicePanel } from './ChoicePanel.js'
+import { Button } from './ui/button.js'
 
 // The live event stream (#405/#314): a projection of the selected project's
 // `.the-framework/events.jsonl`, streamed over a Telefunc Channel
-// (server/events.telefunc.ts) that pushes one `FrameworkEvent` per new line. The row
-// rendering is shared with run replay via EventList.
+// (server/events.telefunc.ts) that pushes one `FrameworkEvent` per new line. The same
+// projection drives the write side (#405): the interactive gate the run parks on and
+// a Stop button, both posted back over Telefunc (server/control.telefunc.ts).
 export function EventStream({ projectId }: { projectId: string | null }) {
   const [events, setEvents] = useState<FrameworkEvent[]>([])
 
@@ -40,5 +45,19 @@ export function EventStream({ projectId }: { projectId: string | null }) {
       </div>
     )
   }
-  return <EventList events={events} />
+
+  const choice = pendingChoice(events)
+  return (
+    <>
+      {isRunActive(events) && (
+        <div className="flex items-center justify-end border-b border-border px-4 py-2">
+          <Button variant="outline" size="sm" onClick={() => void sendStop(projectId)}>
+            Stop run
+          </Button>
+        </div>
+      )}
+      {choice && <ChoicePanel key={choice.id} projectId={projectId} choice={choice} />}
+      <EventList events={events} />
+    </>
+  )
 }

--- a/packages/framework-dashboard/lib/live-state.ts
+++ b/packages/framework-dashboard/lib/live-state.ts
@@ -1,0 +1,39 @@
+import type { FrameworkEvent, ChoiceRequest } from '@gemstack/framework'
+
+// Live-run state derived from the event stream — kept pure so it can be driven and
+// tested on its own, away from React. The dashboard is a projection of the same
+// events.jsonl the run writes; the interactive gate and the Stop button read that
+// projection rather than any extra state.
+
+/** The `choice` event carries the full request; strip the `kind` discriminant. */
+type ChoiceEvent = { kind: 'choice' } & ChoiceRequest
+
+/**
+ * The choice gate the run is currently parked on, or null. A `choice` event opens a
+ * gate; a matching `choice-resolved` (same id) closes it. Later events win, so a
+ * re-fired gate (#324 loops the plan approval with a fresh id) supersedes an earlier
+ * one, and a resolved gate never lingers.
+ */
+export function pendingChoice(events: readonly FrameworkEvent[]): ChoiceRequest | null {
+  const resolved = new Set<string>()
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i]!
+    if (event.kind === 'choice-resolved') {
+      resolved.add(event.id)
+      continue
+    }
+    if (event.kind === 'choice' && !resolved.has(event.id)) {
+      const { kind: _kind, ...request } = event as ChoiceEvent
+      return request
+    }
+  }
+  return null
+}
+
+/**
+ * Whether the run is still going, i.e. worth showing a Stop button. A run ends with a
+ * single `end` event; until one arrives (and once anything has streamed) it is live.
+ */
+export function isRunActive(events: readonly FrameworkEvent[]): boolean {
+  return events.length > 0 && !events.some(event => event.kind === 'end')
+}

--- a/packages/framework-dashboard/server/control.telefunc.ts
+++ b/packages/framework-dashboard/server/control.telefunc.ts
@@ -1,0 +1,36 @@
+import { defaultProjectsProvider, appendControl, type ChoiceBy } from '@gemstack/framework'
+
+// The write side over Telefunc (#405): steering a live run from the new dashboard.
+// The reverse of the event stream — events flow run -> events.jsonl -> Channel ->
+// browser; steering flows browser -> here -> the project's `.the-framework/
+// control.jsonl` -> run, which tails that file and aborts or resolves its gate. Same
+// file-is-the-seam design as the daemon's onStop/onChoice (#344/#393), so no daemon
+// process coupling: any live run in the project is steerable. (Starting a run needs a
+// spawn + the daemon's busy guard, so it rides with the daemon-serves-the-bundle
+// keystone, not this slice.)
+
+/** The registry path for a project id, or undefined when unknown (a no-op steer). */
+async function projectPath(projectId: string): Promise<string | undefined> {
+  return defaultProjectsProvider().resolvePath(projectId)
+}
+
+/** Stop the project's live run (the Stop button): append a stop entry to its control log. */
+export async function sendStop(projectId: string): Promise<void> {
+  const cwd = await projectPath(projectId)
+  if (cwd) await appendControl(cwd, { kind: 'stop' })
+}
+
+/**
+ * Resolve the project's parked choice gate (#304/#332): `pick` is one option id for a
+ * single-select, or the selected subset for a multi-select. `by` records who picked
+ * (a human here, vs the autopilot countdown or a headless auto-accept).
+ */
+export async function sendChoice(
+  projectId: string,
+  id: string,
+  pick: string | string[],
+  by: ChoiceBy = 'user',
+): Promise<void> {
+  const cwd = await projectPath(projectId)
+  if (cwd) await appendControl(cwd, { kind: 'choice', id, pick, by })
+}


### PR DESCRIPTION
The write side of the new dashboard (#405): stop a run and resolve its interactive gates from the browser. Steering is the reverse of the event stream and stays file-based, so there is no daemon coupling. The RPCs append to the project's .the-framework/control.jsonl (keyed by project, same as the read RPCs), and any live run tails that file and acts on it. That is the same control channel the daemon's Stop/choice buttons already use (#344/#393), so the run side is unchanged.

What changed:
- server/control.telefunc.ts: sendStop(projectId) and sendChoice(projectId, id, pick, by). pick is one option id or the selected subset, so the same call covers the #332 multiselect.
- lib/live-state.ts: pure pendingChoice(events) and isRunActive(events) derived from the streamed events, so the gate and the Stop button read the same projection.
- ChoicePanel.tsx: the "Your call" gate, rendering a single-select list, a multi-select checklist, or an Approve/Decline confirm, posting the pick over Telefunc.
- EventStream.tsx: show the gate on a pending choice and a Stop button while the run is live.

Not here: starting a run needs a process spawn plus the daemon's one-run-per-project busy guard (in-memory in the daemon). That is exactly the daemon-relationship question on #405 (does the daemon keep orchestration, or does it fold into the dashboard server), so start rides with the daemon-serves-the-bundle keystone rather than getting a second, racy guard in this process.

Verified against a real --fake run:
- Drove sendChoice (single + multi subset) and sendStop over the real /_telefunc wire; control.jsonl got exactly {"kind":"choice","id":...,"pick":"proceed"|["a","c"],"by":"user"} and {"kind":"stop"} - byte-identical to what the daemon writes. Unknown project is a 200 no-op.
- pendingChoice/isRunActive unit-checked (open gate pending, resolved cleared, re-fired #324 gate supersedes, multi flag preserved, active until end).
- turbo typecheck clean, vite build clean (shields generated for sendStop + sendChoice).
- Browser render of the panel is the one unobserved piece (no browser in env), same as prior dashboard PRs.

Private package, so no changeset.

Ref #405