### PR TITLE
fix(dashboard): stop dropping failed reads, share the async effects

### DIFF
--- a/.changeset/olive-pumas-shake.md
+++ b/.changeset/olive-pumas-shake.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework-dashboard': patch
+---
+
+Stop dropping failed dashboard reads. Every panel wrote its own async effect and only the usage panel caught, so a daemon restart made each of the others an unhandled rejection every tick. They now share two hooks (`useLoaded`/`usePolled`) that keep the last value through a failed read, reset on a project switch rather than showing the previous project's data, and retire an in-flight read on unmount — including the Runs rail's `reload`, which was unguarded and could write a stale project's runs.

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 import type { DashboardData, ActiveRun, ProjectStat, ProjectQueue } from '@gemstack/framework'
 import { FolderGit2, Zap, ListChecks, History } from 'lucide-react'
 import { onDashboard } from '../server/reads.telefunc.js'
@@ -6,6 +6,7 @@ import { ActivityChart } from './ActivityChart.js'
 import { RunOutcomes } from './RunOutcomes.js'
 import { UsagePanel } from './UsagePanel.js'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card.js'
+import { usePolled } from '../lib/use-async.js'
 import { cn } from '../lib/utils.js'
 
 // The Overview dashboard page (#471). What used to be a cramped, collapsible section in the
