### PR TITLE
feat(framework): restore the dashboard actions (global options, presets, autopilot countdown, deploy card, add project)

### DIFF
--- a/.changeset/dashboard-actions.md
+++ b/.changeset/dashboard-actions.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Restore the dashboard actions on the new dashboard (#433): the Start form now carries the Global options (autopilot, technical, vanilla, eco) and the run presets (Research, Readability, Maintainability), the interactive choice gate auto-accepts the recommended pick on an autopilot countdown, a Deploy card shows the chosen render + target, and projects can be added from the Projects sidebar over a new `sendAddProject` telefunction. Adds a browser-safe `deployPlan` projection and the preset builders to `@gemstack/framework/client`.

--- a/packages/framework-dashboard/components/ChoicePanel.tsx
+++ b/packages/framework-dashboard/components/ChoicePanel.tsx
@@ -1,24 +1,29 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { ChoiceRequest } from '@gemstack/framework'
 import { sendChoice } from '../server/control.telefunc.js'
+import { autopilotOn, setAutopilot } from '../lib/autopilot.js'
 import { Button } from './ui/button.js'
 import { cn } from '../lib/utils.js'
 
 // "Your call" — the interactive gate the run parks on (#304/#332), rendered from the
 // live event stream and posted back over Telefunc (server/control.telefunc.ts) to the
 // project's control.jsonl. Three shapes: an Approve/Decline confirm (#358), a
-// multi-select checklist (#332), and the single-select list (#304). The panel clears
-// itself when the resulting `choice-resolved` event streams in (pendingChoice drops
-// it); mount it with `key={choice.id}` so a re-fired gate resets local state.
+// multi-select checklist (#332), and the single-select list (#304). When Autopilot is on
+// it auto-accepts the recommended pick after a countdown (#433), which any mouse movement
+// cancels. The panel clears itself when the resulting `choice-resolved` event streams in
+// (pendingChoice drops it); mount it with `key={choice.id}` so a re-fired gate resets state.
 export function ChoicePanel({ projectId, choice }: { projectId: string; choice: ChoiceRequest }) {
   const [busy, setBusy] = useState(false)
   const [checked, setChecked] = useState<Set<string>>(
     () => new Set(choice.multi ? choice.options.filter(o => o.default).map(o => o.id) : []),
   )
+  const [autopilot, setAutopilotState] = useState(autopilotOn)
+  const [secondsLeft, setSecondsLeft] = useState<number | null>(null)
+  const [cancelled, setCancelled] = useState(false)
 
-  const post = (pick: string | string[]) => {
+  const post = (pick: string | string[], by: 'user' | 'autopilot' = 'user') => {
     setBusy(true)
-    void sendChoice(projectId, choice.id, pick).catch(() => setBusy(false))
+    void sendChoice(projectId, choice.id, pick, by).catch(() => setBusy(false))
   }
 
   const toggle = (id: string) =>
@@ -30,6 +35,45 @@ export function ChoicePanel({ projectId, choice }: { projectId: string; choice: 
 
   const approveId = choice.recommended ?? choice.options[0]?.id
   const declineId = choice.options.find(o => o.id !== approveId)?.id ?? approveId
+
+  // What the countdown accepts: the checked subset for a multi-select, else the
+  // recommended option (an Approve for a confirm gate).
+  const autoPick = (): string | string[] => (choice.multi ? [...checked] : (approveId ?? ''))
+
+  // Any mouse movement cancels the auto-accept — the human is here, so let them pick.
+  useEffect(() => {
+    const cancel = () => setCancelled(true)
+    window.addEventListener('mousemove', cancel, { once: true })
+    return () => window.removeEventListener('mousemove', cancel)
+  }, [])
+
+  // The countdown: tick down once a second while autopilot is on and uncancelled, then
+  // auto-accept. Restarts if autopilot is toggled back on before a pick is made.
+  useEffect(() => {
+    if (!autopilot || cancelled || busy) {
+      setSecondsLeft(null)
+      return
+    }
+    let left = Math.ceil((choice.autoAcceptMs ?? 10000) / 1000)
+    setSecondsLeft(left)
+    const timer = setInterval(() => {
+      left -= 1
+      if (left <= 0) {
+        clearInterval(timer)
+        setSecondsLeft(null)
+        post(autoPick(), 'autopilot')
+      } else {
+        setSecondsLeft(left)
+      }
+    }, 1000)
+    return () => clearInterval(timer)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autopilot, cancelled, busy])
+
+  const toggleAutopilot = (on: boolean) => {
+    setAutopilotState(on)
+    setAutopilot(on) // keep the Start form's Global option in lockstep (#433)
+  }
 
   return (
     <section className="border-b border-border bg-accent/40 p-4">
@@ -89,6 +133,19 @@ export function ChoicePanel({ projectId, choice }: { projectId: string; choice: 
           ))}
         </div>
       )}
+
+      <div className="mt-3 flex items-center gap-3 text-xs text-muted-foreground">
+        <label className="flex cursor-pointer items-center gap-1.5">
+          <input type="checkbox" checked={autopilot} onChange={e => toggleAutopilot(e.target.checked)} disabled={busy} /> Autopilot
+        </label>
+        {autopilot && !busy && (
+          <span>
+            {cancelled
+              ? 'Auto accept canceled — pick manually'
+              : secondsLeft !== null && `● Auto accept in ${secondsLeft}s — move the mouse to cancel`}
+          </span>
+        )}
+      </div>
     </section>
   )
 }

--- a/packages/framework-dashboard/components/ProjectsSidebar.tsx
+++ b/packages/framework-dashboard/components/ProjectsSidebar.tsx
@@ -1,12 +1,13 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, type FormEvent } from 'react'
 import type { ProjectSummary } from '@gemstack/framework'
