### PR TITLE
feat(framework): show the exact prompt sent to the agent each turn

### DIFF
--- a/.changeset/show-prompts-in-dashboard-476.md
+++ b/.changeset/show-prompts-in-dashboard-476.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Show the exact prompt sent to the agent each turn. The run feed used to render a turn's start as just `> prompt sent` and drop the text; now the terminal/log formatter shows a one-line preview, and the dashboard event feed renders the full prompt in a collapsible block (click to expand) for both live runs and replays. The prompt was already carried on the driver `start` event and persisted, so this is a display-only change that surfaces it.

--- a/packages/framework-dashboard/components/EventList.tsx
+++ b/packages/framework-dashboard/components/EventList.tsx
@@ -17,12 +17,27 @@ export function EventList({ events, stick = true }: { events: FrameworkEvent[]; 
   return (
     <div className="flex-1 overflow-y-auto p-4">
       <ol className="space-y-1 font-mono text-xs">
-        {events.map((e, i) => (
-          <li key={i} className="flex items-start gap-2">
-            <Badge className="mt-0.5 shrink-0 text-[10px] uppercase text-muted-foreground">{e.kind}</Badge>
-            <span className="whitespace-pre-wrap break-words text-foreground">{(formatFrameworkEvent(e) ?? '').trim()}</span>
-          </li>
-        ))}
+        {events.map((e, i) => {
+          // The exact prompt sent to the agent each turn (#476): it's carried on the
+          // driver `start` event but the one-line formatter drops it, so render it
+          // here in a collapsible block — the "see every prompt" surface without a script.
+          const prompt = e.kind === 'driver' && e.event.type === 'start' ? e.event.prompt : undefined
+          return (
+            <li key={i} className="flex items-start gap-2">
+              <Badge className="mt-0.5 shrink-0 text-[10px] uppercase text-muted-foreground">{e.kind}</Badge>
+              {prompt !== undefined ? (
+                <details className="min-w-0 flex-1">
+                  <summary className="cursor-pointer text-foreground marker:text-muted-foreground">
+                    › prompt sent ({prompt.length.toLocaleString()} chars) — click to expand
+                  </summary>
+                  <pre className="mt-1 max-h-96 overflow-auto whitespace-pre-wrap break-words rounded bg-muted p-2 text-foreground">{prompt}</pre>
+                </details>
+              ) : (
+                <span className="whitespace-pre-wrap break-words text-foreground">{(formatFrameworkEvent(e) ?? '').trim()}</span>
+              )}
+            </li>
+          )
+        })}
       </ol>
       <div ref={bottomRef} />
     </div>

--- a/packages/framework/src/events.test.ts
+++ b/packages/framework/src/events.test.ts
@@ -84,6 +84,18 @@ test('formatFrameworkEvent renders a system-prompt line by length (#343)', () =>
   assert.equal(formatFrameworkEvent({ kind: 'system-prompt', text: 'abcde' }), '  system prompt sent (5 chars)')
 })
 
+test('formatFrameworkEvent shows a preview of the driver prompt, not just "prompt sent" (#476)', () => {
+  assert.equal(
+    formatFrameworkEvent({ kind: 'driver', event: { type: 'start', prompt: 'Build this app end to end' } }),
+    '  › prompt: Build this app end to end',
+  )
+  // Long prompts are truncated for the one-line feed (the dashboard shows the full text).
+  const long = 'x'.repeat(300)
+  const line = formatFrameworkEvent({ kind: 'driver', event: { type: 'start', prompt: long } })!
+  assert.ok(line.startsWith('  › prompt: '))
+  assert.ok(line.length < 160 && line.endsWith('…'))
+})
+
 test('formatFrameworkEvent renders a preview line', () => {
   assert.equal(
     formatFrameworkEvent({ kind: 'preview', url: 'http://localhost:3000', command: 'npm run dev' }),

--- a/packages/framework/src/events.ts
+++ b/packages/framework/src/events.ts
@@ -209,7 +209,7 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
 function formatDriverEvent(event: DriverEvent): string {
   switch (event.type) {
     case 'start':
-      return `  › prompt sent`
+      return `  › prompt: ${truncate(event.prompt, 140)}`
     case 'text':
       return `    ${truncate(event.text)}`
     case 'action':


### PR DESCRIPTION
You couldn't see the prompts The Framework sends to Claude: the feed rendered each turn's start as `> prompt sent` and dropped the text, so judging prompt quality meant digging through Claude Code's session .jsonl files by hand.

The full prompt is already on the driver `start` event and persisted to events.jsonl, so this is display-only:
- Terminal/log formatter shows a one-line prompt preview instead of `prompt sent`.
- Dashboard event feed renders the full prompt in a collapsible block (click to expand), for both live runs and replays.

Tests: formatter preview + truncation covered; framework + dashboard typecheck clean; dashboard bundle rebuilt.

Closes #476