### PR TITLE
feat(framework): serve the usage panel's numbers to the dashboard (#533)

### DIFF
--- a/.changeset/quota-panel-reads.md
+++ b/.changeset/quota-panel-reads.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Serve the usage panel's numbers: an `onQuota` RPC returning the account's quota windows plus where the consumption limits stand, backed by a quota source the daemon polls for its whole life (the per-run guard dies with its run, but the panel has to show the account while nothing is running). A host with no agent to ask reports it has no reading rather than an empty one.

--- a/packages/framework/src/dashboard-rpc/context.ts
+++ b/packages/framework/src/dashboard-rpc/context.ts
@@ -2,6 +2,7 @@ import { getContext } from 'telefunc'
 import { defaultProjectsProvider, type ProjectsProvider } from '../dashboard/projects.js'
 import type { EventsSource } from '../dashboard/telefunc-serve.js'
 import type { PreferencesStore } from '../registry.js'
+import type { QuotaSource } from '../dashboard/quota.js'
 
 /**
  * The {@link ProjectsProvider} a telefunction should read a project id against (#427).
@@ -41,6 +42,19 @@ export function contextEventsSource(): EventsSource | undefined {
 export function contextPreferences(): PreferencesStore | undefined {
   try {
     return getContext<{ preferences?: PreferencesStore }>()?.preferences
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * The quota source on the context, or undefined (#533). The daemon wires a live
+ * poller; a public host (the relay) leaves it unset, since it has no agent to ask
+ * and no business reading someone else's account.
+ */
+export function contextQuota(): QuotaSource | undefined {
+  try {
+    return getContext<{ quota?: QuotaSource }>()?.quota
   } catch {
     return undefined
   }

--- a/packages/framework/src/dashboard-rpc/quota.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/quota.telefunc.ts
@@ -1,0 +1,28 @@
+import { contextQuota } from './context.js'
+import { DEFAULT_CONSUMPTION_LIMITS, consumptionStatus, ConsumptionMeter } from '../consumption.js'
+import type { QuotaView } from '../dashboard/quota.js'
+
+// The usage panel's read surface (#533): where the account's subscription quota stands,
+// and where the user's consumption limits (#519) stand against it. The source is threaded
+// through the Telefunc request context by the daemon, which polls for its whole life; a
+// public host (the relay) leaves it unwired, so the panel reports it has no reading rather
+// than an empty one.
+
+/** An honest empty view: no reading, and no limit measurable against one. */
+function noReading(): QuotaView {
+  // Measured off an empty meter rather than filled with zeroes: an empty bar
+  // reads as "nothing used", which is the one thing this panel must never imply,
+  // so `consumed` / `usedPercent` stay undefined and the UI can say so.
+  return {
+    windows: [],
+    unavailable: 'fetch-failed',
+    limits: consumptionStatus({ meter: new ConsumptionMeter(), limits: DEFAULT_CONSUMPTION_LIMITS }),
+  }
+}
+
+/** Where the account's quota and the user's limits stand. */
+export async function onQuota(): Promise<QuotaView> {
+  const source = contextQuota()
+  if (!source) return noReading()
+  return source.read().catch(() => noReading())
+}

--- a/packages/framework/src/dashboard-rpc/register.ts
+++ b/packages/framework/src/dashboard-rpc/register.ts
@@ -4,6 +4,7 @@ import { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPrevie
 import { onEvents } from './events.telefunc.js'
 import { onProjects, sendAddProject } from './projects.telefunc.js'
 import { onPreferences, savePreferences } from './preferences.telefunc.js'
+import { onQuota } from './quota.telefunc.js'
 
 // The client bakes each RPC key from the dashboard's source path (relative to its Vite
 // root, keeping the `.ts` extension) as `"<telefuncFilePath>:<exportName>"`. Since the
@@ -16,6 +17,7 @@ export const DASHBOARD_TELEFUNC_KEYS = {
   events: '/server/events.telefunc.ts',
   projects: '/server/projects.telefunc.ts',
   preferences: '/server/preferences.telefunc.ts',
+  quota: '/server/quota.telefunc.ts',
 } as const
 
 let registered = false
@@ -30,7 +32,7 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   registered = true
   const reg = (fn: (...args: never[]) => unknown, name: string, key: string): void =>
     __decorateTelefunction(fn as never, name, key, appRootDir)
-  const { reads, control, events, projects, preferences } = DASHBOARD_TELEFUNC_KEYS
+  const { reads, control, events, projects, preferences, quota } = DASHBOARD_TELEFUNC_KEYS
   reg(onRuns, 'onRuns', reads)
   reg(onRun, 'onRun', reads)
   reg(onDocs, 'onDocs', reads)
@@ -54,4 +56,5 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(sendAddProject, 'sendAddProject', projects)
   reg(onPreferences, 'onPreferences', preferences)
   reg(savePreferences, 'savePreferences', preferences)
+  reg(onQuota, 'onQuota', quota)
 }

--- a/packages/framework/src/dashboard/quota.test.ts
+++ b/packages/framework/src/dashboard/quota.test.ts
@@ -1,0 +1,105 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { pollerQuotaSource } from './quota.js'
+import { QuotaPoller } from '../quota-poller.js'
+import { DEFAULT_CONSUMPTION_LIMITS, type ConsumptionLimits } from '../consumption.js'
+import type { DriverQuota } from '../driver/index.js'
+
+const T0 = 1_800_000_000_000
+const HOUR = 60 * 60 * 1000
+
+function week(percentUsed: number): DriverQuota {
+  return {
+    available: true,
+    windows: [
+      { label: 'Current session', kind: 'session', percentUsed: 2, resetsAtText: 'in 2h 53m' },
+      { label: 'Current week (all models)', kind: 'week', percentUsed },
+    ],
+  }
+}
+
+function sourceOf(script: DriverQuota[], limits: ConsumptionLimits = DEFAULT_CONSUMPTION_LIMITS) {
+  let at = T0
+  let i = 0
+  const poller = new QuotaPoller({ read: () => Promise.resolve(script[Math.min(i++, script.length - 1)] as DriverQuota), now: () => at })
+  return { source: pollerQuotaSource(poller, () => Promise.resolve(limits)), poller, advance: (ms: number) => (at += ms) }
+}
+
+test('the usage panel gets the account windows and where the limits stand (#533)', async () => {
+  const { source, poller, advance } = sourceOf([week(10), week(16)])
+  await poller.poll()
+  advance(HOUR)
+  await poller.poll()
+  const view = await source.read()
+  // The account's own bars, as Traycer shows them.
+  assert.equal(view.windows.length, 2)
+  assert.equal(view.windows.find(w => w.kind === 'week')?.percentUsed, 16)
+  assert.equal(view.readAt, T0 + HOUR)
+  assert.equal(view.unavailable, undefined)
+  // And the limits: 6 points of the day's 20.
+  assert.equal(view.limits.daily.consumed, 6)
+  assert.equal(view.limits.daily.usedPercent, 30)
+  assert.equal(view.limits.reached, null)
+})
+
+test('the usage panel keeps the last reading and marks it stale on a blip (#533)', async () => {
+  const { source, poller, advance } = sourceOf([week(10), { available: false, reason: 'fetch-failed' }])
+  await poller.poll()
+  advance(1000)
+  await poller.poll()
+  const view = await source.read()
+  // The number is a second old; blanking it would read as "nothing used".
+  assert.equal(view.windows.find(w => w.kind === 'week')?.percentUsed, 10)
+  assert.equal(view.readAt, T0)
+  assert.equal(view.unavailable, 'fetch-failed')
+})
+
+test('the usage panel reports no reading rather than an empty one (#533)', async () => {
+  const { source } = sourceOf([{ available: false, reason: 'no-subscription' }])
+  const view = await source.read()
+  assert.deepEqual(view.windows, [])
+  // Undefined, not 0: an empty bar would say "nothing used" on an account we
+  // cannot read at all.
+  assert.equal(view.limits.daily.consumed, undefined)
+  assert.equal(view.limits.daily.usedPercent, undefined)
+  assert.equal(view.limits.reached, null)
+})
+
+test('the usage panel leaves the session bar unmeasured when nothing is running (#533)', async () => {
+  const { source, poller } = sourceOf([week(10)])
+  await poller.poll()
+  const view = await source.read()
+  // The panel is account-wide; a session bar belongs to a run's own guard.
+  assert.equal(view.limits.session.consumed, undefined)
+})
+
+test('the usage panel re-reads the limits, so a settings change re-scales the bars (#533)', async () => {
+  let limits: ConsumptionLimits = DEFAULT_CONSUMPTION_LIMITS
+  let at = T0
+  let i = 0
+  const script = [week(10), week(15)]
+  const poller = new QuotaPoller({ read: () => Promise.resolve(script[Math.min(i++, 1)] as DriverQuota), now: () => at })
+  const source = pollerQuotaSource(poller, () => Promise.resolve(limits))
+  await poller.poll()
+  at += HOUR
+  await poller.poll()
+  assert.equal((await source.read()).limits.daily.usedPercent, 25) // 5 of 20
+
+  limits = { ...DEFAULT_CONSUMPTION_LIMITS, daily: { enabled: true, percent: 10 } }
+  // No restart: the same 5 points are now half the day's budget.
+  assert.equal((await source.read()).limits.daily.usedPercent, 50)
+})
+
+test('the usage panel falls back to the defaults when the limits cannot be read (#533)', async () => {
+  const { poller } = sourceOf([week(10)])
+  // An unreadable preferences file must not take the guard rails off.
+  const source = pollerQuotaSource(poller, () => Promise.reject(new Error('registry unreadable')))
+  await poller.poll()
+  assert.equal((await source.read()).limits.daily.budget, 20)
+})
+
+test('stopping the source ends the polling (#533)', () => {
+  const { source, poller } = sourceOf([week(10)])
+  source.stop()
+  assert.equal(poller.isStopped, true)
+})

--- a/packages/framework/src/dashboard/quota.ts
+++ b/packages/framework/src/dashboard/quota.ts
@@ -1,0 +1,71 @@
+import { consumptionStatus, DEFAULT_CONSUMPTION_LIMITS, type ConsumptionLimits, type ConsumptionStatus } from '../consumption.js'
+import { QuotaPoller } from '../quota-poller.js'
+import { ClaudeCodeDriver, type DriverQuotaUnavailableReason, type DriverQuotaWindow } from '../driver/index.js'
+import { readPreferences, resolveConsumptionLimits } from '../registry.js'
+
+/**
+ * Everything the dashboard needs to draw the usage panel (#533): the account's
+ * own windows, and where the user's limits stand against them.
+ */
+export interface QuotaView {
+  /**
+   * The account's quota windows as the agent reported them (session, week, and
+   * a week per model). Empty when we have no reading at all — check
+   * {@link unavailable} before reading that as "nothing used".
+   */
+  windows: DriverQuotaWindow[]
+  /** When the reading was taken, epoch ms. Absent when there has never been one. */
+  readAt?: number
+  /**
+   * Why there is no reading, when there isn't one. Present alongside stale
+   * `windows` too: the last good reading is kept through a blip, and this says
+   * the newest attempt failed, so the UI can mark it stale rather than blank it.
+   */
+  unavailable?: DriverQuotaUnavailableReason
+  /** Where the three limits stand, for their checkboxes and bars. */
+  limits: ConsumptionStatus
+}
+
+/** Where a dashboard reads the quota from. */
+export interface QuotaSource {
+  read(): Promise<QuotaView>
+  /** Stop any polling behind it. */
+  stop(): void
+}
+
+/**
+ * A {@link QuotaSource} backed by a live poller.
+ *
+ * The limits are re-read per call rather than captured, so a user who changes
+ * them in the settings sees the bars re-scale without a restart.
+ */
+export function pollerQuotaSource(poller: QuotaPoller, limits: () => Promise<ConsumptionLimits>): QuotaSource {
+  return {
+    stop: () => poller.stop(),
+    read: async () => {
+      const envelope = poller.current()
+      const view: QuotaView = {
+        windows: envelope.lastGood?.windows ?? [],
+        limits: consumptionStatus({ meter: poller.meter, limits: await limits().catch(() => DEFAULT_CONSUMPTION_LIMITS) }),
+        ...(envelope.lastGoodAt !== undefined ? { readAt: envelope.lastGoodAt } : {}),
+        ...(envelope.latest && !envelope.latest.available ? { unavailable: envelope.latest.reason } : {}),
+      }
+      return view
+    },
+  }
+}
+
+/**
+ * The daemon's own quota source: it polls for the whole life of the dashboard,
+ * not just during a run, because the panel has to show where the account stands
+ * even when nothing is running.
+ *
+ * Separate from the per-run guard on purpose — that one exists to pause a run
+ * and dies with it, this one exists to draw a bar.
+ */
+export function defaultQuotaSource(): QuotaSource {
+  const driver = new ClaudeCodeDriver()
+  const poller = new QuotaPoller({ read: () => driver.readQuota() })
+  poller.start()
+  return pollerQuotaSource(poller, async () => resolveConsumptionLimits(await readPreferences()))
+}

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -3,6 +3,7 @@ import type { AddressInfo } from 'node:net'
 import type { EcoOptions } from '../system-prompt.js'
 import type { ProjectsProvider } from './projects.js'
 import { registryPreferencesStore, type PreferencesStore } from '../registry.js'
+import { defaultQuotaSource, type QuotaSource } from './quota.js'
 import { serveClientBundle } from './static.js'
 import { makeTelefuncMount } from './telefunc-serve.js'
 
@@ -56,6 +57,11 @@ export interface DashboardOptions {
    * never wires one, so preferences stay inert there.
    */
   preferences?: PreferencesStore
+  /**
+   * Where the usage panel reads the quota from (#533). Defaults to the daemon's
+   * own poller; the relay passes nothing and mounts no panel.
+   */
+  quota?: QuotaSource
   /**
    * Serve the new dashboard bundle (#405) from this directory — the prerendered Vike SPA
    * (`index.html` + `assets/**`). The daemon also mounts the dashboard's Telefunc surface
@@ -150,8 +156,19 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
   const preview = opts.onPreview
     ? { start: opts.onPreview, stop: opts.onStopPreview ?? (() => {}), status: opts.onPreviewStatus ?? (() => ({ running: false })) }
     : undefined
+  // The usage panel polls for the dashboard's whole life, not just during a run:
+  // it has to show where the account stands while nothing is running (#533).
+  const quota = clientBundleDir ? (opts.quota ?? defaultQuotaSource()) : undefined
   const telefuncMount = clientBundleDir
-    ? makeTelefuncMount(opts.onStart, opts.projects, undefined, opts.onAddProject, opts.preferences ?? registryPreferencesStore(), preview)
+    ? makeTelefuncMount(
+        opts.onStart,
+        opts.projects,
+        undefined,
+        opts.onAddProject,
+        opts.preferences ?? registryPreferencesStore(),
+        preview,
+        quota,
+      )
     : undefined
 
   const server = createServer((req, res) => {
@@ -175,7 +192,15 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
       server.removeListener('error', rejectPromise)
       const address = server.address() as AddressInfo
       const url = `http://${host}:${address.port}`
-      resolvePromise({ url, close: () => closeServer(server) })
+      resolvePromise({
+        url,
+        close: async () => {
+          // Stop polling with the server: the poller outlives every run by design,
+          // so nothing else would ever end it.
+          quota?.stop()
+          await closeServer(server)
+        },
+      })
     })
   })
 }

--- a/packages/framework/src/dashboard/telefunc-serve.ts
+++ b/packages/framework/src/dashboard/telefunc-serve.ts
@@ -5,6 +5,7 @@ import { registerDashboardTelefunctions } from '../dashboard-rpc/register.js'
 import type { ProjectsProvider } from './projects.js'
 import type { FrameworkEvent } from '../events.js'
 import type { PreferencesStore } from '../registry.js'
+import type { QuotaSource } from './quota.js'
 import { isSameOriginRequest, type AddProjectResult, type PreviewResult, type PreviewStatus, type StartRunKind, type StartRunOptions, type StartRunResult } from './server.js'
 
 /** Wired by the daemon so `sendStart` can reach the daemon's own `startRun` closure. */
@@ -46,6 +47,9 @@ export interface DashboardContext {
   /** The user-preferences store (#410). The daemon/foreground wire the real registry file;
    * a public host (the relay) leaves it unset so `onPreferences`/`savePreferences` are inert. */
   preferences?: PreferencesStore
+  /** The quota source behind the usage panel (#533). The daemon wires a live poller;
+   * a public host (the relay) leaves it unset, so `onQuota` reports it has no reading. */
+  quota?: QuotaSource
 }
 
 let instance: Telefunc | undefined
@@ -77,6 +81,7 @@ export function makeTelefuncMount(
   addProject?: AddProjectHandler,
   preferences?: PreferencesStore,
   preview?: PreviewHandlers,
+  quota?: QuotaSource,
 ): (req: IncomingMessage, res: ServerResponse) => Promise<boolean> {
   return async (req, res) => {
     if (!isSameOriginRequest(req)) {
@@ -92,6 +97,7 @@ export function makeTelefuncMount(
       ...(projects ? { projects } : {}),
       ...(eventsSource ? { eventsSource } : {}),
       ...(preferences ? { preferences } : {}),
+      ...(quota ? { quota } : {}),
     }
     // Never let a telefunc failure become an unhandled rejection that kills the daemon:
     // telefunc 0.2.22 throws on a bare `GET /_telefunc` (it passes the request as a body,

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -84,6 +84,7 @@ export {
   CONSUMPTION_LIMIT_LABEL,
 } from './consumption.js'
 export { startConsumptionGuard, type ConsumptionGuard, type StartConsumptionGuardOptions } from './consumption-guard.js'
+export { pollerQuotaSource, defaultQuotaSource, type QuotaView, type QuotaSource } from './dashboard/quota.js'
 export {
   QuotaPoller,
   DEFAULT_POLL_MS,


### PR DESCRIPTION
Closes #533. The read side of your bars: the dashboard had no way to ask where the quota stands.

`onQuota` returns both halves of your screenshot — the account's own windows (Current session, Current week), and where your three limits stand for their checkboxes and bars.

### Worth a look

- **The daemon owns its own poller.** The per-run guard (#532) dies with its run, but the panel has to show the account while nothing is running. It stops with the server, since nothing else would ever end it.
- **The limits are re-read per call**, so changing them in the settings re-scales the bars without a restart.
- **No reading is reported as no reading, never as zeroes.** An empty bar reads as "nothing used", which is the one thing this panel must never imply. The last good reading survives a blip and is marked stale rather than blanked.
- **The relay leaves it unwired.** A public host has no agent to ask and no business reading someone else's account.

**Not in scope:** the panel itself (next), and the resume.

### Verification

7 new tests (562 total, 0 failing, typecheck + build clean), covering the stale-on-blip retention, the unreadable account, the unmeasured session bar, and the live re-scale.