### PR TITLE
feat(framework): serve the new dashboard for per-run + resume in single-project mode (#427)

### DIFF
--- a/.changeset/per-run-new-dashboard.md
+++ b/.changeset/per-run-new-dashboard.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Serve the new Vike + Telefunc dashboard for per-run foreground runs and `--resume`, not just the daemon. `framework "<prompt>"` and `framework --resume` now serve the rebuilt dashboard in single-project mode, scoped to that run's workspace without touching the global registry, and the live run steers over its own `.the-framework/control.jsonl` even with no daemon running. Falls back to the legacy `page.ts` when the bundle is absent or `--no-persist` is set. Adds `singleProjectProvider` and `resolveDashboardBundle` to the public surface.

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -16,7 +16,7 @@ import {
 } from '@gemstack/ai-autopilot'
 import { ClaudeCodeDriver, type ClaudeCodeDriverOptions, type Driver, type DriverSession, type PermissionMode } from './driver/index.js'
 import { hostExecutor } from './host-exec.js'
-import { startDashboard, type Dashboard } from './dashboard/index.js'
+import { startDashboard, singleProjectProvider, resolveDashboardBundle, type Dashboard } from './dashboard/index.js'
 import { startRelay, relayPublisher, type RelayPublisher } from './relay.js'
 import { randomUUID } from 'node:crypto'
 import { formatFrameworkEvent, CLAUDE_CODE_SESSION_LINK, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
@@ -805,8 +805,16 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     for (const resolve of pendingChoices.values()) resolve({ picked: 'proceed', by: 'auto' })
     pendingChoices.clear()
   })
+  // Serve the new Vike + Telefunc dashboard (#405/#427) for this run, in single-project
+  // mode: the SPA reads this one `cwd` (its own `.the-framework/events.jsonl` +
+  // control.jsonl) without touching the global registry, so a one-shot run never
+  // pollutes the Projects list. The bundle rides in `.the-framework/events.jsonl`, so it
+  // needs the store: without --persist there is nothing to stream, and we fall back to
+  // page.ts. An old install missing the built bundle also falls back (resolve -> undefined).
   let dashboard: Dashboard | undefined
+  let clientBundleDir: string | undefined
   if (opts.dashboard) {
+    if (opts.persist) clientBundleDir = await resolveDashboardBundle()
     try {
       dashboard = await startDashboard({
         ...(opts.port !== undefined ? { port: opts.port } : {}),
@@ -819,12 +827,20 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
           }
         },
         cwd,
+        ...(clientBundleDir
+          ? { clientBundleDir, dashboardMode: 'next' as const, projects: singleProjectProvider(cwd) }
+          : {}),
       })
       io.out(`◆ dashboard: ${dashboard.url}`)
     } catch (err) {
+      clientBundleDir = undefined
       io.err(`could not start dashboard (${err instanceof Error ? err.message : String(err)}); continuing headless`)
     }
   }
+  // The new dashboard steers this live run purely through control.jsonl (its Stop /
+  // choice picks are Telefunc writes to that file, #427), so tail it whenever the new
+  // dashboard is up — not only when a daemon is (the condition just below).
+  const newDashboard = dashboard !== undefined && clientBundleDir !== undefined
 
   // Persist the orchestration state so a restart can --resume it (#211). The log
   // is the dashboard's own event stream, appended to .the-framework/ in the workspace.
@@ -839,14 +855,14 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     }
   }
 
-  // The persistent daemon dashboard steers this run through .the-framework/control.jsonl
-  // (#344): its Stop button and choice picks append entries, we tail the file and
-  // abort / resolve the parked gate. Reset first so a previous run's picks can never
-  // fire into this one (gate ids repeat across runs). Only wired when the machine's
-  // daemon is live (#393): the one daemon steers runs in any project, and it writes
-  // to this run's own control.jsonl. Without a daemon, headless behavior is identical.
+  // Steer this run through .the-framework/control.jsonl (#344): a Stop button or choice
+  // pick appends an entry, we tail the file and abort / resolve the parked gate. Reset
+  // first so a previous run's picks can never fire into this one (gate ids repeat across
+  // runs). Wired when the machine's daemon is live (#393, it steers any project's run) or
+  // when this run's own new dashboard is up (#427, it too steers over control.jsonl).
+  // Otherwise headless behavior is identical.
   let control: ControlWatcher | undefined
