### PR TITLE
chore(framework): adversarial cases for the meta-select benchmark (#502)

### DIFF
--- a/packages/framework/bench/README.md
+++ b/packages/framework/bench/README.md
@@ -10,6 +10,8 @@ The harness runs a hand-labeled corpus (`src/meta-select-bench.ts`, `META_SELECT
 - **over-fire** — picked a preset when `none` (plain flow) was the right answer. This is the "it boxes the AI" failure Rom is worried about.
 - **miss / misroute** — fell back to `none` when a preset fit, or picked the wrong preset.
 
+The corpus has two bands: clear-cut cases (does it do the easy thing) and an **adversarial** band that actually stresses the doubt — vague / unclear-goal intents where `none` is right (so over-fire shows), trap-`none` intents dressed in domain keywords, genuinely cross-domain intents (scored against a set of defensible picks via `alsoAcceptable`), and mismatched intent-vs-workspace signals.
+
 The scoring is pure and unit-tested (`src/meta-select-bench.test.ts`); this runner just drives a live model.
 
 ### Run it

--- a/packages/framework/src/meta-select-bench.test.ts
+++ b/packages/framework/src/meta-select-bench.test.ts
@@ -7,6 +7,7 @@ import {
   META_SELECT_BENCH_CASES,
   NONE,
   formatMetaSelectBenchReport,
+  isAcceptablePick,
   runMetaSelectBench,
   scoreMetaSelectBench,
   type MetaSelectBenchCase,
@@ -91,17 +92,46 @@ test('runMetaSelectBench records a misroute when the router picks the wrong pres
   assert.equal(report.results[0]!.picked, 'software-development')
 })
 
-test('the shipped corpus is well-formed: unique intents, and every label is a real preset or none', () => {
+test('isAcceptablePick: the expected label or a listed alternate counts; anything else does not', () => {
+  const c: MetaSelectBenchCase = { intent: 'i', workspace: 'w', expected: 'web-development', alsoAcceptable: ['data-science'], why: '' }
+  assert.equal(isAcceptablePick(c, 'web-development'), true)
+  assert.equal(isAcceptablePick(c, 'data-science'), true) // defensible alternate
+  assert.equal(isAcceptablePick(c, 'software-development'), false) // a real misroute
+  assert.equal(isAcceptablePick(c, NONE), false)
+})
+
+test('scoreMetaSelectBench: a defensible alternate is correct, not a misroute', () => {
+  const crossDomain: MetaSelectBenchResult = {
+    case: { intent: 'i', workspace: 'w', expected: 'web-development', alsoAcceptable: ['data-science'], why: '' },
+    selection: { preset: 'data-science', modes: [] },
+    picked: 'data-science',
+    correct: isAcceptablePick({ intent: 'i', workspace: 'w', expected: 'web-development', alsoAcceptable: ['data-science'], why: '' }, 'data-science'),
+  }
+  const report = scoreMetaSelectBench([crossDomain])
+  assert.equal(report.correct, 1)
+  assert.equal(report.misroute, 0)
+  // The report still shows it diverged from the primary label, transparently.
+  assert.match(formatMetaSelectBenchReport(report), /defensible alternates taken/)
+  assert.match(formatMetaSelectBenchReport(report), /\[web-development ~ data-science\]/)
+})
+
+test('the shipped corpus is well-formed: unique intents, real labels, valid alternates, and both bands present', () => {
   const validExpected = new Set([...CATALOG.map(p => p.name), 'data-science', 'biological-science', 'product-management', NONE])
+  const realPresets = new Set([...validExpected].filter(n => n !== NONE))
   const intents = new Set<string>()
   for (const c of META_SELECT_BENCH_CASES) {
     assert.ok(c.intent.trim() && c.workspace.trim() && c.why.trim(), `case missing fields: ${c.intent}`)
     assert.ok(!intents.has(c.intent), `duplicate intent: ${c.intent}`)
     intents.add(c.intent)
     assert.ok(validExpected.has(c.expected), `unknown expected label: ${c.expected}`)
+    for (const alt of c.alsoAcceptable ?? []) {
+      assert.ok(realPresets.has(alt), `unknown alternate: ${alt}`)
+      assert.notEqual(alt, c.expected, `alternate duplicates expected: ${c.intent}`)
+    }
   }
-  // It actually covers the contested 'none' band, not just happy presets.
+  // Both bands are present: the contested 'none' band and genuinely cross-domain cases.
   assert.ok(META_SELECT_BENCH_CASES.some(c => c.expected === NONE), 'corpus should include none cases')
+  assert.ok(META_SELECT_BENCH_CASES.some(c => (c.alsoAcceptable?.length ?? 0) > 0), 'corpus should include cross-domain cases')
 })
 
 test('formatMetaSelectBenchReport surfaces the headline number and each wrong pick', () => {

--- a/packages/framework/src/meta-select-bench.ts
+++ b/packages/framework/src/meta-select-bench.ts
@@ -28,8 +28,21 @@ export interface MetaSelectBenchCase {
   workspace: string
   /** The preset name a human would pick, or {@link NONE} for the plain flow. */
   expected: string
+  /**
+   * Other picks that are also defensible for a genuinely cross-domain case (e.g. a chart of
+   * a model's output is arguably web *or* data-science). A pick in here counts as correct,
+   * so the harness tests "did it pick a defensible policy", not "did it match my one guess".
+   * Leave empty for the strict cases — the vague and trap-`none` cases have no alternate,
+   * so an off-target pick there is exactly the over-fire / misroute we want to catch.
+   */
+  alsoAcceptable?: readonly string[]
   /** Why that label — so a reviewer can contest it (the `none` calls especially). */
   why: string
+}
+
+/** True when `picked` is the case's expected label or one of its accepted alternates. */
+export function isAcceptablePick(benchCase: MetaSelectBenchCase, picked: string): boolean {
+  return picked === benchCase.expected || (benchCase.alsoAcceptable?.includes(picked) ?? false)
 }
 
 /** The outcome of running one case through {@link metaSelect}. */
@@ -89,7 +102,7 @@ export function scoreMetaSelectBench(results: readonly MetaSelectBenchResult[]):
     } else {
       missOf++
       if (r.picked === NONE) miss++
-      else if (r.picked !== exp) misroute++
+      else if (!isAcceptablePick(r.case, r.picked)) misroute++ // an accepted alternate is not a misroute
     }
   }
   const total = results.length
@@ -143,7 +156,7 @@ export async function runMetaSelectBench(opts: RunMetaSelectBenchOptions): Promi
         ...(opts.signal ? { signal: opts.signal } : {}),
       })
       const picked = pickedName(selection)
-      const result: MetaSelectBenchResult = { case: benchCase, selection, picked, correct: picked === benchCase.expected }
+      const result: MetaSelectBenchResult = { case: benchCase, selection, picked, correct: isAcceptablePick(benchCase, picked) }
       results.push(result)
       opts.onResult?.(result, index)
     } finally {
@@ -171,14 +184,31 @@ export function formatMetaSelectBenchReport(report: MetaSelectBenchReport): stri
   for (const r of wrong) {
     lines.push(`    [${r.case.expected} -> ${r.picked}] ${r.case.intent}`)
   }
+  // Correct picks that took a defensible alternate rather than the primary label: not a
+  // failure, but worth seeing on the cross-domain cases where the router had a real choice.
+  const alternates = report.results.filter(r => r.correct && r.picked !== r.case.expected)
+  if (alternates.length) {
+    lines.push('  defensible alternates taken:')
+    for (const r of alternates) {
+      lines.push(`    [${r.case.expected} ~ ${r.picked}] ${r.case.intent}`)
+    }
+  }
   return lines.join('\n')
 }
 
 /**
- * The labeled corpus. Small and hand-picked to cover each shipped preset, plus the
- * contested `none` band (a plain question; a trivial one-liner where a full domain review
- * loop is overkill). Labels are defensible, not gospel — the `why` is there to be argued
- * with. Grow it as real runs surface routing the model gets wrong.
+ * The labeled corpus. Two bands:
+ *
+ * 1. Clear-cut cases: one intent that obviously maps to one preset (or obviously to
+ *    `none`). These check the router does the easy thing.
+ * 2. Adversarial cases (#502 follow-up): the ones that actually stress Rom's doubt —
+ *    *vague / unclear-goal* intents where `none` is the honest answer (this is where
+ *    over-fire shows), *trap `none`* intents dressed in domain keywords, genuinely
+ *    *cross-domain* intents (scored with {@link MetaSelectBenchCase.alsoAcceptable}), and
+ *    *mismatched* intent-vs-workspace signals.
+ *
+ * Labels are defensible, not gospel — the `why` is there to be argued with. Grow it as
+ * real runs surface routing the model gets wrong.
  */
 export const META_SELECT_BENCH_CASES: readonly MetaSelectBenchCase[] = [
   // web-development
@@ -264,5 +294,81 @@ export const META_SELECT_BENCH_CASES: readonly MetaSelectBenchCase[] = [
     workspace: 'a small TypeScript utility library',
     expected: NONE,
     why: 'a trivial text edit; a full domain review loop adds nothing here',
+  },
+
+  // --- adversarial band (#502): the cases that actually test the doubt ---
+
+  // vague / unclear-goal: no actionable goal, so 'none' (plain flow) is right. A preset
+  // pick here is over-fire — the exact "generic step boxes the AI" failure Rom flagged.
+  {
+    intent: 'clean this up',
+    workspace: 'a mixed TypeScript repo',
+    expected: NONE,
+    why: 'no concrete goal or scope; there is nothing for a domain loop to key on',
+  },
+  {
+    intent: 'make it better',
+    workspace: 'a small web project',
+    expected: NONE,
+    why: 'no stated objective — a preset would be guessing at intent',
+  },
+  {
+    intent: 'can you take a look',
+    workspace: 'a backend service',
+    expected: NONE,
+    why: 'an open-ended ask with no task; the plain flow should handle it',
+  },
+
+  // trap 'none': trivial work wearing domain keywords. The keyword must not pull a preset.
+  {
+    intent: "Bump the version in the bioinformatics pipeline's README to 2.0",
+    workspace: 'a Snakemake genomics repo',
+    expected: NONE,
+    why: 'a one-line doc edit; "bioinformatics/genomics" should not trigger biological-science',
+  },
+  {
+    intent: "Fix the typo in the data pipeline's log message",
+    workspace: 'a pandas ETL project',
+    expected: NONE,
+    why: 'a cosmetic string fix; "data pipeline" should not trigger data-science',
+  },
+
+  // genuinely cross-domain: two defensible policies. Scored with alsoAcceptable, so the
+  // test is "did it pick a defensible one", not "did it match my single guess".
+  {
+    intent: "Add an accessible bar chart of the churn model's predictions to the dashboard",
+    workspace: 'a Next.js app that reads a trained model',
+    expected: 'web-development',
+    alsoAcceptable: ['data-science'],
+    why: 'the concrete change is accessible UI (web), but it visualizes a model (data) — either is fair',
+  },
+  {
+    intent: 'Add input validation and helpful error messages to the CSV upload form',
+    workspace: 'a Vike app with a data-import feature',
+    expected: 'web-development',
+    alsoAcceptable: ['data-science'],
+    why: 'form UX is a web concern; validating incoming data is a data concern',
+  },
+  {
+    intent: 'Write tests for the statistics module and fix the off-by-one in the p-value calc',
+    workspace: 'a genomics analysis repo',
+    expected: 'biological-science',
+    alsoAcceptable: ['software-development', 'data-science'],
+    why: 'statistical correctness in a bio context, but also plain tests + a bug fix',
+  },
+  {
+    intent: 'Define success metrics and add the analytics events to track signups',
+    workspace: 'a Next.js SaaS app',
+    expected: 'product-management',
+    alsoAcceptable: ['web-development'],
+    why: 'success metrics are a product concern; wiring the events is a web change',
+  },
+
+  // mismatched signals: a strong intent against a contradictory workspace line. Intent wins.
+  {
+    intent: 'Add k-fold cross-validation to the model training script',
+    workspace: 'a product management docs repo',
+    expected: 'data-science',
+    why: 'the intent is unmistakably data-science; the workspace label should not override it',
   },
 ]


### PR DESCRIPTION
Part of #502. Follow-up to #508.

The first benchmark corpus was all clear-cut cases (13/13), so it did not stress the thing Rom actually doubts: *generic / unclear-goal* tasks. This adds an adversarial band that does.

## New cases

- **Vague / unclear-goal** ("clean this up", "make it better", "can you take a look"): `none` is the honest answer, so these catch over-fire.
- **Trap `none`**: trivial work wearing domain keywords ("bump the version in the bioinformatics pipeline's README") — the keyword must not pull a preset.
- **Cross-domain**: genuinely two defensible policies, scored against a set via a new `alsoAcceptable` field, so the test is "did it pick a defensible policy", not "did it match my one guess". Divergences to an accepted alternate are still reported.
- **Mismatched signals**: a strong intent against a contradictory workspace line.

Harness gains `isAcceptablePick` + `alsoAcceptable`; 8 offline unit tests. Still internal tooling (nothing exported from the package API), so no changeset.

## Finding (live, 23 cases)

```
meta-select routing: 19/23 correct (83%)
  over-fire (picked a preset when 'none' was right): 3/7
  miss:                                              0/16
  misroute:                                          1
```

All three **vague** intents over-fired to a preset instead of `none`. The trap-`none` cases correctly stayed `none`, and every cross-domain case routed to a defensible policy. So the signal is clean: **it is unclear-goal prompts, not keywords, that make the router over-fire** — exactly Rom's concern, now measured.

(The one misroute, a p-value correction in a genomics repo routed to `data-science` instead of `biological-science`, is a borderline label I'd argue is defensible either way.)

## Recommendation

Not drop, **narrow**: teach `metaSelect` to return `none` when the intent has no concrete goal (a one-line addition to its prompt), then re-run this benchmark to confirm the over-fire drops without hurting the well-specified cases. Happy to do that as the next PR if you agree with the read.
