### PR TITLE
feat(framework): show the live run in the Runs list with a RUNNING status

### DIFF
--- a/.changeset/live-run-in-runs-list.md
+++ b/.changeset/live-run-in-runs-list.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Dashboard: show the live run in the Runs rail with a RUNNING status. The in-progress run now appears as the top row of the list (pulsing dot, RUNNING badge, and the prompt), matching the history rows, instead of being hidden behind the abstract "Live" button; clicking it follows the live stream as before. `onRuns` prepends the live run (from `run.json`) when one is running, and the Start form seeds an optimistic row so the run shows the instant you click Start, before the spawned process writes its `run.json`.

--- a/packages/framework-dashboard/components/EventStream.tsx
+++ b/packages/framework-dashboard/components/EventStream.tsx
@@ -16,10 +16,12 @@ export function EventStream({
   projectId,
   events,
   readOnly = false,
+  onRunStarted,
 }: {
   projectId: string | null
   events: FrameworkEvent[]
   readOnly?: boolean
+  onRunStarted?: (intent: string) => void
 }) {
   if (!projectId) {
     return <div className="grid flex-1 place-items-center text-sm text-muted-foreground">Select a project to watch its live run.</div>
@@ -50,7 +52,7 @@ export function EventStream({
           </Button>
         </div>
       ) : (
-        <StartRunForm projectId={projectId} />
+        <StartRunForm projectId={projectId} onRunStarted={onRunStarted} />
       )}
       {events.length > 0 ? (
         <>

--- a/packages/framework-dashboard/components/RunHistory.tsx
+++ b/packages/framework-dashboard/components/RunHistory.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import type { RunMeta } from '@gemstack/framework'
 import { onRuns } from '../server/reads.telefunc.js'
 import { Button } from './ui/button.js'
@@ -12,50 +12,95 @@ const STATUS_TONE: Record<string, string> = {
   failed: 'text-red-500',
 }
 
-// The Runs rail (#314 second sidebar): the selected project's archived runs over a
-// Telefunc RPC (server/reads.telefunc.ts). "Live" returns to the live stream; picking a
-// run replays it in the main view. Polls so a run that just finished shows up.
+// The Runs rail (#314 second sidebar): the selected project's runs over a Telefunc RPC
+// (server/reads.telefunc.ts). The live run is prepended by the server with a `running`
+// status, so it shows here the moment it starts; picking it follows the live stream
+// (selectedRunId === null), picking a finished run replays it. `startTick`/`startIntent`
+// come from the Start form: on a new start we show an optimistic `running` row with the
+// typed prompt right away, until the server's real running meta lands on the next poll.
 export function RunHistory({
   projectId,
   selectedRunId,
   onSelect,
+  startTick = 0,
+  startIntent = '',
 }: {
   projectId: string | null
   selectedRunId: string | null
   onSelect: (runId: string | null) => void
+  startTick?: number
+  startIntent?: string
 }) {
   const [runs, setRuns] = useState<RunMeta[]>([])
+  const [optimistic, setOptimistic] = useState<string | null>(null)
+
+  const load = useCallback(() => {
+    if (!projectId) return Promise.resolve()
+    return onRuns(projectId).then(list => setRuns(list))
+  }, [projectId])
 
   useEffect(() => {
+    setOptimistic(null)
     if (!projectId) {
       setRuns([])
       return
     }
     let live = true
-    const load = () => void onRuns(projectId).then(list => live && setRuns(list))
-    load()
-    const poll = setInterval(load, 5000)
+    const tick = () => void load().then(() => live || undefined)
+    tick()
+    const poll = setInterval(tick, 2000)
     return () => {
       live = false
       clearInterval(poll)
     }
-  }, [projectId])
+  }, [projectId, load])
+
+  // A fresh start: seed the optimistic row with the typed prompt and refetch now so the
+  // real running meta replaces it as soon as the spawned process writes its run.json.
+  useEffect(() => {
+    if (startTick === 0) return
+    setOptimistic(startIntent)
+    void load()
+  }, [startTick]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Once the server reports the run as running, the optimistic placeholder is redundant.
+  const realRunning = runs.find(run => run.status === 'running')
+  useEffect(() => {
+    if (realRunning) setOptimistic(null)
+  }, [realRunning])
 
   if (!projectId) return null
+
+  const history = runs.filter(run => run.status !== 'running')
+  const liveActive = selectedRunId === null
 
   return (
     <aside className="flex w-60 shrink-0 flex-col border-r border-border">
       <div className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Runs</div>
       <div className="flex-1 overflow-y-auto px-2">
-        <Button
-          variant="ghost"
-          className={cn('mb-1 w-full justify-start', selectedRunId === null && 'bg-accent text-accent-foreground')}
-          onClick={() => onSelect(null)}
-        >
-          <span className="mr-2 inline-block h-2 w-2 animate-pulse rounded-full bg-primary" /> Live
-        </Button>
-        {runs.length === 0 && <p className="px-2 py-1 text-sm text-muted-foreground">No runs yet.</p>}
-        {runs.map(run => (
+        {realRunning ? (
+          <LiveEntry
+            active={liveActive}
+            intent={realRunning.intent}
+            subtitle={new Date(realRunning.startedAt).toLocaleString()}
+            onClick={() => onSelect(null)}
+          />
+        ) : optimistic !== null ? (
+          <LiveEntry active={liveActive} intent={optimistic} subtitle="starting…" onClick={() => onSelect(null)} />
+        ) : (
+          <Button
+            variant="ghost"
+            className={cn('mb-1 w-full justify-start', liveActive && 'bg-accent text-accent-foreground')}
+            onClick={() => onSelect(null)}
+          >
+            <span className="mr-2 inline-block h-2 w-2 rounded-full bg-muted-foreground" /> Live
+          </Button>
+        )}
+
+        {history.length === 0 && optimistic === null && !realRunning && (
+          <p className="px-2 py-1 text-sm text-muted-foreground">No runs yet.</p>
+        )}
+        {history.map(run => (
           <Button
             key={run.id}
             variant="ghost"
@@ -78,5 +123,37 @@ export function RunHistory({
         ))}
       </div>
     </aside>
+  )
+}
+
+// The live/running run rendered as a list row (not the bare "Live" button): a pulsing dot +
+// RUNNING badge + the prompt, so a just-started run reads the same as its history siblings.
+function LiveEntry({
+  active,
+  intent,
+  subtitle,
+  onClick,
+}: {
+  active: boolean
+  intent: string | undefined
+  subtitle: string
+  onClick: () => void
+}) {
+  return (
+    <Button
+      variant="ghost"
+      className={cn(
+        'mb-0.5 h-auto w-full flex-col items-start gap-0.5 px-2 py-2 text-left',
+        active && 'bg-accent text-accent-foreground',
+      )}
+      onClick={onClick}
+    >
+      <span className="flex w-full items-center gap-2">
+        <span className="inline-block h-2 w-2 shrink-0 animate-pulse rounded-full bg-primary" />
+        <Badge className={cn('shrink-0 border-transparent px-0 text-[10px] uppercase', STATUS_TONE.running)}>running</Badge>
+        <span className="truncate text-xs font-normal text-muted-foreground">{subtitle}</span>
+      </span>
+      <span className="w-full truncate text-sm font-medium">{intent || '(no prompt)'}</span>
+    </Button>
   )
 }

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -28,7 +28,13 @@ const PRESETS: { id: string; label: string; render: () => string }[] = [
 // own `startRun` (with its one-run-per-project busy guard), posted over Telefunc. The
 // Global options (#314/#433) ride along: Autopilot, Technical control, Vanilla, and Eco
 // (with its section drops). Shown when no run is active; a `busy` result means one already is.
-export function StartRunForm({ projectId }: { projectId: string }) {
+export function StartRunForm({
+  projectId,
+  onRunStarted,
+}: {
+  projectId: string
+  onRunStarted?: ((intent: string) => void) | undefined
+}) {
   const [prompt, setPrompt] = useState('')
   const [kind, setKind] = useState<'build' | 'prompt'>('build')
   const [busy, setBusy] = useState(false)
@@ -100,6 +106,10 @@ export function StartRunForm({ projectId }: { projectId: string }) {
     try {
       const result = await sendStart(projectId, text, kind, collectOptions())
       if (result.ok) {
+        // Show the run in the Runs rail immediately (#405): the spawned process
+        // writes its run.json a beat later, so seed an optimistic row with the
+        // typed prompt until the real running meta takes over.
+        onRunStarted?.(text)
         setPrompt('')
         setKind('build')
         setNote(null)

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -25,6 +25,14 @@ export default function Page() {
   const [projectId, setProjectId] = useState<string | null>(rememberedProject)
   // null = follow the live stream; a run id = replay that archived run.
   const [runId, setRunId] = useState<string | null>(null)
+  // A just-started run: bump the tick so the Runs rail shows an optimistic `running` row
+  // with the typed prompt at once, before the spawned process writes its run.json.
+  const [runStart, setRunStart] = useState<{ tick: number; intent: string }>({ tick: 0, intent: '' })
+
+  const onRunStarted = (intent: string) => {
+    setRunId(null) // jump to the live view of the run just started
+    setRunStart(prev => ({ tick: prev.tick + 1, intent }))
+  }
 
   const selectProject = (id: string) => {
     setProjectId(id)
@@ -54,9 +62,19 @@ export default function Page() {
       </header>
       <div className="flex min-h-0 flex-1">
         <ProjectsSidebar selectedId={projectId} onSelect={selectProject} />
-        <RunHistory projectId={projectId} selectedRunId={runId} onSelect={setRunId} />
+        <RunHistory
+          projectId={projectId}
+          selectedRunId={runId}
+          onSelect={setRunId}
+          startTick={runStart.tick}
+          startIntent={runStart.intent}
+        />
         <main className="flex min-w-0 flex-1 flex-col">
-          {projectId && runId ? <RunReplay projectId={projectId} runId={runId} /> : <EventStream projectId={projectId} events={events} />}
+          {projectId && runId ? (
+            <RunReplay projectId={projectId} runId={runId} />
+          ) : (
+            <EventStream projectId={projectId} events={events} onRunStarted={onRunStarted} />
+          )}
         </main>
         <RightRail projectId={projectId} choices={choices} views={views} />
       </div>

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -1,4 +1,4 @@
-import { listRuns, loadRunEvents, type RunMeta } from '../store/index.js'
+import { listRuns, readLiveMeta, loadRunEvents, type RunMeta } from '../store/index.js'
 import { readLogs, type LogEntry } from '../logs.js'
 import { readDocs, type WorkspaceDoc } from '../dashboard/docs.js'
 import { collectQueue, type ProjectQueue } from '../dashboard/queue.js'
@@ -19,10 +19,22 @@ async function projectPath(projectId: string): Promise<string | undefined> {
   return contextProjects().resolvePath(projectId)
 }
 
-/** The project's archived runs, most-recent first (or `[]`). */
+/**
+ * The project's runs, most-recent first (or `[]`). The archived (finished) runs
+ * from `runs/`, plus the live run prepended when one is going — so the sidebar
+ * shows the in-progress run with a `running` status the moment it starts, not
+ * only after it closes. The live run is skipped once it has been archived under
+ * the same id (it then appears from `listRuns` instead), so there is no double.
+ */
 export async function onRuns(projectId: string): Promise<RunMeta[]> {
   const cwd = await projectPath(projectId)
-  return cwd ? listRuns(cwd).catch(() => []) : []
+  if (!cwd) return []
+  const archived = await listRuns(cwd).catch(() => [])
+  const live = await readLiveMeta(cwd).catch(() => undefined)
+  if (live && live.status === 'running' && !archived.some(r => r.id === live.id)) {
+    return [live, ...archived]
+  }
+  return archived
 }
 
 /** One archived run's event log for replay (or `[]` when the run or project is gone). */

--- a/packages/framework/src/store/index.ts
+++ b/packages/framework/src/store/index.ts
@@ -4,6 +4,7 @@ export {
   applyEventToMeta,
   metaFromEvents,
   listRuns,
+  readLiveMeta,
   loadRunEvents,
   runIdFromStartedAt,
   isSafeRunId,

--- a/packages/framework/src/store/run-store.test.ts
+++ b/packages/framework/src/store/run-store.test.ts
@@ -6,6 +6,7 @@ import {
   applyEventToMeta,
   metaFromEvents,
   listRuns,
+  readLiveMeta,
   loadRunEvents,
   RUN_META_VERSION,
   type StoreFs,
@@ -184,6 +185,22 @@ test('listRuns returns archived runs newest-first with intent + status (#303)', 
   assert.equal(runs[1]!.intent, 'a blog with comments')
   assert.equal(runs[1]!.status, 'done')
   assert.equal(runs[1]!.sessionLink, 'https://ex.com/s/sess-123')
+})
+
+test('readLiveMeta reads the in-progress run.json with a running status (before close)', async () => {
+  const fs = memFs()
+  const store = await RunStore.open(CWD, { fs, fresh: true, now: AT })
+  for (const e of RUN.slice(0, -1)) await store.append(e) // every event but the terminal `end`
+  // No close(): the run is still live. Its meta reads back as running with the intent.
+  const live = await readLiveMeta(CWD, fs)
+  assert.ok(live, 'live meta present')
+  assert.equal(live!.status, 'running')
+  assert.equal(live!.intent, 'a blog with comments')
+  assert.equal(live!.id, store.snapshot().id)
+})
+
+test('readLiveMeta yields undefined on a never-run workspace', async () => {
+  assert.equal(await readLiveMeta(CWD, memFs()), undefined)
 })
 
 test('loadRunEvents replays an archived run, and rejects unknown/unsafe ids (#303)', async () => {

--- a/packages/framework/src/store/run-store.ts
+++ b/packages/framework/src/store/run-store.ts
@@ -358,6 +358,23 @@ export async function listRuns(cwd: string, fs: StoreFs = nodeStoreFs()): Promis
 }
 
 /**
+ * The live (in-progress) run's meta snapshot from `.the-framework/run.json`, or
+ * `undefined` when none/unreadable. Unlike {@link listRuns} (which reads the
+ * archived `runs/` copies written on close), this is the run the daemon is
+ * tailing right now — so the dashboard can list it with a `running` status
+ * before it finishes. Missing or torn file yields `undefined`, never throws.
+ */
+export async function readLiveMeta(cwd: string, fs: StoreFs = nodeStoreFs()): Promise<RunMeta | undefined> {
+  const path = join(cwd, FRAMEWORK_DIR, META_FILE)
+  if (!(await fs.exists(path))) return undefined
+  try {
+    return JSON.parse(await fs.read(path)) as RunMeta
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * Read one archived run's event log for replay. Returns `undefined` for an
  * unknown or unsafe id; a torn trailing line is dropped (same rule as the live
  * {@link RunStore.loadEvents}).


### PR DESCRIPTION
Closes #481.

Right now the Runs rail only shows finished runs; the in-progress one hides behind the "Live" button, so after hitting Start you get no confirmation your run exists until it ends.

Now the running run is the top row of the list: pulsing dot + RUNNING badge + the prompt, matching the history rows. Clicking it follows the live stream, same as Live did. And it shows the instant you click Start.

What changed:
- `readLiveMeta()` reads the in-progress `run.json`; `onRuns()` prepends it when a run is running (skipped once it is archived under the same id, so no duplicate).
- The Start form fires `onRunStarted(prompt)`, so the list shows an optimistic RUNNING row with your typed text right away, before the spawned process writes `run.json`. The real meta takes over on the next poll (dropped 5s to 2s).

Tests: two new store unit tests for `readLiveMeta` (live-running read + empty workspace); 16/16 green. Both packages typecheck.