### PR TITLE
feat(framework): read the account's subscription quota (#521)

### DIFF
--- a/.changeset/quota-readout.md
+++ b/.changeset/quota-readout.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Read the account's subscription quota on demand via the agent's own `/usage` command, as `Driver.readQuota()`. Reports the percentage of each window consumed (session, week, per-model week), which is what a consumption limit needs and what the per-turn rate-limit telemetry could not give. Costs no tokens, and the CLI reaches Anthropic with its own credentials, so The Framework never handles the user's token.

--- a/packages/framework/src/driver/claude-code-quota.test.ts
+++ b/packages/framework/src/driver/claude-code-quota.test.ts
@@ -1,0 +1,182 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { Readable, Writable } from 'node:stream'
+import { parseQuotaReadout, readClaudeQuota } from './claude-code-quota.js'
+import type { SpawnLike, SpawnedProcess } from './claude-code.js'
+import { isTransientQuotaReason } from './types.js'
+
+/**
+ * A real 2.1.210 readout, verbatim, including the trailing behaviour breakdown
+ * whose lines are shaped just closely enough to fool a lazier parser.
+ */
+const REAL_READOUT = [
+  'You are currently using your subscription to power your Claude Code usage',
+  '',
+  'Current session: 2% used · resets Jul 15 at 7pm (Asia/Jerusalem)',
+  'Current week (all models): 24% used · resets Jul 18 at 7am (Asia/Jerusalem)',
+  'Current week (Fable): 15% used · resets Jul 18 at 7am (Asia/Jerusalem)',
+  '',
+  "What's contributing to your limits usage?",
+  'Approximate, based on local sessions on this machine — does not include other devices or claude.ai.',
+  '',
+  'Last 24h · 2090 requests · 166 sessions',
+  '  70% of your usage was at >150k context',
+  '  29% of your usage came from subagent-heavy sessions',
+  '  Top skills: /dataviz 2%, /claude-api 1%',
+  '  Top subagents: Explore 1%',
+].join('\n')
+
+test('parseQuotaReadout reads each window off a real readout (#521)', () => {
+  const quota = parseQuotaReadout(REAL_READOUT)
+  assert.equal(quota.available, true)
+  assert.ok(quota.available)
+  assert.deepEqual(quota.windows, [
+    { label: 'Current session', kind: 'session', percentUsed: 2, resetsAtText: 'Jul 15 at 7pm (Asia/Jerusalem)' },
+    { label: 'Current week (all models)', kind: 'week', percentUsed: 24, resetsAtText: 'Jul 18 at 7am (Asia/Jerusalem)' },
+    { label: 'Current week (Fable)', kind: 'week-model', percentUsed: 15, resetsAtText: 'Jul 18 at 7am (Asia/Jerusalem)' },
+  ])
+})
+
+test('parseQuotaReadout ignores the behaviour lines that only look like windows (#521)', () => {
+  const quota = parseQuotaReadout(REAL_READOUT)
+  assert.ok(quota.available)
+  // '70% of your usage...' and 'Top skills: /dataviz 2%' must not become windows.
+  assert.equal(quota.windows.length, 3)
+  assert.ok(quota.windows.every(w => w.label.startsWith('Current ')))
+})
+
+test('parseQuotaReadout keeps reading an account that is burning overage (#521)', () => {
+  // The header differs mid-overage, but the account still has a quota to report.
+  const quota = parseQuotaReadout(
+    [
+      'You are currently using your overages to power your Claude Code usage. We will automatically switch you back to your subscription rate limits when they reset',
+      '',
+      'Current session: 80% used · resets in 2h 53m',
+    ].join('\n'),
+  )
+  assert.ok(quota.available)
+  assert.deepEqual(quota.windows, [
+    { label: 'Current session', kind: 'session', percentUsed: 80, resetsAtText: 'in 2h 53m' },
+  ])
+})
+
+test('parseQuotaReadout takes a fractional percentage', () => {
+  const quota = parseQuotaReadout('Current session: 0.5% used · resets in 1h')
+  assert.ok(quota.available)
+  assert.equal(quota.windows[0]?.percentUsed, 0.5)
+})
+
+test('parseQuotaReadout handles a window with no reset phrase', () => {
+  const quota = parseQuotaReadout('Current session: 12% used')
+  assert.ok(quota.available)
+  assert.deepEqual(quota.windows, [{ label: 'Current session', kind: 'session', percentUsed: 12 }])
+})
+
+test('parseQuotaReadout separates a reworded readout from an account with no quota (#521)', () => {
+  // Header present, windows unreadable: our parser is behind the CLI.
+  assert.deepEqual(parseQuotaReadout('You are currently using your subscription to power your Claude Code usage\n\nSession: nearly full'), {
+    available: false,
+    reason: 'unrecognized',
+  })
+  // No header at all: nothing to report, e.g. API-key auth.
+  assert.deepEqual(parseQuotaReadout('Some other answer entirely'), { available: false, reason: 'no-subscription' })
+})
+
+test('parseQuotaReadout never reports an empty reading as zero use (#521)', () => {
+  const quota = parseQuotaReadout('')
+  // A silent 0% would read as "nothing used" and let a limit run the account dry.
+  assert.equal(quota.available, false)
+})
+
+test('isTransientQuotaReason splits this-attempt failures from setup failures', () => {
+  assert.equal(isTransientQuotaReason('fetch-failed'), true)
+  assert.equal(isTransientQuotaReason('timeout'), true)
+  assert.equal(isTransientQuotaReason('no-subscription'), false)
+  assert.equal(isTransientQuotaReason('agent-not-found'), false)
+  assert.equal(isTransientQuotaReason('unrecognized'), false)
+})
+
+/** A fake process that emits `stdout` then closes with `code`. */
+function fakeSpawn(stdout: string, code = 0, onSpawn?: (args: readonly string[]) => void): SpawnLike {
+  return (_command, args) => {
+    onSpawn?.(args)
+    const out = Readable.from([stdout])
+    const proc: SpawnedProcess = {
+      stdout: out,
+      stderr: Readable.from([]),
+      stdin: new Writable({ write: (_c, _e, cb) => cb() }),
+      on(event, listener) {
+        if (event === 'close') out.on('end', () => (listener as (c: number | null) => void)(code))
+        return proc
+      },
+      kill: () => undefined,
+    }
+    return proc
+  }
+}
+
+test('readClaudeQuota unwraps the CLI json envelope (#521)', async () => {
+  const quota = await readClaudeQuota({
+    spawn: fakeSpawn(JSON.stringify({ type: 'result', subtype: 'success', is_error: false, result: REAL_READOUT })),
+  })
+  assert.ok(quota.available)
+  assert.equal(quota.windows.length, 3)
+})
+
+test('readClaudeQuota asks the CLI for its own usage readout, not a model turn (#521)', async () => {
+  let seen: readonly string[] = []
+  await readClaudeQuota({ spawn: fakeSpawn(JSON.stringify({ result: REAL_READOUT }), 0, args => (seen = args)) })
+  assert.deepEqual([...seen], ['-p', '/usage', '--output-format', 'json'])
+  // --bare would pin the CLI to API-key auth and hide the subscription quota.
+  assert.ok(!seen.includes('--bare'))
+})
+
+test("readClaudeQuota reports the CLI's own error arm as transient (#521)", async () => {
+  const quota = await readClaudeQuota({
+    spawn: fakeSpawn(JSON.stringify({ type: 'result', is_error: true, result: 'usage fetch failed' })),
+  })
+  assert.deepEqual(quota, { available: false, reason: 'fetch-failed' })
+})
+
+test('readClaudeQuota treats a non-zero exit as a transient fetch failure (#521)', async () => {
+  const quota = await readClaudeQuota({ spawn: fakeSpawn('', 1) })
+  assert.deepEqual(quota, { available: false, reason: 'fetch-failed' })
+})
+
+test('readClaudeQuota reports unparseable output rather than guessing (#521)', async () => {
+  const quota = await readClaudeQuota({ spawn: fakeSpawn('not json at all') })
+  assert.deepEqual(quota, { available: false, reason: 'unrecognized' })
+})
+
+test('readClaudeQuota reports a missing binary distinctly (#521)', async () => {
+  const spawn: SpawnLike = () => {
+    const proc: SpawnedProcess = {
+      stdout: Readable.from([]),
+      stderr: Readable.from([]),
+      stdin: new Writable({ write: (_c, _e, cb) => cb() }),
+      on(event, listener) {
+        // ENOENT surfaces as an 'error' event, never as a non-zero exit.
+        if (event === 'error') queueMicrotask(() => (listener as (e: Error) => void)(new Error('ENOENT')))
+        return proc
+      },
+      kill: () => undefined,
+    }
+    return proc
+  }
+  assert.deepEqual(await readClaudeQuota({ spawn }), { available: false, reason: 'agent-not-found' })
+})
+
+test('readClaudeQuota gives up on a hung agent (#521)', async () => {
+  const spawn: SpawnLike = () => {
+    const proc: SpawnedProcess = {
+      // Never ends, never closes.
+      stdout: new Readable({ read: () => undefined }),
+      stderr: Readable.from([]),
+      stdin: new Writable({ write: (_c, _e, cb) => cb() }),
+      on: () => proc,
+      kill: () => undefined,
+    }
+    return proc
+  }
+  assert.deepEqual(await readClaudeQuota({ spawn, timeoutMs: 5 }), { available: false, reason: 'timeout' })
+})

