### PR TITLE
chore: ignore the daemon's in-tree run state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,10 @@ docs/.vitepress/cache/
 
 # Generated from packages/framework/prompts/**/*.md by its gen-prompts script (#551).
 packages/framework/src/prompts.generated.ts
+
+# The Framework writes run state into .the-framework/ when its daemon runs against a repo
+# in-tree (dev). Transient, mirroring the .gitignore the framework seeds on install; LOGS.md
+# stays the only committed part, so it is never ignored here.
+**/.the-framework/events.jsonl
+**/.the-framework/run.json
+**/.the-framework/runs/


### PR DESCRIPTION
Running the daemon against this repo during dev writes a `.the-framework/` run directory (`events.jsonl`, `run.json`, `runs/`) at the root and under `packages/framework`. Nothing installed it, so it never got the `.gitignore` the framework seeds on a real install, and it kept showing up untracked in `git status` (and got swept into `git add -A` more than once across the recent refactor PRs, which I had to unstage each time).

Ignore just the transient run state, at any depth, mirroring the framework's own `LOGS_GITIGNORE`: `LOGS.md` is the committed project DB and stays trackable.

Verified: no `.the-framework/` file is tracked today, no `LOGS.md` is committed, and `git check-ignore` confirms both stray dirs are caught while `LOGS.md` is not.

chore, no changeset.