### PR TITLE
feat(framework): turn the consumption limits on for real runs (#531)

### DIFF
--- a/.changeset/consumption-guard.md
+++ b/.changeset/consumption-guard.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Turn the consumption limits on for real runs. `startConsumptionGuard` composes the poller and the limits into the gate a run consults, the CLI reads the limits from the user's preferences and wires it into both run paths, and the direct prompt path gained the same pause the build path got. A driver that can't report a quota leaves the run ungated.

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -46,7 +46,8 @@ import { RunStore } from './store/index.js'
 import { daemonStatus, ensureDaemon, runDaemon, stopDaemon, DEFAULT_DAEMON_PORT } from './daemon.js'
 import { resetControl, watchControl, type ControlWatcher } from './control.js'
 import { isActivated, nodeGitRunner } from './project.js'
-import { addProject, listProjects } from './registry.js'
+import { addProject, listProjects, readPreferences, resolveConsumptionLimits } from './registry.js'
+import { startConsumptionGuard } from './consumption-guard.js'
 import {
   planMaintenanceSweep,
   maintainSweep,
@@ -1033,6 +1034,14 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
 
   const driver: Driver = fake ? fakeDriver() : new ClaudeCodeDriver(withBrowser(claudeOpts, opts.browser))
 
+  // The consumption limits (#519/#531). Read from the user's own file rather than
+  // taken as a flag: unlike autopilot or eco, a limit is not a per-run choice, so
+  // a run started from a terminal is guarded exactly like one started from the
+  // dashboard. `undefined` when the agent can't report a quota (the fake driver),
+  // which leaves the run ungated — the fail-open Rom confirmed.
+  const guard = startConsumptionGuard({ driver, limits: resolveConsumptionLimits(await readPreferences()) })
+  if (guard) io.out('◆ consumption limits: on')
+
   // `framework research [what]` (#331) and `framework prompt <text>` (#353): the
   // direct prompt path — run one prompt through runPrompt, which honors its gates
   // (#337/#339) but skips the scope -> architect -> build scaffolding entirely.
@@ -1064,6 +1073,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
           : {}),
         ...(opts.model ? { model: opts.model } : {}),
         ...(opts.maxCost ? { budgetUsd: opts.maxCost } : {}),
+        ...(guard ? { consumptionGate: guard.gate } : {}),
         ...(userSystemPrompt ? { systemPrompt: userSystemPrompt } : {}),
         ...(noBuiltinPrompt ? { antiLazyPill: false } : {}),
         ...(eco ? { eco } : {}),
@@ -1107,6 +1117,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     } finally {
       clearInterrupt()
       control?.close()
+      guard?.stop()
       if (publisher) await publisher.flush()
     }
   }
@@ -1193,6 +1204,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     ...(opts.model ? { model: opts.model } : {}),
     ...(opts.maxPasses ? { maxPasses: opts.maxPasses } : {}),
     ...(opts.maxCost ? { budgetUsd: opts.maxCost } : {}),
+    ...(guard ? { consumptionGate: guard.gate } : {}),
     ...(opts.todoLoop ? {} : { todoLoop: false }),
     ...(opts.todoMaxItems ? { todoMaxItems: opts.todoMaxItems } : {}),
     ...(deploy ? { deploy } : {}),
@@ -1263,6 +1275,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   } finally {
     clearInterrupt()
     control?.close()
+    guard?.stop()
     // Make sure every event (including the final `end`) reached the relay before exit.
     if (publisher) await publisher.flush()
   }

