### PR TITLE
fix: wait for the daemon to exit in stop (#514)

### DIFF
--- a/.changeset/daemon-stop-waits-514.md
+++ b/.changeset/daemon-stop-waits-514.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Fix `framework stop` returning before the daemon has actually exited (#514). It signalled SIGTERM and removed the state file straight away, so restarting immediately raced the old process for the port: the new daemon hit EADDRINUSE, never reported itself ("the daemon did not come up in time"), and the old one kept serving a stale bundle with no state file left to stop it by. `stopDaemon` now waits for the process to exit before returning, escalating SIGTERM to SIGKILL if a wedged shutdown outlasts the grace period.

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { mkdtemp, writeFile, appendFile, rm, mkdir, readFile } from 'node:fs/promises'
+import { spawn } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import type { FrameworkEvent } from './events.js'
@@ -182,6 +183,39 @@ test('stopDaemon reports false when nothing is running', async () => {
   try {
     assert.equal(await stopDaemon(env), false)
   } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+// #514: stopDaemon must not return until the process is actually gone — the port is only
+// free once it is, so an immediate restart would otherwise race it (EADDRINUSE -> "the
+// daemon did not come up in time", with the old daemon still serving a stale bundle).
+// This daemon ignores SIGTERM, standing in for a wedged shutdown: only the escalation ends it.
+test('stopDaemon waits for the daemon to exit, escalating past an ignored SIGTERM (#514)', async () => {
+  const cwd = await tmpWorkspace()
+  const env = await configEnv(cwd)
+  const child = spawn(
+    process.execPath,
+    ['-e', "process.on('SIGTERM', () => {}); console.log('ready'); setInterval(() => {}, 1000)"],
+    { stdio: ['ignore', 'pipe', 'ignore'] },
+  )
+  // Wait until it prints ready: before that its SIGTERM handler is not installed yet and the
+  // default action would kill it, which would pass this test for the wrong reason.
+  await new Promise<void>(resolvePromise => child.stdout!.once('data', () => resolvePromise()))
+  try {
+    await writeFile(
+      daemonStatePath(env),
+      JSON.stringify({ pid: child.pid, port: 4200, url: 'http://127.0.0.1:4200', startedAt: '2026-01-01T00:00:00.000Z' }),
+    )
+    assert.equal(await stopDaemon(env, { timeoutMs: 300 }), true)
+    // The contract: once stopDaemon returns, the daemon is gone (so its port is free).
+    assert.equal(isProcessAlive(child.pid!), false)
+  } finally {
+    try {
+      child.kill('SIGKILL')
+    } catch {
+      // already reaped
+    }
     await rm(cwd, { recursive: true, force: true })
   }
 })

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -192,12 +192,24 @@ function delay(ms: number): Promise<void> {
   return new Promise(resolvePromise => setTimeout(resolvePromise, ms))
 }
 
+/** Options for {@link stopDaemon}. */
+export interface StopDaemonOptions {
+  /** Grace period for SIGTERM before escalating to SIGKILL, ms. Default 5000. */
+  timeoutMs?: number
+}
+
 /**
  * Stop the machine's daemon, if any (#393). Returns true when one was running and
  * got a termination signal. The daemon removes its own state file on exit; a stale
  * file (dead process) is cleaned up here.
+ *
+ * Waits for the process to actually exit before returning (#514): the port is only
+ * free once it is gone, so `stop` followed by an immediate restart would otherwise
+ * race it — the new daemon hits EADDRINUSE, never reports itself ("the daemon did not
+ * come up in time"), and the old one keeps serving a stale bundle with no state file.
+ * SIGTERM is escalated to SIGKILL if the grace period lapses.
  */
-export async function stopDaemon(env: NodeJS.ProcessEnv = process.env): Promise<boolean> {
+export async function stopDaemon(env: NodeJS.ProcessEnv = process.env, opts: StopDaemonOptions = {}): Promise<boolean> {
   const state = await readDaemonState(env)
   if (!state) return false
   const alive = isProcessAlive(state.pid)
@@ -207,9 +219,28 @@ export async function stopDaemon(env: NodeJS.ProcessEnv = process.env): Promise<
     } catch {
       // already gone between the check and the signal
     }
+    if (!(await waitForExit(state.pid, opts.timeoutMs ?? 5000))) {
+      // Ignored SIGTERM / wedged shutdown: take the port back rather than leave a zombie.
+      try {
+        process.kill(state.pid, 'SIGKILL')
+      } catch {
+        // raced us to exit
+      }
+      await waitForExit(state.pid, 1000)
+    }
   }
   await rm(daemonStatePath(env), { force: true }).catch(() => {})
   return alive
+}
+
+/** Poll until the process is gone, or the timeout lapses. */
+async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const step = 50
+  for (let waited = 0; waited <= timeoutMs; waited += step) {
+    if (!isProcessAlive(pid)) return true
+    await delay(step)
+  }
+  return !isProcessAlive(pid)
 }
 
 /**


### PR DESCRIPTION
Closes #514.

## The bug
`stopDaemon` sent SIGTERM, then immediately removed the state file and returned, without waiting for the process to exit. Restarting right after raced the port:

1. `stop` signals the daemon and removes its state file, but the old process still holds 4200.
2. `--daemon` sees no state file, so it spawns a new daemon.
3. The new daemon hits EADDRINUSE and never writes its state file.
4. `waitForDaemon` times out -> **"the daemon did not come up in time"**.
5. The **old** daemon is still alive serving the **previous** bundle, and now has no state file, so a later `stop` reports nothing to stop.

Step 5 is the nasty one: a brand-new telefunction returns `Malformed Telefunc Request` while the old RPCs keep working, which reads like a code bug rather than a stale process. I hit this repeatedly building the file tree; the only way out was killing the pid on the port by hand.

## The fix
`stopDaemon` waits for the process to actually exit before returning (polling `isProcessAlive`), escalating SIGTERM -> SIGKILL when a wedged shutdown outlasts the grace period (default 5s, injectable via `timeoutMs`). The port is only free once the process is gone, so an immediate restart no longer races it.

## Verify
- New regression test, and I checked it **fails on the pre-fix code and passes with it** (not a test that passes for the wrong reason). Its daemon ignores SIGTERM, standing in for a wedged shutdown, and waits to print `ready` first — without that handshake the child gets SIGTERM before its handler is installed and dies by default action, which made an earlier version of this test green against the bug.
- Real daemon: three consecutive `stop && --daemon` cycles now come up clean (HTTP 200, no timeout message). Previously this raced.
- Full framework suite green (485 pass).

Follow-up (not needed here): `ensureDaemon` could report EADDRINUSE explicitly instead of the generic "did not come up in time".