--- a/packages/framework/src/driver/claude-code-quota.ts
+++ b/packages/framework/src/driver/claude-code-quota.ts
@@ -122,11 +122,13 @@ export function readClaudeQuota(opts: ReadClaudeQuotaOptions = {}): Promise<Driv
     }
     opts.signal?.addEventListener('abort', onAbort)
 
+    // Deliberately not unref'd: this timer is the only thing guaranteeing the
+    // promise settles, and an unref'd one never fires once the loop goes idle,
+    // leaving the caller awaiting forever. `settle` clears it either way.
     const timer = setTimeout(() => {
       child.kill('SIGTERM')
       settle({ available: false, reason: 'timeout' })
     }, opts.timeoutMs ?? READ_TIMEOUT_MS)
-    timer.unref?.()
 
     child.stdout?.on('data', (chunk: Buffer | string) => chunks.push(String(chunk)))
     // ENOENT lands here rather than as a non-zero exit.

--- a/packages/framework/src/driver/claude-code-quota.ts
+++ b/packages/framework/src/driver/claude-code-quota.ts
@@ -1,0 +1,159 @@
+import { spawn as nodeSpawn } from 'node:child_process'
+import type { DriverQuota, DriverQuotaWindow } from './types.js'
+import type { SpawnLike } from './claude-code.js'
+
+/** How long we wait for the readout before calling it a timeout. */
+const READ_TIMEOUT_MS = 20_000
+
+/**
+ * Present in both subscription headers Claude Code can print (`"your
+ * subscription"` and, mid-overage, `"your overages"`), and in neither
+ * non-subscription case. Matching the shared tail rather than the word
+ * "subscription" is deliberate: an account burning overage still has a quota to
+ * report, and keying on "subscription" would read it as having none.
+ */
+const SUBSCRIPTION_HEADER = /to power your Claude Code usage/
+
+/**
+ * One `"<label>: <n>% used · resets <when>"` line.
+ *
+ * Anchored and strict on `% used` immediately after the colon, because the same
+ * readout carries lines that are shaped just closely enough to match a lazier
+ * pattern (`"Top skills: /dataviz 2%, /claude-api 1%"`, `"  70% of your usage
+ * was at >150k context"`).
+ */
+const WINDOW_LINE = /^(.+?):\s+(\d+(?:\.\d+)?)% used(?:\s*·\s*(.+))?$/
+
+/** Strips the `resets` verb, which is prose framing rather than part of the value. */
+const RESETS_PREFIX = /^resets\s+/
+
+function windowKind(label: string): DriverQuotaWindow['kind'] {
+  if (/^current session$/i.test(label)) return 'session'
+  if (/^current week \(all models\)$/i.test(label)) return 'week'
+  if (/^current week \(.+\)$/i.test(label)) return 'week-model'
+  return 'unknown'
+}
+
+/**
+ * Parse Claude Code's `/usage` readout (#521).
+ *
+ * The agent prints prose, so this is a text parse and a reworded readout is a
+ * real failure mode. It fails to `unrecognized` rather than to an empty reading:
+ * a silent zero would read as "nothing used" and let a consumption limit run the
+ * account dry.
+ */
+export function parseQuotaReadout(text: string): DriverQuota {
+  const windows: DriverQuotaWindow[] = []
+  for (const line of text.split('\n')) {
+    const match = WINDOW_LINE.exec(line.trim())
+    if (!match) continue
+    const [, label, percent, resets] = match
+    if (label === undefined || percent === undefined) continue
+    const resetsAtText = resets?.replace(RESETS_PREFIX, '').trim()
+    windows.push({
+      label,
+      kind: windowKind(label),
+      percentUsed: Number(percent),
+      ...(resetsAtText ? { resetsAtText } : {}),
+    })
+  }
+
+  if (windows.length > 0) return { available: true, windows }
+  // No windows and no subscription header: the account has no quota to report
+  // (API-key auth). With the header, it does have one and we simply failed to
+  // read it, which is a parser problem and must not masquerade as the former.
+  return { available: false, reason: SUBSCRIPTION_HEADER.test(text) ? 'unrecognized' : 'no-subscription' }
+}
+
+/** Options for {@link readClaudeQuota}. */
+export interface ReadClaudeQuotaOptions {
+  /** CLI binary to spawn. Default `"claude"` (resolved on `PATH`). */
+  bin?: string
+  /** Working directory for the child. The read is account-wide, so this is incidental. */
+  cwd?: string
+  /** Environment for the child process. Default `process.env`. */
+  env?: NodeJS.ProcessEnv
+  /** `spawn` override for tests. Default `node:child_process.spawn`. */
+  spawn?: SpawnLike
+  /** Abort the read. */
+  signal?: AbortSignal
+  /** Override the timeout. Default {@link READ_TIMEOUT_MS}. */
+  timeoutMs?: number
+}
+
+/**
+ * Ask Claude Code where the account's subscription quota stands (#521).
+ *
+ * Runs the CLI's own `/usage` command in print mode. Costs nothing: verified on
+ * 2.1.210 as `total_cost_usd: 0` across zero turns and zero tokens, because the
+ * CLI answers it locally rather than by prompting a model. It reaches Anthropic
+ * itself, with its own credentials, so The Framework never reads or handles the
+ * user's token.
+ *
+ * Never pass `--bare` here: it pins the CLI to API-key auth and never reads the
+ * OAuth credentials, so the subscription quota this reads would vanish.
+ */
+export function readClaudeQuota(opts: ReadClaudeQuotaOptions = {}): Promise<DriverQuota> {
+  return new Promise<DriverQuota>(resolvePromise => {
+    if (opts.signal?.aborted) {
+      resolvePromise({ available: false, reason: 'timeout' })
+      return
+    }
+
+    const spawn = opts.spawn ?? (nodeSpawn as unknown as SpawnLike)
+    const child = spawn(opts.bin ?? 'claude', ['-p', '/usage', '--output-format', 'json'], {
+      cwd: opts.cwd ?? process.cwd(),
+      env: opts.env ?? process.env,
+    })
+
+    let settled = false
+    const chunks: string[] = []
+    const settle = (quota: DriverQuota) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      opts.signal?.removeEventListener('abort', onAbort)
+      resolvePromise(quota)
+    }
+
+    const onAbort = () => {
+      child.kill('SIGTERM')
+      settle({ available: false, reason: 'timeout' })
+    }
+    opts.signal?.addEventListener('abort', onAbort)
+
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM')
+      settle({ available: false, reason: 'timeout' })
+    }, opts.timeoutMs ?? READ_TIMEOUT_MS)
+    timer.unref?.()
+
+    child.stdout?.on('data', (chunk: Buffer | string) => chunks.push(String(chunk)))
+    // ENOENT lands here rather than as a non-zero exit.
+    child.on('error', () => settle({ available: false, reason: 'agent-not-found' }))
+    child.on('close', code => {
+      if (code !== 0) {
+        settle({ available: false, reason: 'fetch-failed' })
+        return
+      }
+      settle(parseQuotaResponse(chunks.join('')))
+    })
+  })
+}
+
+/** Unwrap the CLI's `--output-format json` envelope and parse the readout inside it. */
+function parseQuotaResponse(stdout: string): DriverQuota {
+  let envelope: unknown
+  try {
+    envelope = JSON.parse(stdout)
+  } catch {
+    return { available: false, reason: 'unrecognized' }
+  }
+  if (typeof envelope !== 'object' || envelope === null) return { available: false, reason: 'unrecognized' }
+  const obj = envelope as Record<string, unknown>
+  // The CLI's own failure arm, e.g. its usage fetch was refused upstream.
+  if (obj['is_error'] === true) return { available: false, reason: 'fetch-failed' }
+  const result = obj['result']
+  if (typeof result !== 'string') return { available: false, reason: 'unrecognized' }
+  return parseQuotaReadout(result)
+}

