### PR TITLE
feat(framework): capture the agent's rate-limit telemetry (#517)

### DIFF
--- a/.changeset/rate-limit-telemetry.md
+++ b/.changeset/rate-limit-telemetry.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Capture the agent's rate-limit telemetry. Claude Code reports where the account's subscription quota stands on every turn of its `stream-json` output, and the parser was dropping it. It now surfaces as a `rate-limit` driver event carrying the status, the quota window, and when that window resets, so it persists and reaches the dashboard like any other driver event. New `DriverRateLimit` type.

--- a/packages/framework/src/driver/claude-code.test.ts
+++ b/packages/framework/src/driver/claude-code.test.ts
@@ -185,3 +185,57 @@ test('ClaudeCodeDriver writes an --mcp-config file for mcpServers and cleans it 
   await session.dispose()
   assert.ok(!existsSync(configPath))
 })
+
+test('StreamJsonParser surfaces the rate-limit telemetry the agent emits per turn (#517)', () => {
+  const p = new StreamJsonParser()
+  // Real payload shape, captured from `claude -p --output-format stream-json`.
+  const events = p.push(
+    JSON.stringify({
+      type: 'rate_limit_event',
+      rate_limit_info: {
+        status: 'allowed',
+        resetsAt: 1784079000,
+        rateLimitType: 'five_hour',
+        overageStatus: 'rejected',
+        isUsingOverage: false,
+      },
+      session_id: 'sess-1',
+    }),
+  )
+  assert.deepEqual(events, [
+    // Seconds in, millis out.
+    { type: 'rate-limit', limit: { status: 'allowed', window: 'five_hour', resetsAt: 1784079000_000 } },
+  ])
+  // Telemetry must not disturb the turn itself.
+  assert.deepEqual(p.result(), { text: '', sessionId: 'sess-1' })
+})
+
+test('StreamJsonParser passes through rate-limit values it has never seen (#517)', () => {
+  const p = new StreamJsonParser()
+  // We have only ever observed status=allowed / window=five_hour. An unknown
+  // value is the signal we are capturing for, so it must not be dropped.
+  const events = p.push(
+    JSON.stringify({
+      type: 'rate_limit_event',
+      rate_limit_info: { status: 'allowed_warning', resetsAt: 1784079000, rateLimitType: 'seven_day_opus' },
+    }),
+  )
+  assert.deepEqual(events, [
+    { type: 'rate-limit', limit: { status: 'allowed_warning', window: 'seven_day_opus', resetsAt: 1784079000_000 } },
+  ])
+})
+
+test('StreamJsonParser stays silent on a malformed rate_limit_event (#517)', () => {
+  const p = new StreamJsonParser()
+  // Reporting a bogus reset time is worse than reporting nothing.
+  assert.deepEqual(p.push(JSON.stringify({ type: 'rate_limit_event' })), [])
+  assert.deepEqual(p.push(JSON.stringify({ type: 'rate_limit_event', rate_limit_info: null })), [])
+  assert.deepEqual(
+    p.push(JSON.stringify({ type: 'rate_limit_event', rate_limit_info: { status: 'allowed', rateLimitType: 'five_hour' } })),
+    [],
+  )
+  assert.deepEqual(
+    p.push(JSON.stringify({ type: 'rate_limit_event', rate_limit_info: { status: 'allowed', rateLimitType: 'five_hour', resetsAt: 'soon' } })),
+    [],
+  )
+})

--- a/packages/framework/src/driver/claude-code.ts
+++ b/packages/framework/src/driver/claude-code.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { killTree, registerChild, unregisterChild } from './child-registry.js'
-import type { Driver, DriverEvent, DriverPromptOptions, DriverSession, DriverStartOptions, DriverTurn, DriverUsage } from './types.js'
+import type { Driver, DriverEvent, DriverPromptOptions, DriverRateLimit, DriverSession, DriverStartOptions, DriverTurn, DriverUsage } from './types.js'
 
 /** Grace between SIGTERM and the SIGKILL that forces a hung agent tree down. */
 const TERMINATE_GRACE_MS = 5000
