### PR TITLE
refactor(framework): share the run paths' driver-event accounting

### DIFF
--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -1,9 +1,9 @@
-import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
-import { hasSessionIdPlaceholder, resolveSessionLink, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
+import type { Driver, DriverSession } from './driver/index.js'
+import { type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 import { resolveAwaitGate } from './run.js'
 import { composeRunSystem, renderSystemPrompt, type EcoOptions, type TfContext } from './system-prompt.js'
+import { createDriverEventHandler, emitSessionStart } from './run-telemetry.js'
 import { PLAN_DECLINED_MESSAGE, createTurnSignalEmitter, isDeclinedConfirmation, parseAwaitGate } from './turn-gate.js'
-import { UsageMeter } from './usage.js'
 import { CONSUMPTION_LIMIT_LABEL, type ConsumptionWindow } from './consumption.js'
 import { leaveResumeNote } from './todo-loop.js'
 
@@ -96,15 +96,7 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
   // the built-in prompt off, the raw prompt is sent as-is.
   const firstPrompt = opts.antiLazyPill === false ? opts.prompt : renderSystemPrompt(tf).user
 
-  const linkTemplate = opts.sessionLink
-  const literalLink = linkTemplate && !hasSessionIdPlaceholder(linkTemplate) ? linkTemplate : undefined
-  emit({
-    kind: 'session',
-    driver: opts.driver.name,
-    workspace: opts.cwd,
-    fake: opts.driver.name === 'fake',
-    ...(literalLink ? { sessionLink: literalLink } : {}),
-  })
+  emitSessionStart({ emit, driver: opts.driver, cwd: opts.cwd, sessionLink: opts.sessionLink })
   // Surface the exact system prompt the agent runs under (#343). The user prompts
   // ride along as `driver` `start` events, so the dashboard can show them all.
   emit({ kind: 'system-prompt', text: system })
@@ -115,46 +107,19 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
   // A consumption limit (#531) is the other self-stop: the account's quota ran
   // out rather than this run's spend.
   const consumptionController = new AbortController()
-  let consumptionTrip: ConsumptionWindow | undefined
   const runSignal = AbortSignal.any([
     ...(opts.signal ? [opts.signal] : []),
     budgetController.signal,
     consumptionController.signal,
   ])
-  let lastSessionId: string | undefined
-  const usage = new UsageMeter()
-  const onDriverEvent = (event: DriverEvent): void => {
-    emit({ kind: 'driver', event })
-    if (event.type !== 'result') return
-    if (event.sessionId && event.sessionId !== lastSessionId) {
-      lastSessionId = event.sessionId
-      const link = linkTemplate ? resolveSessionLink(linkTemplate, event.sessionId) : undefined
-      emit({ kind: 'session-update', sessionId: event.sessionId, ...(link ? { sessionLink: link } : {}) })
-    }
-    if (!event.usage) return
-    usage.add(event.usage)
-    const totals = usage.totals()
-    emit({ kind: 'usage', ...totals, ...(opts.budgetUsd != null ? { budgetUsd: opts.budgetUsd } : {}) })
-    // No price reported means no cap to cross — see the same gate in run.ts (#540).
-    if (opts.budgetUsd != null && totals.costUsd !== undefined && totals.costUsd >= opts.budgetUsd && !budgetController.signal.aborted) {
-      emit({ kind: 'log', message: `Budget reached: $${totals.costUsd.toFixed(4)} of $${opts.budgetUsd} — stopping the run.` })
-      budgetController.abort(new Error('[framework] budget reached'))
-    }
-    if (opts.consumptionGate && !consumptionController.signal.aborted) {
-      let reached: ConsumptionWindow | null = null
-      try {
-        reached = opts.consumptionGate()
-      } catch (err) {
-        // Fail open: an unreadable quota must not stop the work (Rom on #519).
-        console.error('[framework] consumptionGate threw; carrying on:', err)
-      }
-      if (reached) {
-        consumptionTrip = reached
-        emit({ kind: 'log', message: `${CONSUMPTION_LIMIT_LABEL[reached]} consumption limit reached — pausing the run.` })
-        consumptionController.abort(new Error('[framework] consumption limit reached'))
-      }
-    }
-  }
+  const { onDriverEvent, consumptionTrip } = createDriverEventHandler({
+    emit,
+    sessionLink: opts.sessionLink,
+    budgetUsd: opts.budgetUsd,
+    consumptionGate: opts.consumptionGate,
+    budgetController,
+    consumptionController,
+  })
 
   const session: DriverSession = await opts.driver.start({
     cwd: opts.cwd,
@@ -204,7 +169,7 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
     const detail = budgetStopped
       ? `budget reached ($${opts.budgetUsd})`
       : paused
-        ? `${CONSUMPTION_LIMIT_LABEL[consumptionTrip ?? 'session']} consumption limit reached${resumeNote ? `; will resume from ${resumeNote}` : ''}`
+        ? `${CONSUMPTION_LIMIT_LABEL[consumptionTrip() ?? 'session']} consumption limit reached${resumeNote ? `; will resume from ${resumeNote}` : ''}`
         : err instanceof Error
           ? err.message
           : String(err)

--- a/packages/framework/src/run-telemetry.ts
+++ b/packages/framework/src/run-telemetry.ts
@@ -1,0 +1,113 @@
+import { CONSUMPTION_LIMIT_LABEL, type ConsumptionWindow } from './consumption.js'
+import type { Driver, DriverEvent } from './driver/index.js'
+import { hasSessionIdPlaceholder, resolveSessionLink, type FrameworkEvent } from './events.js'
+import { UsageMeter } from './usage.js'
+
+// The telemetry both entry paths share. A build (`run.ts`) and a direct prompt
+// (`prompt-run.ts`) differ in what they *do* with the agent, but the accounting around
+// it is the same: name the session, follow the driver's event stream, total the usage,
+// and stop the run when it has spent too much (#322) or the account's quota ran out
+// (#529). This lived twice, byte-identical, which is how the backlog loop ended up
+// without a copy of the sibling turn-signal parsing at all (#563).
+
+/** Inputs to {@link emitSessionStart}. */
+export interface SessionStartOptions {
+  emit: (event: FrameworkEvent) => void
+  driver: Driver
+  /** The workspace the run works in. */
+  cwd: string
+  /** The session link, literal or templated with `{sessionId}`. */
+  sessionLink?: string | undefined
+}
+
+/**
+ * Emit the run's opening `session` event. A literal link is shown right away; a
+ * templated one (`.../{sessionId}`) can only resolve once the driver reports its
+ * session id, so it waits for the `session-update` from {@link createDriverEventHandler}.
+ */
+export function emitSessionStart(opts: SessionStartOptions): void {
+  const literal = opts.sessionLink && !hasSessionIdPlaceholder(opts.sessionLink) ? opts.sessionLink : undefined
+  opts.emit({
+    kind: 'session',
+    driver: opts.driver.name,
+    workspace: opts.cwd,
+    fake: opts.driver.name === 'fake',
+    ...(literal ? { sessionLink: literal } : {}),
+  })
+}
+
+/** Inputs to {@link createDriverEventHandler}. */
+export interface DriverEventHandlerOptions {
+  emit: (event: FrameworkEvent) => void
+  /** The session link template, when the caller configured one. */
+  sessionLink?: string | undefined
+  /** The run's spend cap (#322). Omitted = uncapped. */
+  budgetUsd?: number | undefined
+  /** Answers "has the account's quota run out?" between turns (#529). */
+  consumptionGate?: (() => ConsumptionWindow | null) | undefined
+  /** Tripped when the budget cap is crossed. */
+  budgetController: AbortController
+  /** Tripped when the consumption gate reports a window is spent. */
+  consumptionController: AbortController
+}
+
+/** What {@link createDriverEventHandler} hands back. */
+export interface DriverEventHandler {
+  /** Wire this as the driver session's `onEvent`. */
+  onDriverEvent: (event: DriverEvent) => void
+  /** The window whose limit tripped, once the consumption gate has fired. */
+  consumptionTrip: () => ConsumptionWindow | undefined
+}
+
+/**
+ * Watch the driver's black box (#165) and turn it into the run's stream: surface the
+ * real session id as `session-update` once known (that is the honest handle a UI links
+ * to, and it changes per prompt, so re-emit), fold each turn's usage into the run total,
+ * and trip the two self-stops.
+ *
+ * Both stops fire *after* the turn that crossed them: its cost is already spent, so the
+ * point is to stop the next one. Each is signalled once, and the run's `AbortSignal.any`
+ * composition carries it downstream. An agent that reports no price leaves `costUsd`
+ * undefined and so can never trip the budget cap (#540). A consumption gate that throws
+ * is treated as "carry on": an unreadable quota must not stop the work (#519), and the
+ * gate is answered from a cached reading because a live one spawns the agent CLI (~5s).
+ */
+export function createDriverEventHandler(opts: DriverEventHandlerOptions): DriverEventHandler {
+  const { emit, budgetController, consumptionController } = opts
+  let lastSessionId: string | undefined
+  let consumptionTrip: ConsumptionWindow | undefined
+  const usage = new UsageMeter()
+
+  const onDriverEvent = (event: DriverEvent): void => {
+    emit({ kind: 'driver', event })
+    if (event.type !== 'result') return
+    if (event.sessionId && event.sessionId !== lastSessionId) {
+      lastSessionId = event.sessionId
+      const link = opts.sessionLink ? resolveSessionLink(opts.sessionLink, event.sessionId) : undefined
+      emit({ kind: 'session-update', sessionId: event.sessionId, ...(link ? { sessionLink: link } : {}) })
+    }
+    if (!event.usage) return
+    usage.add(event.usage)
+    const totals = usage.totals()
+    emit({ kind: 'usage', ...totals, ...(opts.budgetUsd != null ? { budgetUsd: opts.budgetUsd } : {}) })
+    if (opts.budgetUsd != null && totals.costUsd !== undefined && totals.costUsd >= opts.budgetUsd && !budgetController.signal.aborted) {
+      emit({ kind: 'log', message: `Budget reached: $${totals.costUsd.toFixed(4)} of $${opts.budgetUsd} — stopping the run.` })
+      budgetController.abort(new Error('[framework] budget reached'))
+    }
+    if (opts.consumptionGate && !consumptionController.signal.aborted) {
+      let reached: ConsumptionWindow | null = null
+      try {
+        reached = opts.consumptionGate()
+      } catch (err) {
+        console.error('[framework] consumptionGate threw; carrying on:', err)
+      }
+      if (reached) {
+        consumptionTrip = reached
+        emit({ kind: 'log', message: `${CONSUMPTION_LIMIT_LABEL[reached]} consumption limit reached — pausing the run.` })
+        consumptionController.abort(new Error('[framework] consumption limit reached'))
+      }
+    }
+  }
+
+  return { onDriverEvent, consumptionTrip: () => consumptionTrip }
+}

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -23,15 +23,15 @@ import {
 } from '@gemstack/ai-autopilot'
 import { snapshotWorkspace } from './sandbox.js'
 import { CONSUMPTION_LIMIT_LABEL, type ConsumptionWindow } from './consumption.js'
-import type { Driver, DriverEvent, DriverSession } from './driver/index.js'
+import type { Driver, DriverSession } from './driver/index.js'
 import { composeRunSystem, type EcoOptions, type TfContext } from './system-prompt.js'
+import { createDriverEventHandler, emitSessionStart } from './run-telemetry.js'
 import { AWAIT_PROTOCOL, CONFIRM_APPROVED, CONFIRM_DECLINED, PLAN_DECLINED_MESSAGE, createTurnSignalEmitter, isDeclinedConfirmation, parseAwaitGate, type ParsedAwaitGate } from './turn-gate.js'
 // Value import from todo-loop.js is a benign cycle: todo-loop.js only calls
 // run.js's hoisted function declarations (requestChoices / resolveAwaitGate).
 import { leaveResumeNote, runTodoLoop, type TodoLoopResult } from './todo-loop.js'
 import { continueAfterChoice, decideDeploy, deployWith, domainLoopChecklist, driverBuild, driverChecklist, driverImprove, driverLoopPrompts } from './steps.js'
-import { hasSessionIdPlaceholder, OPEN_LOOP_MODES, pickedIds, resolveSessionLink, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
-import { UsageMeter } from './usage.js'
+import { OPEN_LOOP_MODES, pickedIds, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 
 /**
  * The framework's default full-fledged pass budget. Higher than ai-autopilot's
@@ -289,19 +289,7 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     context: opts.context,
   })
 
-  // The session id is not known until the first driver turn returns, so a
-  // templated link (`.../{sessionId}`) can only resolve later. A literal link is
-  // shown right away; a template waits for `session-update`.
-  const linkTemplate = opts.sessionLink
-  const literalLink = linkTemplate && !hasSessionIdPlaceholder(linkTemplate) ? linkTemplate : undefined
-
-  emit({
-    kind: 'session',
-    driver: opts.driver.name,
-    workspace: opts.cwd,
-    fake: opts.driver.name === 'fake',
-    ...(literalLink ? { sessionLink: literalLink } : {}),
-  })
+  emitSessionStart({ emit, driver: opts.driver, cwd: opts.cwd, sessionLink: opts.sessionLink })
   // Surface the exact system prompt the agent runs under (#343). Nothing is read
   // off disk and appended after this, so the text is the whole of it (#547). The
   // per-turn user prompts ride along as `driver` `start` events, so the dashboard
@@ -332,7 +320,6 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
   // A consumption limit (#529) is the third clean stop: the account's quota, not
   // this run's spend, is what ran out.
   const consumptionController = new AbortController()
-  let consumptionTrip: ConsumptionWindow | undefined
   const runSignal = AbortSignal.any([
     ...(opts.signal ? [opts.signal] : []),
     budgetController.signal,
@@ -340,51 +327,14 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     consumptionController.signal,
   ])
 
-  // Watch the black box for its real session id (the {type:'result'} event) and
-  // surface it as `session-update` once known — that is the honest handle a UI
-  // links to. Re-emit when it changes, since each Claude Code prompt is a fresh
-  // session; the dashboard just updates the link in place. The same result event
-  // carries this turn's usage, which we fold into the run total and gate on (#322).
-  let lastSessionId: string | undefined
-  const usage = new UsageMeter()
-  const onDriverEvent = (event: DriverEvent) => {
-    emit({ kind: 'driver', event })
-    if (event.type !== 'result') return
-    if (event.sessionId && event.sessionId !== lastSessionId) {
-      lastSessionId = event.sessionId
-      const link = linkTemplate ? resolveSessionLink(linkTemplate, event.sessionId) : undefined
-      emit({ kind: 'session-update', sessionId: event.sessionId, ...(link ? { sessionLink: link } : {}) })
-    }
-    if (!event.usage) return
-    usage.add(event.usage)
-    const totals = usage.totals()
-    emit({ kind: 'usage', ...totals, ...(opts.budgetUsd != null ? { budgetUsd: opts.budgetUsd } : {}) })
-    // The turn that crosses the cap has already run (its cost is spent); stop the
-    // run before the next one. Signalled once — the next phase's check ends it.
-    // An agent that reports no price leaves `costUsd` undefined and so can never
-    // trip the cap; the CLI says so up front rather than let it look capped (#540).
-    if (opts.budgetUsd != null && totals.costUsd !== undefined && totals.costUsd >= opts.budgetUsd && !budgetController.signal.aborted) {
-      emit({ kind: 'log', message: `Budget reached: $${totals.costUsd.toFixed(4)} of $${opts.budgetUsd} — stopping the run.` })
-      budgetController.abort(new Error('[framework] budget reached'))
-    }
-    // The consumption limits (#519). Asked only between turns and answered from a
-    // cached reading: a live quota read spawns the whole agent CLI (~5s), so it
-    // can never sit here. A gate that throws is treated as "carry on" — the
-    // fail-open Rom confirmed, since an unreadable quota must not stop the work.
-    if (opts.consumptionGate && !consumptionController.signal.aborted) {
-      let reached: ConsumptionWindow | null = null
-      try {
-        reached = opts.consumptionGate()
-      } catch (err) {
-        console.error('[framework] consumptionGate threw; carrying on:', err)
-      }
-      if (reached) {
-        consumptionTrip = reached
-        emit({ kind: 'log', message: `${CONSUMPTION_LIMIT_LABEL[reached]} consumption limit reached — pausing the run.` })
-        consumptionController.abort(new Error('[framework] consumption limit reached'))
-      }
-    }
-  }
+  const { onDriverEvent, consumptionTrip } = createDriverEventHandler({
+    emit,
+    sessionLink: opts.sessionLink,
+    budgetUsd: opts.budgetUsd,
+    consumptionGate: opts.consumptionGate,
+    budgetController,
+    consumptionController,
+  })
 
   // 2. One driver session for the whole run; each prompt is a fresh invocation.
   const session: DriverSession = await opts.driver.start({
@@ -527,7 +477,7 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
       : budgetStopped
         ? `budget reached ($${opts.budgetUsd})`
         : paused
-          ? `${CONSUMPTION_LIMIT_LABEL[consumptionTrip ?? 'session']} consumption limit reached${resumeNote ? `; will resume from ${resumeNote}` : ''}`
+          ? `${CONSUMPTION_LIMIT_LABEL[consumptionTrip() ?? 'session']} consumption limit reached${resumeNote ? `; will resume from ${resumeNote}` : ''}`
           : err instanceof Error
             ? err.message
             : String(err)


### PR DESCRIPTION
Closes #565

`run.ts` and `prompt-run.ts` each carried their own copy of the same accounting: the session event, session-id/usage tracking, the budget cap (#322), the consumption gate (#529). With comments stripped the two `onDriverEvent` handlers were **30 identical lines**, differing only by a `: void` annotation.

Same shape as #563 one site earlier, and `prompt-run.ts` even pointed at its twin: `// see the same gate in run.ts (#540)`. The copies had not drifted yet. That is the argument for doing it now, not later.

New `run-telemetry.ts` with `emitSessionStart` + `createDriverEventHandler`. Not exported from the barrel, so the public API is unchanged (hence no changeset).

Deliberately NOT included: the teardown/catch block. `run.ts` has a `declined` branch (#358) and disposes a runner, so it differs for real and parameterizing that away would be worse than the duplication.

Behavior is provably unchanged. I captured the full event stream from a fake-driver run on clean main and on this branch, for **both** paths, and diffed:

- direct prompt path: 9 events, byte-identical (exercises session-update, usage, and the budget cap tripping)
- build path: 40 events, byte-identical

Full suite 536 pass / 0 fail on a clean dist-test. Copy-paste detector over `framework/src` goes from 5 clones to 3.