### PR TITLE
Make the new dashboard the default; ship its bundle

### DIFF
--- a/.changeset/dashboard-default-next.md
+++ b/.changeset/dashboard-default-next.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+The new Vike + Telefunc dashboard (#405) is now what the daemon serves by default at `/`; the legacy `page.ts` dashboard moves to `/legacy`. Set `FRAMEWORK_DASHBOARD=legacy` to keep `page.ts` at `/` (the escape hatch), and if a build ever ships without the prerendered bundle the daemon falls back to `page.ts` automatically. The `release` flow now runs `bundle:dashboard` so the published package ships the dashboard assets.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "turbo run test",
     "changeset": "changeset",
     "changeset:version": "changeset version",
-    "release": "turbo run build --filter=./packages/* && changeset publish"
+    "release": "turbo run build bundle:dashboard --filter=./packages/* && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.0",

--- a/packages/framework/scripts/bundle-dashboard.mjs
+++ b/packages/framework/scripts/bundle-dashboard.mjs
@@ -14,8 +14,11 @@ const dest = join(here, '..', 'dist', 'dashboard-client')
 
 const hasIndex = await stat(join(src, 'index.html')).then(s => s.isFile()).catch(() => false)
 if (!hasIndex) {
-  console.error(`[bundle:dashboard] no prerendered bundle at ${src} (build @gemstack/framework-dashboard first)`)
-  process.exit(1)
+  // Skip rather than fail so a standalone `npm pack` of framework never breaks; a
+  // release runs `framework-dashboard build` first (see the root `release` script), and
+  // an install without the bundle just falls back to the legacy page.ts dashboard.
+  console.warn(`[bundle:dashboard] no prerendered bundle at ${src}; skipping (dashboard falls back to page.ts)`)
+  process.exit(0)
 }
 
 await rm(dest, { recursive: true, force: true })

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -386,12 +386,12 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
   // live run tails that file). No project id targets the home project, as before.
   const steer = (id: string | undefined, entry: Parameters<typeof appendControl>[1]): void =>
     void resolveProject(id).then(path => (path ? appendControl(path, entry) : undefined)).catch(() => {})
-  // The new dashboard (#405) is opt-in via `FRAMEWORK_DASHBOARD` (`legacy` mounts its
-  // Telefunc surface + assets so it can be smoke-tested with page.ts still at `/`;
-  // `next` serves the SPA at `/`). Unset = today's behavior, pure page.ts.
-  const dashPref = env['FRAMEWORK_DASHBOARD']
-  const clientBundleDir = dashPref ? await resolveDashboardBundle() : undefined
-  const dashboardMode = dashPref === 'next' ? 'next' : 'legacy'
+  // The new dashboard (#405) is now the default: the daemon serves the prerendered SPA
+  // at `/` (page.ts moves to `/legacy`). `FRAMEWORK_DASHBOARD=legacy` is the escape
+  // hatch back to page.ts at `/`. If the built bundle is absent (an install that never
+  // shipped it), the daemon falls back to page.ts too.
+  const forceLegacy = env['FRAMEWORK_DASHBOARD'] === 'legacy'
+  const clientBundleDir = forceLegacy ? undefined : await resolveDashboardBundle()
   const dashboard: Dashboard = await startDashboard({
     port,
     cwd,
@@ -399,8 +399,7 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     onChoice: (id, pick, by, projectId) => steer(projectId, { kind: 'choice', id, pick, by }),
     onStart: startRun,
     onAddProject: addProjects,
-    ...(clientBundleDir ? { clientBundleDir } : {}),
-    dashboardMode,
+    ...(clientBundleDir ? { clientBundleDir, dashboardMode: 'next' } : {}),
   })
   const eventsPath = join(daemonDir(cwd), EVENTS_FILE)
   const tailer = new EventTailer(eventsPath, event => dashboard.push(event))


### PR DESCRIPTION
Flips the daemon (#405): it now serves the prerendered Vike + Telefunc dashboard at `/` by default, with the legacy `page.ts` at `/legacy`. This is the cutover — the new dashboard is what people see.

Safety kept throughout:
- `FRAMEWORK_DASHBOARD=legacy` is the escape hatch back to `page.ts` at `/` (and no `/_telefunc`), in case anything's off with the new one.
- If a build ever ships without the prerendered bundle, `resolveDashboardBundle()` returns undefined and the daemon falls back to `page.ts` automatically — no hard failure.
- `page.ts` is not removed; it stays at `/legacy` (removal is the final follow-up).

Also wires publishing so the assets actually ship:
- `scripts/bundle-dashboard.mjs` now skips (not fails) when the source bundle is absent, so a standalone `npm pack` of framework never breaks.
- The root `release` script runs `bundle:dashboard` after build, so the published `@gemstack/framework` includes `dist/dashboard-client`.

## Verified on the real daemon
- Default (no env): `/` serves the SPA (client assets, no EventSource), `/legacy` serves page.ts (SSE/EventSource), `/_telefunc` mounted (200).
- `FRAMEWORK_DASHBOARD=legacy`: `/` serves page.ts, `/_telefunc` 404.
- 456 framework tests pass — the daemon tests are mode-agnostic (they assert "The Framework" + 200, which both dashboards satisfy; steering uses the legacy `/stop` + `/choice` routes that still fall through in next mode).

Changeset: `@gemstack/framework` minor.

Closes #424