@@ -317,6 +317,10 @@ export class StreamJsonParser {
     const type = obj['type']
 
     if (type === 'assistant') return this.handleAssistant(obj)
+    if (type === 'rate_limit_event') {
+      const limit = parseRateLimit(obj)
+      return limit ? [{ type: 'rate-limit', limit }] : []
+    }
     if (type === 'result') {
       const result = obj['result']
       if (typeof result === 'string') this.finalText = result
@@ -355,6 +359,26 @@ export class StreamJsonParser {
       ...(this.usage ? { usage: this.usage } : {}),
     }
   }
+}
+
+/**
+ * Pull the account's quota standing off a `rate_limit_event` line (#517):
+ * `{status, resetsAt, rateLimitType}`. The agent emits one per turn, so this is
+ * free telemetry — no extra call, no polling. Returns undefined when the payload
+ * is missing the parts we'd gate on, so a malformed line stays silent rather
+ * than reporting a bogus reset.
+ */
+function parseRateLimit(obj: Record<string, unknown>): DriverRateLimit | undefined {
+  const raw = obj['rate_limit_info']
+  if (typeof raw !== 'object' || raw === null) return undefined
+  const info = raw as Record<string, unknown>
+  const status = info['status']
+  const window = info['rateLimitType']
+  const resetsAt = info['resetsAt']
+  if (typeof status !== 'string' || typeof window !== 'string') return undefined
+  if (typeof resetsAt !== 'number' || !Number.isFinite(resetsAt)) return undefined
+  // The agent reports epoch seconds; the rest of the framework speaks millis.
+  return { status, window, resetsAt: resetsAt * 1000 }
 }
 
 /**

--- a/packages/framework/src/driver/index.ts
+++ b/packages/framework/src/driver/index.ts
@@ -6,6 +6,7 @@ export type {
   DriverTurn,
   DriverEvent,
   DriverUsage,
+  DriverRateLimit,
 } from './types.js'
 export { FakeDriver, FakeDriverSession, type FakeTurn, type FakeDriverOptions } from './fake.js'
 export {

--- a/packages/framework/src/driver/types.ts
+++ b/packages/framework/src/driver/types.ts
@@ -110,6 +110,30 @@ export interface DriverUsage {
 }
 
 /**
+ * Where the account's subscription quota stands, as reported by the wrapped
+ * agent (#517). Claude Code emits one of these per turn on its `stream-json`
+ * output; drivers that cannot report it simply omit it. This is the account
+ * limit, not this run's spend — {@link DriverUsage} covers the latter.
+ */
+export interface DriverRateLimit {
+  /**
+   * Whether the account may still spend against this window: `allowed`,
+   * `allowed_warning`, or `rejected`. Left open rather than a union — only
+   * `allowed` has been observed, and a status we don't know is the signal we're
+   * capturing for, so it must surface rather than be dropped.
+   */
+  status: string
+  /**
+   * Which quota window this reports on (`five_hour`, `seven_day`,
+   * `seven_day_opus`, `seven_day_sonnet`, `weekly`). Left open for the same
+   * reason: the agent adds windows as plans change.
+   */
+  window: string
+  /** When the window resets, epoch **milliseconds** (the agent reports seconds). */
+  resetsAt: number
+}
+
+/**
  * A black-box progress event from the wrapped agent. We forward these to the
  * dashboard for visibility but never gate on them: the loop gates on the code /
  * outcome, not on which tool the agent reached for.
@@ -123,5 +147,7 @@ export type DriverEvent =
   | { type: 'action'; label: string }
   /** The turn settled with this final text. */
   | { type: 'result'; text: string; sessionId?: string; usage?: DriverUsage }
+  /** Where the account's subscription quota stands (#517). */
+  | { type: 'rate-limit'; limit: DriverRateLimit }
   /** The agent (or its transport) errored. */
   | { type: 'error'; message: string }

--- a/packages/framework/src/events.test.ts
+++ b/packages/framework/src/events.test.ts
@@ -125,3 +125,14 @@ test('formatFrameworkEvent renders a usage spend line, with the cap when set (#3
   assert.equal(formatFrameworkEvent({ ...base, costUsd: 0.04, turns: 2 }), '  spend: $0.0400 over 2 turns')
   assert.equal(formatFrameworkEvent({ ...base, costUsd: 0.02, turns: 1, budgetUsd: 5 }), '  spend: $0.0200 / $5 over 1 turn')
 })
