### PR TITLE
refactor(framework): one node:fs adapter behind the four factories

### DIFF
--- a/packages/framework/src/maintenance.ts
+++ b/packages/framework/src/maintenance.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path'
 import { nodeGitRunner, type GitRunner } from './project.js'
+import { nodeFs } from './node-fs.js'
 import { FRAMEWORK_DIR } from './store/index.js'
 
 /**
@@ -31,22 +32,10 @@ export interface MaintenanceFs {
   mkdir(path: string): Promise<void>
 }
 
-/** A {@link MaintenanceFs} backed by `node:fs/promises` (dynamic import, same convention as the registry). */
+/** A {@link MaintenanceFs} backed by `node:fs/promises`. See {@link nodeFs}. */
 export function nodeMaintenanceFs(): MaintenanceFs {
-  return {
-    async read(path) {
-      const { readFile } = await import('node:fs/promises')
-      return readFile(path, 'utf8')
-    },
-    async write(path, contents) {
-      const { writeFile } = await import('node:fs/promises')
-      await writeFile(path, contents, 'utf8')
-    },
-    async mkdir(path) {
-      const { mkdir } = await import('node:fs/promises')
-      await mkdir(path, { recursive: true })
-    },
-  }
+  const { read, write, mkdir } = nodeFs()
+  return { read, write, mkdir }
 }
 
 /** The review-state file path for a repo. */

--- a/packages/framework/src/node-fs.ts
+++ b/packages/framework/src/node-fs.ts
@@ -1,0 +1,72 @@
+/**
+ * The one `node:fs/promises` adapter. Every `node*Fs()` factory in the package
+ * returns this under its own narrow type: the store may append, the registry may
+ * not, and those interfaces stay separate because they are the consumers'
+ * contracts. Only the implementation was worth sharing, and it was written out
+ * four times before this.
+ *
+ * Every import is dynamic, which is the whole point of the convention: a module
+ * that reads files keeps a `node:fs` edge out of its static import graph, so it
+ * can be reached from browser-safe code as long as the read itself never runs
+ * there. `client.test.ts` enforces the graph half.
+ */
+export interface NodeFs {
+  /** Rejects when the file is absent. */
+  read(path: string): Promise<string>
+  write(path: string, contents: string): Promise<void>
+  append(path: string, contents: string): Promise<void>
+  /** True when `path` exists AND is a file. Any stat error reads as `false`. */
+  exists(path: string): Promise<boolean>
+  /** True when `path` exists AND is a directory. Any stat error reads as `false`. */
+  isDirectory(path: string): Promise<boolean>
+  /** Recursive. */
+  mkdir(path: string): Promise<void>
+  /** List a directory's entries (names only). Missing dir yields `[]`. */
+  readdir(path: string): Promise<string[]>
+}
+
+/** The `node:fs/promises` implementation of {@link NodeFs}. */
+export function nodeFs(): NodeFs {
+  return {
+    async read(path) {
+      const { readFile } = await import('node:fs/promises')
+      return readFile(path, 'utf8')
+    },
+    async write(path, contents) {
+      const { writeFile } = await import('node:fs/promises')
+      await writeFile(path, contents, 'utf8')
+    },
+    async append(path, contents) {
+      const { appendFile } = await import('node:fs/promises')
+      await appendFile(path, contents, 'utf8')
+    },
+    async exists(path) {
+      const { stat } = await import('node:fs/promises')
+      try {
+        return (await stat(path)).isFile()
+      } catch {
+        return false
+      }
+    },
+    async isDirectory(path) {
+      const { stat } = await import('node:fs/promises')
+      try {
+        return (await stat(path)).isDirectory()
+      } catch {
+        return false
+      }
+    },
+    async mkdir(path) {
+      const { mkdir } = await import('node:fs/promises')
+      await mkdir(path, { recursive: true })
+    },
+    async readdir(path) {
+      const { readdir } = await import('node:fs/promises')
+      try {
+        return await readdir(path)
+      } catch {
+        return []
+      }
+    },
+  }
+}

--- a/packages/framework/src/project.ts
+++ b/packages/framework/src/project.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import type { FrameworkSignals } from '@gemstack/ai-autopilot'
+import { nodeFs } from './node-fs.js'
 import { THE_FRAMEWORK_DIR } from './logs.js'
 
 /**
@@ -38,22 +39,10 @@ export interface ProjectFs {
   isDirectory(path: string): Promise<boolean>
 }
 
-/**
- * A {@link ProjectFs} backed by `node:fs/promises`. The import is dynamic so
- * the module core stays free of a hard `node:fs` dependency, same convention
- * as {@link nodeStoreFs}; any stat error reads as `false`.
- */
+/** A {@link ProjectFs} backed by `node:fs/promises`. See {@link nodeFs}. */
 export function nodeProjectFs(): ProjectFs {
-  return {
-    async isDirectory(path) {
-      const { stat } = await import('node:fs/promises')
-      try {
-        return (await stat(path)).isDirectory()
-      } catch {
-        return false
-      }
-    },
-  }
+  const { isDirectory } = nodeFs()
+  return { isDirectory }
 }
 
 /**

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -1,5 +1,6 @@
 import { basename, dirname, join, resolve } from 'node:path'
 import { DEFAULT_CONSUMPTION_LIMITS, type ConsumptionLimit, type ConsumptionLimits } from './consumption.js'
+import { nodeFs } from './node-fs.js'
 
 /**
  * The multi-project registry (#390): the list of projects the user has
@@ -105,26 +106,10 @@ export interface RegistryFs {
   mkdir(path: string): Promise<void>
 }
 
-/**
- * A {@link RegistryFs} backed by `node:fs/promises`. The import is dynamic so
- * the module core stays free of a hard `node:fs` dependency, same convention
- * as {@link nodeProjectFs}.
- */
+/** A {@link RegistryFs} backed by `node:fs/promises`. See {@link nodeFs}. */
 export function nodeRegistryFs(): RegistryFs {
-  return {
-    async read(path) {
-      const { readFile } = await import('node:fs/promises')
-      return readFile(path, 'utf8')
-    },
-    async write(path, contents) {
-      const { writeFile } = await import('node:fs/promises')
-      await writeFile(path, contents, 'utf8')
-    },
-    async mkdir(path) {
-      const { mkdir } = await import('node:fs/promises')
-      await mkdir(path, { recursive: true })
-    },
-  }
+  const { read, write, mkdir } = nodeFs()
+  return { read, write, mkdir }
 }
 
 /** True when `value` is a well-formed {@link ProjectRecord}. */