--- a/packages/framework/src/driver/claude-code.ts
+++ b/packages/framework/src/driver/claude-code.ts
@@ -5,7 +5,8 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { killTree, registerChild, unregisterChild } from './child-registry.js'
-import type { Driver, DriverEvent, DriverPromptOptions, DriverRateLimit, DriverSession, DriverStartOptions, DriverTurn, DriverUsage } from './types.js'
+import { readClaudeQuota } from './claude-code-quota.js'
+import type { Driver, DriverEvent, DriverPromptOptions, DriverQuota, DriverRateLimit, DriverSession, DriverStartOptions, DriverTurn, DriverUsage } from './types.js'
 
 /** Grace between SIGTERM and the SIGKILL that forces a hung agent tree down. */
 const TERMINATE_GRACE_MS = 5000
@@ -83,6 +84,16 @@ export class ClaudeCodeDriver implements Driver {
 
   start(opts: DriverStartOptions): Promise<DriverSession> {
     return Promise.resolve(new ClaudeCodeSession(this.opts, opts))
+  }
+
+  /** Where the account's subscription quota stands (#521). Account-wide, so no session. */
+  readQuota(opts: { signal?: AbortSignal } = {}): Promise<DriverQuota> {
+    return readClaudeQuota({
+      ...(this.opts.bin !== undefined ? { bin: this.opts.bin } : {}),
+      ...(this.opts.env !== undefined ? { env: this.opts.env } : {}),
+      ...(this.opts.spawn !== undefined ? { spawn: this.opts.spawn } : {}),
+      ...(opts.signal !== undefined ? { signal: opts.signal } : {}),
+    })
   }
 }
 