-import { onProjects } from '../server/projects.telefunc.js'
+import { onProjects, sendAddProject } from '../server/projects.telefunc.js'
 import { Button } from './ui/button.js'
 import { cn } from '../lib/utils.js'
 
-// The Projects sidebar (#406/#314). Loads the registry over a Telefunc RPC and lets
-// the user pick which project's live stream to watch. A registry that is empty (no
-// project added yet) shows the how-to hint rather than a blank rail.
+// The Projects sidebar (#406/#314). Loads the registry over a Telefunc RPC and lets the
+// user pick which project's live stream to watch, or add a new one (#396/#433) via the
+// daemon's own install + register. A registry that is empty (no project added yet) shows
+// the how-to hint rather than a blank rail.
 export function ProjectsSidebar({
   selectedId,
   onSelect,
@@ -16,16 +17,18 @@ export function ProjectsSidebar({
 }) {
   const [projects, setProjects] = useState<ProjectSummary[] | null>(null)
 
+  const reload = useCallback(
+    (autoSelect: boolean) => {
+      void onProjects().then(list => {
+        setProjects(list)
+        if (autoSelect && list[0] && !selectedId) onSelect(list[0].id) // auto-select the first
+      })
+    },
+    [selectedId, onSelect],
+  )
+
   useEffect(() => {
-    let live = true
-    void onProjects().then(list => {
-      if (!live) return
-      setProjects(list)
-      if (list[0] && !selectedId) onSelect(list[0].id) // auto-select the first
-    })
-    return () => {
-      live = false
-    }
+    reload(true)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -36,7 +39,7 @@ export function ProjectsSidebar({
         {projects === null && <p className="px-2 py-1 text-sm text-muted-foreground">Loading…</p>}
         {projects?.length === 0 && (
           <p className="px-2 py-1 text-sm text-muted-foreground">
-            No projects yet. Run <code className="rounded bg-muted px-1">framework</code> in a repo to add one.
+            No projects yet. Add one below, or run <code className="rounded bg-muted px-1">framework</code> in a repo.
           </p>
         )}
         {projects?.map(p => (
@@ -62,6 +65,76 @@ export function ProjectsSidebar({
           </Button>
         ))}
       </div>
+      <AddProject onAdded={() => reload(true)} />
     </aside>
+  )
+}
+
+// Add project(s) (#396/#433): install a single repo, or every git repo directly under a
+// directory, and register each so it joins the list. The daemon does the work; this posts
+// the path over the `sendAddProject` telefunction and reloads on success.
+function AddProject({ onAdded }: { onAdded: () => void }) {
+  const [open, setOpen] = useState(false)
+  const [path, setPath] = useState('')
+  const [directory, setDirectory] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault()
+    const trimmed = path.trim()
+    if (!trimmed || busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await sendAddProject(trimmed, directory)
+      if (result.ok) {
+        setPath('')
+        setDirectory(false)
+        setOpen(false)
+        onAdded()
+      } else {
+        setError(result.error)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add the project.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!open) {
+    return (
+      <div className="border-t border-border p-2">
+        <Button variant="outline" size="sm" className="w-full" onClick={() => setOpen(true)}>
+          + Add project
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={submit} className="border-t border-border p-3">
+      <input
+        value={path}
+        onChange={e => setPath(e.target.value)}
+        placeholder="/absolute/path/to/repo"
+        autoFocus
+        disabled={busy}
+        className="mb-2 w-full rounded-md border border-border bg-transparent px-2 py-1 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
+      />
+      <label className="mb-2 flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
+        <input type="checkbox" checked={directory} onChange={e => setDirectory(e.target.checked)} disabled={busy} /> It&apos;s a folder of repos
+      </label>
+      {error && <p className="mb-2 text-xs text-red-500">{error}</p>}
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={() => setOpen(false)}>
+          Cancel
+        </Button>
+        <Button type="submit" size="sm" disabled={busy || !path.trim()}>
+          {busy ? 'Adding…' : 'Add'}
+        </Button>
+      </div>
+    </form>
   )
 }

--- a/packages/framework-dashboard/components/RunOverview.tsx
+++ b/packages/framework-dashboard/components/RunOverview.tsx
@@ -1,5 +1,5 @@
 import type { FrameworkEvent } from '@gemstack/framework'
-import { architectPlan, decisionLedger, loopStatus, sessionInfo } from '@gemstack/framework/client'
+import { architectPlan, decisionLedger, loopStatus, sessionInfo, deployPlan } from '@gemstack/framework/client'
 import { Badge } from './ui/badge.js'
 
 // The run overview (#431): the "moat" the wrapped agent's own chat cannot show, rebuilt
@@ -12,8 +12,9 @@ export function RunOverview({ events }: { events: FrameworkEvent[] }) {
   const ledger = decisionLedger(events)
   const loop = loopStatus(events)
   const session = sessionInfo(events)
+  const deploy = deployPlan(events)
 
-  if (!plan && !loop && !session?.sessionLink) return null
+  if (!plan && !loop && !deploy && !session?.sessionLink) return null
 
   return (
     <div className="grid gap-3 border-b border-border p-4 md:grid-cols-2">
@@ -68,6 +69,16 @@ export function RunOverview({ events }: { events: FrameworkEvent[] }) {
               {loop.passing ? 'No blockers — the checklist passed.' : `Pass ${loop.pass} in progress…`}
             </p>
           )}
+        </section>
+      )}
+
+      {deploy && (
+        <section className="rounded-lg border border-border p-3 md:col-span-2">
+          <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Deploy</h3>
+          <p className="text-sm">
+            <span className="font-medium uppercase">{deploy.render}</span> → {deploy.target}
+            <span className="text-muted-foreground"> ({deploy.reason})</span>
+          </p>
         </section>
       )}
 

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -1,30 +1,110 @@
-import { useState, type FormEvent } from 'react'
+import { useState, type FormEvent, type KeyboardEvent } from 'react'
+import {
+  renderResearchPrompt,
+  renderReadabilityPrompt,
+  renderMaintainabilityPrompt,
+  renderMaintainabilityMinimalPrompt,
+} from '@gemstack/framework/client'
 import { sendStart } from '../server/control.telefunc.js'
+import { autopilotOn, setAutopilot } from '../lib/autopilot.js'
 import { Button } from './ui/button.js'
+import { cn } from '../lib/utils.js'
 
-// Start a run in the selected project (#405): the one write that goes through the
-// daemon's own `startRun` (with its one-run-per-project busy guard), posted over
-// Telefunc. Shown when no run is active; a `busy` result means one already is.
+// The presets (#353/#433): each PREFILLS the textarea with a rendered prompt and runs it
+// verbatim (`kind: 'prompt'`), the same as the old page.ts. Emptying the box falls back to
+// a normal `build` run.
+const PRESETS: { id: string; label: string; render: () => string }[] = [
+  { id: 'research', label: 'Research', render: renderResearchPrompt },
+  { id: 'readability', label: 'Readability', render: renderReadabilityPrompt },
+  { id: 'maintainability', label: 'Maintainability', render: renderMaintainabilityPrompt },
+  { id: 'maintainability-minimal', label: 'Maintainability (minimal)', render: renderMaintainabilityMinimalPrompt },
+]
+
+// Start a run in the selected project (#405): the one write that goes through the daemon's
+// own `startRun` (with its one-run-per-project busy guard), posted over Telefunc. The
+// Global options (#314/#433) ride along: Autopilot, Technical control, Vanilla, and Eco
+// (with its section drops). Shown when no run is active; a `busy` result means one already is.
 export function StartRunForm({ projectId }: { projectId: string }) {
   const [prompt, setPrompt] = useState('')
+  const [kind, setKind] = useState<'build' | 'prompt'>('build')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [note, setNote] = useState<string | null>(null)
 
-  const submit = async (e: FormEvent) => {
-    e.preventDefault()
+  const [autopilot, setAutopilotState] = useState(autopilotOn)
+  const [technical, setTechnical] = useState(false)
+  const [vanilla, setVanilla] = useState(false)
+  const [eco, setEco] = useState(false)
+  const [ecoPlanning, setEcoPlanning] = useState(false)
+  const [ecoResearch, setEcoResearch] = useState(false)
+  const [ecoMaintenance, setEcoMaintenance] = useState(false)
+
+  // Vanilla removes the system prompt entirely, so Eco (which only trims it) has nothing
+  // left to act on.
+  const ecoDisabled = vanilla
+
+  const collectOptions = () => {
+    const ecoOpts = {
+      ...(ecoPlanning ? { autoPlanning: true } : {}),
+      ...(ecoResearch ? { autoResearch: true } : {}),
+      ...(ecoMaintenance ? { autoMaintenance: true } : {}),
+    }
+    return {
+      ...(autopilot ? { autopilot: true } : {}),
+      ...(technical ? { technical: true } : {}),
+      ...(vanilla ? { vanilla: true } : {}),
+      ...(eco && !vanilla && Object.keys(ecoOpts).length ? { eco: ecoOpts } : {}),
+    }
+  }
+
+  const submit = async (e?: FormEvent) => {
+    e?.preventDefault()
     const text = prompt.trim()
     if (!text || busy) return
     setBusy(true)
     setError(null)
+    setNote('Starting…')
     try {
-      const result = await sendStart(projectId, text)
-      if (result.ok) setPrompt('')
-      else setError(result.busy ? 'A run is already active for this project.' : result.error)
+      const result = await sendStart(projectId, text, kind, collectOptions())
+      if (result.ok) {
+        setPrompt('')
+        setKind('build')
+        setNote(null)
+      } else {
+        setNote(null)
+        setError(result.busy ? 'A run is already active for this project.' : result.error)
+      }
     } catch (err) {
+      setNote(null)
       setError(err instanceof Error ? err.message : 'Failed to start the run.')
     } finally {
       setBusy(false)
     }
+  }
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') void submit()
+  }
+
+  const loadPreset = (p: (typeof PRESETS)[number]) => {
+    setPrompt(p.render())
+    setKind('prompt')
+    setError(null)
+    setNote(`${p.label} preset loaded — review or edit, then Start`)
+  }
+
+  const onPromptChange = (value: string) => {
+    setPrompt(value)
+    // An emptied box is a fresh start: back to a normal build run.
+    if (!value.trim() && kind !== 'build') {
+      setKind('build')
+      setNote(null)
+    }
+  }
+
+  const toggleAutopilot = (on: boolean) => {
+    setAutopilotState(on)
+    setAutopilot(on) // keep the choice-gate countdown in lockstep (#433)
   }
 
   return (
@@ -32,14 +112,54 @@ export function StartRunForm({ projectId }: { projectId: string }) {
       <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Start a run</div>
       <textarea
         value={prompt}
-        onChange={e => setPrompt(e.target.value)}
+        onChange={e => onPromptChange(e.target.value)}
+        onKeyDown={onKeyDown}
         placeholder="Describe what to build…"
         rows={2}
         disabled={busy}
         className="w-full resize-y rounded-md border border-border bg-transparent p-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
       />
-      {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
-      <div className="mt-2 flex justify-end">
+
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        {PRESETS.map(p => (
+          <Button key={p.id} type="button" variant="outline" size="sm" disabled={busy} onClick={() => loadPreset(p)}>
+            {p.label}
+          </Button>
+        ))}
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1.5 text-xs text-muted-foreground">
+        <label className="flex cursor-pointer items-center gap-1.5" title="Auto-accept the recommended choice after a countdown; also relaxes the maintenance stance">
+          <input type="checkbox" checked={autopilot} onChange={e => toggleAutopilot(e.target.checked)} disabled={busy} /> Autopilot
+        </label>
+        <label className="flex cursor-pointer items-center gap-1.5" title="Expose technical detail (e.g. tech-stack choices)">
+          <input type="checkbox" checked={technical} onChange={e => setTechnical(e.target.checked)} disabled={busy} /> Technical control
+        </label>
+        <label className="flex cursor-pointer items-center gap-1.5" title="Remove all system prompts: the same as raw Claude Code">
+          <input type="checkbox" checked={vanilla} onChange={e => setVanilla(e.target.checked)} disabled={busy} /> Vanilla
+        </label>
+        <label className={cn('flex items-center gap-1.5', ecoDisabled ? 'opacity-40' : 'cursor-pointer')} title="Trim the built-in system prompt to save tokens">
+          <input type="checkbox" checked={eco && !ecoDisabled} onChange={e => setEco(e.target.checked)} disabled={busy || ecoDisabled} /> Eco
+        </label>
+      </div>
+
+      {eco && !ecoDisabled && (
+        <div className="mt-1.5 flex flex-wrap gap-x-4 gap-y-1.5 pl-4 text-xs text-muted-foreground">
+          <label className="flex cursor-pointer items-center gap-1.5" title="Drop the planning section, letting the agent plan on its own">
+            <input type="checkbox" checked={ecoPlanning} onChange={e => setEcoPlanning(e.target.checked)} disabled={busy} /> Auto planning
+          </label>
+          <label className="flex cursor-pointer items-center gap-1.5" title="Drop the alternatives/variability section">
+            <input type="checkbox" checked={ecoResearch} onChange={e => setEcoResearch(e.target.checked)} disabled={busy} /> Auto research
+          </label>
+          <label className="flex cursor-pointer items-center gap-1.5" title="Drop the maintenance section">
+            <input type="checkbox" checked={ecoMaintenance} onChange={e => setEcoMaintenance(e.target.checked)} disabled={busy} /> Auto maintenance
+          </label>
+        </div>
+      )}
+
+      {error && <p className="mt-2 text-xs text-red-500">{error}</p>}
+      <div className="mt-2 flex items-center justify-end gap-2">
+        {note && <span className="text-xs text-muted-foreground">{note}</span>}
         <Button type="submit" disabled={busy || !prompt.trim()}>
           {busy ? 'Starting…' : 'Start run'}
         </Button>

--- a/packages/framework-dashboard/lib/autopilot.ts
+++ b/packages/framework-dashboard/lib/autopilot.ts
@@ -1,0 +1,15 @@
+// The autopilot preference (#433), shared by the Start form's Global options and the
+// choice-gate countdown so the two stay in lockstep, as the old page.ts did. Persisted in
+// localStorage under the same `framework:autopilot` key; default on (the demo default).
+// Guarded for prerender, where `window`/`localStorage` do not exist.
+const KEY = 'framework:autopilot'
+
+export function autopilotOn(): boolean {
+  if (typeof localStorage === 'undefined') return true
+  return localStorage.getItem(KEY) !== '0' // absent (null) or anything but '0' -> on
+}
+
+export function setAutopilot(on: boolean): void {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(KEY, on ? '1' : '0')
+}

--- a/packages/framework-dashboard/server/projects.telefunc.ts
+++ b/packages/framework-dashboard/server/projects.telefunc.ts
@@ -1,4 +1,4 @@
 // Re-export shim (#405): the Projects telefunction lives in @gemstack/framework so the
 // daemon serves it in-process. The file path keeps the baked RPC key
 // `/server/projects.telefunc.ts`. See framework's dashboard-rpc/register.ts.
-export { onProjects } from '@gemstack/framework/dashboard-rpc'
+export { onProjects, sendAddProject } from '@gemstack/framework/dashboard-rpc'

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -8,8 +8,16 @@ export {
   decisionLedger,
   loopStatus,
   sessionInfo,
+  deployPlan,
   type ArchitectPlan,
   type Decision,
   type LoopStatus,
   type SessionInfo,
+  type DeployPlan,
 } from './run-view.js'
+// The Start-a-run presets (#433): pure prompt builders (no Node imports) the dashboard
+// prefills into the textarea, then runs verbatim as a `prompt` kind.
+export { renderResearchPrompt } from './research-preset.js'
+export { renderReadabilityPrompt } from './readability-preset.js'
+export { renderMaintainabilityPrompt } from './maintainability-preset.js'
+export { renderMaintainabilityMinimalPrompt } from './maintainability-minimal-preset.js'

--- a/packages/framework/src/dashboard-rpc/index.ts
+++ b/packages/framework/src/dashboard-rpc/index.ts
@@ -5,5 +5,5 @@
 export { onRuns, onRun, onDocs, onProjectLog } from './reads.telefunc.js'
 export { sendStop, sendChoice, sendStart } from './control.telefunc.js'
 export { onEvents } from './events.telefunc.js'
-export { onProjects } from './projects.telefunc.js'
+export { onProjects, sendAddProject } from './projects.telefunc.js'
 export { registerDashboardTelefunctions, DASHBOARD_TELEFUNC_KEYS } from './register.js'

--- a/packages/framework/src/dashboard-rpc/projects.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/projects.telefunc.ts
@@ -1,5 +1,8 @@
+import { getContext } from 'telefunc'
 import { contextProjects } from './context.js'
 import type { ProjectSummary } from '../dashboard/projects.js'
+import type { AddProjectResult } from '../dashboard/server.js'
+import type { DashboardContext } from '../dashboard/telefunc-serve.js'
 
 // The Projects sidebar behind the new dashboard (#405): the global registry (#390) the
 // daemon and CLI write — id, path, name, activated, last activity. The per-run
@@ -7,4 +10,19 @@ import type { ProjectSummary } from '../dashboard/projects.js'
 // The live event stream is its own Telefunc Channel (events.telefunc.ts).
 export async function onProjects(): Promise<ProjectSummary[]> {
   return contextProjects().list()
+}
+
+/**
+ * Add project(s) from the dashboard (#396/#433): install a single repo, or every git
+ * repo under a directory, and register each so it joins the Projects list. Like
+ * `sendStart` this needs the daemon (it spawns git + writes the shared registry), so it
+ * calls the daemon's own `addProject` closure from the Telefunc request context. Returns
+ * the daemon's {@link AddProjectResult}; a public host (the relay) leaves it unwired.
+ */
+export async function sendAddProject(path: string, directory: boolean): Promise<AddProjectResult> {
+  const { addProject } = getContext<DashboardContext>()
+  if (!addProject) return { ok: false, error: 'adding projects is not enabled on this server' }
+  const trimmed = path.trim()
+  if (!trimmed) return { ok: false, error: 'a project path is required' }
+  return addProject(trimmed, directory)
 }

--- a/packages/framework/src/dashboard-rpc/register.ts
+++ b/packages/framework/src/dashboard-rpc/register.ts
@@ -2,7 +2,7 @@ import { __decorateTelefunction } from 'telefunc'
 import { onRuns, onRun, onDocs, onProjectLog } from './reads.telefunc.js'
 import { sendStop, sendChoice, sendStart } from './control.telefunc.js'
 import { onEvents } from './events.telefunc.js'
-import { onProjects } from './projects.telefunc.js'
+import { onProjects, sendAddProject } from './projects.telefunc.js'
 
 // The client bakes each RPC key from the dashboard's source path (relative to its Vite
 // root, keeping the `.ts` extension) as `"<telefuncFilePath>:<exportName>"`. Since the
@@ -38,4 +38,5 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(sendStart, 'sendStart', control)
   reg(onEvents, 'onEvents', events)
   reg(onProjects, 'onProjects', projects)
+  reg(sendAddProject, 'sendAddProject', projects)
 }

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -168,7 +168,7 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
   // foreground dashboard passes a single-project provider, #427); unset -> the global
   // registry, as the daemon uses. `projects` above already defaulted, so pass the raw
   // option so an unset one stays undefined on the context (the RPC falls back).
-  const telefuncMount = clientBundleDir ? makeTelefuncMount(onStart, opts.projects) : undefined
+  const telefuncMount = clientBundleDir ? makeTelefuncMount(onStart, opts.projects, undefined, onAddProject) : undefined
 
   const server = createServer((req, res) => {
     if (clientBundleDir) {

--- a/packages/framework/src/dashboard/telefunc-serve.ts
+++ b/packages/framework/src/dashboard/telefunc-serve.ts
@@ -4,7 +4,7 @@ import { Telefunc } from 'telefunc/node'
 import { registerDashboardTelefunctions } from '../dashboard-rpc/register.js'
 import type { ProjectsProvider } from './projects.js'
 import type { FrameworkEvent } from '../events.js'
-import { isSameOriginRequest, type StartRunKind, type StartRunOptions, type StartRunResult } from './server.js'
+import { isSameOriginRequest, type AddProjectResult, type StartRunKind, type StartRunOptions, type StartRunResult } from './server.js'
 
 /** Wired by the daemon so `sendStart` can reach the daemon's own `startRun` closure. */
 export type StartRunHandler = (
@@ -13,6 +13,9 @@ export type StartRunHandler = (
   options: StartRunOptions,
   projectId?: string,
 ) => StartRunResult | Promise<StartRunResult>
+
+/** Wired by the daemon so `sendAddProject` can install + register a repo (#433). */
+export type AddProjectHandler = (path: string, directory: boolean) => AddProjectResult | Promise<AddProjectResult>
 
 /** Resolve a project id to its live event stream (#426): the relay feeds `onEvents` from
  * its own in-memory stream rather than a file on disk. */
@@ -27,6 +30,7 @@ export type EventsSource = (projectId: string) => AsyncIterable<FrameworkEvent> 
  */
 export interface DashboardContext {
   startRun?: StartRunHandler
+  addProject?: AddProjectHandler
   projects?: ProjectsProvider
   eventsSource?: EventsSource
 }
@@ -57,6 +61,7 @@ export function makeTelefuncMount(
   startRun?: StartRunHandler,
   projects?: ProjectsProvider,
   eventsSource?: EventsSource,
+  addProject?: AddProjectHandler,
 ): (req: IncomingMessage, res: ServerResponse) => Promise<boolean> {
   return async (req, res) => {
     if (!isSameOriginRequest(req)) {
@@ -67,6 +72,7 @@ export function makeTelefuncMount(
     const tf = setup()
     const context: DashboardContext = {
       ...(startRun ? { startRun } : {}),
+      ...(addProject ? { addProject } : {}),
       ...(projects ? { projects } : {}),
       ...(eventsSource ? { eventsSource } : {}),
     }

--- a/packages/framework/src/run-view.test.ts
+++ b/packages/framework/src/run-view.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { architectPlan, decisionLedger, loopStatus, sessionInfo } from './run-view.js'
+import { architectPlan, decisionLedger, loopStatus, sessionInfo, deployPlan } from './run-view.js'
 import type { FrameworkEvent } from './events.js'
 
 const architect = (stack: string, extra: Record<string, unknown> = {}): FrameworkEvent => ({
@@ -72,4 +72,14 @@ test('sessionInfo merges the opening session with the latest session-update link
   assert.equal(info?.sessionId, 'sess-1')
   assert.equal(info?.sessionLink, 'https://claude.ai/code/sess-1')
   assert.equal(sessionInfo([{ kind: 'log', message: 'x' }]), null)
+})
+
+test('deployPlan returns the chosen deploy target from the deploy event; latest wins (#433)', () => {
+  const boot = (event: Record<string, unknown>): FrameworkEvent => ({ kind: 'bootstrap', event: event as never })
+  assert.equal(deployPlan([{ kind: 'log', message: 'x' }]), null) // no deploy yet
+  const plan = deployPlan([
+    boot({ type: 'deploy', plan: { render: 'ssg', target: 'github-pages', reason: 'static' }, result: { deployed: false } }),
+    boot({ type: 'deploy', plan: { render: 'ssr', target: 'dokploy', reason: 'per-request data' }, result: { deployed: true } }),
+  ])
+  assert.deepEqual(plan, { render: 'ssr', target: 'dokploy', reason: 'per-request data' })
 })

--- a/packages/framework/src/run-view.ts
+++ b/packages/framework/src/run-view.ts
@@ -99,6 +99,24 @@ export function loopStatus(events: readonly FrameworkEvent[]): LoopStatus | null
   return status
 }
 
+/** The chosen deploy plan (#433): how the app renders and where it lands, from the `deploy` bootstrap event. */
+export interface DeployPlan {
+  render: 'ssr' | 'ssg' | 'spa'
+  target: string
+  reason: string
+}
+
+/** The deploy plan the run decided on, or null before the deploy phase ran. Latest wins. */
+export function deployPlan(events: readonly FrameworkEvent[]): DeployPlan | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i]!
+    if (event.kind !== 'bootstrap' || event.event.type !== 'deploy') continue
+    const p = event.event.plan
+    return { render: p.render, target: p.target, reason: p.reason }
+  }
+  return null
+}
+
 /** The wrapped agent session (#431): its id and a deep link, when one is known. */
 export interface SessionInfo {
   driver?: string


### PR DESCRIPTION
Closes #433.

Restores the actions the #405 rebuild dropped, so the new dashboard reaches parity with the old page.ts. This is the last thing before page.ts can go (#426 part 3).

What's back:
- **Start: Global options + presets.** The Start form carries autopilot / technical control / vanilla / eco (with its section drops), and the Research / Readability / Maintainability / Maintainability (minimal) presets prefill the textarea and run verbatim (`kind: 'prompt'`). Ctrl+Enter submits. `StartRunOptions` / `sendStart` already accepted the full shape daemon-side; the form now passes it.
- **Choice: autopilot countdown.** The parked gate auto-accepts the recommended pick after a countdown when autopilot is on, cancelled by any mouse movement, recorded as `by: 'autopilot'`. Shared `framework:autopilot` pref keeps it in lockstep with the Start form's toggle.
- **Deploy card.** A read-only `deployPlan` projection (render, target, reason) rendered beside the other run-view cards. New browser-safe export on `@gemstack/framework/client`.
- **Add project.** A new `sendAddProject` telefunction (the daemon already wires `onAddProject`), plus an Add form on the Projects sidebar that reloads on success.

Deploy stays display-only in both dashboards. The elaborate page.ts run-start watchdog is intentionally not ported; the busy/error result plus the live event stream already show the run starting.

Verified on a real daemon (no browser in env for the React render):
- `sendAddProject` over the wire: bad path returns a path error (proving `addProject` is threaded into the Telefunc context, not the 'not enabled' fallback), a real repo installs (`added: 1`) and appears in `onProjects`, cross-origin is 403.
- A fake `--autopilot` run emits a real `deploy` event (`ssr -> cloudflare`); `deployPlan` unit-tested.
- Workspace typecheck 22/22, framework 470 tests (0 fail), dashboard build + prerender clean (shield lists `sendAddProject`).