### PR TITLE
feat(framework): rich prompt editor (Tiptap) with / commands and @ references

### DIFF
--- a/.changeset/tiptap-prompt-editor.md
+++ b/.changeset/tiptap-prompt-editor.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Replace the dashboard's Start-a-run textarea with a rich prompt editor (Tiptap). Type `/` for commands (load a preset, or insert an agent action like `showMultiSelect()`) and `@` for references (the repeated macro tags `<AWAIT>` / `<REVIEW_FILE>` / `<TODO_FILE>` / `<SESSION_NAME>`, and the registered projects — a project mention also adds its repo to the run context). Tokens render as chips but serialize back to the exact plain text the agent already reads, so the run contract is unchanged. Markdown is live (StarterKit shortcuts) and round-trips faithfully, so a loaded preset comes back essentially verbatim with its tags chip-ified.

--- a/packages/framework-dashboard/components/PromptEditor.tsx
+++ b/packages/framework-dashboard/components/PromptEditor.tsx
@@ -59,7 +59,7 @@ function applyTemplate(editor: Editor, text: string): void {
 }
 
 export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(function PromptEditor(
-  { onChange, onSubmit, onPreset, onMentionProject, projects, presets, disabled = false, placeholder = 'Describe what to build…  ( / for commands, @ for references )' },
+  { onChange, onSubmit, onPreset, onMentionProject, projects, presets, disabled = false, placeholder = 'Describe what to build…  ( / commands · < tags · @ projects )' },
   ref,
 ) {
   const [isEmpty, setIsEmpty] = useState(true)
@@ -120,35 +120,38 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
           if (action) insertToken(ed, range, action)
         },
       }),
-      // `@` — references: the repeated macro tags + the registered projects.
+      // `<` — tags: the repeated macros, which all read as `<NAME>`. Typing `<` opens the
+      // menu; a non-matching character or a space closes it (the suggestion ends on a space,
+      // and the menu hides when nothing matches), so a stray `<` in prose is not a trap.
       makeTrigger({
-        char: '@',
-        key: 'at',
-        items: query => {
-          const macroItems: SuggestionItem[] = MACRO_TOKENS.filter(m => m.label.toLowerCase().includes(query)).map(m => ({
+        char: '<',
+        key: 'tag',
+        items: query =>
+          MACRO_TOKENS.filter(m => m.label.toLowerCase().includes(query)).map(m => ({
             id: `macro:${m.text}`,
             label: m.label,
             hint: m.hint,
             group: 'Tags',
-          }))
-          const projectItems: SuggestionItem[] = projectsRef.current
-            .filter(p => p.name.toLowerCase().includes(query))
-            .slice(0, 6)
-            .map(p => ({ id: `project:${p.id}`, label: `@${p.name}`, hint: 'project', group: 'Projects' }))
-          return [...macroItems, ...projectItems]
-        },
+          })),
         onSelect: (item, { editor: ed, range }) => {
-          if (item.id.startsWith('macro:')) {
-            const macro = MACRO_TOKENS.find(m => `macro:${m.text}` === item.id)
-            if (macro) insertToken(ed, range, macro)
-            return
-          }
-          if (item.id.startsWith('project:')) {
-            const project = projectsRef.current.find(p => `project:${p.id}` === item.id)
-            if (project) {
-              insertToken(ed, range, { kind: 'project', label: `@${project.name}`, text: `@${project.name}` })
-              onMentionRef.current?.(project.path)
-            }
+          const macro = MACRO_TOKENS.find(m => `macro:${m.text}` === item.id)
+          if (macro) insertToken(ed, range, macro)
+        },
+      }),
+      // `@` — references: the registered projects. A mention also focuses the run on that repo.
+      makeTrigger({
+        char: '@',
+        key: 'at',
+        items: query =>
+          projectsRef.current
+            .filter(p => p.name.toLowerCase().includes(query))
+            .slice(0, 8)
+            .map(p => ({ id: `project:${p.id}`, label: `@${p.name}`, hint: 'project', group: 'Projects' })),
+        onSelect: (item, { editor: ed, range }) => {
+          const project = projectsRef.current.find(p => `project:${p.id}` === item.id)
+          if (project) {
+            insertToken(ed, range, { kind: 'project', label: `@${project.name}`, text: `@${project.name}` })
+            onMentionRef.current?.(project.path)
           }
         },
       }),

--- a/packages/framework-dashboard/components/PromptEditor.tsx
+++ b/packages/framework-dashboard/components/PromptEditor.tsx
@@ -1,0 +1,196 @@
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import type { ProjectSummary } from '@gemstack/framework'
+import { EditorContent, useEditor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import { Markdown } from 'tiptap-markdown'
+import type { Editor, Range } from '@tiptap/core'
+import { Token, MACRO_TOKENS, ACTION_TOKENS, type TokenSpec } from './prompt-editor/tokens.js'
+import { makeTrigger } from './prompt-editor/suggestion.js'
+import { tokenizeEditorDoc } from './prompt-editor/tokenize.js'
+import type { SuggestionItem } from './prompt-editor/SuggestionList.js'
+
+// The rich prompt editor (#470): a Tiptap surface that replaces the plain textarea. `/` opens
+// commands (load a preset, insert an agent action like `showMultiSelect()`), `@` opens
+// references (the repeated macro tags `<AWAIT>`/`<REVIEW_FILE>`… and the registered projects).
+// Inserted tokens render as chips but serialize back to the exact prompt text the agent reads,
+// so nothing downstream changes. Markdown is live (StarterKit shortcuts) and round-trips via
+// tiptap-markdown. The editor is imperative for preset loading; text flows out via onChange.
+
+export interface PromptEditorHandle {
+  /** Replace the content with a preset/template string, chip-ifying its tokens. */
+  loadTemplate: (text: string) => void
+  clear: () => void
+  focus: () => void
+}
+
+interface PromptEditorProps {
+  onChange: (markdown: string) => void
+  /** Cmd/Ctrl+Enter. */
+  onSubmit: () => void
+  /** A preset picked from the `/` menu (so the form can flip to a `prompt` run). */
+  onPreset?: (label: string) => void
+  /** A project referenced via `@` (so the form can add it to the run context). */
+  onMentionProject?: (path: string) => void
+  projects: ProjectSummary[]
+  presets: { id: string; label: string; render: () => string }[]
+  disabled?: boolean
+  placeholder?: string
+}
+
+/** Insert a token chip at the suggestion range, followed by a space. */
+function insertToken(editor: Editor, range: Range, spec: TokenSpec): void {
+  editor
+    .chain()
+    .focus()
+    .deleteRange(range)
+    .insertContent([{ type: 'token', attrs: { kind: spec.kind, label: spec.label, text: spec.text } }, { type: 'text', text: ' ' }])
+    .run()
+}
+
+export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(function PromptEditor(
+  { onChange, onSubmit, onPreset, onMentionProject, projects, presets, disabled = false, placeholder = 'Describe what to build…  ( / for commands, @ for references )' },
+  ref,
+) {
+  const [isEmpty, setIsEmpty] = useState(true)
+
+  // Refs so the once-built suggestion closures always see the latest props/editor.
+  const projectsRef = useRef(projects)
+  const presetsRef = useRef(presets)
+  const onPresetRef = useRef(onPreset)
+  const onMentionRef = useRef(onMentionProject)
+  const onChangeRef = useRef(onChange)
+  const onSubmitRef = useRef(onSubmit)
+  useEffect(() => {
+    projectsRef.current = projects
+    presetsRef.current = presets
+    onPresetRef.current = onPreset
+    onMentionRef.current = onMentionProject
+    onChangeRef.current = onChange
+    onSubmitRef.current = onSubmit
+  })
+
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [
+      StarterKit,
+      // breaks:true keeps a single newline as a hard break, so a preset's line-per-line
+      // definition block (REVIEW_FILE: … / TODO_FILE: …) survives the markdown round-trip
+      // instead of collapsing into one paragraph.
+      Markdown.configure({ html: false, linkify: false, breaks: true, transformPastedText: true }),
+      Token,
+      // `/` — commands: presets (load a template) + agent actions (insert a call token).
+      makeTrigger({
+        char: '/',
+        key: 'slash',
+        items: query => {
+          const presetItems: SuggestionItem[] = presetsRef.current
+            .filter(p => p.id.includes(query) || p.label.toLowerCase().includes(query))
+            .map(p => ({ id: `preset:${p.id}`, label: `/${p.id}`, hint: p.label, group: 'Presets' }))
+          const actionItems: SuggestionItem[] = ACTION_TOKENS.filter(a => a.label.toLowerCase().includes(query)).map(a => ({
+            id: `action:${a.text}`,
+            label: a.label,
+            hint: a.hint,
+            group: 'Actions',
+          }))
+          return [...presetItems, ...actionItems]
+        },
+        onSelect: (item, { editor: ed, range }) => {
+          if (item.id.startsWith('preset:')) {
+            const preset = presetsRef.current.find(p => `preset:${p.id}` === item.id)
+            if (preset) {
+              ed.chain().focus().deleteRange(range).run()
+              loadTemplate(preset.render())
+              onPresetRef.current?.(preset.label)
+            }
+            return
+          }
+          const action = ACTION_TOKENS.find(a => `action:${a.text}` === item.id)
+          if (action) insertToken(ed, range, action)
+        },
+      }),
+      // `@` — references: the repeated macro tags + the registered projects.
+      makeTrigger({
+        char: '@',
+        key: 'at',
+        items: query => {
+          const macroItems: SuggestionItem[] = MACRO_TOKENS.filter(m => m.label.toLowerCase().includes(query)).map(m => ({
+            id: `macro:${m.text}`,
+            label: m.label,
+            hint: m.hint,
+            group: 'Tags',
+          }))
+          const projectItems: SuggestionItem[] = projectsRef.current
+            .filter(p => p.name.toLowerCase().includes(query))
+            .slice(0, 6)
+            .map(p => ({ id: `project:${p.id}`, label: `@${p.name}`, hint: 'project', group: 'Projects' }))
+          return [...macroItems, ...projectItems]
+        },
+        onSelect: (item, { editor: ed, range }) => {
+          if (item.id.startsWith('macro:')) {
+            const macro = MACRO_TOKENS.find(m => `macro:${m.text}` === item.id)
+            if (macro) insertToken(ed, range, macro)
+            return
+          }
+          if (item.id.startsWith('project:')) {
+            const project = projectsRef.current.find(p => `project:${p.id}` === item.id)
+            if (project) {
+              insertToken(ed, range, { kind: 'project', label: `@${project.name}`, text: `@${project.name}` })
+              onMentionRef.current?.(project.path)
+            }
+          }
+        },
+      }),
+    ],
+    editorProps: {
+      attributes: { class: 'pe-prose focus:outline-none' },
+      handleKeyDown: (_view, event) => {
+        if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+          event.preventDefault()
+          onSubmitRef.current()
+          return true
+        }
+        return false
+      },
+    },
+    onUpdate: ({ editor: ed }) => {
+      setIsEmpty(ed.isEmpty)
+      onChangeRef.current(ed.storage.markdown.getMarkdown())
+    },
+  })
+
+  // Replace the content with a template and turn its token strings into chips.
+  function loadTemplate(text: string): void {
+    if (!editor) return
+    editor.commands.setContent(text)
+    tokenizeEditorDoc(editor)
+    setIsEmpty(editor.isEmpty)
+    onChangeRef.current(editor.storage.markdown.getMarkdown())
+    editor.commands.focus('end')
+  }
+
+  useImperativeHandle(ref, () => ({
+    loadTemplate,
+    clear: () => {
+      editor?.commands.clearContent()
+      setIsEmpty(true)
+      onChangeRef.current('')
+    },
+    focus: () => editor?.commands.focus('end'),
+  }))
+
+  useEffect(() => {
+    editor?.setEditable(!disabled)
+  }, [editor, disabled])
+
+  return (
+    <div className="relative">
+      <EditorContent
+        editor={editor}
+        className="max-h-64 min-h-[4.5rem] w-full overflow-y-auto rounded-md border border-border bg-transparent p-2 text-sm focus-within:ring-2 focus-within:ring-[var(--color-primary)]"
+      />
+      {isEmpty && (
+        <span className="pointer-events-none absolute left-2 top-2 text-sm text-muted-foreground">{placeholder}</span>
+      )}
+    </div>
+  )
+})