--- a/packages/framework/src/driver/index.ts
+++ b/packages/framework/src/driver/index.ts
@@ -7,7 +7,12 @@ export type {
   DriverEvent,
   DriverUsage,
   DriverRateLimit,
+  DriverQuota,
+  DriverQuotaWindow,
+  DriverQuotaUnavailableReason,
 } from './types.js'
+export { isTransientQuotaReason } from './types.js'
+export { readClaudeQuota, parseQuotaReadout, type ReadClaudeQuotaOptions } from './claude-code-quota.js'
 export { FakeDriver, FakeDriverSession, type FakeTurn, type FakeDriverOptions } from './fake.js'
 export {
   ClaudeCodeDriver,

--- a/packages/framework/src/driver/types.ts
+++ b/packages/framework/src/driver/types.ts
@@ -25,6 +25,15 @@ export interface Driver {
   readonly name: string
   /** Boot a session bound to a workspace directory. */
   start(opts: DriverStartOptions): Promise<DriverSession>
+  /**
+   * Ask the agent where the account's subscription quota stands (#521), for the
+   * consumption limits in #519. Account-wide and independent of any session, so
+   * it hangs off the driver rather than off {@link DriverSession}.
+   *
+   * Optional: an agent that can't report it omits the method entirely, the same
+   * way {@link DriverRateLimit} is omitted by drivers that can't emit it.
+   */
+  readQuota?(opts?: { signal?: AbortSignal }): Promise<DriverQuota>
 }
 
 /** How to boot a {@link DriverSession}. */
@@ -132,6 +141,75 @@ export interface DriverRateLimit {
   /** When the window resets, epoch **milliseconds** (the agent reports seconds). */
   resetsAt: number
 }
+
+/**
+ * One quota window and how much of it the account has burned (#521).
+ *
+ * The three concepts here are easy to confuse. {@link DriverUsage} is what *this
+ * run* spent. {@link DriverRateLimit} is a per-turn traffic light (are we still
+ * allowed to spend, and when does the window reset). This is the missing middle:
+ * the *proportion* of a window consumed, which is the only one of the three that
+ * can fill a progress bar.
+ */
+export interface DriverQuotaWindow {
+  /** The window's name exactly as the agent phrased it, e.g. `"Current session"`. */
+  label: string
+  /**
+   * Normalized window, so callers can gate without matching on prose.
+   * `session` is Claude's 5-hour window, `week` its all-models week, and
+   * `week-model` a single model's week (Opus/Sonnet get their own).
+   *
+   * Note there is deliberately no `day`: Claude measures a 5-hour session and a
+   * week, and nothing per day (#519 was specced against a daily limit that does
+   * not exist).
+   */
+  kind: 'session' | 'week' | 'week-model' | 'unknown'
+  /** How much of the window is gone, 0-100. */
+  percentUsed: number
+  /**
+   * When the window resets, as the agent worded it (`"Jul 18 at 7am
+   * (Asia/Jerusalem)"`). Prose, not a timestamp: the agent prints no year, so
+   * parsing it to an epoch would be guesswork. {@link DriverRateLimit.resetsAt}
+   * carries the exact epoch for the window it reports on.
+   */
+  resetsAtText?: string
+}
+
+/**
+ * Why a quota read came back empty.
+ *
+ * The split that matters is transient vs authoritative. `fetch-failed` and
+ * `timeout` describe *this attempt* (the agent's own usage fetch can be refused
+ * upstream, with a penalty window), so a recent reading is still worth showing.
+ * Every other reason describes the account or the install and is a statement
+ * about the setup, so a retained reading must not outlive it.
+ */
+export type DriverQuotaUnavailableReason =
+  /** The agent's own usage fetch failed, e.g. refused upstream. Transient. */
+  | 'fetch-failed'
+  /** The agent did not answer in time. Transient. */
+  | 'timeout'
+  /** The agent binary isn't installed or isn't on `PATH`. */
+  | 'agent-not-found'
+  /** The account has no subscription quota to report (e.g. API-key auth). */
+  | 'no-subscription'
+  /** The agent answered, but not in a shape we recognize (it reworded the readout). */
+  | 'unrecognized'
+
+/** Whether a {@link DriverQuotaUnavailableReason} describes this attempt rather than the setup. */
+export function isTransientQuotaReason(reason: DriverQuotaUnavailableReason): boolean {
+  return reason === 'fetch-failed' || reason === 'timeout'
+}
+
+/**
+ * Where the account's subscription quota stands (#521), as a whole reading.
+ *
+ * Modelled as available-or-not rather than as an empty window list, so a caller
+ * can't mistake "we couldn't ask" for "nothing is used".
+ */
+export type DriverQuota =
+  | { available: true; windows: DriverQuotaWindow[] }
+  | { available: false; reason: DriverQuotaUnavailableReason }
 
 /**
  * A black-box progress event from the wrapped agent. We forward these to the

--- a/packages/framework/src/maintenance.ts
+++ b/packages/framework/src/maintenance.ts
@@ -8,8 +8,9 @@ import { FRAMEWORK_DIR } from './store/index.js'
  * the maintainability loop on them. Per-repo review state is a small local file
  * (`.the-framework/maintenance.json`, gitignored) recording the last-reviewed commit,
  * so a sweep only ever acts on new work. The capacity gate is the existing budget cap
- * (`--max-cost`) — the account's usage *limit* isn't retrievable under subscription
- * auth (see usage.ts), so #298's "check the limit" half is out of reach for now.
+ * (`--max-cost`). #298's "check the limit" half is reachable after all — the agent
+ * reports the account's quota per turn (#517) and on demand (#521) — but this sweep
+ * does not gate on it yet; that is #519's consumption limits.
  */
 
 /** The per-repo review-state filename under `.the-framework/`. */

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -221,8 +221,9 @@ export interface RunFrameworkOptions {
    * Stop the run once cumulative agent cost reaches this many USD (budget cap,
    * #322). Checked after each turn that reports usage: the turn that crosses the
    * cap finishes, then the run stops itself (a clean stop, not a failure). Omit
-   * for no cap. The framework infers spend from what the agent reports, since the
-   * account's usage *limit* is not retrievable under subscription auth.
+   * for no cap. This gates on what *this run* spent, which is a separate question
+   * from where the account's quota stands (readable via #517 / #521, and gated on
+   * by #519's consumption limits).
    */
   budgetUsd?: number
   /**


### PR DESCRIPTION
Closes #521. The read half of #519.

#519 needs a percentage to fill a progress bar. The rate-limit telemetry from #517 is only a traffic light: it says whether we may still spend, never how much is left.

Claude Code answers that itself:

```
$ claude -p "/usage" --output-format json
Current session: 2% used · resets Jul 15 at 6:59pm (Asia/Jerusalem)
Current week (all models): 25% used · resets Jul 18 at 6:59am (Asia/Jerusalem)
Current week (Fable): 15% used · resets Jul 18 at 6:59am (Asia/Jerusalem)
```

Zero turns, zero tokens, $0 on 2.1.210. The CLI reaches Anthropic with its own credentials, so we never read or handle the user's token. Same source Traycer uses.

This is `Driver.readQuota()`, optional on the seam like the `DriverRateLimit` an agent may or may not emit. **Not in scope:** the limits, the pausing, the UI, and the polling policy (#519).

### Notes for the reviewer

- The readout is prose, so the parse is strict. The same output carries lines shaped close enough to fool a lazier pattern (`Top skills: /dataviz 2%`, `70% of your usage was at >150k context`); the test fixture is a real readout including those.
- An unreadable readout fails to a reason, never to an empty reading. A silent `0%` would read as "nothing used" and let a consumption limit run the account dry.
- Reasons split transient (the agent's own usage fetch was refused upstream) from authoritative (no subscription), because only the former leaves a recent reading worth keeping.
- The header differs mid-overage (`your overages`, not `your subscription`), so keying on the word "subscription" would misread an overage account as having no quota.
- `--bare` must never be passed here: it pins the CLI to API-key auth and never reads the OAuth credentials, i.e. exactly the quota being read. There's a test asserting the args.
- Also corrects `maintenance.ts` and `run.ts`, which still claimed the account limit was unreachable under subscription auth. #518 fixed that claim in `usage.ts` and missed these two.

### Verification

15 new tests, and driven end-to-end against the real 2.1.210 CLI, which returned the three windows above correctly classified. Worth knowing for #519: the real call takes **~5s** (it spawns the whole CLI), so the polling wants to be slow and cached.