### PR TITLE
feat(framework): decide when a consumption limit is reached (#523)

### DIFF
--- a/.changeset/consumption-limits-decision.md
+++ b/.changeset/consumption-limits-decision.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Add the consumption-limit decision layer: `ConsumptionMeter` tracks the account's weekly quota meter over time, and `consumptionStatus` reports where the session / 5h / daily limits stand and which one is reached. Handles the weekly reset, reports partial coverage honestly, and fails open when the quota can't be read.

--- a/packages/framework/src/consumption.test.ts
+++ b/packages/framework/src/consumption.test.ts
@@ -1,0 +1,168 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import {
+  ConsumptionMeter,
+  DEFAULT_CONSUMPTION_LIMITS,
+  FIVE_HOURS_MS,
+  ONE_DAY_MS,
+  budgetsFrom,
+  consumptionStatus,
+  type ConsumptionLimits,
+} from './consumption.js'
+
+const T0 = 1_800_000_000_000
+const HOUR = 60 * 60 * 1000
+
+function meterOf(...samples: [hoursAgo: number, weeklyPercent: number][]): ConsumptionMeter {
+  const meter = new ConsumptionMeter()
+  for (const [hoursAgo, weeklyPercent] of samples) meter.record({ at: T0 - hoursAgo * HOUR, weeklyPercent })
+  return meter
+}
+
+test("budgetsFrom resolves Rom's chain into weekly-meter points (#523)", () => {
+  // A day is 20% of the week; a 5h stretch 60% of that day; a session 40% of it.
+  assert.deepEqual(budgetsFrom(DEFAULT_CONSUMPTION_LIMITS), { daily: 20, fiveHour: 12, session: 8 })
+})
+
+test('budgetsFrom rescales the shorter limits when the day changes (#523)', () => {
+  const limits: ConsumptionLimits = {
+    daily: { enabled: true, percent: 50 },
+    fiveHour: { enabled: true, percent: 60 },
+    session: { enabled: true, percent: 40 },
+  }
+  assert.deepEqual(budgetsFrom(limits), { daily: 50, fiveHour: 30, session: 20 })
+})
+
+test('ConsumptionMeter measures what was spent across a window (#523)', () => {
+  const meter = meterOf([10, 10], [5, 14], [0, 20])
+  const rolling = meter.rolling(ONE_DAY_MS, T0)
+  assert.equal(rolling?.points, 10)
+  assert.equal(rolling?.complete, false) // only 10h of samples for a 24h window
+})
+
+test('ConsumptionMeter counts only the requested window, not everything it holds (#523)', () => {
+  const meter = meterOf([10, 10], [5, 14], [0, 20])
+  // The 5h window starts at the sample reading 14, so only 6 points are inside it.
+  assert.equal(meter.rolling(FIVE_HOURS_MS, T0)?.points, 6)
+})
+
+test('ConsumptionMeter reports the weekly reset as spend since the reset, not a negative (#523)', () => {
+  // The meter drops at the week boundary: 90 -> 3 means 3 points spent since it reset.
+  const meter = meterOf([6, 88], [4, 90], [2, 3], [0, 5])
+  const rolling = meter.rolling(ONE_DAY_MS, T0)
+  // 88->90 is 2, the reset segment contributes its 3 outright, then 3->5 is 2.
+  assert.equal(rolling?.points, 7)
+  assert.ok((rolling?.points ?? -1) >= 0)
+})
+
+test('ConsumptionMeter says how much of the window it can vouch for (#523)', () => {
+  const complete = meterOf([30, 0], [24, 5], [0, 9])
+  const rolling = complete.rolling(ONE_DAY_MS, T0)
+  assert.equal(rolling?.complete, true)
+  assert.equal(rolling?.coveredMs, ONE_DAY_MS)
+
+  // Daemon was down until 6h ago: a "24h" figure really only covers 6h.
+  const partial = meterOf([6, 5], [0, 9])
+  const short = partial.rolling(ONE_DAY_MS, T0)
+  assert.equal(short?.complete, false)
+  assert.equal(short?.coveredMs, 6 * HOUR)
+  assert.equal(short?.points, 4)
+})
+
+test('ConsumptionMeter reports no reading as unknown, never as zero (#523)', () => {
+  // Zero would read as "nothing spent" and leave every limit unreachable.
+  assert.equal(new ConsumptionMeter().rolling(ONE_DAY_MS, T0), undefined)
+})
+
+test('ConsumptionMeter measures a session from when it started (#523)', () => {
+  const meter = meterOf([8, 10], [3, 12], [0, 18])
+  assert.equal(meter.since(T0 - 3 * HOUR, T0)?.points, 6)
+})
+
+test('ConsumptionMeter ignores an out-of-order reading (#523)', () => {
+  const meter = new ConsumptionMeter()
+  meter.record({ at: T0, weeklyPercent: 10 })
+  // A late arrival would look like a weekly reset and inflate consumption.
+  meter.record({ at: T0 - HOUR, weeklyPercent: 4 })
+  assert.equal(meter.size, 1)
+})
+
+test('ConsumptionMeter.prune keeps the sample the widest window measures from (#523)', () => {
+  const meter = meterOf([40, 1], [26, 2], [20, 4], [0, 9])
+  meter.prune(T0, ONE_DAY_MS)
+  // The 26h-old sample is the baseline for a 24h window, so it has to survive.
+  assert.equal(meter.rolling(ONE_DAY_MS, T0)?.complete, true)
+  assert.equal(meter.rolling(ONE_DAY_MS, T0)?.points, 7)
+  assert.equal(meter.size, 3)
+})
+
+test('consumptionStatus fills each bar against its own budget (#523)', () => {
+  // 4 points spent in the last 5h, all of it this session.
+  const meter = meterOf([6, 10], [4, 10], [0, 14])
+  const status = consumptionStatus({
+    meter,
+    limits: DEFAULT_CONSUMPTION_LIMITS,
+    sessionStartedAt: T0 - 4 * HOUR,
+    now: T0,
+  })
+  assert.equal(status.daily.consumed, 4)
+  assert.equal(status.daily.usedPercent, 20) // 4 of 20 points
+  assert.equal(status.fiveHour.usedPercent, (4 / 12) * 100)
+  assert.equal(status.session.usedPercent, 50) // 4 of 8 points
+  assert.equal(status.reached, null)
+})
+
+test('consumptionStatus pauses for the session limit once it is spent (#523)', () => {
+  const meter = meterOf([2, 10], [0, 18]) // 8 points this session = the whole session budget
+  const status = consumptionStatus({ meter, limits: DEFAULT_CONSUMPTION_LIMITS, sessionStartedAt: T0 - 2 * HOUR, now: T0 })
+  assert.equal(status.session.reached, true)
+  assert.equal(status.reached, 'session')
+})
+
+test('consumptionStatus surfaces the widest limit when several are spent (#523)', () => {
+  // 22 points in 2h: past the day's 20, the 5h's 12 and the session's 8.
+  const meter = meterOf([2, 10], [0, 32])
+  const status = consumptionStatus({ meter, limits: DEFAULT_CONSUMPTION_LIMITS, sessionStartedAt: T0 - 2 * HOUR, now: T0 })
+  assert.equal(status.daily.reached, true)
+  assert.equal(status.fiveHour.reached, true)
+  assert.equal(status.session.reached, true)
+  // Daily takes the longest to recover, so it's the one to report.
+  assert.equal(status.reached, 'daily')
+})
+
+test('consumptionStatus ignores a disabled limit (#523)', () => {
+  const meter = meterOf([2, 10], [0, 32])
+  const limits: ConsumptionLimits = {
+    ...DEFAULT_CONSUMPTION_LIMITS,
+    daily: { enabled: false, percent: 20 },
+    fiveHour: { enabled: false, percent: 60 },
+  }
+  const status = consumptionStatus({ meter, limits, sessionStartedAt: T0 - 2 * HOUR, now: T0 })
+  assert.equal(status.daily.reached, false)
+  // Still measured, so its bar can be drawn while the limit is off.
+  assert.equal(status.daily.consumed, 22)
+  assert.equal(status.reached, 'session')
+})
+
+test('consumptionStatus never pauses on a quota it could not read (#523)', () => {
+  // Fail-open: a reworded readout must not stop the user's work.
+  const status = consumptionStatus({ meter: new ConsumptionMeter(), limits: DEFAULT_CONSUMPTION_LIMITS, now: T0 })
+  assert.equal(status.reached, null)
+  assert.equal(status.daily.consumed, undefined)
+  assert.equal(status.daily.usedPercent, undefined)
+})
+
+test('consumptionStatus leaves the session bar unmeasured when nothing is running (#523)', () => {
+  const meter = meterOf([2, 10], [0, 14])
+  const status = consumptionStatus({ meter, limits: DEFAULT_CONSUMPTION_LIMITS, now: T0 })
+  assert.equal(status.session.consumed, undefined)
+  assert.equal(status.session.reached, false)
+  assert.equal(status.daily.consumed, 4)
+})
+
+test('consumptionStatus keeps a full bar at 100 rather than overflowing it (#523)', () => {
+  const meter = meterOf([1, 0], [0, 40])
+  const status = consumptionStatus({ meter, limits: DEFAULT_CONSUMPTION_LIMITS, sessionStartedAt: T0 - HOUR, now: T0 })
+  assert.equal(status.daily.usedPercent, 100)
+  assert.equal(status.session.usedPercent, 100)
+})

--- a/packages/framework/src/consumption.ts
+++ b/packages/framework/src/consumption.ts
@@ -1,0 +1,261 @@
+/**
+ * Consumption limits (#523, the decision half of #519): how much of the
+ * account's subscription The Framework may burn before it pauses itself.
+ *
+ * Everything here is denominated in **points of the weekly meter** — one point
+ * is 1% of the account's weekly allowance, the one real number the agent gives
+ * us (#521). Rom's limits chain down from it: a day may spend 20% of the week,
+ * and a rolling 5h / a single session may spend 60% / 40% of that day. So the
+ * budgets work out to 20, 12 and 8 points respectively.
+ *
+ * The meter is account-wide: it counts the user's own interactive work too, not
+ * only ours (Rom's call on #519). That errs towards pausing early, which is the
+ * point of the feature.
+ */
+
+/** A rolling 5-hour window, in ms. Matches the agent's own session window. */
+export const FIVE_HOURS_MS = 5 * 60 * 60 * 1000
+
+/** A rolling day, in ms. */
+export const ONE_DAY_MS = 24 * 60 * 60 * 1000
+
+/** One reading of the weekly meter. */
+export interface QuotaSample {
+  /** When it was read, epoch ms. */
+  at: number
+  /** The account's weekly allowance consumed so far, 0-100. */
+  weeklyPercent: number
+}
+
+/** Consumption across a window, and how much of that window we can actually vouch for. */
+export interface RollingConsumption {
+  /** Points of the weekly meter consumed across {@link coveredMs}. */
+  points: number
+  /**
+   * How much of the requested window the samples really span. Shorter than the
+   * window whenever we weren't watching for all of it (the daemon was down, or
+   * this is a cold start).
+   */
+  coveredMs: number
+  /** Whether the samples span the whole window, i.e. {@link points} is the full story. */
+  complete: boolean
+}
+
+/**
+ * A rolling record of the weekly meter, from which consumption over any recent
+ * window can be derived.
+ *
+ * Keeping samples rather than a running total is what makes the weekly reset
+ * tractable: the meter drops to ~0 at the boundary, and only the raw readings
+ * let us tell "the week rolled over" apart from "nothing was spent".
+ */
+export class ConsumptionMeter {
+  private samples: QuotaSample[] = []
+
+  /**
+   * Record a reading. Out-of-order readings are dropped rather than sorted in:
+   * they'd corrupt the reset detection, which reads meaning into a drop between
+   * *consecutive* samples.
+   */
+  record(sample: QuotaSample): void {
+    const last = this.samples[this.samples.length - 1]
+    if (last && sample.at < last.at) return
+    this.samples.push(sample)
+  }
+
+  /** Drop samples older than `keepMs` before `now`, keeping the one that spans the boundary. */
+  prune(now: number, keepMs = ONE_DAY_MS): void {
+    const cutoff = now - keepMs
+    // Keep the newest sample at-or-before the cutoff: it's the baseline the
+    // widest window measures from, so dropping it would shorten our coverage.
+    let keepFrom = 0
+    for (let i = 0; i < this.samples.length; i++) {
+      const s = this.samples[i]
+      if (s && s.at <= cutoff) keepFrom = i
+      else break
+    }
+    if (keepFrom > 0) this.samples = this.samples.slice(keepFrom)
+  }
+
+  /** The most recent reading, if any. */
+  latest(): QuotaSample | undefined {
+    return this.samples[this.samples.length - 1]
+  }
+
+  /** How many readings are held. */
+  get size(): number {
+    return this.samples.length
+  }
+
+  /**
+   * Consumption since `from` (epoch ms), measured from the newest sample at or
+   * before it. `undefined` when there is nothing to measure against, which is
+   * "we don't know" and must not be read as zero.
+   */
+  since(from: number, now = Date.now()): RollingConsumption | undefined {
+    if (this.samples.length === 0) return undefined
+    let baselineIndex = 0
+    for (let i = 0; i < this.samples.length; i++) {
+      const s = this.samples[i]
+      if (s && s.at <= from) baselineIndex = i
+    }
+    const baseline = this.samples[baselineIndex]
+    if (!baseline) return undefined
+    const windowMs = Math.max(0, now - from)
+    const spannedMs = Math.max(0, now - baseline.at)
+    return {
+      points: this.consumedFrom(baselineIndex),
+      coveredMs: Math.min(windowMs, spannedMs),
+      // The baseline predates the window, so the samples span all of it.
+      complete: baseline.at <= from,
+    }
+  }
+
+  /** Consumption across the last `windowMs`. `undefined` when there is nothing to measure. */
+  rolling(windowMs: number, now = Date.now()): RollingConsumption | undefined {
+    return this.since(now - windowMs, now)
+  }
+
+  /**
+   * Sum consumption from `startIndex` to the newest sample.
+   *
+   * A drop between consecutive readings means the weekly window reset, so
+   * everything on the meter after it was spent since the reset: that segment
+   * contributes the new reading outright, not a negative delta.
+   */
+  private consumedFrom(startIndex: number): number {
+    let total = 0
+    for (let i = startIndex + 1; i < this.samples.length; i++) {
+      const prev = this.samples[i - 1]
+      const cur = this.samples[i]
+      if (!prev || !cur) continue
+      total += cur.weeklyPercent >= prev.weeklyPercent ? cur.weeklyPercent - prev.weeklyPercent : cur.weeklyPercent
+    }
+    return total
+  }
+}
+
+/** One of Rom's three limits. */
+export type ConsumptionWindow = 'session' | 'five-hour' | 'daily'
+
+/** A single limit: a share, and whether it's on. */
+export interface ConsumptionLimit {
+  enabled: boolean
+  /** The share this limit allows, as a percentage of what it's measured against. */
+  percent: number
+}
+
+/**
+ * The three limits (#519). `daily` is a share of the weekly allowance; the other
+ * two are shares of whatever `daily` works out to, so raising the day's budget
+ * raises all three together.
+ */
+export interface ConsumptionLimits {
+  /** Share of the weekly allowance one day may consume. */
+  daily: ConsumptionLimit
+  /** Share of the day's budget a rolling 5h may consume. */
+  fiveHour: ConsumptionLimit
+  /** Share of the day's budget one session may consume. */
+  session: ConsumptionLimit
+}
+
+/** Rom's defaults (#519). */
+export const DEFAULT_CONSUMPTION_LIMITS: ConsumptionLimits = {
+  daily: { enabled: true, percent: 20 },
+  fiveHour: { enabled: true, percent: 60 },
+  session: { enabled: true, percent: 40 },
+}
+
+/** What each limit works out to, in points of the weekly meter. */
+export interface ConsumptionBudgets {
+  daily: number
+  fiveHour: number
+  session: number
+}
+
+/** Resolve the limits into weekly-meter points. */
+export function budgetsFrom(limits: ConsumptionLimits): ConsumptionBudgets {
+  const daily = limits.daily.percent
+  return {
+    daily,
+    fiveHour: (limits.fiveHour.percent / 100) * daily,
+    session: (limits.session.percent / 100) * daily,
+  }
+}
+
+/** Where one limit stands: enough to draw its bar and to know if it's reached. */
+export interface LimitStatus {
+  enabled: boolean
+  /** Points allowed. */
+  budget: number
+  /** Points consumed, or `undefined` when we have nothing to measure against. */
+  consumed: number | undefined
+  /** How full the bar is, 0-100. `undefined` mirrors {@link consumed}. */
+  usedPercent: number | undefined
+  /** Whether the window's figure covers the whole window. */
+  complete: boolean
+  /** Whether this limit is enabled, measurable, and spent. */
+  reached: boolean
+}
+
+/** Where all three limits stand. */
+export interface ConsumptionStatus {
+  session: LimitStatus
+  fiveHour: LimitStatus
+  daily: LimitStatus
+  /**
+   * The limit to pause for, or `null`. Widest-first (`daily`, then `five-hour`,
+   * then `session`), so what surfaces is the one that takes longest to recover.
+   */
+  reached: ConsumptionWindow | null
+}
+
+function statusFor(limit: ConsumptionLimit, budget: number, consumption: RollingConsumption | undefined): LimitStatus {
+  const consumed = consumption?.points
+  // No reading is "we don't know", never "nothing spent": treating it as zero
+  // would leave every bar empty and every limit unreachable, which is exactly
+  // the failure the limits exist to prevent.
+  const reached = limit.enabled && consumed !== undefined && budget > 0 && consumed >= budget
+  return {
+    enabled: limit.enabled,
+    budget,
+    consumed,
+    usedPercent: consumed === undefined || budget <= 0 ? undefined : Math.min(100, (consumed / budget) * 100),
+    complete: consumption?.complete ?? false,
+    reached,
+  }
+}
+
+/**
+ * Where the three limits stand, given the meter and when the current session
+ * started (#523).
+ *
+ * A limit that cannot be measured is never *reached*: an unreadable quota
+ * shouldn't stop the user's work, and the per-run budget cap (`--max-cost`)
+ * still applies underneath. That is a deliberate fail-open.
+ */
+export function consumptionStatus(input: {
+  meter: ConsumptionMeter
+  limits: ConsumptionLimits
+  /** When the current session started, epoch ms. Omit when nothing is running. */
+  sessionStartedAt?: number
+  now?: number
+}): ConsumptionStatus {
+  const now = input.now ?? Date.now()
+  const budgets = budgetsFrom(input.limits)
+  const daily = statusFor(input.limits.daily, budgets.daily, input.meter.rolling(ONE_DAY_MS, now))
+  const fiveHour = statusFor(input.limits.fiveHour, budgets.fiveHour, input.meter.rolling(FIVE_HOURS_MS, now))
+  const session = statusFor(
+    input.limits.session,
+    budgets.session,
+    input.sessionStartedAt === undefined ? undefined : input.meter.since(input.sessionStartedAt, now),
+  )
+  const reached: ConsumptionWindow | null = daily.reached
+    ? 'daily'
+    : fiveHour.reached
+      ? 'five-hour'
+      : session.reached
+        ? 'session'
+        : null
+  return { session, fiveHour, daily, reached }
+}

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -67,6 +67,22 @@ export {
 } from './run.js'
 export { snapshotWorkspace, SANDBOX_IGNORE, type SnapshotOptions } from './sandbox.js'
 export {
+  ConsumptionMeter,
+  consumptionStatus,
+  budgetsFrom,
+  DEFAULT_CONSUMPTION_LIMITS,
+  FIVE_HOURS_MS,
+  ONE_DAY_MS,
+  type QuotaSample,
+  type RollingConsumption,
+  type ConsumptionLimit,
+  type ConsumptionLimits,
+  type ConsumptionBudgets,
+  type ConsumptionWindow,
+  type ConsumptionStatus,
+  type LimitStatus,
+} from './consumption.js'
+export {
   startRelay,
   relayPublisher,
   type Relay,


### PR DESCRIPTION
Closes #523. The decision half of #519, on top of the read half (#522).

#521 reads where the account's quota stands. This turns readings over time into "may we keep spending?".

Everything is in **points of the weekly meter** (one point = 1% of the weekly allowance), the one real number the agent gives us. Your limits chain down from it, so with the defaults a day is 20 points, a rolling 5h is 12, and one session is 8. Change the day's share and the other two rescale with it.

Per your call on #519, the meter is account-wide: it counts your own interactive Claude Code work too, which errs towards pausing early.

### Three things worth a look

- **The weekly reset.** The meter drops to ~0 at the boundary, so a naive delta goes negative and hides real spend. Keeping raw samples is what lets a drop between consecutive readings mean "the week rolled over", with the new reading counting outright.
- **Partial coverage.** If the daemon was down for a stretch, a "24h" figure really covers less than 24h, so each window reports how much it can actually vouch for instead of quietly under-reporting.
- **Unknown is not zero.** No reading means we don't know. Treating it as "nothing spent" would leave every bar empty and every limit unreachable, which is the exact failure this feature exists to prevent.

### One decision to confirm

A limit that can't be measured is never *reached* — a deliberate fail-open. A reworded readout shouldn't stop everyone's work, and the per-run `--max-cost` cap still applies underneath. Say if you'd rather it fail closed.

**Not in scope:** the pausing and the Resume entry, the config plumbing, the polling policy, and the UI. All #519.

### Verification

17 new tests (522 total, 0 failing, typecheck clean), covering the reset, partial coverage, disabled limits, the unmeasurable case, and the widest-first reporting when several limits are spent at once.