### PR TITLE
fix(framework): business-knowledge docs at repo root, commented context (#591)

### DIFF
--- a/.changeset/knowledge-docs-repo-root.md
+++ b/.changeset/knowledge-docs-repo-root.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Apply Rom's #559 review to the business-knowledge docs (#537): drop `README.md` (a repo's own `README.md` already covers the overview), move `DECISIONS.md` and `KNOWLEDGE-BASE.md` to the repo root, and show each doc's one-line gloss in the injected `Context:` too, not just the post-merge prompt. The `## Business knowledge` prompt text is now his verbatim wording.

--- a/packages/framework/prompts/post_merge_prompt.md
+++ b/packages/framework/prompts/post_merge_prompt.md
@@ -11,9 +11,8 @@ If the changes introduced by ${{ tf.session_name }} can potentially lead to secu
 
 ## Business knowledge
 
-Consider whether the changes introduced by ${{ tf.session_name }} taught you something that belongs in these documents, and update them if so (create one if it doesn't exist yet):
-- `.the-framework/README.md` (whole repo overview)
-- `.the-framework/DECISIONS.md` (decisions taken, and why)
-- `.the-framework/KNOWLEDGE-BASE.md` (business knowledge about the project)
+If you didn't already, consider updating the following based on the changes and discussions of ${{ tf.session_name }} (you can create the files if they're missing):
+- `DECISIONS.md` (decisions taken, and why)
+- `KNOWLEDGE-BASE.md` (knowledge and insights related to the project)
 
 Only write what a future agent would need and cannot get from the code itself.

--- a/packages/framework/src/post-merge-prompt.test.ts
+++ b/packages/framework/src/post-merge-prompt.test.ts
@@ -18,7 +18,7 @@ test('the business-knowledge section names every knowledge doc (#537)', () => {
   // agent gets told to read one set of files and update another.
   assert.ok(POST_MERGE_PROMPT_TEMPLATE.includes('## Business knowledge'))
   for (const doc of KNOWLEDGE_DOCS) {
-    assert.ok(POST_MERGE_PROMPT_TEMPLATE.includes(doc), `missing ${doc}`)
+    assert.ok(POST_MERGE_PROMPT_TEMPLATE.includes(`\`${doc.path}\``), `missing ${doc.path}`)
   }
 })
 

--- a/packages/framework/src/system-prompt.test.ts
+++ b/packages/framework/src/system-prompt.test.ts
@@ -12,8 +12,10 @@ import {
 } from './system-prompt.js'
 import { loadUserSystemPrompt, SYSTEM_PROMPT_FILE } from './system-prompt-file.js'
 
