### PR TITLE
feat(framework): --browser gives the agent a real browser (chrome-devtools-mcp)

### DIFF
--- a/.changeset/browser-mcp-452.md
+++ b/.changeset/browser-mcp-452.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Add `--browser`: give the agent a real browser during the run via chrome-devtools-mcp. When set, the driver writes a temp `--mcp-config` wiring `chrome-devtools-mcp`, so the agent can navigate pages, read console + network output, inspect the DOM, and screenshot while it works instead of flying blind on frontend changes. Off by default; host-side only (no runner change), and the MCP servers merge with the user's own rather than replacing them. The `ClaudeCodeDriver` gains an `mcpServers` option backing this.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -25,6 +25,8 @@ import {
   runLogKind,
   runPostMergeSuite,
   POST_MERGE_PASSES,
+  withBrowser,
+  BROWSER_MCP_SERVERS,
   workspaceSummary,
   type CliIO,
 } from './cli.js'
@@ -67,6 +69,20 @@ test('parseArgs reads --bootstrap (#297/#448)', () => {
 test('parseArgs reads --post-merge (#326)', () => {
   assert.equal(parseArgs(['x']).postMerge, false)
   assert.equal(parseArgs(['--post-merge', 'x']).postMerge, true)
+})
+
+test('parseArgs reads --browser (#452)', () => {
+  assert.equal(parseArgs(['x']).browser, false)
+  assert.equal(parseArgs(['--browser', 'x']).browser, true)
+})
+
+test('withBrowser folds chrome-devtools-mcp into driver options only when enabled (#452)', () => {
+  const base = claudeDriverOptions({ skipPermissions: false })
+  assert.equal(withBrowser(base, false).mcpServers, undefined)
+  const withIt = withBrowser(base, true)
+  assert.deepEqual(withIt.mcpServers, BROWSER_MCP_SERVERS)
+  // Non-mutating: the base options are untouched.
+  assert.equal(base.mcpServers, undefined)
 })
 
 test('promptRunArgs runs a headless prompt and carries NO --post-merge (recursion guard, #326)', () => {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -14,7 +14,7 @@ import {
   type DomainPreset,
   type FrameworkSignals,
 } from '@gemstack/ai-autopilot'
-import { ClaudeCodeDriver, type ClaudeCodeDriverOptions, type Driver, type DriverSession, type PermissionMode } from './driver/index.js'
+import { ClaudeCodeDriver, type ClaudeCodeDriverOptions, type Driver, type DriverSession, type McpServerSpec, type PermissionMode } from './driver/index.js'
 import { hostExecutor } from './host-exec.js'
 import { startDashboard, singleProjectProvider, resolveDashboardBundle, type Dashboard } from './dashboard/index.js'
 import { startRelay, relayPublisher, type RelayPublisher } from './relay.js'
@@ -160,6 +160,9 @@ Options:
   --post-merge           When the run signals setReadyForMerge(), fire the post-merge
                          quality suite: maintainability, readability, and security-audit
                          prompts, one after another (#326).
+  --browser              Give the agent a real browser during the run via
+                         chrome-devtools-mcp: navigate pages, read console + network,
+                         inspect the DOM, and screenshot. Off by default (#452).
   --kind <name>          Build event kind the preset's review loop fires for, e.g.
                          bug-fix or major-change (default: the-framework.yml's event,
                          else the preset's own, else major-change). Selects which
@@ -237,6 +240,8 @@ export interface CliOptions {
   bootstrap: boolean
   /** `--post-merge`: fire the #326 post-merge quality suite (maintainability/readability/security-audit) when the run signals setReadyForMerge(). */
   postMerge: boolean
+  /** `--browser`: give the agent a real browser via chrome-devtools-mcp (navigate, console, network, DOM, screenshot) during the run (#452). */
+  browser: boolean
   buildEvent?: string | undefined
   maxPasses?: number
   maxCost?: number
@@ -299,6 +304,7 @@ export function parseArgs(argv: string[]): CliOptions {
     context: [],
     bootstrap: false,
     postMerge: false,
+    browser: false,
     dashboard: true,
     relayServe: false,
     composeExtensions: false,
@@ -356,6 +362,9 @@ export function parseArgs(argv: string[]): CliOptions {
         break
       case '--post-merge':
         opts.postMerge = true
+        break
+      case '--browser':
+        opts.browser = true
         break
       case '--eco-auto-planning':
         opts.eco.autoPlanning = true
@@ -534,6 +543,23 @@ export function claudeDriverOptions(opts: Pick<CliOptions, 'permissionMode' | 's
   return opts.skipPermissions
     ? { dangerouslySkipPermissions: true }
     : { permissionMode: opts.permissionMode ?? 'bypassPermissions' }
+}
+
+/**
+ * The `--browser` MCP wiring (#452): chrome-devtools-mcp is a maintained stdio
+ * server that launches its own Chromium and exposes DevTools tools (navigate,
+ * console, network, DOM, screenshot). `npx -y` resolves it on demand so there is
+ * nothing to pre-install. Merged into the build driver only, not the short
+ * preset-router turn.
+ */
+export const BROWSER_MCP_SERVERS: Record<string, McpServerSpec> = {
+  'chrome-devtools': { command: 'npx', args: ['-y', 'chrome-devtools-mcp@latest'] },
+}
+
+/** Fold the `--browser` MCP server into driver options when the flag is set. */
+export function withBrowser(base: ClaudeCodeDriverOptions, browser: boolean): ClaudeCodeDriverOptions {
+  if (!browser) return base
+  return { ...base, mcpServers: { ...base.mcpServers, ...BROWSER_MCP_SERVERS } }
 }
 
 /** The active Open Loop modes from the mode flags, in a stable order. */
@@ -1005,7 +1031,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     io.err(`note: --sandbox docker has no effect without --serve.`)
   }
 
-  const driver: Driver = fake ? fakeDriver() : new ClaudeCodeDriver(claudeOpts)
+  const driver: Driver = fake ? fakeDriver() : new ClaudeCodeDriver(withBrowser(claudeOpts, opts.browser))
 
   // `framework research [what]` (#331) and `framework prompt <text>` (#353): the
   // direct prompt path — run one prompt through runPrompt, which honors its gates

--- a/packages/framework/src/driver/claude-code.test.ts
+++ b/packages/framework/src/driver/claude-code.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { Readable, Writable } from 'node:stream'
+import { existsSync, readFileSync } from 'node:fs'
 import { ClaudeCodeDriver, StreamJsonParser, runClaude, type SpawnLike, type SpawnedProcess } from './claude-code.js'
 import type { DriverEvent } from './types.js'
 
@@ -151,4 +152,36 @@ test('ClaudeCodeDriver builds correct CLI args (permission mode, system, model)'
   assert.ok(captured.includes('You are a Vike expert'))
   assert.ok(captured.includes('--model'))
   assert.ok(captured.includes('claude-haiku-4-5-20251001'))
+})
+
+test('ClaudeCodeDriver omits --mcp-config when no mcpServers are configured', async () => {
+  let captured: string[] = []
+  const spawn: SpawnLike = (_cmd, args) => {
+    captured = [...args]
+    return fakeSpawn([JSON.stringify({ type: 'result', result: 'ok' })])(_cmd, args, { cwd: '/ws', env: {} })
+  }
+  const session = await new ClaudeCodeDriver({ spawn }).start({ cwd: '/ws' })
+  await session.prompt('go')
+  assert.ok(!captured.includes('--mcp-config'))
+})
+
+test('ClaudeCodeDriver writes an --mcp-config file for mcpServers and cleans it up on dispose', async () => {
+  let captured: string[] = []
+  const spawn: SpawnLike = (_cmd, args) => {
+    captured = [...args]
+    return fakeSpawn([JSON.stringify({ type: 'result', result: 'ok' })])(_cmd, args, { cwd: '/ws', env: {} })
+  }
+  const mcpServers = { 'chrome-devtools': { command: 'npx', args: ['-y', 'chrome-devtools-mcp@latest'] } }
+  const session = await new ClaudeCodeDriver({ spawn, mcpServers }).start({ cwd: '/ws' })
+  await session.prompt('go')
+  const idx = captured.indexOf('--mcp-config')
+  assert.ok(idx >= 0)
+  const configPath = captured[idx + 1]!
+  assert.deepEqual(JSON.parse(readFileSync(configPath, 'utf8')), { mcpServers })
+  // The path is stable across prompts in the same session (written once).
+  const first = [...captured]
+  await session.prompt('again')
+  assert.equal(captured[captured.indexOf('--mcp-config') + 1], first[first.indexOf('--mcp-config') + 1])
+  await session.dispose()
+  assert.ok(!existsSync(configPath))
 })

--- a/packages/framework/src/driver/claude-code.ts
+++ b/packages/framework/src/driver/claude-code.ts
@@ -1,7 +1,9 @@
 import { spawn as nodeSpawn } from 'node:child_process'
 import { createInterface } from 'node:readline'
 import { readFile } from 'node:fs/promises'
-import { resolve } from 'node:path'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
 import { killTree, registerChild, unregisterChild } from './child-registry.js'
 import type { Driver, DriverEvent, DriverPromptOptions, DriverSession, DriverStartOptions, DriverTurn, DriverUsage } from './types.js'
 
@@ -10,6 +12,13 @@ const TERMINATE_GRACE_MS = 5000
 
 /** Claude Code permission modes we pass through to the CLI. */
 export type PermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan'
+
+/** A stdio MCP server spec, as written into the `--mcp-config` file (#452). */
+export interface McpServerSpec {
+  command: string
+  args?: string[]
+  env?: Record<string, string>
+}
 
 /** The slice of `child_process.spawn` this driver needs. Injectable for tests. */
 export type SpawnLike = (
@@ -44,6 +53,13 @@ export interface ClaudeCodeDriverOptions {
   dangerouslySkipPermissions?: boolean
   /** Extra CLI args appended verbatim (escape hatch). */
   extraArgs?: string[]
+  /**
+   * MCP servers to expose to the agent for this session (#452). Written to a
+   * temp config file passed via `--mcp-config`, so they merge with the user's
+   * own configured MCP servers rather than replacing them. Used by `--browser`
+   * to wire chrome-devtools-mcp (a real browser + DevTools tools) into the run.
+   */
+  mcpServers?: Record<string, McpServerSpec>
   /** Environment for the child process. Default `process.env`. */
   env?: NodeJS.ProcessEnv
   /** `spawn` override for tests. Default `node:child_process.spawn`. */
@@ -76,6 +92,8 @@ let sessionCounter = 0
 export class ClaudeCodeSession implements DriverSession {
   readonly id: string
   readonly cwd: string
+  /** Path to the written `--mcp-config` file, lazily created on first use. */
+  private mcpConfigPath: string | undefined
 
   constructor(
     private readonly config: ClaudeCodeDriverOptions,
@@ -115,8 +133,17 @@ export class ClaudeCodeSession implements DriverSession {
   }
 
   dispose(): Promise<void> {
-    // Each prompt spawns and reaps its own process, so there is nothing durable
-    // to tear down. The session id reaches the UI via the emitted result event.
+    // Each prompt spawns and reaps its own process, so the only durable thing is
+    // the temp MCP config file; drop it. The session id reaches the UI via the
+    // emitted result event.
+    if (this.mcpConfigPath) {
+      try {
+        rmSync(dirname(this.mcpConfigPath), { recursive: true, force: true })
+      } catch {
+        // Best effort: the temp dir lands under the OS tmp and is reaped anyway.
+      }
+      this.mcpConfigPath = undefined
+    }
     return Promise.resolve()
   }
 
@@ -126,8 +153,27 @@ export class ClaudeCodeSession implements DriverSession {
     else args.push('--permission-mode', this.config.permissionMode ?? 'acceptEdits')
     if (system) args.push('--append-system-prompt', system)
     if (this.startOpts.model) args.push('--model', this.startOpts.model)
+    const mcpConfig = this.mcpConfigFile()
+    if (mcpConfig) args.push('--mcp-config', mcpConfig)
     if (this.config.extraArgs) args.push(...this.config.extraArgs)
     return args
+  }
+
+  /**
+   * Lazily materialize the `--mcp-config` file for {@link ClaudeCodeDriverOptions.mcpServers}.
+   * Written once and reused across the session's prompts; `undefined` when no
+   * servers are configured. Not `--strict-mcp-config`, so these merge with the
+   * user's own MCP servers rather than replacing them.
+   */
+  private mcpConfigFile(): string | undefined {
+    const servers = this.config.mcpServers
+    if (!servers || Object.keys(servers).length === 0) return undefined
+    if (!this.mcpConfigPath) {
+      const dir = mkdtempSync(join(tmpdir(), 'framework-mcp-'))
+      this.mcpConfigPath = join(dir, 'mcp.json')
+      writeFileSync(this.mcpConfigPath, JSON.stringify({ mcpServers: servers }))
+    }
+    return this.mcpConfigPath
   }
 }
 

--- a/packages/framework/src/driver/index.ts
+++ b/packages/framework/src/driver/index.ts
@@ -14,6 +14,7 @@ export {
   StreamJsonParser,
   runClaude,
   type ClaudeCodeDriverOptions,
+  type McpServerSpec,
   type PermissionMode,
   type SpawnLike,
   type SpawnedProcess,


### PR DESCRIPTION
Phase 1 of #452: give the agent a real browser during a run, host side only, no runner change.

Adds `--browser`. When set, the build driver writes a temp `--mcp-config` wiring `chrome-devtools-mcp` (a maintained stdio server that launches its own Chromium). The agent can then navigate pages, read console + network output, inspect the DOM, and screenshot while it works, instead of only type-checking and guessing whether a frontend change works.

Notes:
- Off by default. `npx -y chrome-devtools-mcp@latest` resolves it on demand, nothing to pre-install.
- Merges with the user's own MCP servers (not `--strict-mcp-config`).
- Scoped to the build driver only, not the short preset-router turn.
- `ClaudeCodeDriver` gains an `mcpServers` option backing this; the temp config is written once per session and removed on dispose.

Phase 2 (bundling Chromium into the sandbox runner image) stays gated on the agent-in-container move, tracked in #452.

Closes #452