### PR TITLE
refactor(ai-sdk): one contentToString, with the separator explicit

### DIFF
--- a/packages/ai-sdk/src/memory-extract.ts
+++ b/packages/ai-sdk/src/memory-extract.ts
@@ -5,11 +5,11 @@ import { Output } from './output.js'
 import type {
   AiMessage,
   AiMiddleware,
-  ContentPart,
   MemoryEntry,
   RemembersSpec,
 } from './types.js'
 import type { UserMemoryLookup } from './memory.js'
+import { contentToString } from './util/content.js'
 
 export interface MemoryExtractOptions {
   /**
@@ -174,7 +174,7 @@ function extractLatestTurn(messages: AiMessage[]): { user: string; assistant: st
     const m = messages[i]
     if (!m || m.role !== 'assistant') continue
     if (m.toolCalls && m.toolCalls.length > 0) continue   // tool-call step, not a final reply
-    const text = contentToString(m.content)
+    const text = contentToString(m.content, '\n')
     if (text.length === 0) continue
     assistantText  = text
     lastAssistantIdx = i
@@ -186,21 +186,13 @@ function extractLatestTurn(messages: AiMessage[]): { user: string; assistant: st
   for (let i = lastAssistantIdx - 1; i >= 0; i--) {
     const m = messages[i]
     if (!m || m.role !== 'user') continue
-    const text = contentToString(m.content)
+    const text = contentToString(m.content, '\n')
     if (text.length === 0) continue
     return { user: text, assistant: assistantText }
   }
   return null
 }
 
-function contentToString(content: string | ContentPart[]): string {
-  if (typeof content === 'string') return content
-  const out: string[] = []
-  for (const p of content) {
-    if (p.type === 'text' && typeof p.text === 'string') out.push(p.text)
-  }
-  return out.join('\n')
-}
 
 function mergeTags(modelTags: string[] | undefined, specTags: string[]): string[] {
   if (!modelTags || modelTags.length === 0) return [...specTags]

--- a/packages/ai-sdk/src/providers/anthropic.ts
+++ b/packages/ai-sdk/src/providers/anthropic.ts
@@ -15,6 +15,7 @@ import type {
   ToolChoice,
 } from '../types.js'
 import { base64ToUtf8 } from '../base64.js'
+import { contentToString } from '../util/content.js'
 
 export interface AnthropicConfig {
   apiKey: string
@@ -168,10 +169,6 @@ export function splitSystemMessages(messages: AiMessage[]): { system: string | u
   return { system, messages: rest }
 }
 
-function contentToString(content: string | import('../types.js').ContentPart[]): string {
-  if (typeof content === 'string') return content
-  return content.filter(p => p.type === 'text').map(p => (p as { text: string }).text).join('')
-}
 
 function contentToAnthropicParts(content: string | import('../types.js').ContentPart[]): unknown[] | string {
   if (typeof content === 'string') return content

--- a/packages/ai-sdk/src/providers/google.ts
+++ b/packages/ai-sdk/src/providers/google.ts
@@ -35,6 +35,7 @@ import {
   durationToGoogleTtl,
   _internals as _registryInternals,
 } from './google-cache-registry.js'
+import { contentToString } from '../util/content.js'
 
 export interface GoogleConfig {
   apiKey: string
@@ -229,10 +230,6 @@ export class GoogleAdapter implements ProviderAdapter {
 
 // ─── Conversion Helpers ──────────────────────────────────
 
-function contentToString(content: string | import('../types.js').ContentPart[]): string {
-  if (typeof content === 'string') return content
-  return content.filter(p => p.type === 'text').map(p => (p as { text: string }).text).join('')
-}
 
 function contentToGeminiParts(content: string | import('../types.js').ContentPart[]): unknown[] {
   if (typeof content === 'string') return [{ text: content }]

--- a/packages/ai-sdk/src/providers/openai.ts
+++ b/packages/ai-sdk/src/providers/openai.ts
@@ -36,6 +36,7 @@ import type {
 } from '../types.js'
 import { cyrb53Hex } from '../util/hash.js'
 import { base64ToUtf8 } from '../base64.js'
+import { contentToString } from '../util/content.js'
 
 export interface OpenAIConfig {
   apiKey: string
@@ -206,10 +207,6 @@ export class OpenAIAdapter implements ProviderAdapter {
 
 // ─── Conversion Helpers ──────────────────────────────────
 
-function contentToString(content: string | import('../types.js').ContentPart[]): string {
-  if (typeof content === 'string') return content
-  return content.filter(p => p.type === 'text').map(p => (p as { text: string }).text).join('')
-}
 
 function contentToOpenAIParts(content: string | import('../types.js').ContentPart[]): unknown[] | string {
   if (typeof content === 'string') return content

--- a/packages/ai-sdk/src/util/content.test.ts
+++ b/packages/ai-sdk/src/util/content.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { contentToString } from './content.js'
+import type { ContentPart } from '../types.js'
+
+describe('contentToString', () => {
+  const mixed: ContentPart[] = [
+    { type: 'text', text: 'Hello' },
+    { type: 'image', data: 'x', mimeType: 'image/png' },
+    { type: 'text', text: 'world' },
+  ]
+
+  it('passes a plain string through untouched', () => {
+    assert.equal(contentToString('already text'), 'already text')
+  })
+
+  it('joins text parts with no separator by default, which is what the providers send', () => {
+    assert.equal(contentToString(mixed), 'Helloworld')
+  })
+
+  it('takes a separator, which is what memory extraction needs (#572)', () => {
+    assert.equal(contentToString(mixed, '\n'), 'Hello\nworld')
+  })
+
+  it('drops parts that carry no text', () => {
+    assert.equal(contentToString([{ type: 'image', data: 'x', mimeType: 'image/png' }]), '')
+    assert.equal(contentToString([{ type: 'document', data: 'x', mimeType: 'application/pdf' }]), '')
+    assert.equal(contentToString([]), '')
+  })
+
+  it('keeps the parts in order', () => {
+    const parts: ContentPart[] = [
+      { type: 'text', text: 'a' },
+      { type: 'text', text: 'b' },
+      { type: 'text', text: 'c' },
+    ]
+    assert.equal(contentToString(parts, '-'), 'a-b-c')
+  })
+})

--- a/packages/ai-sdk/src/util/content.ts
+++ b/packages/ai-sdk/src/util/content.ts
@@ -1,0 +1,19 @@
+import type { ContentPart } from '../types.js'
+
+/**
+ * Flatten a message's content to plain text: a string passes through, and a
+ * {@link ContentPart} list contributes its text parts in order. Image and document
+ * parts have no text and are dropped.
+ *
+ * `separator` is explicit because the call sites genuinely disagree: the providers
+ * join with `''` (the parts are contiguous chunks of one message) while memory
+ * extraction joins with `'\n'`. Whether that difference is intended is #572; this
+ * only makes it visible at the call site rather than hidden in a fourth copy.
+ */
+export function contentToString(content: string | ContentPart[], separator = ''): string {
+  if (typeof content === 'string') return content
+  const text: string[] = []
+  // `type === 'text'` narrows the union, so the part's `text` needs no cast or guard.
+  for (const part of content) if (part.type === 'text') text.push(part.text)
+  return text.join(separator)
+}


### PR DESCRIPTION
Closes #572. The semantic question it raised is split out as #573 and deliberately left open.

`contentToString` existed **four times**. The three providers were byte-identical. `memory-extract.ts` had the same name and the same signature but joined with `"\n"` instead of `""`, so the same two-part message reached a provider as `"Helloworld"` and memory extraction as `"Hello\nworld"`.

One helper in `util/`, separator a parameter defaulting to `""`. Every call site keeps exactly the behaviour it has today; the difference is now stated at the call site instead of hidden in a fourth copy. I did not decide which join is correct: that is #573.

Free fixes that came with it: `ContentPart` is a discriminated union, so `type === "text"` already narrows it. The providers' `as { text: string }` cast and memory-extract's `typeof p.text === "string"` guard were both unnecessary and are gone.

Internal only, not barrel-exported, so no changeset.

Verified both old behaviours are preserved by recomputing each old copy independently and comparing:

```
matches old provider copy? true
matches old memory copy?   true
```

ai-sdk suite 872 pass / 0 fail (5 new tests on the helper, including one pinning each of the two separators).