### PR TITLE
feat(framework): post-merge quality suite on setReadyForMerge() (#326)

### DIFF
--- a/.changeset/post-merge-quality-suite-326.md
+++ b/.changeset/post-merge-quality-suite-326.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Add the post-merge quality suite (#326): when a run signals `setReadyForMerge()`, optionally fire the maintainability, readability, and security-audit passes over the same workspace. Enabled per run by the new `--post-merge` CLI flag, or from the dashboard's Global options via a "Post-merge cleanup" toggle (persisted as the `postMergeQuality` preference, mapped to `--post-merge` on the spawned run). The three passes run **sequentially** — they edit and commit the same git tree, so concurrent writers would race on the index lock; worktree-isolated parallelism is a follow-up. Each pass is a plain `framework prompt` child carrying no `--post-merge`, so a quality pass never triggers its own suite. Off by default.

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -44,6 +44,7 @@ export function StartRunForm({ projectId }: { projectId: string }) {
   const ecoPlanning = preferences.ecoPlanning ?? false
   const ecoResearch = preferences.ecoResearch ?? false
   const ecoMaintenance = preferences.ecoMaintenance ?? false
+  const postMergeQuality = preferences.postMergeQuality ?? false
 
   // Context selector (#439/#314): the agent can reach every registered repo, so ticking a
   // subset narrows its focus — the picked paths become one `Context:` line in the system
@@ -82,6 +83,7 @@ export function StartRunForm({ projectId }: { projectId: string }) {
       ...(technical ? { technical: true } : {}),
       ...(vanilla ? { vanilla: true } : {}),
       ...(eco && !vanilla && Object.keys(ecoOpts).length ? { eco: ecoOpts } : {}),
+      ...(postMergeQuality ? { postMerge: true } : {}),
       ...(context.size ? { context: [...context] } : {}),
     }
   }
@@ -164,6 +166,9 @@ export function StartRunForm({ projectId }: { projectId: string }) {
         </label>
         <label className={cn('flex items-center gap-1.5', ecoDisabled ? 'opacity-40' : 'cursor-pointer')} title="Trim the built-in system prompt to save tokens">
           <input type="checkbox" checked={eco && !ecoDisabled} onChange={e => updatePreferences({ eco: e.target.checked })} disabled={busy || ecoDisabled} /> Eco
+        </label>
+        <label className="flex cursor-pointer items-center gap-1.5" title="When the run signals it's ready for merge, run maintainability, readability, and security-audit passes">
+          <input type="checkbox" checked={postMergeQuality} onChange={e => updatePreferences({ postMergeQuality: e.target.checked })} disabled={busy} /> Post-merge cleanup
         </label>
       </div>
 

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -18,10 +18,13 @@ import {
   frameworkVersion,
   mergeRunConfig,
   parseArgs,
+  promptRunArgs,
   resolveDomainPreset,
   runCli,
   runLogEntry,
   runLogKind,
+  runPostMergeSuite,
+  POST_MERGE_PASSES,
   workspaceSummary,
   type CliIO,
 } from './cli.js'
@@ -59,6 +62,41 @@ test('parseArgs collects repeatable --context directories (#439)', () => {
 test('parseArgs reads --bootstrap (#297/#448)', () => {
   assert.equal(parseArgs(['x']).bootstrap, false)
   assert.equal(parseArgs(['--bootstrap', 'x']).bootstrap, true)
+})
+
+test('parseArgs reads --post-merge (#326)', () => {
+  assert.equal(parseArgs(['x']).postMerge, false)
+  assert.equal(parseArgs(['--post-merge', 'x']).postMerge, true)
+})
+
+test('promptRunArgs runs a headless prompt and carries NO --post-merge (recursion guard, #326)', () => {
+  const args = promptRunArgs('audit this', '/work/app', '/bin/framework', 3)
+  assert.deepEqual(args, ['/bin/framework', 'prompt', 'audit this', '--no-dashboard', '--cwd', '/work/app', '--max-cost', '3'])
+  // The guard: a quality pass must not trigger its own post-merge suite.
+  assert.equal(args.includes('--post-merge'), false)
+  // maxCost is optional.
+  assert.equal(promptRunArgs('x', '/w', '/bin/f').includes('--max-cost'), false)
+})
+
+test('runPostMergeSuite runs maintainability -> readability -> security-audit in order, best-effort (#326)', async () => {
+  const { io, out } = capture()
+  const seen: string[] = []
+  // Middle pass "fails" (resolves false): the suite must continue past it.
+  const run = (prompt: string) => {
+    seen.push(prompt)
+    return Promise.resolve(!/humans to read/.test(prompt)) // the readability pass "fails"
+  }
+  await runPostMergeSuite('/work/app', '/bin/framework', io, undefined, run)
+  assert.equal(seen.length, 3)
+  assert.match(seen[0]!, /maintainable/)
+  assert.match(seen[1]!, /easy as possible for humans to read/)
+  assert.match(seen[2]!, /^Security audit/)
+  assert.deepEqual(
+    POST_MERGE_PASSES.map(p => p.label),
+    ['maintainability', 'readability', 'security-audit'],
+  )
+  // The failed middle pass is reported, and the last pass still ran.
+  assert.ok(out.some(l => /readability did not complete/.test(l)))
 })
 
 test('parseArgs reads the maintain subcommand + its bounds (#298)', () => {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -55,6 +55,8 @@ import {
   type RepoReview,
 } from './maintenance.js'
 import { renderMaintainabilityPrompt } from './maintainability-preset.js'
+import { renderReadabilityPrompt } from './readability-preset.js'
+import { renderSecurityAuditPrompt } from './security-audit-preset.js'
 import { runPrompt } from './prompt-run.js'
 import { renderResearchPrompt } from './research-preset.js'
 
@@ -155,6 +157,9 @@ Options:
   --bootstrap            Bootstrap mode: a brand-new project from an empty dir. Makes
                          the first turn stop for a plan (interpretations / PLAN) before
                          writing any code, instead of charging ahead.
+  --post-merge           When the run signals setReadyForMerge(), fire the post-merge
+                         quality suite: maintainability, readability, and security-audit
+                         prompts, one after another (#326).
   --kind <name>          Build event kind the preset's review loop fires for, e.g.
                          bug-fix or major-change (default: the-framework.yml's event,
                          else the preset's own, else major-change). Selects which
@@ -230,6 +235,8 @@ export interface CliOptions {
   context: string[]
   /** `--bootstrap`: bootstrap mode (#297/#448) — a new project from an empty dir; stop for a plan first. */
   bootstrap: boolean
+  /** `--post-merge`: fire the #326 post-merge quality suite (maintainability/readability/security-audit) when the run signals setReadyForMerge(). */
+  postMerge: boolean
   buildEvent?: string | undefined
   maxPasses?: number
   maxCost?: number
@@ -291,6 +298,7 @@ export function parseArgs(argv: string[]): CliOptions {
     eco: { autoPlanning: false, autoResearch: false, autoMaintenance: false },
     context: [],
     bootstrap: false,
+    postMerge: false,
     dashboard: true,
     relayServe: false,
     composeExtensions: false,
@@ -345,6 +353,9 @@ export function parseArgs(argv: string[]): CliOptions {
         break
       case '--bootstrap':
         opts.bootstrap = true
+        break
+      case '--post-merge':
+        opts.postMerge = true
         break
       case '--eco-auto-planning':
         opts.eco.autoPlanning = true
@@ -917,6 +928,9 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // set by a user interrupt or a budget cap (#322). Trusted over which signal
   // aborted, since a budget stop trips an internal signal the CLI never sees.
   let stoppedCleanly = false
+  // The agent signalled setReadyForMerge() this run (#326): with --post-merge on, fire the
+  // quality suite once the run settles (not mid-run — it would race the agent's own git work).
+  let sawReadyForMerge = false
   // Record the finished run in the project log `.the-framework/LOGS.md` (#379). The
   // kind + title are known up front; the session id/link arrive mid-run, and the
   // `end` event (fired once by both run paths) closes the entry. Best-effort: the
@@ -931,6 +945,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
       logSessionId = event.sessionId
       if (event.sessionLink) logSessionLink = event.sessionLink
     }
+    if (event.kind === 'ready-for-merge') sawReadyForMerge = true
     if (event.kind === 'end') {
       if (event.stopped) stoppedCleanly = true
       const entry = runLogEntry({
@@ -946,6 +961,15 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     io.out(formatFrameworkEvent(event))
     void store?.append(event)
     publisher?.publish(event)
+  }
+
+  // Fire the #326 post-merge quality suite once a --post-merge run has settled and the agent
+  // signalled setReadyForMerge(). Skipped for a fake/offline run and when the run was stopped.
+  const maybeFirePostMerge = async (): Promise<void> => {
+    if (!opts.postMerge || !sawReadyForMerge || stoppedCleanly || fake) return
+    const binPath = process.argv[1]
+    if (!binPath) return
+    await runPostMergeSuite(cwd, binPath, io, opts.maxCost)
   }
 
   // AI meta-select: with no preset chosen explicitly, infer the best fit (+ modes +
@@ -1032,6 +1056,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
           : '\n✓ research done: see the REVIEW-PROBLEMS / TODO files it wrote.',
       )
       await store?.close()
+      await maybeFirePostMerge()
       if (dashboard) {
         io.out(`\nDashboard still live at ${dashboard.url}. Press Ctrl+C to exit.`)
         await waitForInterrupt()
@@ -1181,6 +1206,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     // ledger is legible without the dashboard. Both best-effort.
     await store?.close()
     await writeDecisions(cwd, ledger, io)
+    await maybeFirePostMerge()
     // Stay up while the dashboard and/or the app are live, then tear both down.
     if (dashboard || preview) {
       if (dashboard) io.out(`\nDashboard still live at ${dashboard.url}. Press Ctrl+C to exit.`)
@@ -1366,18 +1392,72 @@ function describeReview(r: RepoReview): string {
  * Resolves true on a clean exit (0). Never re-execs a test entry (fork-bomb guard).
  */
 function spawnMaintenanceRun(review: RepoReview, binPath: string, maxCost?: number): Promise<boolean> {
+  // Scope the maintainability pass to the un-reviewed range so the agent knows what to look at.
+  const what = review.reviewedSha ? `the changes in ${short(review.reviewedSha)}..${short(review.headSha)}` : 'the recent changes'
+  return spawnPromptRun(renderMaintainabilityPrompt(what), review.path, binPath, maxCost)
+}
+
+/**
+ * Run one direct prompt by spawning `framework prompt "<prompt>" --cwd <dir> --no-dashboard`,
+ * reusing the whole run path (preflight, driver, budget cap, LOGS.md). The child inherits
+ * stdio so its run streams to the terminal. Note it carries no `--post-merge`, so a quality
+ * pass never triggers its own post-merge suite (the recursion guard). Resolves true on a
+ * clean exit (0). Never re-execs a test entry (fork-bomb guard).
+ */
+/**
+ * The argv a spawned `framework prompt` child runs with. Pure so a test can assert it:
+ * note it carries **no** `--post-merge`, which is the post-merge recursion guard (a quality
+ * pass must not trigger its own suite).
+ */
+export function promptRunArgs(prompt: string, cwd: string, binPath: string, maxCost?: number): string[] {
+  const args = [binPath, 'prompt', prompt, '--no-dashboard', '--cwd', cwd]
+  if (maxCost !== undefined) args.push('--max-cost', String(maxCost))
+  return args
+}
+
+function spawnPromptRun(prompt: string, cwd: string, binPath: string, maxCost?: number): Promise<boolean> {
   if (process.env.NODE_TEST_CONTEXT || /\.test\.[cm]?[jt]s$/.test(binPath)) {
     return Promise.resolve(false) // refuse to spawn from a test entry
   }
-  // Scope the maintainability pass to the un-reviewed range so the agent knows what to look at.
-  const what = review.reviewedSha ? `the changes in ${short(review.reviewedSha)}..${short(review.headSha)}` : 'the recent changes'
-  const args = [binPath, 'prompt', renderMaintainabilityPrompt(what), '--no-dashboard', '--cwd', review.path]
-  if (maxCost !== undefined) args.push('--max-cost', String(maxCost))
+  const args = promptRunArgs(prompt, cwd, binPath, maxCost)
   return new Promise<boolean>(resolvePromise => {
     const child = spawn(process.execPath, args, { stdio: 'inherit' })
     child.once('error', () => resolvePromise(false))
     child.once('exit', code => resolvePromise(code === 0))
   })
+}
+
+/** How the suite spawns one pass; injectable so tests observe order without spawning. */
+export type PromptRunner = (prompt: string, cwd: string, binPath: string, maxCost?: number) => Promise<boolean>
+
+/** The post-merge quality passes (#326), in the order they run. */
+export const POST_MERGE_PASSES: readonly { label: string; render: () => string }[] = [
+  { label: 'maintainability', render: () => renderMaintainabilityPrompt() },
+  { label: 'readability', render: () => renderReadabilityPrompt() },
+  { label: 'security-audit', render: () => renderSecurityAuditPrompt() },
+]
+
+/**
+ * Fire the #326 post-merge quality suite after a run signalled setReadyForMerge(): the
+ * maintainability, readability, and security-audit prompts, each a `framework prompt` child
+ * on the same workspace. Runs them **one after another** (not in parallel): the three passes
+ * edit and commit the same git tree, so concurrent writers would race on the index lock —
+ * sequential is the safe MVP (worktree-isolated parallelism is a follow-up). Best-effort:
+ * a failed pass is logged and the suite continues.
+ */
+export async function runPostMergeSuite(
+  cwd: string,
+  binPath: string,
+  io: CliIO,
+  maxCost?: number,
+  run: PromptRunner = spawnPromptRun,
+): Promise<void> {
+  io.out(`\n◆ post-merge quality suite: ${POST_MERGE_PASSES.map(p => p.label).join(' → ')}`)
+  for (const pass of POST_MERGE_PASSES) {
+    io.out(`\n◆ post-merge: ${pass.label}`)
+    const ok = await run(pass.render(), cwd, binPath, maxCost)
+    if (!ok) io.out(`  ! post-merge ${pass.label} did not complete cleanly; continuing.`)
+  }
 }
 
 async function runRelayServer(opts: CliOptions, io: CliIO): Promise<number> {

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -57,6 +57,8 @@ test('startOptionFlags maps only enabled Global options to CLI flags (#314)', ()
   ])
   // Bootstrap mode (#297/#448): maps to --bootstrap.
   assert.deepEqual(startOptionFlags({ bootstrap: true }), ['--bootstrap'])
+  // Post-merge quality suite (#326): maps to --post-merge.
+  assert.deepEqual(startOptionFlags({ postMerge: true }), ['--post-merge'])
 })
 
 const logEvent = (message: string): FrameworkEvent => ({ kind: 'log', message })

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -68,6 +68,7 @@ export function startOptionFlags(options: StartRunOptions): string[] {
   if (options.eco?.autoMaintenance) flags.push('--eco-auto-maintenance')
   for (const dir of options.context ?? []) if (typeof dir === 'string' && dir.trim()) flags.push('--context', dir)
   if (options.bootstrap) flags.push('--bootstrap')
+  if (options.postMerge) flags.push('--post-merge')
   return flags
 }
 

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -77,6 +77,8 @@ export interface StartRunOptions {
   context?: string[]
   /** Bootstrap mode (#297/#448): a new project from an empty dir; maps to `--bootstrap`. */
   bootstrap?: boolean
+  /** Post-merge quality suite (#326): on setReadyForMerge(), fire maintainability/readability/security-audit; maps to `--post-merge`. */
+  postMerge?: boolean
 }
 
 /**

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -196,7 +196,7 @@ export {
   type VersionFetcher,
   type UpdateStatus,
 } from './update-check.js'
-export { runCli, parseArgs, buildDeployTarget, workspaceSummary, autoSelectPreset, type CliIO, type CliOptions } from './cli.js'
+export { runCli, parseArgs, buildDeployTarget, workspaceSummary, autoSelectPreset, runPostMergeSuite, promptRunArgs, POST_MERGE_PASSES, type PromptRunner, type CliIO, type CliOptions } from './cli.js'
 export {
   metaSelect,
   metaSelectPrompt,

--- a/packages/framework/src/registry.test.ts
+++ b/packages/framework/src/registry.test.ts
@@ -153,11 +153,11 @@ test('readRegistry reads a legacy bare-array file as { projects, preferences: {}
 test('readRegistry reads the object form with preferences and drops unknown/non-boolean fields', async () => {
   const raw = JSON.stringify({
     projects: [APP_A],
-    preferences: { autopilot: false, eco: true, ecoPlanning: 'yes', bogus: 1 },
+    preferences: { autopilot: false, eco: true, ecoPlanning: 'yes', bogus: 1, postMergeQuality: true },
   })
   assert.deepEqual(await readRegistry(memFs({ [FILE]: raw }), ENV), {
     projects: [APP_A],
-    preferences: { autopilot: false, eco: true }, // ecoPlanning (non-boolean) + bogus dropped
+    preferences: { autopilot: false, eco: true, postMergeQuality: true }, // ecoPlanning (non-boolean) + bogus dropped
   })
 })
 

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -32,6 +32,8 @@ export interface Preferences {
   ecoPlanning?: boolean
   ecoResearch?: boolean
   ecoMaintenance?: boolean
+  /** Post-merge quality suite (#326): fire maintainability/readability/security-audit on setReadyForMerge(). */
+  postMergeQuality?: boolean
 }
 
 /**
@@ -141,6 +143,7 @@ const PREFERENCE_KEYS = [
   'ecoPlanning',
   'ecoResearch',
   'ecoMaintenance',
+  'postMergeQuality',
 ] as const
 
 /** Keep only the known boolean preference fields, so a hand-edited or browser-supplied


### PR DESCRIPTION
Part of #326. The last piece of the action layer: when a run signals `setReadyForMerge()`, fire the quality passes Rom described — **maintainability, readability, security-audit** — over the same workspace. Builds on the lifecycle signals (#464) and the security-audit preset (#463), both merged.

## Design calls (from the #326 thread)
- **Eager on setReadyForMerge**, per Rom: the suite fires as soon as the signal arrives (after the run settles). The 'fire only after an *actual* merge' half of his design needs git/PR-merge awareness we don't have yet; that's the follow-up. The toggle here is exactly his 'Eager post-merge cleanup' setting.
- **Sequential, not parallel** (Rom OK'd skipping parallelization): the three passes edit and commit the *same* git tree, so concurrent writers would race on `index.lock`. Worktree-isolated parallel is a clean follow-up.
- **Off by default**: it spawns three extra runs, so it's opt-in.

## What
- **CLI `--post-merge`**: the shared `onEvent` funnel records the `ready-for-merge` event; after the run settles the suite fires, gated on `--post-merge` + the signal + not-stopped + not-fake. Firing *after* the run (not mid-run) avoids racing the primary agent's own git work.
- **`runPostMergeSuite`**: runs maintainability → readability → security-audit one after another, each a `framework prompt` child (reusing the `spawnMaintenanceRun` mechanism). Best-effort: a failed pass is logged and the suite continues.
- **Recursion guard**: each child carries **no** `--post-merge`, so a quality pass can't trigger its own suite. Enforced by the pure `promptRunArgs` builder (unit-asserted).
- **Dashboard-reachable**: a 'Post-merge cleanup' Global option in the Start form → `postMergeQuality` preference (sanitized + persisted) → `StartRunOptions.postMerge` → `--post-merge` on the daemon-spawned run. Mirrors `--bootstrap`/autopilot exactly.

## Verify
- New unit tests: `parseArgs --post-merge`; `startOptionFlags` maps `postMerge → --post-merge`; `sanitizePreferences` keeps `postMergeQuality`; `promptRunArgs` carries `--no-dashboard`/`--cwd` and **never** `--post-merge` (the recursion guard); `runPostMergeSuite` runs the three passes in order and continues past a failed one.
- Framework suite 483 (482 pass / 0 fail / 1 pre-existing skip); framework typecheck + build clean; framework-dashboard typecheck clean.
- The real-LLM end-to-end (a live run emits ready-for-merge → three children spawn + commit) is a logged-in-shell run; the plumbing is fully unit-covered and reuses the proven maintenance-spawn path.