### PR TITLE
feat(framework): dashboard toggle for --browser

### DIFF
--- a/.changeset/browser-dashboard-toggle-467.md
+++ b/.changeset/browser-dashboard-toggle-467.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Add a "Browser" toggle to the dashboard Start form so `--browser` (give the agent a real browser via chrome-devtools-mcp, #452) is reachable from daemon/dashboard-started runs, not just the CLI. Mirrors the Post-merge cleanup pref: a `browser` preference flows to `StartRunOptions.browser` and on to the `--browser` flag.

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -45,6 +45,7 @@ export function StartRunForm({ projectId }: { projectId: string }) {
   const ecoResearch = preferences.ecoResearch ?? false
   const ecoMaintenance = preferences.ecoMaintenance ?? false
   const postMergeQuality = preferences.postMergeQuality ?? false
+  const browser = preferences.browser ?? false
 
   // Context selector (#439/#314): the agent can reach every registered repo, so ticking a
   // subset narrows its focus — the picked paths become one `Context:` line in the system
@@ -84,6 +85,7 @@ export function StartRunForm({ projectId }: { projectId: string }) {
       ...(vanilla ? { vanilla: true } : {}),
       ...(eco && !vanilla && Object.keys(ecoOpts).length ? { eco: ecoOpts } : {}),
       ...(postMergeQuality ? { postMerge: true } : {}),
+      ...(browser ? { browser: true } : {}),
       ...(context.size ? { context: [...context] } : {}),
     }
   }
@@ -169,6 +171,9 @@ export function StartRunForm({ projectId }: { projectId: string }) {
         </label>
         <label className="flex cursor-pointer items-center gap-1.5" title="When the run signals it's ready for merge, run maintainability, readability, and security-audit passes">
           <input type="checkbox" checked={postMergeQuality} onChange={e => updatePreferences({ postMergeQuality: e.target.checked })} disabled={busy} /> Post-merge cleanup
+        </label>
+        <label className="flex cursor-pointer items-center gap-1.5" title="Give the agent a real browser via chrome-devtools-mcp: navigate pages, read console + network, inspect the DOM, and screenshot">
+          <input type="checkbox" checked={browser} onChange={e => updatePreferences({ browser: e.target.checked })} disabled={busy} /> Browser
         </label>
       </div>
 

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -59,6 +59,8 @@ test('startOptionFlags maps only enabled Global options to CLI flags (#314)', ()
   assert.deepEqual(startOptionFlags({ bootstrap: true }), ['--bootstrap'])
   // Post-merge quality suite (#326): maps to --post-merge.
   assert.deepEqual(startOptionFlags({ postMerge: true }), ['--post-merge'])
+  // Browser via chrome-devtools-mcp (#452): maps to --browser.
+  assert.deepEqual(startOptionFlags({ browser: true }), ['--browser'])
 })
 
 const logEvent = (message: string): FrameworkEvent => ({ kind: 'log', message })

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -69,6 +69,7 @@ export function startOptionFlags(options: StartRunOptions): string[] {
   for (const dir of options.context ?? []) if (typeof dir === 'string' && dir.trim()) flags.push('--context', dir)
   if (options.bootstrap) flags.push('--bootstrap')
   if (options.postMerge) flags.push('--post-merge')
+  if (options.browser) flags.push('--browser')
   return flags
 }
 

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -79,6 +79,8 @@ export interface StartRunOptions {
   bootstrap?: boolean
   /** Post-merge quality suite (#326): on setReadyForMerge(), fire maintainability/readability/security-audit; maps to `--post-merge`. */
   postMerge?: boolean
+  /** Give the agent a real browser via chrome-devtools-mcp during the run (#452); maps to `--browser`. */
+  browser?: boolean
 }
 
 /**

--- a/packages/framework/src/registry.test.ts
+++ b/packages/framework/src/registry.test.ts
@@ -153,11 +153,11 @@ test('readRegistry reads a legacy bare-array file as { projects, preferences: {}
 test('readRegistry reads the object form with preferences and drops unknown/non-boolean fields', async () => {
   const raw = JSON.stringify({
     projects: [APP_A],
-    preferences: { autopilot: false, eco: true, ecoPlanning: 'yes', bogus: 1, postMergeQuality: true },
+    preferences: { autopilot: false, eco: true, ecoPlanning: 'yes', bogus: 1, postMergeQuality: true, browser: true },
   })
   assert.deepEqual(await readRegistry(memFs({ [FILE]: raw }), ENV), {
     projects: [APP_A],
-    preferences: { autopilot: false, eco: true, postMergeQuality: true }, // ecoPlanning (non-boolean) + bogus dropped
+    preferences: { autopilot: false, eco: true, postMergeQuality: true, browser: true }, // ecoPlanning (non-boolean) + bogus dropped
   })
 })
 

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -34,6 +34,8 @@ export interface Preferences {
   ecoMaintenance?: boolean
   /** Post-merge quality suite (#326): fire maintainability/readability/security-audit on setReadyForMerge(). */
   postMergeQuality?: boolean
+  /** Give the agent a real browser via chrome-devtools-mcp during the run (#452); maps to `--browser`. */
+  browser?: boolean
 }
 
 /**
@@ -144,6 +146,7 @@ const PREFERENCE_KEYS = [
   'ecoResearch',
   'ecoMaintenance',
   'postMergeQuality',
+  'browser',
 ] as const
 
 /** Keep only the known boolean preference fields, so a hand-edited or browser-supplied


### PR DESCRIPTION
Follow-up to #452. Makes the `--browser` capability reachable from the dashboard, not just the CLI.

Adds a "Browser" toggle to the Start form, mirroring the Post-merge cleanup pref exactly:
- `Preferences.browser` (persisted in the-framework.json, sanitized) ->
- `StartRunOptions.browser` ->
- `--browser` flag via `startOptionFlags`.

Off by default. Tests cover the flag mapping and pref sanitize; framework + dashboard typecheck and the dashboard bundle builds clean.

Closes #467