--- a/packages/framework/src/store/run-store.ts
+++ b/packages/framework/src/store/run-store.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path'
 import type { FrameworkEvent } from '../events.js'
+import { nodeFs } from '../node-fs.js'
 
 /**
  * Persisted orchestration state (#211). The dashboard is a pure projection of the
@@ -400,44 +401,10 @@ export async function loadRunEvents(
   return events
 }
 
-/**
- * A {@link StoreFs} backed by `node:fs/promises`. The import is dynamic so the
- * store core stays free of a hard `node:fs` dependency — same convention as
- * ai-autopilot's `nodeLedgerFs`.
- */
+/** A {@link StoreFs} backed by `node:fs/promises`. See {@link nodeFs}. */
 export function nodeStoreFs(): StoreFs {
-  return {
-    async read(path) {
-      const { readFile } = await import('node:fs/promises')
-      return readFile(path, 'utf8')
-    },
-    async write(path, contents) {
-      const { writeFile } = await import('node:fs/promises')
-      await writeFile(path, contents, 'utf8')
-    },
-    async append(path, contents) {
-      const { appendFile } = await import('node:fs/promises')
-      await appendFile(path, contents, 'utf8')
-    },
-    async exists(path) {
-      const { stat } = await import('node:fs/promises')
-      try {
-        return (await stat(path)).isFile()
-      } catch {
-        return false
-      }
-    },
-    async mkdir(path) {
-      const { mkdir } = await import('node:fs/promises')
-      await mkdir(path, { recursive: true })
-    },
-    async readdir(path) {
-      const { readdir } = await import('node:fs/promises')
-      try {
-        return await readdir(path)
-      } catch {
-        return []
-      }
-    },
-  }
+  // Destructured rather than returned whole: the narrow interface is the contract,
+  // so the object should not carry methods the store was never handed.
+  const { read, write, append, exists, mkdir, readdir } = nodeFs()
+  return { read, write, append, exists, mkdir, readdir }
 }


### PR DESCRIPTION
Four factories each hand-rolled the same `node:fs/promises` adapter:

| factory | interface |
|---|---|
| `nodeStoreFs` | `read, write, append, exists, mkdir, readdir` |
| `nodeRegistryFs` | `read, write, mkdir` |
| `nodeMaintenanceFs` | `read, write, mkdir` |
| `nodeProjectFs` | `isDirectory` |

`read`/`write`/`mkdir` were byte-identical in the three that have them. The comments already admitted the copying: each said "same convention as" and pointed at a different sibling (`nodeProjectFs` -> `nodeStoreFs` -> ai-autopilot's `nodeLedgerFs` -> `nodeProjectFs`), so the convention was documented in a circle rather than shared.

One `nodeFs()` holds every primitive; each factory returns the slice its own interface declares. **The four narrow interfaces stay** - they are the consumers' contracts and deliberately small (a store may append, a registry may not). Only the implementation is shared. 13 dynamic imports across four files become 7 in one.

The signatures are unchanged, so no public API change even though three are barrel-exported. Hence no changeset.

### The bit worth reviewing

Each factory **destructures** rather than returning `nodeFs()` whole. Returning it whole passed all 545 tests, but widened the runtime surface: `nodeRegistryFs()` came back carrying `append`/`exists`/`readdir`/`isDirectory` it never had. The types still hid them, so nothing failed. The probe caught it; the suite did not.

### Verified

Exercised all 7 primitives against a real temp dir, before and after. Output identical, including the edges that differ between the factories:

- `read(missing)` rejects ENOENT
- `exists(dir)` is `false` (it is `stat().isFile()`)
- `isDirectory(file)` is `false`, and it is `stat().isDirectory()` - **not** a rename of `exists`
- `readdir(missing)` yields `[]`, `mkdir` is recursive and idempotent
- the runtime surface of each factory's object is unchanged

The `client.test.ts` browser-safety guard (#431/#520) still passes: it walks the compiled graph from `client.js` and fails on any `node:` specifier, dynamic `import()` included. None of these four is reachable from the client barrel, and `node-fs.ts` is not either.

545 tests pass, typecheck clean.

### Noticed, not changed

`project.ts` line 1 is `import { readFileSync } from 'node:fs'`, so its own doc's rationale for the dynamic import ("the module core stays free of a hard `node:fs` dependency") was already false for that file. Left alone; it is not what this PR is about.

Out of scope: ai-autopilot's `nodeLedgerFs`/`nodeOverviewFs` are the same shape again, but sharing across the package boundary would couple two independently published packages for a few lines.

Closes #583
