### PR TITLE
feat(framework): restore the rich run view on the new dashboard (#431)

### DIFF
--- a/.changeset/dashboard-run-view.md
+++ b/.changeset/dashboard-run-view.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Add event-stream projections for the dashboard's run overview: `architectPlan`, `decisionLedger`, `loopStatus`, and `sessionInfo` derive the chosen stack + rationale, the decisions ledger, the production-grade loop status, and the live session from a `FrameworkEvent[]`. They plus `formatFrameworkEvent` are re-exported from a new browser-safe `@gemstack/framework/client` subpath (no Node imports), so the dashboard renders the rich run view — the stack/PROS-CONS card, decisions, loop status, and a human-readable event log instead of raw JSON — across the live view, past-run replay, and the relay watch view.

--- a/packages/framework-dashboard/components/EventList.tsx
+++ b/packages/framework-dashboard/components/EventList.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useRef } from 'react'
 import type { FrameworkEvent } from '@gemstack/framework'
+import { formatFrameworkEvent } from '@gemstack/framework/client'
 import { Badge } from './ui/badge.js'
 
 // Presentational event log, shared by the live stream and past-run replay. Each
-// FrameworkEvent is a kind badge + a one-line summary; the pane sticks to the bottom
-// as events arrive (live) — replay renders the whole list at once.
+// FrameworkEvent is a kind badge + its human-readable line (the same formatter the
+// terminal uses, so a `driver` turn reads "· Read" / "‹ turn complete" rather than raw
+// JSON); the pane sticks to the bottom as events arrive (live), replay renders at once.
 export function EventList({ events, stick = true }: { events: FrameworkEvent[]; stick?: boolean }) {
   const bottomRef = useRef<HTMLDivElement>(null)
 
@@ -18,20 +20,11 @@ export function EventList({ events, stick = true }: { events: FrameworkEvent[]; 
         {events.map((e, i) => (
           <li key={i} className="flex items-start gap-2">
             <Badge className="mt-0.5 shrink-0 text-[10px] uppercase text-muted-foreground">{e.kind}</Badge>
-            <span className="whitespace-pre-wrap break-words text-foreground">{summarizeEvent(e)}</span>
+            <span className="whitespace-pre-wrap break-words text-foreground">{formatFrameworkEvent(e).trim()}</span>
           </li>
         ))}
       </ol>
       <div ref={bottomRef} />
     </div>
   )
-}
-
-/** A one-line human summary of an event: its message when it has one, else compact JSON. */
-export function summarizeEvent(event: FrameworkEvent): string {
-  const record = event as Record<string, unknown>
-  if (typeof record['message'] === 'string') return record['message']
-  if (typeof record['title'] === 'string') return record['title']
-  const { kind, ...rest } = record
-  return Object.keys(rest).length ? JSON.stringify(rest) : String(kind)
 }

--- a/packages/framework-dashboard/components/EventStream.tsx
+++ b/packages/framework-dashboard/components/EventStream.tsx
@@ -7,6 +7,7 @@ import { pendingChoice, isRunActive } from '../lib/live-state.js'
 import { EventList } from './EventList.js'
 import { ChoicePanel } from './ChoicePanel.js'
 import { StartRunForm } from './StartRunForm.js'
+import { RunOverview } from './RunOverview.js'
 import { Button } from './ui/button.js'
 
 // The live event stream (#405/#314): a projection of the selected project's
@@ -41,12 +42,16 @@ export function EventStream({ projectId, readOnly = false }: { projectId: string
   }
 
   // Read-only watch mode (the relay, #426): no steering (no Stop/Start, no interactive
-  // gate), just the live event feed. The stream is served from the relay's in-memory run.
+  // gate), just the run overview + the live event feed, both projected from the stream.
   if (readOnly) {
-    return events.length > 0 ? (
-      <EventList events={events} />
-    ) : (
-      <div className="grid flex-1 place-items-center text-sm text-muted-foreground">Waiting for the run to start…</div>
+    if (events.length === 0) {
+      return <div className="grid flex-1 place-items-center text-sm text-muted-foreground">Waiting for the run to start…</div>
+    }
+    return (
+      <>
+        <RunOverview events={events} />
+        <EventList events={events} />
+      </>
     )
   }
 
@@ -65,7 +70,10 @@ export function EventStream({ projectId, readOnly = false }: { projectId: string
       )}
       {choice && <ChoicePanel key={choice.id} projectId={projectId} choice={choice} />}
       {events.length > 0 ? (
-        <EventList events={events} />
+        <>
+          <RunOverview events={events} />
+          <EventList events={events} />
+        </>
       ) : (
         <div className="grid flex-1 place-items-center text-sm text-muted-foreground">No events yet.</div>
       )}

--- a/packages/framework-dashboard/components/RunOverview.tsx
+++ b/packages/framework-dashboard/components/RunOverview.tsx
@@ -1,0 +1,100 @@
+import type { FrameworkEvent } from '@gemstack/framework'
+import { architectPlan, decisionLedger, loopStatus, sessionInfo } from '@gemstack/framework/client'
+import { Badge } from './ui/badge.js'
+
+// The run overview (#431): the "moat" the wrapped agent's own chat cannot show, rebuilt
+// on the new dashboard. Each card is a pure projection of the event stream (run-view.ts
+// in @gemstack/framework) — the chosen stack + PROS/CONS + rejected alternatives, the
+// decisions ledger, the production-grade loop status, and a link to the live session.
+// Cards render only when their data has arrived, so an early run shows nothing extra.
+export function RunOverview({ events }: { events: FrameworkEvent[] }) {
+  const plan = architectPlan(events)
+  const ledger = decisionLedger(events)
+  const loop = loopStatus(events)
+  const session = sessionInfo(events)
+
+  if (!plan && !loop && !session?.sessionLink) return null
+
+  return (
+    <div className="grid gap-3 border-b border-border p-4 md:grid-cols-2">
+      {plan && (
+        <section className="rounded-lg border border-border p-3">
+          <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Stack &amp; rationale</h3>
+          <p className="text-sm font-medium">{plan.stack}</p>
+          {(plan.pros.length > 0 || plan.cons.length > 0) && (
+            <div className="mt-2 grid grid-cols-2 gap-3 text-xs">
+              <ul className="space-y-0.5">
+                {plan.pros.map((p, i) => (
+                  <li key={i} className="text-foreground">
+                    <span className="text-primary">＋</span> {p}
+                  </li>
+                ))}
+              </ul>
+              <ul className="space-y-0.5">
+                {plan.cons.map((c, i) => (
+                  <li key={i} className="text-muted-foreground">
+                    <span>－</span> {c}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {plan.alternatives.length > 0 && (
+            <p className="mt-2 text-xs text-muted-foreground">
+              Considered: {plan.alternatives.map(a => `${a.option} (${a.whyNot})`).join('; ')}
+            </p>
+          )}
+        </section>
+      )}
+
+      {loop && (
+        <section className="rounded-lg border border-border p-3">
+          <h3 className="mb-1 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Loop status
+            <Badge className={loop.productionGrade ? 'text-primary' : loop.finished ? 'text-muted-foreground' : ''}>
+              {loop.productionGrade ? 'production-grade' : loop.finished ? 'stopped' : `pass ${loop.pass}`}
+            </Badge>
+          </h3>
+          {loop.blockers.length > 0 ? (
+            <ul className="space-y-0.5 text-xs">
+              {loop.blockers.map((b, i) => (
+                <li key={i} className="text-foreground">
+                  <span className="text-muted-foreground">☐</span> {b}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              {loop.passing ? 'No blockers — the checklist passed.' : `Pass ${loop.pass} in progress…`}
+            </p>
+          )}
+        </section>
+      )}
+
+      {ledger.length > 0 && (
+        <section className="rounded-lg border border-border p-3 md:col-span-2">
+          <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Decisions ledger</h3>
+          <ul className="space-y-0.5 text-xs">
+            {ledger.map((d, i) => (
+              <li key={i} className={d.rejected ? 'text-muted-foreground line-through decoration-muted-foreground/40' : 'text-foreground'}>
+                <span className="font-medium">{d.choice}</span>
+                <span className="text-muted-foreground"> — {d.why}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {session?.sessionLink && (
+        <a
+          href={session.sessionLink}
+          target="_blank"
+          rel="noreferrer"
+          className="text-xs text-primary underline underline-offset-2 md:col-span-2"
+        >
+          Open session{session.sessionId ? ` (${session.sessionId})` : ''} ↗
+        </a>
+      )}
+    </div>
+  )
+}

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -43,6 +43,10 @@
     "./dashboard-rpc": {
       "import": "./dist/dashboard-rpc/index.js",
       "types": "./dist/dashboard-rpc/index.d.ts"
+    },
+    "./client": {
+      "import": "./dist/client.js",
+      "types": "./dist/client.d.ts"
     }
   },
   "scripts": {

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -1,0 +1,15 @@
+// Browser-safe entry for the dashboard client (#431). Only pure event projections live
+// here — `formatFrameworkEvent` and the run-view derivations — with no Node imports, so
+// the client can import these at runtime without dragging the server barrel (relay,
+// sandbox, node:fs/http, …) into the browser bundle. Types come from the root entry.
+export { formatFrameworkEvent, pickedIds } from './events.js'
+export {
+  architectPlan,
+  decisionLedger,
+  loopStatus,
+  sessionInfo,
+  type ArchitectPlan,
+  type Decision,
+  type LoopStatus,
+  type SessionInfo,
+} from './run-view.js'

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -93,6 +93,16 @@ export {
   OPEN_LOOP_MODES,
 } from './events.js'
 export {
+  architectPlan,
+  decisionLedger,
+  loopStatus,
+  sessionInfo,
+  type ArchitectPlan,
+  type Decision,
+  type LoopStatus,
+  type SessionInfo,
+} from './run-view.js'
+export {
   assessRepo,
   planMaintenanceSweep,
   maintainSweep,

--- a/packages/framework/src/run-view.test.ts
+++ b/packages/framework/src/run-view.test.ts
@@ -1,0 +1,75 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { architectPlan, decisionLedger, loopStatus, sessionInfo } from './run-view.js'
+import type { FrameworkEvent } from './events.js'
+
+const architect = (stack: string, extra: Record<string, unknown> = {}): FrameworkEvent => ({
+  kind: 'bootstrap',
+  event: { type: 'architect', stack, decisions: [], ...extra } as never,
+})
+
+test('architectPlan returns the chosen stack + rationale from the architect event (#431)', () => {
+  const events: FrameworkEvent[] = [
+    { kind: 'log', message: 'hi' },
+    architect('Vike + Prisma', {
+      decisions: [{ choice: 'Prisma on Postgres', why: 'relational catalog' }],
+      pros: ['edge deploy'],
+      cons: ['smaller ecosystem'],
+      alternatives: [{ option: 'Next.js', whyNot: 'constrained edge deploy' }],
+    }),
+  ]
+  const plan = architectPlan(events)
+  assert.equal(plan?.stack, 'Vike + Prisma')
+  assert.deepEqual(plan?.pros, ['edge deploy'])
+  assert.deepEqual(plan?.cons, ['smaller ecosystem'])
+  assert.deepEqual(plan?.decisions, [{ choice: 'Prisma on Postgres', why: 'relational catalog' }])
+  assert.deepEqual(plan?.alternatives, [{ option: 'Next.js', whyNot: 'constrained edge deploy' }])
+})
+
+test('architectPlan is null before the architect runs; latest wins on re-architect', () => {
+  assert.equal(architectPlan([{ kind: 'log', message: 'x' }]), null)
+  const plan = architectPlan([architect('Vike'), architect('Next.js')])
+  assert.equal(plan?.stack, 'Next.js') // #324 re-architect supersedes
+})
+
+test('decisionLedger accumulates decisions then lists rejected alternatives (#431)', () => {
+  const events: FrameworkEvent[] = [
+    architect('Vike', { decisions: [{ choice: 'Vike for SSR', why: 'SEO' }] }),
+    architect('Vike + auth', {
+      decisions: [{ choice: 'vike-auth', why: 'sessions' }],
+      alternatives: [{ option: 'Next.js', whyNot: 'edge deploy' }],
+    }),
+  ]
+  const ledger = decisionLedger(events)
+  assert.deepEqual(ledger, [
+    { choice: 'Vike for SSR', why: 'SEO', rejected: false },
+    { choice: 'vike-auth', why: 'sessions', rejected: false },
+    { choice: 'Next.js', why: 'edge deploy', rejected: true },
+  ])
+})
+
+test('loopStatus tracks the latest checklist verdict and closes on done (#431)', () => {
+  const boot = (event: Record<string, unknown>): FrameworkEvent => ({ kind: 'bootstrap', event: event as never })
+  assert.equal(loopStatus([{ kind: 'log', message: 'x' }]), null) // no checklist yet
+
+  const failing = loopStatus([boot({ type: 'checklist', pass: 1, blockers: ['no tests'], passing: false })])
+  assert.deepEqual(failing, { pass: 1, passing: false, blockers: ['no tests'], productionGrade: false, finished: false })
+
+  const done = loopStatus([
+    boot({ type: 'checklist', pass: 1, blockers: ['no tests'], passing: false }),
+    boot({ type: 'done', result: { passes: 2, blockers: [], productionGrade: true } }),
+  ])
+  assert.deepEqual(done, { pass: 2, passing: true, blockers: [], productionGrade: true, finished: true })
+})
+
+test('sessionInfo merges the opening session with the latest session-update link (#431)', () => {
+  const events: FrameworkEvent[] = [
+    { kind: 'session', driver: 'claude', workspace: '/repo', fake: false },
+    { kind: 'session-update', sessionId: 'sess-1', sessionLink: 'https://claude.ai/code/sess-1' },
+  ]
+  const info = sessionInfo(events)
+  assert.equal(info?.driver, 'claude')
+  assert.equal(info?.sessionId, 'sess-1')
+  assert.equal(info?.sessionLink, 'https://claude.ai/code/sess-1')
+  assert.equal(sessionInfo([{ kind: 'log', message: 'x' }]), null)
+})

--- a/packages/framework/src/run-view.ts
+++ b/packages/framework/src/run-view.ts
@@ -1,0 +1,125 @@
+import type { FrameworkEvent } from './events.js'
+
+// Derived run state for the dashboard's overview cards (#431): the chosen stack + its
+// rationale, the decisions ledger, the production-grade loop status, and the live session
+// link — each a pure projection of the same FrameworkEvent stream the log renders, so the
+// live dashboard and a past-run replay show the identical summary. Kept here (not in the
+// dashboard) so it is unit-tested against the real event shapes. The bootstrap phase
+// (architect/checklist/deploy) carries the structured data; we surface it as cards.
+
+/** The architect's chosen stack and why (#431), from the last `architect` bootstrap event. */
+export interface ArchitectPlan {
+  stack: string
+  decisions: { choice: string; why: string }[]
+  pros: string[]
+  cons: string[]
+  alternatives: { option: string; whyNot: string }[]
+}
+
+/** The chosen stack + rationale, or null before the architect has run. Latest wins (#324 re-architect). */
+export function architectPlan(events: readonly FrameworkEvent[]): ArchitectPlan | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i]!
+    if (event.kind !== 'bootstrap' || event.event.type !== 'architect') continue
+    const a = event.event
+    return {
+      stack: a.stack,
+      decisions: a.decisions.map(d => ({ choice: d.choice, why: d.why })),
+      pros: [...(a.pros ?? [])],
+      cons: [...(a.cons ?? [])],
+      alternatives: (a.alternatives ?? []).map(x => ({ option: x.option, whyNot: x.whyNot })),
+    }
+  }
+  return null
+}
+
+/** One row of the decisions ledger: a made choice, or a considered-and-rejected alternative. */
+export interface Decision {
+  choice: string
+  why: string
+  rejected: boolean
+}
+
+/**
+ * The decisions ledger (#431): every architect decision in the order made (a later
+ * re-architect of the same choice supersedes the earlier one), then the latest plan's
+ * rejected alternatives. Empty until the architect has run.
+ */
+export function decisionLedger(events: readonly FrameworkEvent[]): Decision[] {
+  const made = new Map<string, string>() // choice -> why, insertion-ordered, last write wins the reason
+  for (const event of events) {
+    if (event.kind !== 'bootstrap' || event.event.type !== 'architect') continue
+    for (const d of event.event.decisions) {
+      made.delete(d.choice)
+      made.set(d.choice, d.why)
+    }
+  }
+  const decisions: Decision[] = [...made].map(([choice, why]) => ({ choice, why, rejected: false }))
+  const plan = architectPlan(events)
+  for (const alt of plan?.alternatives ?? []) decisions.push({ choice: alt.option, why: alt.whyNot, rejected: true })
+  return decisions
+}
+
+/** The production-grade loop status (#431): the current pass, whether it passed, and any blockers. */
+export interface LoopStatus {
+  pass: number
+  passing: boolean
+  blockers: string[]
+  /** True once the run reached production-grade (the loop ended with no blockers). */
+  productionGrade: boolean
+  /** True once a `done` bootstrap event has fired (the loop is over). */
+  finished: boolean
+}
+
+/**
+ * The latest checklist verdict (#431), from the `checklist`/`improve`/`done` bootstrap
+ * events. Null until a checklist has run (a prototype build never loops). `done` closes
+ * it out with the final production-grade verdict.
+ */
+export function loopStatus(events: readonly FrameworkEvent[]): LoopStatus | null {
+  let status: LoopStatus | null = null
+  for (const event of events) {
+    if (event.kind !== 'bootstrap') continue
+    const e = event.event
+    if (e.type === 'checklist') {
+      status = { pass: e.pass, passing: e.passing, blockers: [...e.blockers], productionGrade: e.passing, finished: false }
+    } else if (e.type === 'improve') {
+      status = { pass: e.pass, passing: false, blockers: [...e.blockers], productionGrade: false, finished: false }
+    } else if (e.type === 'done') {
+      const r = e.result
+      status = {
+        pass: r.passes,
+        passing: r.productionGrade,
+        blockers: [...r.blockers],
+        productionGrade: r.productionGrade,
+        finished: true,
+      }
+    }
+  }
+  return status
+}
+
+/** The wrapped agent session (#431): its id and a deep link, when one is known. */
+export interface SessionInfo {
+  driver?: string
+  fake?: boolean
+  sessionId?: string
+  sessionLink?: string
+}
+
+/**
+ * The session behind the run (#431): the driver + workspace from the opening `session`
+ * event, then the id and any deep link from the latest `session-update`. Null before the
+ * session opens. The link is what the old dashboard surfaced as "open session".
+ */
+export function sessionInfo(events: readonly FrameworkEvent[]): SessionInfo | null {
+  let info: SessionInfo | null = null
+  for (const event of events) {
+    if (event.kind === 'session') {
+      info = { driver: event.driver, fake: event.fake, ...(event.sessionLink ? { sessionLink: event.sessionLink } : {}) }
+    } else if (event.kind === 'session-update') {
+      info = { ...(info ?? {}), sessionId: event.sessionId, ...(event.sessionLink ? { sessionLink: event.sessionLink } : {}) }
+    }
+  }
+  return info
+}


### PR DESCRIPTION
Closes #431.

You spotted that the new dashboard dropped the old page.ts run view: the main panel was a raw event log (driver events dumped JSON) and the derived cards were gone. This restores them as pure projections of the event stream.

## What
- New `run-view.ts` in @gemstack/framework: `architectPlan`, `decisionLedger`, `loopStatus`, `sessionInfo` derive the chosen stack + rationale, the decisions ledger, the production-grade loop status, and the live session from a `FrameworkEvent[]`. Unit-tested against the real event shapes (5 tests).
- New **browser-safe `@gemstack/framework/client` subpath** re-exporting those + `formatFrameworkEvent`, so the client imports them at runtime without dragging the server barrel (relay, sandbox, node:fs/http) into the browser bundle.
- Dashboard: a `RunOverview` card strip — **Stack & rationale** (stack + PROS/CONS + rejected alternatives), **Decisions ledger**, **Loop status** (badge + blockers), and an **"open session"** link — above a now **human-readable `EventList`** (reuses `formatFrameworkEvent`, so a driver turn reads `· Read` / `‹ turn complete` not raw JSON). Shown on the live view, past-run replay, and the relay watch view alike.

## Verified
- 5 new unit tests for the derivations; 468 framework tests pass; both packages typecheck + build clean.
- Ran the derivations against a real `--fake` build run: the Stack card (Vike + Prisma + vike-auth, 2 pros / 2 cons, Next.js alternative), Decisions ledger (2 made + 1 rejected), Loop status (pass 2, production-grade), and readable log rows all populate correctly.
- Browser-checked live on a running daemon + relay watch view (user reviewed).

First slice of the run-view parity gap. The missing **actions** (Global options on Start, Add project, Deploy panel, autopilot countdown) are a separate follow-up.