### PR TITLE
feat(framework): pick the agent that drives a run with `--agent`

### DIFF
--- a/.changeset/agent-flag.md
+++ b/.changeset/agent-flag.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/framework': minor
+---
+
+Add `--agent claude|codex`, which picks the agent that drives a run. The Codex driver shipped but nothing selected it, so it was unreachable; now both driver paths (the build itself and the auto-select routing turn before it) honor the flag, and preflight probes the agent you asked for rather than always `claude`. Default stays `claude`.
+
+Codex reports no price and no quota, so the spend cap and the consumption limits cannot gate it and previously would have no-opped in silence. A run now says which guards are not in force instead of letting `--max-cost` imply one, and it no longer offers a Claude Code session link for a session that isn't Claude's.

--- a/packages/framework/src/agent.ts
+++ b/packages/framework/src/agent.ts
@@ -1,0 +1,75 @@
+import { ClaudeCodeDriver, CodexDriver, type ClaudeCodeDriverOptions, type Driver } from './driver/index.js'
+
+/**
+ * Which agent drives a run (#542). Each is a whole coding-agent CLI the user
+ * already pays for, driven on their own subscription with no API key (#495).
+ *
+ * This is the table `--agent` picks from: adding the third agent is one entry
+ * here plus its driver, not another branch at every call site.
+ */
+export const AGENTS = ['claude', 'codex'] as const
+
+/** An agent `--agent` can name. */
+export type AgentName = (typeof AGENTS)[number]
+
+/** Whether `value` names an agent we can drive. */
+export function isAgentName(value: string | undefined): value is AgentName {
+  return value !== undefined && (AGENTS as readonly string[]).includes(value)
+}
+
+/** What we know about an agent before we run it. */
+export interface AgentSpec {
+  /** How to say it in a sentence, e.g. "Claude Code". */
+  label: string
+  /** The CLI binary, resolved on PATH. */
+  bin: string
+  /** Shown when preflight cannot find {@link bin}. */
+  installHint: string
+  /**
+   * Whether the agent prices its own turns. When it doesn't, the spend cap
+   * (#322) has no number to gate on and silently never fires, so the CLI says
+   * so instead of implying a guard that isn't there (#540).
+   */
+  reportsCost: boolean
+}
+
+/** The agents we can drive, and what each can tell us about itself. */
+export const AGENT_SPECS: Record<AgentName, AgentSpec> = {
+  claude: {
+    label: 'Claude Code',
+    bin: 'claude',
+    installHint: 'install Claude Code and make sure `claude` is on your PATH: https://claude.com/claude-code',
+    reportsCost: true,
+  },
+  codex: {
+    label: 'Codex',
+    bin: 'codex',
+    installHint: 'install the Codex CLI and make sure `codex` is on your PATH: https://developers.openai.com/codex/cli',
+    reportsCost: false,
+  },
+}
+
+/** Options for {@link createDriver}. */
+export interface CreateDriverOptions {
+  agent: AgentName
+  /** Claude Code driver options. Ignored by any other agent, which has its own. */
+  claudeOpts?: ClaudeCodeDriverOptions
+}
+
+/**
+ * Build the {@link Driver} for the picked agent — the one place a run path turns
+ * `--agent` into a real agent.
+ *
+ * Codex takes none of the Claude options: its sandbox is its own flag rather
+ * than a permission mode, and it has no MCP config for `--browser`. Those are
+ * dropped here and reported at the call site, so a flag that cannot apply says
+ * so rather than looking honored.
+ */
+export function createDriver(opts: CreateDriverOptions): Driver {
+  switch (opts.agent) {
+    case 'codex':
+      return new CodexDriver()
+    case 'claude':
+      return new ClaudeCodeDriver(opts.claudeOpts ?? {})
+  }
+}

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -25,12 +25,14 @@ import {
   runLogKind,
   runPostMergeSuite,
   POST_MERGE_PASSES,
+  unguardedNotices,
   withBrowser,
   BROWSER_MCP_SERVERS,
   workspaceSummary,
   type CliIO,
 } from './cli.js'
 import { readLogs } from './logs.js'
