### PR TITLE
feat: file tree in the dashboard project panel (#492)

### DIFF
--- a/.changeset/panel-file-tree-492.md
+++ b/.changeset/panel-file-tree-492.md
@@ -1,0 +1,7 @@
+---
+"@gemstack/framework": minor
+---
+
+Add a file tree to the dashboard's project panel (#492). It lives as the first tab in the right rail (Files · Docs · Log) and is a file-level context picker: a lazy, collapsible tree (animate-ui Files) built from `git ls-files`, where ticking a file adds it to the run Context — the same set the `#` picker and whole-repo Context selector feed. Per-file git-status dots (untracked/modified/deleted) come from a new `onProjectFileStatus` RPC, rolled up to folders.
+
+Also refines the project action bar: git status folds inline on the left; Open on GitHub / Open folder / Open in editor become icon-only buttons with tooltips (a small Base UI Tooltip, no Radix added); and Preview is renamed Serve — a play button that becomes a segmented Open ↗ / Stop ⏹ control while serving.

--- a/packages/framework-dashboard/components/EventStream.tsx
+++ b/packages/framework-dashboard/components/EventStream.tsx
@@ -7,6 +7,10 @@ import { PreviewBar } from './PreviewBar.js'
 import { RunOverview } from './RunOverview.js'
 import { Button } from './ui/button.js'
 
+const NO_FILES: string[] = []
+const NO_CONTEXT = new Set<string>()
+const NOOP = () => {}
+
 // The live event view (#405/#314): a projection of the selected project's
 // `.the-framework/events.jsonl`, streamed over a Telefunc Channel by the shell's
 // `useLiveEvents` hook and passed in as `events`. The main column shows the run overview,
@@ -52,7 +56,16 @@ export function EventStream({
           </Button>
         </div>
       ) : (
-        <StartRunForm projectId={projectId} onRunStarted={onRunStarted} />
+        // Non-relay steering path (unreached today — the relay always mounts readOnly). The
+        // file Context lives in the shell there; this fallback wires inert handlers.
+        <StartRunForm
+          projectId={projectId}
+          onRunStarted={onRunStarted}
+          files={NO_FILES}
+          context={NO_CONTEXT}
+          addContext={NOOP}
+          toggleContext={NOOP}
+        />
       )}
       {events.length > 0 ? (
         <>

--- a/packages/framework-dashboard/components/FileTree.tsx
+++ b/packages/framework-dashboard/components/FileTree.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Check, FileIcon } from 'lucide-react'
+import { onProjectFileStatus } from '../server/reads.telefunc.js'
+import {
+  Files,
+  FolderItem,
+  FolderTrigger,
+  FolderPanel,
+  SubFiles,
+  FileItem,
+} from './animate-ui/components/base/files/index.js'
+
+type FileGitStatus = 'untracked' | 'modified' | 'deleted'
+
+// The project panel's file tree (#492): a lazy, collapsible tree built from the flat
+// `git ls-files` list (onProjectFiles, shared with the `#` picker #504). It is a file-level
+// CONTEXT PICKER, not an editor — clicking a file toggles it in the run Context, the same
+// set the `#` chips and the whole-repo Context selector feed. Localhost-only: no files (the
+// relay has no checkout) renders nothing. Uses the animate-ui Files primitives for the
+// animated folder expand/collapse and hover highlight, plus per-file git-status dots.
+
+type TreeNode = {
+  name: string
+  path: string
+  dirs: Map<string, TreeNode>
+  files: string[]
+}
+
+/** Build a nested tree from repo-relative paths like `src/dashboard/foo.ts`. */
+function buildTree(paths: string[]): TreeNode {
+  const root: TreeNode = { name: '', path: '', dirs: new Map(), files: [] }
+  for (const p of paths) {
+    const parts = p.split('/')
+    let node = root
+    for (let i = 0; i < parts.length - 1; i++) {
+      const seg = parts[i]!
+      const childPath = node.path ? `${node.path}/${seg}` : seg
+      let child = node.dirs.get(seg)
+      if (!child) {
+        child = { name: seg, path: childPath, dirs: new Map(), files: [] }
+        node.dirs.set(seg, child)
+      }
+      node = child
+    }
+    node.files.push(p)
+  }
+  return root
+}
+
+/** Roll each changed file's status up to its ancestor folders so a folder dots when dirty. */
+function foldersFromStatus(status: Record<string, FileGitStatus>): Map<string, FileGitStatus> {
+  const dirs = new Map<string, FileGitStatus>()
+  for (const [path, st] of Object.entries(status)) {
+    const parts = path.split('/')
+    let acc = ''
+    for (let i = 0; i < parts.length - 1; i++) {
+      acc = acc ? `${acc}/${parts[i]}` : parts[i]!
+      const prev = dirs.get(acc)
+      dirs.set(acc, prev && prev !== st ? 'modified' : st) // mixed children read as modified
+    }
+  }
+  return dirs
+}
+
+const byName = (a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name)
+
+export function FileTree({
+  projectId,
+  files,
+  selected,
+  onToggle,
+}: {
+  projectId: string
+  files: string[]
+  selected: Set<string>
+  onToggle: (path: string) => void
+}) {
+  const [query, setQuery] = useState('')
+
+  // Per-file git status for the dots (#492): polled so it tracks a run editing files.
+  const [status, setStatus] = useState<Record<string, FileGitStatus>>({})
+  useEffect(() => {
+    let live = true
+    setStatus({})
+    const load = () => void onProjectFileStatus(projectId).then(s => live && setStatus(s))
+    load()
+    const poll = setInterval(load, 8_000)
+    return () => {
+      live = false
+      clearInterval(poll)
+    }
+  }, [projectId])
+
+  const folderStatus = useMemo(() => foldersFromStatus(status), [status])
+
+  // A search narrows to matching files (and the folders on their way), so the tree is usable
+  // on a large repo without scrolling. Empty query shows everything.
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return q ? files.filter(f => f.toLowerCase().includes(q)) : files
+  }, [files, query])
+
+  const tree = useMemo(() => buildTree(visible), [visible])
+
+  const renderNode = (node: TreeNode) => (
+    <>
+      {[...node.dirs.values()].sort(byName).map(dir => {
+        const dirGit = folderStatus.get(dir.path)
+        return (
+          <FolderItem key={dir.path} value={dir.path}>
+            <FolderTrigger {...(dirGit ? { gitStatus: dirGit } : {})}>{dir.name}</FolderTrigger>
+            <FolderPanel>
+              <SubFiles>{renderNode(dir)}</SubFiles>
+            </FolderPanel>
+          </FolderItem>
+        )
+      })}
+      {[...node.files]
+        .sort((a, b) => a.localeCompare(b))
+        .map(path => {
+          const name = path.slice(path.lastIndexOf('/') + 1)
+          const isOn = selected.has(path)
+          const git = status[path]
+          return (
+            <FileItem
+              key={path}
+              icon={isOn ? Check : FileIcon}
+              title={path}
+              className={'pointer-events-auto cursor-pointer' + (isOn ? ' text-primary' : '')}
+              onClick={() => onToggle(path)}
+              {...(git ? { gitStatus: git } : {})}
+            >
+              {name}
+            </FileItem>
+          )
+        })}
+    </>
+  )
+
+  if (files.length === 0) return null
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col p-2">
+      <input
+        type="search"
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        placeholder="Filter files…"
+        className="mb-2 w-full rounded border border-border bg-background px-2 py-1 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]"
+      />
+      <Files className="min-h-0 flex-1 text-sm">{renderNode(tree)}</Files>
+    </div>
+  )
+}

--- a/packages/framework-dashboard/components/GitStatusBar.tsx
+++ b/packages/framework-dashboard/components/GitStatusBar.tsx
@@ -7,7 +7,8 @@ import { cn } from '../lib/utils.js'
 // The project panel's git status (#491, part of #488): active branch, a clean/dirty dot, and
 // the linked PR. Reads `onGitStatus`, polled so it tracks a run committing/branching. Hidden
 // when the project is not a git repo (or on the relay, which has no local checkout).
