### PR TITLE
chore(framework): benchmark the meta-select routing step (#502)

### DIFF
--- a/packages/framework/bench/README.md
+++ b/packages/framework/bench/README.md
@@ -1,0 +1,30 @@
+# Benchmarks
+
+## meta-select routing (#502)
+
+Does the AI meta-select step (auto-picking a domain preset for a task, `src/meta-select.ts`) route to the policy a human would pick? Rom's doubt on #485 is that a generic "pick the build policy" instruction boxes the model without a clear goal. So measure it before we keep it.
+
+The harness runs a hand-labeled corpus (`src/meta-select-bench.ts`, `META_SELECT_BENCH_CASES`) through `metaSelect` and reports three numbers:
+
+- **accuracy** — correct picks / total.
+- **over-fire** — picked a preset when `none` (plain flow) was the right answer. This is the "it boxes the AI" failure Rom is worried about.
+- **miss / misroute** — fell back to `none` when a preset fit, or picked the wrong preset.
+
+The scoring is pure and unit-tested (`src/meta-select-bench.test.ts`); this runner just drives a live model.
+
+### Run it
+
+```bash
+pnpm --filter @gemstack/framework build          # dist/ must exist
+pnpm --filter @gemstack/framework bench:meta-select
+MODEL=claude-haiku-4-5-20251001 pnpm --filter @gemstack/framework bench:meta-select
+```
+
+Needs the `claude` CLI installed and logged in (it drives a real model). Output is a per-case ok/XX list plus the summary.
+
+### Reading the result (the #502 decision)
+
+- High accuracy **and** low over-fire → the step earns its keep; the router adds value.
+- Low accuracy or high over-fire → the generic step is boxing the model; narrow it to clear-goal cases or drop it.
+
+The corpus is small and its labels are arguable on purpose (each case carries a `why`). Grow it with real routing the model gets wrong.

--- a/packages/framework/bench/meta-select.mjs
+++ b/packages/framework/bench/meta-select.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// Live benchmark for the meta-select routing step (#502): run the hand-labeled corpus
+// through a real model and print how well it routes. Requires the `claude` CLI logged in.
+//
+//   pnpm --filter @gemstack/framework build   # first, so dist/ exists
+//   pnpm --filter @gemstack/framework bench:meta-select
+//   MODEL=claude-haiku-4-5-20251001 pnpm --filter @gemstack/framework bench:meta-select
+//
+// The scoring lives in src/meta-select-bench.ts (unit-tested); this is just the live runner.
+import { ClaudeCodeDriver } from '../dist/index.js'
+import {
+  META_SELECT_BENCH_CASES,
+  formatMetaSelectBenchReport,
+  runMetaSelectBench,
+} from '../dist/meta-select-bench.js'
+import { presetCatalog } from '../dist/meta-select.js'
+import { builtinDomainPresets } from '@gemstack/ai-autopilot'
+
+const presets = await builtinDomainPresets()
+const catalog = presetCatalog(presets)
+const driver = new ClaudeCodeDriver({ permissionMode: 'acceptEdits' })
+
+console.log(`Running ${META_SELECT_BENCH_CASES.length} meta-select cases against ${catalog.length} presets...\n`)
+
+const report = await runMetaSelectBench({
+  driver,
+  cases: META_SELECT_BENCH_CASES,
+  catalog,
+  cwd: process.cwd(),
+  ...(process.env.MODEL ? { model: process.env.MODEL } : {}),
+  onResult: (r, i) => {
+    const mark = r.correct ? 'ok ' : 'XX '
+    console.log(`${mark}${String(i + 1).padStart(2)}. [${r.case.expected} -> ${r.picked}] ${r.case.intent}`)
+  },
+})
+
+console.log(`\n${formatMetaSelectBenchReport(report)}`)

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -55,6 +55,7 @@
     "typecheck": "tsc --noEmit",
     "test": "tsc -p tsconfig.test.json && cd dist-test && node --test",
     "bundle:dashboard": "node scripts/bundle-dashboard.mjs",
+    "bench:meta-select": "node bench/meta-select.mjs",
     "clean": "rm -rf dist dist-test"
   },
   "dependencies": {

--- a/packages/framework/src/meta-select-bench.test.ts
+++ b/packages/framework/src/meta-select-bench.test.ts
@@ -1,0 +1,114 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { FakeDriver } from './driver/index.js'
+import { presetCatalog } from './meta-select.js'
+import type { DomainPreset } from '@gemstack/ai-autopilot'
+import {
+  META_SELECT_BENCH_CASES,
+  NONE,
+  formatMetaSelectBenchReport,
+  runMetaSelectBench,
+  scoreMetaSelectBench,
+  type MetaSelectBenchCase,
+  type MetaSelectBenchResult,
+} from './meta-select-bench.js'
+
+const loop = (on: string[]) => ({ on, run: [] as string[] }) as DomainPreset['loops'][number]
+const preset = (name: string): DomainPreset => ({
+  name,
+  title: name,
+  description: `${name} preset`,
+  loops: [loop(['major-change'])],
+  prompts: [],
+  skills: [],
+})
+const CATALOG = presetCatalog([preset('web-development'), preset('software-development')])
+
+/** Build a result without a live model, to test scoring in isolation. */
+function result(expected: string, picked: string): MetaSelectBenchResult {
+  return {
+    case: { intent: 'x', workspace: 'y', expected, why: 'z' },
+    selection: picked === NONE ? { modes: [] } : { preset: picked, modes: [] },
+    picked,
+    correct: picked === expected,
+  }
+}
+
+test('scoreMetaSelectBench: accuracy, over-fire, miss, and misroute are tallied distinctly', () => {
+  const report = scoreMetaSelectBench([
+    result('web-development', 'web-development'), // correct
+    result('software-development', 'software-development'), // correct
+    result(NONE, 'web-development'), // over-fire
+    result('web-development', NONE), // miss
+    result('web-development', 'software-development'), // misroute
+  ])
+  assert.equal(report.total, 5)
+  assert.equal(report.correct, 2)
+  assert.equal(report.accuracy, 2 / 5)
+  assert.deepEqual(report.overFire, { count: 1, of: 1 })
+  assert.deepEqual(report.miss, { count: 1, of: 4 }) // 4 cases expected a real preset (only one fell back to none)
+  assert.equal(report.misroute, 1)
+  assert.deepEqual(report.perExpected['web-development'], { total: 3, correct: 1 })
+  assert.deepEqual(report.perExpected[NONE], { total: 1, correct: 0 })
+})
+
+test('scoreMetaSelectBench: an empty run is 0/0 with zero accuracy, never NaN', () => {
+  const report = scoreMetaSelectBench([])
+  assert.equal(report.total, 0)
+  assert.equal(report.accuracy, 0)
+})
+
+test('runMetaSelectBench drives each case through metaSelect and scores a perfect run', async () => {
+  // A scripted driver that "routes" by echoing the expected preset embedded in the intent,
+  // so the harness plumbing (session per case, parse, score) is exercised with no model.
+  const cases: MetaSelectBenchCase[] = [
+    { intent: 'PICK:web-development', workspace: 'w', expected: 'web-development', why: '' },
+    { intent: 'PICK:none', workspace: 'w', expected: NONE, why: '' },
+  ]
+  const driver = new FakeDriver({
+    respond: (prompt: string) => {
+      const want = /PICK:(\S+)/.exec(prompt)?.[1] ?? NONE
+      const preset = want === NONE ? NONE : want
+      return '```json\n' + JSON.stringify({ preset, modes: [], event: 'default', why: 'test' }) + '\n```'
+    },
+  })
+  const report = await runMetaSelectBench({ driver, cases, catalog: CATALOG, cwd: '/tmp/ws' })
+  assert.equal(report.total, 2)
+  assert.equal(report.correct, 2)
+  assert.equal(report.accuracy, 1)
+})
+
+test('runMetaSelectBench records a misroute when the router picks the wrong preset', async () => {
+  const cases: MetaSelectBenchCase[] = [
+    { intent: 'a web change', workspace: 'w', expected: 'web-development', why: '' },
+  ]
+  const driver = new FakeDriver({
+    respond: () => '```json\n' + JSON.stringify({ preset: 'software-development', modes: [], why: 'x' }) + '\n```',
+  })
+  const report = await runMetaSelectBench({ driver, cases, catalog: CATALOG, cwd: '/tmp/ws' })
+  assert.equal(report.correct, 0)
+  assert.equal(report.misroute, 1)
+  assert.equal(report.results[0]!.picked, 'software-development')
+})
+
+test('the shipped corpus is well-formed: unique intents, and every label is a real preset or none', () => {
+  const validExpected = new Set([...CATALOG.map(p => p.name), 'data-science', 'biological-science', 'product-management', NONE])
+  const intents = new Set<string>()
+  for (const c of META_SELECT_BENCH_CASES) {
+    assert.ok(c.intent.trim() && c.workspace.trim() && c.why.trim(), `case missing fields: ${c.intent}`)
+    assert.ok(!intents.has(c.intent), `duplicate intent: ${c.intent}`)
+    intents.add(c.intent)
+    assert.ok(validExpected.has(c.expected), `unknown expected label: ${c.expected}`)
+  }
+  // It actually covers the contested 'none' band, not just happy presets.
+  assert.ok(META_SELECT_BENCH_CASES.some(c => c.expected === NONE), 'corpus should include none cases')
+})
+
+test('formatMetaSelectBenchReport surfaces the headline number and each wrong pick', () => {
+  const text = formatMetaSelectBenchReport(
+    scoreMetaSelectBench([result('web-development', 'web-development'), result(NONE, 'web-development')]),
+  )
+  assert.match(text, /1\/2 correct/)
+  assert.match(text, /over-fire/)
+  assert.match(text, /\[none -> web-development\]/)
+})

--- a/packages/framework/src/meta-select-bench.ts
+++ b/packages/framework/src/meta-select-bench.ts
@@ -1,0 +1,268 @@
+import type { Driver } from './driver/index.js'
+import { META_SELECT_SYSTEM, metaSelect, type MetaSelection, type PresetCatalogEntry } from './meta-select.js'
+
+/**
+ * A benchmark for the AI meta-select step (#204/#502): does auto-picking the domain
+ * preset actually route to the policy a human would pick? Rom's doubt on #485 is that a
+ * generic "pick the build policy" instruction boxes the model without a clear goal — so
+ * before we keep it, measure it rather than assume. This harness runs {@link metaSelect}
+ * over a labeled corpus and scores the routing: overall accuracy, how often it *over-fires*
+ * (picks a preset when the plain flow was right), and how often it *misses* (falls back to
+ * the plain flow when a preset fit). Those three numbers are the decision input for #502.
+ *
+ * The scoring ({@link scoreMetaSelectBench}) is pure and unit-tested; the live run
+ * ({@link runMetaSelectBench}) drives a real model through the given {@link Driver}. The
+ * corpus ({@link META_SELECT_BENCH_CASES}) is deliberately small and hand-labeled — each
+ * case carries a `why` so a human can challenge the label, since the "none" cases are
+ * exactly the contested zone Rom is pointing at.
+ */
+
+/** `'none'` = the plain framework flow is the right answer (no domain preset fits). */
+export const NONE = 'none'
+
+/** One labeled routing case: an intent + a one-line workspace summary, and the expected pick. */
+export interface MetaSelectBenchCase {
+  /** The user's request, as they would type it to `framework`. */
+  intent: string
+  /** A one-line summary of the workspace, as the CLI passes to {@link metaSelect}. */
+  workspace: string
+  /** The preset name a human would pick, or {@link NONE} for the plain flow. */
+  expected: string
+  /** Why that label — so a reviewer can contest it (the `none` calls especially). */
+  why: string
+}
+
+/** The outcome of running one case through {@link metaSelect}. */
+export interface MetaSelectBenchResult {
+  case: MetaSelectBenchCase
+  selection: MetaSelection
+  /** What the router picked, normalized to a name or {@link NONE}. */
+  picked: string
+  correct: boolean
+}
+
+/** Aggregate metrics over a set of {@link MetaSelectBenchResult}s — the #502 decision input. */
+export interface MetaSelectBenchReport {
+  total: number
+  correct: number
+  /** correct / total, in [0, 1]. */
+  accuracy: number
+  /** Expected {@link NONE} but a preset was picked: the "generic step boxes the AI" failure. */
+  overFire: { count: number; of: number }
+  /** Expected a preset but {@link NONE} was picked: a fit the router failed to catch. */
+  miss: { count: number; of: number }
+  /** Expected preset A, picked preset B (both real): routed to the wrong policy. */
+  misroute: number
+  /** Per expected-preset tally (includes {@link NONE}). */
+  perExpected: Record<string, { total: number; correct: number }>
+  results: MetaSelectBenchResult[]
+}
+
+/** Normalize a {@link MetaSelection} to the picked name, or {@link NONE} when no preset fit. */
+export function pickedName(selection: MetaSelection): string {
+  return selection.preset ?? NONE
+}
+
+/**
+ * Score a set of already-run cases. Pure: no model, no IO — so the metrics are testable
+ * and the same function scores a live run or a replayed one.
+ */
+export function scoreMetaSelectBench(results: readonly MetaSelectBenchResult[]): MetaSelectBenchReport {
+  const perExpected: Record<string, { total: number; correct: number }> = {}
+  let correct = 0
+  let overFire = 0
+  let overFireOf = 0
+  let miss = 0
+  let missOf = 0
+  let misroute = 0
+  for (const r of results) {
+    const exp = r.case.expected
+    const bucket = (perExpected[exp] ??= { total: 0, correct: 0 })
+    bucket.total++
+    if (r.correct) {
+      correct++
+      bucket.correct++
+    }
+    if (exp === NONE) {
+      overFireOf++
+      if (r.picked !== NONE) overFire++
+    } else {
+      missOf++
+      if (r.picked === NONE) miss++
+      else if (r.picked !== exp) misroute++
+    }
+  }
+  const total = results.length
+  return {
+    total,
+    correct,
+    accuracy: total === 0 ? 0 : correct / total,
+    overFire: { count: overFire, of: overFireOf },
+    miss: { count: miss, of: missOf },
+    misroute,
+    perExpected,
+    results: [...results],
+  }
+}
+
+/** Options for {@link runMetaSelectBench}. */
+export interface RunMetaSelectBenchOptions {
+  driver: Driver
+  cases: readonly MetaSelectBenchCase[]
+  catalog: readonly PresetCatalogEntry[]
+  /** Where the driver runs its (throwaway) classification turn. Content is irrelevant. */
+  cwd: string
+  /** Model override passed to the driver. */
+  model?: string
+  signal?: AbortSignal
+  /** Called after each case, so a runner can stream progress. */
+  onResult?: (result: MetaSelectBenchResult, index: number) => void
+}
+
+/**
+ * Run every case through {@link metaSelect} and score the routing. One short-lived session
+ * per case (framed with {@link META_SELECT_SYSTEM}, like the CLI), disposed after — a case
+ * must not see the previous one's context. Sequential on purpose: a classification turn is
+ * cheap, and serial keeps the run gentle on rate limits and its output stable.
+ */
+export async function runMetaSelectBench(opts: RunMetaSelectBenchOptions): Promise<MetaSelectBenchReport> {
+  const results: MetaSelectBenchResult[] = []
+  for (const [index, benchCase] of opts.cases.entries()) {
+    if (opts.signal?.aborted) break
+    const session = await opts.driver.start({
+      cwd: opts.cwd,
+      system: META_SELECT_SYSTEM,
+      ...(opts.model ? { model: opts.model } : {}),
+      ...(opts.signal ? { signal: opts.signal } : {}),
+    })
+    try {
+      const selection = await metaSelect(session, {
+        intent: benchCase.intent,
+        catalog: opts.catalog,
+        workspace: benchCase.workspace,
+        ...(opts.signal ? { signal: opts.signal } : {}),
+      })
+      const picked = pickedName(selection)
+      const result: MetaSelectBenchResult = { case: benchCase, selection, picked, correct: picked === benchCase.expected }
+      results.push(result)
+      opts.onResult?.(result, index)
+    } finally {
+      await session.dispose()
+    }
+  }
+  return scoreMetaSelectBench(results)
+}
+
+/** Render a {@link MetaSelectBenchReport} as a compact human-readable summary. */
+export function formatMetaSelectBenchReport(report: MetaSelectBenchReport): string {
+  const pct = (n: number, d: number) => (d === 0 ? 'n/a' : `${((n / d) * 100).toFixed(0)}%`)
+  const lines: string[] = []
+  lines.push(`meta-select routing: ${report.correct}/${report.total} correct (${pct(report.correct, report.total)})`)
+  lines.push(`  over-fire (picked a preset when 'none' was right): ${report.overFire.count}/${report.overFire.of}`)
+  lines.push(`  miss (fell back to 'none' when a preset fit):       ${report.miss.count}/${report.miss.of}`)
+  lines.push(`  misroute (picked the wrong preset):                 ${report.misroute}`)
+  lines.push('  by expected:')
+  for (const [name, { total, correct }] of Object.entries(report.perExpected)) {
+    lines.push(`    ${name.padEnd(20)} ${correct}/${total} (${pct(correct, total)})`)
+  }
+  lines.push('  misses & misroutes:')
+  const wrong = report.results.filter(r => !r.correct)
+  if (wrong.length === 0) lines.push('    (none)')
+  for (const r of wrong) {
+    lines.push(`    [${r.case.expected} -> ${r.picked}] ${r.case.intent}`)
+  }
+  return lines.join('\n')
+}
+
+/**
+ * The labeled corpus. Small and hand-picked to cover each shipped preset, plus the
+ * contested `none` band (a plain question; a trivial one-liner where a full domain review
+ * loop is overkill). Labels are defensible, not gospel — the `why` is there to be argued
+ * with. Grow it as real runs surface routing the model gets wrong.
+ */
+export const META_SELECT_BENCH_CASES: readonly MetaSelectBenchCase[] = [
+  // web-development
+  {
+    intent: 'Add a dark-mode toggle to the site header',
+    workspace: 'a Vike + React web app',
+    expected: 'web-development',
+    why: 'browser UI change — accessibility / perf / web-security review is the fitting loop',
+  },
+  {
+    intent: "Fix the signup form so it is fully keyboard accessible",
+    workspace: 'a Next.js app (App Router)',
+    expected: 'web-development',
+    why: 'an a11y fix on rendered markup, the web-development loop owns a11y',
+  },
+  {
+    intent: 'Add OpenGraph and Twitter meta tags to every route',
+    workspace: 'an Astro content site',
+    expected: 'web-development',
+    why: 'per-route markup on a browser app',
+  },
+  // data-science
+  {
+    intent: 'Add k-fold cross-validation to the churn model training script',
+    workspace: 'a Python ML repo with notebooks',
+    expected: 'data-science',
+    why: 'model training methodology — reproducibility / method review',
+  },
+  {
+    intent: 'The feature pipeline silently drops rows; make it validate its inputs',
+    workspace: 'a pandas ETL project',
+    expected: 'data-science',
+    why: 'a data pipeline correctness change — data validation is the point',
+  },
+  // biological-science
+  {
+    intent: 'Add the missing controls to the RNA-seq differential-expression analysis',
+    workspace: 'a bioinformatics pipeline (Snakemake + R)',
+    expected: 'biological-science',
+    why: 'experimental design / controls in a life-science analysis',
+  },
+  {
+    intent: 'Recompute the p-values with Benjamini-Hochberg multiple-testing correction',
+    workspace: 'a genomics analysis repo',
+    expected: 'biological-science',
+    why: 'statistical rigor on a biological dataset',
+  },
+  // product-management
+  {
+    intent: 'Draft the acceptance criteria and success metrics for the referral feature',
+    workspace: 'a product spec repo (markdown docs only)',
+    expected: 'product-management',
+    why: 'requirement + measurable-outcome work, no stack concern',
+  },
+  {
+    intent: 'Write the PRD for the onboarding revamp and define how we measure it',
+    workspace: 'a docs-only planning repo',
+    expected: 'product-management',
+    why: 'a product outcome drives it, not code',
+  },
+  // software-development
+  {
+    intent: 'Refactor the payment service to remove the duplicated retry logic',
+    workspace: 'a Go microservices monorepo',
+    expected: 'software-development',
+    why: 'stack-agnostic engineering hygiene — review / tests / security',
+  },
+  {
+    intent: 'Add unit tests and fix the data race in the job queue',
+    workspace: 'a Rust backend service',
+    expected: 'software-development',
+    why: 'general engineering: tests + a concurrency correctness fix, no web/data/PM angle',
+  },
+  // none — the contested band Rom is pointing at
+  {
+    intent: 'What is the difference between a left join and an inner join?',
+    workspace: 'an empty directory',
+    expected: NONE,
+    why: 'a question, not a build task — no review loop applies',
+  },
+  {
+    intent: 'Update the copyright year in the LICENSE file to 2026',
+    workspace: 'a small TypeScript utility library',
+    expected: NONE,
+    why: 'a trivial text edit; a full domain review loop adds nothing here',
+  },
+]


### PR DESCRIPTION
Part of #502.

Rom's ask on #485/#502: don't keep the generic "pick the build policy" meta-select step on assumption, back it with a benchmark. This adds one.

## What

- `META_SELECT_BENCH_CASES` (`src/meta-select-bench.ts`): a small, hand-labeled corpus covering each shipped preset plus the contested `none` band (a plain question; a trivial one-liner where a full domain review loop is overkill). Each case carries a `why` so labels can be argued with.
- A harness that runs `metaSelect` over the corpus and scores routing: accuracy, **over-fire** (picks a preset when `none` was right, the "it boxes the AI" failure Rom is pointing at), miss, and misroute. Scoring is pure and unit-tested; the live runner drives a real model.
- `pnpm --filter @gemstack/framework bench:meta-select` runs it live. Six unit tests cover the scoring and plumbing offline (no model).

Internal tooling only: nothing is exported from the package's public API, so no changeset.

## First measurement

```
meta-select routing: 13/13 correct (100%)
  over-fire (picked a preset when 'none' was right): 0/2
  miss (fell back to 'none' when a preset fit):       0/11
  misroute (picked the wrong preset):                 0
```

Every preset 2-3/3, and both `none` cases stayed `none`. On this corpus the step routes accurately and does not over-fire.

## Honest caveat

13 clear-cut cases is a green light, not a verdict. The corpus is deliberately unambiguous, so it does not yet stress the exact case Rom worries about: genuinely unclear-goal tasks. The value here is that #502 now has a runnable measurement to grow with adversarial / ambiguous cases before we make the keep-narrow-drop call. My read: keep it for now, the data does not support dropping it.
