### PR TITLE
feat(framework): dashboard "Open on GitHub" button

### DIFF
--- a/.changeset/project-open-on-github.md
+++ b/.changeset/project-open-on-github.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Add an "Open on GitHub" button to the dashboard project panel. When the repo has a github.com `origin` remote, the panel shows a one-click link to it (backed by a new `onGithubUrl` read that normalizes the ssh/https remote forms). Hidden when there is no GitHub remote, so it never shows empty.

--- a/packages/framework-dashboard/components/ProjectActions.tsx
+++ b/packages/framework-dashboard/components/ProjectActions.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import { Github } from 'lucide-react'
+import { onGithubUrl } from '../server/reads.telefunc.js'
+import { Button } from './ui/button.js'
+
+// Project-panel quick actions (#488). For now just "Open on GitHub" (#489): when the repo has
+// a github.com origin remote, a one-click link to it. Hidden entirely when there is no GitHub
+// remote (or on the relay, where there is no local checkout), so the bar never shows empty.
+export function ProjectActions({ projectId }: { projectId: string }) {
+  const [githubUrl, setGithubUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    let live = true
+    setGithubUrl(null)
+    void onGithubUrl(projectId).then(url => live && setGithubUrl(url))
+    return () => {
+      live = false
+    }
+  }, [projectId])
+
+  if (!githubUrl) return null
+
+  return (
+    <div className="flex items-center gap-2 border-b border-border px-4 py-2">
+      <a href={githubUrl} target="_blank" rel="noreferrer" title={githubUrl}>
+        <Button variant="outline" size="sm" className="gap-1.5">
+          <Github className="h-4 w-4" /> Open on GitHub
+        </Button>
+      </a>
+    </div>
+  )
+}

--- a/packages/framework-dashboard/components/ProjectHome.tsx
+++ b/packages/framework-dashboard/components/ProjectHome.tsx
@@ -1,5 +1,6 @@
 import type { FrameworkEvent } from '@gemstack/framework'
 import { StartRunForm } from './StartRunForm.js'
+import { ProjectActions } from './ProjectActions.js'
 import { PreviewBar } from './PreviewBar.js'
 import { RunOverview } from './RunOverview.js'
 
@@ -18,6 +19,7 @@ export function ProjectHome({
 }) {
   return (
     <>
+      <ProjectActions projectId={projectId} />
       <PreviewBar projectId={projectId} />
       <StartRunForm projectId={projectId} onRunStarted={onRunStarted} />
       {events.length > 0 && <RunOverview events={events} />}

--- a/packages/framework-dashboard/server/reads.telefunc.ts
+++ b/packages/framework-dashboard/server/reads.telefunc.ts
@@ -3,4 +3,4 @@
 // the client bakes the RPC key `/server/reads.telefunc.ts` — the exact key the daemon
 // registers the impls under (see framework's dashboard-rpc/register.ts). The telefunc
 // Vite transform turns these named re-exports into client RPC stubs.
-export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard } from '@gemstack/framework/dashboard-rpc'
+export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl } from '@gemstack/framework/dashboard-rpc'

--- a/packages/framework/src/dashboard-rpc/index.ts
+++ b/packages/framework/src/dashboard-rpc/index.ts
@@ -2,7 +2,7 @@
 // implementations live here in @gemstack/framework so `sendStart` (added with the serve
 // wiring) can reach the daemon's `startRun`; the framework-dashboard client imports
 // these through thin re-export shims so the baked RPC keys stay `/server/*.telefunc.ts`.
-export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard } from './reads.telefunc.js'
+export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl } from './reads.telefunc.js'
 export { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus } from './control.telefunc.js'
 export { onEvents } from './events.telefunc.js'
 export { onProjects, sendAddProject } from './projects.telefunc.js'

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -4,6 +4,7 @@ import { readDocs, type WorkspaceDoc } from '../dashboard/docs.js'
 import { collectQueue, type ProjectQueue } from '../dashboard/queue.js'
 import { buildOverview, type Overview } from '../dashboard/overview.js'
 import { buildDashboard, type DashboardData } from '../dashboard/dashboard.js'
+import { githubUrlFor } from '../dashboard/github.js'
 import { contextProjects } from './context.js'
 import type { FrameworkEvent } from '../events.js'
 
@@ -73,4 +74,11 @@ export async function onOverview(): Promise<Overview> {
 export async function onDashboard(): Promise<DashboardData> {
   const projects = await contextProjects().list().catch(() => [])
   return buildDashboard(projects)
+}
+
+/** The project's GitHub URL from its `origin` remote (#489), or null (no remote / not GitHub / relay). */
+export async function onGithubUrl(projectId: string): Promise<string | null> {
+  const cwd = await projectPath(projectId)
+  if (!cwd) return null
+  return (await githubUrlFor(cwd)) ?? null
 }

--- a/packages/framework/src/dashboard-rpc/register.ts
+++ b/packages/framework/src/dashboard-rpc/register.ts
@@ -1,5 +1,5 @@
 import { __decorateTelefunction } from 'telefunc'
-import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard } from './reads.telefunc.js'
+import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl } from './reads.telefunc.js'
 import { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus } from './control.telefunc.js'
 import { onEvents } from './events.telefunc.js'
 import { onProjects, sendAddProject } from './projects.telefunc.js'
@@ -38,6 +38,7 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(onQueue, 'onQueue', reads)
   reg(onOverview, 'onOverview', reads)
   reg(onDashboard, 'onDashboard', reads)
