### PR TITLE
fix(framework): ensure presets exist at post-merge time, not only on install (#598)

### DIFF
--- a/.changeset/ensure-presets-post-merge.md
+++ b/.changeset/ensure-presets-post-merge.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+`runPostMerge` now materializes the quality presets before queueing, so the post-merge TODO entries' `filePath` values always resolve (#598). Previously the presets were written only on install and are gitignored, so a repo activated before that feature shipped, or a fresh clone, had no preset files and the queued entry pointed at a path that did not exist. Best-effort: a materialize failure is reported, never fatal.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join, dirname } from 'node:path'
 import { appendControl } from './control.js'
 import { daemonStatePath } from './daemon.js'
-import { EVENTS_FILE, FRAMEWORK_DIR } from './store/index.js'
+import { EVENTS_FILE, FRAMEWORK_DIR, type StoreFs } from './store/index.js'
 import {
   activeModes,
   antiLazyPillOff,
@@ -37,6 +37,20 @@ function capture(): { io: CliIO; out: string[]; err: string[] } {
   const out: string[] = []
   const err: string[] = []
   return { io: { out: l => out.push(l), err: l => err.push(l) }, out, err }
+}
+
+/** An in-memory {@link StoreFs} so runPostMerge's preset materialization never touches disk. */
+function memFs(): StoreFs & { files: Map<string, string> } {
+  const files = new Map<string, string>()
+  return {
+    files,
+    async read(p) { const v = files.get(p); if (v === undefined) throw new Error(`ENOENT: ${p}`); return v },
+    async write(p, c) { files.set(p, c) },
+    async append(p, c) { files.set(p, (files.get(p) ?? '') + c) },
+    async exists(p) { return files.has(p) },
+    async mkdir() {},
+    async readdir() { return [] },
+  }
 }
 
 test('parseArgs reads flags and the intent words', () => {
@@ -95,7 +109,7 @@ test('runPostMerge queues the follow-ups in ONE run instead of running the prese
     seen.push(prompt)
     return Promise.resolve(true)
   }
-  await runPostMerge('/work/app', '/bin/framework', io, { session_name: 'add-oauth' }, undefined, undefined, run)
+  await runPostMerge('/work/app', '/bin/framework', io, { session_name: 'add-oauth' }, undefined, undefined, run, memFs())
   // One child run, not three: it asks for TODO entries rather than doing the passes.
   assert.equal(seen.length, 1)
   const prompt = seen[0]!
@@ -122,6 +136,7 @@ test('runPostMerge gates the readability entry on technical_control (#326)', asy
         seen.push(p)
         return Promise.resolve(true)
       },
+      memFs(),
     )
     return seen[0]!
   }
@@ -132,9 +147,18 @@ test('runPostMerge gates the readability entry on technical_control (#326)', asy
 test('runPostMerge is best-effort: a failed queueing run is reported, never thrown (#326)', async () => {
   const { io, out } = capture()
   await runPostMerge('/work/app', '/bin/framework', io, { session_name: 'add-oauth' }, undefined, undefined, () =>
-    Promise.resolve(false),
+    Promise.resolve(false), memFs(),
   )
   assert.ok(out.some(l => /post-merge queueing did not complete/.test(l)))
+})
+
+test('runPostMerge materializes the presets so the queued filePaths resolve (#598)', async () => {
+  const { io } = capture()
+  const fs = memFs()
+  await runPostMerge('/work/app', '/bin/framework', io, { session_name: 'add-oauth' }, undefined, undefined, () => Promise.resolve(true), fs)
+  // The entry points at .the-framework/presets/maintainability.md; that file must now exist.
+  assert.ok(fs.files.has(join('/work/app', '.the-framework/presets/maintainability.md')))
+  assert.ok(fs.files.has(join('/work/app', '.the-framework/presets/security_audit.md')))
 })
 
 test('parseArgs reads the maintain subcommand + its bounds (#298)', () => {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -34,7 +34,8 @@ import { loadUserSystemPrompt, SYSTEM_PROMPT_FILE } from './system-prompt-file.j
 import { checkForUpdate, formatUpdateStatus, nodeVersionFetcher } from './update-check.js'
 import { appendLog, type LogEntry } from './logs.js'
 import { preflight } from './preflight.js'
-import { RunStore } from './store/index.js'
+import { RunStore, nodeStoreFs, type StoreFs } from './store/index.js'
+import { materializePresets } from './presets.js'
 import { daemonStatus, ensureDaemon, runDaemon, stopDaemon, DEFAULT_DAEMON_PORT } from './daemon.js'
 import { resetControl, watchControl, type ControlWatcher } from './control.js'
 import { isActivated, nodeGitRunner } from './project.js'
@@ -1426,7 +1427,16 @@ export async function runPostMerge(
   maxCost?: number,
   eco?: EcoOptions,
   run: PromptRunner = spawnPromptRun,
+  fs: StoreFs = nodeStoreFs(),
 ): Promise<void> {
+  // Ensure the presets exist so the queued entries' filePaths resolve, even in a repo
+  // activated before they shipped or a fresh clone (they are gitignored) (#598). Best-effort,
+  // like the rest of this run: a materialize failure must not block the queueing.
+  try {
+    await materializePresets(cwd, fs)
+  } catch (err) {
+    io.out(`  ! post-merge: could not materialize presets (${err instanceof Error ? err.message : String(err)})`)
+  }
   io.out(`\n◆ post-merge: queueing quality follow-ups for ${tf.session_name}`)
   const ok = await run(renderPostMergePrompt(tf, eco), cwd, binPath, maxCost)
   if (!ok) io.out(`  ! post-merge queueing did not complete cleanly.`)


### PR DESCRIPTION
Follow-up to #597. The presets are materialized on install and gitignored, so a repo activated before #597 shipped (or a fresh clone) has no `.the-framework/presets/*.md`, and a post-merge TODO entry's `filePath` (`Apply .the-framework/presets/maintainability.md ...`) points at a file that does not exist. The picked-up agent then can't open it and the quality pass silently fails, which breaks the zero-intervention autopilot bar.

`runPostMerge` now materializes the presets before queueing (best-effort, `fs` injectable). Cheap and idempotent.

Proven end to end: `runPostMerge` in a fresh dir with no install writes all five preset files. The new test is mutation-checked (fails without the materialize call). 541/1 skip/0 fail, typecheck clean.

Closes #598