### PR TITLE
refactor(framework): share the await-gate rounds

### DIFF
--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -1,9 +1,9 @@
 import type { Driver, DriverSession } from './driver/index.js'
 import { type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
-import { resolveAwaitGate } from './run.js'
+import { runAwaitRounds } from './run.js'
 import { composeRunSystem, renderSystemPrompt, type EcoOptions, type TfContext } from './system-prompt.js'
 import { createDriverEventHandler, emitSessionStart } from './run-telemetry.js'
-import { PLAN_DECLINED_MESSAGE, createTurnSignalEmitter, isDeclinedConfirmation, parseAwaitGate } from './turn-gate.js'
+import { createTurnSignalEmitter } from './turn-gate.js'
 import { CONSUMPTION_LIMIT_LABEL, type ConsumptionWindow } from './consumption.js'
 import { leaveResumeNote } from './todo-loop.js'
 
@@ -65,9 +65,6 @@ export interface RunPromptResult {
   /** Every event emitted, in order. */
   events: FrameworkEvent[]
 }
-
-/** How many times the prompt may stop to ask (and be resumed) before it just finishes. */
-const MAX_AWAIT_ROUNDS = 5
 
 /**
  * Run one prompt to completion through the driver, pausing on each await gate
@@ -134,29 +131,21 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
   const emitTurnSignals = createTurnSignalEmitter(emit)
 
   try {
-    let turn = await session.prompt(firstPrompt, { signal: runSignal })
-    emitTurnSignals(turn.text)
-    let gate = parseAwaitGate(turn.text)
-    for (let round = 0; round < MAX_AWAIT_ROUNDS && gate; round++) {
-      const answer = await resolveAwaitGate(gate, round, { requestChoice: opts.requestChoice, emit, signal: runSignal })
-      if (isDeclinedConfirmation(gate, answer)) {
-        // A declined plan (#358) ends the run cleanly: the user takes over with fresh instructions.
-        emit({ kind: 'log', message: PLAN_DECLINED_MESSAGE })
-        gate = undefined
-        break
-      }
-      emit({ kind: 'log', message: `Continuing with your choice: ${answer}` })
-      turn = await session.prompt(
+    // A declined plan (#358) ends the run cleanly: the user takes over with fresh instructions.
+    const rounds = await runAwaitRounds({
+      session,
+      prompt: firstPrompt,
+      continuation: (gate, answer) =>
         `You paused to ask: "${gate.title}". The user chose: ${answer}. Continue with that decision, and do not ask again unless a genuinely new choice comes up.`,
-        { signal: runSignal },
-      )
-      emitTurnSignals(turn.text)
-      gate = parseAwaitGate(turn.text)
-    }
+      emitTurnSignals,
+      requestChoice: opts.requestChoice,
+      emit,
+      signal: runSignal,
+    })
     // The agent kept asking past the limit: finish with the latest turn rather than loop.
-    if (gate) emit({ kind: 'log', message: 'Finishing the run (await limit reached).' })
+    if (rounds.exhausted) emit({ kind: 'log', message: 'Finishing the run (await limit reached).' })
     emit({ kind: 'end', ok: true })
-    return { text: turn.text, events }
+    return { text: rounds.text, events }
   } catch (err) {
     // A user interrupt or the budget cap is a clean stop, not a failure (#322).
     const budgetStopped = budgetController.signal.aborted && opts.signal?.aborted !== true

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -5,11 +5,12 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { defineDomainPreset, defineLoop } from '@gemstack/ai-autopilot'
 import type { Prompt } from '@gemstack/ai-autopilot'
-import { DEFAULT_MAX_PASSES, requestChoices, requestMultiSelect, runFramework, type ChoicesOption, type MultiSelectOption } from './run.js'
+import { DEFAULT_MAX_PASSES, requestChoices, requestMultiSelect, runAwaitRounds, runFramework, type ChoicesOption, type MultiSelectOption } from './run.js'
 import { FAKE_DEPLOY, FAKE_INTENT, FAKE_SIGNALS, fakeDriver } from './fake-script.js'
 import { FakeDriver, type Driver, type DriverSession } from './driver/index.js'
 import { composeRunSystem } from './system-prompt.js'
 import type { ChoiceRequest, FrameworkEvent } from './events.js'
+import { MAX_AWAIT_ROUNDS, PLAN_DECLINED_MESSAGE } from './turn-gate.js'
 
 /** A driver that records the `system` framing it is started with, delegating the run to the fake. */
 function recordingDriver(): { driver: Driver; system: () => string } {
@@ -802,4 +803,82 @@ test('runFramework carries on when the gate itself fails (#529)', async () => {
 test('runFramework leaves the run ungated with no consumption gate (#529)', async () => {
   const { result } = await runFramework({ intent: FAKE_INTENT, driver: fakeDriver(), cwd: '/tmp/ws', signals: FAKE_SIGNALS })
   assert.ok(result)
+})
+
+// The await rounds shared by the direct prompt path and the backlog loop (#569). Both used
+// to carry their own copy, which is how the turn-signal emission missed one of them (#563).
+
+/** A gate the fake agent can emit, in the wire shape `parseAwaitGate` reads. */
+const choicesGate = (title: string): string =>
+  `${title}\n\`\`\`await-choices\n${JSON.stringify({ title, options: [{ id: 'a', label: 'Option A' }, { id: 'b', label: 'Option B' }] })}\n\`\`\``
+
+const confirmGate = (title: string): string =>
+  `${title}\n\`\`\`await-confirmation\n${JSON.stringify({ title })}\n\`\`\``
+
+test('runAwaitRounds resolves a gate, re-prompts with the answer, and emits every turn signal', async () => {
+  const events: FrameworkEvent[] = []
+  const prompts: string[] = []
+  const signalled: string[] = []
+  const driver = new FakeDriver({
+    respond: (prompt, i) => {
+      prompts.push(prompt)
+      return i === 0 ? choicesGate('Which way?') : 'All done.'
+    },
+  })
+  const session = await driver.start({ cwd: '/tmp/ws' })
+  const result = await runAwaitRounds({
+    session,
+    prompt: 'open',
+    continuation: (gate, answer) => `resume: ${gate.title} -> ${answer}`,
+    emitTurnSignals: text => void signalled.push(text),
+    requestChoice: async () => ({ picked: 'b' }),
+    emit: e => void events.push(e),
+  })
+
+  assert.deepEqual(result, { text: 'All done.', declined: false, exhausted: false })
+  assert.deepEqual(prompts, ['open', 'resume: Which way? -> Option B']) // the caller owns the wording
+  assert.ok(events.some(e => e.kind === 'log' && e.message === 'Continuing with your choice: Option B'))
+  // Every turn goes through the signal emitter, the gate turn included (#563).
+  assert.equal(signalled.length, 2)
+  assert.match(signalled[0]!, /await-choices/)
+  assert.equal(signalled[1], 'All done.')
+})
+
+test('runAwaitRounds reports a declined plan and stops instead of re-prompting (#358)', async () => {
+  const events: FrameworkEvent[] = []
+  const prompts: string[] = []
+  const driver = new FakeDriver({ respond: prompt => (prompts.push(prompt), confirmGate('Plan ok?')) })
+  const session = await driver.start({ cwd: '/tmp/ws' })
+  const result = await runAwaitRounds({
+    session,
+    prompt: 'open',
+    continuation: () => 'should never be sent',
+    emitTurnSignals: () => {},
+    requestChoice: async () => ({ picked: 'decline' }),
+    emit: e => void events.push(e),
+  })
+
+  assert.equal(result.declined, true)
+  assert.equal(result.exhausted, false)
+  assert.deepEqual(prompts, ['open']) // it stopped rather than continuing
+  assert.ok(events.some(e => e.kind === 'log' && e.message === PLAN_DECLINED_MESSAGE))
+})
+
+test('runAwaitRounds gives up after MAX_AWAIT_ROUNDS and reports it exhausted', async () => {
+  const prompts: string[] = []
+  // An agent that asks forever: the cap is what stops it.
+  const driver = new FakeDriver({ respond: prompt => (prompts.push(prompt), choicesGate('Again?')) })
+  const session = await driver.start({ cwd: '/tmp/ws' })
+  const result = await runAwaitRounds({
+    session,
+    prompt: 'open',
+    continuation: () => 'again',
+    emitTurnSignals: () => {},
+    requestChoice: async () => ({ picked: 'a' }),
+    emit: () => {},
+  })
+
+  assert.equal(result.exhausted, true)
+  assert.equal(result.declined, false)
+  assert.equal(prompts.length, MAX_AWAIT_ROUNDS + 1) // the opener, then one per round
 })

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -26,7 +26,7 @@ import { CONSUMPTION_LIMIT_LABEL, type ConsumptionWindow } from './consumption.j
 import type { Driver, DriverSession } from './driver/index.js'
 import { composeRunSystem, type EcoOptions, type TfContext } from './system-prompt.js'
 import { createDriverEventHandler, emitSessionStart } from './run-telemetry.js'
-import { AWAIT_PROTOCOL, CONFIRM_APPROVED, CONFIRM_DECLINED, PLAN_DECLINED_MESSAGE, createTurnSignalEmitter, isDeclinedConfirmation, parseAwaitGate, type ParsedAwaitGate } from './turn-gate.js'
+import { AWAIT_PROTOCOL, CONFIRM_APPROVED, CONFIRM_DECLINED, MAX_AWAIT_ROUNDS, PLAN_DECLINED_MESSAGE, createTurnSignalEmitter, isDeclinedConfirmation, parseAwaitGate, type ParsedAwaitGate } from './turn-gate.js'
 // Value import from todo-loop.js is a benign cycle: todo-loop.js only calls
 // run.js's hoisted function declarations (requestChoices / resolveAwaitGate).
 import { leaveResumeNote, runTodoLoop, type TodoLoopResult } from './todo-loop.js'
@@ -490,8 +490,6 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
   }
 }
 
-/** How many times a build may stop to ask (and be resumed) before it just proceeds (#337). */
-const MAX_AWAIT_ROUNDS = 5
 
 /**
  * The agent-authored await gate (#337 / #339): the turn-boundary counterpart to the
@@ -604,6 +602,69 @@ export async function resolveAwaitGate(
   })
   return gate.options.find(o => o.id === pickedId)?.label ?? pickedId
 }
+
+/** What {@link runAwaitRounds} hands back. */
+export interface AwaitRoundsResult {
+  /** The last turn's text. */
+  text: string
+  /** A confirmation gate was declined (#358): the caller stops rather than build on it. */
+  declined: boolean
+  /** The agent was still asking when the round cap ran out. */
+  exhausted: boolean
+}
+
+/** Inputs to {@link runAwaitRounds}. */
+export interface AwaitRoundsOptions {
+  session: DriverSession
+  /** The prompt that opens the exchange. */
+  prompt: string
+  /**
+   * The prompt that resumes the agent once the user has answered a gate. The caller owns
+   * the wording (it is agent-facing text, and each path says something different), so this
+   * takes it rather than templating it here.
+   */
+  continuation: (gate: ParsedAwaitGate, answer: string) => string
+  /** Emit the signals each turn carries (#563). */
+  emitTurnSignals: (text: string) => void
+  requestChoice?: ((req: ChoiceRequest) => Promise<ChoicePick>) | undefined
+  emit: (event: FrameworkEvent) => void
+  signal?: AbortSignal | undefined
+}
+
+/**
+ * Prompt the agent and honor its await gates (#337/#339) until it stops asking: resolve each
+ * gate to the user's answer, re-prompt with it, and repeat up to {@link MAX_AWAIT_ROUNDS}.
+ * A declined plan (#358) ends the exchange rather than re-prompting.
+ *
+ * Every turn here is a turn like any other, so each one's signals are emitted. That is the
+ * point of sharing this: the direct prompt path and the backlog loop each had their own copy
+ * of these rounds, and the emission had to be added to each by hand (#563).
+ *
+ * The build's {@link agentAwaitGate} is deliberately not this: it wraps a supervisor pass
+ * rather than a raw prompt, and skips gates entirely when headless.
+ */
+export async function runAwaitRounds(opts: AwaitRoundsOptions): Promise<AwaitRoundsResult> {
+  const { session, emit, emitTurnSignals } = opts
+  const deps = { requestChoice: opts.requestChoice, emit, signal: opts.signal }
+  const signalOpt = opts.signal ? { signal: opts.signal } : {}
+
+  let turn = await session.prompt(opts.prompt, signalOpt)
+  emitTurnSignals(turn.text)
+  let gate = parseAwaitGate(turn.text)
+  for (let round = 0; round < MAX_AWAIT_ROUNDS && gate; round++) {
+    const answer = await resolveAwaitGate(gate, round, deps)
+    if (isDeclinedConfirmation(gate, answer)) {
+      emit({ kind: 'log', message: PLAN_DECLINED_MESSAGE })
+      return { text: turn.text, declined: true, exhausted: false }
+    }
+    emit({ kind: 'log', message: `Continuing with your choice: ${answer}` })
+    turn = await session.prompt(opts.continuation(gate, answer), signalOpt)
+    emitTurnSignals(turn.text)
+    gate = parseAwaitGate(turn.text)
+  }
+  return { text: turn.text, declined: false, exhausted: gate !== undefined }
+}
+
 
 /** The recommended fallback pick when a single-select gate cannot get a real answer. */
 const PROCEED: ChoicePick = { picked: 'proceed', by: 'auto' }

--- a/packages/framework/src/todo-loop.ts
+++ b/packages/framework/src/todo-loop.ts
@@ -2,8 +2,8 @@ import { readdir, readFile, stat, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { DriverSession } from './driver/index.js'
 import type { ChoicePick, ChoiceRequest, FrameworkEvent } from './events.js'
-import { requestChoices, resolveAwaitGate } from './run.js'
-import { PLAN_DECLINED_MESSAGE, createTurnSignalEmitter, isDeclinedConfirmation, parseAwaitGate } from './turn-gate.js'
+import { requestChoices, runAwaitRounds } from './run.js'
+import { createTurnSignalEmitter } from './turn-gate.js'
 
 /**
  * The backlog loop (#323): once the main work settles, consume the agent's own
@@ -284,9 +284,6 @@ export async function runTodoLoop(opts: TodoLoopOptions): Promise<TodoLoopResult
   return { completed, reason: 'max-items', ...(file ? { file } : {}) }
 }
 
-/** How many times one backlog item may stop to ask before the turn just finishes. */
-const MAX_AWAIT_ROUNDS = 5
-
 /** One backlog item's turn: complete the first open entry, honoring await gates. */
 async function promptItem(
   session: DriverSession,
@@ -298,24 +295,16 @@ async function promptItem(
     emitTurnSignals: (text: string) => void
   },
 ): Promise<void> {
-  const signalOpt = deps.signal ? { signal: deps.signal } : {}
   const prompt = `Open \`${fileName}\` at the workspace root and work on the FIRST open entry only. Complete it fully and verify your work. Then update \`${fileName}\`: check the entry off (or remove it). Do not start any other entry.`
-  let turn = await session.prompt(prompt, signalOpt)
-  deps.emitTurnSignals(turn.text)
-  let gate = parseAwaitGate(turn.text)
-  for (let round = 0; round < MAX_AWAIT_ROUNDS && gate; round++) {
-    const answer = await resolveAwaitGate(gate, round, deps)
-    if (isDeclinedConfirmation(gate, answer)) {
-      // A declined plan (#358) ends the item turn; the loop's stall check takes it from there.
-      deps.emit({ kind: 'log', message: PLAN_DECLINED_MESSAGE })
-      return
-    }
-    deps.emit({ kind: 'log', message: `Continuing with your choice: ${answer}` })
-    turn = await session.prompt(
+  // A declined plan (#358) ends the item turn; the loop's stall check takes it from there.
+  await runAwaitRounds({
+    session,
+    prompt,
+    continuation: (gate, answer) =>
       `You paused to ask: "${gate.title}". The user chose: ${answer}. Continue the backlog entry with that decision, and do not ask again unless a genuinely new choice comes up.`,
-      signalOpt,
-    )
-    deps.emitTurnSignals(turn.text)
-    gate = parseAwaitGate(turn.text)
-  }
+    emitTurnSignals: deps.emitTurnSignals,
+    requestChoice: deps.requestChoice,
+    emit: deps.emit,
+    signal: deps.signal,
+  })
 }

--- a/packages/framework/src/turn-gate.ts
+++ b/packages/framework/src/turn-gate.ts
@@ -62,6 +62,13 @@ export type ParsedAwaitGate =
 export const CONFIRM_APPROVED = 'Approve'
 export const CONFIRM_DECLINED = 'Decline'
 
+/**
+ * How many times the agent may stop to ask, and be resumed, before a run stops honoring
+ * gates and just finishes. A property of the await protocol, so every path that runs gates
+ * shares it: a build, a direct prompt, and the backlog loop each used to declare their own.
+ */
+export const MAX_AWAIT_ROUNDS = 5
+
 /** The log line printed when a confirmation gate is declined (#358). */
 export const PLAN_DECLINED_MESSAGE = 'Plan declined, awaiting user instructions.'
 


### PR DESCRIPTION
Closes #569

`MAX_AWAIT_ROUNDS = 5` was declared **three times**, all private. The loop around it existed twice: `prompt-run.ts` and `todo-loop.ts` ran the same eight steps, differing only in how they reported a decline.

This is exactly where #563 happened. The turn-signal emission had to be added to each copy by hand, and the third copy never got one. Now the control flow is shared, so the next fix lands everywhere by construction.

- `MAX_AWAIT_ROUNDS` moves to `turn-gate.ts`, which owns the await protocol it caps.
- `runAwaitRounds` sits beside `resolveAwaitGate` in `run.ts`, where both callers already import from, so it adds no import cycle.
- Not barrel-exported, so the public API is unchanged (no changeset).

**Deliberately out of scope:**

1. `run.ts`s `agentAwaitGate`. It wraps a supervisor pass rather than a raw prompt and has an `if (!requestChoice) return run` short-circuit that `prompt-run.ts:30-33` documents as intentional. It only takes the shared constant.
2. **The continuation prompt wording.** All three sites keep their own literal, byte for byte. That text is agent-facing, so unifying it is a design call: filed as #570.

Verified by diffing behavior against main, not just by tests passing:

- await gate rounds: **byte-identical** (same events, same logs, and the same continuation prompt text reaches the agent, which is the proof no prompt text moved)
- direct prompt path: 9 events byte-identical
- build path: 40 events byte-identical

Three new tests pin the shared contract (resolve/re-prompt/signals, declined, exhausted). Reverting the signal emission inside `runAwaitRounds` makes the first one fail, so it genuinely covers the #563 regression for both paths at once. Full suite 542 pass / 0 fail.