### PR TITLE
feat(framework): let the user set the consumption limits (#527)

### DIFF
--- a/.changeset/consumption-limits-config.md
+++ b/.changeset/consumption-limits-config.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Let the user set the consumption limits. The preferences now carry a checkbox and a percentage per limit, and `resolveConsumptionLimits` fills any gap with the defaults. Preference sanitizing was boolean-only, so a percentage was silently dropped on both read and write; it now validates per-limit and falls back to the default rather than leaving the account unguarded.

--- a/packages/framework/src/consumption.ts
+++ b/packages/framework/src/consumption.ts
@@ -215,14 +215,18 @@ function statusFor(limit: ConsumptionLimit, budget: number, consumption: Rolling
   // No reading is "we don't know", never "nothing spent": treating it as zero
   // would leave every bar empty and every limit unreachable, which is exactly
   // the failure the limits exist to prevent.
-  const reached = limit.enabled && consumed !== undefined && budget > 0 && consumed >= budget
+  const measurable = consumed !== undefined
+  // A zero budget allows nothing, so it is spent the moment we can measure it.
+  // Reading it as "never reached" would make 0% a setting that quietly does
+  // nothing, which is worse than it plainly stopping the work.
+  const spent = measurable && (budget <= 0 || consumed >= budget)
   return {
     enabled: limit.enabled,
     budget,
     consumed,
-    usedPercent: consumed === undefined || budget <= 0 ? undefined : Math.min(100, (consumed / budget) * 100),
+    usedPercent: !measurable ? undefined : budget <= 0 ? 100 : Math.min(100, (consumed / budget) * 100),
     complete: consumption?.complete ?? false,
-    reached,
+    reached: limit.enabled && spent,
   }
 }
 

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -198,6 +198,7 @@ export {
   REGISTRY_FILE,
   type ProjectRecord,
   type Registry,
+  resolveConsumptionLimits,
   type Preferences,
   type PreferencesStore,
   type RegistryFs,

--- a/packages/framework/src/registry.test.ts
+++ b/packages/framework/src/registry.test.ts
@@ -1,12 +1,14 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { join } from 'node:path'
+import { ConsumptionMeter, DEFAULT_CONSUMPTION_LIMITS, consumptionStatus } from './consumption.js'
 import {
   addProject,
   listProjects,
   projectId,
   readPreferences,
   readRegistry,
+  resolveConsumptionLimits,
   registryPreferencesStore,
   registryPath,
   removeProject,
@@ -192,4 +194,75 @@ test('registryPreferencesStore round-trips through the same file', async () => {
   assert.deepEqual(await store.read(), {})
   await store.save({ vanilla: true })
   assert.deepEqual(await store.read(), { vanilla: true })
+})
+
+const LIMITS = {
+  daily: { enabled: true, percent: 25 },
+  fiveHour: { enabled: false, percent: 50 },
+  session: { enabled: true, percent: 30 },
+}
+
+test('preferences round-trip the consumption limits (#527)', async () => {
+  const fs = memFs({ [FILE]: JSON.stringify([APP_A]) })
+  await writePreferences({ autopilot: true, consumptionLimits: LIMITS }, fs, ENV)
+  // Every other preference is a boolean; a percentage used to be dropped silently.
+  assert.deepEqual(await readPreferences(fs, ENV), { autopilot: true, consumptionLimits: LIMITS })
+})
+
+test('a hand-edited limit falls back to the default rather than unguarding the account (#527)', async () => {
+  const raw = JSON.stringify({
+    projects: [APP_A],
+    preferences: {
+      consumptionLimits: {
+        daily: { enabled: true, percent: 25 },
+        fiveHour: { enabled: 'yes', percent: 50 }, // enabled isn't a boolean
+        session: { enabled: true, percent: 'lots' }, // percent isn't a number
+      },
+    },
+  })
+  const prefs = await readPreferences(memFs({ [FILE]: raw }), ENV)
+  assert.deepEqual(prefs.consumptionLimits, {
+    daily: { enabled: true, percent: 25 }, // the good one survives
+    fiveHour: DEFAULT_CONSUMPTION_LIMITS.fiveHour,
+    session: DEFAULT_CONSUMPTION_LIMITS.session,
+  })
+})
+
+test('an out-of-range percentage is clamped, not thrown away (#527)', async () => {
+  const raw = JSON.stringify({
+    projects: [APP_A],
+    preferences: { consumptionLimits: { daily: { enabled: true, percent: 150 }, session: { enabled: true, percent: -5 } } },
+  })
+  const prefs = await readPreferences(memFs({ [FILE]: raw }), ENV)
+  assert.equal(prefs.consumptionLimits?.daily.percent, 100)
+  assert.equal(prefs.consumptionLimits?.session.percent, 0)
+})
+
+test('a junk limits object is ignored entirely (#527)', async () => {
+  const raw = JSON.stringify({ projects: [APP_A], preferences: { consumptionLimits: 'all of them' } })
+  assert.deepEqual(await readPreferences(memFs({ [FILE]: raw }), ENV), {})
+})
+
+test('resolveConsumptionLimits guards a user who never opened the settings (#527)', () => {
+  // Unlike every other preference, absent must not mean off.
+  assert.deepEqual(resolveConsumptionLimits(undefined), DEFAULT_CONSUMPTION_LIMITS)
+  assert.deepEqual(resolveConsumptionLimits({}), DEFAULT_CONSUMPTION_LIMITS)
+  assert.deepEqual(resolveConsumptionLimits({ autopilot: true }), DEFAULT_CONSUMPTION_LIMITS)
+})
+
+test('resolveConsumptionLimits keeps what the user set (#527)', () => {
+  assert.deepEqual(resolveConsumptionLimits({ consumptionLimits: LIMITS }), LIMITS)
+})
+
+test('a zero budget stops the work rather than quietly doing nothing (#527)', () => {
+  const meter = new ConsumptionMeter()
+  meter.record({ at: 1_000, weeklyPercent: 5 })
+  meter.record({ at: 2_000, weeklyPercent: 5 })
+  const limits = resolveConsumptionLimits({
+    consumptionLimits: { ...DEFAULT_CONSUMPTION_LIMITS, daily: { enabled: true, percent: 0 } },
+  })
+  const status = consumptionStatus({ meter, limits, now: 2_000 })
+  assert.equal(status.daily.reached, true)
+  assert.equal(status.daily.usedPercent, 100)
+  assert.equal(status.reached, 'daily')
 })

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -1,4 +1,5 @@
 import { basename, dirname, join, resolve } from 'node:path'
+import { DEFAULT_CONSUMPTION_LIMITS, type ConsumptionLimit, type ConsumptionLimits } from './consumption.js'
 
 /**
  * The multi-project registry (#390): the list of projects the user has
@@ -36,6 +37,16 @@ export interface Preferences {
   postMergeQuality?: boolean
   /** Give the agent a real browser via chrome-devtools-mcp during the run (#452); maps to `--browser`. */
   browser?: boolean
+  /**
+   * How much of the subscription The Framework may burn before it pauses itself
+   * (#527, the settings behind #519).
+   *
+   * The only preference where **absent does not mean off**: the rest are flat
+   * booleans a user opts into, but an unset limit should protect the account
+   * rather than leave it unguarded, so absent means {@link DEFAULT_CONSUMPTION_LIMITS}.
+   * Read it through {@link resolveConsumptionLimits} rather than directly.
+   */
+  consumptionLimits?: ConsumptionLimits
 }
 
 /**
@@ -149,8 +160,41 @@ const PREFERENCE_KEYS = [
   'browser',
 ] as const
 
-/** Keep only the known boolean preference fields, so a hand-edited or browser-supplied
- * object never lands junk (or non-booleans) in the user's home file. */
+const CONSUMPTION_LIMIT_KEYS = ['daily', 'fiveHour', 'session'] as const
+
+/**
+ * Read one limit out of a hand-edited or browser-supplied object.
+ *
+ * `undefined` for anything we can't trust, so the caller falls back to the
+ * default rather than to an unguarded account. The percentage is clamped rather
+ * than rejected: a plausible-but-out-of-range number is a slip, and honouring
+ * the nearest legal value beats silently reverting to something else entirely.
+ */
+function sanitizeConsumptionLimit(value: unknown): ConsumptionLimit | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+  const input = value as Record<string, unknown>
+  const percent = input['percent']
+  if (typeof input['enabled'] !== 'boolean') return undefined
+  if (typeof percent !== 'number' || !Number.isFinite(percent)) return undefined
+  return { enabled: input['enabled'], percent: Math.min(100, Math.max(0, percent)) }
+}
+
+/** Read the three limits, falling back per-limit so one bad entry can't unguard the rest. */
+function sanitizeConsumptionLimits(value: unknown): ConsumptionLimits | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+  const input = value as Record<string, unknown>
+  const limits = {} as ConsumptionLimits
+  let any = false
+  for (const key of CONSUMPTION_LIMIT_KEYS) {
+    const limit = sanitizeConsumptionLimit(input[key])
+    if (limit) any = true
+    limits[key] = limit ?? DEFAULT_CONSUMPTION_LIMITS[key]
+  }
+  return any ? limits : undefined
+}
+
+/** Keep only the known preference fields, so a hand-edited or browser-supplied
+ * object never lands junk (or the wrong type) in the user's home file. */
 function sanitizePreferences(value: unknown): Preferences {
   if (typeof value !== 'object' || value === null) return {}
   const input = value as Record<string, unknown>
@@ -158,7 +202,26 @@ function sanitizePreferences(value: unknown): Preferences {
   for (const key of PREFERENCE_KEYS) {
     if (typeof input[key] === 'boolean') preferences[key] = input[key] as boolean
   }
+  const consumptionLimits = sanitizeConsumptionLimits(input['consumptionLimits'])
+  if (consumptionLimits) preferences.consumptionLimits = consumptionLimits
   return preferences
+}
+
+/**
+ * The limits in force: what the user set, with {@link DEFAULT_CONSUMPTION_LIMITS}
+ * filling any gap.
+ *
+ * Absent means the defaults rather than "off", so a user who has never opened
+ * the settings is still guarded (#519).
+ */
+export function resolveConsumptionLimits(preferences: Preferences | undefined): ConsumptionLimits {
+  const set = preferences?.consumptionLimits
+  if (!set) return DEFAULT_CONSUMPTION_LIMITS
+  return {
+    daily: set.daily ?? DEFAULT_CONSUMPTION_LIMITS.daily,
+    fiveHour: set.fiveHour ?? DEFAULT_CONSUMPTION_LIMITS.fiveHour,
+    session: set.session ?? DEFAULT_CONSUMPTION_LIMITS.session,
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #527. The settings behind #519, on top of the limits (#524) and the poller (#526).

Your UI is a checkbox and a percentage per limit, so the preferences now carry both.

### The trap this had to clear

`sanitizePreferences` hard-filtered every preference to `typeof === 'boolean'`, because every setting so far is a checkbox. A percentage would have been **dropped silently on both read and write**, with no error to show for it. It now validates the limits properly.

### Decisions worth a look

- **Absent means your defaults, not off.** This is the only preference that works that way. The rest are flat booleans a user opts into, but a limit nobody has set should still protect the account.
- **One bad entry can't unguard the other two.** A hand-edited file falls back per-limit, so a broken `fiveHour` still leaves `daily` and `session` in force.
- **An out-of-range percentage is clamped, not rejected.** `150` is a slip; honouring the nearest legal value beats silently reverting to something else entirely.
- **Also closes a hole in #524:** a zero budget was never "reached", which made `0%` a setting that quietly did nothing. It now stops the work, which is what asking for nothing plainly means.

### Verification

7 new tests (541 total, 0 failing, typecheck clean): the round-trip that used to silently drop, per-limit fallback, clamping, junk input, the absent-means-defaults resolution, and the zero budget.

**Remaining for #519:** the pause and Resume note, the server waking at the reset, and the bars.