### PR TITLE
feat(framework): dashboard "Open folder" / "Open in editor" project actions

### DIFF
--- a/.changeset/project-open-in-app.md
+++ b/.changeset/project-open-in-app.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Add "Open folder" and "Open in editor" buttons to the dashboard project panel (localhost-only). The daemon spawns the OS file manager (open / xdg-open / explorer) or an editor (the `code` CLI, or `$FRAMEWORK_EDITOR`) on the project's own path. A missing command surfaces a friendly error. Safe on a public host: no local checkout to resolve, so nothing is spawned.

--- a/packages/framework-dashboard/components/ProjectActions.tsx
+++ b/packages/framework-dashboard/components/ProjectActions.tsx
@@ -1,32 +1,71 @@
 import { useEffect, useState } from 'react'
-import { Github } from 'lucide-react'
+import { Github, FolderOpen, Code } from 'lucide-react'
 import { onGithubUrl } from '../server/reads.telefunc.js'
+import { sendOpenInApp } from '../server/control.telefunc.js'
 import { Button } from './ui/button.js'
 
-// Project-panel quick actions (#488). For now just "Open on GitHub" (#489): when the repo has
-// a github.com origin remote, a one-click link to it. Hidden entirely when there is no GitHub
-// remote (or on the relay, where there is no local checkout), so the bar never shows empty.
+// Project-panel quick actions (#488). "Open on GitHub" (#489) when the repo has a github.com
+// remote, plus localhost-only "Open folder" / "Open in editor" (#490) that ask the daemon to
+// spawn the OS file manager / editor on the project's path. This bar only renders in the local
+// dashboard (the relay shows RelayView instead), so the localhost actions never appear there.
 export function ProjectActions({ projectId }: { projectId: string }) {
   const [githubUrl, setGithubUrl] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     let live = true
     setGithubUrl(null)
+    setError(null)
     void onGithubUrl(projectId).then(url => live && setGithubUrl(url))
     return () => {
       live = false
     }
   }, [projectId])
 
-  if (!githubUrl) return null
+  const open = async (target: 'files' | 'editor') => {
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await sendOpenInApp(projectId, target)
+      if (!result.ok) setError(result.error)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to open.')
+    } finally {
+      setBusy(false)
+    }
+  }
 
   return (
-    <div className="flex items-center gap-2 border-b border-border px-4 py-2">
-      <a href={githubUrl} target="_blank" rel="noreferrer" title={githubUrl}>
-        <Button variant="outline" size="sm" className="gap-1.5">
-          <Github className="h-4 w-4" /> Open on GitHub
-        </Button>
-      </a>
+    <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-2">
+      {githubUrl && (
+        <a href={githubUrl} target="_blank" rel="noreferrer" title={githubUrl}>
+          <Button variant="outline" size="sm" className="gap-1.5">
+            <Github className="h-4 w-4" /> Open on GitHub
+          </Button>
+        </a>
+      )}
+      <Button
+        variant="outline"
+        size="sm"
+        className="gap-1.5"
+        disabled={busy}
+        title="Reveal the repo in your file manager (Finder / Explorer)"
+        onClick={() => void open('files')}
+      >
+        <FolderOpen className="h-4 w-4" /> Open folder
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        className="gap-1.5"
+        disabled={busy}
+        title="Open the repo in your editor (code, or $FRAMEWORK_EDITOR)"
+        onClick={() => void open('editor')}
+      >
+        <Code className="h-4 w-4" /> Open in editor
+      </Button>
+      {error && <p className="w-full text-xs text-red-500">{error}</p>}
     </div>
   )
 }

--- a/packages/framework-dashboard/server/control.telefunc.ts
+++ b/packages/framework-dashboard/server/control.telefunc.ts
@@ -1,4 +1,4 @@
 // Re-export shim (#405): the steering telefunctions live in @gemstack/framework so the
 // daemon serves them in-process. The file path keeps the baked RPC key
 // `/server/control.telefunc.ts`. See framework's dashboard-rpc/register.ts.
-export { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus } from '@gemstack/framework/dashboard-rpc'
+export { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus, sendOpenInApp } from '@gemstack/framework/dashboard-rpc'

--- a/packages/framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/control.telefunc.ts
@@ -1,5 +1,6 @@
 import { getContext } from 'telefunc'
 import { appendControl } from '../control.js'