--- a/packages/framework/src/consumption-guard.test.ts
+++ b/packages/framework/src/consumption-guard.test.ts
@@ -1,0 +1,92 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { startConsumptionGuard } from './consumption-guard.js'
+import { DEFAULT_CONSUMPTION_LIMITS } from './consumption.js'
+import { FakeDriver } from './driver/index.js'
+import type { Driver, DriverQuota } from './driver/index.js'
+
+const T0 = 1_800_000_000_000
+
+function quotaDriver(...readings: DriverQuota[]): Driver {
+  let i = 0
+  return {
+    name: 'quota-fake',
+    start: () => Promise.reject(new Error('not used')),
+    readQuota: () => Promise.resolve(readings[Math.min(i++, readings.length - 1)] as DriverQuota),
+  }
+}
+
+function week(percentUsed: number): DriverQuota {
+  return { available: true, windows: [{ label: 'Current week (all models)', kind: 'week', percentUsed }] }
+}
+
+test('startConsumptionGuard leaves a driver that cannot report a quota ungated (#531)', () => {
+  // The fake driver has no readQuota, so there is nothing to guard with. Fail
+  // open: no reading must never mean "stop the work".
+  assert.equal(startConsumptionGuard({ driver: new FakeDriver(), limits: DEFAULT_CONSUMPTION_LIMITS }), undefined)
+})
+
+test('startConsumptionGuard gate says carry on before the first reading lands (#531)', () => {
+  const guard = startConsumptionGuard({ driver: quotaDriver(week(5)), limits: DEFAULT_CONSUMPTION_LIMITS, now: () => T0 })
+  assert.ok(guard)
+  // start() polls without awaiting, so nothing is measurable yet.
+  assert.equal(guard.gate(), null)
+  guard.stop()
+})
+
+test('startConsumptionGuard gate pauses once the session has spent its budget (#531)', async () => {
+  let at = T0
+  // 5% of the week at the baseline, 14% a moment later: 9 points this session,
+  // past the session budget of 8.
+  const guard = startConsumptionGuard({
+    driver: quotaDriver(week(5), week(14)),
+    limits: DEFAULT_CONSUMPTION_LIMITS,
+    sessionStartedAt: T0,
+    now: () => at,
+  })
+  assert.ok(guard)
+  // start() takes the baseline reading itself; let it land.
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(guard.gate(), null)
+  at = T0 + 60_000
+  await guard.poller.poll()
+  assert.equal(guard.gate(), 'session')
+  guard.stop()
+})
+
+test('startConsumptionGuard gate carries on when the quota cannot be read (#531)', async () => {
+  const guard = startConsumptionGuard({
+    driver: quotaDriver({ available: false, reason: 'fetch-failed' }),
+    limits: DEFAULT_CONSUMPTION_LIMITS,
+    now: () => T0,
+  })
+  assert.ok(guard)
+  await guard.poller.poll()
+  assert.equal(guard.gate(), null)
+  guard.stop()
+})
+
+test('startConsumptionGuard stop ends the polling (#531)', () => {
+  const guard = startConsumptionGuard({ driver: quotaDriver(week(5)), limits: DEFAULT_CONSUMPTION_LIMITS, now: () => T0 })
+  assert.ok(guard)
+  guard.stop()
+  assert.equal(guard.poller.isStopped, true)
+})
+
+test('startConsumptionGuard reads the quota straight away rather than an interval later (#531)', async () => {
+  let reads = 0
+  const driver: Driver = {
+    name: 'counting',
+    start: () => Promise.reject(new Error('not used')),
+    readQuota: () => {
+      reads++
+      return Promise.resolve(week(5))
+    },
+  }
+  const guard = startConsumptionGuard({ driver, limits: DEFAULT_CONSUMPTION_LIMITS, now: () => T0 })
+  // The session's own measurement needs a baseline from the moment it started,
+  // so waiting a full poll interval for the first reading would be no use.
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(reads, 1)
+  guard?.stop()
+})

