### PR TITLE
fix(ai-autopilot): drop the Vike nudge from the architect system prompt

### DIFF
--- a/.changeset/architect-drop-vike-nudge.md
+++ b/.changeset/architect-drop-vike-nudge.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/ai-autopilot": patch
+---
+
+Remove the Vike nudge from the architect system prompt. The prompt no longer tells the model to "Prefer Vike as the default" or to "Default to the GemStack stack (Vike + Prisma)"; it now picks the stack that best fits the app and reasons from the objective Vike-vs-Next tradeoffs without favoring either. Nudging toward a framework in a system prompt erodes trust in the architect's rationale.

--- a/packages/ai-autopilot/src/bootstrap/steps.ts
+++ b/packages/ai-autopilot/src/bootstrap/steps.ts
@@ -38,14 +38,14 @@ export const STACK_TRADEOFFS = `Ground the stack justification in these objectiv
   included (image/font/routing), first-class Vercel deploy. Downsides: heavier,
   React-only, a more opinionated server model, and more constrained edge/Cloudflare
   support.
-Prefer Vike as the default for edge, multi-renderer, or portability; prefer Next
-when the team wants the largest ecosystem and Vercel-native features.`
+Weigh these against the app's actual needs. Neither is a default; pick the one
+the requirements point to.`
 
 const DEFAULT_ARCHITECT_INSTRUCTIONS = `You are the lead architect. Choose the stack and structure for the app the user
 describes and commit to it — act like a senior engineer who decides and explains,
-not one who asks permission. Default to the GemStack stack (Vike + Prisma)
-unless the intent clearly calls for something else. Only choose packages that are
-published and installable on npm. Narrate what you are building
+not one who asks permission. Choose the stack that best fits what the user is
+building. Only choose packages that are published and installable on npm.
+Narrate what you are building
 and why in a sentence or two, and list the key choices so they are recorded and
 not re-litigated later.
 


### PR DESCRIPTION
Closes #499. Part of #498.

Rom on #485: mentioning/nudging Vike in a system prompt erodes trust. This drops the nudge from the architect prompt (`packages/ai-autopilot/src/bootstrap/steps.ts`):

- removed "Prefer Vike as the default for edge, multi-renderer, or portability..."
- removed "Default to the GemStack stack (Vike + Prisma)" -> now "Choose the stack that best fits what the user is building"

This is option (a) from the #485 thread: drop the nudge, keep the objective Vike-vs-Next tradeoffs so the architect still reasons from real facts. If you want option (b) (pull all framework-choice guidance out to a public `skills/choose-js-framework.md`), that's a clean follow-up on top of this.

Tests: ai-autopilot 321/321, framework 460/460 green. No test asserted the nudge text; the objective tradeoffs (asserted via `renderer-agnostic`) are untouched.