@@ -14,18 +15,7 @@ import { cn } from '../lib/utils.js'
 // projection of the same files over the `onDashboard` Telefunc read, polled so it stays live.
 // Selecting anything here jumps into that project. Shown by the shell when no project is picked.
 export function DashboardPage({ onSelectProject }: { onSelectProject: (id: string) => void }) {
-  const [data, setData] = useState<DashboardData | null>(null)
-
-  useEffect(() => {
-    let live = true
-    const load = () => void onDashboard().then(d => live && setData(d))
-    load()
-    const poll = setInterval(load, 5000)
-    return () => {
-      live = false
-      clearInterval(poll)
-    }
-  }, [])
+  const { value: data } = usePolled<DashboardData | null>(onDashboard, null, 5000, [])
 
   return (
     <div className="min-h-0 flex-1 overflow-y-auto">

--- a/packages/framework-dashboard/components/DocsPanel.tsx
+++ b/packages/framework-dashboard/components/DocsPanel.tsx
@@ -1,30 +1,16 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import type { WorkspaceDoc } from '@gemstack/framework'
 import { onDocs } from '../server/reads.telefunc.js'
 import { Button } from './ui/button.js'
 import { Markdown } from './Markdown.js'
+import { usePolled } from '../lib/use-async.js'
 import { cn } from '../lib/utils.js'
 
 // The surfaced documents (#319/#328): the PLAN/TODO the agent writes, rendered beside
 // the run. Telefunc RPC (server/reads.telefunc.ts), polled so edits mid-run show up.
 export function DocsPanel({ projectId }: { projectId: string | null }) {
-  const [docs, setDocs] = useState<WorkspaceDoc[]>([])
+  const { value: docs } = usePolled<WorkspaceDoc[]>(projectId ? () => onDocs(projectId) : null, [], 4000, [projectId])
   const [active, setActive] = useState(0)
-
-  useEffect(() => {
-    if (!projectId) {
-      setDocs([])
-      return
-    }
-    let live = true
-    const load = () => void onDocs(projectId).then(list => live && setDocs(list))
-    load()
-    const poll = setInterval(load, 4000)
-    return () => {
-      live = false
-      clearInterval(poll)
-    }
-  }, [projectId])
 
   if (!projectId) return null
   if (docs.length === 0) return <p className="p-4 text-sm text-muted-foreground">No PLAN/TODO docs yet.</p>

--- a/packages/framework-dashboard/components/FileTree.tsx
+++ b/packages/framework-dashboard/components/FileTree.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Check, FileIcon } from 'lucide-react'
 import { onProjectFileStatus } from '../server/reads.telefunc.js'
+import { usePolled } from '../lib/use-async.js'
 import {
   Files,
   FolderItem,
@@ -11,6 +12,9 @@ import {
 } from './animate-ui/components/base/files/index.js'
 
 type FileGitStatus = 'untracked' | 'modified' | 'deleted'
+
+/** Stable, so the `useMemo` on `status` doesn't re-run for a fresh empty object. */
+const EMPTY_STATUS: Record<string, FileGitStatus> = {}
 
 // The project panel's file tree (#492): a lazy, collapsible tree built from the flat
 // `git ls-files` list (onProjectFiles, shared with the `#` picker #504). It is a file-level
@@ -78,18 +82,12 @@ export function FileTree({
   const [query, setQuery] = useState('')
 
   // Per-file git status for the dots (#492): polled so it tracks a run editing files.
-  const [status, setStatus] = useState<Record<string, FileGitStatus>>({})
-  useEffect(() => {
-    let live = true
-    setStatus({})
-    const load = () => void onProjectFileStatus(projectId).then(s => live && setStatus(s))
-    load()
-    const poll = setInterval(load, 8_000)
-    return () => {
-      live = false
-      clearInterval(poll)
-    }
-  }, [projectId])
+  const { value: status } = usePolled<Record<string, FileGitStatus>>(
+    () => onProjectFileStatus(projectId),
+    EMPTY_STATUS,
+    8_000,
+    [projectId],
+  )
 
   const folderStatus = useMemo(() => foldersFromStatus(status), [status])
 

--- a/packages/framework-dashboard/components/GitStatusBar.tsx
+++ b/packages/framework-dashboard/components/GitStatusBar.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react'
 import type { GitStatus } from '@gemstack/framework'
 import { GitBranch } from 'lucide-react'
 import { onGitStatus } from '../server/reads.telefunc.js'
+import { usePolled } from '../lib/use-async.js'
 import { cn } from '../lib/utils.js'
 
 // The project panel's git status (#491, part of #488): active branch, a clean/dirty dot, and
@@ -9,19 +9,7 @@ import { cn } from '../lib/utils.js'
 // when the project is not a git repo (or on the relay, which has no local checkout).
 // `inline` renders just the status (for the project action bar); otherwise a full-width row.
 export function GitStatusBar({ projectId, inline = false }: { projectId: string; inline?: boolean }) {
-  const [status, setStatus] = useState<GitStatus | null>(null)
-
-  useEffect(() => {
-    let live = true
-    setStatus(null)
-    const load = () => void onGitStatus(projectId).then(s => live && setStatus(s))
-    load()
-    const poll = setInterval(load, 10_000)
-    return () => {
-      live = false
-      clearInterval(poll)
-    }
-  }, [projectId])
+  const { value: status } = usePolled<GitStatus | null>(() => onGitStatus(projectId), null, 10_000, [projectId])
 
   if (!status) return null
 

--- a/packages/framework-dashboard/components/ProjectActions.tsx
+++ b/packages/framework-dashboard/components/ProjectActions.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Github, FolderOpen, Code } from 'lucide-react'
 import { onGithubUrl } from '../server/reads.telefunc.js'
+import { useLoaded } from '../lib/use-async.js'
 import { sendOpenInApp } from '../server/control.telefunc.js'
 import { PreviewBar } from './PreviewBar.js'
 import { GitStatusBar } from './GitStatusBar.js'
@@ -12,19 +13,13 @@ import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './ui/t
 // spawn the OS file manager / editor on the project's path. This bar only renders in the local
 // dashboard (the relay shows RelayView instead), so the localhost actions never appear there.
 export function ProjectActions({ projectId }: { projectId: string }) {
-  const [githubUrl, setGithubUrl] = useState<string | null>(null)
+  const githubUrl = useLoaded<string | null>(() => onGithubUrl(projectId), null, [projectId])
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  useEffect(() => {
-    let live = true
-    setGithubUrl(null)
-    setError(null)
-    void onGithubUrl(projectId).then(url => live && setGithubUrl(url))
-    return () => {
-      live = false
-    }
-  }, [projectId])
+  // `error` belongs to open(), not to the read, so clearing it on a switch is its own effect:
+  // otherwise the last project's failure stays on screen next to the new project's actions.
+  useEffect(() => setError(null), [projectId])
 
   const open = async (target: 'files' | 'editor') => {
     setBusy(true)

--- a/packages/framework-dashboard/components/ProjectLogPanel.tsx
+++ b/packages/framework-dashboard/components/ProjectLogPanel.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react'
 import type { LogEntry } from '@gemstack/framework'
 import { onProjectLog } from '../server/reads.telefunc.js'
 import { Badge } from './ui/badge.js'
+import { useLoaded } from '../lib/use-async.js'
 import { cn } from '../lib/utils.js'
 
 const STATUS_TONE: Record<string, string> = {
@@ -14,19 +14,7 @@ const STATUS_TONE: Record<string, string> = {
 // The committed project log (#378/#379): `.the-framework/LOGS.md`, every finished
 // loop/prompt/build run newest-first, over a Telefunc RPC (server/reads.telefunc.ts).
 export function ProjectLogPanel({ projectId }: { projectId: string | null }) {
-  const [logs, setLogs] = useState<LogEntry[]>([])
-
-  useEffect(() => {
-    if (!projectId) {
-      setLogs([])
-      return
-    }
-    let live = true
-    void onProjectLog(projectId).then(list => live && setLogs(list))
-    return () => {
-      live = false
-    }
-  }, [projectId])
+  const logs = useLoaded<LogEntry[]>(projectId ? () => onProjectLog(projectId) : null, [], [projectId])
 
   if (!projectId) return null
   if (logs.length === 0) return <p className="p-4 text-sm text-muted-foreground">No committed log entries yet.</p>

--- a/packages/framework-dashboard/components/RunReplay.tsx
+++ b/packages/framework-dashboard/components/RunReplay.tsx
@@ -1,21 +1,13 @@
-import { useEffect, useState } from 'react'
 import type { FrameworkEvent } from '@gemstack/framework'
 import { onRun } from '../server/reads.telefunc.js'
 import { EventList } from './EventList.js'
+import { useLoaded } from '../lib/use-async.js'
 
 // Replay one archived run: load its event log over a Telefunc RPC and render it in the
 // same EventList the live stream uses (no auto-scroll — it is a static log).
 export function RunReplay({ projectId, runId }: { projectId: string; runId: string }) {
-  const [events, setEvents] = useState<FrameworkEvent[] | null>(null)
-
-  useEffect(() => {
-    let live = true
-    setEvents(null)
-    void onRun(projectId, runId).then(list => live && setEvents(list))
-    return () => {
-      live = false
-    }
-  }, [projectId, runId])
+  // null until the first answer: "Loading run…" and "no events" are different things.
+  const events = useLoaded<FrameworkEvent[] | null>(() => onRun(projectId, runId), null, [projectId, runId])
 
   if (events === null) return <div className="grid flex-1 place-items-center text-sm text-muted-foreground">Loading run…</div>
   if (events.length === 0) return <div className="grid flex-1 place-items-center text-sm text-muted-foreground">This run has no events.</div>

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type FormEvent } from 'react'
+import { useRef, useState, type FormEvent } from 'react'
 import type { ProjectSummary } from '@gemstack/framework'
 import {
   renderResearchPrompt,
@@ -10,6 +10,7 @@ import {
 import { sendStart } from '../server/control.telefunc.js'
 import { onProjects } from '../server/projects.telefunc.js'
 import { usePreferences, updatePreferences, autopilotEnabled } from '../lib/preferences.js'
+import { useLoaded } from '../lib/use-async.js'
 import { PromptEditor, type PromptEditorHandle } from './PromptEditor.js'
 import { SystemPromptDisclosure } from './SystemPromptDisclosure.js'
 import { Button } from './ui/button.js'
@@ -71,16 +72,8 @@ export function StartRunForm({
   // Context selector (#439/#314): the agent can reach every registered repo, so ticking a
   // subset narrows its focus — the picked paths become one `Context:` line in the system
   // prompt. Loaded from the same registry the Projects sidebar shows.
-  const [projects, setProjects] = useState<ProjectSummary[]>([])
+  const projects = useLoaded<ProjectSummary[]>(onProjects, [], [])
   const [showContext, setShowContext] = useState(false)
-
-  useEffect(() => {
-    let live = true
-    void onProjects().then(list => live && setProjects(list))
-    return () => {
-      live = false
-    }
-  }, [])
 
   // Vanilla removes the system prompt entirely, so Eco (which only trims it) has nothing
   // left to act on.

--- a/packages/framework-dashboard/lib/quota.test.ts
+++ b/packages/framework-dashboard/lib/quota.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import type { QuotaView } from '@gemstack/framework'
+
+// The RPC is a telefunc shim over the wire, so stub it: these tests are about the
+// hook's own behavior (poll, keep-last-on-failure, stop on unmount), not the daemon.
+const onQuota = vi.hoisted(() => vi.fn())
+vi.mock('../server/quota.telefunc.js', () => ({ onQuota }))
+
+const { useQuota } = await import('./quota.js')
+
+const limit = { enabled: false, budget: 0, consumed: undefined, usedPercent: undefined, complete: true, reached: false }
+
+/** A reading the hook should pass straight through; `percentUsed` just tells them apart. */
+const view = (percentUsed: number): QuotaView => ({
+  windows: [{ label: 'Current session', kind: 'session', percentUsed }],
+  limits: { session: limit, fiveHour: limit, daily: limit, reached: null },
+})
+
+/** Let queued RPCs settle and React apply the state they resolved with. */
+const settle = (ms = 0): Promise<void> => act(async () => void (await vi.advanceTimersByTimeAsync(ms)))
+
+describe('useQuota', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    onQuota.mockReset()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('is undefined until the first answer arrives, then reports it', async () => {
+    onQuota.mockResolvedValue(view(10))
+    const { result } = renderHook(() => useQuota())
+    expect(result.current).toBeUndefined() // nothing to show yet, not "nothing used"
+    await settle()
+    expect(result.current).toEqual(view(10))
+  })
+
+  test('refreshes on its interval', async () => {
+    onQuota.mockResolvedValue(view(10))
+    const { result } = renderHook(() => useQuota())
+    await settle()
+
+    onQuota.mockResolvedValue(view(55))
+    await settle(30_000)
+    expect(result.current).toEqual(view(55))
+  })
+
+  test('a failed refresh keeps the last view rather than blanking it', async () => {
+    onQuota.mockResolvedValue(view(42))
+    const { result } = renderHook(() => useQuota())
+    await settle()
+
+    onQuota.mockRejectedValue(new Error('daemon restarted'))
+    await settle(30_000)
+    expect(result.current).toEqual(view(42)) // an empty bar would read as "nothing used"
+  })
+
+  test('stops polling once unmounted', async () => {
+    onQuota.mockResolvedValue(view(10))
+    const { unmount } = renderHook(() => useQuota())
+    await settle()
+    expect(onQuota).toHaveBeenCalledTimes(1)
+
+    unmount()
+    await settle(90_000)
+    expect(onQuota).toHaveBeenCalledTimes(1) // no ticks after teardown
+  })
+})

--- a/packages/framework-dashboard/lib/quota.ts
+++ b/packages/framework-dashboard/lib/quota.ts
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react'
 import type { QuotaView } from '@gemstack/framework'
 import { onQuota } from '../server/quota.telefunc.js'
+import { usePolled } from './use-async.js'
 
 // The usage panel's data (#535). The daemon polls the agent for us and caches the answer,
 // so this only has to ask the daemon for what it already knows — cheap, unlike the read
@@ -16,26 +16,5 @@ const REFRESH_MS = 30_000
  * than blanking it: an empty bar reads as "nothing used".
  */
 export function useQuota(): QuotaView | undefined {
-  const [view, setView] = useState<QuotaView | undefined>(undefined)
-
-  useEffect(() => {
-    let live = true
-    const load = (): void => {
-      void onQuota()
-        .then(next => {
-          if (live) setView(next)
-        })
-        .catch(() => {
-          // Keep whatever we last showed; the next tick may well succeed.
-        })
-    }
-    load()
-    const timer = setInterval(load, REFRESH_MS)
-    return () => {
-      live = false
-      clearInterval(timer)
-    }
-  }, [])
-
-  return view
+  return usePolled<QuotaView | undefined>(onQuota, undefined, REFRESH_MS, []).value
 }

--- a/packages/framework-dashboard/lib/use-async.test.ts
+++ b/packages/framework-dashboard/lib/use-async.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useLoaded, usePolled } from './use-async.js'
+
+/** Let queued reads settle and React apply the state they resolved with. */
+const settle = (ms = 0): Promise<void> => act(async () => void (await vi.advanceTimersByTimeAsync(ms)))
+
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => vi.useRealTimers())
+
+describe('useLoaded', () => {
+  test('holds the initial value until the answer arrives, then reports it', async () => {
+    const load = vi.fn().mockResolvedValue('answer')
+    const { result } = renderHook(() => useLoaded(load, 'initial', []))
+    expect(result.current).toBe('initial')
+    await settle()
+    expect(result.current).toBe('answer')
+  })
+
+  test('does not read at all when there is nothing to read yet', async () => {
+    const { result } = renderHook(() => useLoaded<string[]>(null, [], [undefined]))
+    await settle()
+    expect(result.current).toEqual([])
+  })
+
+  test('re-reads when deps change, and resets rather than showing the last dep-s value', async () => {
+    const load = vi.fn((id: string) => Promise.resolve(`data-${id}`))
+    const { result, rerender } = renderHook(({ id }) => useLoaded(() => load(id), 'initial', [id]), {
+      initialProps: { id: 'a' },
+    })
+    await settle()
+    expect(result.current).toBe('data-a')
+
+    rerender({ id: 'b' })
+    expect(result.current).toBe('initial') // not 'data-a': b's panel must not show a's data
+    await settle()
+    expect(result.current).toBe('data-b')
+  })
+
+  test('a read that lands after its deps changed is dropped', async () => {
+    let resolveA: (v: string) => void = () => {}
+    const load = vi.fn((id: string) =>
+      id === 'a' ? new Promise<string>(r => (resolveA = r)) : Promise.resolve(`data-${id}`),
+    )
+    const { result, rerender } = renderHook(({ id }) => useLoaded(() => load(id), 'initial', [id]), {
+      initialProps: { id: 'a' },
+    })
+    rerender({ id: 'b' })
+    await settle()
+    expect(result.current).toBe('data-b')
+
+    resolveA('data-a') // a's read finally lands, but a is not what is on screen
+    await settle()
+    expect(result.current).toBe('data-b')
+  })
+
+  test('a rejected read keeps the last value rather than blanking it', async () => {
+    const load = vi.fn().mockResolvedValue('answer')
+    const { result } = renderHook(() => useLoaded(load, 'initial', []))
+    await settle()
+
+    load.mockRejectedValue(new Error('daemon restarted'))
+    await settle()
+    expect(result.current).toBe('answer') // and no unhandled rejection: vitest fails the run on one
+  })
+})
+
+describe('usePolled', () => {
+  test('re-reads on its interval', async () => {
+    const load = vi.fn().mockResolvedValue(1)
+    const { result } = renderHook(() => usePolled(load, 0, 5000, []))
+    await settle()
+    expect(result.current.value).toBe(1)
+
+    load.mockResolvedValue(2)
+    await settle(5000)
+    expect(result.current.value).toBe(2)
+  })
+
+  test('stops polling once unmounted', async () => {
+    const load = vi.fn().mockResolvedValue(1)
+    const { unmount } = renderHook(() => usePolled(load, 0, 5000, []))
+    await settle()
+    expect(load).toHaveBeenCalledTimes(1)
+
+    unmount()
+    await settle(50_000)
+    expect(load).toHaveBeenCalledTimes(1)
+  })
+
+  test('a rejected read keeps the last value and polling survives it', async () => {
+    const load = vi.fn().mockResolvedValue(1)
+    const { result } = renderHook(() => usePolled(load, 0, 5000, []))
+    await settle()
+
+    load.mockRejectedValue(new Error('daemon restarted'))
+    await settle(5000)
+    expect(result.current.value).toBe(1) // kept, not blanked
+
+    load.mockResolvedValue(3)
+    await settle(5000)
+    expect(result.current.value).toBe(3) // the next tick recovers
+  })
+
+  test('reload reads immediately, without waiting for the next tick', async () => {
+    const load = vi.fn().mockResolvedValue(1)
+    const { result } = renderHook(() => usePolled(load, 0, 5000, []))
+    await settle()
+
+    load.mockResolvedValue(2)
+    await act(async () => result.current.reload())
+    expect(result.current.value).toBe(2)
+  })
+
+  test('reload cannot write back after unmount', async () => {
+    let resolveLate: (v: number) => void = () => {}
+    const load = vi.fn().mockResolvedValue(1)
+    const { result, unmount } = renderHook(() => usePolled(load, 0, 5000, []))
+    await settle()
+
+    load.mockReturnValue(new Promise<number>(r => (resolveLate = r)))
+    const { reload } = result.current
+    reload()
+    unmount()
+    resolveLate(99) // the in-flight reload lands after teardown
+    await settle()
+    expect(result.current.value).toBe(1) // never applied
+  })
+
+  test('does not poll when there is nothing to read yet', async () => {
+    const { result } = renderHook(() => usePolled<string[]>(null, [], 5000, [undefined]))
+    await settle(20_000)
+    expect(result.current.value).toEqual([])
+  })
+})

--- a/packages/framework-dashboard/lib/use-async.ts
+++ b/packages/framework-dashboard/lib/use-async.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef, useState, type DependencyList } from 'react'
+
+// Every panel here reads the same way: ask the daemon, hold the answer, drop it on the
+// floor if the component moved on. That was written out 12 times, and only the usage
+// panel remembered to catch — so a daemon restart made every other tick an unhandled
+// rejection. These two hooks are that pattern, once.
+
+/**
+ * A rejected read keeps the last value rather than blanking it, which is what the usage
+ * panel already did deliberately: an empty bar reads as "nothing used" rather than "no
+ * answer". The next tick usually succeeds.
+ */
+function useAsyncValue<T>(
+  load: (() => Promise<T>) | null,
+  initial: T,
+  everyMs: number | null,
+  deps: DependencyList,
+): { value: T; reload: () => void } {
+  const [value, setValue] = useState<T>(initial)
+  // Captured once, like useState's own initial: it is also what a dep change resets to,
+  // and callers pass literals like `[]` that would otherwise be a new value every render.
+  const initialRef = useRef(initial)
+  // A dep change and an unmount both retire the in-flight read. `reload` reads the same
+  // token, so an imperative refetch can't write back after either.
+  const liveRef = useRef({ live: false })
+
+  const apply = useCallback((token: { live: boolean }, run: () => Promise<T>) => {
+    void run()
+      .then(next => {
+        if (token.live) setValue(next)
+      })
+      .catch(() => {
+        // Keep whatever we last showed; the next read may well succeed.
+      })
+  }, [])
+
+  useEffect(() => {
+    const token = { live: true }
+    liveRef.current = token
+    setValue(initialRef.current) // a switch shows nothing rather than the last project's data
+    if (!load) return () => void (token.live = false)
+    const run = (): void => apply(token, load)
+    run()
+    if (everyMs === null) return () => void (token.live = false)
+    const timer = setInterval(run, everyMs)
+    return () => {
+      token.live = false
+      clearInterval(timer)
+    }
+    // The caller owns the dep list: `load` closes over exactly these, by contract.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps)
+
+  const reload = useCallback(() => {
+    if (!load) return
+    apply(liveRef.current, load)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps)
+
+  return { value, reload }
+}
+
+/**
+ * Read once, and again whenever `deps` change.
+ *
+ * Pass `null` for `load` when there is nothing to read yet (no project selected): the
+ * value stays `initial` and no read is made. `load` must close over exactly `deps`.
+ */
+export function useLoaded<T>(load: (() => Promise<T>) | null, initial: T, deps: DependencyList): T {
+  return useAsyncValue(load, initial, null, deps).value
+}
+
+/**
+ * Read now, again every `everyMs`, and again whenever `deps` change. Polling stops on
+ * unmount. `reload` reads immediately, for when a local action means the next tick is
+ * too late to wait for.
+ *
+ * Pass `null` for `load` when there is nothing to read yet. `load` must close over
+ * exactly `deps`.
+ */
+export function usePolled<T>(
+  load: (() => Promise<T>) | null,
+  initial: T,
+  everyMs: number,
+  deps: DependencyList,
+): { value: T; reload: () => void } {
+  return useAsyncValue(load, initial, everyMs, deps)
+}

--- a/packages/framework-dashboard/lib/use-runs.test.ts
+++ b/packages/framework-dashboard/lib/use-runs.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import type { RunMeta } from '@gemstack/framework'
+
+const onRuns = vi.hoisted(() => vi.fn())
+vi.mock('../server/reads.telefunc.js', () => ({ onRuns }))
+
+const { useRuns } = await import('./use-runs.js')
+
+const runs = (id: string): RunMeta[] => [{ id, status: 'done' } as RunMeta]
+const settle = (ms = 0): Promise<void> => act(async () => void (await vi.advanceTimersByTimeAsync(ms)))
+
+describe('useRuns', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    onRuns.mockReset()
+  })
+  afterEach(() => vi.useRealTimers())
+
+  test('reads nothing until a project is selected', async () => {
+    const { result } = renderHook(() => useRuns(null))
+    await settle(10_000)
+    expect(onRuns).not.toHaveBeenCalled()
+    expect(result.current.runs).toEqual([])
+  })
+
+  test('polls the selected project every 2s', async () => {
+    onRuns.mockResolvedValue(runs('a1'))
+    const { result } = renderHook(() => useRuns('a'))
+    await settle()
+    expect(result.current.runs).toEqual(runs('a1'))
+
+    onRuns.mockResolvedValue(runs('a2'))
+    await settle(2000)
+    expect(result.current.runs).toEqual(runs('a2'))
+  })
+
+  test('reload shows a just-started run without waiting for the next tick', async () => {
+    onRuns.mockResolvedValue(runs('a1'))
+    const { result } = renderHook(() => useRuns('a'))
+    await settle()
+
+    onRuns.mockResolvedValue(runs('a2'))
+    await act(async () => result.current.reload())
+    expect(result.current.runs).toEqual(runs('a2'))
+  })
+
+  test('a reload in flight during a project switch cannot write the old project s runs', async () => {
+    let resolveA: (v: RunMeta[]) => void = () => {}
+    onRuns.mockResolvedValue(runs('a1'))
+    const { result, rerender } = renderHook(({ id }) => useRuns(id), { initialProps: { id: 'a' } })
+    await settle()
+
+    onRuns.mockReturnValue(new Promise<RunMeta[]>(r => (resolveA = r)))
+    result.current.reload() // in flight against project a
+    onRuns.mockResolvedValue(runs('b1'))
+    rerender({ id: 'b' })
+    await settle()
+    expect(result.current.runs).toEqual(runs('b1'))
+
+    resolveA(runs('a-late')) // a's reload lands after the switch
+    await settle()
+    expect(result.current.runs).toEqual(runs('b1')) // b's rail never shows a's runs
+  })
+
+  test('switching project clears the previous project s runs rather than showing them', async () => {
+    onRuns.mockResolvedValue(runs('a1'))
+    const { result, rerender } = renderHook(({ id }) => useRuns(id), { initialProps: { id: 'a' } })
+    await settle()
+    expect(result.current.runs).toEqual(runs('a1'))
+
+    let resolveB: (v: RunMeta[]) => void = () => {}
+    onRuns.mockReturnValue(new Promise<RunMeta[]>(r => (resolveB = r)))
+    rerender({ id: 'b' })
+    expect(result.current.runs).toEqual([]) // not a's runs, while b is still loading
+
+    await act(async () => resolveB(runs('b1')))
+    expect(result.current.runs).toEqual(runs('b1'))
+  })
+
+  test('a failed read keeps the last runs rather than emptying the rail', async () => {
+    onRuns.mockResolvedValue(runs('a1'))
+    const { result } = renderHook(() => useRuns('a'))
+    await settle()
+
+    onRuns.mockRejectedValue(new Error('daemon restarted'))
+    await settle(2000)
+    expect(result.current.runs).toEqual(runs('a1')) // and no unhandled rejection
+  })
+})

--- a/packages/framework-dashboard/lib/use-runs.ts
+++ b/packages/framework-dashboard/lib/use-runs.ts
@@ -1,35 +1,18 @@
-import { useCallback, useEffect, useState } from 'react'
 import type { RunMeta } from '@gemstack/framework'
 import { onRuns } from '../server/reads.telefunc.js'
+import { usePolled } from './use-async.js'
 
 // The selected project's runs (live + archived), polled. Owned by the shell (+Page) so both
 // the Runs rail and the main pane read one list: the rail renders the rows, the pane routes
 // the selected run to its live view or replay by that run's status.
 export function useRuns(projectId: string | null): { runs: RunMeta[]; reload: () => void } {
-  const [runs, setRuns] = useState<RunMeta[]>([])
-
-  const reload = useCallback(() => {
-    if (!projectId) {
-      setRuns([])
-      return
-    }
-    void onRuns(projectId).then(setRuns)
-  }, [projectId])
-
-  useEffect(() => {
-    if (!projectId) {
-      setRuns([])
-      return
-    }
-    let live = true
-    const tick = () => void onRuns(projectId).then(list => live && setRuns(list))
-    tick()
-    const poll = setInterval(tick, 2000)
-    return () => {
-      live = false
-      clearInterval(poll)
-    }
-  }, [projectId])
-
+  // `reload` is the shared guarded one now: it used to be a second, unguarded copy of the
+  // read, so a run started just before a project switch could write the old project's runs.
+  const { value: runs, reload } = usePolled<RunMeta[]>(
+    projectId ? () => onRuns(projectId) : null,
+    [],
+    2000,
+    [projectId],
+  )
   return { runs, reload }
 }

--- a/packages/framework-dashboard/package.json
+++ b/packages/framework-dashboard/package.json
@@ -12,6 +12,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -36,12 +37,16 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^20.0.0",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^6.0.3",
+    "jsdom": "^29.1.1",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.4.0",
-    "vite": "^8.0.0"
+    "vite": "^8.0.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { onProjectFiles } from '../../server/reads.telefunc.js'
 import { ProjectsSidebar } from '../../components/ProjectsSidebar.js'
 import { RunHistory } from '../../components/RunHistory.js'
@@ -11,7 +11,11 @@ import { RelayView } from '../../components/RelayView.js'
 import { Badge } from '../../components/ui/badge.js'
 import { useLiveEvents } from '../../lib/use-live-events.js'
 import { useRuns } from '../../lib/use-runs.js'
+import { useLoaded } from '../../lib/use-async.js'
 import { pendingChoices, agentViews } from '../../lib/live-state.js'
+
+/** Stable, so `files` keeps one identity while no project is selected. */
+const EMPTY_FILES: string[] = []
 
 // The dashboard shell (#405 phase 2): Projects | Runs | main | Docs/Log rail. The main pane
 // is one of three views chosen by the Runs-rail selection: the project home/launcher (Live,
@@ -52,19 +56,7 @@ export default function Page() {
 
   // The selected project's files (git ls-files), fetched once here and handed to both the
   // `#` picker and the tree. Empty when no project / on the relay (no checkout).
-  const [files, setFiles] = useState<string[]>([])
-  useEffect(() => {
-    if (!projectId) {
-      setFiles([])
-      return
-    }
-    let live = true
-    setFiles([])
-    void onProjectFiles(projectId).then(list => live && setFiles(list))
-    return () => {
-      live = false
-    }
-  }, [projectId])
+  const files = useLoaded<string[]>(projectId ? () => onProjectFiles(projectId) : null, EMPTY_FILES, [projectId])
 
   const onRunStarted = (intent: string) => {
     // Stay on the home launcher (it must stay visible so you can launch again); the new run

--- a/packages/framework-dashboard/vitest.config.ts
+++ b/packages/framework-dashboard/vitest.config.ts
@@ -1,0 +1,19 @@
+import { fileURLToPath } from 'node:url'
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vitest/config'
+
+// Unit tests for the dashboard's hooks and components. Deliberately NOT vite.config.ts:
+// that one carries vike() and telefunc(), which serve the app and only get in the way
+// here. All the unit tests need is the JSX transform and the `@` alias.
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: { '@': fileURLToPath(new URL('.', import.meta.url)) },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    include: ['**/*.test.ts', '**/*.test.tsx'],
+    exclude: ['node_modules/**', 'dist/**'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,12 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.0.0
         version: 4.3.2(vite@8.1.4(@types/node@20.19.43)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.43
@@ -341,6 +347,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.4(@types/node@20.19.43)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       tailwindcss:
         specifier: ^4.0.0
         version: 4.3.2
@@ -350,6 +359,9 @@ importers:
       vite:
         specifier: ^8.0.0
         version: 8.1.4(@types/node@20.19.43)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@20.19.43)(jsdom@29.1.1)(vite@8.1.4(@types/node@20.19.43)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/mcp:
     dependencies:
@@ -1380,6 +1392,9 @@ packages:
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.3.2':
     resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
 
@@ -1473,6 +1488,25 @@ packages:
     resolution: {integrity: sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@tiptap/core@2.27.2':
     resolution: {integrity: sha512-ABL1N6eoxzDzC1bYvkMbvyexHacszsKdVPYqhl5GwHLOvpZcv9VE9QaKwDILTyz5voCA0lGcAAXZp+qnXOk5lQ==}
@@ -1647,6 +1681,15 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -1796,6 +1839,35 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   '@vue/compiler-core@3.5.39':
     resolution: {integrity: sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==}
 
@@ -1923,15 +1995,26 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -2011,6 +2094,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -2159,6 +2246,9 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -2207,6 +2297,9 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -2239,6 +2332,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -2258,6 +2354,10 @@ packages:
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.5.2:
     resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
@@ -2676,6 +2776,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -2817,6 +2921,10 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -2899,6 +3007,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
@@ -2942,6 +3053,10 @@ packages:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
@@ -3046,6 +3161,9 @@ packages:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
       react: ^19.2.7
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-streaming@0.4.20:
     resolution: {integrity: sha512-jUZqdDVrXcKCNR1PGclIK9Ggeb1+8jP6WRWDSYbu8OsOCHiu/F+PGtVx+0thIoSzOdKxaNMSowk0bNlLsPv2jw==}
@@ -3183,6 +3301,9 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -3220,12 +3341,18 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -3285,9 +3412,20 @@ packages:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tippy.js@6.3.7:
     resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
@@ -3534,6 +3672,47 @@ packages:
       postcss:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vue@3.5.39:
     resolution: {integrity: sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==}
     peerDependencies:
@@ -3568,6 +3747,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrappy@1.0.2:
@@ -4694,6 +4878,8 @@ snapshots:
   '@stablelib/base64@1.0.1':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.3.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -4761,6 +4947,27 @@ snapshots:
       '@tailwindcss/oxide': 4.3.2
       tailwindcss: 4.3.2
       vite: 8.1.4(@types/node@20.19.43)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@tiptap/core@2.27.2(@tiptap/pm@2.27.2)':
     dependencies:
@@ -4950,6 +5157,15 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/aria-query@5.0.4': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.9': {}
 
   '@types/hast@3.0.4':
@@ -5102,6 +5318,47 @@ snapshots:
       vite: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
       vue: 3.5.39(typescript@5.9.3)
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@20.19.43)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.4(@types/node@20.19.43)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@vue/compiler-core@3.5.39':
     dependencies:
       '@babel/parser': 7.29.7
@@ -5220,13 +5477,21 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-styles@5.2.0: {}
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   array-union@2.1.0: {}
+
+  assertion-error@2.0.1: {}
 
   asynckit@0.4.0:
     optional: true
@@ -5312,6 +5577,8 @@ snapshots:
   caniuse-lite@1.0.30001803: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -5425,6 +5692,8 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  dom-accessibility-api@0.5.16: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -5463,6 +5732,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -5515,6 +5786,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   etag@1.8.1: {}
 
   event-target-shim@5.0.1:
@@ -5528,6 +5803,8 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.1.0
+
+  expect-type@1.4.0: {}
 
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
@@ -5993,6 +6270,8 @@ snapshots:
     dependencies:
       react: 19.2.7
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -6116,6 +6395,8 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  obug@2.1.3: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -6184,6 +6465,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
   perfect-debounce@2.1.0: {}
 
   picocolors@1.1.1: {}
@@ -6213,6 +6496,12 @@ snapshots:
       source-map-js: 1.2.1
 
   prettier@2.8.8: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   process@0.11.10:
     optional: true
@@ -6367,6 +6656,8 @@ snapshots:
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-streaming@0.4.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -6577,6 +6868,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   sirv@3.0.2:
@@ -6607,6 +6900,8 @@ snapshots:
 
   srvx@0.11.21: {}
 
+  stackback@0.0.2: {}
+
   standardwebhooks@1.0.0:
     dependencies:
       '@stablelib/base64': 1.0.1
@@ -6614,6 +6909,8 @@ snapshots:
     optional: true
 
   statuses@2.0.2: {}
+
+  std-env@4.2.0: {}
 
   string_decoder@1.3.0:
     dependencies:
@@ -6663,10 +6960,16 @@ snapshots:
 
   term-size@2.2.1: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tippy.js@6.3.7:
     dependencies:
@@ -6923,6 +7226,34 @@ snapshots:
       - universal-cookie
       - yaml
 
+  vitest@4.1.10(@types/node@20.19.43)(jsdom@29.1.1)(vite@8.1.4(@types/node@20.19.43)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@20.19.43)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.4(@types/node@20.19.43)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.43
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
   vue@3.5.39(typescript@5.9.3):
     dependencies:
       '@vue/compiler-dom': 3.5.39
@@ -6957,6 +7288,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrappy@1.0.2: {}
 


### PR DESCRIPTION
Stacked on #578 (needs its test setup). Review that one first; this diff is against it.

Every panel wrote out the same `let live = true` effect: ask the daemon, hold the answer, drop it if the component moved on. Twelve copies, and only the usage panel remembered to catch, so a daemon restart made each of the other eleven an unhandled rejection every tick.

They are now two hooks, `useLoaded` and `usePolled`. A failed read keeps the last value, which is what the usage panel already documented ("an empty bar reads as 'nothing used'"); a dep change resets rather than showing the previous project's data; an in-flight read is retired on unmount.

Reading all 12 first paid off: they are not 12 copies of one thing. **Three real defects fall out of `use-runs` alone**, each pinned by a test that fails against the old code:

- `reload` (public API, used by `+Page` so a just-started run appears before the next 2s tick) was a **second copy of the read with no `live` guard at all** (`.then(setRuns)`). Starting a run just before a project switch could write the old project's runs into the new project's rail. It now shares the effect's guard.
- Switching project **left the previous project's runs on screen** until the new read landed. FileTree, GitStatusBar, RunReplay and +Page already reset; DocsPanel, ProjectLogPanel and use-runs did not. Now all of them do. This is the one visible behavior change, and it is deliberate.
- A failed read threw.

**PreviewBar keeps its own effect.** It splits one result into two states, discards a non-running status, fuses the liveness check with that domain rule, and co-owns `url`/`command` with its `open()`/`stop()` handlers. It is a rehydrate-then-hand-over pattern, not load-and-display; forcing it through a generic hook would cost more than the duplication does.

`ProjectActions` kept a one-line effect for the `error` it resets but does not own.

12 copies to 1. -165/+49 across the call sites.

What is actually verified, beyond the suite going green:

- `quota.test.ts` is **byte-unchanged from #578**, written against the old implementation, and passes against the hook. That is the behavior-preserved evidence.
- The `use-runs` tests **fail against the old implementation** (2 failures + an unhandled rejection) and pass against the hooks. The bugs were real, not inferred.
- The hooks' own tests were mutation-checked: dropping the `.catch()`, the `live` guard, `clearInterval`, or the reset each fails the run.
- 21 tests, typecheck clean, `vite build` bundles every touched file, dev server boots 200.

Closes #579
