### PR TITLE
feat(framework): report an agent's tokens when it reports no price

### DIFF
--- a/.changeset/optional-cost.md
+++ b/.changeset/optional-cost.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/framework': minor
+---
+
+Report an agent's tokens when it reports no price. `DriverUsage.costUsd` is now optional: tokens are what every agent reports, a price is what only some do. Codex reported real token counts that we were dropping on the floor, and now surfaces them; a run with no price shows `tokens: 13,570 (5 out)` rather than nothing at all, and never a `$0` that would read as free. Claude runs are unchanged and still show their spend line.
+
+The spend cap only ever fires on a reported price, so it stays Claude-only and the CLI says so rather than implying otherwise. We deliberately do not invent prices from a model table: that number would go stale silently, and under a subscription nobody is billed per token anyway. What a subscription actually spends is quota, which the consumption limits gate on.

--- a/packages/framework/src/driver/codex.test.ts
+++ b/packages/framework/src/driver/codex.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { Readable, Writable } from 'node:stream'
-import { CodexDriver, CodexJsonParser } from './codex.js'
+import { CodexDriver, CodexJsonParser, parseCodexUsage } from './codex.js'
 import type { SpawnLike, SpawnedProcess } from './claude-code.js'
 import type { Driver, DriverEvent } from './types.js'
 
@@ -20,7 +20,9 @@ test('CodexJsonParser takes the last message as the turn (#539)', () => {
   const p = new CodexJsonParser()
   for (const line of REAL_RUN) p.push(line)
   // Codex narrates as it goes; the last message is its answer, not the first.
-  assert.deepEqual(p.result(), { text: 'Created hello.txt', sessionId: '019f660b-bf69-7d62-a96c-34aad1f083db' })
+  const turn = p.result()
+  assert.equal(turn.text, 'Created hello.txt')
+  assert.equal(turn.sessionId, '019f660b-bf69-7d62-a96c-34aad1f083db')
 })
 
 test('CodexJsonParser streams text and surfaces tool kinds only (#539)', () => {
@@ -33,11 +35,52 @@ test('CodexJsonParser streams text and surfaces tool kinds only (#539)', () => {
   ])
 })
 