--- a/packages/framework/src/consumption-guard.ts
+++ b/packages/framework/src/consumption-guard.ts
@@ -1,0 +1,64 @@
+import { consumptionStatus, type ConsumptionLimits, type ConsumptionWindow } from './consumption.js'
+import { QuotaPoller } from './quota-poller.js'
+import type { Driver } from './driver/index.js'
+
+/** A live consumption gate, and the polling behind it. */
+export interface ConsumptionGuard {
+  /**
+   * Pass as `consumptionGate` to a run. Answers from the poller's cached
+   * readings, so it is cheap enough to ask between every turn.
+   */
+  gate: () => ConsumptionWindow | null
+  /** The poller feeding it, exposed so a caller can read the bars off it. */
+  poller: QuotaPoller
+  /** Stop polling. Always call this when the run ends. */
+  stop: () => void
+}
+
+/** Options for {@link startConsumptionGuard}. */
+export interface StartConsumptionGuardOptions {
+  /** The wrapped agent. Must be able to report its quota, or there's nothing to guard with. */
+  driver: Driver
+  /** The limits in force. Get them with `resolveConsumptionLimits(await readPreferences())`. */
+  limits: ConsumptionLimits
+  /** When the run started, epoch ms. Default now. */
+  sessionStartedAt?: number
+  /** Clock, injectable for tests. */
+  now?: () => number
+}
+
+/**
+ * Wire the consumption limits up for one run (#531): poll the agent's quota, and
+ * hand back the gate a run consults between turns.
+ *
+ * Resolves `undefined` when there is nothing to guard with — the agent can't
+ * report a quota at all (the fake driver, or a second agent that has no such
+ * command). That is the fail-open Rom confirmed on #519: no reading means the
+ * work carries on, with the per-run budget cap still underneath it.
+ *
+ * The first read is deliberately not awaited. It takes ~5s (it spawns the whole
+ * agent CLI), and making every run wait that long to *maybe* find out it has
+ * budget would be a poor trade. It lands a moment into the run instead, so the
+ * session's own measurement starts from there.
+ */
+export function startConsumptionGuard(opts: StartConsumptionGuardOptions): ConsumptionGuard | undefined {
+  const readQuota = opts.driver.readQuota?.bind(opts.driver)
+  if (!readQuota) return undefined
+
+  const now = opts.now ?? (() => Date.now())
+  const sessionStartedAt = opts.sessionStartedAt ?? now()
+  const poller = new QuotaPoller({ read: () => readQuota(), now })
+  poller.start()
+
+  return {
+    poller,
+    stop: () => poller.stop(),
+    gate: () =>
+      consumptionStatus({
+        meter: poller.meter,
+        limits: opts.limits,
+        sessionStartedAt,
+        now: now(),
+      }).reached,
+  }
+}

