### PR TITLE
ci: check the prompting hasn't drifted from #326

### DIFF
--- a/.github/workflows/prompt-drift.yml
+++ b/.github/workflows/prompt-drift.yml
@@ -1,0 +1,32 @@
+name: Prompt drift
+
+# The system prompt is designed and reviewed on issue #326, and the repo is meant to follow it
+# ("change it there first"). Nothing enforced that, and a rewrite on the issue went unnoticed in
+# the repo for two days. This checks the two are still in sync.
+#
+# Not part of CI: it depends on the GitHub API being reachable, and a network blip should never
+# block an unrelated PR. It runs daily, on demand, and on PRs that touch the prompting itself.
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'packages/framework/prompts/**'
+      - 'packages/framework/scripts/check-prompt-drift.mjs'
+      - 'packages/framework/scripts/op-326-post-merge.snapshot.md'
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      # No install: the check is dependency-free on purpose, so it keeps working when the
+      # workspace doesn't build.
+      - run: node packages/framework/scripts/check-prompt-drift.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -56,7 +56,8 @@
     "test": "node scripts/gen-prompts.mjs && tsc -p tsconfig.test.json && cd dist-test && node --test",
     "bundle:dashboard": "node scripts/bundle-dashboard.mjs",
     "clean": "rm -rf dist dist-test src/prompts.generated.ts",
-    "gen:prompts": "node scripts/gen-prompts.mjs"
+    "gen:prompts": "node scripts/gen-prompts.mjs",
+    "check:prompt-drift": "node scripts/check-prompt-drift.mjs"
   },
   "dependencies": {
     "@gemstack/ai-autopilot": "workspace:^",

--- a/packages/framework/scripts/check-prompt-drift.mjs
+++ b/packages/framework/scripts/check-prompt-drift.mjs
@@ -1,0 +1,124 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Fail when the prompting in `prompts/` no longer matches the #326 issue, which is where the
+// system prompt is designed and reviewed ("change it there first").
+//
+// Why this exists: the system prompt was rewritten on the issue on 2026-07-13 and the repo was
+// only synced on 2026-07-15. Nothing noticed for two days. `gen-prompts.mjs` guards the
+// .md -> .ts direction; this guards the direction that actually broke, issue -> .md.
+//
+// The two blocks are checked differently, because only one of them can ever match byte-for-byte:
+//   - Block 1 (`## System prompt`) ships verbatim, so `prompts/system_prompt.md` IS the copy to
+//     compare against. Any difference is drift, in either direction.
+//   - Block 2 (`## Post-merge prompt`) cannot ship verbatim: it nests a `${{ }}` fragment inside
+//     another one, which the renderer cannot parse, so what ships is a flattened equivalent.
+//     There is nothing to byte-compare, so instead we snapshot the block and fail when it
+//     changes: that means the design moved and a human has to re-flatten it.
+
+const here = dirname(fileURLToPath(import.meta.url))
+const systemPromptFile = join(here, '..', 'prompts', 'system_prompt.md')
+const snapshotFile = join(here, 'op-326-post-merge.snapshot.md')
+
+const REPO = 'gemstack-land/gemstack'
+const ISSUE = 326
+
+/** The ```md blocks of the issue body, in order. Block 1 = system prompt, block 2 = post-merge. */
+function extractPromptBlocks(body) {
+  return [...body.matchAll(/```md\n([\s\S]*?)\n```/g)].map(m => m[1])
+}
+
+/** Compare ignoring only trailing whitespace: the files on disk end with a newline, the blocks don't. */
+const normalize = text => text.replace(/\s+$/, '')
+
+/** The first line that differs, so a failure points at the change instead of just announcing one. */
+function firstDifference(a, b, labelA, labelB) {
+  const left = a.split('\n')
+  const right = b.split('\n')
+  const pad = Math.max(labelA.length, labelB.length)
+  for (let i = 0; i < Math.max(left.length, right.length); i++) {
+    if (left[i] !== right[i]) {
+      const show = (label, line) => `${label.padEnd(pad)}  ${JSON.stringify(line ?? '(ends here)')}`
+      return `line ${i + 1}:\n  ${show(labelA, left[i])}\n  ${show(labelB, right[i])}`
+    }
+  }
+  return '(no line differs; trailing whitespace only)'
+}
+
+async function fetchIssueBody() {
+  const url = `https://api.github.com/repos/${REPO}/issues/${ISSUE}`
+  const headers = { accept: 'application/vnd.github+json' }
+  if (process.env.GITHUB_TOKEN) headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`
+
+  let response
+  try {
+    response = await fetch(url, { headers })
+  } catch (cause) {
+    // GitHub being unreachable is not drift. Skip rather than wedge a PR on someone else's outage.
+    throw new SkipError(`could not reach the GitHub API: ${cause.message}`)
+  }
+  if (response.status >= 500) throw new SkipError(`GitHub API returned ${response.status}`)
+  // A 401/403/404 is our own misconfiguration, and silently passing would make the check a no-op.
+  if (!response.ok) throw new Error(`GitHub API returned ${response.status} for ${url}`)
+  return (await response.json()).body
+}
+
+class SkipError extends Error {}
+
+async function main() {
+  const update = process.argv.includes('--update')
+  const body = await fetchIssueBody()
+  const blocks = extractPromptBlocks(body)
+  if (blocks.length !== 2) {
+    throw new Error(
+      `expected 2 \`\`\`md blocks in ${REPO}#${ISSUE}, found ${blocks.length}. ` +
+        `The issue's structure changed; this check needs updating along with it.`,
+    )
+  }
+  const [systemBlock, postMergeBlock] = blocks.map(normalize)
+
+  if (update) {
+    await writeFile(snapshotFile, `${postMergeBlock}\n`)
+    console.log(`Updated ${snapshotFile} to the current #${ISSUE} post-merge block.`)
+    return
+  }
+
+  const failures = []
+
+  const shipped = normalize(await readFile(systemPromptFile, 'utf8'))
+  if (systemBlock !== shipped) {
+    failures.push(
+      `prompts/system_prompt.md has drifted from ${REPO}#${ISSUE} (block 1).\n` +
+        `  issue: ${systemBlock.length} chars, repo: ${shipped.length} chars\n` +
+        `  first difference at ${firstDifference(systemBlock, shipped, 'issue:', 'repo:')}\n` +
+        `  The issue is the source of truth: copy the block into prompts/system_prompt.md.`,
+    )
+  }
+
+  const snapshot = normalize(await readFile(snapshotFile, 'utf8'))
+  if (postMergeBlock !== snapshot) {
+    failures.push(
+      `The post-merge block (block 2) of ${REPO}#${ISSUE} changed since it was last reviewed.\n` +
+        `  snapshot: ${snapshot.length} chars, issue: ${postMergeBlock.length} chars\n` +
+        `  first difference at ${firstDifference(postMergeBlock, snapshot, 'issue:', 'snapshot:')}\n` +
+        `  It cannot be copied verbatim (it nests \`\${{ }}\` fragments). Re-flatten it into\n` +
+        `  prompts/post_merge_prompt.md, then run: pnpm --filter @gemstack/framework check:prompt-drift --update`,
+    )
+  }
+
+  if (failures.length) {
+    console.error(`\n${failures.join('\n\n')}\n`)
+    process.exit(1)
+  }
+  console.log(`prompts/ is in sync with ${REPO}#${ISSUE} (block 1 ${systemBlock.length} chars, block 2 snapshot ${snapshot.length} chars).`)
+}
+
+main().catch(error => {
+  if (error instanceof SkipError) {
+    console.warn(`Skipping the prompt drift check: ${error.message}`)
+    return
+  }
+  console.error(error.message)
+  process.exit(1)
+})

