### PR TITLE
feat(framework): pause the run when a consumption limit is reached (#529)

### DIFF
--- a/.changeset/consumption-pause.md
+++ b/.changeset/consumption-pause.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Pause a run when a consumption limit is reached. `runFramework` takes a `consumptionGate` consulted between turns; a reached limit stops the run cleanly (like the budget cap) and leaves a `Resume <session name>` entry on the workspace's backlog, so a later run picks the work back up. An unreadable quota carries on rather than stopping the work.

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -1,5 +1,8 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { defineDomainPreset, defineFrameworkExtension, defineLoop, definePersona, defineSkill } from '@gemstack/ai-autopilot'
 import type { Prompt } from '@gemstack/ai-autopilot'
 import { DEFAULT_MAX_PASSES, requestChoices, requestMultiSelect, runFramework, type ChoicesOption, type MultiSelectOption } from './run.js'
@@ -1059,4 +1062,101 @@ test('runFramework runs the backlog loop after the build when opted in (#323)', 
   } finally {
     await rm(cwd, { recursive: true, force: true })
   }
+})
+
+test('runFramework pauses the run once a consumption limit is reached (#529)', async () => {
+  const events: FrameworkEvent[] = []
+  await assert.rejects(
+    runFramework({
+      intent: FAKE_INTENT,
+      driver: fakeDriver(),
+      cwd: '/tmp/ws',
+      signals: FAKE_SIGNALS,
+      consumptionGate: () => 'daily',
+      onEvent: e => events.push(e),
+    }),
+  )
+  assert.ok(events.some(e => e.kind === 'log' && e.message === 'Daily consumption limit reached — pausing the run.'))
+  const end = events.at(-1)!
+  assert.equal(end.kind, 'end')
+  // A limit is a clean stop, like the budget cap — not a failure.
+  assert.equal(end.kind === 'end' && end.stopped, true)
+  assert.ok(end.kind === 'end' && end.detail?.startsWith('Daily consumption limit reached'))
+})
+
+test('runFramework leaves a resume note on the backlog when it pauses (#529)', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'framework-pause-'))
+  try {
+    const events: FrameworkEvent[] = []
+    await assert.rejects(
+      runFramework({
+        intent: FAKE_INTENT,
+        driver: fakeDriver(),
+        cwd,
+        signals: FAKE_SIGNALS,
+        consumptionGate: () => 'five-hour',
+        onEvent: e => events.push(e),
+      }),
+    )
+    // The backlog is what a later run drains, so the note needs no machinery of its own.
+    const todo = await readFile(join(cwd, 'TODO.md'), 'utf8')
+    assert.match(todo, /^- \[ \] Resume .+$/m)
+    assert.ok(events.some(e => e.kind === 'log' && e.message.includes('to pick up when the limit resets')))
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('runFramework appends the resume note to an existing backlog (#529)', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'framework-pause-'))
+  try {
+    await writeFile(join(cwd, 'TODO.md'), '- [ ] Something already open') // no trailing newline
+    await assert.rejects(
+      runFramework({ intent: FAKE_INTENT, driver: fakeDriver(), cwd, signals: FAKE_SIGNALS, consumptionGate: () => 'session' }),
+    )
+    const todo = await readFile(join(cwd, 'TODO.md'), 'utf8')
+    // The existing entry survives and the note lands on its own line.
+    assert.match(todo, /- \[ \] Something already open\n- \[ \] Resume /)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('runFramework carries on while the limits are clear (#529)', async () => {
+  const events: FrameworkEvent[] = []
+  let asked = 0
+  const { result } = await runFramework({
+    intent: FAKE_INTENT,
+    driver: fakeDriver(),
+    cwd: '/tmp/ws',
+    signals: FAKE_SIGNALS,
+    consumptionGate: () => {
+      asked++
+      return null
+    },
+    onEvent: e => events.push(e),
+  })
+  assert.ok(result)
+  assert.ok(asked > 0, 'the gate is consulted between turns')
+  const end = events.at(-1)!
+  assert.equal(end.kind === 'end' && end.ok, true)
+})
+
+test('runFramework carries on when the gate itself fails (#529)', async () => {
+  // Fail-open, per Rom on #519: an unreadable quota must not stop the work.
+  const { result } = await runFramework({
+    intent: FAKE_INTENT,
+    driver: fakeDriver(),
+    cwd: '/tmp/ws',
+    signals: FAKE_SIGNALS,
+    consumptionGate: () => {
+      throw new Error('quota unreadable')
+    },
+  })
+  assert.ok(result)
+})
+
+test('runFramework leaves the run ungated with no consumption gate (#529)', async () => {
+  const { result } = await runFramework({ intent: FAKE_INTENT, driver: fakeDriver(), cwd: '/tmp/ws', signals: FAKE_SIGNALS })
+  assert.ok(result)
 })

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -35,13 +35,14 @@ import {
   type Verdict,
 } from '@gemstack/ai-autopilot'
 import { snapshotWorkspace } from './sandbox.js'
+import type { ConsumptionWindow } from './consumption.js'
 import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { memoryFraming, type LoadedMemory } from './memory.js'
 import { composeRunSystem, type EcoOptions, type TfContext } from './system-prompt.js'
 import { AWAIT_PROTOCOL, CONFIRM_APPROVED, CONFIRM_DECLINED, PLAN_DECLINED_MESSAGE, isDeclinedConfirmation, parseAwaitGate, parseMarkdownViews, parseSessionName, parseReadyForMerge, type ParsedAwaitGate } from './turn-gate.js'
 // Value import from todo-loop.js is a benign cycle: todo-loop.js only calls
 // run.js's hoisted function declarations (requestChoices / resolveAwaitGate).
-import { runTodoLoop, type TodoLoopResult } from './todo-loop.js'
+import { appendTodoEntry, runTodoLoop, type TodoLoopResult } from './todo-loop.js'
 import { continueAfterChoice, decideDeploy, deployWith, domainLoopChecklist, driverArchitect, driverBuild, driverChecklist, driverImprove, driverLoopPrompts, reArchitect, type AwaitResolver } from './steps.js'
 import { hasSessionIdPlaceholder, OPEN_LOOP_MODES, pickedIds, resolveSessionLink, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 import { UsageMeter } from './usage.js'
@@ -227,6 +228,16 @@ export interface RunFrameworkOptions {
    */
   budgetUsd?: number
   /**
+   * Consult the consumption limits between turns (#529): return the limit that
+   * has been reached to pause the run, or `null` to carry on.
+   *
+   * Must answer from a cached reading — a live quota read spawns the whole agent
+   * CLI (~5s). Compose one from a `QuotaPoller` and `consumptionStatus`. Omit to
+   * leave the run ungated, which is also what a gate that throws resolves to:
+   * an unreadable quota must never stop the user's work (Rom's call on #519).
+   */
+  consumptionGate?: () => ConsumptionWindow | null
+  /**
    * Run the backlog loop (#323) after the build settles: consume the agent's own
    * `TODO_<slug>.agent.md` / `TODO.md` one entry per turn until empty, gating
    * before each entry when {@link requestChoice} is wired. Default: on for real
@@ -286,6 +297,33 @@ export interface RunFrameworkResult {
  * a {@link FrameworkEvent}. Reversible: swap in a real deploy target, or a
  * different `Driver`, without touching this wiring.
  */
+/** How each limit reads in a log line and a stop reason. */
+const CONSUMPTION_LIMIT_LABEL: Record<ConsumptionWindow, string> = {
+  session: 'Session',
+  'five-hour': '5h',
+  daily: 'Daily',
+}
+
+/**
+ * Leave a "resume me" entry on the workspace's backlog, so a later run picks the
+ * paused work back up (Rom's call on #519). The backlog is already what a run
+ * drains, so this needs no machinery of its own.
+ *
+ * Named after the session when the agent gave itself one, since that is what the
+ * user recognizes; an unnamed run says so plainly rather than inventing an id.
+ */
+async function leaveResumeNote(
+  cwd: string,
+  events: FrameworkEvent[],
+  emit: (event: FrameworkEvent) => void,
+): Promise<string | undefined> {
+  const named = [...events].reverse().find((e): e is Extract<FrameworkEvent, { kind: 'session-name' }> => e.kind === 'session-name')
+  const entry = `Resume ${named?.name ?? 'the paused run'}`
+  const file = await appendTodoEntry(cwd, entry)
+  if (file) emit({ kind: 'log', message: `Left "${entry}" on ${file} to pick up when the limit resets.` })
+  return file
+}
+
 export async function runFramework(opts: RunFrameworkOptions): Promise<RunFrameworkResult> {
   const events: FrameworkEvent[] = []
   const emit = (event: FrameworkEvent) => {
@@ -404,10 +442,15 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
   // A declined plan (#358) also stops the run cleanly, like the budget cap: nothing
   // downstream should review or improve work the user just declined.
   const declineController = new AbortController()
+  // A consumption limit (#529) is the third clean stop: the account's quota, not
+  // this run's spend, is what ran out.
+  const consumptionController = new AbortController()
+  let consumptionTrip: ConsumptionWindow | undefined
   const runSignal = AbortSignal.any([
     ...(opts.signal ? [opts.signal] : []),
     budgetController.signal,
     declineController.signal,
+    consumptionController.signal,
   ])
 
   // Watch the black box for its real session id (the {type:'result'} event) and
@@ -434,6 +477,23 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     if (opts.budgetUsd != null && totals.costUsd >= opts.budgetUsd && !budgetController.signal.aborted) {
       emit({ kind: 'log', message: `Budget reached: $${totals.costUsd.toFixed(4)} of $${opts.budgetUsd} — stopping the run.` })
       budgetController.abort(new Error('[framework] budget reached'))
+    }
+    // The consumption limits (#519). Asked only between turns and answered from a
+    // cached reading: a live quota read spawns the whole agent CLI (~5s), so it
+    // can never sit here. A gate that throws is treated as "carry on" — the
+    // fail-open Rom confirmed, since an unreadable quota must not stop the work.
+    if (opts.consumptionGate && !consumptionController.signal.aborted) {
+      let reached: ConsumptionWindow | null = null
+      try {
+        reached = opts.consumptionGate()
+      } catch (err) {
+        console.error('[framework] consumptionGate threw; carrying on:', err)
+      }
+      if (reached) {
+        consumptionTrip = reached
+        emit({ kind: 'log', message: `${CONSUMPTION_LIMIT_LABEL[reached]} consumption limit reached — pausing the run.` })
+        consumptionController.abort(new Error('[framework] consumption limit reached'))
+      }
     }
   }
 
@@ -594,14 +654,22 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     // its own signal, so it trips when the caller's signal did not.
     const budgetStopped = budgetController.signal.aborted && opts.signal?.aborted !== true
     const declined = declineController.signal.aborted
-    const stopped = opts.signal?.aborted === true || budgetController.signal.aborted || declined
+    const paused = consumptionController.signal.aborted && opts.signal?.aborted !== true
+    const stopped =
+      opts.signal?.aborted === true || budgetController.signal.aborted || declined || consumptionController.signal.aborted
+    // Leave word to pick this up again (#529). Written here rather than at the
+    // trip because the note is file I/O and the trip is a sync event handler; a
+    // fire-and-forget write could lose the race with the run unwinding.
+    const resumeNote = paused ? await leaveResumeNote(opts.cwd, events, emit) : undefined
     const detail = declined
       ? 'plan declined'
       : budgetStopped
         ? `budget reached ($${opts.budgetUsd})`
-        : err instanceof Error
-          ? err.message
-          : String(err)
+        : paused
+          ? `${CONSUMPTION_LIMIT_LABEL[consumptionTrip ?? 'session']} consumption limit reached${resumeNote ? `; will resume from ${resumeNote}` : ''}`
+          : err instanceof Error
+            ? err.message
+            : String(err)
     emit({ kind: 'end', ok: false, ...(stopped ? { stopped: true } : {}), detail })
     throw err
   } finally {

--- a/packages/framework/src/todo-loop.ts
+++ b/packages/framework/src/todo-loop.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile, stat } from 'node:fs/promises'
+import { readdir, readFile, stat, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { DriverSession } from './driver/index.js'
 import type { ChoicePick, ChoiceRequest, FrameworkEvent } from './events.js'
@@ -55,17 +55,16 @@ export function parseTodoEntries(md: string): string[] {
 }
 
 /**
- * Locate the workspace's backlog: the most recently modified session-scoped
- * `TODO_<slug>.agent.md` (#323/#326), falling back to the flat `TODO.md` the
- * current pill writes (#301) — the same dual convention as the doc sidebar.
- * Returns `undefined` when no backlog exists or none has open entries.
+ * The workspace's backlog files, best first: the most recently modified
+ * session-scoped `TODO_<slug>.agent.md` (#323/#326), then the flat `TODO.md`
+ * the current pill writes (#301) — the same dual convention as the doc sidebar.
  */
-export async function findTodoBacklog(cwd: string): Promise<TodoBacklog | undefined> {
+async function backlogCandidates(cwd: string): Promise<string[]> {
   let names: string[]
   try {
     names = (await readdir(cwd, { withFileTypes: true })).filter(e => e.isFile()).map(e => e.name)
   } catch {
-    return undefined
+    return []
   }
   const scoped = names.filter(name => TODO_FILE_PATTERN.test(name))
   const candidates: string[] = []
@@ -79,7 +78,38 @@ export async function findTodoBacklog(cwd: string): Promise<TodoBacklog | undefi
     candidates.push(...scoped)
   }
   if (names.includes(FLAT_TODO_FILE)) candidates.push(FLAT_TODO_FILE)
+  return candidates
+}
 
+/**
+ * Append an open entry to this run's backlog, creating the flat {@link FLAT_TODO_FILE}
+ * when the workspace has none. Resolves with the file written, or `undefined` if
+ * it couldn't be written.
+ *
+ * This is how a paused run leaves word to pick itself up again (#529): the
+ * backlog is already the thing a later run drains, so a resume note needs no
+ * machinery of its own. Never throws — it is called while a run is already
+ * unwinding, and must not mask the reason it stopped.
+ */
+export async function appendTodoEntry(cwd: string, entry: string): Promise<string | undefined> {
+  const name = (await backlogCandidates(cwd))[0] ?? FLAT_TODO_FILE
+  const path = join(cwd, name)
+  try {
+    const existing = await readFile(path, 'utf8').catch(() => '')
+    const separator = existing === '' || existing.endsWith('\n') ? '' : '\n'
+    await writeFile(path, `${existing}${separator}- [ ] ${entry}\n`, 'utf8')
+    return name
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Locate the workspace's backlog and its open entries. Returns `undefined` when
+ * no backlog exists or none of them has an open entry.
+ */
+export async function findTodoBacklog(cwd: string): Promise<TodoBacklog | undefined> {
+  const candidates = await backlogCandidates(cwd)
   for (const name of candidates) {
     const md = await readFile(join(cwd, name), 'utf8').catch(() => undefined)
     if (md === undefined) continue


### PR DESCRIPTION
Closes #529. The act half of #519: the limits could be set (#528), fed (#526) and judged (#524), but nothing acted on them.

Your call on #519, built: pause the current session(s) on all three limits, and leave a `Resume <session name>` entry behind. The backlog is already what a later run drains, so the resume needs no machinery of its own.

### Worth a look

- **A reached limit is a clean stop, like the budget cap.** The account's quota ran out, not the run, so surfaces show "stopped" rather than a failure.
- **The gate answers from a cached reading.** A live quota read spawns the whole agent CLI (~5s), so it can never sit between turns. Compose the gate from a `QuotaPoller` and `consumptionStatus`.
- **An unreadable quota carries on**, per your "Agreed, keep running". A gate that throws is treated as "no limit reached".
- **The note is written while the run unwinds, not at the trip.** The trip is a sync event handler and the note is file I/O, so a fire-and-forget write could lose the race with the run finishing. For the same reason the append never throws: it must not mask why the run stopped.
- The note is named after the session when the agent gave itself one, since that's what you'd recognize. An unnamed run says "Resume the paused run" rather than inventing an id.

**Not in scope:** wiring the poller in at the daemon/CLI, the server waking itself at the reset, and the bars.

### Verification

6 new tests (547 total, 0 failing, typecheck clean), including the note landing on a real temp workspace and appending cleanly to a backlog that has no trailing newline.