+
+test('formats the rate-limit line by how much the quota actually matters (#517)', () => {
+  const at = Date.UTC(2026, 6, 15, 4, 30)
+  const line = (status: string) => formatFrameworkEvent({ kind: 'driver', event: { type: 'rate-limit', limit: { status, window: 'five_hour', resetsAt: at } } })!
+  assert.match(line('allowed'), /^\s+· quota allowed \(five_hour\)/)
+  assert.match(line('allowed_warning'), /^\s+! quota running low \(five_hour\)/)
+  assert.match(line('rejected'), /^\s+✗ quota exhausted \(five_hour\)/)
+  // An unseen status still renders rather than blowing up or vanishing.
+  assert.match(line('some_new_status'), /quota some_new_status/)
+  assert.ok(line('allowed').includes(new Date(at).toISOString()))
+})

--- a/packages/framework/src/events.ts
+++ b/packages/framework/src/events.ts
@@ -1,5 +1,5 @@
 import type { BootstrapEvent } from '@gemstack/ai-autopilot'
-import type { DriverEvent } from './driver/index.js'
+import type { DriverEvent, DriverRateLimit } from './driver/index.js'
 
 /** One selectable option in an interactive {@link ChoiceRequest} (#304). */
 export interface ChoiceOption {
@@ -216,9 +216,19 @@ function formatDriverEvent(event: DriverEvent): string {
       return `    · ${event.label}`
     case 'result':
       return `  ‹ turn complete`
+    case 'rate-limit':
+      return `    ${formatRateLimit(event.limit)}`
     case 'error':
       return `  ! agent error: ${event.message}`
   }
+}
+
+/** Quiet on the happy path: only worth a line when the quota is actually tight. */
+function formatRateLimit(limit: DriverRateLimit): string {
+  const resets = new Date(limit.resetsAt).toISOString()
+  if (limit.status === 'rejected') return `✗ quota exhausted (${limit.window}), resets ${resets}`
+  if (limit.status === 'allowed_warning') return `! quota running low (${limit.window}), resets ${resets}`
+  return `· quota ${limit.status} (${limit.window}), resets ${resets}`
 }
 
 function formatBootstrapEvent(event: BootstrapEvent): string {

--- a/packages/framework/src/usage.ts
+++ b/packages/framework/src/usage.ts
@@ -21,9 +21,12 @@ const ZERO: UsageTotals = {
 
 /**
  * Accumulates per-turn {@link DriverUsage} into a running total for the whole
- * run. The framework can't retrieve the account's usage *limit* under
- * subscription auth, so it infers consumption from what the agent already
- * reports each turn (the alternative from #322) and lets a budget cap gate on it.
+ * run and lets a budget cap gate on it (#322).
+ *
+ * This tracks what *this run* spent, not where the account's subscription quota
+ * stands — the agent reports that separately, per turn, as `DriverRateLimit`
+ * (#517). An earlier version of this note claimed the account limit was
+ * unreachable under subscription auth; it isn't.
  */
 export class UsageMeter {
   private totalsState: UsageTotals = { ...ZERO }


### PR DESCRIPTION
Closes #517. Part of #298.

The agent already tells us where the account's quota stands, on every turn. We were dropping it.

`claude -p --output-format stream-json` emits a `rate_limit_event` per turn with the status, the window it applies to, and when that window resets. `StreamJsonParser` only handled `assistant` and `result`, so it went on the floor. This surfaces it as a `rate-limit` driver event. `{kind:'driver'}` forwards driver events wholesale, so it persists and reaches the dashboard with no new event kind.

This is the capture half of the #298 usage guard, deliberately without the guard. Every status other than `allowed` is unobserved: `allowed_warning` and `rejected` are strings in the 2.1.210 binary, not something I have watched fire. Logging from real runs catches them naturally instead of burning quota to force them. Build the gate once we have seen a real one.

`status` and `window` are typed open rather than as unions for the same reason: a value we don't know is exactly the signal this is capturing for, so it has to surface rather than be dropped. The formatter stays quiet on the happy path and only gets loud when the quota is actually tight.

Also corrects `usage.ts`, which claimed the framework "can't retrieve the account's usage limit under subscription auth". That was wrong, and it had already propagated into my triage on #298.

Verified end to end, not just unit-tested: fed a real captured `claude -p --output-format stream-json` run through the built parser. Real payload parses to `{status:"allowed", window:"five_hour", resetsAt:1784079000000}`, renders as `· quota allowed (five_hour), resets 2026-07-15T01:30:00.000Z`, turn text intact, other events untouched. 28/28 tests pass in the two touched files.
