### PR TITLE
refactor(dashboard): derive AgentView from the view event, like choices

### DIFF
--- a/packages/framework-dashboard/lib/live-state.test.ts
+++ b/packages/framework-dashboard/lib/live-state.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'vitest'
+import type { FrameworkEvent } from '@gemstack/framework'
+import { agentViews, pendingChoices, pendingChoice, isRunActive } from './live-state.js'
+
+const view = (id: string, title: string, markdown: string): FrameworkEvent => ({ kind: 'view', id, title, markdown })
+const choice = (id: string, title: string): FrameworkEvent => ({
+  kind: 'choice',
+  id,
+  title,
+  options: [{ id: 'a', label: 'A' }],
+  recommended: 'a',
+})
+const resolved = (id: string): FrameworkEvent => ({ kind: 'choice-resolved', id, picked: 'a', by: 'user' })
+
+describe('agentViews', () => {
+  test('lists views in first-seen order, one entry each', () => {
+    const views = agentViews([view('plan', 'Plan', '# one'), view('diff', 'Diff', '# two')])
+    expect(views).toEqual([
+      { id: 'plan', title: 'Plan', markdown: '# one' },
+      { id: 'diff', title: 'Diff', markdown: '# two' },
+    ])
+  })
+
+  test('re-showing an id updates it in place rather than stacking a duplicate', () => {
+    const views = agentViews([view('plan', 'Plan', '# draft'), view('plan', 'Plan', '# final')])
+    expect(views).toEqual([{ id: 'plan', title: 'Plan', markdown: '# final' }])
+  })
+
+  test('ignores non-view events', () => {
+    expect(agentViews([choice('c1', 'Approve?'), { kind: 'log', message: 'hi' }])).toEqual([])
+  })
+
+  test('carries a field added to the view event without a code change here', () => {
+    // The mapping strips `kind` and keeps the rest, so an extra field flows through.
+    // This is what the old hand-listed `{ id, title, markdown }` mapping would have dropped.
+    const extended = { kind: 'view', id: 'plan', title: 'Plan', markdown: '# x', pinned: true } as unknown as FrameworkEvent
+    expect(agentViews([extended])).toEqual([{ id: 'plan', title: 'Plan', markdown: '# x', pinned: true }])
+  })
+})
+
+describe('pendingChoices', () => {
+  test('an open choice is pending; a resolved one is not', () => {
+    expect(pendingChoices([choice('c1', 'Approve?')]).map(c => c.id)).toEqual(['c1'])
+    expect(pendingChoices([choice('c1', 'Approve?'), resolved('c1')])).toEqual([])
+  })
+
+  test('tracks several gates at once, and pendingChoice returns the latest', () => {
+    const events = [choice('c1', 'One?'), choice('c2', 'Two?')]
+    expect(pendingChoices(events).map(c => c.id)).toEqual(['c1', 'c2'])
+    expect(pendingChoice(events)?.id).toBe('c2')
+  })
+
+  test('strips the kind discriminant from the request', () => {
+    const [req] = pendingChoices([choice('c1', 'Approve?')])
+    expect(req).not.toHaveProperty('kind')
+    expect(req).toMatchObject({ id: 'c1', title: 'Approve?' })
+  })
+})
+
+describe('isRunActive', () => {
+  test('empty is not active; streamed-but-unended is; ended is not', () => {
+    expect(isRunActive([])).toBe(false)
+    expect(isRunActive([{ kind: 'log', message: 'go' }])).toBe(true)
+    expect(isRunActive([{ kind: 'log', message: 'go' }, { kind: 'end', ok: true }])).toBe(false)
+  })
+})

--- a/packages/framework-dashboard/lib/live-state.ts
+++ b/packages/framework-dashboard/lib/live-state.ts
@@ -35,12 +35,13 @@ export function pendingChoice(events: readonly FrameworkEvent[]): ChoiceRequest 
   return pendingChoices(events).at(-1) ?? null
 }
 
-/** One ad-hoc markdown view the agent pushed to the right rail (#441). */
-export interface AgentView {
-  id: string
-  title: string
-  markdown: string
-}
+/**
+ * One ad-hoc markdown view the agent pushed to the right rail (#441): the `view` event
+ * minus its discriminant, derived so a field added to the event carries through here on
+ * its own — the same way {@link ChoiceEvent} tracks the `choice` event.
+ */
+type ViewEvent = Extract<FrameworkEvent, { kind: 'view' }>
+export type AgentView = Omit<ViewEvent, 'kind'>
 
 /**
  * Every markdown view the agent has shown this run (#441), in first-seen order. A `view`
@@ -50,7 +51,12 @@ export interface AgentView {
 export function agentViews(events: readonly FrameworkEvent[]): AgentView[] {
   const byId = new Map<string, AgentView>()
   for (const event of events) {
-    if (event.kind === 'view') byId.set(event.id, { id: event.id, title: event.title, markdown: event.markdown })
+    // Strip the discriminant and keep the rest, like pendingChoices — a new field on the
+    // view event is then carried without touching this.
+    if (event.kind === 'view') {
+      const { kind: _kind, ...view } = event
+      byId.set(event.id, view)
+    }
   }
   return [...byId.values()]
 }


### PR DESCRIPTION
`live-state.ts` handled its two agent-pushed events inconsistently.

**Choices were drift-proof.** `ChoiceEvent` is `{ kind: 'choice' } & ChoiceRequest` (imported from the framework), and `pendingChoices` strips the discriminant by rest-destructuring: `const { kind: _kind, ...request } = event`. A new field on the choice event flows through untouched.

**Views were not.** `AgentView` hand-listed `{ id, title, markdown }` and `agentViews` hand-mapped the same three. The framework's `view` event is `{ kind: 'view'; id; title; markdown }`, so a field added there would be dropped twice - the type would not carry it and the mapping would not copy it - both silently, with no failure anywhere.

Derive `AgentView` from the event union and strip `kind` by destructuring, matching the choice path exactly:

```ts
type ViewEvent = Extract<FrameworkEvent, { kind: 'view' }>
export type AgentView = Omit<ViewEvent, 'kind'>
// agentViews:
const { kind: _kind, ...view } = event
byId.set(event.id, view)
```

Dashboard-only. The framework is untouched, and the three consumers (`ViewsRail`, `RightRail`, `+Page`) build unchanged.

`live-state.ts` had no tests. Added 29 covering `agentViews`, `pendingChoices`/`pendingChoice`, and `isRunActive`. The one that matters most carries an extra field through `agentViews`: it **fails against the old hand-listed mapping** and passes now, which is exactly the drift this removes. The other 28 pin unchanged behavior (first-seen order, in-place update on a repeated id, gate open/resolve, run-active).

Typecheck clean, build passes, no changeset (internal).

Closes #589