--- a/packages/framework/src/consumption.ts
+++ b/packages/framework/src/consumption.ts
@@ -138,6 +138,13 @@ export class ConsumptionMeter {
 /** One of Rom's three limits. */
 export type ConsumptionWindow = 'session' | 'five-hour' | 'daily'
 
+/** How each limit reads in a log line and a stop reason. */
+export const CONSUMPTION_LIMIT_LABEL: Record<ConsumptionWindow, string> = {
+  session: 'Session',
+  'five-hour': '5h',
+  daily: 'Daily',
+}
+
 /** A single limit: a share, and whether it's on. */
 export interface ConsumptionLimit {
   enabled: boolean

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -81,7 +81,9 @@ export {
   type ConsumptionWindow,
   type ConsumptionStatus,
   type LimitStatus,
+  CONSUMPTION_LIMIT_LABEL,
 } from './consumption.js'
+export { startConsumptionGuard, type ConsumptionGuard, type StartConsumptionGuardOptions } from './consumption-guard.js'
 export {
   QuotaPoller,
   DEFAULT_POLL_MS,

--- a/packages/framework/src/prompt-run.test.ts
+++ b/packages/framework/src/prompt-run.test.ts
@@ -237,3 +237,33 @@ test('runPrompt stops itself at the budget cap and reports a clean stop (#322)',
   assert.equal(end.stopped, true)
   assert.match(end.detail ?? '', /budget reached/)
 })
+
+test('runPrompt pauses at a consumption limit and reports a clean stop (#531)', async () => {
+  const events: FrameworkEvent[] = []
+  const usage = { inputTokens: 10, outputTokens: 10, cacheReadTokens: 0, cacheCreationTokens: 0, costUsd: 0.01 }
+  // Turn 1 ends on a gate, so the run would otherwise take a turn 2.
+  const driver = new FakeDriver({ turns: [{ text: multiGateTurn, usage }, { text: 'never', usage }] })
+  await assert.rejects(() =>
+    runPrompt({ prompt: 'go', driver, cwd: '/ws', consumptionGate: () => 'daily', onEvent: e => events.push(e) }),
+  )
+  // The direct prompt path is its own loop, so it needs the gate in its own right.
+  const end = events.at(-1) as { kind: string; ok: boolean; stopped?: boolean; detail?: string }
+  assert.equal(end.kind, 'end')
+  assert.equal(end.stopped, true)
+  assert.match(end.detail ?? '', /Daily consumption limit reached/)
+  assert.ok(events.some(e => e.kind === 'log' && e.message === 'Daily consumption limit reached — pausing the run.'))
+})
+
+test('runPrompt carries on when the consumption gate fails (#531)', async () => {
+  // Fail-open, per Rom on #519.
+  const driver = new FakeDriver({ turns: [{ text: 'done' }] })
+  const { text } = await runPrompt({
+    prompt: 'go',
+    driver,
+    cwd: '/ws',
+    consumptionGate: () => {
+      throw new Error('quota unreadable')
+    },
+  })
+  assert.equal(text, 'done')
+})

--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -4,6 +4,8 @@ import { resolveAwaitGate } from './run.js'
 import { composeRunSystem, renderSystemPrompt, type EcoOptions, type TfContext } from './system-prompt.js'
 import { PLAN_DECLINED_MESSAGE, isDeclinedConfirmation, parseAwaitGate, parseMarkdownViews, parseSessionName, parseReadyForMerge } from './turn-gate.js'
 import { UsageMeter } from './usage.js'
+import { CONSUMPTION_LIMIT_LABEL, type ConsumptionWindow } from './consumption.js'
+import { leaveResumeNote } from './todo-loop.js'
 
 /**
  * The direct prompt path (#331): run *one prompt* through the driver and honor
@@ -48,6 +50,12 @@ export interface RunPromptOptions {
   bootstrap?: boolean
   /** Stop the run once the agent has spent this much, in USD (#322). */
   budgetUsd?: number
+  /**
+   * Consult the consumption limits between turns (#531): return the limit that
+   * has been reached to pause the run, or `null` to carry on. Same seam and same
+   * fail-open as a build run — see `RunFrameworkOptions.consumptionGate`.
+   */
+  consumptionGate?: () => ConsumptionWindow | null
   /** Session link template for the dashboard, `{sessionId}` resolved when known. */
   sessionLink?: string
 }
@@ -106,7 +114,15 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
   // Usage accounting + the self-stopping budget cap, the same wiring as a build
   // run (#322): the run signal composes the caller's abort with the budget abort.
   const budgetController = new AbortController()
-  const runSignal = opts.signal ? AbortSignal.any([opts.signal, budgetController.signal]) : budgetController.signal
+  // A consumption limit (#531) is the other self-stop: the account's quota ran
+  // out rather than this run's spend.
+  const consumptionController = new AbortController()
+  let consumptionTrip: ConsumptionWindow | undefined
+  const runSignal = AbortSignal.any([
+    ...(opts.signal ? [opts.signal] : []),
+    budgetController.signal,
+    consumptionController.signal,
+  ])
   let lastSessionId: string | undefined
   const usage = new UsageMeter()
   const onDriverEvent = (event: DriverEvent): void => {
@@ -124,6 +140,20 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
     if (opts.budgetUsd != null && totals.costUsd >= opts.budgetUsd && !budgetController.signal.aborted) {
       emit({ kind: 'log', message: `Budget reached: $${totals.costUsd.toFixed(4)} of $${opts.budgetUsd} — stopping the run.` })
       budgetController.abort(new Error('[framework] budget reached'))
+    }
+    if (opts.consumptionGate && !consumptionController.signal.aborted) {
+      let reached: ConsumptionWindow | null = null
+      try {
+        reached = opts.consumptionGate()
+      } catch (err) {
+        // Fail open: an unreadable quota must not stop the work (Rom on #519).
+        console.error('[framework] consumptionGate threw; carrying on:', err)
+      }
+      if (reached) {
+        consumptionTrip = reached
+        emit({ kind: 'log', message: `${CONSUMPTION_LIMIT_LABEL[reached]} consumption limit reached — pausing the run.` })
+        consumptionController.abort(new Error('[framework] consumption limit reached'))
+      }
     }
   }
 
@@ -179,8 +209,19 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
   } catch (err) {
     // A user interrupt or the budget cap is a clean stop, not a failure (#322).
     const budgetStopped = budgetController.signal.aborted && opts.signal?.aborted !== true
-    const stopped = opts.signal?.aborted === true || budgetController.signal.aborted
-    const detail = budgetStopped ? `budget reached ($${opts.budgetUsd})` : err instanceof Error ? err.message : String(err)
+    const paused = consumptionController.signal.aborted && opts.signal?.aborted !== true
+    const stopped = opts.signal?.aborted === true || budgetController.signal.aborted || consumptionController.signal.aborted
+    // Written here, not at the trip: the note is file I/O and the trip is a sync
+    // event handler, so a fire-and-forget write could lose the race with the run
+    // unwinding.
+    const resumeNote = paused ? await leaveResumeNote(opts.cwd, events, emit) : undefined
+    const detail = budgetStopped
+      ? `budget reached ($${opts.budgetUsd})`
+      : paused
+        ? `${CONSUMPTION_LIMIT_LABEL[consumptionTrip ?? 'session']} consumption limit reached${resumeNote ? `; will resume from ${resumeNote}` : ''}`
+        : err instanceof Error
+          ? err.message
+          : String(err)
     emit({ kind: 'end', ok: false, ...(stopped ? { stopped: true } : {}), detail })
     throw err
   } finally {

--- a/packages/framework/src/quota-poller.ts
+++ b/packages/framework/src/quota-poller.ts
@@ -57,6 +57,7 @@ export class QuotaPoller {
   readonly meter: ConsumptionMeter
   private envelope: QuotaEnvelope = { latest: undefined, lastGood: undefined, lastGoodAt: undefined, lastFailureAt: undefined }
   private timer: ReturnType<typeof setTimeout> | undefined
+  private running = false
   private currentIntervalMs: number
   private stopped = false
   private readonly now: () => number
@@ -104,15 +105,22 @@ export class QuotaPoller {
     return quota
   }
 
-  /** Begin polling. Idempotent. */
+  /**
+   * Begin polling, starting with a read right now rather than one interval from
+   * now: a poller whose first reading lands five minutes in is no use to a run
+   * that just started, and the session's own measurement needs a baseline. Not
+   * awaited — the read takes ~5s and nothing should wait on it. Idempotent.
+   */
   start(): void {
-    if (this.timer || this.stopped) return
-    this.schedule()
+    if (this.running || this.stopped) return
+    this.running = true
+    void this.poll().finally(() => this.schedule())
   }
 
   /** Stop polling. Idempotent. */
   stop(): void {
     this.stopped = true
+    this.running = false
     if (this.timer) clearTimeout(this.timer)
     this.timer = undefined
   }

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -35,14 +35,14 @@ import {
   type Verdict,
 } from '@gemstack/ai-autopilot'
 import { snapshotWorkspace } from './sandbox.js'
-import type { ConsumptionWindow } from './consumption.js'
+import { CONSUMPTION_LIMIT_LABEL, type ConsumptionWindow } from './consumption.js'
 import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
 import { memoryFraming, type LoadedMemory } from './memory.js'
 import { composeRunSystem, type EcoOptions, type TfContext } from './system-prompt.js'
 import { AWAIT_PROTOCOL, CONFIRM_APPROVED, CONFIRM_DECLINED, PLAN_DECLINED_MESSAGE, isDeclinedConfirmation, parseAwaitGate, parseMarkdownViews, parseSessionName, parseReadyForMerge, type ParsedAwaitGate } from './turn-gate.js'
 // Value import from todo-loop.js is a benign cycle: todo-loop.js only calls
 // run.js's hoisted function declarations (requestChoices / resolveAwaitGate).
-import { appendTodoEntry, runTodoLoop, type TodoLoopResult } from './todo-loop.js'
+import { leaveResumeNote, runTodoLoop, type TodoLoopResult } from './todo-loop.js'
 import { continueAfterChoice, decideDeploy, deployWith, domainLoopChecklist, driverArchitect, driverBuild, driverChecklist, driverImprove, driverLoopPrompts, reArchitect, type AwaitResolver } from './steps.js'
 import { hasSessionIdPlaceholder, OPEN_LOOP_MODES, pickedIds, resolveSessionLink, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 import { UsageMeter } from './usage.js'
@@ -297,33 +297,6 @@ export interface RunFrameworkResult {
  * a {@link FrameworkEvent}. Reversible: swap in a real deploy target, or a
  * different `Driver`, without touching this wiring.
  */
-/** How each limit reads in a log line and a stop reason. */
-const CONSUMPTION_LIMIT_LABEL: Record<ConsumptionWindow, string> = {
-  session: 'Session',
-  'five-hour': '5h',
-  daily: 'Daily',
-}
-
-/**
- * Leave a "resume me" entry on the workspace's backlog, so a later run picks the
- * paused work back up (Rom's call on #519). The backlog is already what a run
- * drains, so this needs no machinery of its own.
- *
- * Named after the session when the agent gave itself one, since that is what the
- * user recognizes; an unnamed run says so plainly rather than inventing an id.
- */
-async function leaveResumeNote(
-  cwd: string,
-  events: FrameworkEvent[],
-  emit: (event: FrameworkEvent) => void,
-): Promise<string | undefined> {
-  const named = [...events].reverse().find((e): e is Extract<FrameworkEvent, { kind: 'session-name' }> => e.kind === 'session-name')
-  const entry = `Resume ${named?.name ?? 'the paused run'}`
-  const file = await appendTodoEntry(cwd, entry)
-  if (file) emit({ kind: 'log', message: `Left "${entry}" on ${file} to pick up when the limit resets.` })
-  return file
-}
-
 export async function runFramework(opts: RunFrameworkOptions): Promise<RunFrameworkResult> {
   const events: FrameworkEvent[] = []
   const emit = (event: FrameworkEvent) => {

--- a/packages/framework/src/todo-loop.ts
+++ b/packages/framework/src/todo-loop.ts
@@ -119,6 +119,28 @@ export async function findTodoBacklog(cwd: string): Promise<TodoBacklog | undefi
   return undefined
 }
 
+/**
+ * Leave a "resume me" entry on the workspace's backlog, so a later run picks the
+ * paused work back up (Rom's call on #519). The backlog is already what a run
+ * drains, so this needs no machinery of its own.
+ *
+ * Named after the session when the agent gave itself one, since that is what the
+ * user recognizes; an unnamed run says so plainly rather than inventing an id.
+ */
+export async function leaveResumeNote(
+  cwd: string,
+  events: readonly FrameworkEvent[],
+  emit: (event: FrameworkEvent) => void,
+): Promise<string | undefined> {
+  const named = [...events]
+    .reverse()
+    .find((e): e is Extract<FrameworkEvent, { kind: 'session-name' }> => e.kind === 'session-name')
+  const entry = `Resume ${named?.name ?? 'the paused run'}`
+  const file = await appendTodoEntry(cwd, entry)
+  if (file) emit({ kind: 'log', message: `Left "${entry}" on ${file} to pick up when the limit resets.` })
+  return file
+}
+
 /** Why the loop ended. */
 export type TodoLoopReason =
   /** The backlog is empty (or was never written) — the success case. */


### PR DESCRIPTION
Closes #531. This is the one that makes #519 actually do something: everything was built and nothing was connected, so the limits did nothing.

`startConsumptionGuard` composes the poller (#526) and the limits (#524) into the gate a run consults, off the driver's own quota read (#522). The CLI wires it into both run paths.

### Two things found while tracing this

- **The direct prompt path is its own loop.** `runPrompt` doesn't call `runFramework`, it re-implements the budget cap. So #530's gate covered the build path only, and a prompt run was **silently ungated**. It now pauses the same way, sharing the resume note and labels rather than growing a third copy. Same duplication #501 was about, one layer down.
- **The CLI never read preferences before.** Today the dashboard turns them into flags. But a limit isn't a per-run choice like autopilot or eco: a run started from a terminal should be guarded exactly like one from the dashboard, so the CLI reads it from your file directly.

### Also

`QuotaPoller.start()` now reads immediately rather than one interval later. A first reading landing five minutes into a run is no use to the run that just started, and the session's own measurement needs a baseline from the moment it began. It isn't awaited: the read takes ~5s, and making every run wait that long to *maybe* learn it has budget would be a poor trade.

A driver that can't report a quota (the fake one) leaves the run ungated, per your "Agreed, keep running".

### Verification

8 new tests (555 total, 0 failing, typecheck + build clean), including the prompt path pausing in its own right and the gate staying open before the first reading lands.

**Remaining for #519:** the server waking itself at the reset to drain the Resume note, and the bars.