--- a/packages/framework-dashboard/components/PromptEditor.tsx
+++ b/packages/framework-dashboard/components/PromptEditor.tsx
@@ -47,6 +47,17 @@ function insertToken(editor: Editor, range: Range, spec: TokenSpec): void {
     .run()
 }
 
+/**
+ * Replace the editor content with a template and chip-ify its token strings. Takes the live
+ * editor instance (not a captured one), so it works from the `/` menu — whose closures are
+ * built once on first render, when the useEditor result is still null.
+ */
+function applyTemplate(editor: Editor, text: string): void {
+  editor.commands.setContent(text)
+  tokenizeEditorDoc(editor)
+  editor.commands.focus('end')
+}
+
 export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(function PromptEditor(
   { onChange, onSubmit, onPreset, onMentionProject, projects, presets, disabled = false, placeholder = 'Describe what to build…  ( / for commands, @ for references )' },
   ref,
@@ -98,8 +109,9 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
           if (item.id.startsWith('preset:')) {
             const preset = presetsRef.current.find(p => `preset:${p.id}` === item.id)
             if (preset) {
-              ed.chain().focus().deleteRange(range).run()
-              loadTemplate(preset.render())
+              applyTemplate(ed, preset.render())
+              setIsEmpty(ed.isEmpty)
+              onChangeRef.current(ed.storage.markdown.getMarkdown())
               onPresetRef.current?.(preset.label)
             }
             return
@@ -161,11 +173,9 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
   // Replace the content with a template and turn its token strings into chips.
   function loadTemplate(text: string): void {
     if (!editor) return
-    editor.commands.setContent(text)
-    tokenizeEditorDoc(editor)
+    applyTemplate(editor, text)
     setIsEmpty(editor.isEmpty)
     onChangeRef.current(editor.storage.markdown.getMarkdown())
-    editor.commands.focus('end')
   }
 
   useImperativeHandle(ref, () => ({

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FormEvent, type KeyboardEvent } from 'react'
+import { useEffect, useRef, useState, type FormEvent } from 'react'
 import type { ProjectSummary } from '@gemstack/framework'
 import {
   renderResearchPrompt,
@@ -10,6 +10,7 @@ import {
 import { sendStart } from '../server/control.telefunc.js'
 import { onProjects } from '../server/projects.telefunc.js'
 import { usePreferences, updatePreferences, autopilotEnabled } from '../lib/preferences.js'
+import { PromptEditor, type PromptEditorHandle } from './PromptEditor.js'
 import { Button } from './ui/button.js'
 import { cn } from '../lib/utils.js'
 
@@ -40,6 +41,7 @@ export function StartRunForm({
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [note, setNote] = useState<string | null>(null)
+  const editorRef = useRef<PromptEditorHandle>(null)
 
   // The Global options persist daemon-side (#410), shared with the choice-gate countdown.
   const preferences = usePreferences()
@@ -110,6 +112,7 @@ export function StartRunForm({
         // writes its run.json a beat later, so seed an optimistic row with the
         // typed prompt until the real running meta takes over.
         onRunStarted?.(text)
+        editorRef.current?.clear()
         setPrompt('')
         setKind('build')
         setNote(null)
@@ -125,15 +128,12 @@ export function StartRunForm({
     }
   }
 
-  const onKeyDown = (e: KeyboardEvent) => {
-    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') void submit()
-  }
-
-  const loadPreset = (p: (typeof PRESETS)[number]) => {
-    setPrompt(p.render())
+  // A preset button (or the `/` menu) loads the rendered template into the editor, which
+  // chip-ifies its tags; the run then goes verbatim as a `prompt` kind.
+  const loadPreset = (label: string) => {
     setKind('prompt')
     setError(null)
-    setNote(`${p.label} preset loaded — review or edit, then Start`)
+    setNote(`${label} preset loaded — review or edit, then Start`)
   }
 
   const onPromptChange = (value: string) => {
@@ -145,22 +145,40 @@ export function StartRunForm({
     }
   }
 
+  const addContext = (path: string) =>
+    setContext(prev => {
+      const next = new Set(prev)
+      next.add(path)
+      return next
+    })
+
   return (
     <form onSubmit={submit} className="border-b border-border p-4">
       <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Start a run</div>
-      <textarea
-        value={prompt}
-        onChange={e => onPromptChange(e.target.value)}
-        onKeyDown={onKeyDown}
-        placeholder="Describe what to build…"
-        rows={2}
+      <PromptEditor
+        ref={editorRef}
+        onChange={onPromptChange}
+        onSubmit={() => void submit()}
+        onPreset={loadPreset}
+        onMentionProject={addContext}
+        projects={projects}
+        presets={PRESETS}
         disabled={busy}
-        className="w-full resize-y rounded-md border border-border bg-transparent p-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
       />
 
       <div className="mt-2 flex flex-wrap gap-1.5">
         {PRESETS.map(p => (
-          <Button key={p.id} type="button" variant="outline" size="sm" disabled={busy} onClick={() => loadPreset(p)}>
+          <Button
+            key={p.id}
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={busy}
+            onClick={() => {
+              editorRef.current?.loadTemplate(p.render())
+              loadPreset(p.label)
+            }}
+          >
             {p.label}
           </Button>
         ))}

--- a/packages/framework-dashboard/components/prompt-editor/SuggestionList.tsx
+++ b/packages/framework-dashboard/components/prompt-editor/SuggestionList.tsx
@@ -1,0 +1,89 @@
+import { forwardRef, useEffect, useImperativeHandle, useState } from 'react'
+import { cn } from '../../lib/utils.js'
+
+// The floating command/reference menu (#470) the `/` and `@` triggers open. A shadcn-style
+// popover surface driven imperatively by @tiptap/suggestion (which owns positioning), so it
+// is a plain list here: arrow keys move, Enter/Tab pick, and items may carry a group header.
+export interface SuggestionItem {
+  id: string
+  label: string
+  hint?: string | undefined
+  /** Optional section header; consecutive items with the same group render under one label. */
+  group?: string | undefined
+}
+
+export interface SuggestionListProps {
+  items: SuggestionItem[]
+  command: (item: SuggestionItem) => void
+}
+
+export interface SuggestionListRef {
+  onKeyDown: (event: KeyboardEvent) => boolean
+}
+
+export const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>(function SuggestionList(
+  { items, command },
+  ref,
+) {
+  const [selected, setSelected] = useState(0)
+
+  // Reset the highlight whenever the filtered list changes so it never points past the end.
+  useEffect(() => setSelected(0), [items])
+
+  useImperativeHandle(ref, () => ({
+    onKeyDown: event => {
+      if (items.length === 0) return false
+      if (event.key === 'ArrowDown') {
+        setSelected(i => (i + 1) % items.length)
+        return true
+      }
+      if (event.key === 'ArrowUp') {
+        setSelected(i => (i - 1 + items.length) % items.length)
+        return true
+      }
+      if (event.key === 'Enter' || event.key === 'Tab') {
+        const item = items[selected]
+        if (item) command(item)
+        return true
+      }
+      return false
+    },
+  }))
+
+  if (items.length === 0) {
+    return (
+      <div className="w-64 rounded-md border border-border bg-card p-2 text-sm text-muted-foreground shadow-md">
+        No matches
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-h-72 w-64 overflow-y-auto rounded-md border border-border bg-card p-1 text-sm shadow-md">
+      {items.map((item, i) => (
+        <div key={item.id}>
+          {item.group && (i === 0 || items[i - 1]?.group !== item.group) && (
+            <div className="px-2 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70">
+              {item.group}
+            </div>
+          )}
+          <button
+            type="button"
+            onMouseDown={e => {
+              e.preventDefault()
+              command(item)
+            }}
+            onMouseEnter={() => setSelected(i)}
+            className={cn(
+              'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left',
+              i === selected ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/60',
+            )}
+          >
+            <span className="truncate font-medium">{item.label}</span>
+            {item.hint && <span className="ml-auto truncate text-xs text-muted-foreground">{item.hint}</span>}
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+})

--- a/packages/framework-dashboard/components/prompt-editor/suggestion.ts
+++ b/packages/framework-dashboard/components/prompt-editor/suggestion.ts
@@ -49,6 +49,9 @@ function makeRender() {
   let getRect: (() => DOMRect | null) | null = null
 
   const draw = (items: SuggestionItem[], command: (item: SuggestionItem) => void): void => {
+    // Close the menu when nothing matches, so a `<`/`@`/`/` with no hit (or a stray `<` in
+    // prose) is not a trap. The plugin stays active — it reappears if a later key matches.
+    if (el) el.style.display = items.length === 0 ? 'none' : ''
     root?.render(
       createElement(SuggestionList, {
         items,

--- a/packages/framework-dashboard/components/prompt-editor/suggestion.ts
+++ b/packages/framework-dashboard/components/prompt-editor/suggestion.ts
@@ -1,0 +1,100 @@
+import { Extension, type Editor, type Range } from '@tiptap/core'
+import Suggestion from '@tiptap/suggestion'
+import { PluginKey } from '@tiptap/pm/state'
+import { createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { SuggestionList, type SuggestionItem, type SuggestionListRef } from './SuggestionList.js'
+
+// Wire @tiptap/suggestion (the `/` and `@` triggers, #470) to the floating SuggestionList.
+// The suggestion plugin owns detection + positioning; this renders the React menu into a
+// fixed portal at the caret and forwards key events to it. Each trigger gets its own
+// PluginKey so the two menus never clash.
+export interface TriggerConfig {
+  /** The trigger character: `/` for commands, `@` for references. */
+  char: string
+  /** Unique plugin key name. */
+  key: string
+  /** Filter the menu items for the typed query (already lowercased is fine). */
+  items: (query: string) => SuggestionItem[]
+  /** Perform the insertion when an item is picked. */
+  onSelect: (item: SuggestionItem, ctx: { editor: Editor; range: Range }) => void
+}
+
+/** Position a fixed portal just below the caret rect, flipping up near the viewport bottom. */
+function place(el: HTMLElement, rect: DOMRect | null): void {
+  if (!rect) return
+  const below = window.innerHeight - rect.bottom
+  el.style.left = `${rect.left}px`
+  if (below < 320) {
+    el.style.top = ''
+    el.style.bottom = `${window.innerHeight - rect.top + 4}px`
+  } else {
+    el.style.bottom = ''
+    el.style.top = `${rect.bottom + 4}px`
+  }
+}
+
+function makeRender() {
+  let el: HTMLDivElement | null = null
+  let root: Root | null = null
+  let listRef: SuggestionListRef | null = null
+
+  const draw = (items: SuggestionItem[], command: (item: SuggestionItem) => void): void => {
+    root?.render(
+      createElement(SuggestionList, {
+        items,
+        command,
+        ref: (r: SuggestionListRef | null) => {
+          listRef = r
+        },
+      }),
+    )
+  }
+
+  return {
+    onStart(props: { items: SuggestionItem[]; command: (item: SuggestionItem) => void; clientRect?: (() => DOMRect | null) | null }) {
+      el = document.createElement('div')
+      el.style.position = 'fixed'
+      el.style.zIndex = '50'
+      document.body.appendChild(el)
+      root = createRoot(el)
+      place(el, props.clientRect?.() ?? null)
+      draw(props.items, props.command)
+    },
+    onUpdate(props: { items: SuggestionItem[]; command: (item: SuggestionItem) => void; clientRect?: (() => DOMRect | null) | null }) {
+      if (el) place(el, props.clientRect?.() ?? null)
+      draw(props.items, props.command)
+    },
+    onKeyDown(props: { event: KeyboardEvent }) {
+      if (props.event.key === 'Escape') return false
+      return listRef?.onKeyDown(props.event) ?? false
+    },
+    onExit() {
+      root?.unmount()
+      el?.remove()
+      root = null
+      el = null
+      listRef = null
+    },
+  }
+}
+
+/** An editor extension that adds one suggestion trigger. */
+export function makeTrigger(config: TriggerConfig): Extension {
+  return Extension.create({
+    name: `suggestion-${config.key}`,
+    addProseMirrorPlugins() {
+      return [
+        Suggestion({
+          editor: this.editor,
+          char: config.char,
+          pluginKey: new PluginKey(config.key),
+          items: ({ query }: { query: string }) => config.items(query.toLowerCase()),
+          command: ({ editor, range, props }: { editor: Editor; range: Range; props: SuggestionItem }) =>
+            config.onSelect(props, { editor, range }),
+          render: makeRender,
+        }),
+      ]
+    },
+  })
+}

--- a/packages/framework-dashboard/components/prompt-editor/suggestion.ts
+++ b/packages/framework-dashboard/components/prompt-editor/suggestion.ts
@@ -34,10 +34,19 @@ function place(el: HTMLElement, rect: DOMRect | null): void {
   }
 }
 
+type RenderProps = {
+  items: SuggestionItem[]
+  command: (item: SuggestionItem) => void
+  clientRect?: (() => DOMRect | null) | null
+}
+
 function makeRender() {
   let el: HTMLDivElement | null = null
   let root: Root | null = null
   let listRef: SuggestionListRef | null = null
+  // The latest caret-rect getter, re-read on scroll/resize so the menu tracks the caret
+  // instead of staying pinned where it first opened.
+  let getRect: (() => DOMRect | null) | null = null
 
   const draw = (items: SuggestionItem[], command: (item: SuggestionItem) => void): void => {
     root?.render(
@@ -51,18 +60,27 @@ function makeRender() {
     )
   }
 
+  const reposition = (): void => {
+    if (el) place(el, getRect?.() ?? null)
+  }
+
   return {
-    onStart(props: { items: SuggestionItem[]; command: (item: SuggestionItem) => void; clientRect?: (() => DOMRect | null) | null }) {
+    onStart(props: RenderProps) {
       el = document.createElement('div')
       el.style.position = 'fixed'
       el.style.zIndex = '50'
       document.body.appendChild(el)
       root = createRoot(el)
-      place(el, props.clientRect?.() ?? null)
+      getRect = props.clientRect ?? null
+      reposition()
       draw(props.items, props.command)
+      // Capture-phase scroll catches the editor's own scroll container, not just the window.
+      window.addEventListener('scroll', reposition, true)
+      window.addEventListener('resize', reposition)
     },
-    onUpdate(props: { items: SuggestionItem[]; command: (item: SuggestionItem) => void; clientRect?: (() => DOMRect | null) | null }) {
-      if (el) place(el, props.clientRect?.() ?? null)
+    onUpdate(props: RenderProps) {
+      getRect = props.clientRect ?? null
+      reposition()
       draw(props.items, props.command)
     },
     onKeyDown(props: { event: KeyboardEvent }) {
@@ -70,11 +88,14 @@ function makeRender() {
       return listRef?.onKeyDown(props.event) ?? false
     },
     onExit() {
+      window.removeEventListener('scroll', reposition, true)
+      window.removeEventListener('resize', reposition)
       root?.unmount()
       el?.remove()
       root = null
       el = null
       listRef = null
+      getRect = null
     },
   }
 }

--- a/packages/framework-dashboard/components/prompt-editor/tokenize.ts
+++ b/packages/framework-dashboard/components/prompt-editor/tokenize.ts
@@ -1,0 +1,30 @@
+import type { Editor } from '@tiptap/core'
+import { TOKEN_PATTERN, specForText } from './tokens.js'
+
+// Turn the plain token strings in the editor (e.g. from a just-loaded preset) into token
+// chips (#470). Scans every text node for `<MACRO>` / `showX()` matches and replaces each
+// with a token node in one transaction, applied back-to-front so earlier offsets stay valid.
+export function tokenizeEditorDoc(editor: Editor): void {
+  const tokenType = editor.schema.nodes.token
+  if (!tokenType) return
+
+  const matches: { from: number; to: number; text: string }[] = []
+  editor.state.doc.descendants((node, pos) => {
+    if (!node.isText || !node.text) return
+    // Leave tokens inside inline code untouched so a `path/<SESSION_NAME>.md` span stays a
+    // single verbatim code span rather than being split around a chip.
+    if (node.marks.some(mark => mark.type.name === 'code')) return
+    for (const m of node.text.matchAll(TOKEN_PATTERN)) {
+      const from = pos + (m.index ?? 0)
+      matches.push({ from, to: from + m[0].length, text: m[0] })
+    }
+  })
+  if (matches.length === 0) return
+
+  const tr = editor.state.tr
+  for (const match of matches.reverse()) {
+    const spec = specForText(match.text)
+    tr.replaceWith(match.from, match.to, tokenType.create({ kind: spec.kind, label: spec.label, text: spec.text }))
+  }
+  editor.view.dispatch(tr)
+}

--- a/packages/framework-dashboard/components/prompt-editor/tokens.ts
+++ b/packages/framework-dashboard/components/prompt-editor/tokens.ts
@@ -1,4 +1,4 @@
-import { Node, mergeAttributes } from '@tiptap/core'
+import { Node, mergeAttributes, nodeInputRule } from '@tiptap/core'
 
 // The prompt editor's tokens (#470). A token is an inline chip that reads as a pill in the
 // editor but serializes back to the EXACT plain text the agent already parses today — an
@@ -40,9 +40,13 @@ export const ACTION_TOKENS: TokenSpec[] = [
 /** Match any insertable token in free text, so a loaded preset can be chip-ified (tokenize.ts). */
 export const TOKEN_PATTERN = /<[A-Z][A-Z0-9_]*>|show[A-Za-z]+\(\)/g
 
-/** The token spec for a matched string, or a bare macro/action chip when it is not catalogued. */
+/**
+ * The token spec for a matched string. A catalogued macro/action matches case-insensitively
+ * and normalizes to its canonical form (so a typed `<await>` becomes the `<AWAIT>` the agent
+ * expects); anything else keeps exactly what was typed.
+ */
 export function specForText(text: string): TokenSpec {
-  const known = [...MACRO_TOKENS, ...ACTION_TOKENS].find(t => t.text === text)
+  const known = [...MACRO_TOKENS, ...ACTION_TOKENS].find(t => t.text.toLowerCase() === text.toLowerCase())
   if (known) return known
   if (text.endsWith('()')) return { kind: 'action', label: text, text }
   return { kind: 'macro', label: text.replace(/^<|>$/g, ''), text }
@@ -86,6 +90,19 @@ export const Token = Node.create({
   // Plain-text extraction (editor.getText) — mirrors the markdown serialization below.
   renderText({ node }) {
     return node.attrs.text
+  },
+
+  // Auto-convert a fully typed token into a chip: `<NAME>` when the closing `>` lands, and
+  // `showX()` when the closing `)` lands. specForText normalizes a known token's case.
+  addInputRules() {
+    const toAttrs = (match: RegExpMatchArray) => {
+      const spec = specForText(match[0])
+      return { kind: spec.kind, label: spec.label, text: spec.text }
+    }
+    return [
+      nodeInputRule({ find: /<([A-Za-z][A-Za-z0-9_]*)>$/, type: this.type, getAttributes: toAttrs }),
+      nodeInputRule({ find: /(show[A-Za-z]+\(\))$/, type: this.type, getAttributes: toAttrs }),
+    ]
   },
 
   addStorage() {

--- a/packages/framework-dashboard/components/prompt-editor/tokens.ts
+++ b/packages/framework-dashboard/components/prompt-editor/tokens.ts
@@ -1,0 +1,101 @@
+import { Node, mergeAttributes } from '@tiptap/core'
+
+// The prompt editor's tokens (#470). A token is an inline chip that reads as a pill in the
+// editor but serializes back to the EXACT plain text the agent already parses today — an
+// angle-bracket macro (`<AWAIT>`, `<REVIEW_FILE>`), an action call (`showMultiSelect()`), or
+// a reference (`@my-app`). Because a chip flattens to its `text` verbatim, the prompt over
+// the wire is unchanged: presets, the run contract, everything downstream stays the same.
+
+/** What a token is, which drives its chip colour and which menu inserts it. */
+export type TokenKind = 'macro' | 'action' | 'reference' | 'project'
+
+/** One insertable token: how it reads (label) and how it serializes (text). */
+export interface TokenSpec {
+  kind: TokenKind
+  /** The chip label shown in the editor. */
+  label: string
+  /** The exact string written to the prompt on submit. */
+  text: string
+  /** One-line menu hint. */
+  hint?: string
+}
+
+/** Agent macros defined-and-referenced in the preset templates (#331/#326); the repeated tags. */
+export const MACRO_TOKENS: TokenSpec[] = [
+  { kind: 'macro', label: 'AWAIT', text: '<AWAIT>', hint: 'Stop and wait for the user' },
+  { kind: 'macro', label: 'REVIEW_FILE', text: '<REVIEW_FILE>', hint: 'The review scratch file' },
+  { kind: 'macro', label: 'TODO_FILE', text: '<TODO_FILE>', hint: 'The session TODO file' },
+  { kind: 'macro', label: 'PLAN_FILE', text: '<PLAN_FILE>', hint: 'The session plan file' },
+  { kind: 'macro', label: 'SESSION_NAME', text: '<SESSION_NAME>', hint: 'The sanitized branch slug' },
+  { kind: 'macro', label: 'FUNCTION', text: '<FUNCTION>', hint: 'A function placeholder' },
+]
+
+/** Agent action calls that become turn-boundary gates (#339/#340). */
+export const ACTION_TOKENS: TokenSpec[] = [
+  { kind: 'action', label: 'showChoices()', text: 'showChoices()', hint: 'Single-select gate' },
+  { kind: 'action', label: 'showMultiSelect()', text: 'showMultiSelect()', hint: 'Multi-select gate' },
+  { kind: 'action', label: 'showMarkdown()', text: 'showMarkdown()', hint: 'Push a markdown view' },
+]
+
+/** Match any insertable token in free text, so a loaded preset can be chip-ified (tokenize.ts). */
+export const TOKEN_PATTERN = /<[A-Z][A-Z0-9_]*>|show[A-Za-z]+\(\)/g
+
+/** The token spec for a matched string, or a bare macro/action chip when it is not catalogued. */
+export function specForText(text: string): TokenSpec {
+  const known = [...MACRO_TOKENS, ...ACTION_TOKENS].find(t => t.text === text)
+  if (known) return known
+  if (text.endsWith('()')) return { kind: 'action', label: text, text }
+  return { kind: 'macro', label: text.replace(/^<|>$/g, ''), text }
+}
+
+/**
+ * The inline token node. It is an atom (edited as one unit, not character-by-character) that
+ * carries its display `label` and its serialized `text`. `tiptap-markdown` serializes it by
+ * writing `text` raw — no escaping — so `<AWAIT>` survives as `<AWAIT>` rather than `\<AWAIT\>`.
+ */
+export const Token = Node.create({
+  name: 'token',
+  group: 'inline',
+  inline: true,
+  atom: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      kind: { default: 'macro' as TokenKind },
+      label: { default: '' },
+      text: { default: '' },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'span[data-token]' }]
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    return [
+      'span',
+      mergeAttributes(HTMLAttributes, {
+        'data-token': node.attrs.kind,
+        class: 'pe-token',
+      }),
+      node.attrs.label || node.attrs.text,
+    ]
+  },
+
+  // Plain-text extraction (editor.getText) — mirrors the markdown serialization below.
+  renderText({ node }) {
+    return node.attrs.text
+  },
+
+  addStorage() {
+    return {
+      markdown: {
+        serialize(state: { write: (s: string) => void }, node: { attrs: { text: string } }) {
+          state.write(node.attrs.text)
+        },
+        parse: {},
+      },
+    }
+  },
+})

--- a/packages/framework-dashboard/components/prompt-editor/tokens.ts
+++ b/packages/framework-dashboard/components/prompt-editor/tokens.ts
@@ -99,9 +99,11 @@ export const Token = Node.create({
       const spec = specForText(match[0])
       return { kind: spec.kind, label: spec.label, text: spec.text }
     }
+    // No capture groups: nodeInputRule replaces only the captured sub-match when one exists,
+    // which would leave the surrounding `<` `>` behind. Match the whole token instead.
     return [
-      nodeInputRule({ find: /<([A-Za-z][A-Za-z0-9_]*)>$/, type: this.type, getAttributes: toAttrs }),
-      nodeInputRule({ find: /(show[A-Za-z]+\(\))$/, type: this.type, getAttributes: toAttrs }),
+      nodeInputRule({ find: /<[A-Za-z][A-Za-z0-9_]*>$/, type: this.type, getAttributes: toAttrs }),
+      nodeInputRule({ find: /show[A-Za-z]+\(\)$/, type: this.type, getAttributes: toAttrs }),
     ]
   },
 

--- a/packages/framework-dashboard/layouts/tailwind.css
+++ b/packages/framework-dashboard/layouts/tailwind.css
@@ -52,3 +52,87 @@ body {
   background-color: var(--background);
   color: var(--foreground);
 }
+
+/* Prompt editor (#470): live-markdown prose + token chips. Kept lightweight — the box is a
+   prompt input, not a document, so just enough structure for lists/emphasis/code to read. */
+.pe-prose {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.pe-prose p {
+  margin: 0;
+}
+.pe-prose p + p,
+.pe-prose ul,
+.pe-prose ol,
+.pe-prose pre,
+.pe-prose blockquote {
+  margin-top: 0.4rem;
+}
+.pe-prose ul {
+  list-style: disc;
+  padding-left: 1.25rem;
+}
+.pe-prose ol {
+  list-style: decimal;
+  padding-left: 1.25rem;
+}
+.pe-prose h1,
+.pe-prose h2,
+.pe-prose h3 {
+  font-weight: 600;
+  margin-top: 0.5rem;
+}
+.pe-prose code {
+  border-radius: 0.25rem;
+  background: var(--muted);
+  padding: 0.05rem 0.3rem;
+  font-size: 0.85em;
+}
+.pe-prose pre {
+  border-radius: 0.375rem;
+  background: var(--muted);
+  padding: 0.5rem 0.6rem;
+  overflow-x: auto;
+}
+.pe-prose pre code {
+  background: transparent;
+  padding: 0;
+}
+.pe-prose blockquote {
+  border-left: 2px solid var(--border);
+  padding-left: 0.6rem;
+  color: var(--muted-foreground);
+}
+
+/* Token chips. A `data-token` kind tints the pill; all are non-editable atoms. */
+.pe-token {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 0.3rem;
+  padding: 0 0.3rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8em;
+  line-height: 1.4;
+  white-space: nowrap;
+  border: 1px solid transparent;
+}
+.pe-token[data-token='macro'] {
+  background: color-mix(in oklab, var(--primary) 18%, transparent);
+  color: var(--primary);
+  border-color: color-mix(in oklab, var(--primary) 35%, transparent);
+}
+.pe-token[data-token='action'] {
+  background: color-mix(in oklab, var(--primary) 12%, transparent);
+  color: var(--foreground);
+  border-color: var(--border);
+}
+.pe-token[data-token='reference'],
+.pe-token[data-token='project'] {
+  background: var(--accent);
+  color: var(--accent-foreground);
+  border-color: var(--border);
+}
+.ProseMirror-selectednode.pe-token {
+  outline: 2px solid var(--primary);
+}

--- a/packages/framework-dashboard/package.json
+++ b/packages/framework-dashboard/package.json
@@ -16,6 +16,11 @@
   },
   "dependencies": {
     "@gemstack/framework": "workspace:^",
+    "@tiptap/core": "^2.10.0",
+    "@tiptap/pm": "^2.10.0",
+    "@tiptap/react": "^2.10.0",
+    "@tiptap/starter-kit": "^2.10.0",
+    "@tiptap/suggestion": "^2.10.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.469.0",
@@ -23,6 +28,7 @@
     "react-dom": "^19.2.0",
     "tailwind-merge": "^2.6.0",
     "telefunc": "^0.2.5",
+    "tiptap-markdown": "^0.8.10",
     "vike": "^0.4.235",
     "vike-react": "^0.6.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,21 @@ importers:
       '@gemstack/framework':
         specifier: workspace:^
         version: link:../framework
+      '@tiptap/core':
+        specifier: ^2.10.0
+        version: 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm':
+        specifier: ^2.10.0
+        version: 2.27.2
+      '@tiptap/react':
+        specifier: ^2.10.0
+        version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tiptap/starter-kit':
+        specifier: ^2.10.0
+        version: 2.27.2
+      '@tiptap/suggestion':
+        specifier: ^2.10.0
+        version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -323,6 +338,9 @@ importers:
       telefunc:
         specifier: ^0.2.5
         version: 0.2.22(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(srvx@0.11.21)(vite@8.1.4(@types/node@20.19.43)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      tiptap-markdown:
+        specifier: ^0.8.10
+        version: 0.8.10(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
       vike:
         specifier: ^0.4.235
         version: 0.4.260(hono@4.12.27)(react-streaming@0.4.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(srvx@0.11.21)(vite@8.1.4(@types/node@20.19.43)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -1014,6 +1032,9 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@popperjs/core@2.11.8':
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -1040,6 +1061,9 @@ packages:
 
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
+  '@remirror/core-constants@3.0.0':
+    resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
 
   '@rolldown/binding-android-arm64@1.1.5':
     resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
@@ -1434,6 +1458,143 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@tiptap/core@2.27.2':
+    resolution: {integrity: sha512-ABL1N6eoxzDzC1bYvkMbvyexHacszsKdVPYqhl5GwHLOvpZcv9VE9QaKwDILTyz5voCA0lGcAAXZp+qnXOk5lQ==}
+    peerDependencies:
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-blockquote@2.27.2':
+    resolution: {integrity: sha512-oIGZgiAeA4tG3YxbTDfrmENL4/CIwGuP3THtHsNhwRqwsl9SfMk58Ucopi2GXTQSdYXpRJ0ahE6nPqB5D6j/Zw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-bold@2.27.2':
+    resolution: {integrity: sha512-bR7J5IwjCGQ0s3CIxyMvOCnMFMzIvsc5OVZKscTN5UkXzFsaY6muUAIqtKxayBUucjtUskm5qZowJITCeCb1/A==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-bubble-menu@2.27.2':
+    resolution: {integrity: sha512-VkwlCOcr0abTBGzjPXklJ92FCowG7InU8+Od9FyApdLNmn0utRYGRhw0Zno6VgE9EYr1JY4BRnuSa5f9wlR72w==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-bullet-list@2.27.2':
+    resolution: {integrity: sha512-gmFuKi97u5f8uFc/GQs+zmezjiulZmFiDYTh3trVoLRoc2SAHOjGEB7qxdx7dsqmMN7gwiAWAEVurLKIi1lnnw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-code-block@2.27.2':
+    resolution: {integrity: sha512-KgvdQHS4jXr79aU3wZOGBIZYYl9vCB7uDEuRFV4so2rYrfmiYMw3T8bTnlNEEGe4RUeAms1i4fdwwvQp9nR1Dw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-code@2.27.2':
+    resolution: {integrity: sha512-7X9AgwqiIGXoZX7uvdHQsGsjILnN/JaEVtqfXZnPECzKGaWHeK/Ao4sYvIIIffsyZJA8k5DC7ny2/0sAgr2TuA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-document@2.27.2':
+    resolution: {integrity: sha512-CFhAYsPnyYnosDC4639sCJnBUnYH4Cat9qH5NZWHVvdgtDwu8GZgZn2eSzaKSYXWH1vJ9DSlCK+7UyC3SNXIBA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-dropcursor@2.27.2':
+    resolution: {integrity: sha512-oEu/OrktNoQXq1x29NnH/GOIzQZm8ieTQl3FK27nxfBPA89cNoH4mFEUmBL5/OFIENIjiYG3qWpg6voIqzswNw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-floating-menu@2.27.2':
+    resolution: {integrity: sha512-GUN6gPIGXS7ngRJOwdSmtBRBDt9Kt9CM/9pSwKebhLJ+honFoNA+Y6IpVyDvvDMdVNgBchiJLs6qA5H97gAePQ==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-gapcursor@2.27.2':
+    resolution: {integrity: sha512-/c9VF1HBxj+AP54XGVgCmD9bEGYc5w5OofYCFQgM7l7PB1J00A4vOke0oPkHJnqnOOyPlFaxO/7N6l3XwFcnKA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-hard-break@2.27.2':
+    resolution: {integrity: sha512-kSRVGKlCYK6AGR0h8xRkk0WOFGXHIIndod3GKgWU49APuIGDiXd8sziXsSlniUsWmqgDmDXcNnSzPcV7AQ8YNg==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-heading@2.27.2':
+    resolution: {integrity: sha512-iM3yeRWuuQR/IRQ1djwNooJGfn9Jts9zF43qZIUf+U2NY8IlvdNsk2wTOdBgh6E0CamrStPxYGuln3ZS4fuglw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-history@2.27.2':
+    resolution: {integrity: sha512-+hSyqERoFNTWPiZx4/FCyZ/0eFqB9fuMdTB4AC/q9iwu3RNWAQtlsJg5230bf/qmyO6bZxRUc0k8p4hrV6ybAw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-horizontal-rule@2.27.2':
+    resolution: {integrity: sha512-WGWUSgX+jCsbtf9Y9OCUUgRZYuwjVoieW5n6mAUohJ9/6gc6sGIOrUpBShf+HHo6WD+gtQjRd+PssmX3NPWMpg==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
+  '@tiptap/extension-italic@2.27.2':
+    resolution: {integrity: sha512-1OFsw2SZqfaqx5Fa5v90iNlPRcqyt+lVSjBwTDzuPxTPFY4Q0mL89mKgkq2gVHYNCiaRkXvFLDxaSvBWbmthgg==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-list-item@2.27.2':
+    resolution: {integrity: sha512-eJNee7IEGXMnmygM5SdMGDC8m/lMWmwNGf9fPCK6xk0NxuQRgmZHL6uApKcdH6gyNcRPHCqvTTkhEP7pbny/fg==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-ordered-list@2.27.2':
+    resolution: {integrity: sha512-M7A4tLGJcLPYdLC4CI2Gwl8LOrENQW59u3cMVa+KkwG1hzSJyPsbDpa1DI6oXPC2WtYiTf22zrbq3gVvH+KA2w==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-paragraph@2.27.2':
+    resolution: {integrity: sha512-elYVn2wHJJ+zB9LESENWOAfI4TNT0jqEN34sMA/hCtA4im1ZG2DdLHwkHIshj/c4H0dzQhmsS/YmNC5Vbqab/A==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-strike@2.27.2':
+    resolution: {integrity: sha512-HHIjhafLhS2lHgfAsCwC1okqMsQzR4/mkGDm4M583Yftyjri1TNA7lzhzXWRFWiiMfJxKtdjHjUAQaHuteRTZw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-text-style@2.27.2':
+    resolution: {integrity: sha512-Omk+uxjJLyEY69KStpCw5fA9asvV+MGcAX2HOxyISDFoLaL49TMrNjhGAuz09P1L1b0KGXo4ml7Q3v/Lfy4WPA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/extension-text@2.27.2':
+    resolution: {integrity: sha512-Xk7nYcigljAY0GO9hAQpZ65ZCxqOqaAlTPDFcKerXmlkQZP/8ndx95OgUb1Xf63kmPOh3xypurGS2is3v0MXSA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+
+  '@tiptap/pm@2.27.2':
+    resolution: {integrity: sha512-kaEg7BfiJPDQMKbjVIzEPO3wlcA+pZb2tlcK9gPrdDnEFaec2QTF1sXz2ak2IIb2curvnIrQ4yrfHgLlVA72wA==}
+
+  '@tiptap/react@2.27.2':
+    resolution: {integrity: sha512-0EAs8Cpkfbvben1PZ34JN2Nd79Dhioynm2jML27DBbf1VWPk+FFWFGTMLUT0bu+Np5iVxio8fqV9t0mc4D6thA==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tiptap/starter-kit@2.27.2':
+    resolution: {integrity: sha512-bb0gJvPoDuyRUQ/iuN52j1//EtWWttw+RXAv1uJxfR0uKf8X7uAqzaOOgwjknoCIDC97+1YHwpGdnRjpDkOBxw==}
+
+  '@tiptap/suggestion@2.27.2':
+    resolution: {integrity: sha512-dQyvCIg0hcAVeh4fCIVCxogvbp+bF+GpbUb8sNlgnGrmHXnapGxzkvrlHnvneXZxLk/j7CxmBPKJNnm4Pbx4zw==}
+    peerDependencies:
+      '@tiptap/core': ^2.7.0
+      '@tiptap/pm': ^2.7.0
+
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
 
@@ -1479,14 +1640,23 @@ packages:
   '@types/jsdom@28.0.3':
     resolution: {integrity: sha512-/HQ2uFoetFTXuye8vzIcHw2z6Fwi7Hi/qcgC+RoS9NCyewiqxhVGqlG+ViGB6lkax481R6dmhf1I7lIGlzJStQ==}
 
+  '@types/linkify-it@3.0.5':
+    resolution: {integrity: sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==}
+
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@13.0.9':
+    resolution: {integrity: sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==}
 
   '@types/markdown-it@14.1.2':
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@1.0.5':
+    resolution: {integrity: sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==}
 
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
@@ -1513,6 +1683,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
@@ -1901,6 +2074,9 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  crelt@1.0.7:
+    resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1992,6 +2168,10 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
@@ -2030,6 +2210,10 @@ packages:
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -2434,6 +2618,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -2465,6 +2652,13 @@ packages:
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
 
+  markdown-it-task-lists@2.1.1:
+    resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
+
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2474,6 +2668,9 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -2594,6 +2791,9 @@ packages:
       zod:
         optional: true
 
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
@@ -2700,6 +2900,64 @@ packages:
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
+  prosemirror-changeset@2.4.1:
+    resolution: {integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==}
+
+  prosemirror-collab@1.3.1:
+    resolution: {integrity: sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==}
+
+  prosemirror-commands@1.7.1:
+    resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
+
+  prosemirror-dropcursor@1.8.3:
+    resolution: {integrity: sha512-FoYbsJR8gK+DGlqhNoE29Loa38eIZPzQRIb1VMaDNBoo4OLP6vVof/jR8qFY/6XvUd6Dhug8MDCHl2a/h8RTfQ==}
+
+  prosemirror-gapcursor@1.4.1:
+    resolution: {integrity: sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==}
+
+  prosemirror-history@1.5.0:
+    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
+
+  prosemirror-inputrules@1.5.1:
+    resolution: {integrity: sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==}
+
+  prosemirror-keymap@1.2.3:
+    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
+
+  prosemirror-markdown@1.13.5:
+    resolution: {integrity: sha512-ac8trNQ01ybKDRTcfUc56LZufG3oYyU4N25qSXgp8dS0U4JtzzCj7oQlKu5v09VSmS5IseYoQ2yDkTbo7f7D8Q==}
+
+  prosemirror-menu@1.3.2:
+    resolution: {integrity: sha512-6VgUJTYod0nMBlCaYJGhXGLu7Gt4AvcwcOq0YfJCY/6Uh+3S7UsWhpy6rJFCBFOmonq1hD8KyWOtZhkppd4YPg==}
+
+  prosemirror-model@1.25.11:
+    resolution: {integrity: sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==}
+
+  prosemirror-schema-basic@1.2.4:
+    resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
+
+  prosemirror-schema-list@1.5.1:
+    resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
+
+  prosemirror-state@1.4.4:
+    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
+
+  prosemirror-tables@1.8.5:
+    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
+
+  prosemirror-trailing-node@3.0.0:
+    resolution: {integrity: sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==}
+    peerDependencies:
+      prosemirror-model: ^1.22.1
+      prosemirror-state: ^1.4.2
+      prosemirror-view: ^1.33.8
+
+  prosemirror-transform@1.12.0:
+    resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==}
+
+  prosemirror-view@1.42.1:
+    resolution: {integrity: sha512-rRqzZnRgkyh69XoOMrfFJHwauHscLBmHbq772kwbic1ymQAM8gXjzEbJse5j1ep2UO2HRIAQL0bY3kZ/RoqjVw==}
+
   protobufjs@7.6.4:
     resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
     engines: {node: '>=12.0.0'}
@@ -2707,6 +2965,10 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2794,6 +3056,9 @@ packages:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rope-sequence@1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
   rou3@0.8.1:
     resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
@@ -2971,6 +3236,14 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  tippy.js@6.3.7:
+    resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
+
+  tiptap-markdown@0.8.10:
+    resolution: {integrity: sha512-iDVkR2BjAqkTDtFX0h94yVvE2AihCXlF0Q7RIXSJPRSR5I0PA1TMuAg6FHFpmqTn4tPxJ0by0CK7PUMlnFLGEQ==}
+    peerDependencies:
+      '@tiptap/core': ^2.0.3
+
   tldts-core@7.4.7:
     resolution: {integrity: sha512-rNlAI8fKn/JckBMUSbNL/ES2kmDiurWaE49l+ikwEc9A6lFR7gMx9AhgQMQKBK4H5w4pKLH64JzZfB99uRsGNQ==}
 
@@ -3028,6 +3301,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -3066,6 +3342,11 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -3207,6 +3488,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -4058,6 +4342,8 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@popperjs/core@2.11.8': {}
+
   '@protobufjs/aspromise@1.1.2':
     optional: true
 
@@ -4086,6 +4372,8 @@ snapshots:
 
   '@protobufjs/utf8@1.1.1':
     optional: true
+
+  '@remirror/core-constants@3.0.0': {}
 
   '@rolldown/binding-android-arm64@1.1.5':
     optional: true
@@ -4379,6 +4667,165 @@ snapshots:
       tailwindcss: 4.3.2
       vite: 8.1.4(@types/node@20.19.43)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
+  '@tiptap/core@2.27.2(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/pm': 2.27.2
+
+  '@tiptap/extension-blockquote@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-bold@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-bubble-menu@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+      tippy.js: 6.3.7
+
+  '@tiptap/extension-bullet-list@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-code-block@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+
+  '@tiptap/extension-code@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-document@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-dropcursor@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+
+  '@tiptap/extension-floating-menu@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+      tippy.js: 6.3.7
+
+  '@tiptap/extension-gapcursor@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+
+  '@tiptap/extension-hard-break@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-heading@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-history@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+
+  '@tiptap/extension-horizontal-rule@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+
+  '@tiptap/extension-italic@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-list-item@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-ordered-list@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-paragraph@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-strike@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-text-style@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/extension-text@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+
+  '@tiptap/pm@2.27.2':
+    dependencies:
+      prosemirror-changeset: 2.4.1
+      prosemirror-collab: 1.3.1
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.3
+      prosemirror-gapcursor: 1.4.1
+      prosemirror-history: 1.5.0
+      prosemirror-inputrules: 1.5.1
+      prosemirror-keymap: 1.2.3
+      prosemirror-markdown: 1.13.5
+      prosemirror-menu: 1.3.2
+      prosemirror-model: 1.25.11
+      prosemirror-schema-basic: 1.2.4
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.1)
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.1
+
+  '@tiptap/react@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/extension-bubble-menu': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
+      '@tiptap/extension-floating-menu': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+      '@types/use-sync-external-store': 0.0.6
+      fast-deep-equal: 3.1.3
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+
+  '@tiptap/starter-kit@2.27.2':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/extension-blockquote': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-bold': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-bullet-list': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-code': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-code-block': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
+      '@tiptap/extension-document': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-dropcursor': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
+      '@tiptap/extension-gapcursor': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
+      '@tiptap/extension-hard-break': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-heading': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-history': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
+      '@tiptap/extension-horizontal-rule': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
+      '@tiptap/extension-italic': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-list-item': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-ordered-list': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-paragraph': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-strike': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-text': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/extension-text-style': 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))
+      '@tiptap/pm': 2.27.2
+
+  '@tiptap/suggestion@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)':
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@tiptap/pm': 2.27.2
+
   '@ts-morph/common@0.27.0':
     dependencies:
       fast-glob: 3.3.3
@@ -4421,7 +4868,14 @@ snapshots:
       parse5: 8.0.1
       undici-types: 7.28.0
 
+  '@types/linkify-it@3.0.5': {}
+
   '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@13.0.9':
+    dependencies:
+      '@types/linkify-it': 3.0.5
+      '@types/mdurl': 1.0.5
 
   '@types/markdown-it@14.1.2':
     dependencies:
@@ -4431,6 +4885,8 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/mdurl@1.0.5': {}
 
   '@types/mdurl@2.0.0': {}
 
@@ -4454,6 +4910,8 @@ snapshots:
   '@types/tough-cookie@4.0.5': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/web-bluetooth@0.0.21': {}
 
@@ -4818,6 +5276,8 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  crelt@1.0.7: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -4897,6 +5357,8 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
+  entities@4.5.0: {}
+
   entities@7.0.1: {}
 
   entities@8.0.0: {}
@@ -4951,6 +5413,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
+
+  escape-string-regexp@4.0.0: {}
 
   esprima@4.0.1: {}
 
@@ -5399,6 +5863,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -5427,6 +5895,17 @@ snapshots:
 
   mark.js@8.11.1: {}
 
+  markdown-it-task-lists@2.1.1: {}
+
+  markdown-it@14.3.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   math-intrinsics@1.1.0: {}
 
   mdast-util-to-hast@13.2.1:
@@ -5442,6 +5921,8 @@ snapshots:
       vfile: 6.0.3
 
   mdn-data@2.27.1: {}
+
+  mdurl@2.0.0: {}
 
   media-typer@1.1.0: {}
 
@@ -5539,6 +6020,8 @@ snapshots:
       zod: 4.4.3
     optional: true
 
+  orderedmap@2.1.1: {}
+
   outdent@0.5.0: {}
 
   p-filter@2.1.0:
@@ -5618,6 +6101,109 @@ snapshots:
 
   property-information@7.2.0: {}
 
+  prosemirror-changeset@2.4.1:
+    dependencies:
+      prosemirror-transform: 1.12.0
+
+  prosemirror-collab@1.3.1:
+    dependencies:
+      prosemirror-state: 1.4.4
+
+  prosemirror-commands@1.7.1:
+    dependencies:
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-dropcursor@1.8.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.1
+
+  prosemirror-gapcursor@1.4.1:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.42.1
+
+  prosemirror-history@1.5.0:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.1
+      rope-sequence: 1.3.4
+
+  prosemirror-inputrules@1.5.1:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-keymap@1.2.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      w3c-keyname: 2.2.8
+
+  prosemirror-markdown@1.13.5:
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.3.0
+      prosemirror-model: 1.25.11
+
+  prosemirror-menu@1.3.2:
+    dependencies:
+      crelt: 1.0.7
+      prosemirror-commands: 1.7.1
+      prosemirror-history: 1.5.0
+      prosemirror-state: 1.4.4
+
+  prosemirror-model@1.25.11:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-schema-basic@1.2.4:
+    dependencies:
+      prosemirror-model: 1.25.11
+
+  prosemirror-schema-list@1.5.1:
+    dependencies:
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-state@1.4.4:
+    dependencies:
+      prosemirror-model: 1.25.11
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.1
+
+  prosemirror-tables@1.8.5:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.1
+
+  prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.1):
+    dependencies:
+      '@remirror/core-constants': 3.0.0
+      escape-string-regexp: 4.0.0
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.42.1
+
+  prosemirror-transform@1.12.0:
+    dependencies:
+      prosemirror-model: 1.25.11
+
+  prosemirror-view@1.42.1:
+    dependencies:
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
   protobufjs@7.6.4:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -5637,6 +6223,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -5763,6 +6351,8 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.62.2
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
+
+  rope-sequence@1.3.4: {}
 
   rou3@0.8.1: {}
 
@@ -5958,6 +6548,18 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tippy.js@6.3.7:
+    dependencies:
+      '@popperjs/core': 2.11.8
+
+  tiptap-markdown@0.8.10(@tiptap/core@2.27.2(@tiptap/pm@2.27.2)):
+    dependencies:
+      '@tiptap/core': 2.27.2(@tiptap/pm@2.27.2)
+      '@types/markdown-it': 13.0.9
+      markdown-it: 14.3.0
+      markdown-it-task-lists: 2.1.1
+      prosemirror-markdown: 1.13.5
+
   tldts-core@7.4.7: {}
 
   tldts@7.4.7:
@@ -6016,6 +6618,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  uc.micro@2.1.0: {}
+
   undici-types@6.21.0: {}
 
   undici-types@7.28.0: {}
@@ -6054,6 +6658,10 @@ snapshots:
       browserslist: 4.28.5
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  use-sync-external-store@1.6.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   vary@1.1.2: {}
 
@@ -6205,6 +6813,8 @@ snapshots:
       '@vue/shared': 3.5.39
     optionalDependencies:
       typescript: 5.9.3
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
Closes #470.

## What

Swaps the dashboard's Start-a-run `<textarea>` for a Tiptap rich editor with three trigger menus:

- **`/` = commands** — load a preset (`/research`, `/readability`, …) or insert an agent action (`showChoices()`, `showMultiSelect()`, `showMarkdown()`).
- **`<` = tags** — the repeated agent macros, which all read as `<NAME>` (`<AWAIT>`, `<REVIEW_FILE>`, `<TODO_FILE>`, `<SESSION_NAME>`, `<PLAN_FILE>`, `<FUNCTION>`).
- **`@` = projects** — the registered projects; a mention also adds that repo to the run **context** (unifies with the #439 context selector).

Inserted tokens render as **chips** but serialize back to the **exact plain text** the agent already parses, so the run contract, presets, options, and context are all unchanged. Markdown is live (StarterKit shortcuts) and round-trips via `tiptap-markdown`, so loading a preset chip-ifies its tags while the text comes back essentially verbatim.

Typing a complete token by hand also converts it: `<await>` becomes an `AWAIT` chip the moment the `>` lands (case is normalized to the canonical `<AWAIT>`), and `showMultiSelect()` converts when the `)` lands.

## Design notes

The insight from the issue discussion: the preset prompts are templates full of *repeated tokens* (`<REVIEW_FILE>`, `<AWAIT>`, `showMultiSelect()`), not file paths. So the editor makes those first-class. Since every tag reads as `<NAME>`, they're triggered by `<` rather than folded into `@`; `@` stays projects-only.

The suggestion menu is a lightweight shadcn-styled popover surface (a fixed portal at the caret) because `@tiptap/suggestion` drives positioning imperatively. It repositions on scroll/resize so it tracks the caret, and hides when nothing matches (plus a space ends the suggestion), so a stray `<` in prose is not a trap.

## Verify

- Both packages typecheck; dashboard builds + prerenders clean (SSR-safe via `immediatelyRender: false`).
- Headless round-trip (jsdom + the real `tokens.ts`/`tokenize.ts` + the real Research preset): all tags (`<REVIEW_FILE>`, `<TODO_FILE>`, `<AWAIT>`, `<SESSION_NAME>`, `showMultiSelect()`) survive un-escaped; body bullets and the line-per-line definition block are preserved (`breaks: true`); code spans like `` `...<SESSION_NAME>.agent.md` `` stay verbatim (the tokenizer skips inline code).
- Headless keystroke simulation: typing `<await>` serializes to exactly `<AWAIT>` (single chip, no leftover delimiters); `showMultiSelect()` converts mid-sentence.
- Ran on the bundled daemon; the served bundle carries the editor (ProseMirror + tiptap + chips).

## Follow-ups (phase 2)
- `@file` workspace file search (new daemon RPC).
- `@pr` / `this PR` auto-detect via `git`/`gh`.
- Param chips (`<PARAM:what>`) as click-to-edit fill-in fields.