### PR TITLE
fix(framework): auto git-init a non-repo folder when adding a project

### DIFF
--- a/.changeset/auto-git-init-add-project-473.md
+++ b/.changeset/auto-git-init-add-project-473.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Adding a project that isn't a git repo now initializes one for you instead of failing with `fatal: not a git repository`. `installProject` detects a non-repo folder and runs `git init` before its usual commit-and-install flow, so a plain directory can be added straight from the dashboard. The install result reports `initialized: true` when it did so.

--- a/packages/framework/src/install.test.ts
+++ b/packages/framework/src/install.test.ts
@@ -55,7 +55,7 @@ const CWD = '/proj'
 
 test('installProject on a clean repo seeds the log and makes exactly one install commit', async () => {
   const fs = memFs()
-  const { git, calls } = fakeGit(args => (args[0] === 'status' ? '' : ''))
+  const { git, calls } = fakeGit(args => (args[0] === 'rev-parse' ? 'true' : ''))
 
   assert.deepEqual(await installProject(CWD, { git, fs }), { ok: true })
   assert.equal(fs.files.get(logsPath(CWD)), LOGS_HEADER)
@@ -66,7 +66,7 @@ test('installProject on a clean repo seeds the log and makes exactly one install
 
 test('installProject seeds .the-framework/.gitignore so only LOGS.md is committed (#313)', async () => {
   const fs = memFs()
-  const { git } = fakeGit(() => '')
+  const { git } = fakeGit(args => (args[0] === 'rev-parse' ? 'true' : ''))
 
   await installProject(CWD, { git, fs })
   assert.equal(fs.files.get(gitignorePath(CWD)), LOGS_GITIGNORE)
@@ -77,7 +77,10 @@ test('installProject seeds .the-framework/.gitignore so only LOGS.md is committe
 
 test('installProject on a dirty repo commits the pre-existing changes first', async () => {
   const fs = memFs()
-  const { git, calls } = fakeGit(args => (args[0] === 'status' ? ' M file.ts\n' : ''))
+  const { git, calls } = fakeGit(args => {
+    if (args[0] === 'rev-parse') return 'true'
+    return args[0] === 'status' ? ' M file.ts\n' : ''
+  })
 
   assert.deepEqual(await installProject(CWD, { git, fs }), { ok: true })
 
@@ -96,6 +99,7 @@ test('installProject on an already-activated repo is a no-op that never calls gi
 test('installProject surfaces a git failure as { ok: false }, never throws', async () => {
   const fs = memFs()
   const { git } = fakeGit(args => {
+    if (args[0] === 'rev-parse') return 'true'
     if (args[0] === 'commit') throw new Error('nothing to commit')
     return ''
   })
@@ -103,9 +107,23 @@ test('installProject surfaces a git failure as { ok: false }, never throws', asy
   assert.deepEqual(await installProject(CWD, { git, fs }), { ok: false, error: 'nothing to commit' })
 })
 
+test('installProject initializes a git repo when the folder is not one yet, then installs', async () => {
+  const fs = memFs()
+  // rev-parse fails on a non-repo folder; every other git call succeeds.
+  const { git, calls } = fakeGit(args => {
+    if (args[0] === 'rev-parse') throw new Error('not a git repository')
+    return ''
+  })
+
+  assert.deepEqual(await installProject(CWD, { git, fs }), { ok: true, initialized: true })
+  assert.ok(calls.some(args => args[0] === 'init'), 'ran git init')
+  const commits = calls.filter(args => args[0] === 'commit').map(args => args[2])
+  assert.deepEqual(commits, ['[The Framework] install The Framework'])
+})
+
 test('the seeded LOGS.md is a valid empty log', async () => {
   const fs = memFs()
-  const { git } = fakeGit(() => '')
+  const { git } = fakeGit(args => (args[0] === 'rev-parse' ? 'true' : ''))
 
   await installProject(CWD, { git, fs })
   assert.equal(fs.files.get(logsPath(CWD)), LOGS_HEADER)

--- a/packages/framework/src/install.ts
+++ b/packages/framework/src/install.ts
@@ -13,7 +13,7 @@ import { nodeStoreFs, type StoreFs } from './store/index.js'
 
 /** The outcome of {@link installProject}. Failures are values, never throws. */
 export type InstallResult =
-  | { ok: true; alreadyActivated?: boolean }
+  | { ok: true; alreadyActivated?: boolean; initialized?: boolean }
   | { ok: false; error: string }
 
 /** Injectable seams for {@link installProject}. */
@@ -35,6 +35,13 @@ export async function installProject(cwd: string, deps: InstallDeps = {}): Promi
   if (await fs.exists(logsPath(cwd))) return { ok: true, alreadyActivated: true }
 
   try {
+    // Auto-initialize a repo when the folder isn't one yet: The Framework treats
+    // git as the source of truth, so `git init` it for the user rather than erroring.
+    const insideRepo = await git(['rev-parse', '--is-inside-work-tree'], cwd)
+      .then(out => out.trim() === 'true')
+      .catch(() => false)
+    if (!insideRepo) await git(['init'], cwd)
+
     // Commit pre-existing changes first so the install commit is clean.
     const status = await git(['status', '--porcelain'], cwd)
     if (status.trim()) {
@@ -52,7 +59,7 @@ export async function installProject(cwd: string, deps: InstallDeps = {}): Promi
 
     await git(['add', '-A'], cwd)
     await git(['commit', '-m', '[The Framework] install The Framework'], cwd)
-    return { ok: true }
+    return insideRepo ? { ok: true } : { ok: true, initialized: true }
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) }
   }


### PR DESCRIPTION
Adding a folder that isn't a git repo failed with `fatal: not a git repository` because `installProject` runs `git status` immediately.

The Framework uses git as the source of truth, so the folder does need to be a repo, but now we create it for the user: `installProject` checks `git rev-parse --is-inside-work-tree` and runs `git init` when the folder isn't a repo, then proceeds with the usual commit-and-install flow. The result carries `initialized: true` so the UI can surface it later.

Tests: new coverage for the auto-init path; existing install tests updated for the added repo-detection call. install.test.ts green (9/9), typecheck clean.

Closes #473