### PR TITLE
feat(framework): one assembly path for a run's system prompt

### DIFF
--- a/.changeset/single-system-assembly-501.md
+++ b/.changeset/single-system-assembly-501.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Assemble a run's system prompt in one place. The build path (`runFramework`) and the direct-prompt path (`runPrompt`) each inlined the same composition (the #326 prompt block, the always-on emit protocols, then the run's persona/skill/memory framing), and the two drifted apart, which is what dropped the #326 action layer from `--vanilla` builds (#500). Both now go through a single exported `composeRunSystem()` in `system-prompt.ts`, with unit tests pinning the order and the unconditional emit protocols so the two paths can never diverge again.

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -224,11 +224,13 @@ export {
 export {
   loadUserSystemPrompt,
   systemPromptBlock,
+  composeRunSystem,
   renderSystemPrompt,
   SYSTEM_PROMPT_TEMPLATE,
   SYSTEM_PROMPT_FILE,
   BOOTSTRAP_PREAMBLE,
   type SystemPromptOptions,
+  type RunSystemOptions,
   type TfContext,
   type RenderedSystemPrompt,
 } from './system-prompt.js'

--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -1,8 +1,8 @@
 import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { hasSessionIdPlaceholder, resolveSessionLink, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 import { resolveAwaitGate } from './run.js'
-import { renderSystemPrompt, systemPromptBlock, type EcoOptions, type TfContext } from './system-prompt.js'
-import { AWAIT_PROTOCOL, SIGNAL_PROTOCOL, PLAN_DECLINED_MESSAGE, isDeclinedConfirmation, parseAwaitGate, parseMarkdownViews, parseSessionName, parseReadyForMerge } from './turn-gate.js'
+import { composeRunSystem, renderSystemPrompt, type EcoOptions, type TfContext } from './system-prompt.js'
+import { PLAN_DECLINED_MESSAGE, isDeclinedConfirmation, parseAwaitGate, parseMarkdownViews, parseSessionName, parseReadyForMerge } from './turn-gate.js'
 import { UsageMeter } from './usage.js'
 
 /**
@@ -84,8 +84,7 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
     prompt: opts.prompt,
     params: { autopilot: opts.autopilot === true, ...(opts.eco ? { eco: opts.eco } : {}) },
   }
-  const promptBlock = systemPromptBlock({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt, tf, context: opts.context, bootstrap: opts.bootstrap })
-  const system = [...(promptBlock ? [promptBlock] : []), AWAIT_PROTOCOL, SIGNAL_PROTOCOL].join('\n\n')
+  const system = composeRunSystem({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt, tf, context: opts.context, bootstrap: opts.bootstrap })
   // The template's `# User prompt` half carries the prompt (today it renders to
   // exactly `opts.prompt`; any framing Rom adds around the slot rides along). With
   // the built-in prompt off, the raw prompt is sent as-is.

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -37,8 +37,8 @@ import {
 import { snapshotWorkspace } from './sandbox.js'
 import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { memoryFraming, type LoadedMemory } from './memory.js'
-import { systemPromptBlock, type EcoOptions, type TfContext } from './system-prompt.js'
-import { AWAIT_PROTOCOL, SIGNAL_PROTOCOL, CONFIRM_APPROVED, CONFIRM_DECLINED, PLAN_DECLINED_MESSAGE, isDeclinedConfirmation, parseAwaitGate, parseMarkdownViews, parseSessionName, parseReadyForMerge, type ParsedAwaitGate } from './turn-gate.js'
+import { composeRunSystem, type EcoOptions, type TfContext } from './system-prompt.js'
+import { AWAIT_PROTOCOL, CONFIRM_APPROVED, CONFIRM_DECLINED, PLAN_DECLINED_MESSAGE, isDeclinedConfirmation, parseAwaitGate, parseMarkdownViews, parseSessionName, parseReadyForMerge, type ParsedAwaitGate } from './turn-gate.js'
 // Value import from todo-loop.js is a benign cycle: todo-loop.js only calls
 // run.js's hoisted function declarations (requestChoices / resolveAwaitGate).
 import { runTodoLoop, type TodoLoopResult } from './todo-loop.js'
@@ -350,21 +350,17 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     prompt: opts.intent,
     params: { autopilot: opts.modes?.includes('autopilot') ?? false, ...(opts.eco ? { eco: opts.eco } : {}) },
   }
-  const promptBlock = systemPromptBlock({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt, tf, context: opts.context, bootstrap: opts.bootstrap })
-  // The await protocol (#337) concretizes the pill's showChoices()/AWAIT macros into a
-  // signal the turn-boundary gate can detect. The signal protocol (#326) does the same for
-  // the setSessionName()/setReadyForMerge() lifecycle actions. Both are unconditional (like
-  // the direct-prompt path, prompt-run.ts): the agent needs the emit protocol even with the
-  // built-in prompt off (--vanilla), else setReadyForMerge() never fires and --post-merge
-  // never runs (#500).
-  const system = [
-    ...(promptBlock ? [promptBlock] : []),
-    AWAIT_PROTOCOL,
-    SIGNAL_PROTOCOL,
-    ...personas.map(personaInstructions),
-    ...skills.map(skillInstructions),
-    ...(memoryBlock ? [memoryBlock] : []),
-  ].join('\n\n')
+  // One assembly path for the whole system channel (#501): the #326 prompt block, the
+  // always-on emit protocols, then this run's persona / skill / memory framing. Shared
+  // with the direct-prompt path so the two can never drift (the drift behind #500).
+  const system = composeRunSystem({
+    antiLazyPill: opts.antiLazyPill,
+    user: opts.systemPrompt,
+    tf,
+    context: opts.context,
+    bootstrap: opts.bootstrap,
+    framing: [...personas.map(personaInstructions), ...skills.map(skillInstructions), memoryBlock],
+  })
 
   // The session id is not known until the first driver turn returns, so a
   // templated link (`.../{sessionId}`) can only resolve later. A literal link is

--- a/packages/framework/src/system-prompt.test.ts
+++ b/packages/framework/src/system-prompt.test.ts
@@ -5,12 +5,14 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   BOOTSTRAP_PREAMBLE,
+  composeRunSystem,
   loadUserSystemPrompt,
   renderSystemPrompt,
   systemPromptBlock,
   SYSTEM_PROMPT_FILE,
   SYSTEM_PROMPT_TEMPLATE,
 } from './system-prompt.js'
+import { AWAIT_PROTOCOL, SIGNAL_PROTOCOL } from './turn-gate.js'
 
 test('loadUserSystemPrompt reads and trims SYSTEM.md', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'system-prompt-'))
@@ -165,4 +167,24 @@ test('no eco flags renders every section, and eco never touches the template', (
 test('vanilla (antiLazyPill false) wins over eco: no built-in prompt at all (#314)', () => {
   const block = systemPromptBlock({ antiLazyPill: false, tf: { prompt: 'x', params: { eco: { autoResearch: true } } } })
   assert.equal(block, '')
+})
+
+test('composeRunSystem: the built-in block, then both emit protocols, then framing, in order (#501)', () => {
+  const system = composeRunSystem({ framing: ['PERSONA-A', 'SKILL-B'] })
+  // The one assembly path both runFramework and runPrompt go through.
+  const expected = [renderSystemPrompt().system, AWAIT_PROTOCOL, SIGNAL_PROTOCOL, 'PERSONA-A', 'SKILL-B'].join('\n\n')
+  assert.equal(system, expected)
+})
+
+test('composeRunSystem keeps the emit protocols even with the built-in prompt off (#500/#501)', () => {
+  // The drift that #500 fixed, now pinned at the single assembly point: --vanilla drops the
+  // #326 block, but the agent still gets the AWAIT + SIGNAL emit contract.
+  const system = composeRunSystem({ antiLazyPill: false })
+  assert.ok(!system.includes('# System prompt'), 'built-in #326 prompt is off')
+  assert.equal(system, [AWAIT_PROTOCOL, SIGNAL_PROTOCOL].join('\n\n'))
+})
+
+test('composeRunSystem drops empty framing entries (e.g. an absent memory block) (#501)', () => {
+  const system = composeRunSystem({ antiLazyPill: false, framing: ['PERSONA-A', '', 'SKILL-B'] })
+  assert.equal(system, [AWAIT_PROTOCOL, SIGNAL_PROTOCOL, 'PERSONA-A', 'SKILL-B'].join('\n\n'))
 })

--- a/packages/framework/src/system-prompt.ts
+++ b/packages/framework/src/system-prompt.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { renderTemplate } from './prompt-template.js'
+import { AWAIT_PROTOCOL, SIGNAL_PROTOCOL } from './turn-gate.js'
 
 /**
  * Rom's system prompt (#326), verbatim, as a template. It supersedes the
@@ -231,4 +232,37 @@ export function systemPromptBlock(opts: SystemPromptOptions = {}): string {
   const user = opts.user?.trim()
   if (user) parts.push(user)
   return parts.join('\n\n')
+}
+
+/** Inputs to {@link composeRunSystem}: a {@link systemPromptBlock} plus the run's own framing. */
+export interface RunSystemOptions extends SystemPromptOptions {
+  /**
+   * Extra framing appended after the emit protocols: the build run's persona / skill /
+   * memory blocks. The direct-prompt run has none. Empty entries are dropped.
+   */
+  framing?: readonly string[] | undefined
+}
+
+/**
+ * Assemble a run's full system channel — the single place it is composed (#501), so the
+ * build path ({@link ./run.runFramework}) and the direct-prompt path ({@link ./prompt-run.runPrompt})
+ * cannot drift. That drift is exactly what dropped the #326 action layer from `--vanilla`
+ * builds (#500): the two sites each inlined the composition and one nested the protocols
+ * inside the built-in-prompt branch.
+ *
+ * Order is fixed: the #326 prompt block (context / bootstrap / built-in prompt / user
+ * SYSTEM.md) first, then the always-on emit protocols, then any caller framing. The
+ * protocols are unconditional — they are the *emit contract* (how the agent signals an
+ * awaited choice and the setSessionName()/setReadyForMerge() lifecycle), not prompt
+ * content — so the agent needs them even with the built-in prompt off.
+ */
+export function composeRunSystem(opts: RunSystemOptions = {}): string {
+  const { framing, ...blockOpts } = opts
+  const promptBlock = systemPromptBlock(blockOpts)
+  return [
+    ...(promptBlock ? [promptBlock] : []),
+    AWAIT_PROTOCOL,
+    SIGNAL_PROTOCOL,
+    ...(framing ?? []).filter(Boolean),
+  ].join('\n\n')
 }


### PR DESCRIPTION
Closes #501. Part of #498.

Rom's point on #485: the system prompt is the most critical part of The Framework, so it deserves a clean internal architecture and unit tests. #500 proved the risk concretely: the build path and the direct-prompt path each inlined the same system-channel composition, they drifted, and one dropped the #326 action layer on `--vanilla` builds.

## What

- One exported `composeRunSystem()` in `system-prompt.ts` is now the single place a run's system channel is assembled: the #326 prompt block, then the always-on emit protocols (`AWAIT` + `SIGNAL`), then the run's persona/skill/memory framing.
- `runFramework` (build) and `runPrompt` (direct prompt) both call it instead of inlining the array. They can no longer diverge.
- Unit tests pin the order and, critically, that the emit protocols stay even with the built-in prompt off (the #500 class of bug, now caught at the assembly point).

## Already in place (so #501 is mostly satisfied by existing work)

- The assembly was already centralized in `system-prompt.ts` (`systemPromptBlock` / `renderSystemPrompt`) with 20 unit tests.
- It is already inspectable: every run emits a `system-prompt` event with the exact injected text (#343), shown in the dashboard.

This PR closes the last gap: the two run paths now share one assembly function rather than two copies.

## Tests

Behavior is identical (pure consolidation). Framework suite green: 318 pass / 1 skip / 0 fail across all files except the slow `cli.test.js` and the pre-existing `daemon.test.js` env failures (dashboard bundle not built in a fresh worktree). New tests: `composeRunSystem` order, the vanilla-keeps-protocols pin, and empty-framing drop.
