### PR TITLE
Start a run from the new dashboard over Telefunc (sendStart)

### DIFF
--- a/.changeset/dashboard-send-start.md
+++ b/.changeset/dashboard-send-start.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+The new dashboard can now start a run over Telefunc (#405). A `sendStart` telefunction reaches the daemon's own `startRun` closure through the Telefunc request context, so it runs in-process with the one-run-per-project busy guard intact (a second start returns `busy`). Served at `/_telefunc` alongside the read + steer RPCs, same-origin guarded.

--- a/packages/framework-dashboard/components/EventStream.tsx
+++ b/packages/framework-dashboard/components/EventStream.tsx
@@ -6,6 +6,7 @@ import { sendStop } from '../server/control.telefunc.js'
 import { pendingChoice, isRunActive } from '../lib/live-state.js'
 import { EventList } from './EventList.js'
 import { ChoicePanel } from './ChoicePanel.js'
+import { StartRunForm } from './StartRunForm.js'
 import { Button } from './ui/button.js'
 
 // The live event stream (#405/#314): a projection of the selected project's
@@ -38,26 +39,26 @@ export function EventStream({ projectId }: { projectId: string | null }) {
   if (!projectId) {
     return <div className="grid flex-1 place-items-center text-sm text-muted-foreground">Select a project to watch its live run.</div>
   }
-  if (events.length === 0) {
-    return (
-      <div className="grid flex-1 place-items-center text-sm text-muted-foreground">
-        Waiting for events… (start a run in this project)
-      </div>
-    )
-  }
 
+  const active = isRunActive(events)
   const choice = pendingChoice(events)
   return (
     <>
-      {isRunActive(events) && (
+      {active ? (
         <div className="flex items-center justify-end border-b border-border px-4 py-2">
           <Button variant="outline" size="sm" onClick={() => void sendStop(projectId)}>
             Stop run
           </Button>
         </div>
+      ) : (
+        <StartRunForm projectId={projectId} />
       )}
       {choice && <ChoicePanel key={choice.id} projectId={projectId} choice={choice} />}
-      <EventList events={events} />
+      {events.length > 0 ? (
+        <EventList events={events} />
+      ) : (
+        <div className="grid flex-1 place-items-center text-sm text-muted-foreground">No events yet.</div>
+      )}
     </>
   )
 }

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -1,0 +1,49 @@
+import { useState, type FormEvent } from 'react'
+import { sendStart } from '../server/control.telefunc.js'
+import { Button } from './ui/button.js'
+
+// Start a run in the selected project (#405): the one write that goes through the
+// daemon's own `startRun` (with its one-run-per-project busy guard), posted over
+// Telefunc. Shown when no run is active; a `busy` result means one already is.
+export function StartRunForm({ projectId }: { projectId: string }) {
+  const [prompt, setPrompt] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault()
+    const text = prompt.trim()
+    if (!text || busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await sendStart(projectId, text)
+      if (result.ok) setPrompt('')
+      else setError(result.busy ? 'A run is already active for this project.' : result.error)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to start the run.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="border-b border-border p-4">
+      <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Start a run</div>
+      <textarea
+        value={prompt}
+        onChange={e => setPrompt(e.target.value)}
+        placeholder="Describe what to build…"
+        rows={2}
+        disabled={busy}
+        className="w-full resize-y rounded-md border border-border bg-transparent p-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
+      />
+      {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
+      <div className="mt-2 flex justify-end">
+        <Button type="submit" disabled={busy || !prompt.trim()}>
+          {busy ? 'Starting…' : 'Start run'}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/packages/framework-dashboard/server/control.telefunc.ts
+++ b/packages/framework-dashboard/server/control.telefunc.ts
@@ -1,4 +1,4 @@
 // Re-export shim (#405): the steering telefunctions live in @gemstack/framework so the
 // daemon serves them in-process. The file path keeps the baked RPC key
 // `/server/control.telefunc.ts`. See framework's dashboard-rpc/register.ts.
-export { sendStop, sendChoice } from '@gemstack/framework/dashboard-rpc'
+export { sendStop, sendChoice, sendStart } from '@gemstack/framework/dashboard-rpc'

--- a/packages/framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/control.telefunc.ts
@@ -1,6 +1,9 @@
+import { getContext } from 'telefunc'
 import { appendControl } from '../control.js'
 import { defaultProjectsProvider } from '../dashboard/projects.js'
 import type { ChoiceBy } from '../events.js'
+import type { StartRunKind, StartRunOptions, StartRunResult } from '../dashboard/server.js'
+import type { DashboardContext } from '../dashboard/telefunc-serve.js'
 
 // The write side behind the new dashboard (#405): steering a live run. The reverse of
 // the event stream — events flow run -> events.jsonl -> Channel -> browser; steering
@@ -34,4 +37,25 @@ export async function sendChoice(
 ): Promise<void> {
   const cwd = await projectPath(projectId)
   if (cwd) await appendControl(cwd, { kind: 'choice', id, pick, by })
+}
+
+/**
+ * Start a run in the project (#405, #345): the one write that needs the daemon, since
+ * spawning goes through the daemon's own `startRun` closure (with its one-run-per-
+ * project busy guard). The daemon provides `startRun` on the Telefunc request context,
+ * so this runs in-process. `kind` defaults to a plain build run; a `build`/`prompt`
+ * needs a non-empty prompt, `research` may be empty (its "what" defaults server-side).
+ * Returns the daemon's {@link StartRunResult} — `busy` when a run is already active.
+ */
+export async function sendStart(
+  projectId: string,
+  prompt: string,
+  kind: StartRunKind = 'build',
+  options: StartRunOptions = {},
+): Promise<StartRunResult> {
+  const { startRun } = getContext<DashboardContext>()
+  if (!startRun) return { ok: false, error: 'starting a run is not enabled on this server' }
+  const text = prompt.trim()
+  if (!text && kind !== 'research') return { ok: false, error: 'a non-empty prompt is required' }
+  return startRun(text, kind, options, projectId)
 }

--- a/packages/framework/src/dashboard-rpc/index.ts
+++ b/packages/framework/src/dashboard-rpc/index.ts
@@ -3,7 +3,7 @@
 // wiring) can reach the daemon's `startRun`; the framework-dashboard client imports
 // these through thin re-export shims so the baked RPC keys stay `/server/*.telefunc.ts`.
 export { onRuns, onRun, onDocs, onProjectLog } from './reads.telefunc.js'
-export { sendStop, sendChoice } from './control.telefunc.js'
+export { sendStop, sendChoice, sendStart } from './control.telefunc.js'
 export { onEvents } from './events.telefunc.js'
 export { onProjects } from './projects.telefunc.js'
 export { registerDashboardTelefunctions, DASHBOARD_TELEFUNC_KEYS } from './register.js'

--- a/packages/framework/src/dashboard-rpc/register.ts
+++ b/packages/framework/src/dashboard-rpc/register.ts
@@ -1,6 +1,6 @@
 import { __decorateTelefunction } from 'telefunc'
 import { onRuns, onRun, onDocs, onProjectLog } from './reads.telefunc.js'
-import { sendStop, sendChoice } from './control.telefunc.js'
+import { sendStop, sendChoice, sendStart } from './control.telefunc.js'
 import { onEvents } from './events.telefunc.js'
 import { onProjects } from './projects.telefunc.js'
 
@@ -35,6 +35,7 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(onProjectLog, 'onProjectLog', reads)
   reg(sendStop, 'sendStop', control)
   reg(sendChoice, 'sendChoice', control)
+  reg(sendStart, 'sendStart', control)
   reg(onEvents, 'onEvents', events)
   reg(onProjects, 'onProjects', projects)
 }

--- a/packages/framework/src/dashboard/telefunc-serve.ts
+++ b/packages/framework/src/dashboard/telefunc-serve.ts
@@ -4,13 +4,18 @@ import { Telefunc } from 'telefunc/node'
 import { registerDashboardTelefunctions } from '../dashboard-rpc/register.js'
 import { isSameOriginRequest, type StartRunKind, type StartRunOptions, type StartRunResult } from './server.js'
 
-/** Wired by the daemon so `sendStart` (added with this mount) can reach `startRun`. */
+/** Wired by the daemon so `sendStart` can reach the daemon's own `startRun` closure. */
 export type StartRunHandler = (
   prompt: string,
   kind: StartRunKind,
   options: StartRunOptions,
   projectId?: string,
 ) => StartRunResult | Promise<StartRunResult>
+
+/** The Telefunc request context the mount provides; `sendStart` reads `startRun` from it. */
+export interface DashboardContext {
+  startRun?: StartRunHandler
+}
 
 let instance: Telefunc | undefined
 
@@ -44,6 +49,7 @@ export function makeTelefuncMount(
       return true
     }
     const tf = setup()
-    return tf.serve({ req, res, context: (startRun ? { startRun } : {}) as never })
+    const context: DashboardContext = startRun ? { startRun } : {}
+    return tf.serve({ req, res, context: context as never })
   }
 }


### PR DESCRIPTION
The one dashboard write that needs the daemon (#405, #345): starting a run. A `sendStart` telefunction reaches the daemon's own `startRun` closure through the Telefunc request context, so spawning runs in-process with the one-run-per-project busy guard intact. This is the payoff of option (a) — Telefunc mounted in the daemon process, so a start RPC calls `startRun` directly rather than proxying.

## What changed
- `dashboard-rpc/control.telefunc.ts`: `sendStart(projectId, prompt, kind='build', options)` reads `startRun` off `getContext()`, validates (a `build`/`prompt` needs a non-empty prompt; `research` may be empty), and returns the daemon's `StartRunResult` (so `busy` surfaces when a run is already active).
- `telefunc-serve.ts`: a `DashboardContext` type; the mount already provided `{ startRun }` from PR1, so no daemon change was needed.
- `register.ts`: register `sendStart` under the `/server/control.telefunc.ts` key.
- `framework-dashboard`: the control shim re-exports `sendStart`; a new `StartRunForm` posts it and shows busy/error; `EventStream` shows the form when no run is active (and the Stop button when one is).

## Verified
- `sendStart` over the real wire with a stubbed `startRun`: correct args (`prompt`, `build`, `{}`, `projectId`), empty prompt rejected before any spawn, `busy` result passed through.
- Over the real daemon: an empty-prompt `sendStart` returns the validation error (not "starting not enabled"), proving `startRun` is threaded into the context — without spawning real Claude. The spawn mechanics + busy guard are already covered by the daemon's #345 tests.
- 456 framework tests pass; both packages typecheck + build (9 telefunctions shielded incl. `sendStart`).

Changeset: `@gemstack/framework` minor. framework-dashboard is private (no changeset).

Next: flip the default to `next` + wire `bundle:dashboard` into release, then retire page.ts.

Closes #422