### PR TITLE
chore(framework): benchmark the architect prompt (#511)

### DIFF
--- a/packages/framework/bench/README.md
+++ b/packages/framework/bench/README.md
@@ -30,3 +30,20 @@ Needs the `claude` CLI installed and logged in (it drives a real model). Output 
 - Low accuracy or high over-fire → the generic step is boxing the model; narrow it to clear-goal cases or drop it.
 
 The corpus is small and its labels are arguable on purpose (each case carries a `why`). Grow it with real routing the model gets wrong.
+
+## architect prompt (#485 / #499)
+
+Does the architect prompt (`architectPrompt` in `src/steps.ts`) pick a sane stack for the app, give the honest tradeoffs it promises, and stay unbiased? #499 already had to strip a Vike nudge from it, so this benchmark guards the same trust concern.
+
+The harness (`src/architect-bench.ts`) runs a labeled corpus of app ideas through `driverArchitect` and reports:
+
+- **sane stacks** — for apps whose *type* dictates the family (a CLI is not a web app, a mobile app is not Next.js), did it pick something in the acceptable set and nothing clearly wrong.
+- **honest tradeoffs** — how often the plan carried a pro **and** a con **and** a rejected alternative (the architect prompt asks for all three).
+- **framework balance** — across genuinely framework-agnostic web apps, which frontend framework it picked. A heavy skew to one (e.g. Vike) is the bias #499 was about.
+
+```bash
+pnpm --filter @gemstack/framework build
+pnpm --filter @gemstack/framework bench:architect
+```
+
+Same requirements as above (a logged-in `claude` CLI). Scoring is pure and unit-tested; the runner just drives the model.

--- a/packages/framework/bench/architect.mjs
+++ b/packages/framework/bench/architect.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// Live benchmark for the architect prompt (#485/#499): run a labeled corpus of app ideas
+// through the architect and report whether it picks sane stacks, gives honest tradeoffs,
+// and stays framework-balanced on agnostic web apps. Requires the `claude` CLI logged in.
+//
+//   pnpm --filter @gemstack/framework build
+//   pnpm --filter @gemstack/framework bench:architect
+//   MODEL=claude-haiku-4-5-20251001 pnpm --filter @gemstack/framework bench:architect
+//
+// Scoring lives in src/architect-bench.ts (unit-tested); this is just the live runner.
+import { ClaudeCodeDriver } from '../dist/index.js'
+import {
+  ARCHITECT_BENCH_CASES,
+  formatArchitectBenchReport,
+  runArchitectBench,
+} from '../dist/architect-bench.js'
+
+const driver = new ClaudeCodeDriver({ permissionMode: 'acceptEdits' })
+
+console.log(`Running ${ARCHITECT_BENCH_CASES.length} architect cases...\n`)
+
+const report = await runArchitectBench({
+  driver,
+  cases: ARCHITECT_BENCH_CASES,
+  cwd: process.cwd(),
+  ...(process.env.MODEL ? { model: process.env.MODEL } : {}),
+  onResult: (r, i) => {
+    const tag = r.case.webAgnostic ? `bal:${r.framework}` : r.stackFit ? 'ok ' : 'XX '
+    const flags = `${r.complete ? '' : ' [no tradeoffs]'}`
+    console.log(`${tag.padEnd(12)} ${String(i + 1).padStart(2)}. ${r.stack}${flags}  <- ${r.case.intent}`)
+  },
+})
+
+console.log(`\n${formatArchitectBenchReport(report)}`)

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -56,6 +56,7 @@
     "test": "tsc -p tsconfig.test.json && cd dist-test && node --test",
     "bundle:dashboard": "node scripts/bundle-dashboard.mjs",
     "bench:meta-select": "node bench/meta-select.mjs",
+    "bench:architect": "node bench/architect.mjs",
     "clean": "rm -rf dist dist-test"
   },
   "dependencies": {

--- a/packages/framework/src/architect-bench.test.ts
+++ b/packages/framework/src/architect-bench.test.ts
@@ -1,0 +1,111 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { FakeDriver } from './driver/index.js'
+import {
+  ARCHITECT_BENCH_CASES,
+  detectFramework,
+  formatArchitectBenchReport,
+  isComplete,
+  isStackFit,
+  runArchitectBench,
+  scoreArchitectBench,
+  type ArchitectBenchCase,
+  type ArchitectBenchResult,
+} from './architect-bench.js'
+import type { ArchitectPlan } from '@gemstack/ai-autopilot'
+
+const plan = (over: Partial<ArchitectPlan> = {}): ArchitectPlan => ({
+  stack: 'Next.js + Prisma',
+  narration: 'n',
+  decisions: [],
+  pros: ['fast'],
+  cons: ['heavy'],
+  alternatives: [{ option: 'Vike', whyNot: 'smaller ecosystem' }],
+  ...over,
+})
+
+const resultOf = (c: ArchitectBenchCase, p: ArchitectPlan): ArchitectBenchResult => ({
+  case: c,
+  plan: p,
+  stack: p.stack,
+  stackFit: isStackFit(c, p.stack),
+  complete: isComplete(p),
+  framework: detectFramework(p.stack),
+})
+
+test('detectFramework picks the named frontend framework, most specific first', () => {
+  assert.equal(detectFramework('SvelteKit + Drizzle'), 'sveltekit') // not plain "svelte"
+  assert.equal(detectFramework('Next.js (React) + Prisma'), 'next') // not plain "react"
+  assert.equal(detectFramework('Vike + Vue'), 'vike')
+  assert.equal(detectFramework('Express + Postgres'), 'other')
+})
+
+test('isComplete requires a pro, a con, and a rejected alternative', () => {
+  assert.equal(isComplete(plan()), true)
+  assert.equal(isComplete(plan({ cons: [] })), false)
+  assert.equal(isComplete(plan({ alternatives: [] })), false)
+  assert.equal(isComplete(plan({ pros: [] })), false)
+})
+
+test('isStackFit needs an accept match and no reject match', () => {
+  const c: ArchitectBenchCase = { intent: 'i', accept: [/express|fastify/i], reject: [/react|vue/i], why: '' }
+  assert.equal(isStackFit(c, 'Fastify + Postgres'), true)
+  assert.equal(isStackFit(c, 'Django'), false) // no accept match
+  assert.equal(isStackFit(c, 'Express + React admin'), false) // reject match wins
+})
+
+test('scoreArchitectBench: web-agnostic cases feed the balance, not the fit rate', () => {
+  const category: ArchitectBenchCase = { intent: 'cli', accept: [/node/i], reject: [/react/i], why: '' }
+  const agnostic: ArchitectBenchCase = { intent: 'web', accept: [/./], webAgnostic: true, why: '' }
+  const report = scoreArchitectBench([
+    resultOf(category, plan({ stack: 'Node CLI', pros: ['x'], cons: ['y'], alternatives: [{ option: 'a', whyNot: 'b' }] })),
+    resultOf(category, plan({ stack: 'React SPA' })), // unfit (reject match)
+    resultOf(agnostic, plan({ stack: 'Vike + React' })),
+    resultOf(agnostic, plan({ stack: 'Next.js' })),
+  ])
+  assert.deepEqual(report.stackFit, { count: 1, of: 2 }) // only the two category cases count toward fit
+  assert.deepEqual(report.frameworkBalance, { vike: 1, next: 1 })
+  assert.equal(report.complete.of, 4)
+})
+
+test('runArchitectBench drives each case through the architect and scores the plan', async () => {
+  const cases: ArchitectBenchCase[] = [
+    { intent: 'a CLI', accept: [/node|go/i], reject: [/react|vike/i], why: '' },
+    { intent: 'a web app', accept: [/./], webAgnostic: true, why: '' },
+  ]
+  // A scripted driver returning a sane plan for each: a Node CLI, then a Vike web app.
+  const replies = [
+    { stack: 'Node.js + TypeScript', narration: 'a cli', decisions: [], pros: ['simple'], cons: ['no ui'], alternatives: [{ option: 'Go', whyNot: 'slower to write' }] },
+    { stack: 'Vike + React', narration: 'a web app', decisions: [], pros: ['portable'], cons: ['smaller ecosystem'], alternatives: [{ option: 'Next.js', whyNot: 'heavier' }] },
+  ]
+  let i = 0
+  const driver = new FakeDriver({ respond: () => '```json\n' + JSON.stringify(replies[i++]) + '\n```' })
+  const report = await runArchitectBench({ driver, cases, cwd: '/tmp/ws' })
+  assert.deepEqual(report.stackFit, { count: 1, of: 1 }) // the CLI got a sane, non-web stack
+  assert.deepEqual(report.complete, { count: 2, of: 2 }) // both plans had pros + cons + an alternative
+  assert.deepEqual(report.frameworkBalance, { vike: 1 })
+})
+
+test('the shipped corpus is well-formed: unique intents, an accept pattern each, and both kinds present', () => {
+  const intents = new Set<string>()
+  for (const c of ARCHITECT_BENCH_CASES) {
+    assert.ok(c.intent.trim() && c.why.trim(), `case missing fields: ${c.intent}`)
+    assert.ok(!intents.has(c.intent), `duplicate intent: ${c.intent}`)
+    intents.add(c.intent)
+    assert.ok(c.accept.length > 0, `case has no accept pattern: ${c.intent}`)
+  }
+  assert.ok(ARCHITECT_BENCH_CASES.some(c => c.webAgnostic), 'corpus should include web-agnostic cases')
+  assert.ok(ARCHITECT_BENCH_CASES.some(c => !c.webAgnostic), 'corpus should include category cases')
+})
+
+test('formatArchitectBenchReport surfaces the headline, the balance, and questionable stacks', () => {
+  const category: ArchitectBenchCase = { intent: 'a CLI tool', accept: [/node/i], reject: [/react/i], why: '' }
+  const agnostic: ArchitectBenchCase = { intent: 'a web app', accept: [/./], webAgnostic: true, why: '' }
+  const text = formatArchitectBenchReport(
+    scoreArchitectBench([resultOf(category, plan({ stack: 'React SPA' })), resultOf(agnostic, plan({ stack: 'Vike' }))]),
+  )
+  assert.match(text, /sane stacks/)
+  assert.match(text, /framework balance/)
+  assert.match(text, /questionable stacks/)
+  assert.match(text, /\[React SPA\] a CLI tool/)
+})

--- a/packages/framework/src/architect-bench.ts
+++ b/packages/framework/src/architect-bench.ts
@@ -1,0 +1,286 @@
+import { DecisionLedger, type ArchitectPlan } from '@gemstack/ai-autopilot'
+import type { Driver } from './driver/index.js'
+import { driverArchitect } from './steps.js'
+
+/**
+ * A benchmark for the architect prompt (`architectPrompt` in `steps.ts`) — the turn that
+ * decides an app's stack. Rom's line on #485: the system prompt is the most critical part
+ * of The Framework, and #499 already had to strip a Vike nudge from this one because a
+ * biased stack pick erodes trust. So, like the meta-select benchmark (#502), measure it
+ * rather than assume: does the architect pick a *sane* stack for the app, does it give the
+ * *honest tradeoffs* the prompt demands (pros AND cons AND a rejected alternative), and —
+ * the trust check — on genuinely framework-agnostic web apps, is it *balanced* across
+ * frameworks rather than defaulting to Vike?
+ *
+ * Scoring ({@link scoreArchitectBench}) is pure and unit-tested; the live run
+ * ({@link runArchitectBench}) drives a real model through the given {@link Driver}. The
+ * corpus ({@link ARCHITECT_BENCH_CASES}) is hand-labeled — each case says which stacks are
+ * sane (`accept`) and, where a whole category would be wrong, which are not (`reject`).
+ */
+
+/** One labeled architect case. */
+export interface ArchitectBenchCase {
+  /** The app the user asks for. */
+  intent: string
+  /** The picked stack fits if it matches at least one of these. */
+  accept: readonly RegExp[]
+  /** ...and matches none of these (a category that is clearly wrong for this app). */
+  reject?: readonly RegExp[]
+  /**
+   * A web app where any modern framework is a fine choice. These do not test stack-fit
+   * (they always fit); they feed the framework-balance tally — the #499 trust check.
+   */
+  webAgnostic?: boolean
+  /** Why these labels — so a reviewer can contest them. */
+  why: string
+}
+
+/** The outcome of running one case through the architect. */
+export interface ArchitectBenchResult {
+  case: ArchitectBenchCase
+  plan: ArchitectPlan
+  /** The picked stack, verbatim. */
+  stack: string
+  /** The stack matched an `accept` pattern and no `reject` pattern. */
+  stackFit: boolean
+  /** The plan carried at least one pro, one con, and one rejected alternative. */
+  complete: boolean
+  /** The frontend framework detected in the stack, or `'other'`. Used for the balance tally. */
+  framework: string
+}
+
+/** Aggregate metrics over a set of {@link ArchitectBenchResult}s — the decision input. */
+export interface ArchitectBenchReport {
+  total: number
+  /** Cases whose picked stack was sane for the app (excludes web-agnostic cases). */
+  stackFit: { count: number; of: number }
+  /** Cases whose plan gave the full honest tradeoff (pros + cons + a rejected alternative). */
+  complete: { count: number; of: number }
+  /**
+   * Framework distribution across the web-agnostic cases (the trust check): a heavy skew to
+   * one framework is the bias #499 was worried about. `{}` when there are no such cases.
+   */
+  frameworkBalance: Record<string, number>
+  results: ArchitectBenchResult[]
+}
+
+/** Known frontend frameworks, most specific first, for the balance tally. */
+const FRAMEWORKS: readonly { name: string; re: RegExp }[] = [
+  { name: 'sveltekit', re: /\bsveltekit\b/i },
+  { name: 'next', re: /\bnext(\.js)?\b/i },
+  { name: 'nuxt', re: /\bnuxt\b/i },
+  { name: 'remix', re: /\bremix\b/i },
+  { name: 'astro', re: /\bastro\b/i },
+  { name: 'vike', re: /\bvike\b/i },
+  { name: 'solidstart', re: /\bsolid(start)?\b/i },
+  { name: 'react', re: /\breact\b/i },
+  { name: 'vue', re: /\bvue\b/i },
+  { name: 'svelte', re: /\bsvelte\b/i },
+]
+
+/** The frontend framework named in a stack string, or `'other'` if none is recognized. */
+export function detectFramework(stack: string): string {
+  return FRAMEWORKS.find(f => f.re.test(stack))?.name ?? 'other'
+}
+
+/** Whether a plan carries the full honest tradeoff the architect prompt asks for. */
+export function isComplete(plan: ArchitectPlan): boolean {
+  return (plan.pros?.length ?? 0) > 0 && (plan.cons?.length ?? 0) > 0 && (plan.alternatives?.length ?? 0) > 0
+}
+
+/** Whether a picked stack is sane for the case: matches an accept and no reject. */
+export function isStackFit(benchCase: ArchitectBenchCase, stack: string): boolean {
+  const accepted = benchCase.accept.some(re => re.test(stack))
+  const rejected = benchCase.reject?.some(re => re.test(stack)) ?? false
+  return accepted && !rejected
+}
+
+/**
+ * Score already-run cases. Pure: no model, no IO. Web-agnostic cases are excluded from the
+ * stack-fit rate (they always fit) and instead feed the framework-balance tally.
+ */
+export function scoreArchitectBench(results: readonly ArchitectBenchResult[]): ArchitectBenchReport {
+  let fit = 0
+  let fitOf = 0
+  let complete = 0
+  const frameworkBalance: Record<string, number> = {}
+  for (const r of results) {
+    if (r.complete) complete++
+    if (r.case.webAgnostic) {
+      frameworkBalance[r.framework] = (frameworkBalance[r.framework] ?? 0) + 1
+    } else {
+      fitOf++
+      if (r.stackFit) fit++
+    }
+  }
+  return {
+    total: results.length,
+    stackFit: { count: fit, of: fitOf },
+    complete: { count: complete, of: results.length },
+    frameworkBalance,
+    results: [...results],
+  }
+}
+
+/** Options for {@link runArchitectBench}. */
+export interface RunArchitectBenchOptions {
+  driver: Driver
+  cases: readonly ArchitectBenchCase[]
+  /** Where the driver runs the (throwaway) architect turn. */
+  cwd: string
+  model?: string
+  signal?: AbortSignal
+  onResult?: (result: ArchitectBenchResult, index: number) => void
+}
+
+/**
+ * Run every case through {@link driverArchitect} and score it. One short-lived session per
+ * case, disposed after. No system prompt is injected: the architect prompt is self-contained,
+ * so this measures that prompt itself (the thing #499 changed), not the #326 framing around
+ * it. Sequential — an architect turn is not cheap and serial keeps the run stable.
+ */
+export async function runArchitectBench(opts: RunArchitectBenchOptions): Promise<ArchitectBenchReport> {
+  const results: ArchitectBenchResult[] = []
+  for (const [index, benchCase] of opts.cases.entries()) {
+    if (opts.signal?.aborted) break
+    const session = await opts.driver.start({
+      cwd: opts.cwd,
+      system: '',
+      ...(opts.model ? { model: opts.model } : {}),
+      ...(opts.signal ? { signal: opts.signal } : {}),
+    })
+    try {
+      const architect = driverArchitect(session, {})
+      // driverArchitect only reads ctx.intent; scope + ledger satisfy the contract with a
+      // fresh (empty) ledger so no prior decision steers the pick.
+      const plan = await architect({ intent: benchCase.intent, scope: 'full', ledger: new DecisionLedger() })
+      const stack = plan.stack ?? ''
+      const result: ArchitectBenchResult = {
+        case: benchCase,
+        plan,
+        stack,
+        stackFit: isStackFit(benchCase, stack),
+        complete: isComplete(plan),
+        framework: detectFramework(stack),
+      }
+      results.push(result)
+      opts.onResult?.(result, index)
+    } finally {
+      await session.dispose()
+    }
+  }
+  return scoreArchitectBench(results)
+}
+
+/** Render an {@link ArchitectBenchReport} as a compact human-readable summary. */
+export function formatArchitectBenchReport(report: ArchitectBenchReport): string {
+  const pct = (n: number, d: number) => (d === 0 ? 'n/a' : `${((n / d) * 100).toFixed(0)}%`)
+  const lines: string[] = []
+  lines.push(`architect: ${report.stackFit.count}/${report.stackFit.of} sane stacks (${pct(report.stackFit.count, report.stackFit.of)})`)
+  lines.push(`  honest tradeoffs (pros + cons + a rejected alternative): ${report.complete.count}/${report.complete.of} (${pct(report.complete.count, report.complete.of)})`)
+  const balance = Object.entries(report.frameworkBalance).sort((a, b) => b[1] - a[1])
+  if (balance.length) {
+    lines.push(`  framework balance on agnostic web apps (${balance.reduce((n, [, c]) => n + c, 0)} cases):`)
+    for (const [name, count] of balance) lines.push(`    ${name.padEnd(12)} ${count}`)
+  }
+  const unfit = report.results.filter(r => !r.case.webAgnostic && !r.stackFit)
+  const incomplete = report.results.filter(r => !r.complete)
+  if (unfit.length) {
+    lines.push('  questionable stacks:')
+    for (const r of unfit) lines.push(`    [${r.stack}] ${r.case.intent}`)
+  }
+  if (incomplete.length) {
+    lines.push('  missing tradeoffs:')
+    for (const r of incomplete) lines.push(`    ${r.case.intent}`)
+  }
+  return lines.join('\n')
+}
+
+const WEB = /\b(next(\.js)?|vike|nuxt|sveltekit|remix|astro|react|vue|svelte|solid(start)?|angular)\b/i
+const SERVER = /\b(express|fastify|hono|nest(js)?|koa|adonis|node(\.js)?|django|flask|fastapi|rails|laravel|go\b|gin|rust|axum|spring)\b/i
+
+/**
+ * The labeled corpus. Two kinds:
+ * - **category cases** — an app whose *type* dictates the stack family (a CLI is not a web
+ *   app; a mobile app is not Next.js). These test stack-fit with `accept` + `reject`.
+ * - **web-agnostic cases** — plain web apps where any modern framework is fine. They feed
+ *   the framework-balance tally, the trust check that #499 was about.
+ * Labels are defensible, not gospel — the `why` is there to argue with.
+ */
+export const ARCHITECT_BENCH_CASES: readonly ArchitectBenchCase[] = [
+  {
+    intent: 'A command-line tool that bulk-renames files with a --dry-run flag',
+    accept: [/\b(node(\.js)?|deno|bun|typescript|go\b|rust|python)\b/i],
+    reject: [WEB],
+    why: 'a CLI needs a runtime, not a web framework',
+  },
+  {
+    intent: 'A JSON REST API for a todo list backed by Postgres, no frontend',
+    accept: [SERVER],
+    reject: [/\bastro\b|\bhugo\b|\beleventy\b|\bgatsby\b|create-react-app|vite \+ react/i],
+    why: 'a headless API wants a server framework, not a static-site generator or a SPA',
+  },
+  {
+    intent: 'A cross-platform mobile app to track workouts offline',
+    accept: [/\b(react native|expo|flutter|ionic|capacitor|kotlin multiplatform)\b/i],
+    // Reject a *web frontend* framework used as the app shell (it would not be native), but
+    // not a server framework — a mobile app may legitimately have a backend.
+    reject: [/\b(next(\.js)?|vike|nuxt|astro|remix|sveltekit)\b/i],
+    why: 'a native mobile app needs a mobile framework, not a web frontend',
+  },
+  {
+    intent: 'A desktop note-taking app with local file storage and a system tray',
+    // Accept requires a desktop shell; that alone is the test. No reject on web frameworks:
+    // Tauri / Electron legitimately embed a web frontend (React/Vike/etc.) inside the shell.
+    accept: [/\b(electron|tauri|neutralino|wails|\.net maui|qt)\b/i],
+    why: 'a desktop app wants a desktop shell (which may embed a web UI)',
+  },
+  {
+    intent: 'A nightly Python job that scrapes prices and writes a CSV report',
+    accept: [/\b(python|node(\.js)?|typescript|go\b)\b/i],
+    reject: [WEB],
+    why: 'a batch script needs a runtime, not a UI framework',
+  },
+  {
+    intent: 'A documentation site generated from markdown files',
+    accept: [/\b(astro|vike|next(\.js)?|nuxt|vitepress|docusaurus|eleventy|hugo|starlight|sveltekit)\b/i],
+    why: 'a docs site wants a static-site / content meta-framework — many are fine',
+  },
+  // web-agnostic: any modern framework is a fine pick — these feed the balance tally.
+  {
+    intent: 'A web app to manage a personal book library with search',
+    accept: [WEB],
+    webAgnostic: true,
+    why: 'a straightforward CRUD web app; no framework is uniquely right',
+  },
+  {
+    intent: 'A realtime team chat web app with channels and presence',
+    accept: [WEB],
+    webAgnostic: true,
+    why: 'realtime web app; several frameworks handle it well',
+  },
+  {
+    intent: 'A web dashboard showing charts of sales data with filters',
+    accept: [WEB],
+    webAgnostic: true,
+    why: 'a data dashboard web app; framework choice is open',
+  },
+  {
+    intent: 'A small marketing website with a contact form',
+    accept: [WEB],
+    webAgnostic: true,
+    why: 'a content site; many frameworks fit',
+  },
+  {
+    intent: 'A web-based kanban board with drag-and-drop cards',
+    accept: [WEB],
+    webAgnostic: true,
+    why: 'an interactive web app; framework-agnostic',
+  },
+  {
+    intent: 'An online storefront with a product catalog and cart',
+    accept: [WEB],
+    webAgnostic: true,
+    why: 'an e-commerce web app; several stacks are reasonable',
+  },
+]


### PR DESCRIPTION
Closes #511. Follow-up to #485 / #499.

Same idea as the meta-select benchmark (#502), applied to the other critical prompt: the architect turn that picks an app's stack. #499 already had to strip a Vike nudge from it, so this guards the same trust concern with a number instead of a vibe.

## What

`src/architect-bench.ts` runs a labeled corpus of app ideas through `driverArchitect` and scores three things:

- **sane stacks** — for apps whose type dictates the family (a CLI is not a web app, a mobile app is not Next.js), did it pick something acceptable and nothing clearly wrong.
- **honest tradeoffs** — how often the plan carried a pro AND a con AND a rejected alternative (the prompt asks for all three).
- **framework balance** — on genuinely framework-agnostic web apps, which frontend it picked. A heavy skew is the bias #499 was about.

Pure, unit-tested scoring (`isStackFit` / `isComplete` / `detectFramework` / `scoreArchitectBench`) + a live runner (`pnpm --filter @gemstack/framework bench:architect`). 7 offline tests. Internal tooling, nothing exported from the package API, so no changeset.

## Result (live, 12 cases)

```
architect: 6/6 sane stacks (100%)
  honest tradeoffs (pros + cons + a rejected alternative): 12/12 (100%)
  framework balance on agnostic web apps (6 cases):
    vike  4
    next  2
```

- Stack choice is solid: CLI -> Node, headless API -> Fastify, mobile -> Expo, desktop -> Tauri, batch -> Python, docs -> Vike/SSG.
- The prompt reliably delivers the honest tradeoff it promises (12/12).
- **Framework balance: a reproducible ~2:1 lean to Vike** on agnostic web apps, even with the explicit nudge gone (#499). It is not wrong — the reasoning cited edge/portability — but a consistent lean toward the house framework is the exact thing #499 flagged, and now it is measurable run-to-run.

## Note on the corpus

The first run flagged a Tauri desktop pick as a miss — that was a mislabel in the benchmark (Tauri is a correct desktop shell that embeds a web frontend), not an architect error. Fixed the label before this result. No prompt change proposed here: the read is the architect is in good shape; the Vike lean is a watch item, not a bug. If we later want to act on it, the harness is ready to prove any change.
