### PR TITLE
fix(framework): report a failed relay publish instead of dropping it

### DIFF
--- a/.changeset/nervous-donkeys-invent.md
+++ b/.changeset/nervous-donkeys-invent.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Report a failed relay publish instead of dropping it. `relayPublisher` never checked the HTTP response, so only a thrown fetch reached `onError` and every error status was silent: `--share <url>` printed a shareable link and then reported nothing, forever.

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -900,7 +900,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   }
 
   // Publish the run to a relay (#230) so teammates can watch it live. Best-effort:
-  // a relay that is down never fails the run (relayPublisher swallows POST errors).
+  // a relay that is down reports each failed POST here but never fails the run.
   let publisher: RelayPublisher | undefined
   if (opts.share) {
     publisher = relayPublisher(opts.share, randomUUID(), err =>

--- a/packages/framework/src/relay.test.ts
+++ b/packages/framework/src/relay.test.ts
@@ -164,6 +164,36 @@ test('relayPublisher does not hang flush() when the relay accepts but never resp
   }
 })
 
+test('relayPublisher reports a rejected publish, which fetch resolves rather than throws (#575)', async () => {
+  // maxBodyBytes small enough that one event trips the relay's 413.
+  const relay = await startRelay({ ...local, maxBodyBytes: 512, clientBundleDir: '/no/such/bundle' })
+  try {
+    const errors: unknown[] = []
+    const pub = relayPublisher(relay.url, 'over-cap', e => errors.push(e))
+    pub.publish({ kind: 'log', message: 'x'.repeat(2000) })
+    await pub.flush()
+    assert.equal(errors.length, 1) // an error STATUS is a failed POST, same as a thrown fetch
+    assert.match(String(errors[0]), /413/)
+  } finally {
+    await relay.close()
+  }
+})
+
+test('relayPublisher keeps publishing after a rejected event, and stays quiet when accepted (#575)', async () => {
+  const relay = await startRelay({ ...local, maxBodyBytes: 512, clientBundleDir: '/no/such/bundle' })
+  try {
+    const errors: unknown[] = []
+    const pub = relayPublisher(relay.url, 'mixed', e => errors.push(e))
+    pub.publish({ kind: 'log', message: 'x'.repeat(2000) }) // rejected: 413
+    pub.publish({ kind: 'log', message: 'small' }) // accepted: 202
+    await pub.flush()
+    assert.equal(errors.length, 1) // only the rejected one reported; best-effort, the run goes on
+    assert.deepEqual(relay.runIds(), ['mixed'])
+  } finally {
+    await relay.close()
+  }
+})
+
 test('healthz is 200; a bad publish is rejected without crashing the run', async () => {
   const relay = await startRelay({ ...local, clientBundleDir: '/no/such/bundle' })
   try {

--- a/packages/framework/src/relay.ts
+++ b/packages/framework/src/relay.ts
@@ -250,12 +250,15 @@ export function relayPublisher(
         try {
           // Timeout so a relay that accepts but never responds can't wedge flush()
           // (awaited on shutdown) and hang the whole CLI on exit.
-          await fetch(`${root}/publish`, {
+          const res = await fetch(`${root}/publish`, {
             method: 'POST',
             headers: { 'content-type': 'application/json' },
             body: JSON.stringify(event),
             signal: AbortSignal.timeout(timeoutMs),
           })
+          // fetch only throws on a transport failure, so a rejected event (413 over
+          // the body cap, 400, or a URL that isn't a relay) would otherwise be silent.
+          if (!res.ok) throw new Error(`relay answered ${res.status} ${res.statusText}`.trimEnd())
         } catch (err) {
           onError?.(err)
         }


### PR DESCRIPTION
`relayPublisher` says "a failed POST is reported via `onError` but never interrupts the run". It only did the second half: the `fetch` result was discarded, so only a *thrown* fetch reached `onError`. Every error *status* resolved and was dropped.

Probed against a real relay, before and after:

| scenario | before | after |
|---|---|---|
| 413, event over the 256KiB cap | silent | `relay answered 413 Payload Too Large` |
| `--share https://example.com` | silent | `relay answered 405 Method Not Allowed` |
| connection refused (control) | reported | reported |

Best-effort is unchanged: a rejected publish is reported and the run goes on.

Two tests, both verified to fail with the fix reverted (and nothing else fails). Also corrected the `cli.ts` comment that claimed the publisher "swallows POST errors", which is what it did rather than what it was meant to do.

545 tests pass, typecheck clean.

Closes #575