-test('CodexJsonParser reports no usage rather than a free-looking zero (#539)', () => {
+test('CodexJsonParser reports the tokens but never a price (#540)', () => {
   const p = new CodexJsonParser()
   for (const line of REAL_RUN) p.push(line)
-  // Codex reports tokens but never a price. `costUsd: 0` would read as free.
-  assert.equal(p.result().usage, undefined)
+  const usage = p.result().usage
+  // The tokens are real and reported; `costUsd: 0` would read as free, so it is absent.
+  assert.deepEqual(usage, {
+    inputTokens: 2226, // 12210 total - 9984 cached
+    outputTokens: 5,
+    cacheReadTokens: 9984,
+    cacheCreationTokens: 0,
+  })
+  assert.equal(usage?.costUsd, undefined)
+  assert.equal('costUsd' in usage!, false)
+})
+
+test('parseCodexUsage splits the cached tokens out of the inclusive input total (#540)', () => {
+  // Verbatim from codex-cli 0.144.4. `input_tokens` is the whole input, cached
+  // included: repeating one prompt held it at 12218 while cached rose to 12032.
+  const usage = parseCodexUsage({ input_tokens: 12218, cached_input_tokens: 12032, output_tokens: 6, reasoning_output_tokens: 0 })
+  assert.deepEqual(usage, {
+    inputTokens: 186,
+    outputTokens: 6,
+    cacheReadTokens: 12032,
+    cacheCreationTokens: 0,
+  })
+})
+
+test('parseCodexUsage does not double-count reasoning tokens (#540)', () => {
+  // reasoning_output_tokens is a subset of output_tokens, as cached_input_tokens
+  // is of input_tokens — adding it would inflate the count.
+  const usage = parseCodexUsage({ input_tokens: 100, cached_input_tokens: 0, output_tokens: 500, reasoning_output_tokens: 400 })
+  assert.equal(usage?.outputTokens, 500)
+})
+
+test('parseCodexUsage survives a missing or malformed payload (#540)', () => {
+  assert.equal(parseCodexUsage(undefined), undefined)
+  assert.equal(parseCodexUsage('nonsense'), undefined)
+  // Absent fields read as 0 rather than NaN, and a nonsense cache count can never
+  // push the uncached input negative.
+  assert.deepEqual(parseCodexUsage({}), { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 })
+  assert.deepEqual(parseCodexUsage({ input_tokens: 10, cached_input_tokens: 999 }), {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 10,
+    cacheCreationTokens: 0,
+  })
 })
 
 test('CodexJsonParser ignores noise that is not an event (#539)', () => {

--- a/packages/framework/src/driver/codex.ts
+++ b/packages/framework/src/driver/codex.ts
@@ -2,7 +2,7 @@ import { spawn as nodeSpawn } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { runAgentCli, type AgentCliParser, type SpawnLike } from './claude-code.js'
-import type { Driver, DriverEvent, DriverPromptOptions, DriverSession, DriverStartOptions, DriverTurn } from './types.js'
+import type { Driver, DriverEvent, DriverPromptOptions, DriverSession, DriverStartOptions, DriverTurn, DriverUsage } from './types.js'
 
 /**
  * Codex's sandbox policy for the shell commands the model writes.
@@ -40,11 +40,10 @@ export interface CodexDriverOptions {
  *
  * - **No system-prompt flag.** Codex has no `--append-system-prompt`, so the
  *   framing is prepended to the prompt instead. Same words reach the agent.
- * - **No usage.** Codex reports token counts but never a price, and nothing
- *   about the subscription's remaining quota. So it omits {@link DriverTurn.usage}
- *   entirely rather than claim a run cost `$0`, which would read as free. The
- *   budget cap (#322) and the consumption limits (#519) are Claude-only until
- *   that's resolved (#540).
+ * - **Tokens, no price.** Codex reports token counts but never a price, so usage
+ *   carries the counts and omits `costUsd` rather than claim a turn cost `$0`,
+ *   which would read as free (#540). The budget cap (#322) gates on a price, so
+ *   it cannot fire here; the CLI says so at startup instead of implying it.
  * - **No quota read.** No `readQuota`, for the same reason: the seam is optional
  *   precisely so an agent that can't report one simply doesn't.
  */
@@ -136,6 +135,7 @@ export class CodexSession implements DriverSession {
 export class CodexJsonParser implements AgentCliParser {
   private text = ''
   private sessionId: string | undefined
+  private usage: DriverUsage | undefined
 
   push(line: string): DriverEvent[] {
     let obj: Record<string, unknown>
@@ -149,6 +149,12 @@ export class CodexJsonParser implements AgentCliParser {
     if (type === 'thread.started') {
       const id = obj['thread_id']
       if (typeof id === 'string') this.sessionId = id
+      return []
+    }
+
+    if (type === 'turn.completed') {
+      const usage = parseCodexUsage(obj['usage'])
+      if (usage) this.usage = usage
       return []
     }
 
@@ -175,8 +181,46 @@ export class CodexJsonParser implements AgentCliParser {
   }
 
   result(): DriverTurn {
-    // No `usage`, deliberately: Codex reports tokens but no price, and a `$0`
-    // would read as free rather than as "we don't know" (#540).
-    return { text: this.text, ...(this.sessionId ? { sessionId: this.sessionId } : {}) }
+    // Tokens but no `costUsd`: Codex prices nothing, and a `$0` would read as free
+    // rather than as "we don't know" (#540).
+    return {
+      text: this.text,
+      ...(this.sessionId ? { sessionId: this.sessionId } : {}),
+      ...(this.usage ? { usage: this.usage } : {}),
+    }
+  }
+}
+
+/**
+ * Map Codex's `turn.completed` usage onto {@link DriverUsage}. The dialect is
+ * OpenAI's Responses API shape, flattened:
+ * `{input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens}`.
+ *
+ * Two things that shape the mapping, both verified against codex-cli 0.144.4:
+ *
+ * - `input_tokens` is the **total** input, cached included. Repeating one prompt
+ *   held it at 12218 while `cached_input_tokens` rose 9984 -> 12032; a non-cached
+ *   count would have fallen. So the uncached part is the difference, which is what
+ *   `inputTokens` means here.
+ * - `reasoning_output_tokens` is a **subset** of `output_tokens` (as
+ *   `cached_input_tokens` is of `input_tokens`), so adding it would double-count.
+ *
+ * No price, and no cache-*write* count: OpenAI caches implicitly and bills no
+ * separate write, so `cacheCreationTokens` is honestly 0 rather than a guess.
+ */
+export function parseCodexUsage(raw: unknown): DriverUsage | undefined {
+  if (typeof raw !== 'object' || raw === null) return undefined
+  const usage = raw as Record<string, unknown>
+  const num = (key: string): number => {
+    const value = usage[key]
+    return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : 0
+  }
+  const input = num('input_tokens')
+  const cached = Math.min(num('cached_input_tokens'), input)
+  return {
+    inputTokens: input - cached,
+    outputTokens: num('output_tokens'),
+    cacheReadTokens: cached,
+    cacheCreationTokens: 0,
   }
 }

--- a/packages/framework/src/driver/types.ts
+++ b/packages/framework/src/driver/types.ts
@@ -104,10 +104,23 @@ export interface DriverTurn {
  * Token and cost accounting for one turn, as reported by the wrapped agent (#322).
  * Claude Code emits this on its final `result` line; drivers that cannot report
  * it simply omit it. Costs are whatever the agent computed, in USD.
+ *
+ * Tokens are the part every agent reports; the price is the part only some do
+ * (#540). So `costUsd` is optional and the tokens are not: Codex reports counts
+ * and no price, and an agent that can't price a turn reports the tokens it does
+ * know rather than nothing at all.
  */
 export interface DriverUsage {
-  /** Cost of the turn in USD, as reported by the agent. */
-  costUsd: number
+  /**
+   * Cost of the turn in USD, when the agent prices its own turns. Omitted when it
+   * doesn't — never `0`, which would read as free rather than as unknown.
+   *
+   * Note this is a notional price under a subscription: the user pays a flat fee,
+   * and the agent reports what the turn would have cost on metered API pricing.
+   * What a subscription actually spends is quota, which {@link DriverQuota}
+   * carries and the consumption limits (#519) gate on.
+   */
+  costUsd?: number
   /** Non-cached input tokens. */
   inputTokens: number
   /** Output tokens. */

--- a/packages/framework/src/events.test.ts
+++ b/packages/framework/src/events.test.ts
@@ -126,6 +126,20 @@ test('formatFrameworkEvent renders a usage spend line, with the cap when set (#3
   assert.equal(formatFrameworkEvent({ ...base, costUsd: 0.02, turns: 1, budgetUsd: 5 }), '  spend: $0.0200 / $5 over 1 turn')
 })
 
+test('formatFrameworkEvent reports tokens when the agent reported no price (#540)', () => {
+  // Codex's shape. A `$0.0000` spend line would read as free rather than unknown.
+  const line = formatFrameworkEvent({
+    kind: 'usage',
+    inputTokens: 186,
+    outputTokens: 6,
+    cacheReadTokens: 12032,
+    cacheCreationTokens: 0,
+    turns: 1,
+  })
+  assert.equal(line, '  tokens: 12,224 (6 out) over 1 turn — no price reported')
+  assert.doesNotMatch(line!, /\$/)
+})
+
 test('formats the rate-limit line by how much the quota actually matters (#517)', () => {
   const at = Date.UTC(2026, 6, 15, 4, 30)
   const line = (status: string) => formatFrameworkEvent({ kind: 'driver', event: { type: 'rate-limit', limit: { status, window: 'five_hour', resetsAt: at } } })!

--- a/packages/framework/src/events.ts
+++ b/packages/framework/src/events.ts
@@ -126,10 +126,13 @@ export type FrameworkEvent =
    * Cumulative token + cost usage for the run so far (#322). Emitted after each
    * agent turn that reports usage; the dashboard renders a live spend readout and
    * the run stops itself once `costUsd` reaches the budget cap, if one is set.
+   *
+   * `costUsd` is absent when the agent reports tokens but no price (#540), which
+   * is also when no budget cap can fire.
    */
   | {
       kind: 'usage'
-      costUsd: number
+      costUsd?: number
       inputTokens: number
       outputTokens: number
       cacheReadTokens: number
@@ -181,10 +184,16 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
       return `  session: ${event.name}`
     case 'ready-for-merge':
       return `✓ ready for merge`
-    case 'usage':
-      return `  spend: $${event.costUsd.toFixed(4)}${
-        event.budgetUsd ? ` / $${event.budgetUsd}` : ''
-      } over ${event.turns} turn${event.turns === 1 ? '' : 's'}`
+    case 'usage': {
+      const turns = `over ${event.turns} turn${event.turns === 1 ? '' : 's'}`
+      // No price to show: report the tokens the agent *did* report, rather than a
+      // `$0.0000` that would read as free (#540).
+      if (event.costUsd === undefined) {
+        const tokens = event.inputTokens + event.cacheReadTokens + event.outputTokens
+        return `  tokens: ${tokens.toLocaleString('en-US')} (${event.outputTokens.toLocaleString('en-US')} out) ${turns} — no price reported`
+      }
+      return `  spend: $${event.costUsd.toFixed(4)}${event.budgetUsd ? ` / $${event.budgetUsd}` : ''} ${turns}`
+    }
     case 'modes': {
       const shown = event.all.map(m => `${event.active.includes(m) ? '[x]' : '[ ]'} ${m}`).join('  ')
       return `  modes: ${shown}`

--- a/packages/framework/src/prompt-run.test.ts
+++ b/packages/framework/src/prompt-run.test.ts
@@ -238,6 +238,25 @@ test('runPrompt stops itself at the budget cap and reports a clean stop (#322)',
   assert.match(end.detail ?? '', /budget reached/)
 })
 
+test('runPrompt cannot cap an agent that reports no price, and says so in tokens (#540)', async () => {
+  const events: FrameworkEvent[] = []
+  // Codex's shape: tokens, no costUsd. Same script as the cap test above, so the
+  // only difference is the missing price.
+  const usage = { inputTokens: 10, outputTokens: 10, cacheReadTokens: 0, cacheCreationTokens: 0 }
+  const driver = new FakeDriver({ turns: [{ text: multiGateTurn, usage }, { text: 'second turn ran', usage }] })
+  const { text } = await runPrompt({ prompt: 'go', driver, cwd: '/ws', budgetUsd: 0.5, onEvent: e => events.push(e) })
+  // The cap never fires: there is no price to compare against it.
+  assert.equal(text, 'second turn ran')
+  assert.equal(events.some(e => e.kind === 'log' && e.message.startsWith('Budget reached:')), false)
+  // The tokens are still metered and reported, which is the point of #540.
+  const usageEvents = events.filter(e => e.kind === 'usage')
+  assert.equal(usageEvents.length, 2)
+  const last = usageEvents.at(-1)!
+  assert.equal(last.kind === 'usage' && last.costUsd, undefined)
+  assert.equal(last.kind === 'usage' && last.inputTokens, 20)
+  assert.equal(last.kind === 'usage' && last.turns, 2)
+})
+
 test('runPrompt pauses at a consumption limit and reports a clean stop (#531)', async () => {
   const events: FrameworkEvent[] = []
   const usage = { inputTokens: 10, outputTokens: 10, cacheReadTokens: 0, cacheCreationTokens: 0, costUsd: 0.01 }

--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -137,7 +137,8 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
     usage.add(event.usage)
     const totals = usage.totals()
     emit({ kind: 'usage', ...totals, ...(opts.budgetUsd != null ? { budgetUsd: opts.budgetUsd } : {}) })
-    if (opts.budgetUsd != null && totals.costUsd >= opts.budgetUsd && !budgetController.signal.aborted) {
+    // No price reported means no cap to cross — see the same gate in run.ts (#540).
+    if (opts.budgetUsd != null && totals.costUsd !== undefined && totals.costUsd >= opts.budgetUsd && !budgetController.signal.aborted) {
       emit({ kind: 'log', message: `Budget reached: $${totals.costUsd.toFixed(4)} of $${opts.budgetUsd} — stopping the run.` })
       budgetController.abort(new Error('[framework] budget reached'))
     }

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -118,7 +118,8 @@ test('runFramework accumulates per-turn usage and emits a running total (#322)',
   if (last.kind !== 'usage') return
   // One usage event per turn that reported usage; totals grow monotonically.
   assert.equal(last.turns, usage.length)
-  assert.ok(Math.abs(last.costUsd - last.turns * 0.02) < 1e-9)
+  // The fake driver prices its turns, so the total carries a cost.
+  assert.ok(Math.abs(last.costUsd! - last.turns * 0.02) < 1e-9)
   assert.ok(last.cacheReadTokens > 0)
   // No cap was set, so the total carries no budget and the run finished cleanly.
   assert.equal(last.budgetUsd, undefined)

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -447,7 +447,9 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     emit({ kind: 'usage', ...totals, ...(opts.budgetUsd != null ? { budgetUsd: opts.budgetUsd } : {}) })
     // The turn that crosses the cap has already run (its cost is spent); stop the
     // run before the next one. Signalled once — the next phase's check ends it.
-    if (opts.budgetUsd != null && totals.costUsd >= opts.budgetUsd && !budgetController.signal.aborted) {
+    // An agent that reports no price leaves `costUsd` undefined and so can never
+    // trip the cap; the CLI says so up front rather than let it look capped (#540).
+    if (opts.budgetUsd != null && totals.costUsd !== undefined && totals.costUsd >= opts.budgetUsd && !budgetController.signal.aborted) {
       emit({ kind: 'log', message: `Budget reached: $${totals.costUsd.toFixed(4)} of $${opts.budgetUsd} — stopping the run.` })
       budgetController.abort(new Error('[framework] budget reached'))
     }

--- a/packages/framework/src/usage.test.ts
+++ b/packages/framework/src/usage.test.ts
@@ -4,15 +4,17 @@ import { UsageMeter } from './usage.js'
 
 const turn = { costUsd: 0.02, inputTokens: 100, outputTokens: 40, cacheReadTokens: 900, cacheCreationTokens: 50 }
 
-test('UsageMeter starts at zero', () => {
-  assert.deepEqual(new UsageMeter().totals(), {
-    costUsd: 0,
+test('UsageMeter starts at zero, with no cost until one is reported (#540)', () => {
+  const totals = new UsageMeter().totals()
+  assert.deepEqual(totals, {
     inputTokens: 0,
     outputTokens: 0,
     cacheReadTokens: 0,
     cacheCreationTokens: 0,
     turns: 0,
   })
+  // Absent, not 0: a `$0` total would read as "this run was free".
+  assert.equal('costUsd' in totals, false)
 })
 
 test('UsageMeter sums each field and counts turns (#322)', () => {
@@ -27,6 +29,30 @@ test('UsageMeter sums each field and counts turns (#322)', () => {
     cacheCreationTokens: 100,
     turns: 2,
   })
+})
+
+test('UsageMeter counts tokens for an agent that reports no price (#540)', () => {
+  // Codex's shape: real token counts, no costUsd.
+  const m = new UsageMeter()
+  m.add({ inputTokens: 186, outputTokens: 6, cacheReadTokens: 12032, cacheCreationTokens: 0 })
+  m.add({ inputTokens: 186, outputTokens: 6, cacheReadTokens: 12032, cacheCreationTokens: 0 })
+  const totals = m.totals()
+  assert.equal(totals.turns, 2)
+  assert.equal(totals.inputTokens, 372)
+  assert.equal(totals.cacheReadTokens, 24064)
+  // The tokens are real, so they total; the price was never reported, so it stays absent.
+  assert.equal(totals.costUsd, undefined)
+  assert.equal('costUsd' in totals, false)
+})
+
+test('UsageMeter totals a cost from the turns that had one (#540)', () => {
+  // Mixed is not a real run today (one agent per run), but the total must still
+  // mean "what we know was spent" rather than silently drop the priced turns.
+  const m = new UsageMeter()
+  m.add({ inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheCreationTokens: 0 })
+  m.add(turn)
+  assert.equal(m.totals().costUsd, 0.02)
+  assert.equal(m.totals().turns, 2)
 })
 
 test('UsageMeter.totals returns a snapshot, not the live state', () => {

--- a/packages/framework/src/usage.ts
+++ b/packages/framework/src/usage.ts
@@ -10,8 +10,12 @@ export interface UsageTotals extends DriverUsage {
   turns: number
 }
 
+/**
+ * The starting total. `costUsd` is absent rather than `0`: an agent that never
+ * prices a turn must not accumulate a total that reads as "this run was free"
+ * (#540). It appears as soon as one turn reports a price.
+ */
 const ZERO: UsageTotals = {
-  costUsd: 0,
   inputTokens: 0,
   outputTokens: 0,
   cacheReadTokens: 0,
@@ -31,10 +35,15 @@ const ZERO: UsageTotals = {
 export class UsageMeter {
   private totalsState: UsageTotals = { ...ZERO }
 
-  /** Fold one turn's usage into the running total. */
+  /**
+   * Fold one turn's usage into the running total. A turn that reports no price
+   * still counts its tokens; it just leaves the cost total where it was, so an
+   * unpriced run totals `undefined` rather than `$0` (#540).
+   */
   add(usage: DriverUsage): void {
+    const costUsd = usage.costUsd === undefined ? this.totalsState.costUsd : (this.totalsState.costUsd ?? 0) + usage.costUsd
     this.totalsState = {
-      costUsd: this.totalsState.costUsd + usage.costUsd,
+      ...(costUsd === undefined ? {} : { costUsd }),
       inputTokens: this.totalsState.inputTokens + usage.inputTokens,
       outputTokens: this.totalsState.outputTokens + usage.outputTokens,
       cacheReadTokens: this.totalsState.cacheReadTokens + usage.cacheReadTokens,


### PR DESCRIPTION
Closes #540.

Picks the first option on the issue: **make the price optional, report the tokens**. Not pricing it ourselves, and not leaving Codex unmetered.

## Why this one

Tokens are the unit *every* agent reports; a price is the unit only some do. So the price is what should bend.

Codex was already handing us real counts every turn (`turn.completed.usage`) and we dropped them on the floor, because `DriverUsage` required a `costUsd` and the driver would rather omit usage than claim $0. So today a Codex run reports no tokens at all. That's the part worth fixing.

Against pricing it ourselves: it's a number we invent and then have to maintain per model, and it goes stale silently, which is worse than an absent number because it looks authoritative. It's also fiction on top of fiction here. Under a subscription nobody is billed per token, so even the price Claude reports is notional (the API-equivalent). What a subscription actually spends is quota, which #519's limits already gate on. Inventing dollars would be inventing a unit the user isn't charged in, to gate a thing quota already gates better.

The issue worried this ripples into "the meter, the events, and the dashboard, all of which assume a number". The meter and the events did; the dashboard turned out not to consume the usage event at all, so the blast radius is one package.

## What changes

- `costUsd` optional on `DriverUsage`; the meter totals tokens regardless and leaves cost **absent rather than 0** (a $0 total reads as free).
- No price, no cap: the budget gate needs a number to compare, so it can't fire. #542 says so at startup rather than letting `--max-cost` look enforced.
- Codex parses its usage. It's the OpenAI Responses shape, flattened, and two things there are easy to get wrong, so both are pinned by tests against codex-cli 0.144.4:
  - `input_tokens` is the **inclusive** total. Repeating one prompt held it at 12218 while `cached_input_tokens` rose 9984 -> 12032; a non-cached count would have fallen. The uncached part is the difference.
  - `reasoning_output_tokens` is a **subset** of `output_tokens`, so adding it would double-count.

Claude runs are untouched: still `spend: $0.0821 over 1 turn`.

## Proof

Live Codex, no API key: `tokens: 13,570 (5 out) over 1 turn — no price reported` where it previously printed nothing. Same prompt on Claude still prints its spend line. 579 tests pass.

Stacked conceptually on #542 (which makes `--agent codex` reachable at all) but touches different files, so it merges in either order.