### PR TITLE
feat(framework): dashboard Live as a permanent launcher; each run its own view

### DIFF
--- a/packages/framework-dashboard/components/ProjectHome.tsx
+++ b/packages/framework-dashboard/components/ProjectHome.tsx
@@ -1,0 +1,26 @@
+import type { FrameworkEvent } from '@gemstack/framework'
+import { StartRunForm } from './StartRunForm.js'
+import { PreviewBar } from './PreviewBar.js'
+import { RunOverview } from './RunOverview.js'
+
+// The project home / launcher — what "Live" selects. Always the Start form + preset cards +
+// the current stack overview; it is never consumed by a run. Starting one appends a run to
+// the rail and adds that run's own view (RunLive) alongside — this page stays put, so you can
+// launch again. (Actually running several at once lands with git worktrees, #453.)
+export function ProjectHome({
+  projectId,
+  events,
+  onRunStarted,
+}: {
+  projectId: string
+  events: FrameworkEvent[]
+  onRunStarted?: ((intent: string) => void) | undefined
+}) {
+  return (
+    <>
+      <PreviewBar projectId={projectId} />
+      <StartRunForm projectId={projectId} onRunStarted={onRunStarted} />
+      {events.length > 0 && <RunOverview events={events} />}
+    </>
+  )
+}

--- a/packages/framework-dashboard/components/RunHistory.tsx
+++ b/packages/framework-dashboard/components/RunHistory.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useState } from 'react'
-import type { RunMeta } from '@gemstack/framework'
-import { onRuns } from '../server/reads.telefunc.js'
+import { useEffect, useState } from 'react'
+import type { RunMeta, RunStatus } from '@gemstack/framework'
 import { Button } from './ui/button.js'
 import { Badge } from './ui/badge.js'
 import { cn } from '../lib/utils.js'
@@ -12,132 +11,96 @@ const STATUS_TONE: Record<string, string> = {
   failed: 'text-red-500',
 }
 
-// The Runs rail (#314 second sidebar): the selected project's runs over a Telefunc RPC
-// (server/reads.telefunc.ts). The live run is prepended by the server with a `running`
-// status, so it shows here the moment it starts; picking it follows the live stream
-// (selectedRunId === null), picking a finished run replays it. `startTick`/`startIntent`
-// come from the Start form: on a new start we show an optimistic `running` row with the
-// typed prompt right away, until the server's real running meta lands on the next poll.
+// The Runs rail (#314 second sidebar). "Live" is the permanent home/launcher — selecting it
+// shows the Start form + cards (ProjectHome), and it is never consumed by a run. Every run
+// (live + archived, from `onRuns`) is its own row below it; selecting a run shows that run's
+// own view (its live output while running, a replay once finished). `runs` is owned by the
+// shell so the rail and the main pane share one list. `startTick`/`startIntent` seed an
+// optimistic "starting…" row the instant Start is clicked, until the real run.json lands.
 export function RunHistory({
   projectId,
+  runs,
   selectedRunId,
   onSelect,
   startTick = 0,
   startIntent = '',
 }: {
   projectId: string | null
+  runs: RunMeta[]
   selectedRunId: string | null
   onSelect: (runId: string | null) => void
   startTick?: number
   startIntent?: string
 }) {
-  const [runs, setRuns] = useState<RunMeta[]>([])
   const [optimistic, setOptimistic] = useState<string | null>(null)
 
-  const load = useCallback(() => {
-    if (!projectId) return Promise.resolve()
-    return onRuns(projectId).then(list => setRuns(list))
-  }, [projectId])
-
   useEffect(() => {
-    setOptimistic(null)
-    if (!projectId) {
-      setRuns([])
-      return
-    }
-    let live = true
-    const tick = () => void load().then(() => live || undefined)
-    tick()
-    const poll = setInterval(tick, 2000)
-    return () => {
-      live = false
-      clearInterval(poll)
-    }
-  }, [projectId, load])
-
-  // A fresh start: seed the optimistic row with the typed prompt and refetch now so the
-  // real running meta replaces it as soon as the spawned process writes its run.json.
-  useEffect(() => {
-    if (startTick === 0) return
-    setOptimistic(startIntent)
-    void load()
+    if (startTick > 0) setOptimistic(startIntent)
   }, [startTick]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Once the server reports the run as running, the optimistic placeholder is redundant.
-  const realRunning = runs.find(run => run.status === 'running')
+  const hasRunning = runs.some(run => run.status === 'running')
   useEffect(() => {
-    if (realRunning) setOptimistic(null)
-  }, [realRunning])
+    if (hasRunning) setOptimistic(null)
+  }, [hasRunning])
+  useEffect(() => {
+    setOptimistic(null)
+  }, [projectId])
 
   if (!projectId) return null
 