--- a/packages/framework/scripts/op-326-post-merge.snapshot.md
+++ b/packages/framework/scripts/op-326-post-merge.snapshot.md
@@ -1,0 +1,12 @@
+TODO_FILE: `TODO_<SESSION_NAME>.agent.md`
+
+## Maintenance
+
+If the changes introduced by ${{ tf.session_name }} aren't trivial and have refactor potential, add the following to <TODO_FILE>
+- "Apply preset `maintainability` on the changes introduced by ${{ tf.session_name }}"
+${{ !tf.settings.technical_control ? '' : (`
+- "Apply preset `readability` on the changes introduced by ${{ tf.session_name }}"
+`.trim() + '\n') }}
+
+If the changes introduced by ${{ tf.session_name }} can potentially lead to security issues, add the following to <TODO_FILE>
+- "Apply preset `security_audit` on the changes introduced by ${{ tf.session_name }}"


### PR DESCRIPTION
Closes #561

The system prompt is designed on #326 and the repo follows it. Nothing checked that, and the last rewrite on the issue sat unsynced for two days.

- Block 1 ships verbatim -> compared byte-for-byte with `prompts/system_prompt.md`.
- Block 2 cannot ship verbatim (nested `${{ }}`, #556) -> snapshotted, and any change fails with "re-flatten this".

Runs daily + on demand + on PRs touching the prompting. Not in CI: it needs the GitHub API and a blip should not block an unrelated PR. Unreachable API skips; a 404 fails loudly, so it cannot rot into a no-op.

No prompt text changed. Verified by running all four paths: green today (block 1 2354 chars both sides), fails on a planted block-1 edit and on a planted block-2 change, skips on an unreachable API.