### PR TITLE
feat(dashboard): the usage panel (#535)

### DIFF
--- a/.changeset/usage-panel.md
+++ b/.changeset/usage-panel.md
@@ -1,0 +1,6 @@
+---
+'@gemstack/framework': minor
+'@gemstack/framework-dashboard': minor
+---
+
+Add the usage panel: what the account has left (the agent's own quota windows) and how much of it The Framework may spend before it pauses itself (the three consumption limits, each with a checkbox and a bar). Replaces the dashboard's "Usage & credits" placeholder.

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -4,6 +4,7 @@ import { FolderGit2, Zap, ListChecks, History } from 'lucide-react'
 import { onDashboard } from '../server/reads.telefunc.js'
 import { ActivityChart } from './ActivityChart.js'
 import { RunOutcomes } from './RunOutcomes.js'
+import { UsagePanel } from './UsagePanel.js'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card.js'
 import { cn } from '../lib/utils.js'
 
@@ -97,12 +98,7 @@ export function DashboardPage({ onSelectProject }: { onSelectProject: (id: strin
               </CardContent>
             </Card>
 
-            <Card className="border-dashed">
-              <CardContent className="flex items-center gap-3 text-sm text-muted-foreground">
-                <span className="font-medium text-foreground">Usage &amp; credits</span>
-                <span>Token usage and credit metering will appear here once runs report cost.</span>
-              </CardContent>
-            </Card>
+            <UsagePanel />
           </>
         )}
       </div>

--- a/packages/framework-dashboard/components/UsagePanel.tsx
+++ b/packages/framework-dashboard/components/UsagePanel.tsx
@@ -1,0 +1,146 @@
+import type { ConsumptionLimits, DriverQuotaWindow, LimitStatus, Preferences, QuotaView } from '@gemstack/framework'
+import { DEFAULT_CONSUMPTION_LIMITS } from '@gemstack/framework/client'
+import { useQuota } from '../lib/quota.js'
+import { usePreferences, updatePreferences } from '../lib/preferences.js'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card.js'
+import { cn } from '../lib/utils.js'
+
+// The usage panel (#519): what the account has left, and how much of it The Framework may
+// spend before it pauses itself. Two halves, because they answer different questions —
+// "am I about to run out?" (the account's own windows) and "will my agents stop?" (the limits).
+
+/** The three limits, in the order they bite: widest first. */
+const LIMITS: { key: keyof ConsumptionLimits; label: string; hint: string }[] = [
+  { key: 'daily', label: 'Daily', hint: 'How much of your week a single day may consume' },
+  { key: 'fiveHour', label: 'Last 5h', hint: "How much of the day's budget a rolling 5 hours may consume" },
+  { key: 'session', label: 'This session', hint: "How much of the day's budget one run may consume" },
+]
+
+function limitsOf(preferences: Preferences): ConsumptionLimits {
+  // Absent means the defaults, not off: a user who never opened this is still guarded.
+  return preferences.consumptionLimits ?? DEFAULT_CONSUMPTION_LIMITS
+}
+
+/** A bar, or an explicit "we don't know" — never an empty bar, which would read as "nothing used". */
+function Meter({ percent, muted }: { percent: number | undefined; muted?: boolean }) {
+  if (percent === undefined) return <div className="h-1.5 rounded-full bg-muted" />
+  return (
+    <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+      <div
+        className={cn('h-full rounded-full transition-all', muted ? 'bg-muted-foreground/40' : 'bg-primary')}
+        style={{ width: `${Math.max(percent, 1)}%` }}
+      />
+    </div>
+  )
+}
+
+function AccountWindow({ window }: { window: DriverQuotaWindow }) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline justify-between gap-2 text-sm">
+        <span className="font-medium text-foreground">{window.label}</span>
+        <span className="text-xs text-muted-foreground">
+          {window.percentUsed}% used{window.resetsAtText ? ` · resets ${window.resetsAtText}` : ''}
+        </span>
+      </div>
+      <Meter percent={window.percentUsed} />
+    </div>
+  )
+}
+
+function LimitRow({
+  label,
+  hint,
+  status,
+  percent,
+  onToggle,
+}: {
+  label: string
+  hint: string
+  status: LimitStatus
+  percent: number
+  onToggle: (enabled: boolean) => void
+}) {
+  return (
+    <div className={cn('space-y-1', !status.enabled && 'opacity-50')}>
+      <div className="flex items-baseline justify-between gap-2 text-sm">
+        <label className="flex cursor-pointer items-center gap-1.5" title={hint}>
+          <input type="checkbox" checked={status.enabled} onChange={e => onToggle(e.target.checked)} />
+          <span className="font-medium text-foreground">{label}</span>
+          <span className="text-xs text-muted-foreground">{percent}%</span>
+        </label>
+        <span className="text-xs text-muted-foreground">
+          {status.usedPercent === undefined
+            ? 'not measured yet'
+            : `${Math.round(status.usedPercent)}% of its budget${status.reached ? ' · paused' : ''}`}
+        </span>
+      </div>
+      <Meter percent={status.usedPercent} muted={!status.enabled} />
+      {status.consumed !== undefined && !status.complete && status.enabled ? (
+        // Say so rather than let a short window read as low usage.
+        <p className="text-xs text-muted-foreground">Counting from when the dashboard started, so this covers less than the full window.</p>
+      ) : null}
+    </div>
+  )
+}
+
+/** Why there's no reading, in words a user can act on. */
+function unavailableNote(view: QuotaView): string | undefined {
+  switch (view.unavailable) {
+    case undefined:
+      return undefined
+    case 'no-subscription':
+      return "This account has no subscription usage to report, so the limits don't apply."
+    case 'agent-not-found':
+      return 'Claude Code was not found, so usage cannot be read.'
+    case 'unrecognized':
+      return 'Claude Code reported its usage in a way this version does not recognize, so the limits are off.'
+    default:
+      return view.windows.length
+        ? "Couldn't refresh just now, so these numbers may be a little behind."
+        : 'Reading your usage now.'
+  }
+}
+
+export function UsagePanel() {
+  const view = useQuota()
+  const preferences = usePreferences()
+  const limits = limitsOf(preferences)
+
+  const setLimit = (key: keyof ConsumptionLimits, enabled: boolean): void => {
+    updatePreferences({ consumptionLimits: { ...limits, [key]: { ...limits[key], enabled } } })
+  }
+
+  const note = view ? unavailableNote(view) : undefined
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Usage</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {view?.windows.length ? (
+          <div className="space-y-3">{view.windows.map(w => <AccountWindow key={w.label} window={w} />)}</div>
+        ) : null}
+
+        {note ? <p className="text-sm text-muted-foreground">{note}</p> : null}
+
+        {view ? (
+          <div className="space-y-3 border-t pt-4">
+            <p className="text-xs text-muted-foreground">Pause my agents once they have used this much:</p>
+            {LIMITS.map(({ key, label, hint }) => (
+              <LimitRow
+                key={key}
+                label={label}
+                hint={hint}
+                status={view.limits[key]}
+                percent={limits[key].percent}
+                onToggle={enabled => setLimit(key, enabled)}
+              />
+            ))}
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}

--- a/packages/framework-dashboard/lib/quota.ts
+++ b/packages/framework-dashboard/lib/quota.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react'
+import type { QuotaView } from '@gemstack/framework'
+import { onQuota } from '../server/quota.telefunc.js'
+
+// The usage panel's data (#535). The daemon polls the agent for us and caches the answer,
+// so this only has to ask the daemon for what it already knows — cheap, unlike the read
+// behind it. Prerender has no daemon, so it starts empty and loads on the client.
+
+/** How often to ask the daemon for its cached reading. Cheap: no agent is spawned. */
+const REFRESH_MS = 30_000
+
+/**
+ * The account's quota and where the limits stand, refreshed while the panel is open.
+ *
+ * `undefined` until the first answer arrives. A failed call keeps the last view rather
+ * than blanking it: an empty bar reads as "nothing used".
+ */
+export function useQuota(): QuotaView | undefined {
+  const [view, setView] = useState<QuotaView | undefined>(undefined)
+
+  useEffect(() => {
+    let live = true
+    const load = (): void => {
+      void onQuota()
+        .then(next => {
+          if (live) setView(next)
+        })
+        .catch(() => {
+          // Keep whatever we last showed; the next tick may well succeed.
+        })
+    }
+    load()
+    const timer = setInterval(load, REFRESH_MS)
+    return () => {
+      live = false
+      clearInterval(timer)
+    }
+  }, [])
+
+  return view
+}

--- a/packages/framework-dashboard/server/quota.telefunc.ts
+++ b/packages/framework-dashboard/server/quota.telefunc.ts
@@ -1,0 +1,5 @@
+// Re-export shim (#535): the usage-panel telefunction lives in @gemstack/framework so the
+// daemon serves it in-process, off the poller it owns for its whole life. Keeping this file
+// at `server/quota.telefunc.ts` means the client bakes the RPC key `/server/quota.telefunc.ts`
+// — the exact key the daemon registers the impl under (see framework's dashboard-rpc/register.ts).
+export { onQuota } from '@gemstack/framework/dashboard-rpc'

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -19,6 +19,7 @@ export {
 } from './run-view.js'
 // The Start-a-run presets (#433): pure prompt builders (no Node imports) the dashboard
 // prefills into the textarea, then runs verbatim as a `prompt` kind.
+export { DEFAULT_CONSUMPTION_LIMITS } from './consumption.js'
 export { renderResearchPrompt } from './research-preset.js'
 export { renderReadabilityPrompt } from './readability-preset.js'
 export { renderMaintainabilityPrompt } from './maintainability-preset.js'

--- a/packages/framework/src/dashboard-rpc/index.ts
+++ b/packages/framework/src/dashboard-rpc/index.ts
@@ -7,4 +7,5 @@ export { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPrevie
 export { onEvents } from './events.telefunc.js'
 export { onProjects, sendAddProject } from './projects.telefunc.js'
 export { onPreferences, savePreferences, type SavePreferencesResult } from './preferences.telefunc.js'
+export { onQuota } from './quota.telefunc.js'
 export { registerDashboardTelefunctions, DASHBOARD_TELEFUNC_KEYS } from './register.js'


### PR DESCRIPTION
Closes #535. Your actual ask on #519: the checkbox and the progress bar. Replaces the dashboard's "Usage & credits" placeholder.

Two halves, because they answer different questions:

- **What the account has left** — the windows the agent reports (Current session, Current week), as in your Traycer screenshot.
- **What The Framework may spend** — the three limits, each with its checkbox and bar, and a note when one has paused a run.

### Worth a look

- **A reading we don't have is never an empty bar.** That reads as "nothing used", the one thing this panel must not imply. It says "not measured yet".
- **A short window says so.** If the dashboard only started an hour ago, the daily figure covers an hour, and the panel says that rather than passing off a short count as low usage.
- **The unavailable reasons are in words you can act on**: no subscription, Claude Code not found, or a readout this version doesn't recognize — not a silent empty card.

### Verification

Driven end-to-end against the real thing, not just built: started the dashboard, called `onQuota` over Telefunc, and got live numbers off my own subscription.

```
Current session      5% used · resets Jul 15 at 6:59pm
Current week (all)  25% used · resets Jul 18 at 6:59am
Current week (Fable) 15% used
limits: session budget 8 pts, 5h 12 pts, daily 20 pts
```

The first call (before the poller's ~5s read lands) correctly returns no windows and `undefined` consumption rather than zeroes.

**Remaining for #519:** just the resume, which is waiting on your read of the rolling-window point above.