### PR TITLE
feat(framework): drive Codex as a second agent (#539)

### DIFF
--- a/.changeset/codex-driver.md
+++ b/.changeset/codex-driver.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Add `CodexDriver`: The Framework can drive the Codex CLI as a second agent, on the user's own ChatGPT subscription with no API key. Generalizes the agent-CLI process handling into `runAgentCli` so a second agent reuses it rather than copying it. Codex reports no price and no quota, so it omits usage rather than claim a run was free, and the consumption limits stay Claude-only.

--- a/packages/framework/src/driver/claude-code.ts
+++ b/packages/framework/src/driver/claude-code.ts
@@ -188,7 +188,21 @@ export class ClaudeCodeSession implements DriverSession {
   }
 }
 
-interface RunClaudeOptions {
+/**
+ * The slice of a driver's output parser {@link runAgentCli} drives: fed one line
+ * at a time, asked for the turn at the end. Each wrapped agent speaks its own
+ * dialect ({@link StreamJsonParser} for Claude Code, `CodexJsonParser` for
+ * Codex), but the process handling around it is identical.
+ */
+export interface AgentCliParser {
+  /** Fold one line of the agent's output in, and surface anything worth emitting. */
+  push(line: string): DriverEvent[]
+  /** The turn the lines added up to. */
+  result(): DriverTurn
+}
+
+/** How to run one agent-CLI invocation. */
+export interface RunAgentCliOptions {
   bin: string
   args: string[]
   cwd: string
@@ -197,14 +211,35 @@ interface RunClaudeOptions {
   spawn: SpawnLike
   emit: (event: DriverEvent) => void
   signals: AbortSignal[]
+  /** The agent's own output dialect. */
+  parser: AgentCliParser
+  /** The agent's name, for error messages. Default `"claude-code"`. */
+  agent?: string
 }
+
+/** @deprecated Use {@link RunAgentCliOptions}. */
+export type RunClaudeOptions = Omit<RunAgentCliOptions, 'parser' | 'agent'>
 
 /** Spawn one Claude Code invocation and resolve with its final turn. */
 export function runClaude(opts: RunClaudeOptions): Promise<DriverTurn> {
+  return runAgentCli({ ...opts, parser: new StreamJsonParser() })
+}
+
+/**
+ * Spawn one agent-CLI invocation and resolve with its final turn.
+ *
+ * Everything here is about the *process*, not the agent: its own process group
+ * so an interrupt kills the whole tree rather than orphaning it, a SIGTERM/
+ * SIGKILL grace window, abort wiring, and a non-zero exit failing the turn even
+ * when text was streamed first. Only {@link RunAgentCliOptions.parser} knows
+ * which agent is on the other end — a second agent gets all of this for free
+ * rather than a second copy of it.
+ */
+export function runAgentCli(opts: RunAgentCliOptions): Promise<DriverTurn> {
   return new Promise<DriverTurn>((resolvePromise, rejectPromise) => {
     for (const s of opts.signals) {
       if (s.aborted) {
-        rejectPromise(new Error('[framework] claude-code prompt aborted'))
+        rejectPromise(new Error(`[framework] ${opts.agent ?? 'claude-code'} prompt aborted`))
         return
       }
     }
@@ -216,7 +251,8 @@ export function runClaude(opts: RunClaudeOptions): Promise<DriverTurn> {
     const child = opts.spawn(opts.bin, opts.args, { cwd: opts.cwd, env: opts.env, detached: true })
     const pid = child.pid
     if (pid != null) registerChild(pid)
-    const parser = new StreamJsonParser()
+    const parser = opts.parser
+    const agent = opts.agent ?? 'claude-code'
     let settled = false
     let hardKillTimer: ReturnType<typeof setTimeout> | undefined
     const stderrChunks: string[] = []
@@ -251,7 +287,7 @@ export function runClaude(opts: RunClaudeOptions): Promise<DriverTurn> {
       const handler = () => {
         if (settled) return
         terminate()
-        finish(() => rejectPromise(new Error('[framework] claude-code prompt aborted')))
+        finish(() => rejectPromise(new Error(`[framework] ${agent} prompt aborted`)))
       }
       signal.addEventListener('abort', handler)
       return { signal, handler }
@@ -281,7 +317,7 @@ export function runClaude(opts: RunClaudeOptions): Promise<DriverTurn> {
       if (code !== 0) {
         const detail = stderrChunks.join('').trim() || turn.text.trim() || `exit code ${code ?? 'null'}`
         opts.emit({ type: 'error', message: detail })
-        finish(() => rejectPromise(new Error(`[framework] claude-code exited (${code ?? 'null'}): ${detail}`)))
+        finish(() => rejectPromise(new Error(`[framework] ${agent} exited (${code ?? 'null'}): ${detail}`)))
         return
       }
       opts.emit({

--- a/packages/framework/src/driver/codex.test.ts
+++ b/packages/framework/src/driver/codex.test.ts
@@ -1,0 +1,138 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { Readable, Writable } from 'node:stream'
+import { CodexDriver, CodexJsonParser } from './codex.js'
+import type { SpawnLike, SpawnedProcess } from './claude-code.js'
+import type { Driver, DriverEvent } from './types.js'
+
+/** A real codex-cli 0.144.4 run, verbatim: "Create a file hello.txt containing exactly: hi". */
+const REAL_RUN = [
+  JSON.stringify({ type: 'thread.started', thread_id: '019f660b-bf69-7d62-a96c-34aad1f083db' }),
+  JSON.stringify({ type: 'turn.started' }),
+  JSON.stringify({ type: 'item.completed', item: { id: 'item_0', type: 'agent_message', text: 'I’ll create `hello.txt`.' } }),
+  JSON.stringify({ type: 'item.started', item: { id: 'item_1', type: 'file_change', status: 'in_progress' } }),
+  JSON.stringify({ type: 'item.completed', item: { id: 'item_1', type: 'file_change', status: 'completed' } }),
+  JSON.stringify({ type: 'item.completed', item: { id: 'item_2', type: 'agent_message', text: 'Created hello.txt' } }),
+  JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 12210, cached_input_tokens: 9984, output_tokens: 5 } }),
+]
+
+test('CodexJsonParser takes the last message as the turn (#539)', () => {
+  const p = new CodexJsonParser()
+  for (const line of REAL_RUN) p.push(line)
+  // Codex narrates as it goes; the last message is its answer, not the first.
+  assert.deepEqual(p.result(), { text: 'Created hello.txt', sessionId: '019f660b-bf69-7d62-a96c-34aad1f083db' })
+})
+
+test('CodexJsonParser streams text and surfaces tool kinds only (#539)', () => {
+  const p = new CodexJsonParser()
+  const events = REAL_RUN.flatMap(line => p.push(line))
+  assert.deepEqual(events, [
+    { type: 'text', text: 'I’ll create `hello.txt`.' },
+    { type: 'action', label: 'file_change' },
+    { type: 'text', text: 'Created hello.txt' },
+  ])
+})
+
+test('CodexJsonParser reports no usage rather than a free-looking zero (#539)', () => {
+  const p = new CodexJsonParser()
+  for (const line of REAL_RUN) p.push(line)
+  // Codex reports tokens but never a price. `costUsd: 0` would read as free.
+  assert.equal(p.result().usage, undefined)
+})
+
+test('CodexJsonParser ignores noise that is not an event (#539)', () => {
+  const p = new CodexJsonParser()
+  assert.deepEqual(p.push('Reading additional input from stdin...'), [])
+  assert.deepEqual(p.push(''), [])
+  assert.deepEqual(p.push(JSON.stringify({ type: 'turn.started' })), [])
+  assert.deepEqual(p.result(), { text: '' })
+})
+
+/** A fake process that emits the given lines then closes. */
+function fakeSpawn(lines: string[], onSpawn?: (args: readonly string[], stdin: string) => void, code = 0): SpawnLike {
+  return (_command, args) => {
+    const stdout = Readable.from([lines.map(l => l + '\n').join('')])
+    let written = ''
+    const stdin = new Writable({
+      write: (chunk, _e, cb) => {
+        written += String(chunk)
+        cb()
+      },
+    })
+    const proc: SpawnedProcess = {
+      stdout,
+      stderr: Readable.from([]),
+      stdin,
+      on(event, listener) {
+        if (event === 'close') stdout.on('end', () => (onSpawn?.(args, written), (listener as (c: number | null) => void)(code)))
+        return proc
+      },
+      kill: () => undefined,
+    }
+    return proc
+  }
+}
+
+test('CodexDriver runs a prompt through the CLI and returns the turn (#539)', async () => {
+  const events: DriverEvent[] = []
+  const driver = new CodexDriver({ spawn: fakeSpawn(REAL_RUN) })
+  const session = await driver.start({ cwd: '/ws', onEvent: e => events.push(e) })
+  const turn = await session.prompt('build it')
+  assert.equal(turn.text, 'Created hello.txt')
+  assert.equal(turn.sessionId, '019f660b-bf69-7d62-a96c-34aad1f083db')
+  assert.ok(events.some(e => e.type === 'action' && e.label === 'file_change'))
+  assert.ok(events.some(e => e.type === 'result'))
+})
+
+test('CodexDriver runs sandboxed in the workspace, never with the bypass (#539)', async () => {
+  let seen: readonly string[] = []
+  const driver = new CodexDriver({ spawn: fakeSpawn(REAL_RUN, args => (seen = args)) })
+  const session = await driver.start({ cwd: '/ws' })
+  await session.prompt('go')
+  assert.deepEqual([...seen], ['exec', '--json', '--skip-git-repo-check', '--sandbox', 'workspace-write', '-C', '/ws'])
+  // The agent may edit its workspace and nothing else.
+  assert.ok(!seen.includes('--dangerously-bypass-approvals-and-sandbox'))
+  // Codex refuses to run outside a git repo, and a fresh workspace isn't one yet.
+  assert.ok(seen.includes('--skip-git-repo-check'))
+})
+
+test('CodexDriver sends the prompt over stdin, not as an argument (#539)', async () => {
+  let stdin = ''
+  let seen: readonly string[] = []
+  const driver = new CodexDriver({ spawn: fakeSpawn(REAL_RUN, (args, written) => ((seen = args), (stdin = written))) })
+  const session = await driver.start({ cwd: '/ws' })
+  await session.prompt('a very long prompt')
+  // Over stdin so a long prompt never hits the arg-length limit.
+  assert.equal(stdin, 'a very long prompt')
+  assert.ok(!seen.includes('a very long prompt'))
+})
+
+test('CodexDriver prepends the framing, since Codex has no system-prompt flag (#539)', async () => {
+  let stdin = ''
+  const driver = new CodexDriver({ spawn: fakeSpawn(REAL_RUN, (_a, written) => (stdin = written)) })
+  const session = await driver.start({ cwd: '/ws', system: 'You are careful.' })
+  await session.prompt('do the thing', { system: 'Also: be brief.' })
+  assert.equal(stdin, 'You are careful.\n\nAlso: be brief.\n\ndo the thing')
+})
+
+test('CodexDriver passes the model through (#539)', async () => {
+  let seen: readonly string[] = []
+  const driver = new CodexDriver({ spawn: fakeSpawn(REAL_RUN, args => (seen = args)) })
+  const session = await driver.start({ cwd: '/ws', model: 'gpt-5-codex' })
+  await session.prompt('go')
+  assert.ok(seen.includes('-m') && seen.includes('gpt-5-codex'))
+})
+
+test('CodexDriver cannot report a quota, so it says so by omission (#539)', () => {
+  // The seam is optional precisely for this: no readQuota means no consumption
+  // limits for Codex, rather than a made-up number.
+  const driver: Driver = new CodexDriver()
+  assert.equal(driver.readQuota, undefined)
+})
+
+test('CodexDriver fails the turn on a non-zero exit (#539)', async () => {
+  const driver = new CodexDriver({ spawn: fakeSpawn(REAL_RUN, undefined, 1) })
+  const session = await driver.start({ cwd: '/ws' })
+  // A crash mid-build must not pass as a result, even though text streamed first.
+  await assert.rejects(() => session.prompt('go'), /codex exited \(1\)/)
+})

--- a/packages/framework/src/driver/codex.ts
+++ b/packages/framework/src/driver/codex.ts
@@ -1,0 +1,182 @@
+import { spawn as nodeSpawn } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { runAgentCli, type AgentCliParser, type SpawnLike } from './claude-code.js'
+import type { Driver, DriverEvent, DriverPromptOptions, DriverSession, DriverStartOptions, DriverTurn } from './types.js'
+
+/**
+ * Codex's sandbox policy for the shell commands the model writes.
+ * `workspace-write` is our default: the agent can edit the workspace it was
+ * pointed at, but not the rest of the machine. It is the counterpart of Claude
+ * Code's `acceptEdits`, and the reason we never pass Codex's
+ * `--dangerously-bypass-approvals-and-sandbox`.
+ */
+export type CodexSandbox = 'read-only' | 'workspace-write' | 'danger-full-access'
+
+/** Options for {@link CodexDriver}. */
+export interface CodexDriverOptions {
+  /** CLI binary to spawn. Default `"codex"` (resolved on `PATH`). */
+  bin?: string
+  /** Sandbox policy. Default `"workspace-write"`. */
+  sandbox?: CodexSandbox
+  /** Extra CLI args appended verbatim (escape hatch). */
+  extraArgs?: string[]
+  /** Environment for the child process. Default `process.env`. */
+  env?: NodeJS.ProcessEnv
+  /** `spawn` override for tests. Default `node:child_process.spawn`. */
+  spawn?: SpawnLike
+}
+
+/**
+ * The second real {@link Driver} (#539): wraps the **Codex CLI** in its
+ * non-interactive mode (`codex exec --json`), on the user's own ChatGPT
+ * subscription — no API key (#495's "bring your own subscription").
+ *
+ * The seam always said "Claude Code today, Codex later", and this is that. Same
+ * black box: prompt it, let its own loop run, read the code it wrote.
+ *
+ * Three ways it differs from Claude Code, all of them the agent's business
+ * rather than ours:
+ *
+ * - **No system-prompt flag.** Codex has no `--append-system-prompt`, so the
+ *   framing is prepended to the prompt instead. Same words reach the agent.
+ * - **No usage.** Codex reports token counts but never a price, and nothing
+ *   about the subscription's remaining quota. So it omits {@link DriverTurn.usage}
+ *   entirely rather than claim a run cost `$0`, which would read as free. The
+ *   budget cap (#322) and the consumption limits (#519) are Claude-only until
+ *   that's resolved (#540).
+ * - **No quota read.** No `readQuota`, for the same reason: the seam is optional
+ *   precisely so an agent that can't report one simply doesn't.
+ */
+export class CodexDriver implements Driver {
+  readonly name = 'codex'
+  constructor(private readonly opts: CodexDriverOptions = {}) {}
+
+  start(opts: DriverStartOptions): Promise<DriverSession> {
+    return Promise.resolve(new CodexSession(this.opts, opts))
+  }
+}
+
+let sessionCounter = 0
+
+/** One workspace-bound Codex session. `prompt` is a fresh CLI invocation. */
+export class CodexSession implements DriverSession {
+  readonly id: string
+  readonly cwd: string
+
+  constructor(
+    private readonly config: CodexDriverOptions,
+    private readonly startOpts: DriverStartOptions,
+  ) {
+    this.cwd = startOpts.cwd
+    this.id = `codex-${++sessionCounter}`
+  }
+
+  prompt(text: string, opts: DriverPromptOptions = {}): Promise<DriverTurn> {
+    // Codex takes no system-prompt flag, so the framing rides in front of the
+    // prompt. Blank-line separated, so it reads as its own block.
+    const framing = [this.startOpts.system, opts.system].filter(Boolean).join('\n\n')
+    const prompt = framing ? `${framing}\n\n${text}` : text
+    const emit = (event: DriverEvent) => {
+      const on = this.startOpts.onEvent
+      if (!on) return
+      try {
+        on(event)
+      } catch (err) {
+        console.error('[framework] codex onEvent threw; ignoring:', err)
+      }
+    }
+    const signals = [this.startOpts.signal, opts.signal].filter((s): s is AbortSignal => s != null)
+    return runAgentCli({
+      bin: this.config.bin ?? 'codex',
+      args: this.buildArgs(),
+      cwd: this.cwd,
+      env: this.config.env ?? process.env,
+      prompt,
+      spawn: this.config.spawn ?? (nodeSpawn as unknown as SpawnLike),
+      emit,
+      signals,
+      parser: new CodexJsonParser(),
+      agent: 'codex',
+    })
+  }
+
+  async readCode(path: string): Promise<string> {
+    return readFile(resolve(this.cwd, path), 'utf8')
+  }
+
+  dispose(): Promise<void> {
+    // Each prompt spawns and reaps its own process; nothing durable to free.
+    return Promise.resolve()
+  }
+
+  private buildArgs(): string[] {
+    // No prompt argument: it goes over stdin, so a long one never hits the
+    // arg-length limit. `--skip-git-repo-check` because Codex otherwise refuses
+    // to run outside a git repo, and a workspace may legitimately not be one yet.
+    const args = ['exec', '--json', '--skip-git-repo-check', '--sandbox', this.config.sandbox ?? 'workspace-write', '-C', this.cwd]
+    if (this.startOpts.model) args.push('-m', this.startOpts.model)
+    if (this.config.extraArgs) args.push(...this.config.extraArgs)
+    return args
+  }
+}
+
+/**
+ * Parses Codex's `exec --json` output: one JSON event per line.
+ *
+ * The dialect, as observed on codex-cli 0.144.4:
+ * ```
+ * {"type":"thread.started","thread_id":"019f..."}
+ * {"type":"turn.started"}
+ * {"type":"item.completed","item":{"type":"agent_message","text":"..."}}
+ * {"type":"item.started","item":{"type":"file_change","status":"in_progress"}}
+ * {"type":"turn.completed","usage":{"input_tokens":12210,"output_tokens":5}}
+ * ```
+ */
+export class CodexJsonParser implements AgentCliParser {
+  private text = ''
+  private sessionId: string | undefined
+
+  push(line: string): DriverEvent[] {
+    let obj: Record<string, unknown>
+    try {
+      obj = JSON.parse(line) as Record<string, unknown>
+    } catch {
+      return [] // Banners and other noise: not every line is an event.
+    }
+    const type = obj['type']
+
+    if (type === 'thread.started') {
+      const id = obj['thread_id']
+      if (typeof id === 'string') this.sessionId = id
+      return []
+    }
+
+    const item = obj['item']
+    if (typeof item !== 'object' || item === null) return []
+    const itemObj = item as Record<string, unknown>
+    const itemType = itemObj['type']
+
+    if (itemType === 'agent_message' && type === 'item.completed') {
+      const text = itemObj['text']
+      if (typeof text !== 'string') return []
+      // Codex narrates in several messages; the last is its answer, and the
+      // rest are progress. Keep the last as the turn, stream them all.
+      this.text = text
+      return [{ type: 'text', text }]
+    }
+
+    // Any other item is the agent using a tool. We surface the kind only, never
+    // the arguments: the seam is the code and the outcome, not the tool calls.
+    if (type === 'item.started' && typeof itemType === 'string') {
+      return [{ type: 'action', label: itemType }]
+    }
+    return []
+  }
+
+  result(): DriverTurn {
+    // No `usage`, deliberately: Codex reports tokens but no price, and a `$0`
+    // would read as free rather than as "we don't know" (#540).
+    return { text: this.text, ...(this.sessionId ? { sessionId: this.sessionId } : {}) }
+  }
+}

--- a/packages/framework/src/driver/index.ts
+++ b/packages/framework/src/driver/index.ts
@@ -14,6 +14,7 @@ export type {
 export { isTransientQuotaReason } from './types.js'
 export { readClaudeQuota, parseQuotaReadout, type ReadClaudeQuotaOptions } from './claude-code-quota.js'
 export { FakeDriver, FakeDriverSession, type FakeTurn, type FakeDriverOptions } from './fake.js'
+export { CodexDriver, CodexSession, CodexJsonParser, type CodexDriverOptions, type CodexSandbox } from './codex.js'
 export {
   ClaudeCodeDriver,
   ClaudeCodeSession,
@@ -24,4 +25,7 @@ export {
   type PermissionMode,
   type SpawnLike,
   type SpawnedProcess,
+  runAgentCli,
+  type AgentCliParser,
+  type RunAgentCliOptions,
 } from './claude-code.js'


### PR DESCRIPTION
Closes #539. The first real BYOS win (#495): The Framework drives an agent other than Claude Code, on the subscription the user already pays for.

The seam always said "Claude Code today, Codex / opencode later", so there was nothing new to design.

### The refactor

`runClaude`'s body becomes `runAgentCli`, taking the output parser as a seam. The subtle part is all process handling: its own process group so an interrupt kills the tree rather than orphaning it, the SIGTERM/SIGKILL grace window, the abort wiring, a non-zero exit failing the turn even when text streamed first. A second agent should inherit that rather than grow a second copy — that duplication is exactly what bit us between `run.ts` and `prompt-run.ts`.

### Three ways Codex differs, all the agent's business rather than ours

- **No system-prompt flag.** No `--append-system-prompt`, so the framing is prepended to the prompt.
- **No price.** Codex reports tokens but never a cost, so the turn **omits usage entirely** rather than claim it cost `$0`, which reads as *free* rather than as "we don't know". So the spend cap can't gate a Codex run until #540.
- **No quota.** No `readQuota`, so no consumption limits. The seam is optional for exactly this reason.

Never `--dangerously-bypass-approvals-and-sandbox`: `workspace-write` lets it edit the workspace it was given and nothing else, the counterpart of Claude Code's `acceptEdits`. There's a test asserting the bypass isn't in the args.

### Verification

11 new tests (573 total, 0 failing, typecheck clean) off a real recorded run, plus driven against the real CLI with no `OPENAI_API_KEY`:

```
events     : start text action:file_change action:command_execution text result
sessionId  : 019f6616-8467-7222-8281-2a66744fe9c2
usage      : undefined
file wrote : "hello from codex\n"
readCode() : "hello from codex\n"
```

`command_execution` is an item kind I never saw while probing — the parser surfaces any kind generically rather than matching a fixed list, so it came through instead of vanishing.

**Not in scope:** letting the user pick the agent (no `--agent` flag yet). And Gemini is out: Google switched its CLI off for individuals on 18 June, so the third agent is their Antigravity CLI whenever we get to it.