### PR TITLE
feat(framework): keep the quota reading fresh without getting throttled (#525)

### DIFF
--- a/.changeset/quota-poller.md
+++ b/.changeset/quota-poller.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Add `QuotaPoller`: keeps the account's quota reading fresh on a slow timer and feeds the consumption meter. Backs off when the agent's usage fetch is refused rather than retrying into the penalty window, gives up on an authoritative failure, and keeps the last good reading across a transient one.

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -83,6 +83,13 @@ export {
   type LimitStatus,
 } from './consumption.js'
 export {
+  QuotaPoller,
+  DEFAULT_POLL_MS,
+  MAX_POLL_MS,
+  type QuotaEnvelope,
+  type QuotaPollerOptions,
+} from './quota-poller.js'
+export {
   startRelay,
   relayPublisher,
   type Relay,

--- a/packages/framework/src/quota-poller.test.ts
+++ b/packages/framework/src/quota-poller.test.ts
@@ -1,0 +1,141 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { DEFAULT_POLL_MS, MAX_POLL_MS, QuotaPoller } from './quota-poller.js'
+import { ONE_DAY_MS } from './consumption.js'
+import type { DriverQuota } from './driver/index.js'
+
+const T0 = 1_800_000_000_000
+
+function goodAt(weeklyPercent: number, sessionPercent = 1): DriverQuota {
+  return {
+    available: true,
+    windows: [
+      { label: 'Current session', kind: 'session', percentUsed: sessionPercent },
+      { label: 'Current week (all models)', kind: 'week', percentUsed: weeklyPercent },
+      { label: 'Current week (Fable)', kind: 'week-model', percentUsed: 3 },
+    ],
+  }
+}
+
+/** A poller reading a scripted sequence, one entry per poll, on a fake clock. */
+function pollerOf(script: DriverQuota[], startAt = T0) {
+  let at = startAt
+  let i = 0
+  const poller = new QuotaPoller({
+    read: () => Promise.resolve(script[Math.min(i++, script.length - 1)] as DriverQuota),
+    now: () => at,
+  })
+  return { poller, advance: (ms: number) => (at += ms) }
+}
+
+test('QuotaPoller feeds the meter from the weekly window (#525)', async () => {
+  const { poller, advance } = pollerOf([goodAt(10), goodAt(14)])
+  await poller.poll()
+  advance(60_000)
+  await poller.poll()
+  // The session and per-model windows must not be mistaken for the weekly meter.
+  assert.equal(poller.meter.size, 2)
+  assert.equal(poller.meter.rolling(ONE_DAY_MS, T0 + 60_000)?.points, 4)
+})
+
+test('QuotaPoller keeps the last good reading through a transient failure (#525)', async () => {
+  const { poller, advance } = pollerOf([goodAt(10), { available: false, reason: 'fetch-failed' }])
+  await poller.poll()
+  advance(1000)
+  await poller.poll()
+  const env = poller.current()
+  // The blip is the latest attempt, but a minute-old real number still stands:
+  // blanking the bar would read as "nothing used".
+  assert.deepEqual(env.latest, { available: false, reason: 'fetch-failed' })
+  assert.ok(env.lastGood?.available)
+  assert.equal(env.lastGoodAt, T0)
+  assert.equal(env.lastFailureAt, T0 + 1000)
+  assert.equal(poller.isStopped, false)
+})
+
+test('QuotaPoller backs off when the fetch keeps being refused (#525)', async () => {
+  const { poller } = pollerOf([{ available: false, reason: 'fetch-failed' }])
+  assert.equal(poller.intervalMs, DEFAULT_POLL_MS)
+  await poller.poll()
+  assert.equal(poller.intervalMs, DEFAULT_POLL_MS * 2)
+  await poller.poll()
+  // Retrying harder would sit inside the upstream penalty window and keep the
+  // number permanently unavailable.
+  assert.equal(poller.intervalMs, DEFAULT_POLL_MS * 4)
+})
+
+test('QuotaPoller stops stretching the gap at the ceiling (#525)', async () => {
+  const { poller } = pollerOf([{ available: false, reason: 'timeout' }])
+  for (let i = 0; i < 20; i++) await poller.poll()
+  assert.equal(poller.intervalMs, MAX_POLL_MS)
+})
+
+test('QuotaPoller returns to the normal gap once the fetch works again (#525)', async () => {
+  const { poller } = pollerOf([{ available: false, reason: 'fetch-failed' }, { available: false, reason: 'fetch-failed' }, goodAt(9)])
+  await poller.poll()
+  await poller.poll()
+  assert.ok(poller.intervalMs > DEFAULT_POLL_MS)
+  await poller.poll()
+  assert.equal(poller.intervalMs, DEFAULT_POLL_MS)
+})
+
+test('QuotaPoller gives up on an authoritative failure (#525)', async () => {
+  const { poller } = pollerOf([goodAt(10), { available: false, reason: 'no-subscription' }])
+  await poller.poll()
+  await poller.poll()
+  // Nothing changes by asking an API-key account again, and the retained
+  // reading would misrepresent it.
+  assert.equal(poller.isStopped, true)
+  assert.equal(poller.current().lastGood, undefined)
+  assert.equal(poller.current().lastGoodAt, undefined)
+})
+
+test('QuotaPoller gives up when the agent is missing (#525)', async () => {
+  const { poller } = pollerOf([{ available: false, reason: 'agent-not-found' }])
+  await poller.poll()
+  assert.equal(poller.isStopped, true)
+})
+
+test('QuotaPoller treats a reworded readout as authoritative and stops (#525)', async () => {
+  const { poller } = pollerOf([{ available: false, reason: 'unrecognized' }])
+  await poller.poll()
+  // Polling on wouldn't reword it back; this needs a code change, not a retry.
+  assert.equal(poller.isStopped, true)
+})
+
+test('QuotaPoller survives a driver that throws (#525)', async () => {
+  const poller = new QuotaPoller({ read: () => Promise.reject(new Error('spawn exploded')), now: () => T0 })
+  const quota = await poller.poll()
+  // A throw is the same story as a failed fetch: this attempt told us nothing.
+  assert.deepEqual(quota, { available: false, reason: 'fetch-failed' })
+  assert.equal(poller.isStopped, false)
+})
+
+test('QuotaPoller ignores a reading with no weekly window (#525)', async () => {
+  const { poller } = pollerOf([{ available: true, windows: [{ label: 'Current session', kind: 'session', percentUsed: 5 }] }])
+  await poller.poll()
+  // Nothing to anchor the limits to, but it's still a successful read.
+  assert.equal(poller.meter.size, 0)
+  assert.ok(poller.current().lastGood?.available)
+})
+
+test('QuotaPoller prunes samples it no longer needs (#525)', async () => {
+  let at = T0
+  let weekly = 1
+  const poller = new QuotaPoller({ read: () => Promise.resolve(goodAt(weekly)), now: () => at })
+  for (let i = 0; i < 5; i++) {
+    await poller.poll()
+    at += 12 * 60 * 60 * 1000
+    weekly += 1
+  }
+  // Five readings 12h apart, but only a day's worth is ever needed.
+  assert.ok(poller.meter.size <= 3, `kept ${poller.meter.size} samples`)
+})
+
+test('QuotaPoller.stop is idempotent and start does not revive it (#525)', () => {
+  const { poller } = pollerOf([goodAt(1)])
+  poller.stop()
+  poller.stop()
+  poller.start()
+  assert.equal(poller.isStopped, true)
+})

--- a/packages/framework/src/quota-poller.ts
+++ b/packages/framework/src/quota-poller.ts
@@ -1,0 +1,155 @@
+import { ConsumptionMeter } from './consumption.js'
+import { isTransientQuotaReason, type DriverQuota, type DriverQuotaUnavailableReason } from './driver/index.js'
+
+/**
+ * How often to read the quota when everything is healthy. A read spawns the
+ * whole agent CLI (~5s), and the agent's own usage fetch is refused upstream if
+ * asked too often, so this is deliberately slow: the limits work on rolling 5h
+ * and 24h windows, which a 5-minute sample rate resolves comfortably.
+ */
+export const DEFAULT_POLL_MS = 5 * 60 * 1000
+
+/** Longest gap between reads once backoff has stretched it. */
+export const MAX_POLL_MS = 30 * 60 * 1000
+
+/**
+ * What the poller currently believes about the account's quota.
+ *
+ * `latest` is the last attempt as it came back; `lastGood` is the last real
+ * reading. The two are separate so a transient blip doesn't blank a number that
+ * was accurate a minute ago — a bar going empty reads as "nothing used", which
+ * is the one thing this feature must never imply.
+ */
+export interface QuotaEnvelope {
+  /** The most recent attempt, exactly as it came back. `undefined` before the first. */
+  latest: DriverQuota | undefined
+  /** The most recent successful reading, retained across transient failures. */
+  lastGood: (DriverQuota & { available: true }) | undefined
+  /** When {@link lastGood} was read, epoch ms. */
+  lastGoodAt: number | undefined
+  /** When the last failure happened, epoch ms. */
+  lastFailureAt: number | undefined
+}
+
+/** Options for {@link QuotaPoller}. */
+export interface QuotaPollerOptions {
+  /** Read the quota once. Normally `driver.readQuota`. */
+  read: () => Promise<DriverQuota>
+  /** Healthy interval. Default {@link DEFAULT_POLL_MS}. */
+  intervalMs?: number
+  /** Ceiling for the backed-off interval. Default {@link MAX_POLL_MS}. */
+  maxIntervalMs?: number
+  /** The meter to feed. A fresh one by default. */
+  meter?: ConsumptionMeter
+  /** Clock, injectable for tests. */
+  now?: () => number
+}
+
+/**
+ * Keeps a {@link ConsumptionMeter} fed with quota readings (#525).
+ *
+ * Polling is slow by design and backs *off* on failure rather than retrying
+ * into it: the agent's usage fetch is refused upstream when asked too often,
+ * and the penalty window is minutes long, so an eager retry loop would keep the
+ * number permanently unavailable — the opposite of the goal.
+ */
+export class QuotaPoller {
+  readonly meter: ConsumptionMeter
+  private envelope: QuotaEnvelope = { latest: undefined, lastGood: undefined, lastGoodAt: undefined, lastFailureAt: undefined }
+  private timer: ReturnType<typeof setTimeout> | undefined
+  private currentIntervalMs: number
+  private stopped = false
+  private readonly now: () => number
+
+  constructor(private readonly opts: QuotaPollerOptions) {
+    this.meter = opts.meter ?? new ConsumptionMeter()
+    this.currentIntervalMs = opts.intervalMs ?? DEFAULT_POLL_MS
+    this.now = opts.now ?? (() => Date.now())
+  }
+
+  /** What we currently believe. */
+  current(): QuotaEnvelope {
+    return { ...this.envelope }
+  }
+
+  /** The gap before the next read, which grows while the fetch keeps being refused. */
+  get intervalMs(): number {
+    return this.currentIntervalMs
+  }
+
+  /** Whether the poller has given up (an authoritative failure, or {@link stop}). */
+  get isStopped(): boolean {
+    return this.stopped
+  }
+
+  /**
+   * Read once, now, and fold the result in. Safe to call on demand (e.g. right
+   * after a turn settles) alongside the timer.
+   */
+  async poll(): Promise<DriverQuota> {
+    let quota: DriverQuota
+    try {
+      quota = await this.opts.read()
+    } catch {
+      // A driver that throws is the same story as one that reports a failed
+      // fetch: this attempt told us nothing, and it may work next time.
+      quota = { available: false, reason: 'fetch-failed' }
+    }
+    this.envelope = { ...this.envelope, latest: quota }
+    if (quota.available) {
+      this.onGood(quota)
+    } else {
+      this.onBad(quota.reason)
+    }
+    return quota
+  }
+
+  /** Begin polling. Idempotent. */
+  start(): void {
+    if (this.timer || this.stopped) return
+    this.schedule()
+  }
+
+  /** Stop polling. Idempotent. */
+  stop(): void {
+    this.stopped = true
+    if (this.timer) clearTimeout(this.timer)
+    this.timer = undefined
+  }
+
+  private onGood(quota: DriverQuota & { available: true }): void {
+    const at = this.now()
+    this.envelope = { ...this.envelope, lastGood: quota, lastGoodAt: at }
+    // Reset the backoff: the fetch is working again.
+    this.currentIntervalMs = this.opts.intervalMs ?? DEFAULT_POLL_MS
+    const week = quota.windows.find(w => w.kind === 'week')
+    if (week) this.meter.record({ at, weeklyPercent: week.percentUsed })
+    this.meter.prune(at)
+  }
+
+  private onBad(reason: DriverQuotaUnavailableReason): void {
+    this.envelope = { ...this.envelope, lastFailureAt: this.now() }
+    if (!isTransientQuotaReason(reason)) {
+      // Authoritative: no subscription, or no agent. Asking again changes
+      // nothing, and the retained reading would misrepresent the account.
+      this.envelope = { ...this.envelope, lastGood: undefined, lastGoodAt: undefined }
+      this.stop()
+      return
+    }
+    // Transient, so keep lastGood and ask again later — but later than last time.
+    this.currentIntervalMs = Math.min(this.currentIntervalMs * 2, this.opts.maxIntervalMs ?? MAX_POLL_MS)
+  }
+
+  private schedule(): void {
+    if (this.stopped) return
+    this.timer = setTimeout(() => {
+      void this.poll().finally(() => {
+        this.timer = undefined
+        this.schedule()
+      })
+    }, this.currentIntervalMs)
+    // Don't hold the process open just to read a quota; the daemon's own work
+    // decides its lifetime. Unlike the read's timeout, nothing awaits this.
+    this.timer.unref?.()
+  }
+}


### PR DESCRIPTION
Closes #525. The polling policy for #519, between the read (#522) and the decision (#524).

The limits work on rolling 5h and 24h windows, which are only as good as their samples. Nothing was keeping them fed.

Two constraints shape this more than the interval does:

- A read spawns the whole agent CLI (**~5s**), so it can never sit on a hot path.
- Anthropic refuses the agent's underlying usage fetch if asked too often, **with a multi-minute penalty**. So this backs *off* on failure. An eager retry loop would sit inside the penalty window and keep the number permanently unavailable, which is the opposite of the goal.

### Behaviour worth a look

- **Authoritative failure stops it** (no subscription, missing agent, or a readout we no longer recognize). Asking again changes nothing, and the retained reading would misrepresent the account.
- **Transient failure keeps the last good reading.** Blanking a bar reads as "nothing used", the one thing this feature must never imply.
- **The poll timer is unref'd**, unlike the read's timeout in #522. Nothing awaits this one, so it must not hold the process open. The contrast is commented, since the two look alike and want opposite treatment.

### Follow-up worth knowing about

If Claude rewords the readout, the poller stops for good and the limits quietly stop applying. That's the honest consequence of the fail-open you confirmed, and the reason is exposed on the envelope, so the UI can say "we can't read your usage" rather than showing an empty bar. Worth wiring when the bars land (#519).

**Not in scope:** the pausing and Resume entry, the config, the UI.

### Verification

12 new tests (534 total, 0 failing, typecheck clean), on a fake clock: backoff growth and its ceiling, recovery, the authoritative-vs-transient split, a driver that throws, a reading with no weekly window, and pruning.