### PR TITLE
feat(framework): serve the new dashboard from the relay in watch-only mode (#429)

### DIFF
--- a/.changeset/relay-new-dashboard.md
+++ b/.changeset/relay-new-dashboard.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Serve the new Vike + Telefunc dashboard from the run relay (`--share`), in a read-only watch mode. The relay now serves the prerendered SPA and streams events over the same Telefunc `onEvents` Channel the daemon uses, sourced from its in-memory run instead of a file. Only the live event stream is exposed (an empty projects provider neutralizes the file/registry RPCs on the public host, and no run can be started or steered). The shareable viewer URL moves from `/r/:id/` to `/?run=:id` (old links redirect); ingest stays at `/r/:id/publish`. This removes the relay's dependency on the legacy `page.ts`. Adds `makeTelefuncMount`, `serveClientBundle`, `emptyProjectsProvider`, and the `EventsSource` type to the public surface.

--- a/packages/framework-dashboard/components/EventStream.tsx
+++ b/packages/framework-dashboard/components/EventStream.tsx
@@ -14,7 +14,7 @@ import { Button } from './ui/button.js'
 // (server/events.telefunc.ts) that pushes one `FrameworkEvent` per new line. The same
 // projection drives the write side (#405): the interactive gate the run parks on and
 // a Stop button, both posted back over Telefunc (server/control.telefunc.ts).
-export function EventStream({ projectId }: { projectId: string | null }) {
+export function EventStream({ projectId, readOnly = false }: { projectId: string | null; readOnly?: boolean }) {
   const [events, setEvents] = useState<FrameworkEvent[]>([])
 
   useEffect(() => {
@@ -38,6 +38,16 @@ export function EventStream({ projectId }: { projectId: string | null }) {
 
   if (!projectId) {
     return <div className="grid flex-1 place-items-center text-sm text-muted-foreground">Select a project to watch its live run.</div>
+  }
+
+  // Read-only watch mode (the relay, #426): no steering (no Stop/Start, no interactive
+  // gate), just the live event feed. The stream is served from the relay's in-memory run.
+  if (readOnly) {
+    return events.length > 0 ? (
+      <EventList events={events} />
+    ) : (
+      <div className="grid flex-1 place-items-center text-sm text-muted-foreground">Waiting for the run to start…</div>
+    )
   }
 
   const active = isRunActive(events)

--- a/packages/framework-dashboard/components/RelayView.tsx
+++ b/packages/framework-dashboard/components/RelayView.tsx
@@ -1,0 +1,21 @@
+import { EventStream } from './EventStream.js'
+import { Badge } from './ui/badge.js'
+
+// The shared-run watch view (#426/#230): when the dashboard is opened on the relay at
+// `/?run=<id>`, it shows one run read-only, streamed from the relay's in-memory event
+// feed over the same Telefunc `onEvents` Channel the daemon uses. No Projects/Runs/Docs
+// rails and no steering — a teammate with the link watches, they do not drive.
+export function RelayView({ runId }: { runId: string }) {
+  return (
+    <div className="flex h-screen flex-col">
+      <header className="flex items-center gap-3 border-b border-border px-4 py-3">
+        <span className="font-semibold">The Framework</span>
+        <Badge className="text-muted-foreground">watching</Badge>
+        <span className="ml-auto text-xs text-muted-foreground">read-only shared run</span>
+      </header>
+      <main className="flex min-w-0 flex-1 flex-col">
+        <EventStream projectId={runId} readOnly />
+      </main>
+    </div>
+  )
+}

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -4,6 +4,7 @@ import { RunHistory } from '../../components/RunHistory.js'
 import { EventStream } from '../../components/EventStream.js'
 import { RunReplay } from '../../components/RunReplay.js'
 import { RightRail } from '../../components/RightRail.js'
+import { RelayView } from '../../components/RelayView.js'
 import { Badge } from '../../components/ui/badge.js'
 
 // The dashboard shell (#405 phase 2): Projects | Runs | main (live event stream or a
@@ -19,6 +20,13 @@ export default function Page() {
     setProjectId(id)
     setRunId(null) // switching projects always returns to live
   }
+
+  // On the relay (#426), the URL carries `?run=<id>` and there is no local registry or
+  // files — show that one run read-only. `window` is absent during prerender (ssr:false),
+  // so this resolves to the full shell at build time and only flips in the browser. Hooks
+  // above run unconditionally (rules of hooks); this early return is safe after them.
+  const relayRun = typeof window === 'undefined' ? null : new URLSearchParams(window.location.search).get('run')
+  if (relayRun) return <RelayView runId={relayRun} />
 
   return (
     <div className="flex h-screen flex-col">

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -1323,7 +1323,7 @@ function spawnMaintenanceRun(review: RepoReview, binPath: string, maxCost?: numb
 async function runRelayServer(opts: CliOptions, io: CliIO): Promise<number> {
   const relay = await startRelay(opts.port !== undefined ? { port: opts.port } : {})
   io.out(`◆ relay listening at ${relay.url}`)
-  io.out(`  Runs published with \`framework "..." --share ${relay.url}\` are watchable at ${relay.url}/r/<id>/`)
+  io.out(`  Runs published with \`framework "..." --share ${relay.url}\` are watchable at ${relay.url}/?run=<id>`)
   io.out(`  Press Ctrl+C to stop.`)
   await waitForInterrupt()
   await relay.close()

--- a/packages/framework/src/dashboard-rpc/context.ts
+++ b/packages/framework/src/dashboard-rpc/context.ts
@@ -1,5 +1,6 @@
 import { getContext } from 'telefunc'
 import { defaultProjectsProvider, type ProjectsProvider } from '../dashboard/projects.js'
+import type { EventsSource } from '../dashboard/telefunc-serve.js'
 
 /**
  * The {@link ProjectsProvider} a telefunction should read a project id against (#427).
@@ -14,5 +15,19 @@ export function contextProjects(): ProjectsProvider {
     return ctx?.projects ?? defaultProjectsProvider()
   } catch {
     return defaultProjectsProvider()
+  }
+}
+
+/**
+ * The in-memory {@link EventsSource} on the context, or undefined (#426). Only the relay
+ * sets one — it has no `.the-framework/events.jsonl` on disk, so `onEvents` streams from
+ * the relay's in-memory run instead. Unset on the daemon/foreground, where `onEvents`
+ * tails the file as before.
+ */
+export function contextEventsSource(): EventsSource | undefined {
+  try {
+    return getContext<{ eventsSource?: EventsSource }>()?.eventsSource
+  } catch {
+    return undefined
   }
 }

--- a/packages/framework/src/dashboard-rpc/events.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/events.telefunc.ts
@@ -1,9 +1,10 @@
 import { join } from 'node:path'
 import { Channel, type ClientChannel } from 'telefunc'
 import { FRAMEWORK_DIR, EVENTS_FILE } from '../store/index.js'
-import { contextProjects } from './context.js'
+import { contextProjects, contextEventsSource } from './context.js'
 import type { FrameworkEvent } from '../events.js'
 import { tailEvents } from './events-tail.js'
+import { forwardStream } from './stream-channel.js'
 
 // The live event stream behind the new dashboard (#405): the selected project's run,
 // read straight from the same `.the-framework/events.jsonl` the daemon writes. Each new
@@ -20,10 +21,28 @@ async function resolveEventsPath(projectId: string): Promise<string | undefined>
 /**
  * `onEvents(projectId)` returns a Channel that streams the project's live run: the
  * client `.listen()`s for `FrameworkEvent`s and `.close()`s to unsubscribe, which
- * stops the file tail. An unknown project yields a channel that closes immediately
+ * stops the tail. An unknown project yields a channel that closes immediately
  * (mirrors the read model's empty results rather than throwing at the client).
+ *
+ * Two sources, chosen by the mount: the relay (#426) streams from an in-memory run on
+ * the context; everywhere else there is no such source, so it tails the project's
+ * `.the-framework/events.jsonl` on disk.
  */
 export async function onEvents(projectId: string): Promise<ClientChannel<never, FrameworkEvent>> {
+  const source = contextEventsSource()
+  if (source) {
+    // The relay: replay + follow its in-memory run, mirroring how serveSSE consumes it.
+    const stream = source(projectId)
+    const channel = new Channel<never, FrameworkEvent>()
+    if (!stream) {
+      void channel.close()
+      return channel.client
+    }
+    const stop = forwardStream(stream, event => void channel.send(event))
+    channel.onClose(stop)
+    return channel.client
+  }
+
   const channel = new Channel<never, FrameworkEvent>()
   const path = await resolveEventsPath(projectId)
   if (!path) {

--- a/packages/framework/src/dashboard-rpc/stream-channel.test.ts
+++ b/packages/framework/src/dashboard-rpc/stream-channel.test.ts
@@ -1,0 +1,40 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { EventStream } from '@gemstack/ai-autopilot'
+import { forwardStream } from './stream-channel.js'
+
+const tick = () => new Promise(r => setImmediate(r))
+
+test('forwardStream replays a stream\'s buffered history then follows live (#426)', async () => {
+  const stream = new EventStream<{ n: number }>()
+  stream.push({ n: 1 })
+  stream.push({ n: 2 }) // buffered before any consumer, like a viewer joining mid-run
+
+  const got: number[] = []
+  const stop = forwardStream(stream, e => got.push(e.n))
+  await tick()
+  assert.deepEqual(got, [1, 2]) // replayed history
+
+  stream.push({ n: 3 }) // arrives live
+  await tick()
+  assert.deepEqual(got, [1, 2, 3])
+  stop()
+})
+
+test('forwardStream stops on the returned stop fn: no events after it', async () => {
+  const stream = new EventStream<{ n: number }>()
+  const got: number[] = []
+  const stop = forwardStream(stream, e => got.push(e.n))
+  stream.push({ n: 1 })
+  await tick()
+  stop()
+  stream.push({ n: 2 }) // after stop → must not be forwarded
+  await tick()
+  assert.deepEqual(got, [1])
+})
+
+test('forwardStream on an undefined source is a no-op with an idempotent stop', () => {
+  const stop = forwardStream<{ n: number }>(undefined, () => assert.fail('should not send'))
+  stop()
+  stop() // idempotent
+})

--- a/packages/framework/src/dashboard-rpc/stream-channel.ts
+++ b/packages/framework/src/dashboard-rpc/stream-channel.ts
@@ -1,0 +1,29 @@
+/**
+ * Forward an async-iterable of events to a `send` sink until the source is exhausted or
+ * the returned stop function is called (#426). This is the bridge behind the relay's
+ * `onEvents`: the relay's in-memory run is an `AsyncIterable` that replays its buffered
+ * history then follows live (exactly what `serveSSE` consumes), and each value becomes a
+ * `channel.send(event)`. Kept transport-agnostic (a plain `send` callback, not a Channel)
+ * so the pump can be driven and tested on its own; events.telefunc.ts wires the Channel.
+ *
+ * Returns a stop function that halts forwarding and cancels the iterator, releasing the
+ * follower waiting on the next event. Idempotent. An absent source is a no-op.
+ */
+export function forwardStream<T>(iterable: AsyncIterable<T> | undefined, send: (value: T) => void): () => void {
+  if (!iterable) return () => {}
+  const iterator = iterable[Symbol.asyncIterator]()
+  let stopped = false
+  void (async () => {
+    try {
+      for (let next = await iterator.next(); !next.done && !stopped; next = await iterator.next()) {
+        if (!stopped) send(next.value)
+      }
+    } catch {
+      // the stream closed or the consumer went away
+    }
+  })()
+  return () => {
+    stopped = true
+    void iterator.return?.()
+  }
+}

--- a/packages/framework/src/dashboard/index.ts
+++ b/packages/framework/src/dashboard/index.ts
@@ -3,10 +3,13 @@ export {
   summarizeProject,
   defaultProjectsProvider,
   singleProjectProvider,
+  emptyProjectsProvider,
   type ProjectSummary,
   type ProjectsProvider,
   type SummarizeDeps,
 } from './projects.js'
 export { resolveDashboardBundle } from './bundle.js'
+export { makeTelefuncMount, type EventsSource } from './telefunc-serve.js'
+export { serveClientBundle } from './static.js'
 export { dashboardHtml } from './page.js'
 export { readDocs, DOC_CATEGORIES, type WorkspaceDoc } from './docs.js'

--- a/packages/framework/src/dashboard/projects.ts
+++ b/packages/framework/src/dashboard/projects.ts
@@ -87,6 +87,23 @@ export function defaultProjectsProvider(): ProjectsProvider {
  * its `cwd` for the fixed `id` — every read RPC + the event Channel then read the run's
  * own `.the-framework/` files. An unknown id resolves to nothing, as with the registry.
  */
+/**
+ * A {@link ProjectsProvider} that knows no projects (#426): `list()` is empty and
+ * `resolvePath` never resolves. The relay passes this so the file/registry-backed RPCs
+ * (runs, docs, log, and any steer) return nothing on a public, unauthenticated host — it
+ * only serves the live event stream from its own in-memory run (via `eventsSource`).
+ */
+export function emptyProjectsProvider(): ProjectsProvider {
+  return {
+    async list() {
+      return []
+    },
+    async resolvePath() {
+      return undefined
+    },
+  }
+}
+
 export function singleProjectProvider(cwd: string, id = 'home'): ProjectsProvider {
   return {
     async list() {

--- a/packages/framework/src/dashboard/telefunc-serve.ts
+++ b/packages/framework/src/dashboard/telefunc-serve.ts
@@ -3,6 +3,7 @@ import { config } from 'telefunc'
 import { Telefunc } from 'telefunc/node'
 import { registerDashboardTelefunctions } from '../dashboard-rpc/register.js'
 import type { ProjectsProvider } from './projects.js'
+import type { FrameworkEvent } from '../events.js'
 import { isSameOriginRequest, type StartRunKind, type StartRunOptions, type StartRunResult } from './server.js'
 
 /** Wired by the daemon so `sendStart` can reach the daemon's own `startRun` closure. */
@@ -13,14 +14,21 @@ export type StartRunHandler = (
   projectId?: string,
 ) => StartRunResult | Promise<StartRunResult>
 
+/** Resolve a project id to its live event stream (#426): the relay feeds `onEvents` from
+ * its own in-memory stream rather than a file on disk. */
+export type EventsSource = (projectId: string) => AsyncIterable<FrameworkEvent> | undefined
+
 /**
  * The Telefunc request context the mount provides. `sendStart` reads `startRun` from it;
  * every project-keyed RPC reads `projects` (#427) — the daemon leaves it unset to use the
- * global registry, the per-run foreground dashboard passes a single-project provider.
+ * global registry, the per-run foreground dashboard passes a single-project provider. The
+ * relay passes `eventsSource` (#426) so `onEvents` streams its in-memory run instead of a
+ * file, plus an empty `projects` so the file/registry RPCs return nothing on a public host.
  */
 export interface DashboardContext {
   startRun?: StartRunHandler
   projects?: ProjectsProvider
+  eventsSource?: EventsSource
 }
 
 let instance: Telefunc | undefined
@@ -48,6 +56,7 @@ function setup(): Telefunc {
 export function makeTelefuncMount(
   startRun?: StartRunHandler,
   projects?: ProjectsProvider,
+  eventsSource?: EventsSource,
 ): (req: IncomingMessage, res: ServerResponse) => Promise<boolean> {
   return async (req, res) => {
     if (!isSameOriginRequest(req)) {
@@ -59,6 +68,7 @@ export function makeTelefuncMount(
     const context: DashboardContext = {
       ...(startRun ? { startRun } : {}),
       ...(projects ? { projects } : {}),
+      ...(eventsSource ? { eventsSource } : {}),
     }
     return tf.serve({ req, res, context: context as never })
   }

--- a/packages/framework/src/relay.test.ts
+++ b/packages/framework/src/relay.test.ts
@@ -2,10 +2,15 @@ import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { get, request } from 'node:http'
 import { createServer as createNetServer } from 'node:net'
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { startRelay, relayPublisher } from './relay.js'
 import type { FrameworkEvent } from './events.js'
 
-function fetchFull(url: string): Promise<{ status: number; headers: Record<string, string | string[] | undefined>; body: string }> {
+function fetchFull(
+  url: string,
+): Promise<{ status: number; headers: Record<string, string | string[] | undefined>; body: string }> {
   return new Promise((resolvePromise, rejectPromise) => {
     get(url, res => {
       let body = ''
@@ -15,9 +20,14 @@ function fetchFull(url: string): Promise<{ status: number; headers: Record<strin
   })
 }
 
-function send(url: string, method: string, body?: string): Promise<{ status: number; body: string }> {
+function send(
+  url: string,
+  method: string,
+  body?: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: string }> {
   return new Promise((resolvePromise, rejectPromise) => {
-    const req = request(url, { method }, res => {
+    const req = request(url, { method, headers }, res => {
       let b = ''
       res.on('data', c => (b += c))
       res.on('end', () => resolvePromise({ status: res.statusCode ?? 0, body: b }))
@@ -28,104 +38,105 @@ function send(url: string, method: string, body?: string): Promise<{ status: num
   })
 }
 
-// Read SSE `data:` frames until `count` have arrived, then disconnect.
-function readSse(url: string, count: number): Promise<FrameworkEvent[]> {
-  return new Promise((resolvePromise, rejectPromise) => {
-    const req = get(url, res => {
-      let buffer = ''
-      const collected: FrameworkEvent[] = []
-      res.on('data', chunk => {
-        buffer += chunk
-        let nl: number
-        while ((nl = buffer.indexOf('\n\n')) !== -1) {
-          const frame = buffer.slice(0, nl)
-          buffer = buffer.slice(nl + 2)
-          const line = frame.split('\n').find(l => l.startsWith('data: '))
-          if (line) collected.push(JSON.parse(line.slice(6)) as FrameworkEvent)
-          if (collected.length >= count) {
-            req.destroy()
-            resolvePromise(collected)
-            return
-          }
-        }
-      })
-    })
-    req.on('error', rejectPromise)
-  })
+/** POST an `onEvents` call to the relay's Telefunc mount, the dashboard's live-stream RPC. */
+function callOnEvents(base: string, runId: string, origin?: string): Promise<{ status: number; body: string }> {
+  return send(
+    `${base}/_telefunc`,
+    'POST',
+    JSON.stringify({ file: '/server/events.telefunc.ts', name: 'onEvents', args: [runId] }),
+    { 'content-type': 'application/json', ...(origin ? { origin } : {}) },
+  )
 }
 
 const local = { host: '127.0.0.1', port: 0 as const }
 
-test('relay re-serves one run to two browsers, each replaying full history (#230)', async () => {
-  const relay = await startRelay(local)
+/** A temp dir holding a minimal SPA `index.html`, to exercise bundle serving offline. */
+async function fakeBundle(marker: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'relay-bundle-'))
+  await writeFile(join(dir, 'index.html'), `<!doctype html><title>The Framework</title><!-- ${marker} -->`)
+  return dir
+}
+
+test('a viewer GET of a run redirects to the SPA viewer URL /?run=:id (#426)', async () => {
+  const relay = await startRelay({ ...local, clientBundleDir: '/no/such/bundle' })
+  try {
+    for (const path of ['/r/xyz', '/r/xyz/']) {
+      const redirect = await fetchFull(`${relay.url}${path}`)
+      assert.equal(redirect.status, 302)
+      assert.equal(redirect.headers.location, '/?run=xyz')
+    }
+  } finally {
+    await relay.close()
+  }
+})
+
+test('the relay serves the dashboard SPA at / (and its viewer URL); missing bundle is a clean 404', async () => {
+  const bundle = await fakeBundle('spa-here')
+  const served = await startRelay({ ...local, clientBundleDir: bundle })
+  try {
+    const root = await fetchFull(`${served.url}/`)
+    assert.equal(root.status, 200)
+    assert.match(root.body, /spa-here/) // the SPA index.html, not page.ts
+    const viewer = await fetchFull(`${served.url}/?run=abc`)
+    assert.equal(viewer.status, 200)
+    assert.match(viewer.body, /spa-here/) // ?run= is a client concern; same shell is served
+  } finally {
+    await served.close()
+  }
+
+  const bare = await startRelay({ ...local, clientBundleDir: '/no/such/bundle' })
+  try {
+    const root = await fetchFull(`${bare.url}/`)
+    assert.equal(root.status, 404)
+    assert.match(root.body, /not built/)
+  } finally {
+    await bare.close()
+  }
+})
+
+test('onEvents is mounted and streams a run; cross-origin is rejected (#426)', async () => {
+  const relay = await startRelay({ ...local, clientBundleDir: '/no/such/bundle' })
   try {
     relay.ingest('run-1', { kind: 'log', message: 'a' })
-    relay.ingest('run-1', { kind: 'log', message: 'b' })
-    relay.ingest('run-1', { kind: 'log', message: 'c' })
-
-    // Two independent viewers connect after the fact; both replay the whole run.
-    const [one, two] = await Promise.all([
-      readSse(`${relay.url}/r/run-1/events`, 3),
-      readSse(`${relay.url}/r/run-1/events`, 3),
-    ])
-    assert.deepEqual(one.map(e => (e as { message: string }).message), ['a', 'b', 'c'])
-    assert.deepEqual(two.map(e => (e as { message: string }).message), ['a', 'b', 'c'])
+    // A same-origin viewer call returns a live Telefunc Channel for the run (not a 404).
+    const ok = await callOnEvents(relay.url, 'run-1', relay.url)
+    assert.equal(ok.status, 200)
+    assert.match(ok.body, /TelefuncChannel/)
+    // A cross-origin POST is refused: the relay is public, only its own page may call it.
+    const evil = await callOnEvents(relay.url, 'run-1', 'http://evil.com')
+    assert.equal(evil.status, 403)
   } finally {
     await relay.close()
   }
 })
 
-test('relayPublisher POSTs a run to the relay, which re-serves it live', async () => {
-  const relay = await startRelay(local)
-  try {
-    // A viewer connects first; then the run publishes over HTTP.
-    const seen = readSse(`${relay.url}/r/pub/events`, 2)
-    const pub = relayPublisher(relay.url, 'pub')
-    assert.equal(pub.url, `${relay.url}/r/pub/`)
-    pub.publish({ kind: 'log', message: 'from-cli-1' })
-    pub.publish({ kind: 'end', ok: true } as FrameworkEvent)
-    await pub.flush()
-    const events = await seen
-    assert.equal((events[0] as { message: string }).message, 'from-cli-1')
-    assert.equal(events[1]!.kind, 'end')
-  } finally {
-    await relay.close()
-  }
-})
-
-test('runs are isolated by id', async () => {
-  const relay = await startRelay(local)
+test('runs are isolated by id and tracked', async () => {
+  const relay = await startRelay({ ...local, clientBundleDir: '/no/such/bundle' })
   try {
     relay.ingest('run-a', { kind: 'log', message: 'only-a' })
     relay.ingest('run-b', { kind: 'log', message: 'only-b' })
-    const a = await readSse(`${relay.url}/r/run-a/events`, 1)
-    assert.deepEqual(
-      a.map(e => (e as { message: string }).message),
-      ['only-a'],
-    )
     assert.deepEqual(relay.runIds().sort(), ['run-a', 'run-b'])
   } finally {
     await relay.close()
   }
 })
 
-test('GET /r/:id redirects to the trailing-slash page; the page loads relative SSE', async () => {
-  const relay = await startRelay(local)
+test('relayPublisher shares the SPA viewer URL and ingests over /r/:id/publish', async () => {
+  const relay = await startRelay({ ...local, clientBundleDir: '/no/such/bundle' })
   try {
-    const redirect = await fetchFull(`${relay.url}/r/xyz`)
-    assert.equal(redirect.status, 302)
-    assert.equal(redirect.headers.location, '/r/xyz/')
-
-    const page = await fetchFull(`${relay.url}/r/xyz/`)
-    assert.equal(page.status, 200)
-    assert.match(page.body, /new EventSource\('events'\)/) // resolves under /r/xyz/
+    const pub = relayPublisher(relay.url, 'pub')
+    assert.equal(pub.url, `${relay.url}/?run=pub`) // the shareable viewer URL, not /r/pub/
+    pub.publish({ kind: 'log', message: 'from-cli-1' })
+    pub.publish({ kind: 'end', ok: true } as FrameworkEvent)
+    await pub.flush()
+    assert.deepEqual(relay.runIds(), ['pub']) // the events landed in the run's stream
   } finally {
     await relay.close()
   }
 })
 
 test('run count is bounded: least-recently-used runs are evicted at maxRuns (#230 hardening)', async () => {
-  const relay = await startRelay({ ...local, maxRuns: 2 })
+  const relay = await startRelay({ ...local, maxRuns: 2, clientBundleDir: '/no/such/bundle' })
   try {
     relay.ingest('a', { kind: 'log', message: '1' })
     relay.ingest('b', { kind: 'log', message: '1' })
@@ -154,7 +165,7 @@ test('relayPublisher does not hang flush() when the relay accepts but never resp
 })
 
 test('healthz is 200; a bad publish is rejected without crashing the run', async () => {
-  const relay = await startRelay(local)
+  const relay = await startRelay({ ...local, clientBundleDir: '/no/such/bundle' })
   try {
     assert.equal((await fetchFull(`${relay.url}/healthz`)).status, 200)
     assert.equal((await send(`${relay.url}/r/x/publish`, 'GET')).status, 405) // must POST

--- a/packages/framework/src/relay.ts
+++ b/packages/framework/src/relay.ts
@@ -2,24 +2,34 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import type { AddressInfo } from 'node:net'
 import { EventStream } from '@gemstack/ai-autopilot'
 import type { FrameworkEvent } from './events.js'
-import { dashboardHtml } from './dashboard/page.js'
-import { serveSSE } from './dashboard/sse.js'
+import { resolveDashboardBundle } from './dashboard/bundle.js'
+import { serveClientBundle } from './dashboard/static.js'
+import { makeTelefuncMount } from './dashboard/telefunc-serve.js'
+import { emptyProjectsProvider } from './dashboard/projects.js'
 
 /**
  * The hosted run relay (#230): the first slice toward shared team sessions. It
- * ingests a run's {@link FrameworkEvent} stream over HTTP and re-serves the exact
- * same dashboard (SSE + history replay) to N remote browsers, keyed by run id. So
- * two people on different machines open one run URL and both watch it live.
+ * ingests a run's {@link FrameworkEvent} stream over HTTP and re-serves the same new
+ * dashboard (#405) to N remote browsers, keyed by run id. So two people on different
+ * machines open one run URL and both watch it live.
  *
- * Deliberately unauthenticated: anyone with a run's URL can watch it. Accounts,
- * teams, RBAC, and authorized steering layer on later (via vike-auth/-rbac). The
- * relay only projects the stream — it never runs an agent.
+ * It serves the prerendered dashboard SPA and streams events over Telefunc, exactly
+ * like the daemon — except the run comes from the relay's own in-memory stream (fed by
+ * publishers over HTTP), not a file. The dashboard opens in a read-only, single-run
+ * "watch" mode (no Projects/Runs/Docs rails, no Stop/Start), and only the live event
+ * stream is exposed: an empty projects provider (#426) makes the file/registry-backed
+ * RPCs return nothing on this public host.
  *
- * Endpoints (per run id):
+ * Deliberately unauthenticated: anyone with a run's URL can watch it. Accounts, teams,
+ * RBAC, and authorized steering layer on later (via vike-auth/-rbac). The relay only
+ * projects the stream — it never runs an agent.
+ *
+ * Endpoints:
  * - `POST /r/:id/publish` — ingest one event (JSON object) or a batch (JSON array)
- * - `GET  /r/:id/`        — the dashboard page (read-only: no Stop button)
- * - `GET  /r/:id/events`  — the SSE stream (replays history, then follows live)
- * - `GET  /r/:id`         — redirects to `/r/:id/` so the page's relative paths resolve
+ * - `GET  /?run=:id`      — the dashboard SPA in read-only watch mode for that run
+ * - `GET  /r/:id[/]`      — redirects to `/?run=:id` (the viewer URL)
+ * - `POST /_telefunc`     — the dashboard's Telefunc surface (only `onEvents` is live)
+ * - `GET  /assets/…`      — the SPA's static assets
  * - `GET  /healthz`       — liveness probe for the host
  */
 export interface RelayOptions {
@@ -41,13 +51,19 @@ export interface RelayOptions {
    * run is evicted (its stream closed, its viewers dropped). Default 200.
    */
   maxRuns?: number
+  /**
+   * The prerendered dashboard bundle to serve (the SPA `index.html` + `assets/**`).
+   * Defaults to {@link resolveDashboardBundle}; pass a directory to override (tests).
+   * When no bundle is found, the SPA routes 404 while publish/telefunc/healthz still work.
+   */
+  clientBundleDir?: string
 }
 
 /** A running relay. Ingest events programmatically or over HTTP; browsers watch by run id. */
 export interface Relay {
   /** The base URL of the relay (e.g. `http://0.0.0.0:4488`). */
   readonly url: string
-  /** The viewer URL for a run id (`<url>/r/<id>/`). */
+  /** The viewer URL for a run id (`<url>/?run=<id>`). */
   viewerUrl(runId: string): string
   /** Push one event into a run's stream, creating the run on first use. */
   ingest(runId: string, event: FrameworkEvent): void
@@ -59,18 +75,17 @@ export interface Relay {
 
 interface Run {
   stream: EventStream<FrameworkEvent>
-  clients: Set<ServerResponse>
 }
 
 const RUN_PATH = /^\/r\/([^/]+)(\/[^?]*)?/
 
 /** Start the hosted run relay. See {@link Relay}. */
-export function startRelay(opts: RelayOptions = {}): Promise<Relay> {
+export async function startRelay(opts: RelayOptions = {}): Promise<Relay> {
   const host = opts.host ?? '0.0.0.0'
   const port = opts.port ?? 4488
-  const title = opts.title ?? 'The Framework'
   const maxBody = opts.maxBodyBytes ?? 256 * 1024
   const maxRuns = opts.maxRuns ?? 200
+  const clientBundleDir = opts.clientBundleDir ?? (await resolveDashboardBundle())
   // Insertion-ordered as an LRU: touching a run re-inserts it at the end, so the
   // first entry is always the least-recently-used and the eviction victim.
   const runs = new Map<string, Run>()
@@ -86,17 +101,20 @@ export function startRelay(opts: RelayOptions = {}): Promise<Relay> {
     while (runs.size >= maxRuns) {
       const oldest = runs.keys().next().value
       if (oldest === undefined) break
-      const victim = runs.get(oldest)!
-      victim.stream.close()
-      for (const res of victim.clients) res.end()
+      runs.get(oldest)!.stream.close() // closing drains every viewer's Channel follower
       runs.delete(oldest)
     }
-    const r: Run = { stream: new EventStream<FrameworkEvent>(), clients: new Set() }
+    const r: Run = { stream: new EventStream<FrameworkEvent>() }
     runs.set(id, r)
     return r
   }
 
-  const server = createServer((req, res) => handle(req, res, { runs, run, title, maxBody }))
+  // The dashboard's Telefunc surface, mounted like the daemon's — but `onEvents` streams
+  // the relay's own in-memory run (create-on-access, so a viewer can connect before the
+  // publisher), and an empty projects provider neutralizes every file/registry RPC on
+  // this public host. No `startRun`, so a start is never enabled here.
+  const telefunc = makeTelefuncMount(undefined, emptyProjectsProvider(), id => run(id).stream)
+  const server = createServer((req, res) => handle(req, res, { run, maxBody, clientBundleDir, telefunc }))
 
   return new Promise<Relay>((resolvePromise, rejectPromise) => {
     server.once('error', rejectPromise)
@@ -106,7 +124,7 @@ export function startRelay(opts: RelayOptions = {}): Promise<Relay> {
       const url = `http://${host}:${address.port}`
       resolvePromise({
         url,
-        viewerUrl: id => `${url}/r/${encodeURIComponent(id)}/`,
+        viewerUrl: id => `${url}/?run=${encodeURIComponent(id)}`,
         ingest: (id, event) => run(id).stream.push(event),
         runIds: () => [...runs.keys()],
         close: () => closeRelay(server, runs),
@@ -116,55 +134,50 @@ export function startRelay(opts: RelayOptions = {}): Promise<Relay> {
 }
 
 interface HandleCtx {
-  runs: Map<string, Run>
   run: (id: string) => Run
-  title: string
   maxBody: number
+  clientBundleDir: string | undefined
+  telefunc: (req: IncomingMessage, res: ServerResponse) => Promise<boolean>
 }
 
 function handle(req: IncomingMessage, res: ServerResponse, ctx: HandleCtx): void {
-  const url = req.url ?? '/'
-  if (url === '/healthz') {
+  const { pathname } = new URL(req.url ?? '/', 'http://localhost')
+  if (pathname === '/healthz') {
     res.writeHead(200, { 'content-type': 'text/plain' })
     res.end('ok')
     return
   }
-  const m = RUN_PATH.exec(url)
-  if (!m) {
-    res.writeHead(404, { 'content-type': 'text/plain' })
-    res.end('not found')
+  // The dashboard's live event stream (and the rest of its RPC surface, neutralized).
+  if (pathname === '/_telefunc' || pathname.startsWith('/_telefunc/')) {
+    void ctx.telefunc(req, res)
     return
   }
-  const id = decodeURIComponent(m[1]!)
-  const rest = m[2] ?? ''
-
-  // No trailing slash: redirect so the page's relative `events`/`stop` resolve under /r/:id/.
-  if (rest === '') {
-    res.writeHead(302, { location: `/r/${encodeURIComponent(id)}/` })
+  const m = RUN_PATH.exec(pathname)
+  if (m) {
+    const id = decodeURIComponent(m[1]!)
+    const rest = m[2] ?? ''
+    // Ingest is the one thing still under /r/:id/ — the publisher POSTs a run's events here.
+    if (rest === '/publish') {
+      if (req.method !== 'POST') {
+        res.writeHead(405, { 'content-type': 'text/plain', allow: 'POST' })
+        res.end('method not allowed')
+        return
+      }
+      ingestBody(req, res, ctx.run(id), ctx.maxBody)
+      return
+    }
+    // Any viewer GET of a run moved to the SPA at `/?run=:id`; redirect old links there.
+    res.writeHead(302, { location: `/?run=${encodeURIComponent(id)}` })
     res.end()
     return
   }
-  if (rest === '/') {
-    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
-    res.end(dashboardHtml(ctx.title, false)) // read-only: steering is out of scope for the keystone
-    return
-  }
-  if (rest === '/events') {
-    const r = ctx.run(id)
-    serveSSE(req, res, r.stream, r.clients)
-    return
-  }
-  if (rest === '/publish') {
-    if (req.method !== 'POST') {
-      res.writeHead(405, { 'content-type': 'text/plain', allow: 'POST' })
-      res.end('method not allowed')
-      return
-    }
-    ingestBody(req, res, ctx.run(id), ctx.maxBody)
+  // Everything else is the dashboard SPA (`/`, `/?run=:id`, `/assets/**`, SPA fallback).
+  if (ctx.clientBundleDir) {
+    void serveClientBundle(req, res, ctx.clientBundleDir)
     return
   }
   res.writeHead(404, { 'content-type': 'text/plain' })
-  res.end('not found')
+  res.end('dashboard bundle not built')
 }
 
 /** Read a JSON body (one event or an array) and push each event into the run's stream. */
@@ -199,18 +212,14 @@ function ingestBody(req: IncomingMessage, res: ServerResponse, r: Run, maxBody: 
 }
 
 function closeRelay(server: Server, runs: Map<string, Run>): Promise<void> {
-  for (const { stream, clients } of runs.values()) {
-    stream.close()
-    for (const res of clients) res.end()
-    clients.clear()
-  }
+  for (const { stream } of runs.values()) stream.close() // closing drains each Channel follower
   runs.clear()
   return new Promise(resolvePromise => server.close(() => resolvePromise()))
 }
 
 /** A publisher that forwards a run's events to a relay. Best-effort and ordered. */
 export interface RelayPublisher {
-  /** The viewer URL to share (`<base>/r/<id>/`). */
+  /** The viewer URL to share (`<base>/?run=<id>`). */
   readonly url: string
   /** Queue one event to POST to the relay (serialized, so the relay replays in order). */
   publish(event: FrameworkEvent): void
@@ -230,10 +239,12 @@ export function relayPublisher(
   onError?: (err: unknown) => void,
   timeoutMs = 10_000,
 ): RelayPublisher {
-  const root = `${base.replace(/\/+$/, '')}/r/${encodeURIComponent(runId)}`
+  const origin = base.replace(/\/+$/, '')
+  const root = `${origin}/r/${encodeURIComponent(runId)}`
   let chain: Promise<void> = Promise.resolve()
   return {
-    url: `${root}/`,
+    // Share the SPA viewer URL; events still POST to the ingest route under /r/:id/.
+    url: `${origin}/?run=${encodeURIComponent(runId)}`,
     publish(event) {
       chain = chain.then(async () => {
         try {


### PR DESCRIPTION
Part 2 of #426. Closes #429.

The run relay (`--share`) still served the legacy page.ts + SSE, the last thing blocking its deletion. This ports it onto the new Vike + Telefunc dashboard, read-only.

## What
- The relay serves the prerendered SPA and mounts /_telefunc like the daemon, but `onEvents` streams the relay`s own **in-memory run** (fed by publishers over HTTP) instead of a file: an `eventsSource` on the Telefunc context selects the in-memory path, and a small `forwardStream` helper bridges the run`s replay-then-follow stream to a Channel.
- **Public host, so only the live stream is exposed:** an empty projects provider makes the file/registry RPCs (runs, docs, log, steer) return nothing, and with no `startRun` a run can never be started or steered from a shared link.
- The SPA renders a **read-only, single-run watch view** when the URL carries `?run=<id>` (no Projects/Runs/Docs rails, no Stop/Start).
- Viewer URL moves from `/r/:id/` to `/?run=:id` (old links 302-redirect); ingest stays at `/r/:id/publish`.
- Removes the relay`s use of page.ts and sse.ts, so part 3 can delete both.

## Design
Option 1 (live watch-only) from the decision recorded on #426, per the steer that the priority is a working product + clean code. Reversible.

## Verified
- Unit: `forwardStream` replays buffered history then follows live and stops cleanly; rewritten relay suite covers the redirect, SPA serving (200 + clean 404 when unbuilt), `onEvents` mounted + cross-origin 403, ingest/publish contract, run isolation, LRU eviction, publisher URL + flush timeout. 463 framework tests pass; workspace typecheck + build 26/26.
- Real relay (`framework relay`): serves the SPA at `/` and `/?run=`, `/r/:id` 302 -> `/?run=:id`, publish accepted, `onEvents(<run>)` returns a live Telefunc Channel same-origin. End-to-end event delivery is covered by composition (the Channel machinery was browser-verified end to end in #428/part 1; only the source changes here, and `forwardStream` covers that).

Part 3 (delete page.ts + sse.ts + legacy routes) follows. No browser in this env, so the read-only render itself is unobserved (same documented limit as prior slices).