-  const history = runs.filter(run => run.status !== 'running')
-  const liveActive = selectedRunId === null
+  const atHome = selectedRunId === null
 
   return (
     <aside className="flex w-60 shrink-0 flex-col border-r border-border">
       <div className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Runs</div>
       <div className="flex-1 overflow-y-auto px-2">
-        {realRunning ? (
-          <LiveEntry
-            active={liveActive}
-            intent={realRunning.intent}
-            subtitle={new Date(realRunning.startedAt).toLocaleString()}
-            onClick={() => onSelect(null)}
-          />
-        ) : optimistic !== null ? (
-          <LiveEntry active={liveActive} intent={optimistic} subtitle="starting…" onClick={() => onSelect(null)} />
-        ) : (
-          <Button
-            variant="ghost"
-            className={cn('mb-1 w-full justify-start', liveActive && 'bg-accent text-accent-foreground')}
-            onClick={() => onSelect(null)}
-          >
-            <span className="mr-2 inline-block h-2 w-2 rounded-full bg-muted-foreground" /> Live
-          </Button>
+        {/* Permanent home / launcher — always present, never a run. */}
+        <Button
+          variant="ghost"
+          className={cn('mb-1 w-full justify-start', atHome && 'bg-accent text-accent-foreground')}
+          onClick={() => onSelect(null)}
+        >
+          <span className="mr-2 inline-block h-2 w-2 rounded-full bg-primary" /> Live
+        </Button>
+
+        {/* A just-started run, before its run.json exists. */}
+        {optimistic !== null && !hasRunning && (
+          <RunRow status="running" intent={optimistic} subtitle="starting…" active={false} dim onClick={() => onSelect(null)} />
         )}
 
-        {history.length === 0 && optimistic === null && !realRunning && (
+        {runs.length === 0 && optimistic === null && (
           <p className="px-2 py-1 text-sm text-muted-foreground">No runs yet.</p>
         )}
-        {history.map(run => (
-          <Button
+        {runs.map(run => (
+          <RunRow
             key={run.id}
-            variant="ghost"
-            className={cn(
-              'mb-0.5 h-auto w-full flex-col items-start gap-0.5 px-2 py-2 text-left',
-              run.id === selectedRunId && 'bg-accent text-accent-foreground',
-            )}
+            status={run.status}
+            intent={run.intent}
+            subtitle={new Date(run.startedAt).toLocaleString()}
+            active={run.id === selectedRunId}
             onClick={() => onSelect(run.id)}
-          >
-            <span className="flex w-full items-center gap-2">
-              <Badge className={cn('shrink-0 border-transparent px-0 text-[10px] uppercase', STATUS_TONE[run.status])}>
-                {run.status}
-              </Badge>
-              <span className="truncate text-xs font-normal text-muted-foreground">
-                {new Date(run.startedAt).toLocaleString()}
-              </span>
-            </span>
-            <span className="w-full truncate text-sm font-medium">{run.intent || '(no prompt)'}</span>
-          </Button>
+          />
         ))}
       </div>
     </aside>
   )
 }
 
-// The live/running run rendered as a list row (not the bare "Live" button): a pulsing dot +
-// RUNNING badge + the prompt, so a just-started run reads the same as its history siblings.
-function LiveEntry({
-  active,
+// One run row: a pulsing dot + RUNNING badge for a live run, else the terminal-status badge.
+function RunRow({
+  status,
   intent,
   subtitle,
+  active,
   onClick,
+  dim = false,
 }: {
-  active: boolean
+  status: RunStatus
   intent: string | undefined
   subtitle: string
+  active: boolean
   onClick: () => void
+  dim?: boolean
 }) {
   return (
     <Button
@@ -145,12 +108,13 @@ function LiveEntry({
       className={cn(
         'mb-0.5 h-auto w-full flex-col items-start gap-0.5 px-2 py-2 text-left',
         active && 'bg-accent text-accent-foreground',
+        dim && 'opacity-70',
       )}
       onClick={onClick}
     >
       <span className="flex w-full items-center gap-2">
-        <span className="inline-block h-2 w-2 shrink-0 animate-pulse rounded-full bg-primary" />
-        <Badge className={cn('shrink-0 border-transparent px-0 text-[10px] uppercase', STATUS_TONE.running)}>running</Badge>
+        {status === 'running' && <span className="inline-block h-2 w-2 shrink-0 animate-pulse rounded-full bg-primary" />}
+        <Badge className={cn('shrink-0 border-transparent px-0 text-[10px] uppercase', STATUS_TONE[status])}>{status}</Badge>
         <span className="truncate text-xs font-normal text-muted-foreground">{subtitle}</span>
       </span>
       <span className="w-full truncate text-sm font-medium">{intent || '(no prompt)'}</span>

--- a/packages/framework-dashboard/components/RunLive.tsx
+++ b/packages/framework-dashboard/components/RunLive.tsx
@@ -1,0 +1,31 @@
+import type { FrameworkEvent } from '@gemstack/framework'
+import { sendStop } from '../server/control.telefunc.js'
+import { EventList } from './EventList.js'
+import { PreviewBar } from './PreviewBar.js'
+import { RunOverview } from './RunOverview.js'
+import { Button } from './ui/button.js'
+
+// One running run's own view (its output): the run overview + the live event feed from the
+// shared Telefunc Channel, plus a Stop control. Distinct from the home launcher (ProjectHome)
+// and a finished run's replay (RunReplay). Single-run today streams the project's one live
+// feed; per-run streams arrive with worktrees (#453).
+export function RunLive({ projectId, events }: { projectId: string; events: FrameworkEvent[] }) {
+  return (
+    <>
+      <PreviewBar projectId={projectId} />
+      <div className="flex items-center justify-end border-b border-border px-4 py-2">
+        <Button variant="outline" size="sm" onClick={() => void sendStop(projectId)}>
+          Stop run
+        </Button>
+      </div>
+      {events.length > 0 ? (
+        <>
+          <RunOverview events={events} />
+          <EventList events={events} />
+        </>
+      ) : (
+        <div className="grid flex-1 place-items-center text-sm text-muted-foreground">Waiting for the run to start…</div>
+      )}
+    </>
+  )
+}

--- a/packages/framework-dashboard/lib/use-runs.ts
+++ b/packages/framework-dashboard/lib/use-runs.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { RunMeta } from '@gemstack/framework'
+import { onRuns } from '../server/reads.telefunc.js'
+
+// The selected project's runs (live + archived), polled. Owned by the shell (+Page) so both
+// the Runs rail and the main pane read one list: the rail renders the rows, the pane routes
+// the selected run to its live view or replay by that run's status.
+export function useRuns(projectId: string | null): { runs: RunMeta[]; reload: () => void } {
+  const [runs, setRuns] = useState<RunMeta[]>([])
+
+  const reload = useCallback(() => {
+    if (!projectId) {
+      setRuns([])
+      return
+    }
+    void onRuns(projectId).then(setRuns)
+  }, [projectId])
+
+  useEffect(() => {
+    if (!projectId) {
+      setRuns([])
+      return
+    }
+    let live = true
+    const tick = () => void onRuns(projectId).then(list => live && setRuns(list))
+    tick()
+    const poll = setInterval(tick, 2000)
+    return () => {
+      live = false
+      clearInterval(poll)
+    }
+  }, [projectId])
+
+  return { runs, reload }
+}

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -1,18 +1,21 @@
 import { useState } from 'react'
 import { ProjectsSidebar } from '../../components/ProjectsSidebar.js'
 import { RunHistory } from '../../components/RunHistory.js'
-import { EventStream } from '../../components/EventStream.js'
+import { ProjectHome } from '../../components/ProjectHome.js'
+import { RunLive } from '../../components/RunLive.js'
 import { RunReplay } from '../../components/RunReplay.js'
 import { RightRail } from '../../components/RightRail.js'
 import { RelayView } from '../../components/RelayView.js'
 import { Badge } from '../../components/ui/badge.js'
 import { useLiveEvents } from '../../lib/use-live-events.js'
+import { useRuns } from '../../lib/use-runs.js'
 import { pendingChoices, agentViews } from '../../lib/live-state.js'
 
-// The dashboard shell (#405 phase 2): Projects | Runs | main (live event stream or a
-// past-run replay) | Docs/Log rail. Everything over the wire is Telefunc — the
-// Projects RPC, run history, run replay, docs, log, and the live stream (a Channel).
-// A projection of the same .the-framework files the daemon writes.
+// The dashboard shell (#405 phase 2): Projects | Runs | main | Docs/Log rail. The main pane
+// is one of three views chosen by the Runs-rail selection: the project home/launcher (Live,
+// the default — Start form + cards), a running run's own live output (RunLive), or a finished
+// run's replay (RunReplay). Everything over the wire is Telefunc. A projection of the same
+// .the-framework files the daemon writes.
 // Remember the selected project across reloads so a refresh returns you to the same one
 // (#475): otherwise the dashboard resets to auto-selecting the first project, and anything
 // keyed to the selection — a running Preview, the live stream — looks empty for the project
@@ -23,20 +26,24 @@ const rememberedProject = (): string | null =>
 
 export default function Page() {
   const [projectId, setProjectId] = useState<string | null>(rememberedProject)
-  // null = follow the live stream; a run id = replay that archived run.
+  // null = the project home/launcher (Live); a run id = that run's view.
   const [runId, setRunId] = useState<string | null>(null)
-  // A just-started run: bump the tick so the Runs rail shows an optimistic `running` row
+  // A just-started run: bump the tick so the Runs rail shows an optimistic "starting…" row
   // with the typed prompt at once, before the spawned process writes its run.json.
   const [runStart, setRunStart] = useState<{ tick: number; intent: string }>({ tick: 0, intent: '' })
 
+  const { runs, reload } = useRuns(projectId)
+
   const onRunStarted = (intent: string) => {
-    setRunId(null) // jump to the live view of the run just started
+    // Stay on the home launcher (it must stay visible so you can launch again); the new run
+    // just appends to the rail. Reload so its real row replaces the optimistic one quickly.
     setRunStart(prev => ({ tick: prev.tick + 1, intent }))
+    reload()
   }
 
   const selectProject = (id: string) => {
     setProjectId(id)
-    setRunId(null) // switching projects always returns to live
+    setRunId(null) // switching projects always returns to the home launcher
     if (typeof window !== 'undefined') window.localStorage.setItem(SELECTED_PROJECT_KEY, id)
   }
 
@@ -53,6 +60,19 @@ export default function Page() {
   const relayRun = typeof window === 'undefined' ? null : new URLSearchParams(window.location.search).get('run')
   if (relayRun) return <RelayView runId={relayRun} />
 
+  // Route the main pane: home when nothing is selected; a running run gets its live output;
+  // a finished run replays. (One project streams one live feed today; per-run streams land
+  // with worktrees, #453.)
+  const selectedRun = runId ? runs.find(run => run.id === runId) : undefined
+  const renderMain = () => {
+    if (!projectId) {
+      return <div className="grid flex-1 place-items-center text-sm text-muted-foreground">Select a project to start a run.</div>
+    }
+    if (runId === null) return <ProjectHome projectId={projectId} events={events} onRunStarted={onRunStarted} />
+    if (selectedRun?.status === 'running') return <RunLive projectId={projectId} events={events} />
+    return <RunReplay projectId={projectId} runId={runId} />
+  }
+
   return (
     <div className="flex h-screen flex-col">
       <header className="flex items-center gap-3 border-b border-border px-4 py-3">
@@ -64,18 +84,13 @@ export default function Page() {
         <ProjectsSidebar selectedId={projectId} onSelect={selectProject} />
         <RunHistory
           projectId={projectId}
+          runs={runs}
           selectedRunId={runId}
           onSelect={setRunId}
           startTick={runStart.tick}
           startIntent={runStart.intent}
         />
-        <main className="flex min-w-0 flex-1 flex-col">
-          {projectId && runId ? (
-            <RunReplay projectId={projectId} runId={runId} />
-          ) : (
-            <EventStream projectId={projectId} events={events} onRunStarted={onRunStarted} />
-          )}
-        </main>
+        <main className="flex min-w-0 flex-1 flex-col">{renderMain()}</main>
         <RightRail projectId={projectId} choices={choices} views={views} />
       </div>
     </div>


### PR DESCRIPTION
Closes #483.

Reworks the Runs rail and main pane so Live is the project home/launcher, not a run.

- **Live** is permanent: selecting it always shows the Start form + preset cards + stack overview (new `ProjectHome`). It is never consumed by a run, so you can launch again while runs are going.
- **Each run is its own row** (live + archived, from `onRuns`). Selecting a run opens its own view: live output + Stop while running (new `RunLive`), a replay once finished (`RunReplay`).
- Starting a run appends its row and keeps you on Live (an optimistic 'starting...' row shows instantly until the real run.json lands).
- The runs list is lifted into the shell (`useRuns`) so the rail renders the rows and the pane routes the selected run to live-or-replay by its status.

This is the shape multi-run via git worktrees (#453) needs. Single-run backend today still allows one run at a time; concurrency lands with the worktree work.

Client-only (framework-dashboard is private), so no changeset, same as #440/#445. Dashboard typecheck clean.