+import { createDriver } from './agent.js'
 import { FakeDriver } from './driver/index.js'
 import type { FrameworkEvent } from './events.js'
 
@@ -254,6 +256,42 @@ test('parseArgs flags unknown options and bad values', () => {
   assert.match(parseArgs(['--max-cost', '0']).error!, /max-cost/)
   assert.match(parseArgs(['--max-cost', 'abc']).error!, /max-cost/)
   assert.match(parseArgs(['--permission-mode', 'wat']).error!, /permission-mode/)
+  assert.match(parseArgs(['--agent', 'gemini']).error!, /invalid --agent/)
+  assert.match(parseArgs(['--agent']).error!, /invalid --agent/)
+})
+
+test('parseArgs reads --agent, defaulting to claude (#542)', () => {
+  assert.equal(parseArgs(['x']).agent, 'claude')
+  assert.equal(parseArgs(['--agent', 'claude', 'x']).agent, 'claude')
+  assert.equal(parseArgs(['--agent', 'codex', 'x']).agent, 'codex')
+})
+
+test('createDriver builds the agent --agent picked (#542)', () => {
+  assert.equal(createDriver({ agent: 'claude' }).name, 'claude-code')
+  assert.equal(createDriver({ agent: 'codex' }).name, 'codex')
+})
+
+test('unguardedNotices says --max-cost cannot gate an agent with no price (#542/#540)', () => {
+  // The whole point: the cap is only checked on a turn that reports a price, so
+  // on Codex it silently never fires. Saying nothing would read as capped.
+  const notes = unguardedNotices({ agent: 'codex', maxCost: 5, browser: false, permissionMode: undefined, skipPermissions: false })
+  assert.equal(notes.length, 1)
+  assert.match(notes[0]!, /--max-cost \$5 cannot be enforced/)
+  assert.match(notes[0]!, /Codex/)
+})
+
+test('unguardedNotices is silent when the guards really do apply (#542)', () => {
+  const claude = unguardedNotices({ agent: 'claude', maxCost: 5, browser: true, permissionMode: 'plan', skipPermissions: true })
+  assert.deepEqual(claude, [])
+  const noFlags = unguardedNotices({ agent: 'codex', browser: false, permissionMode: undefined, skipPermissions: false })
+  assert.deepEqual(noFlags, [])
+})
+
+test('unguardedNotices flags the Claude-only flags on another agent (#542)', () => {
+  const notes = unguardedNotices({ agent: 'codex', browser: true, permissionMode: 'plan', skipPermissions: false })
+  assert.equal(notes.length, 2)
+  assert.match(notes[0]!, /--browser has no effect/)
+  assert.match(notes[1]!, /--permission-mode/)
 })
 
 test('parseArgs reads --max-cost as a positive USD budget (#322)', () => {
@@ -467,16 +505,22 @@ test('runCli notes --sandbox docker given without --serve (#229)', async () => {
 })
 
 test('chooseSessionLink defaults a live run to the claude.ai/code session list (#212)', () => {
-  assert.equal(chooseSessionLink({ sessionLink: undefined }, false), CLAUDE_CODE_SESSION_LIST)
+  assert.equal(chooseSessionLink({ sessionLink: undefined, agent: 'claude' }, false), CLAUDE_CODE_SESSION_LIST)
   assert.equal(CLAUDE_CODE_SESSION_LIST, 'https://claude.ai/code')
 })
 
 test('chooseSessionLink honors an explicit --session-link over the default', () => {
-  assert.equal(chooseSessionLink({ sessionLink: 'https://x/s/{sessionId}' }, false), 'https://x/s/{sessionId}')
+  assert.equal(chooseSessionLink({ sessionLink: 'https://x/s/{sessionId}', agent: 'claude' }, false), 'https://x/s/{sessionId}')
+  // An explicit link is the user's own, so it stands whatever agent runs.
+  assert.equal(chooseSessionLink({ sessionLink: 'https://x/s/{sessionId}', agent: 'codex' }, false), 'https://x/s/{sessionId}')
 })
 
 test('chooseSessionLink gives no link for a fake run (no real session)', () => {
-  assert.equal(chooseSessionLink({ sessionLink: undefined }, true), undefined)
+  assert.equal(chooseSessionLink({ sessionLink: undefined, agent: 'claude' }, true), undefined)
+})
+
+test('chooseSessionLink does not point a non-Claude session at claude.ai (#542)', () => {
+  assert.equal(chooseSessionLink({ sessionLink: undefined, agent: 'codex' }, false), undefined)
 })
 
 test('runCli --help prints usage and exits 0', async () => {
@@ -559,8 +603,17 @@ test('runCli doctor reports checks and exits by their outcome', async () => {
   const code = await runCli(['doctor'], io)
   const text = out.join('\n')
   assert.match(text, /node:/)
-  assert.match(text, /claude-code:/)
+  assert.match(text, /claude:/)
   assert.ok(code === 0 || code === 1) // depends on whether claude is installed here
+})
+
+test('runCli doctor checks the agent you asked for (#542)', async () => {
+  const { io, out } = capture()
+  const code = await runCli(['doctor', '--agent', 'codex'], io)
+  const text = out.join('\n')
+  assert.match(text, /codex:/)
+  assert.doesNotMatch(text, /claude:/)
+  assert.ok(code === 0 || code === 1) // depends on whether codex is installed here
 })
 
 test('runCli --fake skips preflight (offline never needs the agent CLI)', async () => {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -14,7 +14,8 @@ import {
   type DomainPreset,
   type FrameworkSignals,
 } from '@gemstack/ai-autopilot'
-import { ClaudeCodeDriver, type ClaudeCodeDriverOptions, type Driver, type DriverSession, type McpServerSpec, type PermissionMode } from './driver/index.js'
+import { type ClaudeCodeDriverOptions, type Driver, type DriverSession, type McpServerSpec, type PermissionMode } from './driver/index.js'
+import { AGENTS, AGENT_SPECS, createDriver, isAgentName, type AgentName } from './agent.js'
 import { hostExecutor } from './host-exec.js'
 import { startDashboard, singleProjectProvider, resolveDashboardBundle, type Dashboard } from './dashboard/index.js'
 import { startRelay, relayPublisher, type RelayPublisher } from './relay.js'
@@ -74,10 +75,15 @@ export const CLAUDE_CODE_SESSION_LIST = CLAUDE_CODE_SESSION_LINK
  * The session link to show for a run: the user's `--session-link` if given, else
  * the generic Claude Code entry point for a live run (nothing for `--fake`, which
  * has no real session). Pure, so the default is unit-testable without a live run.
+ *
+ * The default is Claude Code's *own* entry point, so it is only honest on a
+ * Claude run: pointing a Codex session at claude.ai/code offers the user a link
+ * to somewhere their run isn't. Codex keeps its sessions locally with nothing
+ * equivalent to open, so another agent gets no default link at all (#542).
  */
-export function chooseSessionLink(opts: Pick<CliOptions, 'sessionLink'>, fake: boolean): string | undefined {
+export function chooseSessionLink(opts: Pick<CliOptions, 'sessionLink' | 'agent'>, fake: boolean): string | undefined {
   if (opts.sessionLink) return opts.sessionLink
-  return fake ? undefined : CLAUDE_CODE_SESSION_LIST
+  return fake || opts.agent !== 'claude' ? undefined : CLAUDE_CODE_SESSION_LIST
 }
 
 /** Where the CLI writes. Injectable so tests capture output. */
@@ -110,7 +116,7 @@ export function frameworkVersion(): string {
   return cachedVersion
 }
 
-const HELP = `The Framework — turnkey AI orchestration that wraps a coding agent (Claude Code).
+const HELP = `The Framework — turnkey AI orchestration that wraps a coding agent (Claude Code or Codex).
 
 Usage:
   framework                       Run the dashboard in the foreground (Ctrl+C stops it; logs visible).
@@ -132,6 +138,10 @@ Usage:
 
 Options:
   --fake                 Use the fake driver + scripted run (offline / CI).
+  --agent <claude|codex> Which agent CLI drives the run, on your own subscription
+                         (default: claude). Codex reports no price and no quota,
+                         so --max-cost and the consumption limits cannot gate it;
+                         the run says so at startup rather than imply a guard.
   --cwd <dir>            Workspace the agent builds in (default: current directory).
   --model <id>           Model to pass through to the wrapped agent.
   --scope <prototype|full>   How much app to build (default: full).
@@ -224,6 +234,8 @@ export interface CliOptions {
   doctor: boolean
   skipPreflight: boolean
   intent: string
+  /** `--agent <claude|codex>`: which agent CLI drives the run (#542). Default `claude`. */
+  agent: AgentName
   cwd?: string | undefined
   model?: string | undefined
   scope: 'prototype' | 'full'
@@ -296,6 +308,7 @@ export function parseArgs(argv: string[]): CliOptions {
     doctor: false,
     skipPreflight: false,
     intent: '',
+    agent: 'claude',
     scope: 'full',
     autoPreset: true,
     autopilot: false,
@@ -410,6 +423,12 @@ export function parseArgs(argv: string[]): CliOptions {
         } else {
           opts.permissionMode = value
         }
+        break
+      }
+      case '--agent': {
+        const value = argv[++i]
+        if (!isAgentName(value)) opts.error = `invalid --agent: ${value ?? '(missing)'}. Expected: ${AGENTS.join(' | ')}`
+        else opts.agent = value
         break
       }
       case '--cwd':
@@ -563,6 +582,34 @@ export function withBrowser(base: ClaudeCodeDriverOptions, browser: boolean): Cl
   return { ...base, mcpServers: { ...base.mcpServers, ...BROWSER_MCP_SERVERS } }
 }
 
+/**
+ * The flags the picked agent cannot honor (#542), as lines to print at startup.
+ *
+ * A flag that silently does nothing is worse than one that errors. `--agent
+ * codex --max-cost 5` reads as capped and isn't: the cap is only ever checked on
+ * a turn that reports a price, and Codex reports none (#540). The consumption
+ * limits go the same way — no quota to read means no gate. So the run says which
+ * guards are not in force, rather than letting the flag imply they are.
+ */
+export function unguardedNotices(
+  opts: Pick<CliOptions, 'agent' | 'maxCost' | 'browser' | 'permissionMode' | 'skipPermissions'>,
+): string[] {
+  const spec = AGENT_SPECS[opts.agent]
+  const notices: string[] = []
+  if (opts.maxCost != null && !spec.reportsCost) {
+    notices.push(`--max-cost $${opts.maxCost} cannot be enforced: ${spec.label} reports no price per turn, so the spend cap never fires (#540).`)
+  }
+  if (opts.agent !== 'claude') {
+    if (opts.browser) {
+      notices.push(`--browser has no effect on ${spec.label}: the browser tools are wired through Claude Code's MCP config.`)
+    }
+    if (opts.permissionMode !== undefined || opts.skipPermissions) {
+      notices.push(`--permission-mode / --dangerously-skip-permissions have no effect on ${spec.label}: it sandboxes with its own policy (workspace-write).`)
+    }
+  }
+  return notices
+}
+
 /** The active Open Loop modes from the mode flags, in a stable order. */
 export function activeModes(opts: Pick<CliOptions, 'autopilot' | 'technical'>): string[] {
   const modes: string[] = []
@@ -686,17 +733,22 @@ export async function autoSelectPreset(opts: {
   cwd: string
   signals: FrameworkSignals
   claudeOpts: ClaudeCodeDriverOptions
+  /** The agent to route through (#542). Default `claude`. */
+  agent?: AgentName
   signal?: AbortSignal
   io: CliIO
-  /** The driver to route the pick through. Defaults to a Claude Code driver; injected in tests. */
+  /** The driver to route the pick through. Defaults to the picked agent's; injected in tests. */
   driver?: Driver
   /** Narrate the routing turn to the dashboard + terminal (#310), so it isn't a blank while the pick runs. */
   onEvent?: (event: FrameworkEvent) => void
 }): Promise<MetaSelection | undefined> {
   const catalog = presetCatalog(await builtinDomainPresets())
   if (catalog.length === 0) return undefined
-  const driver = opts.driver ?? new ClaudeCodeDriver(opts.claudeOpts)
-  // The routing turn is a real Claude turn that emits no run events, so without
+  // The routing turn runs on the same agent as the build (#542) — picking a preset
+  // with one agent and building with another would be a surprise, and it would
+  // silently need Claude installed for an `--agent codex` run.
+  const driver = opts.driver ?? createDriver({ agent: opts.agent ?? 'claude', claudeOpts: opts.claudeOpts })
+  // The routing turn is a real agent turn that emits no run events, so without
   // this the dashboard sits blank for its first few seconds (#310).
   opts.onEvent?.({ kind: 'log', message: '◆ auto-selecting the best-fit preset from your prompt + workspace…' })
   let session: DriverSession | undefined
@@ -741,7 +793,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     return 0
   }
   if (opts.doctor) {
-    const result = await preflight()
+    const result = await preflight({ agent: opts.agent })
     for (const check of result.checks) io.out(`${check.ok ? '✓' : '✗'} ${check.name}: ${check.detail}`)
     io.out(result.ok ? '\nAll good. You are ready to build.' : '\nSome checks failed. Fix them, then try again.')
     return result.ok ? 0 : 1
@@ -823,12 +875,21 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // Fail early and clearly if a live run's prerequisites are missing — before
   // auto-select and the run, which both need the wrapped agent.
   if (!fake && !opts.skipPreflight) {
-    const pre = await preflight()
+    const pre = await preflight({ agent: opts.agent })
     if (!pre.ok) {
       for (const check of pre.checks.filter(c => !c.ok)) io.err(`✗ ${check.name}: ${check.detail}`)
       io.err('Preflight failed. Fix the above, or pass --skip-preflight, or try `framework --fake`.')
       return 2
     }
+  }
+
+  // Which agent is about to spend the user's subscription, and which guards are
+  // not in force while it does — said *before* the first turn (the auto-select
+  // one below is already a real, billed turn). A cap that turns out not to apply
+  // is worth knowing before the spending, not after (#542).
+  if (!fake) {
+    if (opts.agent !== 'claude') io.out(`◆ agent: ${AGENT_SPECS[opts.agent].label}`)
+    for (const note of unguardedNotices(opts)) io.err(`note: ${note}`)
   }
 
   const claudeOpts = claudeDriverOptions(opts)
@@ -1003,7 +1064,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // build event) from the intent + workspace, then resolve it with the active modes.
   // Narrates through onEvent so the routing turn is visible on the dashboard (#310).
   if (!fake && opts.autoPreset && !presetName && !opts.research && !opts.directPrompt) {
-    const selection = await autoSelectPreset({ intent, cwd, signals, claudeOpts, signal: controller.signal, io, onEvent })
+    const selection = await autoSelectPreset({ intent, cwd, signals, claudeOpts, agent: opts.agent, signal: controller.signal, io, onEvent })
     if (selection?.preset) {
       presetName = selection.preset
       modeList = [...new Set([...modeList, ...selection.modes])]
@@ -1032,15 +1093,18 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     io.err(`note: --sandbox docker has no effect without --serve.`)
   }
 
-  const driver: Driver = fake ? fakeDriver() : new ClaudeCodeDriver(withBrowser(claudeOpts, opts.browser))
+  const driver: Driver = fake ? fakeDriver() : createDriver({ agent: opts.agent, claudeOpts: withBrowser(claudeOpts, opts.browser) })
 
   // The consumption limits (#519/#531). Read from the user's own file rather than
   // taken as a flag: unlike autopilot or eco, a limit is not a per-run choice, so
   // a run started from a terminal is guarded exactly like one started from the
-  // dashboard. `undefined` when the agent can't report a quota (the fake driver),
-  // which leaves the run ungated — the fail-open Rom confirmed.
+  // dashboard. `undefined` when the agent can't report a quota (the fake driver,
+  // or Codex), which leaves the run ungated — the fail-open Rom confirmed.
   const guard = startConsumptionGuard({ driver, limits: resolveConsumptionLimits(await readPreferences()) })
   if (guard) io.out('◆ consumption limits: on')
+  else if (!fake) {
+    io.out(`◆ consumption limits: off — ${AGENT_SPECS[opts.agent].label} reports no quota, so nothing gates your subscription spend.`)
+  }
 
   // `framework research [what]` (#331) and `framework prompt <text>` (#353): the
   // direct prompt path — run one prompt through runPrompt, which honors its gates

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -351,3 +351,12 @@ export {
   FAKE_SIGNALS,
   FAKE_DEPLOY,
 } from './fake-script.js'
+export {
+  AGENTS,
+  AGENT_SPECS,
+  createDriver,
+  isAgentName,
+  type AgentName,
+  type AgentSpec,
+  type CreateDriverOptions,
+} from './agent.js'

--- a/packages/framework/src/preflight.test.ts
+++ b/packages/framework/src/preflight.test.ts
@@ -5,7 +5,7 @@ import { preflight } from './preflight.js'
 test('preflight passes when the agent CLI is present', async () => {
   const result = await preflight({ probe: () => Promise.resolve({ ok: true, stdout: '1.2.3 (Claude Code)' }) })
   assert.equal(result.ok, true)
-  const cc = result.checks.find(c => c.name === 'claude-code')
+  const cc = result.checks.find(c => c.name === 'claude')
   assert.equal(cc?.ok, true)
   assert.match(cc!.detail, /1\.2\.3/)
 })
@@ -13,10 +13,34 @@ test('preflight passes when the agent CLI is present', async () => {
 test('preflight fails with install guidance when the agent CLI is missing', async () => {
   const result = await preflight({ bin: 'claude', probe: () => Promise.resolve({ ok: false, stdout: '' }) })
   assert.equal(result.ok, false)
-  const cc = result.checks.find(c => c.name === 'claude-code')
+  const cc = result.checks.find(c => c.name === 'claude')
   assert.equal(cc?.ok, false)
   assert.match(cc!.detail, /not found/)
   assert.match(cc!.detail, /claude\.com\/claude-code/)
+})
+
+test('preflight probes the picked agent, not always claude (#542)', async () => {
+  const probed: string[] = []
+  const result = await preflight({
+    agent: 'codex',
+    probe: bin => {
+      probed.push(bin)
+      return Promise.resolve({ ok: true, stdout: 'codex-cli 0.144.4' })
+    },
+  })
+  assert.deepEqual(probed, ['codex'])
+  assert.equal(result.ok, true)
+  const cli = result.checks.find(c => c.name === 'codex')
+  assert.match(cli!.detail, /0\.144\.4/)
+})
+
+test('a missing codex points at the codex install, not the claude one (#542)', async () => {
+  const result = await preflight({ agent: 'codex', probe: () => Promise.resolve({ ok: false, stdout: '' }) })
+  assert.equal(result.ok, false)
+  const cli = result.checks.find(c => c.name === 'codex')
+  assert.equal(cli?.ok, false)
+  assert.match(cli!.detail, /`codex` not found/)
+  assert.match(cli!.detail, /openai\.com\/codex/)
 })
 
 test('preflight always reports the node version', async () => {

--- a/packages/framework/src/preflight.ts
+++ b/packages/framework/src/preflight.ts
@@ -1,10 +1,14 @@
 import { execFile } from 'node:child_process'
+import { AGENT_SPECS, type AgentName } from './agent.js'
 
 /**
  * Preflight checks for a live run. A turnkey tool should fail *early and
  * clearly* when a prerequisite is missing, not spawn a broken process mid-run.
- * The main one: is the wrapped agent's CLI (Claude Code) actually installed and
- * runnable? `--fake` needs none of this, so preflight only gates live runs.
+ * The main one: is the wrapped agent's CLI actually installed and runnable?
+ * `--fake` needs none of this, so preflight only gates live runs.
+ *
+ * It probes the agent the run actually picked (#542), so `--agent codex` is
+ * checked against `codex` and fails on `codex` being missing, not `claude`.
  */
 
 /** One preflight check's outcome. */
@@ -24,8 +28,6 @@ export interface PreflightResult {
 /** Probe a binary for a version string. Injectable so tests need no real CLI. */
 export type VersionProbe = (bin: string) => Promise<{ ok: boolean; stdout: string }>
 
-const CLAUDE_INSTALL_HINT = 'install Claude Code and make sure `claude` is on your PATH: https://claude.com/claude-code'
-
 function defaultProbe(bin: string): Promise<{ ok: boolean; stdout: string }> {
   return new Promise(resolvePromise => {
     execFile(bin, ['--version'], { timeout: 10_000 }, (err, stdout) => {
@@ -36,26 +38,30 @@ function defaultProbe(bin: string): Promise<{ ok: boolean; stdout: string }> {
 
 /** Options for {@link preflight}. */
 export interface PreflightOptions {
-  /** The agent CLI binary to probe. Default `"claude"`. */
+  /** The agent to check for. Default `"claude"`. */
+  agent?: AgentName
+  /** The CLI binary to probe. Default the agent's own. */
   bin?: string
   /** Version probe override (tests). Default runs `<bin> --version`. */
   probe?: VersionProbe
 }
 
 /**
- * Run the preflight checks: Node is implicit (we are running), and the wrapped
- * agent CLI must be installed. Returns every check plus an overall `ok`.
+ * Run the preflight checks: Node is implicit (we are running), and the picked
+ * agent's CLI must be installed. Returns every check plus an overall `ok`.
  */
 export async function preflight(opts: PreflightOptions = {}): Promise<PreflightResult> {
-  const bin = opts.bin ?? 'claude'
+  const agent = opts.agent ?? 'claude'
+  const spec = AGENT_SPECS[agent]
+  const bin = opts.bin ?? spec.bin
   const probe = opts.probe ?? defaultProbe
   const checks: PreflightCheck[] = [{ name: 'node', ok: true, detail: process.version }]
 
-  const cc = await probe(bin)
+  const cli = await probe(bin)
   checks.push(
-    cc.ok
-      ? { name: 'claude-code', ok: true, detail: cc.stdout.trim() || 'installed' }
-      : { name: 'claude-code', ok: false, detail: `\`${bin}\` not found — ${CLAUDE_INSTALL_HINT}` },
+    cli.ok
+      ? { name: agent, ok: true, detail: cli.stdout.trim() || 'installed' }
+      : { name: agent, ok: false, detail: `\`${bin}\` not found — ${spec.installHint}` },
   )
 
   return { ok: checks.every(c => c.ok), checks }


### PR DESCRIPTION
Closes #542.

The Codex driver merged in #539 but nothing selected it, so it was unreachable. `--agent claude|codex` picks it. Default stays `claude`, so nothing changes unless you pass it.

- Both driver paths honor it: the build, and the auto-select routing turn before it. That routing turn is a real billed turn, and it would otherwise have needed Claude installed just to start an `--agent codex` run.
- Preflight probes the agent you asked for, so a missing `codex` fails early and points at the codex install rather than the claude one.
- New `agent.ts` holds the table: name -> binary, install hint, driver. The third agent is one entry there, not a branch at each call site.

## The part that isn't cosmetic

Codex reports no price and no quota, so the spend cap (#322) and the consumption limits (#519) cannot gate it, and both no-opped **in silence**. `--agent codex --max-cost 5` read as capped and wasn't. The run now says so, before the first turn spends anything:

```
◆ agent: Codex
note: --max-cost $3 cannot be enforced: Codex reports no price per turn, so the spend cap never fires (#540).
◆ consumption limits: off — Codex reports no quota, so nothing gates your subscription spend.
```

Same reasoning for two smaller lies: `--browser` and `--permission-mode` are Claude-only and now say so instead of looking honored, and a Codex run no longer offers a `claude.ai/code` session link for a session that isn't Claude's.

This is only the honesty half. Whether we make cost optional, price Codex ourselves, or leave it unmetered is still #540.

## Proof

A real `--agent codex` build on a ChatGPT login with no `OPENAI_API_KEY`, from an empty dir: it routed the preset, built `hello.js` + a README, and `node hello.js` prints `55`. Both turns ran on Codex (codex thread ids, not Claude session ids). The same prompt on the default `claude` path still reports `spend: $0.0834 / $2` with `consumption limits: on`, which is the contrast the notices are describing.

582 tests pass.

## Not in this PR

The dashboard's Start still has no agent picker, so a run started there is always Claude. That needs a UI decision, so I left it.