+import { openInApp, type OpenTarget, type OpenResult } from '../dashboard/open-in-app.js'
 import { contextProjects } from './context.js'
 import type { ChoiceBy } from '../events.js'
 import type { PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from '../dashboard/server.js'
@@ -83,4 +84,15 @@ export async function onPreviewStatus(projectId: string): Promise<PreviewStatus>
   const { preview } = getContext<DashboardContext>()
   if (!preview) return { running: false }
   return preview.status(projectId)
+}
+
+/**
+ * Open a project in the OS file manager or an editor (#490). Localhost-only: the daemon
+ * spawns a local command against the project's own registered path. A public host has no
+ * local path to resolve, so it returns an error rather than spawning anything.
+ */
+export async function sendOpenInApp(projectId: string, target: OpenTarget): Promise<OpenResult> {
+  const cwd = await projectPath(projectId)
+  if (!cwd) return { ok: false, error: 'this project has no local path on this server' }
+  return openInApp(cwd, target)
 }

--- a/packages/framework/src/dashboard-rpc/index.ts
+++ b/packages/framework/src/dashboard-rpc/index.ts
@@ -3,7 +3,7 @@
 // wiring) can reach the daemon's `startRun`; the framework-dashboard client imports
 // these through thin re-export shims so the baked RPC keys stay `/server/*.telefunc.ts`.
 export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl, onGitStatus } from './reads.telefunc.js'
-export { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus } from './control.telefunc.js'
+export { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
 export { onEvents } from './events.telefunc.js'
 export { onProjects, sendAddProject } from './projects.telefunc.js'
 export { onPreferences, savePreferences, type SavePreferencesResult } from './preferences.telefunc.js'

--- a/packages/framework/src/dashboard-rpc/register.ts
+++ b/packages/framework/src/dashboard-rpc/register.ts
@@ -1,6 +1,6 @@
 import { __decorateTelefunction } from 'telefunc'
 import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl, onGitStatus } from './reads.telefunc.js'
-import { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus } from './control.telefunc.js'
+import { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
 import { onEvents } from './events.telefunc.js'
 import { onProjects, sendAddProject } from './projects.telefunc.js'
 import { onPreferences, savePreferences } from './preferences.telefunc.js'
@@ -46,6 +46,7 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(sendPreview, 'sendPreview', control)
   reg(sendStopPreview, 'sendStopPreview', control)
   reg(onPreviewStatus, 'onPreviewStatus', control)
+  reg(sendOpenInApp, 'sendOpenInApp', control)
   reg(onEvents, 'onEvents', events)
   reg(onProjects, 'onProjects', projects)
   reg(sendAddProject, 'sendAddProject', projects)

--- a/packages/framework/src/dashboard/open-in-app.test.ts
+++ b/packages/framework/src/dashboard/open-in-app.test.ts
@@ -1,0 +1,35 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { fileManagerCommand, editorCommand, openInApp } from './open-in-app.js'
+
+test('fileManagerCommand picks the OS reveal command', () => {
+  assert.deepEqual(fileManagerCommand('/p', 'darwin'), { command: 'open', args: ['/p'] })
+  assert.deepEqual(fileManagerCommand('/p', 'win32'), { command: 'explorer', args: ['/p'] })
+  assert.deepEqual(fileManagerCommand('/p', 'linux'), { command: 'xdg-open', args: ['/p'] })
+})
+
+test('editorCommand defaults to code, honoring $FRAMEWORK_EDITOR', () => {
+  assert.deepEqual(editorCommand('/p', undefined), { command: 'code', args: ['/p'] })
+  assert.deepEqual(editorCommand('/p', '  '), { command: 'code', args: ['/p'] })
+  assert.deepEqual(editorCommand('/p', 'subl'), { command: 'subl', args: ['/p'] })
+})
+
+test('openInApp returns ok on a successful spawn and reports the command run', async () => {
+  const calls: { command: string; args: string[] }[] = []
+  const result = await openInApp('/repo', 'files', async (command, args) => {
+    calls.push({ command, args })
+  })
+  assert.deepEqual(result, { ok: true })
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0]!.args[0], '/repo')
+})
+
+test('openInApp reports a friendly error when the command is missing', async () => {
+  const result = await openInApp('/repo', 'editor', async () => {
+    const err = new Error('spawn code ENOENT') as NodeJS.ErrnoException
+    err.code = 'ENOENT'
+    throw err
+  })
+  assert.equal(result.ok, false)
+  assert.match((result as { error: string }).error, /not be found|not found/i)
+})

