### PR TITLE
refactor(ai-autopilot): one workspace path guard, and test it

### DIFF
--- a/packages/ai-autopilot/src/runner/docker.ts
+++ b/packages/ai-autopilot/src/runner/docker.ts
@@ -11,6 +11,7 @@ import type {
   PreviewOptions,
 } from './types.js'
 import { RunnerError } from './types.js'
+import { norm, safeSegments } from './path.js'
 
 const delay = (ms: number): Promise<void> => new Promise(res => setTimeout(res, ms))
 
@@ -64,21 +65,9 @@ async function waitForContainerPort(container: string, port: number, timeoutMs: 
   }
 }
 
-/** Normalize a workspace path to a canonical relative form (matches LocalFs/FakeFs). */
-function norm(path: string): string {
-  return path.replace(/^\.?\/+/, '').replace(/\/+$/, '')
-}
-
 /** Resolve `path` to an absolute container path under {@link WORKSPACE}, rejecting escapes. */
 function within(path: string): string {
-  const parts: string[] = []
-  for (const seg of norm(path).split('/')) {
-    if (seg === '' || seg === '.') continue
-    if (seg === '..') {
-      if (parts.length === 0) throw new RunnerError(`path escapes the workspace: ${path}`)
-      parts.pop()
-    } else parts.push(seg)
-  }
+  const parts = safeSegments(path)
   return parts.length ? `${WORKSPACE}/${parts.join('/')}` : WORKSPACE
 }
 

--- a/packages/ai-autopilot/src/runner/fake.ts
+++ b/packages/ai-autopilot/src/runner/fake.ts
@@ -10,6 +10,7 @@ import type {
   PreviewOptions,
 } from './types.js'
 import { RunnerError } from './types.js'
+import { norm } from './path.js'
 
 /** How the fake responds to a command: a static result or a per-command function. */
 export type FakeExec = (command: string, opts: ExecOptions) => ExecResult | Promise<ExecResult>
@@ -25,10 +26,6 @@ export interface FakeRunnerOptions {
   background?: boolean
 }
 