-/** The `Context:` line the #537 knowledge docs stand up on their own, with no dirs picked. */
-const KNOWLEDGE_CONTEXT = `Context: ${KNOWLEDGE_DOCS.join(', ')}`
+/** The knowledge docs as the commented bullets they render to (#559). */
+const KNOWLEDGE_LINES = KNOWLEDGE_DOCS.map(d => `- \`${d.path}\` (${d.comment})`).join('\n')
+/** The `Context:` block the #537 knowledge docs stand up on their own, with no dirs picked. */
+const KNOWLEDGE_CONTEXT = `Context:\n${KNOWLEDGE_LINES}`
 import { AWAIT_PROTOCOL, SIGNAL_PROTOCOL } from './turn-gate.js'
 
 test('loadUserSystemPrompt reads and trims SYSTEM.md', async () => {
@@ -109,9 +111,9 @@ test('systemPromptBlock prepends a Context line for the selected directories (#4
 
 test('systemPromptBlock puts the knowledge docs in context, after the user dirs (#537)', () => {
   const block = systemPromptBlock({ user: 'Only mine.', context: ['/work/api'] })
-  assert.ok(block.startsWith(`Context: /work/api, ${KNOWLEDGE_DOCS.join(', ')}\n\n`))
-  // No dirs picked: the docs still stand up a Context line of their own.
-  assert.ok(systemPromptBlock({}).startsWith(`Context: ${KNOWLEDGE_DOCS.join(', ')}\n\n`))
+  assert.ok(block.startsWith(`Context: /work/api\n${KNOWLEDGE_LINES}\n\n`))
+  // No dirs picked: the docs still stand up a Context block of their own.
+  assert.ok(systemPromptBlock({}).startsWith(`${KNOWLEDGE_CONTEXT}\n\n`))
 })
 
 test('systemPromptBlock adds no knowledge docs when antiLazyPill is false (#537/#547)', () => {
@@ -127,7 +129,7 @@ test('systemPromptBlock is the #326 prompt and the user prompt, in that order, a
   // for a plan, so the override earned nothing and outranked the doc.
   // The knowledge docs (#537) join the Context line, which is paths, not prompt text.
   const block = systemPromptBlock({ user: 'Ship small PRs.', context: ['/work/api'] })
-  const context = `Context: ${['/work/api', ...KNOWLEDGE_DOCS].join(', ')}`
+  const context = `Context: /work/api\n${KNOWLEDGE_LINES}`
   assert.equal(block, [context, renderSystemPrompt().system, 'Ship small PRs.'].join('\n\n'))
 })
 

--- a/packages/framework/src/system-prompt.ts
+++ b/packages/framework/src/system-prompt.ts
@@ -92,12 +92,13 @@ const DEFAULT_TF: TfContext = { prompt: '', params: {} }
  * The project-knowledge documents (#537): what the repo knows about itself, as markdown
  * that travels with the code. {@link systemPromptBlock} puts them in front of every run
  * as in-context paths; the post-merge prompt asks the agent to update them, which is what
- * keeps them current. Workspace-relative, because that is the agent's cwd.
+ * keeps them current. Repo-root, because that is the agent's cwd and where the docs live.
+ * Each carries the one-line gloss Rom wants shown alongside the path (#559). README is
+ * left out: a repo's own `README.md` already covers the overview.
  */
-export const KNOWLEDGE_DOCS: readonly string[] = [
-  '.the-framework/README.md',
-  '.the-framework/DECISIONS.md',
-  '.the-framework/KNOWLEDGE-BASE.md',
+export const KNOWLEDGE_DOCS: readonly { path: string; comment: string }[] = [
+  { path: 'DECISIONS.md', comment: 'decisions taken, and why' },
+  { path: 'KNOWLEDGE-BASE.md', comment: 'knowledge and insights related to the project' },
 ]
 
 /** The two halves of the rendered {@link SYSTEM_PROMPT_TEMPLATE}. */
@@ -195,11 +196,16 @@ export function systemPromptBlock(opts: SystemPromptOptions = {}): string {
   const parts: string[] = []
   // The #439 context line goes first, so it frames whatever prompt follows (or stands
   // alone under `--vanilla`, where there is no built-in prompt to frame).
-  const context = opts.context?.map(d => d.trim()).filter(Boolean) ?? []
+  const dirs = opts.context?.map(d => d.trim()).filter(Boolean) ?? []
   // The knowledge docs ride with the built-in prompt, not with the user's dirs: they are
-  // ours, and `--vanilla` means no framework-authored prompt at all (#547 rule 3).
-  const inContext = opts.antiLazyPill === false ? context : [...context, ...KNOWLEDGE_DOCS]
-  if (inContext.length) parts.push(`Context: ${inContext.join(', ')}`)
+  // ours, and `--vanilla` means no framework-authored prompt at all (#547 rule 3). They
+  // render as commented bullets under the dirs (#559), so the agent sees what each is for.
+  const docs = opts.antiLazyPill === false ? [] : KNOWLEDGE_DOCS
+  if (dirs.length || docs.length) {
+    const head = `Context:${dirs.length ? ` ${dirs.join(', ')}` : ''}`
+    const bullets = docs.map(d => `- \`${d.path}\` (${d.comment})`)
+    parts.push([head, ...bullets].join('\n'))
+  }
   if (opts.antiLazyPill !== false) parts.push(renderSystemPrompt(opts.tf).system)
   const user = opts.user?.trim()
   if (user) parts.push(user)


### PR DESCRIPTION
Applies your #559 review of the #537 business-knowledge feature. Prompt diff is the whole point, so please read it.

- drop `README.md` (the repo's own `README.md` covers the overview)
- `DECISIONS.md` / `KNOWLEDGE-BASE.md` move to the repo root
- the one-line glosses ride in the injected `Context:` too, as bullets
- `## Business knowledge` prompt is your verbatim wording

**One composition choice for you.** The `Context:` injection was one comma-joined line. To carry the glosses I split it: picked dirs stay on the `Context:` line, the docs render as bullets under it:

```
Context: /work/api, /work/ui
- `DECISIONS.md` (decisions taken, and why)
- `KNOWLEDGE-BASE.md` (knowledge and insights related to the project)
```

With no dirs picked it is a bare `Context:` header over the bullets. Say if you'd rather fold the docs onto the line or drop the header.

The rename you asked for (`post-merge` -> `on-before-mergeable`) is split out to #592 to keep this a tight prompt diff.

Note: the prompt-drift check is already red on `main` (you updated the #326 OP block 2 to the preset `filePath` format this morning); that is the separate `## Maintenance` re-flatten, next PR, not this one.

544/1 skip/0 fail, typecheck clean.

Closes #591