### PR TITLE
feat(framework): context selector + trust-on-add for the dashboard

### DIFF
--- a/.changeset/context-selector.md
+++ b/.changeset/context-selector.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/framework': minor
+---
+
+Add the context selector and trust-on-add to the dashboard (#439, part of #314). The Start form gains a "Context" picker — tick the registered repos to focus the agent on, and each becomes one `Context: <dirs>` line in the run's system prompt (the agent can still reach every repo; this just narrows where it looks). Threaded through as a repeatable `--context <dir>` CLI flag and `StartRunOptions.context`. Adding a project now asks "do you trust this repository?" first, warning about prompt-injection risk before the agent is given read access.
+
+Also hardens the daemon's Telefunc mount: a bare `GET /_telefunc` (which a browser tab issues on reconnect) made telefunc throw an unhandled rejection that crashed the daemon; the mount now catches it and returns 400.

--- a/packages/framework-dashboard/components/ProjectsSidebar.tsx
+++ b/packages/framework-dashboard/components/ProjectsSidebar.tsx
@@ -79,25 +79,38 @@ function AddProject({ onAdded }: { onAdded: () => void }) {
   const [directory, setDirectory] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Trust gate (#439/#314): adding a repo lets the agent read its files, so an untrusted
+  // repo is a prompt-injection risk. Confirm trust before actually installing.
+  const [confirming, setConfirming] = useState(false)
 
-  const submit = async (e: FormEvent) => {
+  // Step 1: the user submits the path -> show the trust confirmation, don't add yet.
+  const review = (e: FormEvent) => {
     e.preventDefault()
-    const trimmed = path.trim()
-    if (!trimmed || busy) return
+    if (!path.trim() || busy) return
+    setError(null)
+    setConfirming(true)
+  }
+
+  // Step 2: trust confirmed -> install + register.
+  const confirmAdd = async () => {
+    if (busy) return
     setBusy(true)
     setError(null)
     try {
-      const result = await sendAddProject(trimmed, directory)
+      const result = await sendAddProject(path.trim(), directory)
       if (result.ok) {
         setPath('')
         setDirectory(false)
+        setConfirming(false)
         setOpen(false)
         onAdded()
       } else {
         setError(result.error)
+        setConfirming(false)
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to add the project.')
+      setConfirming(false)
     } finally {
       setBusy(false)
     }
@@ -113,8 +126,33 @@ function AddProject({ onAdded }: { onAdded: () => void }) {
     )
   }
 
+  // The trust confirmation (#439): a plain-language prompt-injection warning before adding.
+  if (confirming) {
+    return (
+      <div className="border-t border-border p-3">
+        <p className="mb-2 text-xs font-medium">Do you trust this repository?</p>
+        <p className="mb-2 break-all text-xs text-muted-foreground">
+          <code className="rounded bg-muted px-1">{path.trim()}</code>
+        </p>
+        <p className="mb-3 text-xs text-muted-foreground">
+          Adding it lets the agent read its files. Hidden instructions in an untrusted repo can hijack the agent
+          (prompt injection) — only add repos you trust.
+        </p>
+        {error && <p className="mb-2 text-xs text-red-500">{error}</p>}
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={() => setConfirming(false)}>
+            Back
+          </Button>
+          <Button type="button" size="sm" disabled={busy} onClick={() => void confirmAdd()}>
+            {busy ? 'Adding…' : 'I trust it — add'}
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
   return (
-    <form onSubmit={submit} className="border-t border-border p-3">
+    <form onSubmit={review} className="border-t border-border p-3">
       <input
         value={path}
         onChange={e => setPath(e.target.value)}
@@ -132,7 +170,7 @@ function AddProject({ onAdded }: { onAdded: () => void }) {
           Cancel
         </Button>
         <Button type="submit" size="sm" disabled={busy || !path.trim()}>
-          {busy ? 'Adding…' : 'Add'}
+          Add
         </Button>
       </div>
     </form>

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -1,4 +1,5 @@
-import { useState, type FormEvent, type KeyboardEvent } from 'react'
+import { useEffect, useState, type FormEvent, type KeyboardEvent } from 'react'
+import type { ProjectSummary } from '@gemstack/framework'
 import {
   renderResearchPrompt,
   renderReadabilityPrompt,
@@ -6,6 +7,7 @@ import {
   renderMaintainabilityMinimalPrompt,
 } from '@gemstack/framework/client'
 import { sendStart } from '../server/control.telefunc.js'
+import { onProjects } from '../server/projects.telefunc.js'
 import { autopilotOn, setAutopilot } from '../lib/autopilot.js'
 import { Button } from './ui/button.js'
 import { cn } from '../lib/utils.js'
@@ -39,6 +41,28 @@ export function StartRunForm({ projectId }: { projectId: string }) {
   const [ecoResearch, setEcoResearch] = useState(false)
   const [ecoMaintenance, setEcoMaintenance] = useState(false)
 
+  // Context selector (#439/#314): the agent can reach every registered repo, so ticking a
+  // subset narrows its focus — the picked paths become one `Context:` line in the system
+  // prompt. Loaded from the same registry the Projects sidebar shows.
+  const [projects, setProjects] = useState<ProjectSummary[]>([])
+  const [context, setContext] = useState<Set<string>>(new Set())
+  const [showContext, setShowContext] = useState(false)
+
+  useEffect(() => {
+    let live = true
+    void onProjects().then(list => live && setProjects(list))
+    return () => {
+      live = false
+    }
+  }, [])
+
+  const toggleContext = (path: string) =>
+    setContext(prev => {
+      const next = new Set(prev)
+      next.has(path) ? next.delete(path) : next.add(path)
+      return next
+    })
+
   // Vanilla removes the system prompt entirely, so Eco (which only trims it) has nothing
   // left to act on.
   const ecoDisabled = vanilla
@@ -54,6 +78,7 @@ export function StartRunForm({ projectId }: { projectId: string }) {
       ...(technical ? { technical: true } : {}),
       ...(vanilla ? { vanilla: true } : {}),
       ...(eco && !vanilla && Object.keys(ecoOpts).length ? { eco: ecoOpts } : {}),
+      ...(context.size ? { context: [...context] } : {}),
     }
   }
 
@@ -154,6 +179,32 @@ export function StartRunForm({ projectId }: { projectId: string }) {
           <label className="flex cursor-pointer items-center gap-1.5" title="Drop the maintenance section">
             <input type="checkbox" checked={ecoMaintenance} onChange={e => setEcoMaintenance(e.target.checked)} disabled={busy} /> Auto maintenance
           </label>
+        </div>
+      )}
+
+      {projects.length > 0 && (
+        <div className="mt-3 text-xs text-muted-foreground">
+          <button
+            type="button"
+            onClick={() => setShowContext(s => !s)}
+            className="flex items-center gap-1 font-medium hover:text-foreground"
+          >
+            <span className="inline-block w-3">{showContext ? '▾' : '▸'}</span>
+            Context{context.size > 0 && <span className="text-primary"> · {context.size} selected</span>}
+          </button>
+          {showContext && (
+            <div className="mt-1.5 pl-4">
+              <p className="mb-1.5 text-muted-foreground/80">Focus the agent on these repos (it can still reach the rest):</p>
+              <div className="flex flex-col gap-1">
+                {projects.map(p => (
+                  <label key={p.id} className="flex cursor-pointer items-center gap-1.5" title={p.path}>
+                    <input type="checkbox" checked={context.has(p.path)} onChange={() => toggleContext(p.path)} disabled={busy} />
+                    <span className="truncate">{p.name}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       )}
 

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -51,6 +51,11 @@ test('parseArgs reads the backlog-loop flags (#323)', () => {
   assert.match(parseArgs(['--max-todo-items', '0', 'x']).error!, /max-todo-items/)
 })
 
+test('parseArgs collects repeatable --context directories (#439)', () => {
+  assert.deepEqual(parseArgs(['x']).context, [])
+  assert.deepEqual(parseArgs(['--context', '/work/api', '--context', '/work/ui', 'x']).context, ['/work/api', '/work/ui'])
+})
+
 test('parseArgs reads the maintain subcommand + its bounds (#298)', () => {
   const dflt = parseArgs(['x'])
   assert.equal(dflt.maintain, false)

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -148,6 +148,9 @@ Options:
   --eco-auto-research    Drop the built-in prompt's "Alternatives" (research) section.
   --eco-auto-maintenance Drop the built-in prompt's "Maintenance" section.
                          (The --eco-* flags trim the #326 prompt to save tokens.)
+  --context <dir>        Focus the agent on this directory (repeatable). Adds one
+                         "Context: <dirs>" line to the system prompt; the agent can
+                         still reach every repo, this just narrows where it looks.
   --kind <name>          Build event kind the preset's review loop fires for, e.g.
                          bug-fix or major-change (default: the-framework.yml's event,
                          else the preset's own, else major-change). Selects which
@@ -219,6 +222,8 @@ export interface CliOptions {
   vanilla: boolean
   /** `--eco-*`: fine-grained #326 section drops to save tokens (#314). */
   eco: Required<EcoOptions>
+  /** `--context <dir>` (repeatable): in-context directories added as one `Context:` line (#439). */
+  context: string[]
   buildEvent?: string | undefined
   maxPasses?: number
   maxCost?: number
@@ -276,6 +281,7 @@ export function parseArgs(argv: string[]): CliOptions {
     technical: false,
     vanilla: false,
     eco: { autoPlanning: false, autoResearch: false, autoMaintenance: false },
+    context: [],
     dashboard: true,
     relayServe: false,
     composeExtensions: false,
@@ -336,6 +342,12 @@ export function parseArgs(argv: string[]): CliOptions {
       case '--eco-auto-maintenance':
         opts.eco.autoMaintenance = true
         break
+      case '--context': {
+        // Repeatable: `--context a --context b` -> the in-context directories (#439).
+        const dir = argv[++i]
+        if (dir) opts.context.push(dir)
+        break
+      }
       case '--kind':
         opts.buildEvent = argv[++i]
         break
@@ -965,6 +977,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     if (userSystemPrompt) io.out(`◆ system prompt: ${SYSTEM_PROMPT_FILE}`)
     if (noBuiltinPrompt) io.out(`◆ built-in system prompt: off (${opts.vanilla ? 'vanilla' : 'the-framework.yml'})`)
     else if (eco) io.out(`◆ eco: dropping ${Object.keys(eco).filter(k => eco[k as keyof EcoOptions]).join(', ')}`)
+    if (opts.context.length) io.out(`◆ context: ${opts.context.join(', ')}`)
     try {
       await runPrompt({
         prompt: opts.directPrompt ? intent : renderResearchPrompt(intent),
@@ -983,6 +996,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
         ...(userSystemPrompt ? { systemPrompt: userSystemPrompt } : {}),
         ...(noBuiltinPrompt ? { antiLazyPill: false } : {}),
         ...(eco ? { eco } : {}),
+        ...(opts.context.length ? { context: opts.context } : {}),
         ...(modeList.includes('autopilot') ? { autopilot: true } : {}),
         ...((): { sessionLink?: string } => {
           const link = chooseSessionLink(opts, fake)
@@ -1083,6 +1097,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   if (userSystemPrompt) io.out(`◆ system prompt: ${SYSTEM_PROMPT_FILE}`)
   if (noBuiltinPrompt) io.out(`◆ built-in system prompt: off (${opts.vanilla ? 'vanilla' : 'the-framework.yml'})`)
   else if (eco) io.out(`◆ eco: dropping ${Object.keys(eco).filter(k => eco[k as keyof EcoOptions]).join(', ')}`)
+  if (opts.context.length) io.out(`◆ context: ${opts.context.join(', ')}`)
 
   const runOpts: RunFrameworkOptions = {
     intent,
@@ -1121,6 +1136,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     ...(userSystemPrompt ? { systemPrompt: userSystemPrompt } : {}),
     ...(noBuiltinPrompt ? { antiLazyPill: false } : {}),
     ...(eco ? { eco } : {}),
+    ...(opts.context.length ? { context: opts.context } : {}),
     ...((): { sessionLink?: string } => {
       const link = chooseSessionLink(opts, fake)
       return link ? { sessionLink: link } : {}

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -48,6 +48,13 @@ test('startOptionFlags maps only enabled Global options to CLI flags (#314)', ()
     '--eco-auto-planning',
     '--eco-auto-maintenance',
   ])
+  // Context (#439): one repeatable --context flag per selected dir; blanks dropped.
+  assert.deepEqual(startOptionFlags({ context: ['/work/api', '  ', '/work/ui'] }), [
+    '--context',
+    '/work/api',
+    '--context',
+    '/work/ui',
+  ])
 })
 
 const logEvent = (message: string): FrameworkEvent => ({ kind: 'log', message })

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -66,6 +66,7 @@ export function startOptionFlags(options: StartRunOptions): string[] {
   if (options.eco?.autoPlanning) flags.push('--eco-auto-planning')
   if (options.eco?.autoResearch) flags.push('--eco-auto-research')
   if (options.eco?.autoMaintenance) flags.push('--eco-auto-maintenance')
+  for (const dir of options.context ?? []) if (typeof dir === 'string' && dir.trim()) flags.push('--context', dir)
   return flags
 }
 

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -65,6 +65,8 @@ export interface StartRunOptions {
   vanilla?: boolean
   /** Fine-grained #326 section drops to save tokens. */
   eco?: EcoOptions
+  /** In-context directories (#439): each becomes a `--context <dir>` flag on the spawned run. */
+  context?: string[]
 }
 
 /**

--- a/packages/framework/src/dashboard/telefunc-serve.ts
+++ b/packages/framework/src/dashboard/telefunc-serve.ts
@@ -76,6 +76,19 @@ export function makeTelefuncMount(
       ...(projects ? { projects } : {}),
       ...(eventsSource ? { eventsSource } : {}),
     }
-    return tf.serve({ req, res, context: context as never })
+    // Never let a telefunc failure become an unhandled rejection that kills the daemon:
+    // telefunc 0.2.22 throws on a bare `GET /_telefunc` (it passes the request as a body,
+    // which `new Request()` rejects for GET), and a browser tab hits that on reconnect.
+    try {
+      return await tf.serve({ req, res, context: context as never })
+    } catch {
+      if (!res.headersSent) {
+        res.writeHead(400, { 'content-type': 'text/plain' })
+        res.end('bad telefunc request')
+      } else {
+        res.end()
+      }
+      return true
+    }
   }
 }

--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -42,6 +42,8 @@ export interface RunPromptOptions {
   autopilot?: boolean
   /** Eco fine-grained control (#314): drop the enabled #326 sections to save tokens. */
   eco?: EcoOptions
+  /** In-context directories (#439): added as one `Context:` line to the system prompt. */
+  context?: readonly string[]
   /** Stop the run once the agent has spent this much, in USD (#322). */
   budgetUsd?: number
   /** Session link template for the dashboard, `{sessionId}` resolved when known. */
@@ -80,7 +82,7 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
     prompt: opts.prompt,
     params: { autopilot: opts.autopilot === true, ...(opts.eco ? { eco: opts.eco } : {}) },
   }
-  const promptBlock = systemPromptBlock({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt, tf })
+  const promptBlock = systemPromptBlock({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt, tf, context: opts.context })
   const system = [...(promptBlock ? [promptBlock] : []), AWAIT_PROTOCOL].join('\n\n')
   // The template's `# User prompt` half carries the prompt (today it renders to
   // exactly `opts.prompt`; any framing Rom adds around the slot rides along). With

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -123,6 +123,8 @@ export interface RunFrameworkOptions {
   antiLazyPill?: boolean
   /** Eco fine-grained control (#314): drop the enabled #326 sections to save tokens. */
   eco?: EcoOptions
+  /** In-context directories (#439): added as one `Context:` line to the system prompt. */
+  context?: readonly string[]
   /**
    * A user-picked Open Loop domain preset ({loops, prompts, skills}) to run the
    * build under (#251). Its skills (and their personas) frame every phase, and
@@ -343,7 +345,7 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     prompt: opts.intent,
     params: { autopilot: opts.modes?.includes('autopilot') ?? false, ...(opts.eco ? { eco: opts.eco } : {}) },
   }
-  const promptBlock = systemPromptBlock({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt, tf })
+  const promptBlock = systemPromptBlock({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt, tf, context: opts.context })
   // The await protocol (#337) concretizes the pill's showChoices()/AWAIT macros into a
   // signal the turn-boundary gate can detect, so it rides along with the pill.
   const system = [

--- a/packages/framework/src/system-prompt.test.ts
+++ b/packages/framework/src/system-prompt.test.ts
@@ -81,6 +81,13 @@ test('systemPromptBlock removes the built-in prompt when antiLazyPill is false',
   assert.equal(systemPromptBlock({ antiLazyPill: false, user: 'Only mine.' }), 'Only mine.')
 })
 
+test('systemPromptBlock prepends a Context line for the selected directories (#439)', () => {
+  const block = systemPromptBlock({ antiLazyPill: false, user: 'Only mine.', context: ['/work/api', ' /work/ui '] })
+  assert.equal(block, 'Context: /work/api, /work/ui\n\nOnly mine.') // trimmed + comma-joined, first
+  assert.equal(systemPromptBlock({ antiLazyPill: false, user: 'x', context: [] }), 'x') // empty adds nothing
+  assert.equal(systemPromptBlock({ antiLazyPill: false, user: 'x', context: ['  '] }), 'x') // blank entries dropped
+})
+
 test('systemPromptBlock ignores a whitespace-only user prompt', () => {
   assert.equal(systemPromptBlock({ user: '   ' }), renderSystemPrompt().system)
   assert.equal(systemPromptBlock({ antiLazyPill: false, user: '  \n ' }), '')

--- a/packages/framework/src/system-prompt.ts
+++ b/packages/framework/src/system-prompt.ts
@@ -180,6 +180,12 @@ export interface SystemPromptOptions {
   user?: string | undefined
   /** Context for the template's `${{...}}` fragments. Default: {@link DEFAULT_TF}. */
   tf?: TfContext | undefined
+  /**
+   * Directories the user picked as in-context (#439/#314). The agent can reach every
+   * registered repo, so this narrows its focus: it prepends one `Context: <dirs>` line to
+   * the block. Empty/absent adds nothing.
+   */
+  context?: readonly string[] | undefined
 }
 
 /**
@@ -192,6 +198,10 @@ export interface SystemPromptOptions {
  */
 export function systemPromptBlock(opts: SystemPromptOptions = {}): string {
   const parts: string[] = []
+  // The #439 context line goes first, so it frames whatever prompt follows (or stands
+  // alone under `--vanilla`, where there is no built-in prompt to frame).
+  const context = opts.context?.map(d => d.trim()).filter(Boolean)
+  if (context && context.length) parts.push(`Context: ${context.join(', ')}`)
   if (opts.antiLazyPill !== false) parts.push(renderSystemPrompt(opts.tf).system)
   const user = opts.user?.trim()
   if (user) parts.push(user)


### PR DESCRIPTION
Closes #439 (part of #314).

Two linked pieces from the #314 vision, plus a stability fix that surfaced while demoing.

**Context selector.** The agent can reach every registered repo, so this lets you narrow its focus. The Start form gets a "Context" picker (a checkbox per registered project); ticking some adds one `Context: <dirs>` line to the run's system prompt. Wiring: client -> `StartRunOptions.context` -> `sendStart` -> daemon maps it to repeatable `--context <dir>` flags -> CLI parses them -> `runPrompt`/`runFramework` -> `systemPromptBlock` prepends the line. A `◆ context: …` echo shows it on the run. Empty selection changes nothing (today's behavior).

**Trust-on-add.** Adding a project now asks "do you trust this repository?" before installing, in plain language: the agent will read the repo's files, and hidden instructions in an untrusted repo can hijack it (prompt injection). Confirm to proceed, Back to cancel.

**Telefunc mount hardening (fix).** A bare `GET /_telefunc` made telefunc 0.2.22 throw an unhandled rejection that crashed the daemon (it passes the request as a body, which `new Request()` rejects for GET). A browser tab issues exactly that on reconnect, so the daemon died on restart with a tab open. The mount now catches it and returns 400. This is the latent crash noted when page.ts was retired (#436).

Verified: workspace typecheck 22/22, build 10/10, framework 446 tests (0 fail; +context unit tests for the system-prompt line, the option flags, and the CLI parse). End to end on a real run: `--context /work/api --context /work/ui` echoes `◆ context: /work/api, /work/ui` and prepends `Context: /work/api, /work/ui` to the system prompt. Real daemon: bare `GET /_telefunc` -> 400 (no crash), RPCs still 200. Both pieces demoed live on the running daemon.