-export function GitStatusBar({ projectId }: { projectId: string }) {
+// `inline` renders just the status (for the project action bar); otherwise a full-width row.
+export function GitStatusBar({ projectId, inline = false }: { projectId: string; inline?: boolean }) {
   const [status, setStatus] = useState<GitStatus | null>(null)
 
   useEffect(() => {
@@ -24,11 +25,11 @@ export function GitStatusBar({ projectId }: { projectId: string }) {
 
   if (!status) return null
 
-  return (
-    <div className="flex items-center gap-2 border-b border-border px-4 py-2 text-xs">
+  const content = (
+    <>
       <span className="flex items-center gap-1.5 text-muted-foreground">
         <GitBranch className="h-3.5 w-3.5" />
-        <span className="font-medium text-foreground" title={`branch ${status.branch}`}>
+        <span className="max-w-[14rem] truncate font-medium text-foreground" title={`branch ${status.branch}`}>
           {status.branch}
         </span>
       </span>
@@ -44,7 +45,7 @@ export function GitStatusBar({ projectId }: { projectId: string }) {
           href={status.pr.url}
           target="_blank"
           rel="noreferrer"
-          className="ml-auto flex items-center gap-1.5 text-primary hover:underline"
+          className={cn('flex items-center gap-1.5 text-primary hover:underline', !inline && 'ml-auto')}
           title={status.pr.title}
         >
           <span>PR #{status.pr.number}</span>
@@ -53,6 +54,10 @@ export function GitStatusBar({ projectId }: { projectId: string }) {
           </span>
         </a>
       )}
-    </div>
+    </>
   )
+
+  if (inline) return <span className="flex items-center gap-2 text-xs">{content}</span>
+
+  return <div className="flex items-center gap-2 border-b border-border px-4 py-2 text-xs">{content}</div>
 }

--- a/packages/framework-dashboard/components/PreviewBar.tsx
+++ b/packages/framework-dashboard/components/PreviewBar.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from 'react'
+import { Play, ExternalLink, Square } from 'lucide-react'
 import { sendPreview, sendStopPreview, onPreviewStatus } from '../server/control.telefunc.js'
 import { Button } from './ui/button.js'
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './ui/tooltip.js'
 
-// On-demand app Preview (#475): a per-project button that serves the project's built result
+// On-demand app Serve (#475): a per-project button that serves the project's built result
 // (its dev script, else a static server) and surfaces the live URL + a Stop. Independent of
 // any agent run — it closes the "let me see what it produced" loop with one click, useful for
 // non-technical users too. State lives daemon-side, so a reload rehydrates via onPreviewStatus.
-export function PreviewBar({ projectId }: { projectId: string }) {
+// `inline` renders just the control (for the project action bar); otherwise a full labelled row.
+export function PreviewBar({ projectId, inline = false }: { projectId: string; inline?: boolean }) {
   const [url, setUrl] = useState<string | null>(null)
   const [command, setCommand] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
@@ -57,27 +60,71 @@ export function PreviewBar({ projectId }: { projectId: string }) {
     }
   }
 
+  // The control (all icon-only, h-9 to match the other actions): a single Serve button when
+  // stopped; once serving, a segmented pair — Open (the live URL ↗) joined to a Stop (⏹) that
+  // collapses it back to Serve. Each segment carries a tooltip.
+  const controls = (
+    <TooltipProvider delay={300} closeDelay={0}>
+      {url ? (
+        <div className="inline-flex h-7 items-center overflow-hidden rounded-md border border-border">
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex h-full items-center px-2 hover:bg-accent hover:text-accent-foreground"
+                />
+              }
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+            </TooltipTrigger>
+            <TooltipContent>Open in browser</TooltipContent>
+          </Tooltip>
+          <span className="h-full w-px bg-border" />
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  onClick={() => void stop()}
+                  disabled={busy}
+                  className="flex h-full items-center px-2 hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+                />
+              }
+            >
+              <Square className="h-3 w-3 fill-current" />
+            </TooltipTrigger>
+            <TooltipContent>Stop serving</TooltipContent>
+          </Tooltip>
+        </div>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger render={<Button variant="outline" size="icon-sm" disabled={busy} onClick={() => void open()} />}>
+            <Play className="h-3.5 w-3.5" />
+          </TooltipTrigger>
+          <TooltipContent>{busy ? 'Starting…' : 'Serve the built result'}</TooltipContent>
+        </Tooltip>
+      )}
+    </TooltipProvider>
+  )
+
+  // Inline: just the control, for the project action bar. Errors sit below on their own line.
+  if (inline) {
+    return (
+      <>
+        {controls}
+        {error && <p className="w-full text-xs text-red-500">{error}</p>}
+      </>
+    )
+  }
+
   return (
     <div className="flex items-center gap-2 border-b border-border px-4 py-2 text-xs">
-      <span className="font-semibold uppercase tracking-wide text-muted-foreground">Preview</span>
-      {url ? (
-        <>
-          <a href={url} target="_blank" rel="noreferrer" className="truncate text-primary hover:underline" title={url}>
-            {url}
-          </a>
-          {command && command !== 'static' && <span className="text-muted-foreground">npm run {command}</span>}
-          <Button variant="outline" size="sm" className="ml-auto" disabled={busy} onClick={() => void stop()}>
-            Stop preview
-          </Button>
-        </>
-      ) : (
-        <>
-          <span className="text-muted-foreground">Serve this project's built result</span>
-          <Button variant="outline" size="sm" className="ml-auto" disabled={busy} onClick={() => void open()}>
-            {busy ? 'Starting…' : '▶ Preview'}
-          </Button>
-        </>
-      )}
+      <span className="font-semibold uppercase tracking-wide text-muted-foreground">Serve</span>
+      {!url && <span className="text-muted-foreground">Serve this project's built result</span>}
+      <span className="ml-auto flex items-center gap-2">{controls}</span>
       {error && <p className="w-full text-red-500">{error}</p>}
     </div>
   )

--- a/packages/framework-dashboard/components/ProjectActions.tsx
+++ b/packages/framework-dashboard/components/ProjectActions.tsx
@@ -2,7 +2,10 @@ import { useEffect, useState } from 'react'
 import { Github, FolderOpen, Code } from 'lucide-react'
 import { onGithubUrl } from '../server/reads.telefunc.js'
 import { sendOpenInApp } from '../server/control.telefunc.js'
-import { Button } from './ui/button.js'
+import { PreviewBar } from './PreviewBar.js'
+import { GitStatusBar } from './GitStatusBar.js'
+import { Button, buttonVariants } from './ui/button.js'
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './ui/tooltip.js'
 
 // Project-panel quick actions (#488). "Open on GitHub" (#489) when the repo has a github.com
 // remote, plus localhost-only "Open folder" / "Open in editor" (#490) that ask the daemon to
@@ -38,33 +41,48 @@ export function ProjectActions({ projectId }: { projectId: string }) {
 
   return (
     <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-2">
-      {githubUrl && (
-        <a href={githubUrl} target="_blank" rel="noreferrer" title={githubUrl}>
-          <Button variant="outline" size="sm" className="gap-1.5">
-            <Github className="h-4 w-4" /> Open on GitHub
-          </Button>
-        </a>
-      )}
-      <Button
-        variant="outline"
-        size="sm"
-        className="gap-1.5"
-        disabled={busy}
-        title="Reveal the repo in your file manager (Finder / Explorer)"
-        onClick={() => void open('files')}
-      >
-        <FolderOpen className="h-4 w-4" /> Open folder
-      </Button>
-      <Button
-        variant="outline"
-        size="sm"
-        className="gap-1.5"
-        disabled={busy}
-        title="Open the repo in your editor (code, or $FRAMEWORK_EDITOR)"
-        onClick={() => void open('editor')}
-      >
-        <Code className="h-4 w-4" /> Open in editor
-      </Button>
+      {/* Git status (#491) reads on the left; the project actions group on the right. Nav
+          actions are icon-only with tooltips; Serve keeps its label + running state. */}
+      <GitStatusBar projectId={projectId} inline />
+      <TooltipProvider delay={300} closeDelay={0}>
+        <span className="ml-auto flex flex-wrap items-center gap-2">
+          {githubUrl && (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <a
+                    href={githubUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className={buttonVariants({ variant: 'outline', size: 'icon-sm' })}
+                  />
+                }
+              >
+                <Github className="h-3.5 w-3.5" />
+              </TooltipTrigger>
+              <TooltipContent>Open on GitHub</TooltipContent>
+            </Tooltip>
+          )}
+          <Tooltip>
+            <TooltipTrigger
+              render={<Button variant="outline" size="icon-sm" disabled={busy} onClick={() => void open('files')} />}
+            >
+              <FolderOpen className="h-3.5 w-3.5" />
+            </TooltipTrigger>
+            <TooltipContent>Open folder (Finder / Explorer)</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger
+              render={<Button variant="outline" size="icon-sm" disabled={busy} onClick={() => void open('editor')} />}
+            >
+              <Code className="h-3.5 w-3.5" />
+            </TooltipTrigger>
+            <TooltipContent>Open in editor (code, or $FRAMEWORK_EDITOR)</TooltipContent>
+          </Tooltip>
+          {/* Serve (#475): one click to serve the built result, alongside the other actions. */}
+          <PreviewBar projectId={projectId} inline />
+        </span>
+      </TooltipProvider>
       {error && <p className="w-full text-xs text-red-500">{error}</p>}
     </div>
   )

--- a/packages/framework-dashboard/components/ProjectHome.tsx
+++ b/packages/framework-dashboard/components/ProjectHome.tsx
@@ -1,8 +1,6 @@
 import type { FrameworkEvent } from '@gemstack/framework'
 import { StartRunForm } from './StartRunForm.js'
 import { ProjectActions } from './ProjectActions.js'
-import { GitStatusBar } from './GitStatusBar.js'
-import { PreviewBar } from './PreviewBar.js'
 import { RunOverview } from './RunOverview.js'
 
 // The project home / launcher — what "Live" selects. Always the Start form + preset cards +
@@ -13,17 +11,30 @@ export function ProjectHome({
   projectId,
   events,
   onRunStarted,
+  files,
+  context,
+  addContext,
+  toggleContext,
 }: {
   projectId: string
   events: FrameworkEvent[]
   onRunStarted?: ((intent: string) => void) | undefined
+  files: string[]
+  context: Set<string>
+  addContext: (path: string) => void
+  toggleContext: (path: string) => void
 }) {
   return (
     <>
       <ProjectActions projectId={projectId} />
-      <GitStatusBar projectId={projectId} />
-      <PreviewBar projectId={projectId} />
-      <StartRunForm projectId={projectId} onRunStarted={onRunStarted} />
+      <StartRunForm
+        projectId={projectId}
+        onRunStarted={onRunStarted}
+        files={files}
+        context={context}
+        addContext={addContext}
+        toggleContext={toggleContext}
+      />
       {events.length > 0 && <RunOverview events={events} />}
     </>
   )

--- a/packages/framework-dashboard/components/RightRail.tsx
+++ b/packages/framework-dashboard/components/RightRail.tsx
@@ -4,12 +4,13 @@ import { DocsPanel } from './DocsPanel.js'
 import { ProjectLogPanel } from './ProjectLogPanel.js'
 import { ChoicesRail } from './ChoicesRail.js'
 import { ViewsRail } from './ViewsRail.js'
+import { FileTree } from './FileTree.js'
 import type { AgentView } from '../lib/live-state.js'
 import { Badge } from './ui/badge.js'
 import { Button } from './ui/button.js'
 import { cn } from '../lib/utils.js'
 
-type Tab = 'choices' | 'views' | 'docs' | 'log'
+type Tab = 'files' | 'choices' | 'views' | 'docs' | 'log'
 
 // The right sidebar (#314 third rail): the interactive choice gates the run parks on
 // (#440), the ad-hoc markdown views the agent pushes (#441), the surfaced docs (PLAN/TODO),
@@ -20,25 +21,44 @@ export function RightRail({
   projectId,
   choices,
   views,
+  files,
+  context,
+  toggleContext,
 }: {
   projectId: string | null
   choices: ChoiceRequest[]
   views: AgentView[]
+  /** The project's files for the Files tab tree (#492); empty on the relay. */
+  files: string[]
+  /** The run Context set, shared with the Start form (#504). */
+  context: Set<string>
+  /** Toggle a file path in the Context. */
+  toggleContext: (path: string) => void
 }) {
   const [tab, setTab] = useState<Tab>('docs')
   const hasChoices = choices.length > 0
   const hasViews = views.length > 0
+  const hasFiles = files.length > 0
 
-  // Pull the rail to the most urgent surface: a choice gate over a view over the docs.
+  // Pull the rail to the most urgent surface: a choice gate over a view, else the file tree
+  // when just browsing a project (#492), else the docs.
   useEffect(() => {
-    setTab(hasChoices ? 'choices' : hasViews ? 'views' : 'docs')
-  }, [hasChoices, hasViews])
+    setTab(hasChoices ? 'choices' : hasViews ? 'views' : hasFiles ? 'files' : 'docs')
+  }, [hasChoices, hasViews, hasFiles])
 
   if (!projectId) return null
 
-  const tabs: Tab[] = [...(hasChoices ? ['choices' as const] : []), ...(hasViews ? ['views' as const] : []), 'docs', 'log']
-  const label = (t: Tab) => (t === 'choices' ? 'Choices' : t === 'views' ? 'Views' : t === 'docs' ? 'Docs' : 'Log')
-  const count = (t: Tab) => (t === 'choices' ? choices.length : t === 'views' ? views.length : 0)
+  // Files first (#492): the project peek surface, before the run's own choices/views/docs/log.
+  const tabs: Tab[] = [
+    ...(hasFiles ? ['files' as const] : []),
+    ...(hasChoices ? ['choices' as const] : []),
+    ...(hasViews ? ['views' as const] : []),
+    'docs',
+    'log',
+  ]
+  const label = (t: Tab) =>
+    t === 'files' ? 'Files' : t === 'choices' ? 'Choices' : t === 'views' ? 'Views' : t === 'docs' ? 'Docs' : 'Log'
+  const count = (t: Tab) => (t === 'choices' ? choices.length : t === 'views' ? views.length : t === 'files' ? context.size : 0)
 
   return (
     <aside className="flex w-80 shrink-0 flex-col border-l border-border">
@@ -57,7 +77,9 @@ export function RightRail({
         ))}
       </div>
       <div className="flex min-h-0 flex-1 flex-col">
-        {tab === 'choices' && hasChoices ? (
+        {tab === 'files' && hasFiles ? (
+          <FileTree projectId={projectId} files={files} selected={context} onToggle={toggleContext} />
+        ) : tab === 'choices' && hasChoices ? (
           <ChoicesRail projectId={projectId} choices={choices} />
         ) : tab === 'views' && hasViews ? (
           <ViewsRail views={views} />

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -9,7 +9,6 @@ import {
 } from '@gemstack/framework/client'
 import { sendStart } from '../server/control.telefunc.js'
 import { onProjects } from '../server/projects.telefunc.js'
-import { onProjectFiles } from '../server/reads.telefunc.js'
 import { usePreferences, updatePreferences, autopilotEnabled } from '../lib/preferences.js'
 import { PromptEditor, type PromptEditorHandle } from './PromptEditor.js'
 import { Button } from './ui/button.js'
@@ -33,9 +32,21 @@ const PRESETS: { id: string; label: string; render: () => string }[] = [
 export function StartRunForm({
   projectId,
   onRunStarted,
+  files,
+  context,
+  addContext,
+  toggleContext,
 }: {
   projectId: string
   onRunStarted?: ((intent: string) => void) | undefined
+  /** The project's files for the `#` picker (#504), owned by the shell. */
+  files: string[]
+  /** The run Context set, shared with the right-rail file tree (#492) — owned by the shell. */
+  context: Set<string>
+  /** Add a path to the Context (from an `@`/`#` mention). */
+  addContext: (path: string) => void
+  /** Toggle a path in the Context (from a repo checkbox). */
+  toggleContext: (path: string) => void
 }) {
   const [prompt, setPrompt] = useState('')
   const [kind, setKind] = useState<'build' | 'prompt'>('build')
@@ -60,7 +71,6 @@ export function StartRunForm({
   // subset narrows its focus — the picked paths become one `Context:` line in the system
   // prompt. Loaded from the same registry the Projects sidebar shows.
   const [projects, setProjects] = useState<ProjectSummary[]>([])
-  const [context, setContext] = useState<Set<string>>(new Set())
   const [showContext, setShowContext] = useState(false)
 
   useEffect(() => {
@@ -70,25 +80,6 @@ export function StartRunForm({
       live = false
     }
   }, [])
-
-  // The current project's files for the `#` picker (#504): repo-relative paths from
-  // `git ls-files`, reloaded when the selected project changes. Empty on the relay.
-  const [files, setFiles] = useState<string[]>([])
-  useEffect(() => {
-    let live = true
-    setFiles([])
-    void onProjectFiles(projectId).then(list => live && setFiles(list))
-    return () => {
-      live = false
-    }
-  }, [projectId])
-
-  const toggleContext = (path: string) =>
-    setContext(prev => {
-      const next = new Set(prev)
-      next.has(path) ? next.delete(path) : next.add(path)
-      return next
-    })
 
   // Vanilla removes the system prompt entirely, so Eco (which only trims it) has nothing
   // left to act on.
@@ -157,13 +148,6 @@ export function StartRunForm({
       setNote(null)
     }
   }
-
-  const addContext = (path: string) =>
-    setContext(prev => {
-      const next = new Set(prev)
-      next.add(path)
-      return next
-    })
 
   return (
     <form onSubmit={submit} className="border-b border-border p-4">

--- a/packages/framework-dashboard/components/animate-ui/components/base/files/index.tsx
+++ b/packages/framework-dashboard/components/animate-ui/components/base/files/index.tsx
@@ -1,0 +1,171 @@
+// @ts-nocheck -- vendored animate-ui component (copied from animate-ui.com); not authored against our exactOptionalPropertyTypes
+import * as React from 'react';
+import { FolderIcon, FolderOpenIcon, FileIcon } from 'lucide-react';
+
+import {
+  Files as FilesPrimitive,
+  FilesHighlight as FilesHighlightPrimitive,
+  FolderItem as FolderItemPrimitive,
+  FolderHeader as FolderHeaderPrimitive,
+  FolderTrigger as FolderTriggerPrimitive,
+  FolderHighlight as FolderHighlightPrimitive,
+  Folder as FolderPrimitive,
+  FolderIcon as FolderIconPrimitive,
+  FileLabel as FileLabelPrimitive,
+  FolderPanel as FolderPanelPrimitive,
+  FileHighlight as FileHighlightPrimitive,
+  File as FilePrimitive,
+  FileIcon as FileIconPrimitive,
+  type FilesProps as FilesPrimitiveProps,
+  type FolderItemProps as FolderItemPrimitiveProps,
+  type FolderPanelProps as FolderPanelPrimitiveProps,
+  type FileProps as FilePrimitiveProps,
+  type FileLabelProps as FileLabelPrimitiveProps,
+} from '@/components/animate-ui/primitives/base/files';
+import { cn } from '@/lib/utils';
+
+type GitStatus = 'untracked' | 'modified' | 'deleted';
+
+type FilesProps = FilesPrimitiveProps;
+
+function Files({ className, children, ...props }: FilesProps) {
+  return (
+    <FilesPrimitive className={cn('p-2 w-full', className)} {...props}>
+      <FilesHighlightPrimitive className="bg-accent rounded-lg pointer-events-none">
+        {children}
+      </FilesHighlightPrimitive>
+    </FilesPrimitive>
+  );
+}
+
+type SubFilesProps = FilesProps;
+
+function SubFiles(props: SubFilesProps) {
+  return <FilesPrimitive {...props} />;
+}
+
+type FolderItemProps = FolderItemPrimitiveProps;
+
+function FolderItem(props: FolderItemProps) {
+  return <FolderItemPrimitive {...props} />;
+}
+
+type FolderTriggerProps = FileLabelPrimitiveProps & {
+  gitStatus?: GitStatus;
+};
+
+function FolderTrigger({
+  children,
+  className,
+  gitStatus,
+  ...props
+}: FolderTriggerProps) {
+  return (
+    <FolderHeaderPrimitive>
+      <FolderTriggerPrimitive className="w-full text-start">
+        <FolderHighlightPrimitive>
+          <FolderPrimitive className="flex items-center justify-between gap-2 p-2 pointer-events-none">
+            <div
+              className={cn(
+                'flex items-center gap-2',
+                gitStatus === 'untracked' && 'text-green-400',
+                gitStatus === 'modified' && 'text-amber-400',
+                gitStatus === 'deleted' && 'text-red-400',
+              )}
+            >
+              <FolderIconPrimitive
+                closeIcon={<FolderIcon className="size-4.5" />}
+                openIcon={<FolderOpenIcon className="size-4.5" />}
+              />
+              <FileLabelPrimitive
+                className={cn('text-sm', className)}
+                {...props}
+              >
+                {children}
+              </FileLabelPrimitive>
+            </div>
+
+            {gitStatus && (
+              <span
+                className={cn(
+                  'rounded-full size-2',
+                  gitStatus === 'untracked' && 'bg-green-400',
+                  gitStatus === 'modified' && 'bg-amber-400',
+                  gitStatus === 'deleted' && 'bg-red-400',
+                )}
+              />
+            )}
+          </FolderPrimitive>
+        </FolderHighlightPrimitive>
+      </FolderTriggerPrimitive>
+    </FolderHeaderPrimitive>
+  );
+}
+
+type FolderPanelProps = FolderPanelPrimitiveProps;
+
+function FolderPanel(props: FolderPanelProps) {
+  return (
+    <div className="relative ml-6 before:absolute before:-left-2 before:inset-y-0 before:w-px before:h-full before:bg-border">
+      <FolderPanelPrimitive {...props} />
+    </div>
+  );
+}
+
+type FileItemProps = FilePrimitiveProps & {
+  icon?: React.ElementType;
+  gitStatus?: GitStatus;
+};
+
+function FileItem({
+  icon: Icon = FileIcon,
+  className,
+  children,
+  gitStatus,
+  ...props
+}: FileItemProps) {
+  return (
+    <FileHighlightPrimitive>
+      <FilePrimitive
+        className={cn(
+          'flex items-center justify-between gap-2 p-2 pointer-events-none',
+          gitStatus === 'untracked' && 'text-green-400',
+          gitStatus === 'modified' && 'text-amber-400',
+          gitStatus === 'deleted' && 'text-red-400',
+        )}
+      >
+        <div className="flex items-center gap-2">
+          <FileIconPrimitive>
+            <Icon className="size-4.5" />
+          </FileIconPrimitive>
+          <FileLabelPrimitive className={cn('text-sm', className)} {...props}>
+            {children}
+          </FileLabelPrimitive>
+        </div>
+
+        {gitStatus && (
+          <span className="text-sm font-medium">
+            {gitStatus === 'untracked' && 'U'}
+            {gitStatus === 'modified' && 'M'}
+            {gitStatus === 'deleted' && 'D'}
+          </span>
+        )}
+      </FilePrimitive>
+    </FileHighlightPrimitive>
+  );
+}
+
+export {
+  Files,
+  FolderItem,
+  FolderTrigger,
+  FolderPanel,
+  FileItem,
+  SubFiles,
+  type FilesProps,
+  type FolderItemProps,
+  type FolderTriggerProps,
+  type FolderPanelProps,
+  type FileItemProps,
+  type SubFilesProps,
+};

--- a/packages/framework-dashboard/components/animate-ui/primitives/base/accordion/index.tsx
+++ b/packages/framework-dashboard/components/animate-ui/primitives/base/accordion/index.tsx
@@ -1,0 +1,180 @@
+// @ts-nocheck -- vendored animate-ui component (copied from animate-ui.com); not authored against our exactOptionalPropertyTypes
+'use client';
+
+import * as React from 'react';
+import { Accordion as AccordionPrimitive } from '@base-ui-components/react/accordion';
+import { AnimatePresence, motion, type HTMLMotionProps } from 'motion/react';
+
+import { getStrictContext } from '@/lib/get-strict-context';
+import { useControlledState } from '@/hooks/use-controlled-state';
+
+type AccordionContextType = {
+  value: string | string[] | undefined;
+  setValue: (value: string | string[] | undefined) => void;
+};
+
+type AccordionItemContextType = {
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+};
+
+const [AccordionProvider, useAccordion] =
+  getStrictContext<AccordionContextType>('AccordionContext');
+
+const [AccordionItemProvider, useAccordionItem] =
+  getStrictContext<AccordionItemContextType>('AccordionItemContext');
+
+type AccordionProps = React.ComponentProps<typeof AccordionPrimitive.Root>;
+
+function Accordion(props: AccordionProps) {
+  const [value, setValue] = useControlledState<string | string[] | undefined>({
+    value: props?.value,
+    defaultValue: props?.defaultValue,
+    onChange: props?.onValueChange as (
+      value: string | string[] | undefined,
+    ) => void,
+  });
+
+  return (
+    <AccordionProvider value={{ value, setValue }}>
+      <AccordionPrimitive.Root
+        data-slot="accordion"
+        {...props}
+        onValueChange={setValue}
+      />
+    </AccordionProvider>
+  );
+}
+
+type AccordionItemProps = React.ComponentProps<typeof AccordionPrimitive.Item>;
+
+function AccordionItem(props: AccordionItemProps) {
+  const { value } = useAccordion();
+  const [isOpen, setIsOpen] = React.useState(
+    value?.includes(props?.value) ?? false,
+  );
+
+  React.useEffect(() => {
+    setIsOpen(value?.includes(props?.value) ?? false);
+  }, [value, props?.value]);
+
+  return (
+    <AccordionItemProvider value={{ isOpen, setIsOpen }}>
+      <AccordionPrimitive.Item data-slot="accordion-item" {...props} />
+    </AccordionItemProvider>
+  );
+}
+
+type AccordionHeaderProps = React.ComponentProps<
+  typeof AccordionPrimitive.Header
+>;
+
+function AccordionHeader(props: AccordionHeaderProps) {
+  return <AccordionPrimitive.Header data-slot="accordion-header" {...props} />;
+}
+
+type AccordionTriggerProps = React.ComponentProps<
+  typeof AccordionPrimitive.Trigger
+>;
+
+function AccordionTrigger(props: AccordionTriggerProps) {
+  return (
+    <AccordionPrimitive.Trigger data-slot="accordion-trigger" {...props} />
+  );
+}
+
+type AccordionPanelProps = Omit<
+  React.ComponentProps<typeof AccordionPrimitive.Panel>,
+  'keepMounted' | 'render'
+> &
+  HTMLMotionProps<'div'> & {
+    keepRendered?: boolean;
+  };
+
+function AccordionPanel({
+  transition = { duration: 0.35, ease: 'easeInOut' },
+  hiddenUntilFound,
+  keepRendered = false,
+  ...props
+}: AccordionPanelProps) {
+  const { isOpen } = useAccordionItem();
+
+  return (
+    <AnimatePresence>
+      {keepRendered ? (
+        <AccordionPrimitive.Panel
+          hidden={false}
+          hiddenUntilFound={hiddenUntilFound}
+          keepMounted
+          render={
+            <motion.div
+              key="accordion-panel"
+              data-slot="accordion-panel"
+              initial={{ height: 0, opacity: 0, '--mask-stop': '0%', y: 20 }}
+              animate={
+                isOpen
+                  ? { height: 'auto', opacity: 1, '--mask-stop': '100%', y: 0 }
+                  : { height: 0, opacity: 0, '--mask-stop': '0%', y: 20 }
+              }
+              transition={transition}
+              style={{
+                maskImage:
+                  'linear-gradient(black var(--mask-stop), transparent var(--mask-stop))',
+                WebkitMaskImage:
+                  'linear-gradient(black var(--mask-stop), transparent var(--mask-stop))',
+                overflow: 'hidden',
+              }}
+              {...props}
+            />
+          }
+        />
+      ) : (
+        isOpen && (
+          <AccordionPrimitive.Panel
+            hidden={false}
+            hiddenUntilFound={hiddenUntilFound}
+            keepMounted
+            render={
+              <motion.div
+                key="accordion-panel"
+                data-slot="accordion-panel"
+                initial={{ height: 0, opacity: 0, '--mask-stop': '0%', y: 20 }}
+                animate={{
+                  height: 'auto',
+                  opacity: 1,
+                  '--mask-stop': '100%',
+                  y: 0,
+                }}
+                exit={{ height: 0, opacity: 0, '--mask-stop': '0%', y: 20 }}
+                transition={transition}
+                style={{
+                  maskImage:
+                    'linear-gradient(black var(--mask-stop), transparent var(--mask-stop))',
+                  WebkitMaskImage:
+                    'linear-gradient(black var(--mask-stop), transparent var(--mask-stop))',
+                  overflow: 'hidden',
+                }}
+                {...props}
+              />
+            }
+          />
+        )
+      )}
+    </AnimatePresence>
+  );
+}
+
+export {
+  Accordion,
+  AccordionItem,
+  AccordionHeader,
+  AccordionTrigger,
+  AccordionPanel,
+  useAccordionItem,
+  type AccordionProps,
+  type AccordionItemProps,
+  type AccordionHeaderProps,
+  type AccordionTriggerProps,
+  type AccordionPanelProps,
+  type AccordionItemContextType,
+};

--- a/packages/framework-dashboard/components/animate-ui/primitives/base/files/index.tsx
+++ b/packages/framework-dashboard/components/animate-ui/primitives/base/files/index.tsx
@@ -1,0 +1,233 @@
+// @ts-nocheck -- vendored animate-ui component (copied from animate-ui.com); not authored against our exactOptionalPropertyTypes
+'use client';
+
+import * as React from 'react';
+import { AnimatePresence, motion, type HTMLMotionProps } from 'motion/react';
+
+import {
+  Highlight,
+  HighlightItem,
+  type HighlightItemProps,
+  type HighlightProps,
+} from '@/components/animate-ui/primitives/effects/highlight';
+import {
+  Accordion,
+  AccordionItem,
+  AccordionHeader,
+  AccordionTrigger,
+  AccordionPanel,
+  type AccordionProps,
+  type AccordionItemProps,
+  type AccordionHeaderProps,
+  type AccordionTriggerProps,
+  type AccordionPanelProps,
+} from '@/components/animate-ui/primitives/base/accordion';
+import { getStrictContext } from '@/lib/get-strict-context';
+import { useControlledState } from '@/hooks/use-controlled-state';
+
+type FilesContextType = {
+  open: string[];
+};
+
+type FolderContextType = {
+  isOpen: boolean;
+};
+
+const [FilesProvider, useFiles] =
+  getStrictContext<FilesContextType>('FilesContext');
+
+const [FolderProvider, useFolder] =
+  getStrictContext<FolderContextType>('FolderContext');
+
+type FilesProps = {
+  children: React.ReactNode;
+  defaultOpen?: string[];
+  open?: string[];
+  onOpenChange?: (open: string[]) => void;
+} & Omit<AccordionProps, 'type' | 'defaultValue' | 'value' | 'onValueChange'>;
+
+function Files({
+  children,
+  defaultOpen,
+  open,
+  onOpenChange,
+  style,
+  ...props
+}: FilesProps) {
+  const [openValue, setOpenValue] = useControlledState({
+    value: open,
+    defaultValue: defaultOpen,
+    onChange: onOpenChange,
+  });
+
+  return (
+    <FilesProvider value={{ open: openValue ?? [] }}>
+      <Accordion
+        data-slot="files"
+        multiple
+        defaultValue={defaultOpen}
+        value={open}
+        onValueChange={setOpenValue}
+        style={{
+          position: 'relative',
+          overflow: 'auto',
+          ...style,
+        }}
+        {...props}
+      >
+        {children}
+      </Accordion>
+    </FilesProvider>
+  );
+}
+
+type FilesHighlightProps = Omit<HighlightProps, 'controlledItems' | 'mode'>;
+
+function FilesHighlight({ hover = true, ...props }: FilesHighlightProps) {
+  return (
+    <Highlight
+      data-slot="files-highlight"
+      controlledItems
+      mode="parent"
+      hover={hover}
+      {...props}
+    />
+  );
+}
+
+type FolderItemProps = AccordionItemProps;
+
+function FolderItem({ value, ...props }: FolderItemProps) {
+  const { open } = useFiles();
+
+  return (
+    <FolderProvider value={{ isOpen: open.includes(value) }}>
+      <AccordionItem data-slot="folder-item" value={value} {...props} />
+    </FolderProvider>
+  );
+}
+
+type FolderHeaderProps = AccordionHeaderProps;
+
+function FolderHeader(props: FolderHeaderProps) {
+  return <AccordionHeader data-slot="folder-header" {...props} />;
+}
+
+type FolderTriggerProps = AccordionTriggerProps;
+
+function FolderTrigger(props: FolderTriggerProps) {
+  return <AccordionTrigger data-slot="folder-trigger" {...props} />;
+}
+
+type FolderPanelProps = AccordionPanelProps;
+
+function FolderPanel(props: FolderPanelProps) {
+  return <AccordionPanel data-slot="folder-panel" {...props} />;
+}
+
+type FileHighlightProps = HighlightItemProps;
+
+function FileHighlight(props: FileHighlightProps) {
+  return <HighlightItem data-slot="file-highlight" {...props} />;
+}
+
+type FileProps = React.ComponentProps<'div'>;
+
+function File(props: FileProps) {
+  return <div data-slot="file" {...props} />;
+}
+
+type FileIconProps = React.ComponentProps<'span'>;
+
+function FileIcon(props: FileIconProps) {
+  return <span data-slot="file-icon" {...props} />;
+}
+
+type FileLabelProps = React.ComponentProps<'span'>;
+
+function FileLabel(props: FileLabelProps) {
+  return <span data-slot="file-label" {...props} />;
+}
+
+type FolderHighlightProps = HighlightItemProps;
+
+function FolderHighlight(props: FolderHighlightProps) {
+  return <HighlightItem data-slot="folder-highlight" {...props} />;
+}
+
+type FolderProps = React.ComponentProps<'div'>;
+
+function Folder(props: FolderProps) {
+  return <div data-slot="folder" {...props} />;
+}
+
+type FolderIconProps = HTMLMotionProps<'span'> & {
+  closeIcon: React.ReactNode;
+  openIcon: React.ReactNode;
+};
+
+function FolderIcon({
+  closeIcon,
+  openIcon,
+  transition = { duration: 0.15 },
+  ...props
+}: FolderIconProps) {
+  const { isOpen } = useFolder();
+
+  return (
+    <AnimatePresence mode="wait">
+      <motion.span
+        key={isOpen ? 'open' : 'close'}
+        data-slot="folder-icon"
+        initial={{ scale: 0.9 }}
+        animate={{ scale: 1 }}
+        exit={{ scale: 0.9 }}
+        transition={transition}
+        {...props}
+      >
+        {isOpen ? openIcon : closeIcon}
+      </motion.span>
+    </AnimatePresence>
+  );
+}
+
+type FolderLabelProps = React.ComponentProps<'span'>;
+
+function FolderLabel(props: FolderLabelProps) {
+  return <span data-slot="folder-label" {...props} />;
+}
+
+export {
+  Files,
+  FilesHighlight,
+  FolderItem,
+  FolderHeader,
+  FolderTrigger,
+  FolderPanel,
+  FileHighlight,
+  File,
+  FileIcon,
+  FileLabel,
+  FolderHighlight,
+  Folder,
+  FolderIcon,
+  FolderLabel,
+  useFiles,
+  useFolder,
+  type FilesProps,
+  type FilesHighlightProps,
+  type FolderItemProps,
+  type FolderHeaderProps,
+  type FolderTriggerProps,
+  type FolderPanelProps,
+  type FileHighlightProps,
+  type FileProps,
+  type FileIconProps,
+  type FileLabelProps,
+  type FolderHighlightProps,
+  type FolderProps,
+  type FolderIconProps,
+  type FolderLabelProps,
+  type FilesContextType,
+  type FolderContextType,
+};

--- a/packages/framework-dashboard/components/animate-ui/primitives/effects/highlight/index.tsx
+++ b/packages/framework-dashboard/components/animate-ui/primitives/effects/highlight/index.tsx
@@ -1,0 +1,641 @@
+// @ts-nocheck -- vendored animate-ui component (copied from animate-ui.com); not authored against our exactOptionalPropertyTypes
+'use client';
+
+import * as React from 'react';
+import { AnimatePresence, motion, type Transition } from 'motion/react';
+
+import { cn } from '@/lib/utils';
+
+type HighlightMode = 'children' | 'parent';
+
+type Bounds = {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+};
+
+const DEFAULT_BOUNDS_OFFSET: Bounds = {
+  top: 0,
+  left: 0,
+  width: 0,
+  height: 0,
+};
+
+type HighlightContextType<T extends string> = {
+  as?: keyof HTMLElementTagNameMap;
+  mode: HighlightMode;
+  activeValue: T | null;
+  setActiveValue: (value: T | null) => void;
+  setBounds: (bounds: DOMRect) => void;
+  clearBounds: () => void;
+  id: string;
+  hover: boolean;
+  click: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+  activeClassName?: string;
+  setActiveClassName: (className: string) => void;
+  transition?: Transition;
+  disabled?: boolean;
+  enabled?: boolean;
+  exitDelay?: number;
+  forceUpdateBounds?: boolean;
+};
+
+const HighlightContext = React.createContext<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  HighlightContextType<any> | undefined
+>(undefined);
+
+function useHighlight<T extends string>(): HighlightContextType<T> {
+  const context = React.useContext(HighlightContext);
+  if (!context) {
+    throw new Error('useHighlight must be used within a HighlightProvider');
+  }
+  return context as unknown as HighlightContextType<T>;
+}
+
+type BaseHighlightProps<T extends React.ElementType = 'div'> = {
+  as?: T;
+  ref?: React.Ref<HTMLDivElement>;
+  mode?: HighlightMode;
+  value?: string | null;
+  defaultValue?: string | null;
+  onValueChange?: (value: string | null) => void;
+  className?: string;
+  style?: React.CSSProperties;
+  transition?: Transition;
+  hover?: boolean;
+  click?: boolean;
+  disabled?: boolean;
+  enabled?: boolean;
+  exitDelay?: number;
+};
+
+type ParentModeHighlightProps = {
+  boundsOffset?: Partial<Bounds>;
+  containerClassName?: string;
+  forceUpdateBounds?: boolean;
+};
+
+type ControlledParentModeHighlightProps<T extends React.ElementType = 'div'> =
+  BaseHighlightProps<T> &
+    ParentModeHighlightProps & {
+      mode: 'parent';
+      controlledItems: true;
+      children: React.ReactNode;
+    };
+
+type ControlledChildrenModeHighlightProps<T extends React.ElementType = 'div'> =
+  BaseHighlightProps<T> & {
+    mode?: 'children' | undefined;
+    controlledItems: true;
+    children: React.ReactNode;
+  };
+
+type UncontrolledParentModeHighlightProps<T extends React.ElementType = 'div'> =
+  BaseHighlightProps<T> &
+    ParentModeHighlightProps & {
+      mode: 'parent';
+      controlledItems?: false;
+      itemsClassName?: string;
+      children: React.ReactElement | React.ReactElement[];
+    };
+
+type UncontrolledChildrenModeHighlightProps<
+  T extends React.ElementType = 'div',
+> = BaseHighlightProps<T> & {
+  mode?: 'children';
+  controlledItems?: false;
+  itemsClassName?: string;
+  children: React.ReactElement | React.ReactElement[];
+};
+
+type HighlightProps<T extends React.ElementType = 'div'> =
+  | ControlledParentModeHighlightProps<T>
+  | ControlledChildrenModeHighlightProps<T>
+  | UncontrolledParentModeHighlightProps<T>
+  | UncontrolledChildrenModeHighlightProps<T>;
+
+function Highlight<T extends React.ElementType = 'div'>({
+  ref,
+  ...props
+}: HighlightProps<T>) {
+  const {
+    as: Component = 'div',
+    children,
+    value,
+    defaultValue,
+    onValueChange,
+    className,
+    style,
+    transition = { type: 'spring', stiffness: 350, damping: 35 },
+    hover = false,
+    click = true,
+    enabled = true,
+    controlledItems,
+    disabled = false,
+    exitDelay = 200,
+    mode = 'children',
+  } = props;
+
+  const localRef = React.useRef<HTMLDivElement>(null);
+  React.useImperativeHandle(ref, () => localRef.current as HTMLDivElement);
+
+  const propsBoundsOffset = (props as ParentModeHighlightProps)?.boundsOffset;
+  const boundsOffset = propsBoundsOffset ?? DEFAULT_BOUNDS_OFFSET;
+  const boundsOffsetTop = boundsOffset.top ?? 0;
+  const boundsOffsetLeft = boundsOffset.left ?? 0;
+  const boundsOffsetWidth = boundsOffset.width ?? 0;
+  const boundsOffsetHeight = boundsOffset.height ?? 0;
+
+  const boundsOffsetRef = React.useRef({
+    top: boundsOffsetTop,
+    left: boundsOffsetLeft,
+    width: boundsOffsetWidth,
+    height: boundsOffsetHeight,
+  });
+
+  React.useEffect(() => {
+    boundsOffsetRef.current = {
+      top: boundsOffsetTop,
+      left: boundsOffsetLeft,
+      width: boundsOffsetWidth,
+      height: boundsOffsetHeight,
+    };
+  }, [
+    boundsOffsetTop,
+    boundsOffsetLeft,
+    boundsOffsetWidth,
+    boundsOffsetHeight,
+  ]);
+
+  const [activeValue, setActiveValue] = React.useState<string | null>(
+    value ?? defaultValue ?? null,
+  );
+  const [boundsState, setBoundsState] = React.useState<Bounds | null>(null);
+  const [activeClassNameState, setActiveClassNameState] =
+    React.useState<string>('');
+
+  const safeSetActiveValue = (id: string | null) => {
+    setActiveValue((prev) => {
+      if (prev !== id) {
+        onValueChange?.(id);
+        return id;
+      }
+      return prev;
+    });
+  };
+
+  const safeSetBoundsRef = React.useRef<
+    ((bounds: DOMRect) => void) | undefined
+  >(undefined);
+
+  React.useEffect(() => {
+    safeSetBoundsRef.current = (bounds: DOMRect) => {
+      if (!localRef.current) return;
+
+      const containerRect = localRef.current.getBoundingClientRect();
+      const offset = boundsOffsetRef.current;
+      const newBounds: Bounds = {
+        top: bounds.top - containerRect.top + offset.top,
+        left: bounds.left - containerRect.left + offset.left,
+        width: bounds.width + offset.width,
+        height: bounds.height + offset.height,
+      };
+
+      setBoundsState((prev) => {
+        if (
+          prev &&
+          prev.top === newBounds.top &&
+          prev.left === newBounds.left &&
+          prev.width === newBounds.width &&
+          prev.height === newBounds.height
+        ) {
+          return prev;
+        }
+        return newBounds;
+      });
+    };
+  });
+
+  const safeSetBounds = (bounds: DOMRect) => {
+    safeSetBoundsRef.current?.(bounds);
+  };
+
+  const clearBounds = React.useCallback(() => {
+    setBoundsState((prev) => (prev === null ? prev : null));
+  }, []);
+
+  React.useEffect(() => {
+    if (value !== undefined) setActiveValue(value);
+    else if (defaultValue !== undefined) setActiveValue(defaultValue);
+  }, [value, defaultValue]);
+
+  const id = React.useId();
+
+  React.useEffect(() => {
+    if (mode !== 'parent') return;
+    const container = localRef.current;
+    if (!container) return;
+
+    const onScroll = () => {
+      if (!activeValue) return;
+      const activeEl = container.querySelector<HTMLElement>(
+        `[data-value="${activeValue}"][data-highlight="true"]`,
+      );
+      if (activeEl)
+        safeSetBoundsRef.current?.(activeEl.getBoundingClientRect());
+    };
+
+    container.addEventListener('scroll', onScroll, { passive: true });
+    return () => container.removeEventListener('scroll', onScroll);
+  }, [mode, activeValue]);
+
+  const render = (children: React.ReactNode) => {
+    if (mode === 'parent') {
+      return (
+        <Component
+          ref={localRef}
+          data-slot="motion-highlight-container"
+          style={{ position: 'relative', zIndex: 1 }}
+          className={(props as ParentModeHighlightProps)?.containerClassName}
+        >
+          <AnimatePresence initial={false} mode="wait">
+            {boundsState && (
+              <motion.div
+                data-slot="motion-highlight"
+                animate={{
+                  top: boundsState.top,
+                  left: boundsState.left,
+                  width: boundsState.width,
+                  height: boundsState.height,
+                  opacity: 1,
+                }}
+                initial={{
+                  top: boundsState.top,
+                  left: boundsState.left,
+                  width: boundsState.width,
+                  height: boundsState.height,
+                  opacity: 0,
+                }}
+                exit={{
+                  opacity: 0,
+                  transition: {
+                    ...transition,
+                    delay: (transition?.delay ?? 0) + (exitDelay ?? 0) / 1000,
+                  },
+                }}
+                transition={transition}
+                style={{ position: 'absolute', zIndex: 0, ...style }}
+                className={cn(className, activeClassNameState)}
+              />
+            )}
+          </AnimatePresence>
+          {children}
+        </Component>
+      );
+    }
+
+    return children;
+  };
+
+  return (
+    <HighlightContext.Provider
+      value={{
+        mode,
+        activeValue,
+        setActiveValue: safeSetActiveValue,
+        id,
+        hover,
+        click,
+        className,
+        style,
+        transition,
+        disabled,
+        enabled,
+        exitDelay,
+        setBounds: safeSetBounds,
+        clearBounds,
+        activeClassName: activeClassNameState,
+        setActiveClassName: setActiveClassNameState,
+        forceUpdateBounds: (props as ParentModeHighlightProps)
+          ?.forceUpdateBounds,
+      }}
+    >
+      {enabled
+        ? controlledItems
+          ? render(children)
+          : render(
+              React.Children.map(children, (child, index) => (
+                <HighlightItem key={index} className={props?.itemsClassName}>
+                  {child}
+                </HighlightItem>
+              )),
+            )
+        : children}
+    </HighlightContext.Provider>
+  );
+}
+
+function getNonOverridingDataAttributes(
+  element: React.ReactElement,
+  dataAttributes: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.keys(dataAttributes).reduce<Record<string, unknown>>(
+    (acc, key) => {
+      if ((element.props as Record<string, unknown>)[key] === undefined) {
+        acc[key] = dataAttributes[key];
+      }
+      return acc;
+    },
+    {},
+  );
+}
+
+type ExtendedChildProps = React.ComponentProps<'div'> & {
+  id?: string;
+  ref?: React.Ref<HTMLElement>;
+  'data-active'?: string;
+  'data-value'?: string;
+  'data-disabled'?: boolean;
+  'data-highlight'?: boolean;
+  'data-slot'?: string;
+};
+
+type HighlightItemProps<T extends React.ElementType = 'div'> =
+  React.ComponentProps<T> & {
+    as?: T;
+    children: React.ReactElement;
+    id?: string;
+    value?: string;
+    className?: string;
+    style?: React.CSSProperties;
+    transition?: Transition;
+    activeClassName?: string;
+    disabled?: boolean;
+    exitDelay?: number;
+    asChild?: boolean;
+    forceUpdateBounds?: boolean;
+  };
+
+function HighlightItem<T extends React.ElementType>({
+  ref,
+  as,
+  children,
+  id,
+  value,
+  className,
+  style,
+  transition,
+  disabled = false,
+  activeClassName,
+  exitDelay,
+  asChild = false,
+  forceUpdateBounds,
+  ...props
+}: HighlightItemProps<T>) {
+  const itemId = React.useId();
+  const {
+    activeValue,
+    setActiveValue,
+    mode,
+    setBounds,
+    clearBounds,
+    hover,
+    click,
+    enabled,
+    className: contextClassName,
+    style: contextStyle,
+    transition: contextTransition,
+    id: contextId,
+    disabled: contextDisabled,
+    exitDelay: contextExitDelay,
+    forceUpdateBounds: contextForceUpdateBounds,
+    setActiveClassName,
+  } = useHighlight();
+
+  const Component = as ?? 'div';
+  const element = children as React.ReactElement<ExtendedChildProps>;
+  const childValue =
+    id ?? value ?? element.props?.['data-value'] ?? element.props?.id ?? itemId;
+  const isActive = activeValue === childValue;
+  const isDisabled = disabled === undefined ? contextDisabled : disabled;
+  const itemTransition = transition ?? contextTransition;
+
+  const localRef = React.useRef<HTMLDivElement>(null);
+  React.useImperativeHandle(ref, () => localRef.current as HTMLDivElement);
+
+  const refCallback = React.useCallback((node: HTMLElement | null) => {
+    localRef.current = node as HTMLDivElement;
+  }, []);
+
+  React.useEffect(() => {
+    if (mode !== 'parent') return;
+    let rafId: number;
+    let previousBounds: Bounds | null = null;
+    const shouldUpdateBounds =
+      forceUpdateBounds === true ||
+      (contextForceUpdateBounds && forceUpdateBounds !== false);
+
+    const updateBounds = () => {
+      if (!localRef.current) return;
+
+      const bounds = localRef.current.getBoundingClientRect();
+
+      if (shouldUpdateBounds) {
+        if (
+          previousBounds &&
+          previousBounds.top === bounds.top &&
+          previousBounds.left === bounds.left &&
+          previousBounds.width === bounds.width &&
+          previousBounds.height === bounds.height
+        ) {
+          rafId = requestAnimationFrame(updateBounds);
+          return;
+        }
+        previousBounds = bounds;
+        rafId = requestAnimationFrame(updateBounds);
+      }
+
+      setBounds(bounds);
+    };
+
+    if (isActive) {
+      updateBounds();
+      setActiveClassName(activeClassName ?? '');
+    } else if (!activeValue) clearBounds();
+
+    if (shouldUpdateBounds) return () => cancelAnimationFrame(rafId);
+  }, [
+    mode,
+    isActive,
+    activeValue,
+    setBounds,
+    clearBounds,
+    activeClassName,
+    setActiveClassName,
+    forceUpdateBounds,
+    contextForceUpdateBounds,
+  ]);
+
+  if (!React.isValidElement(children)) return children;
+
+  const dataAttributes = {
+    'data-active': isActive ? 'true' : 'false',
+    'aria-selected': isActive,
+    'data-disabled': isDisabled,
+    'data-value': childValue,
+    'data-highlight': true,
+  };
+
+  const commonHandlers = hover
+    ? {
+        onMouseEnter: (e: React.MouseEvent<HTMLDivElement>) => {
+          setActiveValue(childValue);
+          element.props.onMouseEnter?.(e);
+        },
+        onMouseLeave: (e: React.MouseEvent<HTMLDivElement>) => {
+          setActiveValue(null);
+          element.props.onMouseLeave?.(e);
+        },
+      }
+    : click
+      ? {
+          onClick: (e: React.MouseEvent<HTMLDivElement>) => {
+            setActiveValue(childValue);
+            element.props.onClick?.(e);
+          },
+        }
+      : {};
+
+  if (asChild) {
+    if (mode === 'children') {
+      return React.cloneElement(
+        element,
+        {
+          key: childValue,
+          ref: refCallback,
+          className: cn('relative', element.props.className),
+          ...getNonOverridingDataAttributes(element, {
+            ...dataAttributes,
+            'data-slot': 'motion-highlight-item-container',
+          }),
+          ...commonHandlers,
+          ...props,
+        },
+        <>
+          <AnimatePresence initial={false} mode="wait">
+            {isActive && !isDisabled && (
+              <motion.div
+                layoutId={`transition-background-${contextId}`}
+                data-slot="motion-highlight"
+                style={{
+                  position: 'absolute',
+                  zIndex: 0,
+                  ...contextStyle,
+                  ...style,
+                }}
+                className={cn(contextClassName, activeClassName)}
+                transition={itemTransition}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{
+                  opacity: 0,
+                  transition: {
+                    ...itemTransition,
+                    delay:
+                      (itemTransition?.delay ?? 0) +
+                      (exitDelay ?? contextExitDelay ?? 0) / 1000,
+                  },
+                }}
+                {...dataAttributes}
+              />
+            )}
+          </AnimatePresence>
+
+          <Component
+            data-slot="motion-highlight-item"
+            style={{ position: 'relative', zIndex: 1 }}
+            className={className}
+            {...dataAttributes}
+          >
+            {children}
+          </Component>
+        </>,
+      );
+    }
+
+    return React.cloneElement(element, {
+      ref: refCallback,
+      ...getNonOverridingDataAttributes(element, {
+        ...dataAttributes,
+        'data-slot': 'motion-highlight-item',
+      }),
+      ...commonHandlers,
+    });
+  }
+
+  return enabled ? (
+    <Component
+      key={childValue}
+      ref={localRef}
+      data-slot="motion-highlight-item-container"
+      className={cn(mode === 'children' && 'relative', className)}
+      {...dataAttributes}
+      {...props}
+      {...commonHandlers}
+    >
+      {mode === 'children' && (
+        <AnimatePresence initial={false} mode="wait">
+          {isActive && !isDisabled && (
+            <motion.div
+              layoutId={`transition-background-${contextId}`}
+              data-slot="motion-highlight"
+              style={{
+                position: 'absolute',
+                zIndex: 0,
+                ...contextStyle,
+                ...style,
+              }}
+              className={cn(contextClassName, activeClassName)}
+              transition={itemTransition}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{
+                opacity: 0,
+                transition: {
+                  ...itemTransition,
+                  delay:
+                    (itemTransition?.delay ?? 0) +
+                    (exitDelay ?? contextExitDelay ?? 0) / 1000,
+                },
+              }}
+              {...dataAttributes}
+            />
+          )}
+        </AnimatePresence>
+      )}
+
+      {React.cloneElement(element, {
+        style: { position: 'relative', zIndex: 1 },
+        className: element.props.className,
+        ...getNonOverridingDataAttributes(element, {
+          ...dataAttributes,
+          'data-slot': 'motion-highlight-item',
+        }),
+      })}
+    </Component>
+  ) : (
+    children
+  );
+}
+
+export {
+  Highlight,
+  HighlightItem,
+  useHighlight,
+  type HighlightProps,
+  type HighlightItemProps,
+};

--- a/packages/framework-dashboard/components/ui/button.tsx
+++ b/packages/framework-dashboard/components/ui/button.tsx
@@ -17,6 +17,7 @@ const buttonVariants = cva(
         default: 'h-9 px-4 py-2',
         sm: 'h-8 px-3',
         icon: 'h-9 w-9',
+        'icon-sm': 'h-7 w-7',
       },
     },
     defaultVariants: { variant: 'default', size: 'default' },
@@ -30,3 +31,5 @@ export interface ButtonProps
 export function Button({ className, variant, size, ...props }: ButtonProps) {
   return <button className={cn(buttonVariants({ variant, size }), className)} {...props} />
 }
+
+export { buttonVariants }

--- a/packages/framework-dashboard/components/ui/tooltip.tsx
+++ b/packages/framework-dashboard/components/ui/tooltip.tsx
@@ -1,0 +1,36 @@
+'use client'
+import type { ComponentProps } from 'react'
+import { Tooltip as TooltipPrimitive } from '@base-ui-components/react/tooltip'
+import { cn } from '../../lib/utils.js'
+
+// A trimmed shadcn-style Tooltip on Base UI (already a dep via animate-ui — no Radix pulled
+// in). Wrap a group in <TooltipProvider> (shared open/close delay), then per item:
+//   <Tooltip><TooltipTrigger render={<Button …/>}>…</TooltipTrigger><TooltipContent>Label</TooltipContent></Tooltip>
+const TooltipProvider = TooltipPrimitive.Provider
+const Tooltip = TooltipPrimitive.Root
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+function TooltipContent({
+  className,
+  sideOffset = 6,
+  children,
+  ...props
+}: ComponentProps<typeof TooltipPrimitive.Popup> & { sideOffset?: number }) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner sideOffset={sideOffset}>
+        <TooltipPrimitive.Popup
+          className={cn(
+            'z-50 rounded-md border border-border bg-card px-2 py-1 text-xs text-card-foreground shadow-md',
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/packages/framework-dashboard/hooks/use-controlled-state.tsx
+++ b/packages/framework-dashboard/hooks/use-controlled-state.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+
+interface CommonControlledStateProps<T> {
+  value?: T;
+  defaultValue?: T;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useControlledState<T, Rest extends any[] = []>(
+  props: CommonControlledStateProps<T> & {
+    onChange?: (value: T, ...args: Rest) => void;
+  },
+): readonly [T, (next: T, ...args: Rest) => void] {
+  const { value, defaultValue, onChange } = props;
+
+  const [state, setInternalState] = React.useState<T>(
+    value !== undefined ? value : (defaultValue as T),
+  );
+
+  React.useEffect(() => {
+    if (value !== undefined) setInternalState(value);
+  }, [value]);
+
+  const setState = React.useCallback(
+    (next: T, ...args: Rest) => {
+      setInternalState(next);
+      onChange?.(next, ...args);
+    },
+    [onChange],
+  );
+
+  return [state, setState] as const;
+}

--- a/packages/framework-dashboard/lib/get-strict-context.tsx
+++ b/packages/framework-dashboard/lib/get-strict-context.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+function getStrictContext<T>(
+  name?: string,
+): readonly [
+  ({
+    value,
+    children,
+  }: {
+    value: T;
+    children?: React.ReactNode;
+  }) => React.JSX.Element,
+  () => T,
+] {
+  const Context = React.createContext<T | undefined>(undefined);
+
+  const Provider = ({
+    value,
+    children,
+  }: {
+    value: T;
+    children?: React.ReactNode;
+  }) => <Context.Provider value={value}>{children}</Context.Provider>;
+
+  const useSafeContext = () => {
+    const ctx = React.useContext(Context);
+    if (ctx === undefined) {
+      throw new Error(`useContext must be used within ${name ?? 'a Provider'}`);
+    }
+    return ctx;
+  };
+
+  return [Provider, useSafeContext] as const;
+}
+
+export { getStrictContext };

--- a/packages/framework-dashboard/package.json
+++ b/packages/framework-dashboard/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@base-ui-components/react": "1.0.0-rc.0",
     "@gemstack/framework": "workspace:^",
     "@tiptap/core": "^2.10.0",
     "@tiptap/pm": "^2.10.0",
@@ -24,6 +25,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.469.0",
+    "motion": "^12.42.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tailwind-merge": "^2.6.0",

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { onProjectFiles } from '../../server/reads.telefunc.js'
 import { ProjectsSidebar } from '../../components/ProjectsSidebar.js'
 import { RunHistory } from '../../components/RunHistory.js'
 import { ProjectHome } from '../../components/ProjectHome.js'
@@ -35,6 +36,36 @@ export default function Page() {
 
   const { runs, reload } = useRuns(projectId)
 
+  // The run Context set lives in the shell (#492/#504) so the two surfaces that feed it share
+  // one source of truth: the `#` file chips + whole-repo Context selector in the Start form
+  // (main pane), and the file tree in the right rail. Reset when the project changes — the
+  // picked file paths are that project's.
+  const [context, setContext] = useState<Set<string>>(new Set())
+  const addContext = (path: string) =>
+    setContext(prev => (prev.has(path) ? prev : new Set(prev).add(path)))
+  const toggleContext = (path: string) =>
+    setContext(prev => {
+      const next = new Set(prev)
+      next.has(path) ? next.delete(path) : next.add(path)
+      return next
+    })
+
+  // The selected project's files (git ls-files), fetched once here and handed to both the
+  // `#` picker and the tree. Empty when no project / on the relay (no checkout).
+  const [files, setFiles] = useState<string[]>([])
+  useEffect(() => {
+    if (!projectId) {
+      setFiles([])
+      return
+    }
+    let live = true
+    setFiles([])
+    void onProjectFiles(projectId).then(list => live && setFiles(list))
+    return () => {
+      live = false
+    }
+  }, [projectId])
+
   const onRunStarted = (intent: string) => {
     // Stay on the home launcher (it must stay visible so you can launch again); the new run
     // just appends to the rail. Reload so its real row replaces the optimistic one quickly.
@@ -45,6 +76,7 @@ export default function Page() {
   const selectProject = (id: string) => {
     setProjectId(id)
     setRunId(null) // switching projects always returns to the home launcher
+    setContext(new Set()) // the picked context is the old project's — start fresh
     if (typeof window !== 'undefined') window.localStorage.setItem(SELECTED_PROJECT_KEY, id)
   }
 
@@ -75,7 +107,18 @@ export default function Page() {
   const selectedRun = runId ? runs.find(run => run.id === runId) : undefined
   const renderMain = () => {
     if (!projectId) return <DashboardPage onSelectProject={selectProject} />
-    if (runId === null) return <ProjectHome projectId={projectId} events={events} onRunStarted={onRunStarted} />
+    if (runId === null)
+      return (
+        <ProjectHome
+          projectId={projectId}
+          events={events}
+          onRunStarted={onRunStarted}
+          files={files}
+          context={context}
+          addContext={addContext}
+          toggleContext={toggleContext}
+        />
+      )
     if (selectedRun?.status === 'running') return <RunLive projectId={projectId} events={events} />
     return <RunReplay projectId={projectId} runId={runId} />
   }
@@ -98,7 +141,14 @@ export default function Page() {
           startIntent={runStart.intent}
         />
         <main className="flex min-w-0 flex-1 flex-col">{renderMain()}</main>
-        <RightRail projectId={projectId} choices={choices} views={views} />
+        <RightRail
+          projectId={projectId}
+          choices={choices}
+          views={views}
+          files={files}
+          context={context}
+          toggleContext={toggleContext}
+        />
       </div>
     </div>
   )

--- a/packages/framework-dashboard/server/reads.telefunc.ts
+++ b/packages/framework-dashboard/server/reads.telefunc.ts
@@ -3,4 +3,4 @@
 // the client bakes the RPC key `/server/reads.telefunc.ts` — the exact key the daemon
 // registers the impls under (see framework's dashboard-rpc/register.ts). The telefunc
 // Vite transform turns these named re-exports into client RPC stubs.
-export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl, onGitStatus, onProjectFiles } from '@gemstack/framework/dashboard-rpc'
+export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from '@gemstack/framework/dashboard-rpc'

--- a/packages/framework-dashboard/vite.config.ts
+++ b/packages/framework-dashboard/vite.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url'
 import react from '@vitejs/plugin-react'
 import vike from 'vike/plugin'
 import { telefunc } from 'telefunc/vite'
@@ -11,6 +12,10 @@ import { defineConfig } from 'vite'
 // there is touched. Production serving (daemon serves the built bundle) is next (#405).
 export default defineConfig({
   plugins: [react(), vike(), telefunc(), tailwindcss()],
+  // `@/*` -> package root, matching tsconfig `paths` (used by the copied-in animate-ui components).
+  resolve: {
+    alias: { '@': fileURLToPath(new URL('.', import.meta.url)) },
+  },
   server: {
     port: 4300,
   },

--- a/packages/framework/src/dashboard-rpc/index.ts
+++ b/packages/framework/src/dashboard-rpc/index.ts
@@ -2,7 +2,7 @@
 // implementations live here in @gemstack/framework so `sendStart` (added with the serve
 // wiring) can reach the daemon's `startRun`; the framework-dashboard client imports
 // these through thin re-export shims so the baked RPC keys stay `/server/*.telefunc.ts`.
-export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl, onGitStatus, onProjectFiles } from './reads.telefunc.js'
+export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from './reads.telefunc.js'
 export { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
 export { onEvents } from './events.telefunc.js'
 export { onProjects, sendAddProject } from './projects.telefunc.js'

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.test.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { onProjectFiles } from './reads.telefunc.js'
+import { onProjectFiles, onProjectFileStatus } from './reads.telefunc.js'
 
 // Outside a Telefunc `serve({ context })` the RPC resolves against the global registry, so an
 // unknown project id has no local path — the same situation as the relay, which has no
@@ -8,4 +8,8 @@ import { onProjectFiles } from './reads.telefunc.js'
 
 test('onProjectFiles for an unknown project returns an empty list', async () => {
   assert.deepEqual(await onProjectFiles('project-that-does-not-exist'), [])
+})
+
+test('onProjectFileStatus for an unknown project returns an empty map', async () => {
+  assert.deepEqual(await onProjectFileStatus('project-that-does-not-exist'), {})
 })

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -7,6 +7,7 @@ import { buildDashboard, type DashboardData } from '../dashboard/dashboard.js'
 import { githubUrlFor } from '../dashboard/github.js'
 import { readGitStatus, type GitStatus } from '../dashboard/git-status.js'
 import { crawlRepoFiles } from '../project.js'
+import { readFileStatuses, type FileGitStatus } from '../dashboard/file-status.js'
 import { contextProjects } from './context.js'
 import type { FrameworkEvent } from '../events.js'
 
@@ -86,6 +87,15 @@ export async function onDashboard(): Promise<DashboardData> {
 export async function onProjectFiles(projectId: string): Promise<string[]> {
   const cwd = await projectPath(projectId)
   return cwd ? crawlRepoFiles(cwd).catch(() => []) : []
+}
+
+/**
+ * Per-file git status for the tree's dots (#492): repo-relative path -> untracked/modified/
+ * deleted, from `git status --porcelain`. `{}` when not a repo / on the relay (no checkout).
+ */
+export async function onProjectFileStatus(projectId: string): Promise<Record<string, FileGitStatus>> {
+  const cwd = await projectPath(projectId)
+  return cwd ? readFileStatuses(cwd).catch(() => ({})) : {}
 }
 
 /** The project's GitHub URL from its `origin` remote (#489), or null (no remote / not GitHub / relay). */

--- a/packages/framework/src/dashboard-rpc/register.ts
+++ b/packages/framework/src/dashboard-rpc/register.ts
@@ -1,5 +1,5 @@
 import { __decorateTelefunction } from 'telefunc'
-import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl, onGitStatus, onProjectFiles } from './reads.telefunc.js'
+import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from './reads.telefunc.js'
 import { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
 import { onEvents } from './events.telefunc.js'
 import { onProjects, sendAddProject } from './projects.telefunc.js'
@@ -41,6 +41,7 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(onGithubUrl, 'onGithubUrl', reads)
   reg(onGitStatus, 'onGitStatus', reads)
   reg(onProjectFiles, 'onProjectFiles', reads)
+  reg(onProjectFileStatus, 'onProjectFileStatus', reads)
   reg(sendStop, 'sendStop', control)
   reg(sendChoice, 'sendChoice', control)
   reg(sendStart, 'sendStart', control)

--- a/packages/framework/src/dashboard/file-status.test.ts
+++ b/packages/framework/src/dashboard/file-status.test.ts
@@ -1,0 +1,24 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { readFileStatuses } from './file-status.js'
+
+const fakeGit = (out: string) => async () => out
+
+test('readFileStatuses maps porcelain codes to untracked/modified/deleted', async () => {
+  const out = [' M src/a.ts', '?? src/new.ts', ' D src/gone.ts', 'A  src/added.ts', 'R  old.ts -> src/renamed.ts'].join('\n')
+  const map = await readFileStatuses('/repo', fakeGit(out))
+  assert.deepEqual(map, {
+    'src/a.ts': 'modified',
+    'src/new.ts': 'untracked',
+    'src/gone.ts': 'deleted',
+    'src/added.ts': 'modified',
+    'src/renamed.ts': 'modified', // a rename dots the new path
+  })
+})
+
+test('readFileStatuses yields {} when git fails (not a repo)', async () => {
+  const map = await readFileStatuses('/repo', async () => {
+    throw new Error('fatal: not a git repository')
+  })
+  assert.deepEqual(map, {})
+})

--- a/packages/framework/src/dashboard/file-status.ts
+++ b/packages/framework/src/dashboard/file-status.ts
@@ -1,0 +1,34 @@
+import { nodeGitRunner, type GitRunner } from '../project.js'
+
+// Per-file git status for the panel's file tree (#492): the working-tree state of each changed
+// file, so the tree can dot untracked/modified/deleted entries. A single `git status --porcelain`
+// read, mapped to repo-relative path -> state. Forgiving: a non-repo / failed git yields `{}`.
+
+/** The tree's per-file git state (matches the animate-ui Files `gitStatus`). */
+export type FileGitStatus = 'untracked' | 'modified' | 'deleted'
+
+/** Strip git's surrounding quotes from a path with special chars (basic; leaves escapes as-is). */
+function unquotePath(path: string): string {
+  return path.length >= 2 && path.startsWith('"') && path.endsWith('"') ? path.slice(1, -1) : path
+}
+
+/**
+ * Read each changed file's status from `git status --porcelain`, keyed by repo-relative path.
+ * `??` is untracked, a `D` in either column is deleted, anything else (M/A/R/C…) reads as
+ * modified. Renames map to the new path. Returns `{}` when the path is not a git repo.
+ */
+export async function readFileStatuses(cwd: string, git: GitRunner = nodeGitRunner()): Promise<Record<string, FileGitStatus>> {
+  const out = await git(['status', '--porcelain'], cwd).catch(() => '')
+  const map: Record<string, FileGitStatus> = {}
+  for (const line of out.split('\n')) {
+    if (line.length < 4) continue
+    const code = line.slice(0, 2)
+    let path = line.slice(3)
+    const arrow = path.indexOf(' -> ')
+    if (arrow !== -1) path = path.slice(arrow + 4) // a rename: dot the new path
+    path = unquotePath(path)
+    if (!path) continue
+    map[path] = code === '??' ? 'untracked' : code.includes('D') ? 'deleted' : 'modified'
+  }
+  return map
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,9 @@ importers:
 
   packages/framework-dashboard:
     dependencies:
+      '@base-ui-components/react':
+        specifier: 1.0.0-rc.0
+        version: 1.0.0-rc.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@gemstack/framework':
         specifier: workspace:^
         version: link:../framework
@@ -326,6 +329,9 @@ importers:
       lucide-react:
         specifier: ^0.469.0
         version: 0.469.0(react@19.2.7)
+      motion:
+        specifier: ^12.42.2
+        version: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.0
         version: 19.2.7
@@ -653,6 +659,29 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
+  '@base-ui-components/react@1.0.0-rc.0':
+    resolution: {integrity: sha512-9lhUFbJcbXvc9KulLev1WTFxS/alJRBWDH/ibKSQaNvmDwMFS2gKp1sTeeldYSfKuS/KC1w2MZutc0wHu2hRHQ==}
+    engines: {node: '>=14.0.0'}
+    deprecated: Package was renamed to @base-ui/react
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@base-ui-components/utils@0.2.2':
+    resolution: {integrity: sha512-rNJCD6TFy3OSRDKVHJDzLpxO3esTV1/drRtWNUpe7rCpPN9HZVHUCuP+6rdDYDGWfXnQHbqi05xOyRP2iZAlkw==}
+    deprecated: Package was renamed to @base-ui/utils
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
@@ -945,6 +974,21 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/react-dom@2.1.9':
+    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
   '@google/genai@2.10.0':
     resolution: {integrity: sha512-e4cFxj3tiuMtsgOT4G9c1hXyGJhg7/Buj7VVeBacRY3fRtkRZZ59Q3nuVp2xbq8BGQXLXCDB253qMhklMOeUDg==}
@@ -2323,6 +2367,20 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  framer-motion@12.42.2:
+    resolution: {integrity: sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -2726,6 +2784,26 @@ packages:
   minisearch@7.2.0:
     resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
 
+  motion-dom@12.42.2:
+    resolution: {integrity: sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==}
+
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
+
+  motion@12.42.2:
+    resolution: {integrity: sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -3034,6 +3112,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -3942,6 +4023,31 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@base-ui-components/react@1.0.0-rc.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui-components/utils': 0.2.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      reselect: 5.2.0
+      tabbable: 6.5.0
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@base-ui-components/utils@0.2.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -4230,6 +4336,23 @@ snapshots:
     optional: true
 
   '@exodus/bytes@1.15.1': {}
+
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/react-dom@2.1.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@floating-ui/utils@0.2.12': {}
 
   '@google/genai@2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
@@ -5552,6 +5675,15 @@ snapshots:
 
   forwarded@0.2.0: {}
 
+  framer-motion@12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      motion-dom: 12.42.2
+      motion-utils: 12.39.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   fresh@2.0.0: {}
 
   fs-extra@7.0.1:
@@ -5972,6 +6104,20 @@ snapshots:
 
   minisearch@7.2.0: {}
 
+  motion-dom@12.42.2:
+    dependencies:
+      motion-utils: 12.39.0
+
+  motion-utils@12.39.0: {}
+
+  motion@12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      framer-motion: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   mri@1.2.0: {}
 
   mrmime@2.0.1: {}
@@ -6293,6 +6439,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  reselect@5.2.0: {}
+
   resolve-from@5.0.0: {}
 
   retry@0.13.1:
@@ -6592,8 +6740,7 @@ snapshots:
       '@ts-morph/common': 0.27.0
       code-block-writer: 13.0.3
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsx@4.22.4:
     dependencies:


### PR DESCRIPTION
Closes #492. Part of #488; builds on #504 (the `#` file picker).

## What
A file tree for the project panel, as the **first tab in the right rail** (Files · Docs · Log). It is a file-level **context picker**, not an editor: a lazy, collapsible tree built from `git ls-files`, where ticking a file adds it to the run Context — the same set the `#` picker and the whole-repo Context selector feed.

- Per-file **git-status dots** (untracked / modified / deleted), rolled up to folders, from a new `onProjectFileStatus` RPC (`git status --porcelain`). Polled so it tracks a run editing files.
- Built on the **animate-ui Files** components (copied in under `components/animate-ui/`, shadcn-style; deps `motion` + `@base-ui-components/react`). Vendored files are `@ts-nocheck` since they predate this repo's `exactOptionalPropertyTypes`.
- Lazy: closed folders stay unmounted.

## Action-bar refinements (same panel)
- Git status folds **inline on the left** of the action toolbar (was its own row).
- **Open on GitHub / Open folder / Open in editor** are now icon-only buttons with tooltips (a small `ui/tooltip.tsx` on **Base UI** — no Radix pulled in).
- **Preview -> Serve**: a play button that becomes a segmented **Open ↗ / Stop ⏹** control while serving. All controls share one height.

## Notes
- The run `context` set + the project file list are lifted to the shell (`+Page`) so the Start form and the rail tree share one source of truth; context resets on project switch.
- Relay path untouched (its dead `StartRunForm` branch gets inert props).

## Verify
- `onProjectFileStatus` over the live daemon: 24 changed files correctly flagged `modified`; `onProjectFiles` unchanged (784 files).
- New unit tests: porcelain parsing (untracked/modified/deleted/rename) + unknown-project degrades to `{}`. Full framework suite green (464 pass).
- Both packages typecheck; dashboard bundle builds and is served on the local daemon.