### PR TITLE
feat: # to add a file to the run context (#504)

### DIFF
--- a/.changeset/architect-drop-vike-nudge.md
+++ b/.changeset/architect-drop-vike-nudge.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/ai-autopilot": patch
+---
+
+Remove the Vike nudge from the architect system prompt. The prompt no longer tells the model to "Prefer Vike as the default" or to "Default to the GemStack stack (Vike + Prisma)"; it now picks the stack that best fits the app and reasons from the objective Vike-vs-Next tradeoffs without favoring either. Nudging toward a framework in a system prompt erodes trust in the architect's rationale.

--- a/.changeset/file-context-picker-504.md
+++ b/.changeset/file-context-picker-504.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Add `#` to the dashboard prompt editor to reference a project file as run context (#504). The finer-grained sibling of `@` (which focuses a whole repo): type `#` to filter the project's files (via `git ls-files`, honoring .gitignore) and pick one, inserting a chip that adds its repo-relative path to the run Context. Backed by a new `onProjectFiles` read RPC; localhost-only, since the relay has no checkout.

--- a/packages/ai-autopilot/src/bootstrap/steps.ts
+++ b/packages/ai-autopilot/src/bootstrap/steps.ts
@@ -38,14 +38,14 @@ export const STACK_TRADEOFFS = `Ground the stack justification in these objectiv
   included (image/font/routing), first-class Vercel deploy. Downsides: heavier,
   React-only, a more opinionated server model, and more constrained edge/Cloudflare
   support.
-Prefer Vike as the default for edge, multi-renderer, or portability; prefer Next
-when the team wants the largest ecosystem and Vercel-native features.`
+Weigh these against the app's actual needs. Neither is a default; pick the one
+the requirements point to.`
 
 const DEFAULT_ARCHITECT_INSTRUCTIONS = `You are the lead architect. Choose the stack and structure for the app the user
 describes and commit to it — act like a senior engineer who decides and explains,
-not one who asks permission. Default to the GemStack stack (Vike + Prisma)
-unless the intent clearly calls for something else. Only choose packages that are
-published and installable on npm. Narrate what you are building
+not one who asks permission. Choose the stack that best fits what the user is
+building. Only choose packages that are published and installable on npm.
+Narrate what you are building
 and why in a sentence or two, and list the key choices so they are recorded and
 not re-litigated later.
 

--- a/packages/framework-dashboard/components/PromptEditor.tsx
+++ b/packages/framework-dashboard/components/PromptEditor.tsx
@@ -31,7 +31,11 @@ interface PromptEditorProps {
   onPreset?: (label: string) => void
   /** A project referenced via `@` (so the form can add it to the run context). */
   onMentionProject?: (path: string) => void
+  /** A file referenced via `#` (so the form can add its repo-relative path to the run context). */
+  onMentionFile?: (relPath: string) => void
   projects: ProjectSummary[]
+  /** The current project's files, repo-relative, for the `#` picker (#504). */
+  files?: string[]
   presets: { id: string; label: string; render: () => string }[]
   disabled?: boolean
   placeholder?: string
@@ -59,23 +63,27 @@ function applyTemplate(editor: Editor, text: string): void {
 }
 
 export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(function PromptEditor(
-  { onChange, onSubmit, onPreset, onMentionProject, projects, presets, disabled = false, placeholder = 'Describe what to build…  ( / commands · < tags · @ projects )' },
+  { onChange, onSubmit, onPreset, onMentionProject, onMentionFile, projects, files = [], presets, disabled = false, placeholder = 'Describe what to build…  ( / commands · < tags · @ projects · # files )' },
   ref,
 ) {
   const [isEmpty, setIsEmpty] = useState(true)
 
   // Refs so the once-built suggestion closures always see the latest props/editor.
   const projectsRef = useRef(projects)
+  const filesRef = useRef(files)
   const presetsRef = useRef(presets)
   const onPresetRef = useRef(onPreset)
   const onMentionRef = useRef(onMentionProject)
+  const onMentionFileRef = useRef(onMentionFile)
   const onChangeRef = useRef(onChange)
   const onSubmitRef = useRef(onSubmit)
   useEffect(() => {
     projectsRef.current = projects
+    filesRef.current = files
     presetsRef.current = presets
     onPresetRef.current = onPreset
     onMentionRef.current = onMentionProject
+    onMentionFileRef.current = onMentionFile
     onChangeRef.current = onChange
     onSubmitRef.current = onSubmit
   })
@@ -153,6 +161,22 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
             insertToken(ed, range, { kind: 'project', label: `@${project.name}`, text: `@${project.name}` })
             onMentionRef.current?.(project.path)
           }
+        },
+      }),
+      // `#` — files: the finer-grained sibling of `@` (#504). Type to filter the project's
+      // files (git ls-files); picking one focuses the run on that file via the Context line.
+      makeTrigger({
+        char: '#',
+        key: 'hash',
+        items: query =>
+          filesRef.current
+            .filter(f => f.toLowerCase().includes(query.toLowerCase()))
+            .slice(0, 8)
+            .map(f => ({ id: `file:${f}`, label: `#${f}`, hint: 'file', group: 'Files' })),
+        onSelect: (item, { editor: ed, range }) => {
+          const rel = item.id.slice('file:'.length)
+          insertToken(ed, range, { kind: 'file', label: `#${rel}`, text: `#${rel}` })
+          onMentionFileRef.current?.(rel)
         },
       }),
     ],

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -9,6 +9,7 @@ import {
 } from '@gemstack/framework/client'
 import { sendStart } from '../server/control.telefunc.js'
 import { onProjects } from '../server/projects.telefunc.js'
