### PR TITLE
fix(framework): one JSONL tailer, so the dashboard gets the hardening

### DIFF
--- a/.changeset/one-jsonl-tailer.md
+++ b/.changeset/one-jsonl-tailer.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Fix the dashboard's event tail dropping a same-length rewrite. There were two JSONL tailers: `JsonlTailer` detects an in-place truncate both by the file shrinking and by it being rewritten to the same length (mtime advanced), while `tailEvents`, which is what the dashboard Channel runs, only checked for a shrink and never read mtime. A fresh run that rewrote `events.jsonl` to the same byte length was invisible to the dashboard. The two tailers, and the two hand-rolled `fs.watch`-plus-poll drivers behind them, are now one `JsonlTailer` + one `followFile`, so the run's control tail and the dashboard's event tail share the tested behavior instead of drifting. `tailEvents` had no test of its own; it has three now.

--- a/packages/framework/src/control.ts
+++ b/packages/framework/src/control.ts
@@ -1,9 +1,8 @@
-import { watch, type FSWatcher } from 'node:fs'
 import { appendFile, mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { ChoiceBy } from './events.js'
 import { FRAMEWORK_DIR } from './store/index.js'
-import { JsonlTailer } from './jsonl-tail.js'
+import { JsonlTailer, followFile } from './jsonl-tail.js'
 
 /**
  * The dashboard-to-run control channel (#344): the reverse of the event log.
@@ -63,32 +62,9 @@ export function watchControl(
   const tailer = new JsonlTailer<ControlEntry>(controlPath(cwd), entry => {
     if (isControlEntry(entry)) onEntry(entry)
   })
-  let pulling = false
-  const pump = async (): Promise<void> => {
-    if (pulling) return
-    pulling = true
-    try {
-      await tailer.pull()
-    } finally {
-      pulling = false
-    }
-  }
-  let watcher: FSWatcher | undefined
-  try {
-    watcher = watch(join(cwd, FRAMEWORK_DIR), () => void pump())
-  } catch {
-    // dir may not be watchable everywhere; the poll backstop still covers it
-  }
-  const poll = setInterval(() => void pump(), pollMs)
-  poll.unref() // never keep the process alive just for steering
-  void pump()
-  return {
-    close: () => {
-      clearInterval(poll)
-      watcher?.close()
-      watcher = undefined
-    },
-  }
+  // unref: never keep the process alive just for steering.
+  const stop = followFile(join(cwd, FRAMEWORK_DIR), () => tailer.pull(), { pollMs, unref: true })
+  return { close: stop }
 }
 
 /** Shape-check a parsed line. A multi-select pick may legitimately be `[]`. */

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -64,6 +64,7 @@ test('startOptionFlags maps only enabled Global options to CLI flags (#314)', ()
 
 const logEvent = (message: string): FrameworkEvent => ({ kind: 'log', message })
 const line = (message: string): string => JSON.stringify(logEvent(message)) + '\n'
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
 
 async function tmpWorkspace(): Promise<string> {
   const cwd = await mkdtemp(join(tmpdir(), 'framework-daemon-'))
@@ -133,7 +134,10 @@ test('EventTailer resets when the log is truncated by a fresh run', async () => 
     await tailer.pull()
     assert.deepEqual(seen, ['old-run'])
 
-    await writeFile(path, line('new-run')) // truncate + rewrite (shorter than offset)
+    // Truncate + rewrite to the SAME byte length (both lines are 35 bytes), so this is
+    // caught by the mtime check, not by the shrink check.
+    await sleep(20) // let mtime advance past the read above
+    await writeFile(path, line('new-run'))
     await tailer.pull()
     assert.deepEqual(seen, ['old-run', 'new-run'])
   } finally {

--- a/packages/framework/src/dashboard-rpc/events-tail.test.ts
+++ b/packages/framework/src/dashboard-rpc/events-tail.test.ts
@@ -1,0 +1,72 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { FrameworkEvent } from '../events.js'
+import { tailEvents } from './events-tail.js'
+
+const line = (message: string): string => JSON.stringify({ kind: 'log', message } satisfies FrameworkEvent) + '\n'
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+
+async function tmpWorkspace(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'framework-events-tail-'))
+}
+
+test('tailEvents seeds with what is already logged, then follows appends', async () => {
+  const cwd = await tmpWorkspace()
+  const path = join(cwd, 'events.jsonl')
+  await writeFile(path, line('first'))
+  const seen: string[] = []
+  const stop = tailEvents<FrameworkEvent>(path, e => void (e.kind === 'log' && seen.push(e.message)))
+  try {
+    await sleep(150)
+    assert.deepEqual(seen, ['first'])
+    await writeFile(path, line('first') + line('second'))
+    await sleep(150)
+    assert.deepEqual(seen, ['first', 'second'])
+  } finally {
+    stop()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('tailEvents resets when a fresh run rewrites the log to the same length (#567)', async () => {
+  const cwd = await tmpWorkspace()
+  const path = join(cwd, 'events.jsonl')
+  // Both lines are the same byte length, so the shrink check alone cannot see this;
+  // it is caught only by the same-length-rewrite detection. That is the whole point.
+  assert.equal(Buffer.byteLength(line('old-run')), Buffer.byteLength(line('new-run')))
+  await writeFile(path, line('old-run'))
+  const seen: string[] = []
+  const stop = tailEvents<FrameworkEvent>(path, e => void (e.kind === 'log' && seen.push(e.message)))
+  try {
+    await sleep(150)
+    assert.deepEqual(seen, ['old-run'])
+    await sleep(20) // let mtime advance past the seeding read
+    await writeFile(path, line('new-run'))
+    await sleep(1400) // fs.watch, and the poll backstop behind it
+    assert.deepEqual(seen, ['old-run', 'new-run'])
+  } finally {
+    stop()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('tailEvents stops pulling once stopped, and skips malformed lines', async () => {
+  const cwd = await tmpWorkspace()
+  const path = join(cwd, 'events.jsonl')
+  await writeFile(path, line('kept') + 'not json at all\n')
+  const seen: string[] = []
+  const stop = tailEvents<FrameworkEvent>(path, e => void (e.kind === 'log' && seen.push(e.message)))
+  try {
+    await sleep(150)
+    assert.deepEqual(seen, ['kept']) // the malformed line never breaks the stream
+    stop()
+    await writeFile(path, line('kept') + line('after-stop'))
+    await sleep(1200)
+    assert.deepEqual(seen, ['kept']) // nothing arrives after the stop
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})

--- a/packages/framework/src/dashboard-rpc/events-tail.ts
+++ b/packages/framework/src/dashboard-rpc/events-tail.ts
@@ -1,74 +1,22 @@
-import { watch, type FSWatcher } from 'node:fs'
-import { open, stat } from 'node:fs/promises'
 import { dirname } from 'node:path'
+import { JsonlTailer, followFile } from '../jsonl-tail.js'
+
+/** How often the poll backstop re-reads the log when `fs.watch` says nothing. */
+const POLL_MS = 1000
 
 /**
  * Tail a `.the-framework/events.jsonl`: read what is already logged, then follow
  * appends. Each complete JSONL line is parsed and handed to `onEvent`; malformed
- * lines are skipped. Offset-based so only new bytes are read, holding a torn trailing
- * line until its newline arrives; a truncate (a fresh run reusing the file) resets us.
- * An `fs.watch` drives it, with a 1s poll backstop since `fs.watch` is unreliable
- * across platforms. Returns a stop function that removes the watcher and the poll.
+ * lines are skipped. Returns a stop function that removes the watcher and the poll.
+ *
+ * The reading is {@link JsonlTailer} and the following is {@link followFile}, the same
+ * two pieces the run's control tail is built from. This used to be its own copy of both,
+ * which is how it ended up missing the tailer's same-length-rewrite detection (#567).
  *
  * Kept transport-agnostic (a plain `onEvent` callback, not a channel) so the file
  * side can be driven on its own; events.telefunc.ts wires it to a Telefunc Channel.
  */
 export function tailEvents<T = unknown>(path: string, onEvent: (event: T) => void): () => void {
-  let offset = 0
-  let buffer = ''
-  let pulling = false
-  let stopped = false
-
-  const pull = async (): Promise<void> => {
-    if (pulling || stopped) return
-    pulling = true
-    try {
-      const size = await stat(path).then(s => s.size).catch(() => -1)
-      if (size < 0) return // file not created yet
-      if (size < offset) {
-        offset = 0
-        buffer = ''
-      }
-      if (size === offset) return
-      const fh = await open(path, 'r')
-      try {
-        const length = size - offset
-        const chunk = Buffer.alloc(length)
-        await fh.read(chunk, 0, length, offset)
-        offset = size
-        buffer += chunk.toString('utf8')
-      } finally {
-        await fh.close()
-      }
-      const lines = buffer.split('\n')
-      buffer = lines.pop() ?? '' // last element is the (possibly empty) trailing fragment
-      for (const line of lines) {
-        if (!line.trim()) continue
-        let event: T
-        try {
-          event = JSON.parse(line) as T
-        } catch {
-          continue // a malformed line never breaks the stream
-        }
-        onEvent(event)
-      }
-    } finally {
-      pulling = false
-    }
-  }
-
-  let watcher: FSWatcher | undefined
-  try {
-    watcher = watch(dirname(path), () => void pull())
-  } catch {
-    // dir may not be watchable everywhere; the poll backstop still covers it
-  }
-  const poll = setInterval(() => void pull(), 1000)
-  void pull() // seed with whatever is already logged
-
-  return () => {
-    stopped = true
-    clearInterval(poll)
-    watcher?.close()
-  }
+  const tailer = new JsonlTailer<T>(path, onEvent)
+  return followFile(dirname(path), () => tailer.pull(), { pollMs: POLL_MS })
 }

--- a/packages/framework/src/jsonl-tail.ts
+++ b/packages/framework/src/jsonl-tail.ts
@@ -1,3 +1,4 @@
+import { watch, type FSWatcher } from 'node:fs'
 import { open } from 'node:fs/promises'
 
 /**
@@ -56,5 +57,51 @@ export class JsonlTailer<T> {
     } finally {
       await fd.close()
     }
+  }
+}
+
+/** Options for {@link followFile}. */
+export interface FollowFileOptions {
+  /** How often the backstop poll runs. */
+  pollMs: number
+  /** Let the process exit with the poll still scheduled (steering must never hold it open). */
+  unref?: boolean
+}
+
+/**
+ * Drive a {@link JsonlTailer} as the file grows: an `fs.watch` on `dir` for latency, plus a
+ * poll backstop because `fs.watch` is unreliable across platforms. Pulls are serialized (a
+ * pull already in flight swallows the next trigger) and stop for good once the returned
+ * function is called. Shared by the run's control tail and the dashboard's event tail, which
+ * hand-rolled this separately and drifted apart.
+ */
+export function followFile(dir: string, pull: () => Promise<void>, opts: FollowFileOptions): () => void {
+  let pulling = false
+  let stopped = false
+  const pump = async (): Promise<void> => {
+    if (pulling || stopped) return
+    pulling = true
+    try {
+      await pull()
+    } finally {
+      pulling = false
+    }
+  }
+
+  let watcher: FSWatcher | undefined
+  try {
+    watcher = watch(dir, () => void pump())
+  } catch {
+    // dir may not be watchable everywhere; the poll backstop still covers it
+  }
+  const poll = setInterval(() => void pump(), opts.pollMs)
+  if (opts.unref) poll.unref()
+  void pump() // seed with whatever is already written
+
+  return () => {
+    stopped = true
+    clearInterval(poll)
+    watcher?.close()
+    watcher = undefined
   }
 }


### PR DESCRIPTION
Closes #567

Two tailers existed and the dashboard used the one without the hardening. `JsonlTailer` catches an in-place truncate both by the file shrinking and by a same-length rewrite (mtime advanced). `tailEvents`, what the dashboard Channel actually runs, only checked the shrink.

Proven with both on the same scenario, before:

```
tailEvents  (dashboard, live path): ["old-run"]
JsonlTailer (hardened, control):    ["old-run","new-run"]
```

after: both `["old-run","new-run"]`.

The tell was in the tests. `daemon.test.ts` has a truncation test commented `// truncate + rewrite (shorter than offset)`, but both its lines are exactly 35 bytes, so `size < offset` is never true and it passed **only** via the mtime branch. The semantics we tested and documented were not the ones the dashboard ran. Comment corrected.

Both layers were duplicated: the read/parse half, and the `fs.watch` + poll driver that `control.ts` and `events-tail.ts` each hand-rolled (already drifted: 300ms + `unref` vs 1000ms + no `unref`). Now one `JsonlTailer` + one `followFile`, 91 lines deleted against 62 added, and the added ones are shared.

`tailEvents` had **no test of its own**, which is how the drift survived. It has three now: one fails against the old code (checked), two pin the behavior the rewrite had to preserve.

Honest severity: low probability. `events.jsonl` lines vary and the shrink check covers the common fresh-run case, so this is duplication with a correctness edge, not something on fire. Full suite 539 pass / 0 fail.