--- a/packages/framework/src/dashboard/open-in-app.ts
+++ b/packages/framework/src/dashboard/open-in-app.ts
@@ -1,0 +1,61 @@
+import { platform } from 'node:os'
+
+// The project panel's "Open in Finder / editor" (#490, part of #488). Localhost-only: the
+// daemon spawns a local command to reveal the repo in the OS file manager or open it in an
+// editor. The path is the project's own registered path (never client input), and a public
+// host has no local checkout to resolve, so there is nothing to spawn there.
+
+/** Which app to open the project in. */
+export type OpenTarget = 'files' | 'editor'
+
+/** The outcome of an open attempt. */
+export type OpenResult = { ok: true } | { ok: false; error: string }
+
+/** Spawns a command, resolving once it launches (not on exit) and rejecting if it can't start. */
+export type SpawnRunner = (command: string, args: string[]) => Promise<void>
+
+/**
+ * A {@link SpawnRunner} backed by `spawn`, detached. Resolves on the `spawn` event so a
+ * long-lived editor (or `explorer`, which exits non-zero even on success) does not block or
+ * error; rejects on the `error` event (e.g. ENOENT when the command is not on PATH).
+ */
+export function nodeSpawnRunner(): SpawnRunner {
+  return (command, args) =>
+    new Promise((resolve, reject) => {
+      void import('node:child_process').then(({ spawn }) => {
+        const child = spawn(command, args, { stdio: 'ignore', detached: true })
+        child.on('error', reject)
+        child.on('spawn', () => {
+          child.unref()
+          resolve()
+        })
+      })
+    })
+}
+
+/** The OS command that reveals a path in the file manager. */
+export function fileManagerCommand(path: string, os: NodeJS.Platform = platform()): { command: string; args: string[] } {
+  if (os === 'darwin') return { command: 'open', args: [path] }
+  if (os === 'win32') return { command: 'explorer', args: [path] }
+  return { command: 'xdg-open', args: [path] }
+}
+
+/** The command to open a path in an editor: `$FRAMEWORK_EDITOR` when set, else the VS Code CLI. */
+export function editorCommand(path: string, editor = process.env.FRAMEWORK_EDITOR): { command: string; args: string[] } {
+  const bin = editor && editor.trim() ? editor.trim() : 'code'
+  return { command: bin, args: [path] }
+}
+
+/** Open the project at `cwd` in the file manager or an editor. Failures are values, never throws. */
+export async function openInApp(cwd: string, target: OpenTarget, run: SpawnRunner = nodeSpawnRunner()): Promise<OpenResult> {
+  const { command, args } = target === 'editor' ? editorCommand(cwd) : fileManagerCommand(cwd)
+  try {
+    await run(command, args)
+    return { ok: true }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException | undefined)?.code === 'ENOENT') {
+      return { ok: false, error: `"${command}" was not found on PATH` }
+    }
+    return { ok: false, error: err instanceof Error ? err.message : 'failed to open' }
+  }
+}


### PR DESCRIPTION
Closes #490. Part of #488.

## What

Two localhost-only buttons in the project panel:
- **Open folder** - reveal the repo in the OS file manager (Finder / Explorer).
- **Open in editor** - open the repo in an editor.

## How

- New `openInApp` (in `dashboard/open-in-app.ts`): picks the OS reveal command (`open` / `xdg-open` / `explorer`) or the editor command (`code`, or `$FRAMEWORK_EDITOR`), and spawns it detached. It resolves on the `spawn` event (not exit), so a long-lived editor - or `explorer`, which exits non-zero even on success - does not block or error; a missing command (ENOENT) returns a friendly error value.
- New `sendOpenInApp(projectId, target)` control RPC. It spawns against the project's own registered path (never client input), so there is no path injection. A public host (the relay) has no local path to resolve, so it returns an error instead of spawning; and this bar only renders in the local dashboard anyway (the relay shows RelayView).

## Verify

- Unit tests: per-OS reveal command, `$FRAMEWORK_EDITOR` override, ok spawn, ENOENT -> friendly error. Full framework dashboard suite green; both packages typecheck; dashboard builds + prerenders clean.
- Live on the bundled daemon: "Open folder" returned `{ok:true}` and actually opened a Finder window on the repo; "Open in editor" returned the friendly `"code" was not found on PATH` on a host without the VS Code CLI (graceful degradation).