### PR TITLE
fix(framework): inject the #326 action layer into build runs even with the built-in prompt off

### DIFF
--- a/.changeset/inject-action-layer-in-build-500.md
+++ b/.changeset/inject-action-layer-in-build-500.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Fix the #326 action-layer protocols being dropped from a build run's system prompt when the built-in prompt is off. `runFramework` nested the `AWAIT_PROTOCOL` and `SIGNAL_PROTOCOL` blocks inside the built-in-prompt branch, so a `--vanilla` build (or `antiLazyPill: false` via `the-framework.yml`) with no `SYSTEM.md` injected neither — leaving the agent with no way to emit `set-session-name` / `ready-for-merge`, so `setReadyForMerge()` and the `--post-merge` quality suite silently never fired. The protocols are now appended unconditionally, matching the direct-prompt path (`runPrompt`).

--- a/packages/framework/src/preset-run.test.ts
+++ b/packages/framework/src/preset-run.test.ts
@@ -111,3 +111,23 @@ test('no loop is exposed without a preset', async () => {
   })
   assert.equal(loop, undefined)
 })
+
+test('the #326 action layer is injected even with the built-in prompt off (#500)', async () => {
+  const { driver, system } = recordingDriver()
+  await runFramework({
+    intent: FAKE_INTENT,
+    driver,
+    cwd: '/tmp/ws',
+    signals: FAKE_SIGNALS,
+    antiLazyPill: false, // --vanilla: drops the built-in #326 prompt, so promptBlock is empty
+  })
+
+  // The built-in prompt is gone, but the emit protocols still ride the system channel —
+  // else the agent never learns how to signal set-session-name / ready-for-merge, so
+  // setReadyForMerge() and the --post-merge suite silently never fire (the build path used
+  // to nest these inside the promptBlock branch; the direct-prompt path always kept them).
+  assert.ok(!system().includes('# System prompt'), 'built-in #326 prompt is off')
+  assert.match(system(), /## Ready for merge/) // SIGNAL_PROTOCOL (#326)
+  assert.match(system(), /```ready-for-merge/)
+  assert.match(system(), /## Awaiting a choice/) // AWAIT_PROTOCOL (#337)
+})

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -352,10 +352,15 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
   }
   const promptBlock = systemPromptBlock({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt, tf, context: opts.context, bootstrap: opts.bootstrap })
   // The await protocol (#337) concretizes the pill's showChoices()/AWAIT macros into a
-  // signal the turn-boundary gate can detect, so it rides along with the pill. The signal
-  // protocol (#326) does the same for the setSessionName()/setReadyForMerge() lifecycle actions.
+  // signal the turn-boundary gate can detect. The signal protocol (#326) does the same for
+  // the setSessionName()/setReadyForMerge() lifecycle actions. Both are unconditional (like
+  // the direct-prompt path, prompt-run.ts): the agent needs the emit protocol even with the
+  // built-in prompt off (--vanilla), else setReadyForMerge() never fires and --post-merge
+  // never runs (#500).
   const system = [
-    ...(promptBlock ? [promptBlock, AWAIT_PROTOCOL, SIGNAL_PROTOCOL] : []),
+    ...(promptBlock ? [promptBlock] : []),
+    AWAIT_PROTOCOL,
+    SIGNAL_PROTOCOL,
     ...personas.map(personaInstructions),
     ...skills.map(skillInstructions),
     ...(memoryBlock ? [memoryBlock] : []),


### PR DESCRIPTION
Closes #500. Part of #498.

## The bug

Rom noticed the #326 system prompt "doesn't seem to be injected at all" on a build run, while the "Review this PR" path did inject. Tracing the two paths found one structural asymmetry:

- Build path (`run.ts`): `AWAIT_PROTOCOL` + `SIGNAL_PROTOCOL` were nested inside the `promptBlock ? [...] : []` branch.
- Direct-prompt path (`prompt-run.ts`): the same two protocols are appended unconditionally.

So when the built-in #326 prompt is off (`--vanilla`, or `antiLazyPill: false` in `the-framework.yml`) and there's no `SYSTEM.md` / `--context` / `--bootstrap`, `promptBlock` is empty and the whole spread is dropped from a build run. The agent then never learns how to emit `set-session-name` / `ready-for-merge`, so `setReadyForMerge()` and the `--post-merge` quality suite silently never fire.

## The fix

Append `AWAIT_PROTOCOL` + `SIGNAL_PROTOCOL` unconditionally in `runFramework`, mirroring `runPrompt`. One-line structural change; the protocols are the emit contract, not the built-in prompt content, so they belong on the system channel regardless.

## Tests

- New regression test in `preset-run.test.ts`: a `--vanilla` build (`antiLazyPill: false`) still injects the action layer (`## Ready for merge`, ```` ```ready-for-merge ````, `## Awaiting a choice`) while the built-in `# System prompt` is absent.
- Framework tests green (135 relevant + full non-daemon suite: 323 pass / 1 skip). The 6 `daemon.test.js` failures are pre-existing on `main` (dashboard bundle not built in a fresh worktree, HTTP 503), unrelated to this change.

## Notes on the epic (#498)

- #499 (Vike nudge) already shipped.
- #501 (clean architecture + unit tests) is largely already satisfied: the assembly path is centralized in `system-prompt.ts` with 20 unit tests, and this PR adds the end-to-end injection pin. Worth a final look but no rewrite needed.
- #502 (the generic "pick the build policy" step) stays parked as a post-MVP design call.
