### PR TITLE
feat(framework): setSessionName() + setReadyForMerge() lifecycle signals (#326)

### DIFF
--- a/.changeset/lifecycle-signals-326.md
+++ b/.changeset/lifecycle-signals-326.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Add the `setSessionName()` and `setReadyForMerge()` lifecycle signals (#326). Both are non-blocking turn-boundary signals, the same shape as the existing `show-markdown` view: the agent emits a fenced `set-session-name` / `ready-for-merge` block and keeps working, and the framework records it and reflects it in the dashboard. `setSessionName(<name>)` labels the run with the `[a-z0-9-]` slug it chose (also its `the-framework/<name>` branch); `setReadyForMerge()` flips the run's status from building to ready-for-review. The dashboard shows the session name and a status dot (amber while building, green once ready) in both the run overview and the cross-project "working now" list. This is the signal the post-merge quality suite will hang off.

--- a/packages/framework-dashboard/components/OverviewSection.tsx
+++ b/packages/framework-dashboard/components/OverviewSection.tsx
@@ -68,8 +68,19 @@ export function OverviewSection({
                       )}
                     >
                       <span className="flex w-full items-center gap-1.5">
-                        <span className="h-2 w-2 shrink-0 animate-pulse rounded-full bg-primary" />
+                        <span
+                          className={cn(
+                            'h-2 w-2 shrink-0 rounded-full',
+                            run.readyForMerge ? 'bg-green-500' : 'animate-pulse bg-amber-500',
+                          )}
+                          title={run.readyForMerge ? 'Ready for merge' : 'Building'}
+                        />
                         <span className="truncate font-medium">{run.projectName}</span>
+                        {run.sessionName && (
+                          <span className="truncate text-xs text-muted-foreground" title={`branch the-framework/${run.sessionName}`}>
+                            {run.sessionName}
+                          </span>
+                        )}
                       </span>
                       {(run.intent || run.scope) && (
                         <span className="truncate pl-3.5 text-xs text-muted-foreground" title={run.intent || run.scope}>

--- a/packages/framework-dashboard/components/RunOverview.tsx
+++ b/packages/framework-dashboard/components/RunOverview.tsx
@@ -1,6 +1,7 @@
 import type { FrameworkEvent } from '@gemstack/framework'
-import { architectPlan, decisionLedger, loopStatus, sessionInfo, deployPlan } from '@gemstack/framework/client'
+import { architectPlan, decisionLedger, loopStatus, sessionInfo, deployPlan, runProgress } from '@gemstack/framework/client'
 import { Badge } from './ui/badge.js'
+import { cn } from '../lib/utils.js'
 
 // The run overview (#431): the "moat" the wrapped agent's own chat cannot show, rebuilt
 // on the new dashboard. Each card is a pure projection of the event stream (run-view.ts
@@ -13,11 +14,22 @@ export function RunOverview({ events }: { events: FrameworkEvent[] }) {
   const loop = loopStatus(events)
   const session = sessionInfo(events)
   const deploy = deployPlan(events)
+  const progress = runProgress(events)
+  const hasProgress = Boolean(progress.sessionName) || progress.readyForMerge
 
-  if (!plan && !loop && !deploy && !session?.sessionLink) return null
+  if (!plan && !loop && !deploy && !session?.sessionLink && !hasProgress) return null
 
   return (
     <div className="grid gap-3 border-b border-border p-4 md:grid-cols-2">
+      {hasProgress && (
+        <div className="flex items-center gap-2 text-sm md:col-span-2">
+          <span
+            className={cn('h-2.5 w-2.5 shrink-0 rounded-full', progress.readyForMerge ? 'bg-green-500' : 'animate-pulse bg-amber-500')}
+          />
+          {progress.sessionName && <span className="font-medium">{progress.sessionName}</span>}
+          <span className="text-xs text-muted-foreground">{progress.readyForMerge ? 'ready for merge' : 'building…'}</span>
+        </div>
+      )}
       {plan && (
         <section className="rounded-lg border border-border p-3">
           <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Stack &amp; rationale</h3>

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -9,11 +9,13 @@ export {
   loopStatus,
   sessionInfo,
   deployPlan,
+  runProgress,
   type ArchitectPlan,
   type Decision,
   type LoopStatus,
   type SessionInfo,
   type DeployPlan,
+  type RunProgress,
 } from './run-view.js'
 // The Start-a-run presets (#433): pure prompt builders (no Node imports) the dashboard
 // prefills into the textarea, then runs verbatim as a `prompt` kind.

--- a/packages/framework/src/dashboard/overview.ts
+++ b/packages/framework/src/dashboard/overview.ts
@@ -20,6 +20,10 @@ export interface ActiveRun {
   scope?: string
   /** ISO timestamp of the run's last event. */
   updatedAt?: string
+  /** The session name the agent chose (#326), when it set one. */
+  sessionName?: string
+  /** Whether the agent signalled `setReadyForMerge()` (#326): drives the building/ready dot. */
+  readyForMerge?: boolean
 }
 
 /** One recently active project, most-recent first. */
@@ -78,6 +82,8 @@ export async function buildOverview(projects: ProjectSummary[], deps: OverviewDe
         ...(meta.intent ? { intent: meta.intent } : {}),
         ...(meta.scope ? { scope: meta.scope } : {}),
         ...(meta.updatedAt ? { updatedAt: meta.updatedAt } : {}),
+        ...(meta.sessionName ? { sessionName: meta.sessionName } : {}),
+        ...(meta.readyForMerge ? { readyForMerge: true } : {}),
       })
     }
   }

--- a/packages/framework/src/events.ts
+++ b/packages/framework/src/events.ts
@@ -111,6 +111,18 @@ export type FrameworkEvent =
    */
   | { kind: 'view'; id: string; title: string; markdown: string }
   /**
+   * The agent named the session (#326): the `[a-z0-9-]` slug it chose (also its
+   * `the-framework/<name>` branch), from a `setSessionName()` signal. Non-blocking;
+   * the dashboard shows it as the run's label. Re-emitted on a rename.
+   */
+  | { kind: 'session-name'; name: string }
+  /**
+   * The agent signalled `setReadyForMerge()` (#326): it believes the work is complete
+   * and ready for human review. Non-blocking — it flips the run's dashboard status from
+   * building (orange) to ready (green); the post-merge quality prompts hang off it.
+   */
+  | { kind: 'ready-for-merge' }
+  /**
    * Cumulative token + cost usage for the run so far (#322). Emitted after each
    * agent turn that reports usage; the dashboard renders a live spend readout and
    * the run stops itself once `costUsd` reaches the budget cap, if one is set.
@@ -165,6 +177,10 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
       return `  ${event.message}`
     case 'view':
       return `▶ view: ${event.title}`
+    case 'session-name':
+      return `  session: ${event.name}`
+    case 'ready-for-merge':
+      return `✓ ready for merge`
     case 'usage':
       return `  spend: $${event.costUsd.toFixed(4)}${
         event.budgetUsd ? ` / $${event.budgetUsd}` : ''

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -97,10 +97,12 @@ export {
   decisionLedger,
   loopStatus,
   sessionInfo,
+  runProgress,
   type ArchitectPlan,
   type Decision,
   type LoopStatus,
   type SessionInfo,
+  type RunProgress,
 } from './run-view.js'
 export {
   assessRepo,

--- a/packages/framework/src/prompt-run.test.ts
+++ b/packages/framework/src/prompt-run.test.ts
@@ -34,6 +34,28 @@ test('runPrompt runs a gateless prompt straight through and emits session + end'
   assert.equal(events.some(e => e.kind === 'choice'), false)
 })
 
+test('runPrompt emits the #326 lifecycle signals a turn declares (session name, ready-for-merge)', async () => {
+  const events: FrameworkEvent[] = []
+  const turn = [
+    'Set up the branch and finished the work.',
+    '```set-session-name',
+    'Add Comments!',
+    '```',
+    '```ready-for-merge',
+    '```',
+  ].join('\n')
+  const driver = new FakeDriver({ turns: [{ text: turn }] })
+  await runPrompt({ prompt: 'add comments', driver, cwd: '/ws', onEvent: e => events.push(e) })
+  assert.deepEqual(
+    events.find(e => e.kind === 'session-name'),
+    { kind: 'session-name', name: 'add-comments' }, // slugified to the branch shape
+  )
+  assert.ok(
+    events.some(e => e.kind === 'ready-for-merge'),
+    'a ready-for-merge event is emitted',
+  )
+})
+
 test('runPrompt surfaces the system prompt (#343); the user prompt rides a driver start event', async () => {
   const events: FrameworkEvent[] = []
   const driver = new FakeDriver({ turns: [{ text: 'done' }] })

--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -2,7 +2,7 @@ import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { hasSessionIdPlaceholder, resolveSessionLink, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 import { resolveAwaitGate } from './run.js'
 import { renderSystemPrompt, systemPromptBlock, type EcoOptions, type TfContext } from './system-prompt.js'
-import { AWAIT_PROTOCOL, PLAN_DECLINED_MESSAGE, isDeclinedConfirmation, parseAwaitGate, parseMarkdownViews } from './turn-gate.js'
+import { AWAIT_PROTOCOL, SIGNAL_PROTOCOL, PLAN_DECLINED_MESSAGE, isDeclinedConfirmation, parseAwaitGate, parseMarkdownViews, parseSessionName, parseReadyForMerge } from './turn-gate.js'
 import { UsageMeter } from './usage.js'
 
 /**
@@ -85,7 +85,7 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
     params: { autopilot: opts.autopilot === true, ...(opts.eco ? { eco: opts.eco } : {}) },
   }
   const promptBlock = systemPromptBlock({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt, tf, context: opts.context, bootstrap: opts.bootstrap })
-  const system = [...(promptBlock ? [promptBlock] : []), AWAIT_PROTOCOL].join('\n\n')
+  const system = [...(promptBlock ? [promptBlock] : []), AWAIT_PROTOCOL, SIGNAL_PROTOCOL].join('\n\n')
   // The template's `# User prompt` half carries the prompt (today it renders to
   // exactly `opts.prompt`; any framing Rom adds around the slot rides along). With
   // the built-in prompt off, the raw prompt is sent as-is.
@@ -136,14 +136,26 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
     onEvent: onDriverEvent,
   })
 
-  // Non-blocking markdown views the agent showed this turn (#441), pushed to the rail.
-  const showViews = (text: string): void => {
+  // Non-blocking signals the agent emitted this turn: markdown views (#441) and the #326
+  // lifecycle signals (session name, ready-for-merge). None stop the turn.
+  let named: string | undefined
+  let ready = false
+  const emitTurnSignals = (text: string): void => {
     for (const view of parseMarkdownViews(text)) emit({ kind: 'view', ...view })
+    const name = parseSessionName(text)
+    if (name && name !== named) {
+      named = name
+      emit({ kind: 'session-name', name })
+    }
+    if (!ready && parseReadyForMerge(text)) {
+      ready = true
+      emit({ kind: 'ready-for-merge' })
+    }
   }
 
   try {
     let turn = await session.prompt(firstPrompt, { signal: runSignal })
-    showViews(turn.text)
+    emitTurnSignals(turn.text)
     let gate = parseAwaitGate(turn.text)
     for (let round = 0; round < MAX_AWAIT_ROUNDS && gate; round++) {
       const answer = await resolveAwaitGate(gate, round, { requestChoice: opts.requestChoice, emit, signal: runSignal })
@@ -158,7 +170,7 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
         `You paused to ask: "${gate.title}". The user chose: ${answer}. Continue with that decision, and do not ask again unless a genuinely new choice comes up.`,
         { signal: runSignal },
       )
-      showViews(turn.text)
+      emitTurnSignals(turn.text)
       gate = parseAwaitGate(turn.text)
     }
     // The agent kept asking past the limit: finish with the latest turn rather than loop.

--- a/packages/framework/src/run-view.test.ts
+++ b/packages/framework/src/run-view.test.ts
@@ -1,7 +1,23 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { architectPlan, decisionLedger, loopStatus, sessionInfo, deployPlan } from './run-view.js'
+import { architectPlan, decisionLedger, loopStatus, sessionInfo, deployPlan, runProgress } from './run-view.js'
 import type { FrameworkEvent } from './events.js'
+
+test('runProgress starts building with no name and flips to ready on setReadyForMerge (#326)', () => {
+  assert.deepEqual(runProgress([]), { readyForMerge: false })
+  const building: FrameworkEvent[] = [{ kind: 'session-name', name: 'add-comments' }]
+  assert.deepEqual(runProgress(building), { sessionName: 'add-comments', readyForMerge: false })
+  const ready: FrameworkEvent[] = [...building, { kind: 'ready-for-merge' }]
+  assert.deepEqual(runProgress(ready), { sessionName: 'add-comments', readyForMerge: true })
+})
+
+test('runProgress takes the latest session name when the agent renames it (#326)', () => {
+  const events: FrameworkEvent[] = [
+    { kind: 'session-name', name: 'first-guess' },
+    { kind: 'session-name', name: 'better-name' },
+  ]
+  assert.equal(runProgress(events).sessionName, 'better-name')
+})
 
 const architect = (stack: string, extra: Record<string, unknown> = {}): FrameworkEvent => ({
   kind: 'bootstrap',

--- a/packages/framework/src/run-view.ts
+++ b/packages/framework/src/run-view.ts
@@ -117,6 +117,28 @@ export function deployPlan(events: readonly FrameworkEvent[]): DeployPlan | null
   return null
 }
 
+/** The run's lifecycle progress (#326): the session name it chose and whether it is ready for merge. */
+export interface RunProgress {
+  /** The `[a-z0-9-]` session name (also the branch), once the agent set one via `setSessionName()`. */
+  sessionName?: string
+  /** True once the agent signalled `setReadyForMerge()`: building (false) -> ready (true). */
+  readyForMerge: boolean
+}
+
+/**
+ * The run's lifecycle progress (#326): the latest `session-name` the agent set and whether
+ * a `ready-for-merge` has fired. Drives the dashboard status label + dot (orange building,
+ * green ready). Always returns a value — an untouched run is `{ readyForMerge: false }`.
+ */
+export function runProgress(events: readonly FrameworkEvent[]): RunProgress {
+  const progress: RunProgress = { readyForMerge: false }
+  for (const event of events) {
+    if (event.kind === 'session-name') progress.sessionName = event.name
+    else if (event.kind === 'ready-for-merge') progress.readyForMerge = true
+  }
+  return progress
+}
+
 /** The wrapped agent session (#431): its id and a deep link, when one is known. */
 export interface SessionInfo {
   driver?: string

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -38,7 +38,7 @@ import { snapshotWorkspace } from './sandbox.js'
 import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { memoryFraming, type LoadedMemory } from './memory.js'
 import { systemPromptBlock, type EcoOptions, type TfContext } from './system-prompt.js'
-import { AWAIT_PROTOCOL, CONFIRM_APPROVED, CONFIRM_DECLINED, PLAN_DECLINED_MESSAGE, isDeclinedConfirmation, parseAwaitGate, parseMarkdownViews, type ParsedAwaitGate } from './turn-gate.js'
+import { AWAIT_PROTOCOL, SIGNAL_PROTOCOL, CONFIRM_APPROVED, CONFIRM_DECLINED, PLAN_DECLINED_MESSAGE, isDeclinedConfirmation, parseAwaitGate, parseMarkdownViews, parseSessionName, parseReadyForMerge, type ParsedAwaitGate } from './turn-gate.js'
 // Value import from todo-loop.js is a benign cycle: todo-loop.js only calls
 // run.js's hoisted function declarations (requestChoices / resolveAwaitGate).
 import { runTodoLoop, type TodoLoopResult } from './todo-loop.js'
@@ -352,9 +352,10 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
   }
   const promptBlock = systemPromptBlock({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt, tf, context: opts.context, bootstrap: opts.bootstrap })
   // The await protocol (#337) concretizes the pill's showChoices()/AWAIT macros into a
-  // signal the turn-boundary gate can detect, so it rides along with the pill.
+  // signal the turn-boundary gate can detect, so it rides along with the pill. The signal
+  // protocol (#326) does the same for the setSessionName()/setReadyForMerge() lifecycle actions.
   const system = [
-    ...(promptBlock ? [promptBlock, AWAIT_PROTOCOL] : []),
+    ...(promptBlock ? [promptBlock, AWAIT_PROTOCOL, SIGNAL_PROTOCOL] : []),
     ...personas.map(personaInstructions),
     ...skills.map(skillInstructions),
     ...(memoryBlock ? [memoryBlock] : []),
@@ -708,12 +709,25 @@ function agentAwaitGate(
 ): (ctx: BuildContext) => Promise<SupervisorRun> {
   return async ctx => {
     const { requestChoice, emit } = deps
-    // Non-blocking markdown views the agent showed this turn (#441), pushed to the rail.
-    const showViews = (text: string): void => {
+    // Non-blocking signals the agent emitted this turn: markdown views (#441) pushed to the
+    // rail, and the #326 lifecycle signals (session name, ready-for-merge) that flip the run's
+    // dashboard status. None stop the turn.
+    let named: string | undefined
+    let ready = false
+    const emitTurnSignals = (text: string): void => {
       for (const view of parseMarkdownViews(text)) emit({ kind: 'view', ...view })
+      const name = parseSessionName(text)
+      if (name && name !== named) {
+        named = name
+        emit({ kind: 'session-name', name })
+      }
+      if (!ready && parseReadyForMerge(text)) {
+        ready = true
+        emit({ kind: 'ready-for-merge' })
+      }
     }
     let run = await base(ctx)
-    showViews(run.text)
+    emitTurnSignals(run.text)
     if (!requestChoice) return run
 
     for (let round = 0; round < MAX_AWAIT_ROUNDS; round++) {
@@ -729,7 +743,7 @@ function agentAwaitGate(
       }
       emit({ kind: 'log', message: `Continuing with your choice: ${answer}` })
       run = await continueAfterChoice(session, ctx, gate.title, answer)
-      showViews(run.text)
+      emitTurnSignals(run.text)
     }
     // The agent kept asking past the limit: proceed with the latest turn rather than loop.
     emit({ kind: 'log', message: 'Proceeding with the build (await limit reached).' })

--- a/packages/framework/src/store/run-store.test.ts
+++ b/packages/framework/src/store/run-store.test.ts
@@ -143,6 +143,17 @@ test('applyEventToMeta marks a user-stopped run as stopped, not failed (#218)', 
   assert.equal(stopped.status, 'stopped')
 })
 
+test('applyEventToMeta records the session name + ready-for-merge lifecycle signals (#326)', () => {
+  const base = metaFromEvents(RUN.slice(0, 4), AT)
+  assert.equal(base.sessionName, undefined)
+  assert.equal(base.readyForMerge, undefined)
+  const named = applyEventToMeta(base, { kind: 'session-name', name: 'add-comments' }, AT)
+  assert.equal(named.sessionName, 'add-comments')
+  const ready = applyEventToMeta(named, { kind: 'ready-for-merge' }, AT)
+  assert.equal(ready.readyForMerge, true)
+  assert.equal(ready.sessionName, 'add-comments') // ready doesn't clobber the name
+})
+
 test('close archives the run into runs/<id>.json + .jsonl for history (#303)', async () => {
   const fs = memFs()
   const store = await RunStore.open(CWD, { fs, fresh: true, now: AT })

--- a/packages/framework/src/store/run-store.ts
+++ b/packages/framework/src/store/run-store.ts
@@ -77,6 +77,10 @@ export interface RunMeta {
   sessionId?: string
   /** The link shown to jump into the live agent session. */
   sessionLink?: string
+  /** The session name the agent chose (#326), also its `the-framework/<name>` branch. */
+  sessionName?: string
+  /** Whether the agent signalled `setReadyForMerge()` (#326): building (false/absent) vs ready (true). */
+  readyForMerge?: boolean
 }
 
 /**
@@ -123,6 +127,12 @@ export function applyEventToMeta(meta: RunMeta, event: FrameworkEvent, at: strin
     case 'session-update':
       next.sessionId = event.sessionId
       if (event.sessionLink) next.sessionLink = event.sessionLink
+      break
+    case 'session-name':
+      next.sessionName = event.name
+      break
+    case 'ready-for-merge':
+      next.readyForMerge = true
       break
     case 'bootstrap': {
       const b = event.event

--- a/packages/framework/src/turn-gate.test.ts
+++ b/packages/framework/src/turn-gate.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { isDeclinedConfirmation, parseAwaitGate, parseChoicesGate, parseConfirmationGate, parseMarkdownViews, parseMultiSelectGate } from './turn-gate.js'
+import { isDeclinedConfirmation, parseAwaitGate, parseChoicesGate, parseConfirmationGate, parseMarkdownViews, parseMultiSelectGate, parseSessionName, parseReadyForMerge } from './turn-gate.js'
 
 const block = (json: string): string => 'Here are the options.\n```await-choices\n' + json + '\n```'
 const multiBlock = (json: string): string => 'Pick some.\n```await-multiselect\n' + json + '\n```'
@@ -147,4 +147,26 @@ test('parseMarkdownViews collects several blocks and keeps the later of a repeat
 
 test('parseMarkdownViews skips a blank block (#441)', () => {
   assert.deepEqual(parseMarkdownViews('```show-markdown\n# Empty\n```'), [])
+})
+
+test('parseSessionName returns undefined when the turn set no session name (#326)', () => {
+  assert.equal(parseSessionName('Working on the branch, no signal here.'), undefined)
+})
+
+test('parseSessionName reads + slugifies the name from a set-session-name block (#326)', () => {
+  assert.equal(parseSessionName('```set-session-name\nadd-comments\n```'), 'add-comments')
+  // Free-form text is slugified to the [a-z0-9-] branch shape.
+  assert.equal(parseSessionName('done.\n```set-session-name\nAdd Comments Feature!\n```'), 'add-comments-feature')
+  // The first non-empty line is the name.
+  assert.equal(parseSessionName('```set-session-name\n\n  my-slug  \nignored\n```'), 'my-slug')
+})
+
+test('parseSessionName keeps the later block when the agent renames mid-turn (#326)', () => {
+  assert.equal(parseSessionName('```set-session-name\nfirst\n```\nthen\n```set-session-name\nsecond\n```'), 'second')
+})
+
+test('parseReadyForMerge is true only when a ready-for-merge block is present (#326)', () => {
+  assert.equal(parseReadyForMerge('Still building the feature.'), false)
+  assert.equal(parseReadyForMerge('All done.\n```ready-for-merge\n```'), true)
+  assert.equal(parseReadyForMerge('```ready-for-merge```'), true) // empty, no inner newline
 })

--- a/packages/framework/src/turn-gate.ts
+++ b/packages/framework/src/turn-gate.ts
@@ -38,6 +38,28 @@ export const AWAIT_PROTOCOL = [
   'This just shows it; you do not stop. Re-emit the same title to update that view in place.',
 ].join('\n')
 
+/**
+ * The session-lifecycle protocol (#326): the code side of the `setSessionName()` and
+ * `setReadyForMerge()` actions Rom's system prompt calls out. Like {@link AWAIT_PROTOCOL},
+ * it does not restate *when* to act — the system prompt owns that — it only pins *how* to
+ * emit the signal so the turn-boundary can detect it. Both are non-blocking: the agent
+ * emits the block and keeps going (the framework records it and reflects it in the
+ * dashboard). Injected alongside AWAIT_PROTOCOL.
+ */
+export const SIGNAL_PROTOCOL = [
+  '## Session name',
+  'When you call setSessionName(<name>) (after creating and checking out the `the-framework/<name>` branch), also emit a `set-session-name` block naming it, so the dashboard shows which session this is. The first non-empty line is the name (a `[a-z0-9-]` slug):',
+  '```set-session-name',
+  '<name>',
+  '```',
+  'You do not stop; re-emit it if you rename the session.',
+  '',
+  '## Ready for merge',
+  'When you call setReadyForMerge() — you believe the work is complete and ready for human review — emit an empty `ready-for-merge` block. This flips the dashboard status from building to ready; it does not stop your turn.',
+  '```ready-for-merge',
+  '```',
+].join('\n')
+
 /** A single-select choice an agent stopped to ask, parsed from an `await-choices` block (#337). */
 export interface ParsedChoicesGate {
   /** The question shown above the options. */
@@ -123,6 +145,32 @@ export function parseMarkdownViews(text: string): ParsedMarkdownView[] {
     byId.set(id, { id, title, markdown })
   }
   return [...byId.values()]
+}
+
+/**
+ * Parse the session name the agent set this turn (#326), from the last `set-session-name`
+ * block (per {@link SIGNAL_PROTOCOL}) — its first non-empty line, slugified to `[a-z0-9-]`
+ * so it matches the branch-name shape. Returns `undefined` when the agent did not set one
+ * (the common case) or the block is blank. A later block in the same turn wins (a rename).
+ */
+export function parseSessionName(text: string): string | undefined {
+  const re = /```set-session-name\s+([\s\S]*?)```/g
+  let name: string | undefined
+  for (const m of text.matchAll(re)) {
+    const line = (m[1] ?? '').split('\n').map(l => l.trim()).find(Boolean)
+    const slug = line ? slugify(line) : ''
+    if (slug && slug !== 'view') name = slug
+  }
+  return name
+}
+
+/**
+ * Whether the agent signalled `setReadyForMerge()` this turn (#326): the presence of a
+ * `ready-for-merge` block (per {@link SIGNAL_PROTOCOL}) anywhere in the text. Non-blocking
+ * and body-less — it just flips the run from building to ready-for-review.
+ */
+export function parseReadyForMerge(text: string): boolean {
+  return /```ready-for-merge\s*```/.test(text) || /```ready-for-merge\s+[\s\S]*?```/.test(text)
 }
 
 /** Find the body + start index of the last fenced block with `tag` in `text`. */


### PR DESCRIPTION
Part of #326. Builds the action layer Rom designed in the issue: the agent-emitted `setSessionName()` and `setReadyForMerge()` signals, end to end.

Both are **non-blocking turn-boundary signals**, the same mechanism as the existing `show-markdown` view (#441) rather than a blocking gate: the agent emits a fenced block and keeps working; the framework detects it at the turn boundary, records it, and reflects it in the dashboard. This fits today's black-box driver seam (#165) with no mid-turn pause.

## What
- **turn-gate**: `parseSessionName` (first non-empty line, slugified to the `[a-z0-9-]` branch shape, latest block wins on a rename) and `parseReadyForMerge`, plus a `SIGNAL_PROTOCOL` const that pins *how* to emit each block (the code side of the macros, like `AWAIT_PROTOCOL`). Injected alongside `AWAIT_PROTOCOL` in both the build (`run.ts`) and direct-prompt (`prompt-run.ts`) paths.
- **events**: `session-name` and `ready-for-merge` `FrameworkEvent` kinds + terminal format lines.
- **run-store**: `sessionName` + `readyForMerge` on `RunMeta`, folded in `applyEventToMeta` (idempotent; ready doesn't clobber the name).
- **run-view**: `runProgress()` client projection (session name + building/ready), exported from `client.ts` + `index.ts`.
- **dashboard**: `RunOverview` gets a status line, and the cross-project "working now" list shows the session name and a **status dot** (amber pulsing while building, solid green once ready), per Rom's dot design in the issue.

## Scope
Rom's dot spec has a third state (green check on *merged*), which he called post-MVP as it needs PR/git awareness; not included. The **parallel post-merge quality suite** that hangs off `setReadyForMerge()` (maintainability + readability + security-audit) is the follow-up PR; the security-audit preset it needs already landed as #463.

## Verify
- New unit tests: `parseSessionName` (slugify, first-line, rename-wins, absent) and `parseReadyForMerge`; `applyEventToMeta` folds both signals; `runProgress` building->ready + rename. Plus an end-to-end `runPrompt` test driving a fake turn that emits both blocks and asserting the real dispatch seam emits `session-name` (slugified) + `ready-for-merge`.
- Framework suite 480 (479 pass / 0 fail / 1 pre-existing skip); framework typecheck + build clean; framework-dashboard typecheck clean.