-/** Normalize a workspace path to a canonical relative form. */
-function norm(path: string): string {
-  return path.replace(/^\.?\/+/, '').replace(/\/+$/, '')
-}
 
 class FakeFs implements RunnerFs {
   constructor(private readonly files: Map<string, string>) {}

--- a/packages/ai-autopilot/src/runner/local.ts
+++ b/packages/ai-autopilot/src/runner/local.ts
@@ -15,6 +15,7 @@ import type {
   PreviewOptions,
 } from './types.js'
 import { RunnerError } from './types.js'
+import { norm } from './path.js'
 
 const delay = (ms: number): Promise<void> => new Promise(res => setTimeout(res, ms))
 
@@ -46,12 +47,13 @@ export interface LocalRunnerOptions {
   previewHost?: string
 }
 
-/** Normalize a workspace path to a canonical relative form (matches FakeFs). */
-function norm(path: string): string {
-  return path.replace(/^\.?\/+/, '').replace(/\/+$/, '')
-}
-
-/** Resolve `path` inside `root`, rejecting anything that escapes the workspace. */
+/**
+ * Resolve `path` inside `root`, rejecting anything that escapes the workspace.
+ *
+ * Not {@link safeSegments}: there is a real filesystem here, so resolving against
+ * the root and asking `node:path` whether we stayed inside also catches what the
+ * host resolves differently. The container and browser runners have no such root.
+ */
 function within(root: string, path: string): string {
   const abs = resolve(root, norm(path))
   const rel = relative(root, abs)

--- a/packages/ai-autopilot/src/runner/path.test.ts
+++ b/packages/ai-autopilot/src/runner/path.test.ts
@@ -1,0 +1,88 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { norm, safeSegments } from './path.js'
+import { RunnerError } from './types.js'
+
+// The guard decides whether an agent can write outside its workspace, so it is
+// tested directly: as a pure function it needs no daemon and no browser, unlike
+// the runners that use it (docker.test.ts is gated on a live Docker daemon, and
+// webcontainer's copy of this had no test at all before it moved here).
+
+describe('norm', () => {
+  it('drops a leading ./ or / so every path is workspace-relative', () => {
+    assert.equal(norm('./a.txt'), 'a.txt')
+    assert.equal(norm('/a.txt'), 'a.txt')
+    assert.equal(norm('///a.txt'), 'a.txt')
+    assert.equal(norm('.//a.txt'), 'a.txt')
+  })
+
+  it('drops trailing slashes', () => {
+    assert.equal(norm('dir/'), 'dir')
+    assert.equal(norm('dir///'), 'dir')
+  })
+
+  it('leaves an already-canonical path alone', () => {
+    assert.equal(norm('a/b.txt'), 'a/b.txt')
+    assert.equal(norm(''), '')
+  })
+
+  it('does not resolve .. — that is the guard s job, not normalization s', () => {
+    assert.equal(norm('../evil.txt'), '../evil.txt')
+  })
+})
+
+describe('safeSegments', () => {
+  it('splits a plain path into its segments', () => {
+    assert.deepEqual(safeSegments('a/b.txt'), ['a', 'b.txt'])
+    assert.deepEqual(safeSegments('plain.txt'), ['plain.txt'])
+  })
+
+  it('treats a host-absolute path as workspace-relative rather than escaping', () => {
+    assert.deepEqual(safeSegments('/abs.txt'), ['abs.txt'])
+  })
+
+  it('drops empty and . segments', () => {
+    assert.deepEqual(safeSegments('./a/./b.txt'), ['a', 'b.txt'])
+    assert.deepEqual(safeSegments('a//b.txt'), ['a', 'b.txt'])
+    assert.deepEqual(safeSegments('trailing/'), ['trailing'])
+  })
+
+  it('resolves .. that stays inside the workspace', () => {
+    assert.deepEqual(safeSegments('ok/../still-ok.txt'), ['still-ok.txt'])
+    assert.deepEqual(safeSegments('a/b/../c.txt'), ['a', 'c.txt'])
+    // Down three then up three lands back at the root, which is still inside.
+    assert.deepEqual(safeSegments('deep/a/b/../../../out.txt'), ['out.txt'])
+  })
+
+  it('yields no segments for the workspace root itself', () => {
+    assert.deepEqual(safeSegments('.'), [])
+    assert.deepEqual(safeSegments(''), [])
+    assert.deepEqual(safeSegments('/'), [])
+  })
+
+  it('rejects every path that climbs out of the workspace', () => {
+    for (const escape of [
+      '../evil.txt',
+      '../../etc/passwd',
+      'a/../../b',
+      './../x',
+      '..',
+      'a/../..',
+      '/../etc/passwd',
+      'a/b/../../../c',
+    ]) {
+      assert.throws(() => safeSegments(escape), RunnerError, `should reject ${escape}`)
+    }
+  })
+
+  it('names the offending path, unnormalized, so the error says what was asked for', () => {
+    assert.throws(() => safeSegments('../../etc/passwd'), {
+      message: '[ai-autopilot] path escapes the workspace: ../../etc/passwd',
+    })
+  })
+
+  it('does not treat a segment merely starting with .. as an escape', () => {
+    assert.deepEqual(safeSegments('..hidden.txt'), ['..hidden.txt'])
+    assert.deepEqual(safeSegments('a/..b/c.txt'), ['a', '..b', 'c.txt'])
+  })
+})

--- a/packages/ai-autopilot/src/runner/path.ts
+++ b/packages/ai-autopilot/src/runner/path.ts
@@ -1,0 +1,44 @@
+import { RunnerError } from './types.js'
+
+// The workspace path rules, in one place. Every runner took a copy of these, and
+// the copies' own comments carried the invariant in prose ("matches LocalFs/FakeFs")
+// — which is the tell that they were required to agree and nothing made them.
+// It matters most for the fake: it is the test double for the real runners, so a
+// drift there means tests passing against something production does not do.
+
+/**
+ * Normalize a workspace path to a canonical relative form: drop a leading `./`
+ * or `/` (a path is always workspace-relative, never host-absolute) and any
+ * trailing slashes.
+ */
+export function norm(path: string): string {
+  return path.replace(/^\.?\/+/, '').replace(/\/+$/, '')
+}
+
+/**
+ * Walk `path` into the segments it names under the workspace root, rejecting any
+ * that climbs out of it — the guard that keeps an agent's writes inside its own
+ * workspace.
+ *
+ * `.` and empty segments are dropped; `..` pops the segment before it, and
+ * throws once there is nothing left to pop. So `a/../b` is `b` and `a/../../b`
+ * is an escape. An empty result means the path named the workspace root itself,
+ * which callers render their own way.
+ *
+ * This is the container/browser form, which has no real filesystem to resolve
+ * against. `LocalRunner` deliberately does not use it: it has a real root, so it
+ * resolves against it and asks `node:path` whether the result stayed inside,
+ * which also catches what the host resolves differently (symlinks, `..` through
+ * a link). Two implementations on purpose, not a copy left behind.
+ */
+export function safeSegments(path: string): string[] {
+  const parts: string[] = []
+  for (const seg of norm(path).split('/')) {
+    if (seg === '' || seg === '.') continue
+    if (seg === '..') {
+      if (parts.length === 0) throw new RunnerError(`path escapes the workspace: ${path}`)
+      parts.pop()
+    } else parts.push(seg)
+  }
+  return parts
+}

--- a/packages/ai-autopilot/src/runner/webcontainer.ts
+++ b/packages/ai-autopilot/src/runner/webcontainer.ts
@@ -16,6 +16,7 @@ import type {
   PreviewOptions,
 } from './types.js'
 import { RunnerError } from './types.js'
+import { norm, safeSegments } from './path.js'
 
 const delay = (ms: number): Promise<void> => new Promise(res => setTimeout(res, ms))
 
@@ -38,21 +39,9 @@ export function webContainerAvailable(): boolean {
  */
 let live: WebContainerRunnerSession | null = null
 
-/** Normalize a workspace path to a canonical relative form (matches LocalFs/FakeFs). */
-function norm(path: string): string {
-  return path.replace(/^\.?\/+/, '').replace(/\/+$/, '')
-}
-
 /** Resolve `path` to a workspace-relative form, rejecting anything that escapes it. */
 function within(path: string): string {
-  const parts: string[] = []
-  for (const seg of norm(path).split('/')) {
-    if (seg === '' || seg === '.') continue
-    if (seg === '..') {
-      if (parts.length === 0) throw new RunnerError(`path escapes the workspace: ${path}`)
-      parts.pop()
-    } else parts.push(seg)
-  }
+  const parts = safeSegments(path)
   return parts.length ? parts.join('/') : '.'
 }
 


### PR DESCRIPTION
The code that decides whether an agent can write outside its workspace was copied across the runners. That is the one thing in the package worth having exactly once.

`norm()` was **byte-identical four times** (fake, docker, local, webcontainer), and the copies' own comments carried the invariant in prose ("matches LocalFs/FakeFs") - which is the tell that they were required to agree and nothing made them. It matters most for the fake: **`FakeFs` is the test double for the real runners**, so a drift there means tests passing against something production does not do.

The escape guard was copied twice, docker and webcontainer: the same segment walk, differing only in what they render at the end (an absolute container path under `/workspace` vs a workspace-relative one). Both keep their rendering; only the walk moved.

`local.ts` stays on its own `resolve`/`relative` check, now documented as deliberate rather than looking like a copy someone forgot: it has a real root, so asking `node:path` whether we stayed inside also catches what the host resolves differently.

### Coverage was the real problem

For a security guard, this was thin:

| runner | escape test |
|---|---|
| local | yes, always runs |
| docker | yes, but the whole file is gated on a live Docker daemon (`dockerAvailable()`) |
| **webcontainer** | **none at all** - its 4 tests cover isolation, kind, lazy import, boot failure |

And the two that existed checked two vectors each. As a pure function the guard is now tested directly, no daemon and no browser: 12 tests over the escape vectors, including `a/../../b`, `/../etc/passwd`, `..`, and the ones that must be *allowed* (`ok/../still-ok.txt`, `deep/a/b/../../../out.txt`, `..hidden.txt`).

### Verified

- **Equivalence:** main's exact `within()` implementations vs the new ones over 23 vectors x 2 runners = **46 comparisons, 0 mismatches**, and the two renderings still differ (`/workspace/a.txt` vs `a.txt`), so the extraction shared the guard without flattening what each runner returns.
- **Behavior:** LocalFs and FakeFs diffed over 15 vectors through the public `RunnerFs` surface: identical.
- **The tests bite:** all four mutations fail the run - dropping the escape throw entirely, loosening `..` to `startsWith('..')`, no longer dropping `.` segments, and `norm` no longer stripping a leading `./`.

296 tests pass, typecheck clean. Internal, so no changeset.

### Recorded, deliberately not fixed here

**`FakeFs` does not enforce the guard the real runners do.** Probed: it accepts *every* vector, `../../etc/passwd` included, where local rejects it. Code exercised only against the fake never sees the escape path. Aligning it is a behavior change with its own blast radius, so it is not folded into a dedup PR - happy to file it separately if you want it.

Closes #585
