### PR TITLE
refactor(ai-autopilot): one makeEmitter, with the engine label explicit

### DIFF
--- a/packages/ai-autopilot/src/bootstrap/bootstrap.ts
+++ b/packages/ai-autopilot/src/bootstrap/bootstrap.ts
@@ -6,6 +6,7 @@ import type {
   BootstrapSteps,
   DeployOutcome,
 } from './types.js'
+import { makeEmitter } from '../util/emitter.js'
 
 /** Thrown when a run is aborted via the `AbortSignal`. */
 export class BootstrapAborted extends Error {
@@ -51,7 +52,7 @@ export class Bootstrap {
     this.steps = opts.steps
     this.maxPasses = maxPasses
     if (opts.signal) this.signal = opts.signal
-    this.emit = makeEmitter(opts.onEvent)
+    this.emit = makeEmitter(opts.onEvent, 'bootstrap')
   }
 
   /** Run the whole flow and resolve with the {@link BootstrapResult}. */
@@ -150,13 +151,3 @@ export function createBootstrap(opts: BootstrapOptions): Bootstrap {
   return new Bootstrap(opts)
 }
 
-function makeEmitter(onEvent: BootstrapOptions['onEvent']): (event: BootstrapEvent) => void {
-  if (!onEvent) return () => {}
-  return event => {
-    try {
-      onEvent(event)
-    } catch (err) {
-      console.error('[ai-autopilot] bootstrap onEvent callback threw; ignoring:', err)
-    }
-  }
-}

--- a/packages/ai-autopilot/src/loop/loop.ts
+++ b/packages/ai-autopilot/src/loop/loop.ts
@@ -10,6 +10,7 @@ import type {
 } from './types.js'
 import type { Verdict } from './verdict.js'
 import { parseVerdict } from './verdict.js'
+import { makeEmitter } from '../util/emitter.js'
 
 /** Options for {@link LoopEngine}. */
 export interface LoopEngineOptions {
@@ -184,13 +185,3 @@ function indexPrompts(prompts: LoopPrompt[] | Record<string, LoopPrompt>): Map<s
   return map
 }
 
-function makeEmitter(onEvent: LoopEngineOptions['onEvent']): (event: LoopProgress) => void {
-  if (!onEvent) return () => {}
-  return (event) => {
-    try {
-      onEvent(event)
-    } catch (err) {
-      console.error('[ai-autopilot] onEvent callback threw; ignoring:', err)
-    }
-  }
-}

--- a/packages/ai-autopilot/src/overview/maintainer.ts
+++ b/packages/ai-autopilot/src/overview/maintainer.ts
@@ -9,6 +9,7 @@ import type {
   OverviewRefresh,
   Regenerate,
 } from './types.js'
+import { makeEmitter } from '../util/emitter.js'
 
 /** Options for {@link CodeOverviewMaintainer}. */
 export interface MaintainerOptions {
@@ -56,7 +57,7 @@ export class CodeOverviewMaintainer {
     this.detect = opts.detect ?? (event => detectMaterialChange(event))
     if (opts.fs) this.fs = opts.fs
     this.path = opts.path ?? OVERVIEW_FILE
-    this.emit = makeEmitter(opts.onEvent)
+    this.emit = makeEmitter(opts.onEvent, 'overview')
   }
 
   /** The current overview, or `undefined` if none has been generated/loaded. */
@@ -117,13 +118,3 @@ export function createOverviewMaintainer(opts: MaintainerOptions): CodeOverviewM
   return new CodeOverviewMaintainer(opts)
 }
 
-function makeEmitter(onEvent: MaintainerOptions['onEvent']): (event: OverviewEvent) => void {
-  if (!onEvent) return () => {}
-  return event => {
-    try {
-      onEvent(event)
-    } catch (err) {
-      console.error('[ai-autopilot] overview onEvent callback threw; ignoring:', err)
-    }
-  }
-}

--- a/packages/ai-autopilot/src/supervisor.ts
+++ b/packages/ai-autopilot/src/supervisor.ts
@@ -5,11 +5,11 @@ import { defaultSynthesize } from './synthesizer.js'
 import type {
   PlannedSubtask,
   SubtaskResult,
-  SupervisorEvent,
   SupervisorOptions,
   SupervisorRun,
   WorkerRouter,
 } from './types.js'
+import { makeEmitter } from './util/emitter.js'
 
 const ZERO_USAGE: TokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
 
@@ -114,17 +114,6 @@ export class Supervisor {
  * Wrap the user's `onEvent` so a throwing callback can never abort a run.
  * Observer errors are reported to the console but otherwise swallowed.
  */
-function makeEmitter(onEvent: SupervisorOptions['onEvent']): (event: SupervisorEvent) => void {
-  if (!onEvent) return () => {}
-  return (event) => {
-    try {
-      onEvent(event)
-    } catch (err) {
-      console.error('[ai-autopilot] onEvent callback threw; ignoring:', err)
-    }
-  }
-}
-
 async function runSubtask(route: WorkerRouter, subtask: PlannedSubtask): Promise<SubtaskResult> {
   try {
     const agent = route(subtask)

--- a/packages/ai-autopilot/src/util/emitter.test.ts
+++ b/packages/ai-autopilot/src/util/emitter.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { makeEmitter } from './emitter.js'
+
+/** Run `fn` with console.error captured, so a swallowed throw can be asserted on. */
+function withCapturedErrors(fn: () => void): string[] {
+  const lines: string[] = []
+  const real = console.error
+  console.error = (...args: unknown[]) => {
+    lines.push(args.map(a => (a instanceof Error ? a.message : String(a))).join(' '))
+  }
+  try {
+    fn()
+  } finally {
+    console.error = real
+  }
+  return lines
+}
+
+describe('makeEmitter', () => {
+  it('passes events straight through', () => {
+    const seen: string[] = []
+    const emit = makeEmitter<string>(e => seen.push(e))
+    emit('a')
+    emit('b')
+    assert.deepEqual(seen, ['a', 'b'])
+  })
+
+  it('is a silent no-op with no callback', () => {
+    const lines = withCapturedErrors(() => makeEmitter<string>(undefined)('a'))
+    assert.deepEqual(lines, [])
+  })
+
+  it('swallows a throwing callback so it cannot take the run down', () => {
+    const emit = makeEmitter<string>(() => {
+      throw new Error('boom')
+    })
+    const lines = withCapturedErrors(() => {
+      emit('a')
+      emit('b') // still emitting after the first throw
+    })
+    assert.equal(lines.length, 2)
+  })
+
+  it('names the engine when given one, and does not when not', () => {
+    const thrower = () => {
+      throw new Error('boom')
+    }
+    // Byte-identical to what each call site logged before they shared this.
+    const unlabelled = withCapturedErrors(() => makeEmitter<string>(thrower)('a'))
+    assert.deepEqual(unlabelled, ['[ai-autopilot] onEvent callback threw; ignoring: boom'])
+
+    const labelled = withCapturedErrors(() => makeEmitter<string>(thrower, 'bootstrap')('a'))
+    assert.deepEqual(labelled, ['[ai-autopilot] bootstrap onEvent callback threw; ignoring: boom'])
+
+    const overview = withCapturedErrors(() => makeEmitter<string>(thrower, 'overview')('a'))
+    assert.deepEqual(overview, ['[ai-autopilot] overview onEvent callback threw; ignoring: boom'])
+  })
+})

--- a/packages/ai-autopilot/src/util/emitter.ts
+++ b/packages/ai-autopilot/src/util/emitter.ts
@@ -1,0 +1,21 @@
+/**
+ * Wrap an engine's optional `onEvent` so progress reporting can never take the run
+ * down: a callback that throws is logged and swallowed, and no callback at all is a
+ * no-op rather than a branch at every emit site.
+ *
+ * `what` names the engine in that log line. It is explicit because the call sites
+ * genuinely disagreed: bootstrap and overview named themselves, supervisor and loop
+ * did not. Passing it in keeps each engine's message exactly as it was, rather than
+ * a fourth copy quietly re-labelling two of them.
+ */
+export function makeEmitter<E>(onEvent: ((event: E) => void) | undefined, what?: string): (event: E) => void {
+  if (!onEvent) return () => {}
+  const label = what ? `${what} onEvent` : 'onEvent'
+  return event => {
+    try {
+      onEvent(event)
+    } catch (err) {
+      console.error(`[ai-autopilot] ${label} callback threw; ignoring:`, err)
+    }
+  }
+}


### PR DESCRIPTION
Every engine wrapped its own `onEvent` the same way: no-op when absent, otherwise log and swallow a throwing callback so progress reporting can never take the run down. Four copies (supervisor, loop, bootstrap, overview).

It had already drifted, which is the reason to do it now. `bootstrap` and `overview` named themselves in the log line; `supervisor` and `loop` did not:

| engine | before |
|---|---|
| supervisor, loop | `[ai-autopilot] onEvent callback threw; ignoring:` |
| bootstrap | `[ai-autopilot] bootstrap onEvent callback threw; ignoring:` |
| overview | `[ai-autopilot] overview onEvent callback threw; ignoring:` |

One generic `makeEmitter<E>(onEvent, what?)` in `util/`, and the label is a parameter each call site passes. That keeps all four messages exactly as they were rather than quietly re-labelling two engines' logs, and puts the disagreement at the call site instead of hiding it in a fourth copy. Same shape as the `contentToString` separator in #574.

Verified rather than assumed:

- Probed a **real Supervisor** with a throwing `onEvent`, before and after: the logged message is **byte-identical**, the run still completes, and the no-callback path stays silent.
- The new tests bite: forcing the label bare, forcing it always-qualified, or dropping the no-callback no-op each fails the run.
- Pruned `SupervisorEvent`, which the extraction left import-line-only (`noUnusedLocals` is off, so typecheck does not catch that).

284 tests pass, typecheck clean. Internal, not barrel-exported, so no changeset.

Closes #581