+  reg(onGithubUrl, 'onGithubUrl', reads)
   reg(sendStop, 'sendStop', control)
   reg(sendChoice, 'sendChoice', control)
   reg(sendStart, 'sendStart', control)

--- a/packages/framework/src/dashboard/github.test.ts
+++ b/packages/framework/src/dashboard/github.test.ts
@@ -1,0 +1,34 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { githubUrlFromRemote, githubUrlFor } from './github.js'
+
+test('githubUrlFromRemote normalizes the common remote forms', () => {
+  const expected = 'https://github.com/gemstack-land/gemstack'
+  assert.equal(githubUrlFromRemote('git@github.com:gemstack-land/gemstack.git'), expected)
+  assert.equal(githubUrlFromRemote('git@github.com:gemstack-land/gemstack'), expected)
+  assert.equal(githubUrlFromRemote('ssh://git@github.com/gemstack-land/gemstack.git'), expected)
+  assert.equal(githubUrlFromRemote('https://github.com/gemstack-land/gemstack.git'), expected)
+  assert.equal(githubUrlFromRemote('https://github.com/gemstack-land/gemstack'), expected)
+  assert.equal(githubUrlFromRemote('https://user@github.com/gemstack-land/gemstack.git\n'), expected)
+})
+
+test('githubUrlFromRemote returns undefined for non-GitHub or junk remotes', () => {
+  assert.equal(githubUrlFromRemote('git@gitlab.com:o/r.git'), undefined)
+  assert.equal(githubUrlFromRemote('https://example.com/o/r.git'), undefined)
+  assert.equal(githubUrlFromRemote('https://github.com/'), undefined)
+  assert.equal(githubUrlFromRemote('https://github.com/only-owner'), undefined)
+  assert.equal(githubUrlFromRemote(''), undefined)
+})
+
+test('githubUrlFor reads origin and returns undefined when git fails', async () => {
+  assert.equal(
+    await githubUrlFor('/x', async () => 'git@github.com:gemstack-land/gemstack.git\n'),
+    'https://github.com/gemstack-land/gemstack',
+  )
+  assert.equal(
+    await githubUrlFor('/x', async () => {
+      throw new Error('no origin')
+    }),
+    undefined,
+  )
+})

--- a/packages/framework/src/dashboard/github.ts
+++ b/packages/framework/src/dashboard/github.ts
@@ -1,0 +1,33 @@
+import { nodeGitRunner, type GitRunner } from '../project.js'
+
+// The project panel's "Open on GitHub" (#489, part of #488). Derives the repo's github.com
+// URL from its `origin` remote so the panel can link straight to it. A read of git state,
+// safe anywhere — the relay has no local checkout, so it resolves to nothing there.
+
+/**
+ * Normalize a git remote URL to an `https://github.com/<owner>/<repo>` URL, or undefined when
+ * it is not a GitHub remote. Handles the scp-style (`git@github.com:o/r.git`), ssh
+ * (`ssh://git@github.com/o/r.git`), and https (`https://github.com/o/r.git`) forms, dropping
+ * a `.git` suffix, an embedded credential, and a trailing slash.
+ */
+export function githubUrlFromRemote(remote: string): string | undefined {
+  const url = remote.trim()
+  const match =
+    url.match(/^git@github\.com:(.+?)$/) ||
+    url.match(/^ssh:\/\/git@github\.com\/(.+?)$/) ||
+    url.match(/^https?:\/\/(?:[^@/]+@)?github\.com\/(.+?)$/)
+  if (!match || !match[1]) return undefined
+  const slug = match[1].replace(/\.git$/, '').replace(/\/$/, '')
+  // Guard against a junk capture: a GitHub slug is `owner/repo`, both non-empty.
+  if (!/^[^/]+\/[^/]+$/.test(slug)) return undefined
+  return `https://github.com/${slug}`
+}
+
+/** The repo's GitHub URL from its `origin` remote, or undefined (no remote / not GitHub). */
+export async function githubUrlFor(cwd: string, git: GitRunner = nodeGitRunner()): Promise<string | undefined> {
+  try {
+    return githubUrlFromRemote(await git(['remote', 'get-url', 'origin'], cwd))
+  } catch {
+    return undefined
+  }
+}


### PR DESCRIPTION
Closes #489. Part of #488.

## What

When the selected project's repo has a github.com `origin` remote, the project panel shows a one-click **Open on GitHub** button (with the GitHub icon). It is hidden when there is no GitHub remote, so the bar never shows empty.

## How

- New `githubUrlFromRemote` / `githubUrlFor` (in `dashboard/github.ts`) normalize the scp-style (`git@github.com:o/r.git`), ssh, and https remote forms to `https://github.com/<owner>/<repo>`, dropping `.git`, an embedded credential, and a trailing slash; junk / non-GitHub remotes return undefined.
- New `onGithubUrl(projectId)` read (registered like the other dashboard reads). Works anywhere and is safe on the relay: no local checkout there, so it resolves to `null`.
- New `ProjectActions` component in the project panel (extensible for the rest of #488). Renders nothing when there is no URL.

## Verify

- Unit tests for the remote-form normalization (scp/ssh/https, `.git`, credential, trailing newline, non-GitHub, junk); full framework dashboard suite green (27); both packages typecheck; dashboard builds + prerenders clean.
- Live on the bundled daemon: the two GitHub-remote projects resolve to `https://github.com/gemstack-land/gemstack`, and a local-only project returns `null` (button hidden).