+import { onProjectFiles } from '../server/reads.telefunc.js'
 import { usePreferences, updatePreferences, autopilotEnabled } from '../lib/preferences.js'
 import { PromptEditor, type PromptEditorHandle } from './PromptEditor.js'
 import { Button } from './ui/button.js'
@@ -69,6 +70,18 @@ export function StartRunForm({
       live = false
     }
   }, [])
+
+  // The current project's files for the `#` picker (#504): repo-relative paths from
+  // `git ls-files`, reloaded when the selected project changes. Empty on the relay.
+  const [files, setFiles] = useState<string[]>([])
+  useEffect(() => {
+    let live = true
+    setFiles([])
+    void onProjectFiles(projectId).then(list => live && setFiles(list))
+    return () => {
+      live = false
+    }
+  }, [projectId])
 
   const toggleContext = (path: string) =>
     setContext(prev => {
@@ -161,7 +174,9 @@ export function StartRunForm({
         onSubmit={() => void submit()}
         onPreset={loadPreset}
         onMentionProject={addContext}
+        onMentionFile={addContext}
         projects={projects}
+        files={files}
         presets={PRESETS}
         disabled={busy}
       />

--- a/packages/framework-dashboard/components/prompt-editor/tokens.ts
+++ b/packages/framework-dashboard/components/prompt-editor/tokens.ts
@@ -7,7 +7,7 @@ import { Node, mergeAttributes, nodeInputRule } from '@tiptap/core'
 // the wire is unchanged: presets, the run contract, everything downstream stays the same.
 
 /** What a token is, which drives its chip colour and which menu inserts it. */
-export type TokenKind = 'macro' | 'action' | 'reference' | 'project'
+export type TokenKind = 'macro' | 'action' | 'reference' | 'project' | 'file'
 
 /** One insertable token: how it reads (label) and how it serializes (text). */
 export interface TokenSpec {

--- a/packages/framework-dashboard/layouts/tailwind.css
+++ b/packages/framework-dashboard/layouts/tailwind.css
@@ -133,6 +133,11 @@ body {
   color: var(--accent-foreground);
   border-color: var(--border);
 }
+.pe-token[data-token='file'] {
+  background: color-mix(in oklab, var(--muted-foreground) 12%, transparent);
+  color: var(--foreground);
+  border-color: var(--border);
+}
 .ProseMirror-selectednode.pe-token {
   outline: 2px solid var(--primary);
 }

--- a/packages/framework-dashboard/server/reads.telefunc.ts
+++ b/packages/framework-dashboard/server/reads.telefunc.ts
@@ -3,4 +3,4 @@
 // the client bakes the RPC key `/server/reads.telefunc.ts` — the exact key the daemon
 // registers the impls under (see framework's dashboard-rpc/register.ts). The telefunc
 // Vite transform turns these named re-exports into client RPC stubs.
-export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl, onGitStatus } from '@gemstack/framework/dashboard-rpc'
+export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl, onGitStatus, onProjectFiles } from '@gemstack/framework/dashboard-rpc'

--- a/packages/framework/src/dashboard-rpc/index.ts
+++ b/packages/framework/src/dashboard-rpc/index.ts
@@ -2,7 +2,7 @@
 // implementations live here in @gemstack/framework so `sendStart` (added with the serve
 // wiring) can reach the daemon's `startRun`; the framework-dashboard client imports
 // these through thin re-export shims so the baked RPC keys stay `/server/*.telefunc.ts`.
-export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl, onGitStatus } from './reads.telefunc.js'
+export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl, onGitStatus, onProjectFiles } from './reads.telefunc.js'
 export { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
 export { onEvents } from './events.telefunc.js'
 export { onProjects, sendAddProject } from './projects.telefunc.js'

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.test.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.test.ts
@@ -1,0 +1,11 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { onProjectFiles } from './reads.telefunc.js'
+
+// Outside a Telefunc `serve({ context })` the RPC resolves against the global registry, so an
+// unknown project id has no local path — the same situation as the relay, which has no
+// checkout. onProjectFiles (#504) must degrade to an empty list rather than throwing.
+
+test('onProjectFiles for an unknown project returns an empty list', async () => {
+  assert.deepEqual(await onProjectFiles('project-that-does-not-exist'), [])
+})

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -6,6 +6,7 @@ import { buildOverview, type Overview } from '../dashboard/overview.js'
 import { buildDashboard, type DashboardData } from '../dashboard/dashboard.js'
 import { githubUrlFor } from '../dashboard/github.js'
 import { readGitStatus, type GitStatus } from '../dashboard/git-status.js'
+import { crawlRepoFiles } from '../project.js'
 import { contextProjects } from './context.js'
 import type { FrameworkEvent } from '../events.js'
 
@@ -75,6 +76,16 @@ export async function onOverview(): Promise<Overview> {
 export async function onDashboard(): Promise<DashboardData> {
   const projects = await contextProjects().list().catch(() => [])
   return buildDashboard(projects)
+}
+
+/**
+ * The project's files for the `#` context picker (#504) and the panel tree (#492): every
+ * file git sees (tracked + untracked, honoring .gitignore), repo-relative and sorted, via
+ * `git ls-files`. Localhost-only by nature — the relay has no checkout, so it resolves `[]`.
+ */
+export async function onProjectFiles(projectId: string): Promise<string[]> {
+  const cwd = await projectPath(projectId)
+  return cwd ? crawlRepoFiles(cwd).catch(() => []) : []
 }
 
 /** The project's GitHub URL from its `origin` remote (#489), or null (no remote / not GitHub / relay). */

--- a/packages/framework/src/dashboard-rpc/register.ts
+++ b/packages/framework/src/dashboard-rpc/register.ts
@@ -1,5 +1,5 @@
 import { __decorateTelefunction } from 'telefunc'
-import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl, onGitStatus } from './reads.telefunc.js'
+import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl, onGitStatus, onProjectFiles } from './reads.telefunc.js'
 import { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
 import { onEvents } from './events.telefunc.js'
 import { onProjects, sendAddProject } from './projects.telefunc.js'
@@ -40,6 +40,7 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(onDashboard, 'onDashboard', reads)
   reg(onGithubUrl, 'onGithubUrl', reads)
   reg(onGitStatus, 'onGitStatus', reads)
+  reg(onProjectFiles, 'onProjectFiles', reads)
   reg(sendStop, 'sendStop', control)
   reg(sendChoice, 'sendChoice', control)
   reg(sendStart, 'sendStart', control)


### PR DESCRIPTION
Closes #504. Part of #488; sibling of #492 (the panel tree, fast-follow).

## What
Adds `#` to the dashboard prompt editor. It is the finer-grained sibling of `@`:
- `@repo` focuses the agent on a whole repo.
- `#file` focuses it on one file.

Type `#` to filter the current project's files and pick one; it inserts a chip and adds the file's repo-relative path to the run Context (the same `Context:` line `@` and the whole-repo Context selector already feed).

## How
- New read RPC `onProjectFiles(projectId)` = `git ls-files --cached --others --exclude-standard` via the existing `crawlRepoFiles` (tracked + untracked, honors .gitignore). Localhost-only by nature: the relay has no checkout, so it returns `[]`.
- The `#` trigger reuses the existing `makeTrigger` infra, mirroring the `@` handler; a new `file` token kind renders the chip.
- `#492` (the lazy panel tree) will reuse this same RPC and the same 'add to context' path.

## Verify
- `onProjectFiles` returns 784 files on this repo, filtering by a query gives the exact picker list, and node_modules/dist are excluded (gitignore honored).
- New unit test: an unknown project id degrades to `[]`.
- typecheck + full framework test suite green; dashboard bundle builds (telefunc shields `onProjectFiles`).

Note: `#file` writes `#path` into the prompt text (like `@name`) and rides along as Context; nothing downstream changes.