-  if (opts.persist && (await daemonStatus())) {
+  if (opts.persist && (newDashboard || (await daemonStatus()))) {
     try {
       await resetControl(cwd)
       control = watchControl(cwd, entry => {
@@ -1335,10 +1351,21 @@ async function resumeRun(opts: CliOptions, io: CliIO): Promise<number> {
   }
   const meta = (await store.readMeta()) ?? store.snapshot()
 
+  // Resume serves the new dashboard too (#427), single-project on this `cwd`: the saved
+  // `.the-framework/events.jsonl` is exactly what the SPA's event Channel tails, so the
+  // past run replays with no extra wiring (it is finished, so there is nothing to steer).
+  // No bundle (old install) falls back to page.ts, byte-identical to before.
   let dashboard: Dashboard | undefined
   if (opts.dashboard) {
+    const clientBundleDir = await resolveDashboardBundle()
     try {
-      dashboard = await startDashboard({ ...(opts.port !== undefined ? { port: opts.port } : {}), cwd })
+      dashboard = await startDashboard({
+        ...(opts.port !== undefined ? { port: opts.port } : {}),
+        cwd,
+        ...(clientBundleDir
+          ? { clientBundleDir, dashboardMode: 'next' as const, projects: singleProjectProvider(cwd) }
+          : {}),
+      })
       io.out(`◆ dashboard (resumed): ${dashboard.url}`)
     } catch (err) {
       io.err(`could not start dashboard (${err instanceof Error ? err.message : String(err)}); replaying to terminal only`)

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -2,10 +2,10 @@ import { spawn } from 'node:child_process'
 import { watch, type FSWatcher } from 'node:fs'
 import { mkdir, readFile, writeFile, rm, stat } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import type { FrameworkEvent } from './events.js'
 import { EVENTS_FILE, FRAMEWORK_DIR } from './store/index.js'
 import { startDashboard, type Dashboard, type StartRunKind, type StartRunOptions, type StartRunResult, type AddProjectResult } from './dashboard/index.js'
+import { resolveDashboardBundle } from './dashboard/bundle.js'
 import { appendControl } from './control.js'
 import { isActivated } from './project.js'
 import { addProject, listProjects, projectId } from './registry.js'
@@ -53,21 +53,6 @@ export interface DaemonState {
 /** The `.the-framework/` directory for a workspace. */
 export function daemonDir(cwd: string): string {
   return join(cwd, FRAMEWORK_DIR)
-}
-
-/**
- * Locate the prerendered dashboard bundle (#405). A published install copies it into
- * `dist/dashboard-client` (see scripts/bundle-dashboard.mjs); the workspace falls back
- * to `packages/framework-dashboard/dist/client`. Returns the directory only when its
- * `index.html` exists, else undefined (the daemon then serves the legacy page.ts).
- */
-async function resolveDashboardBundle(): Promise<string | undefined> {
-  const here = dirname(fileURLToPath(import.meta.url)) // dist/ (or dist-test/) at runtime
-  const candidates = [join(here, 'dashboard-client'), join(here, '..', '..', 'framework-dashboard', 'dist', 'client')]
-  for (const dir of candidates) {
-    if (await stat(join(dir, 'index.html')).then(s => s.isFile()).catch(() => false)) return dir
-  }
-  return undefined
 }
 
 /**

--- a/packages/framework/src/dashboard-rpc/context.ts
+++ b/packages/framework/src/dashboard-rpc/context.ts
@@ -1,0 +1,18 @@
+import { getContext } from 'telefunc'
+import { defaultProjectsProvider, type ProjectsProvider } from '../dashboard/projects.js'
+
+/**
+ * The {@link ProjectsProvider} a telefunction should read a project id against (#427).
+ * The mount puts one on the Telefunc request context: the daemon leaves it unset, so
+ * every RPC resolves against the global registry; the per-run foreground dashboard
+ * passes a single-project provider scoped to its `cwd`. Falls back to the registry when
+ * no context is set (defensive — every real call runs inside `serve({ context })`).
+ */
+export function contextProjects(): ProjectsProvider {
+  try {
+    const ctx = getContext<{ projects?: ProjectsProvider }>()
+    return ctx?.projects ?? defaultProjectsProvider()
+  } catch {
+    return defaultProjectsProvider()
+  }
+}

--- a/packages/framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/control.telefunc.ts
@@ -1,6 +1,6 @@
 import { getContext } from 'telefunc'
 import { appendControl } from '../control.js'
-import { defaultProjectsProvider } from '../dashboard/projects.js'
+import { contextProjects } from './context.js'
 import type { ChoiceBy } from '../events.js'
 import type { StartRunKind, StartRunOptions, StartRunResult } from '../dashboard/server.js'
 import type { DashboardContext } from '../dashboard/telefunc-serve.js'
@@ -13,9 +13,9 @@ import type { DashboardContext } from '../dashboard/telefunc-serve.js'
 // steerable. (Starting a run needs a spawn + the daemon's busy guard, so `sendStart`
 // lands with the daemon-serves-the-bundle wiring, not here.)
 
-/** The registry path for a project id, or undefined when unknown (a no-op steer). */
+/** The path for a project id (registry, or single-project #427), else undefined (no-op steer). */
 async function projectPath(projectId: string): Promise<string | undefined> {
-  return defaultProjectsProvider().resolvePath(projectId)
+  return contextProjects().resolvePath(projectId)
 }
 
 /** Stop the project's live run (the Stop button): append a stop entry to its control log. */

--- a/packages/framework/src/dashboard-rpc/events.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/events.telefunc.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { Channel, type ClientChannel } from 'telefunc'
 import { FRAMEWORK_DIR, EVENTS_FILE } from '../store/index.js'
-import { defaultProjectsProvider } from '../dashboard/projects.js'
+import { contextProjects } from './context.js'
 import type { FrameworkEvent } from '../events.js'
 import { tailEvents } from './events-tail.js'
 
@@ -13,7 +13,7 @@ import { tailEvents } from './events-tail.js'
 
 /** The events file for a project id, or undefined when the project is unknown. */
 async function resolveEventsPath(projectId: string): Promise<string | undefined> {
-  const path = await defaultProjectsProvider().resolvePath(projectId)
+  const path = await contextProjects().resolvePath(projectId)
   return path ? join(path, FRAMEWORK_DIR, EVENTS_FILE) : undefined
 }
 

--- a/packages/framework/src/dashboard-rpc/projects.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/projects.telefunc.ts
@@ -1,8 +1,10 @@
-import { defaultProjectsProvider, type ProjectSummary } from '../dashboard/projects.js'
+import { contextProjects } from './context.js'
+import type { ProjectSummary } from '../dashboard/projects.js'
 
 // The Projects sidebar behind the new dashboard (#405): the global registry (#390) the
-// daemon and CLI write — id, path, name, activated, last activity. The live event
-// stream is its own Telefunc Channel (events.telefunc.ts).
+// daemon and CLI write — id, path, name, activated, last activity. The per-run
+// foreground dashboard (#427) scopes this to a single project via the request context.
+// The live event stream is its own Telefunc Channel (events.telefunc.ts).
 export async function onProjects(): Promise<ProjectSummary[]> {
-  return defaultProjectsProvider().list()
+  return contextProjects().list()
 }

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -1,7 +1,7 @@
 import { listRuns, loadRunEvents, type RunMeta } from '../store/index.js'
 import { readLogs, type LogEntry } from '../logs.js'
 import { readDocs, type WorkspaceDoc } from '../dashboard/docs.js'
-import { defaultProjectsProvider } from '../dashboard/projects.js'
+import { contextProjects } from './context.js'
 import type { FrameworkEvent } from '../events.js'
 
 // The read model behind the new dashboard (#405): the run history, a run's replay, the
@@ -12,9 +12,9 @@ import type { FrameworkEvent } from '../events.js'
 // in framework-dashboard, keeping the baked RPC keys `/server/reads.telefunc.ts`). The
 // live run stream is its own Telefunc Channel (events.telefunc.ts).
 
-/** The registry path for a project id, or undefined when unknown (readers then yield empty). */
+/** The path for a project id (registry, or single-project #427), else undefined -> empty. */
 async function projectPath(projectId: string): Promise<string | undefined> {
-  return defaultProjectsProvider().resolvePath(projectId)
+  return contextProjects().resolvePath(projectId)
 }
 
 /** The project's archived runs, most-recent first (or `[]`). */

--- a/packages/framework/src/dashboard/bundle.ts
+++ b/packages/framework/src/dashboard/bundle.ts
@@ -1,0 +1,22 @@
+import { stat } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Locate the prerendered dashboard bundle (#405): the published package ships it at
+ * `dist/dashboard-client` (see scripts/bundle-dashboard.mjs); the workspace falls back
+ * to `packages/framework-dashboard/dist/client`. Returns the directory only when its
+ * `index.html` exists, else undefined (the caller then serves the legacy page.ts).
+ * Shared by the daemon and the per-run foreground dashboard (#427).
+ */
+export async function resolveDashboardBundle(): Promise<string | undefined> {
+  const here = dirname(fileURLToPath(import.meta.url)) // dist/dashboard (or src/dashboard) at runtime
+  const candidates = [
+    join(here, '..', 'dashboard-client'),
+    join(here, '..', '..', '..', 'framework-dashboard', 'dist', 'client'),
+  ]
+  for (const dir of candidates) {
+    if (await stat(join(dir, 'index.html')).then(s => s.isFile()).catch(() => false)) return dir
+  }
+  return undefined
+}

--- a/packages/framework/src/dashboard/index.ts
+++ b/packages/framework/src/dashboard/index.ts
@@ -2,9 +2,11 @@ export { startDashboard, parseStartOptions, type Dashboard, type DashboardOption
 export {
   summarizeProject,
   defaultProjectsProvider,
+  singleProjectProvider,
   type ProjectSummary,
   type ProjectsProvider,
   type SummarizeDeps,
 } from './projects.js'
+export { resolveDashboardBundle } from './bundle.js'
 export { dashboardHtml } from './page.js'
 export { readDocs, DOC_CATEGORIES, type WorkspaceDoc } from './docs.js'

--- a/packages/framework/src/dashboard/projects.test.ts
+++ b/packages/framework/src/dashboard/projects.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { summarizeProject, type SummarizeDeps } from './projects.js'
+import { summarizeProject, singleProjectProvider, type SummarizeDeps } from './projects.js'
 import type { ProjectRecord } from '../registry.js'
 import type { LogEntry } from '../logs.js'
 
@@ -50,4 +50,26 @@ test('a throwing reader is forgiving: inactive, no activity, never throws', asyn
   )
   assert.equal(summary.activated, false)
   assert.equal('lastActivityAt' in summary, false)
+})
+
+test('singleProjectProvider (#427) lists exactly the one cwd under the fixed id', async () => {
+  const provider = singleProjectProvider('/repos/scratch')
+  const list = await provider.list()
+  assert.equal(list.length, 1)
+  assert.equal(list[0]?.id, 'home')
+  assert.equal(list[0]?.path, '/repos/scratch')
+  assert.equal(list[0]?.name, 'scratch')
+})
+
+test('singleProjectProvider resolves the fixed id to cwd and everything else to nothing', async () => {
+  const provider = singleProjectProvider('/repos/scratch')
+  assert.equal(await provider.resolvePath('home'), '/repos/scratch')
+  assert.equal(await provider.resolvePath('anything-else'), undefined)
+})
+
+test('singleProjectProvider honors a custom id', async () => {
+  const provider = singleProjectProvider('/repos/scratch', 'run-1')
+  assert.equal((await provider.list())[0]?.id, 'run-1')
+  assert.equal(await provider.resolvePath('run-1'), '/repos/scratch')
+  assert.equal(await provider.resolvePath('home'), undefined)
 })

--- a/packages/framework/src/dashboard/projects.ts
+++ b/packages/framework/src/dashboard/projects.ts
@@ -78,3 +78,23 @@ export function defaultProjectsProvider(): ProjectsProvider {
     },
   }
 }
+
+/**
+ * A {@link ProjectsProvider} scoped to one workspace (#427): the per-run foreground
+ * dashboard and `--resume` serve the new SPA for a single `cwd` without touching the
+ * global registry, so a one-shot run never pollutes the Projects list. `list()` yields
+ * exactly that project (the SPA auto-selects the sole entry), and `resolvePath` returns
+ * its `cwd` for the fixed `id` — every read RPC + the event Channel then read the run's
+ * own `.the-framework/` files. An unknown id resolves to nothing, as with the registry.
+ */
+export function singleProjectProvider(cwd: string, id = 'home'): ProjectsProvider {
+  return {
+    async list() {
+      // addedAt is unused by summarizeProject (last activity comes from LOGS.md).
+      return [await summarizeProject({ id, path: cwd, addedAt: '' })]
+    },
+    async resolvePath(reqId) {
+      return reqId === id ? cwd : undefined
+    },
+  }
+}

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -164,7 +164,11 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
   // byte-identical to before (legacy page.ts only). When set, `/_telefunc` (RPCs +
   // Channel) is always mounted, and in `next` mode the SPA takes `/` while page.ts
   // moves to `/legacy` (whose SSE + steer routes still fall through to the legacy handler).
-  const telefuncMount = clientBundleDir ? makeTelefuncMount(onStart) : undefined
+  // The mount resolves project ids against `opts.projects` when set (the per-run
+  // foreground dashboard passes a single-project provider, #427); unset -> the global
+  // registry, as the daemon uses. `projects` above already defaulted, so pass the raw
+  // option so an unset one stays undefined on the context (the RPC falls back).
+  const telefuncMount = clientBundleDir ? makeTelefuncMount(onStart, opts.projects) : undefined
 
   const server = createServer((req, res) => {
     if (clientBundleDir) {

--- a/packages/framework/src/dashboard/telefunc-serve.ts
+++ b/packages/framework/src/dashboard/telefunc-serve.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import { config } from 'telefunc'
 import { Telefunc } from 'telefunc/node'
 import { registerDashboardTelefunctions } from '../dashboard-rpc/register.js'
+import type { ProjectsProvider } from './projects.js'
 import { isSameOriginRequest, type StartRunKind, type StartRunOptions, type StartRunResult } from './server.js'
 
 /** Wired by the daemon so `sendStart` can reach the daemon's own `startRun` closure. */
@@ -12,9 +13,14 @@ export type StartRunHandler = (
   projectId?: string,
 ) => StartRunResult | Promise<StartRunResult>
 
-/** The Telefunc request context the mount provides; `sendStart` reads `startRun` from it. */
+/**
+ * The Telefunc request context the mount provides. `sendStart` reads `startRun` from it;
+ * every project-keyed RPC reads `projects` (#427) — the daemon leaves it unset to use the
+ * global registry, the per-run foreground dashboard passes a single-project provider.
+ */
 export interface DashboardContext {
   startRun?: StartRunHandler
+  projects?: ProjectsProvider
 }
 
 let instance: Telefunc | undefined
@@ -41,6 +47,7 @@ function setup(): Telefunc {
  */
 export function makeTelefuncMount(
   startRun?: StartRunHandler,
+  projects?: ProjectsProvider,
 ): (req: IncomingMessage, res: ServerResponse) => Promise<boolean> {
   return async (req, res) => {
     if (!isSameOriginRequest(req)) {
@@ -49,7 +56,10 @@ export function makeTelefuncMount(
       return true
     }
     const tf = setup()
-    const context: DashboardContext = startRun ? { startRun } : {}
+    const context: DashboardContext = {
+      ...(startRun ? { startRun } : {}),
+      ...(projects ? { projects } : {}),
+    }
     return tf.serve({ req, res, context: context as never })
   }
 }


### PR DESCRIPTION
Part 1 of #426. Closes #427.

`framework "<prompt>"` (foreground) and `framework --resume` still served the legacy page.ts. This ports them onto the new Vike + Telefunc dashboard, in a single-project mode scoped to the run's own workspace.

## What
- Serve the prerendered bundle + mount /_telefunc for the run's `cwd`, resolved through a **single-project `ProjectsProvider`** threaded on the Telefunc request context. A one-shot run never pollutes the global Projects list. The SPA already auto-selects the sole project, so there is no client-side change.
- The live foreground run steers over its own `.the-framework/control.jsonl` (the same file seam the daemon uses), enabled whenever the new dashboard is served rather than only when a daemon is live.
- The daemon leaves the context provider unset, so its RPCs keep resolving against the global registry, unchanged.
- Falls back to page.ts when the built bundle is absent or `--no-persist` leaves no events file to stream.
- New public surface: `singleProjectProvider`, `resolveDashboardBundle` (shared by the daemon + CLI).

## Verified end to end
- `--resume` on a `--fake` run: `/` serves the SPA, `/legacy` serves page.ts; `onProjects` returns exactly one `home` project pointing at the run's cwd; `onRuns`/`onEvents` (Channel) return real data; an unknown id and a cross-origin POST are handled (empty / 403).
- **Live foreground run steered with no daemon:** a fake run paused at the plan-approval gate; `sendChoice(home, plan-approval, proceed)` over Telefunc wrote to control.jsonl, the run's control watcher resolved the gate, and the run finished.
- Daemon smoke: still serves the SPA and resolves projects from the **registry** (not single-project), so the fallback is intact.
- 459 framework tests pass (3 new for `singleProjectProvider`); workspace typecheck 22/22.

Part 2 (relay) stays design-gated on Rom; part 3 (delete page.ts) follows once both land.