### PR TITLE
fix(ai-autopilot): FakeFs enforces the workspace-escape guard like real runners

### DIFF
--- a/.changeset/fake-fs-escape-guard.md
+++ b/.changeset/fake-fs-escape-guard.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/ai-autopilot": patch
+---
+
+FakeFs now enforces the same workspace-escape guard as the real runners. Its filesystem previously stored any path as a map key, so a `write('../evil.txt', ...)` that a real runner rejects was silently accepted. Code exercised only against `FakeRunner` never saw the escape path, then threw against Docker/Local/WebContainer. `FakeFs` now routes every path through the shared `safeSegments` guard, rejecting escapes and resolving `.`/`..` exactly as the real runners do.

--- a/packages/ai-autopilot/src/runner/fake.test.ts
+++ b/packages/ai-autopilot/src/runner/fake.test.ts
@@ -39,6 +39,23 @@ describe('FakeRunnerSession.fs', () => {
     const s = await new FakeRunner().boot()
     await assert.rejects(() => s.fs.read('nope.txt'), RunnerError)
   })
+
+  it('refuses paths that escape the workspace, like the real runners', async () => {
+    const s = await new FakeRunner().boot()
+    for (const path of ['../evil.txt', '../../etc/passwd', 'a/../../b', '..']) {
+      await assert.rejects(() => s.fs.write(path, 'x'), RunnerError)
+      await assert.rejects(() => s.fs.read(path), RunnerError)
+    }
+  })
+
+  it('resolves `.` and in-workspace `..` to the same file the real runners do', async () => {
+    const s = await new FakeRunner().boot()
+    await s.fs.write('src/./a.txt', 'A') // `.` is a no-op segment
+    await s.fs.write('src/tmp/../b.txt', 'B') // `..` pops `tmp`, staying inside
+    assert.equal(await s.fs.read('src/a.txt'), 'A')
+    assert.equal(await s.fs.read('src/b.txt'), 'B')
+    assert.deepEqual(await s.fs.list('src'), ['src/a.txt', 'src/b.txt'])
+  })
 })
 
 describe('FakeRunnerSession.exec', () => {

--- a/packages/ai-autopilot/src/runner/fake.ts
+++ b/packages/ai-autopilot/src/runner/fake.ts
@@ -10,7 +10,15 @@ import type {
   PreviewOptions,
 } from './types.js'
 import { RunnerError } from './types.js'
-import { norm } from './path.js'
+import { safeSegments } from './path.js'
+
+// The fake's canonical map key: the same rules the real runners enforce — reject a
+// path that escapes the workspace, resolve `.`/`..`. Routing every path through it
+// keeps code exercised only against the fake honest about the one path most worth
+// exercising. Empty string is the workspace root, which no file names.
+function fsKey(path: string): string {
+  return safeSegments(path).join('/')
+}
 
 /** How the fake responds to a command: a static result or a per-command function. */
 export type FakeExec = (command: string, opts: ExecOptions) => ExecResult | Promise<ExecResult>
@@ -31,26 +39,26 @@ class FakeFs implements RunnerFs {
   constructor(private readonly files: Map<string, string>) {}
 
   async read(path: string): Promise<string> {
-    const p = norm(path)
+    const p = fsKey(path)
     if (!this.files.has(p)) throw new RunnerError(`no such file: ${path}`)
     return this.files.get(p)!
   }
 
   async write(path: string, contents: string): Promise<void> {
-    this.files.set(norm(path), contents)
+    this.files.set(fsKey(path), contents)
   }
 
   async remove(path: string): Promise<void> {
-    this.files.delete(norm(path))
+    this.files.delete(fsKey(path))
   }
 
   async list(dir?: string): Promise<string[]> {
-    const prefix = dir ? norm(dir) + '/' : ''
+    const prefix = dir ? fsKey(dir) + '/' : ''
     return [...this.files.keys()].filter(p => p.startsWith(prefix)).sort()
   }
 
   async exists(path: string): Promise<boolean> {
-    return this.files.has(norm(path))
+    return this.files.has(fsKey(path))
   }
 }
 
@@ -98,7 +106,7 @@ export class FakeRunnerSession implements RunnerSession {
   ) {
     this.id = id
     for (const [path, contents] of Object.entries(boot.files ?? {})) {
-      this.files.set(norm(path), contents)
+      this.files.set(fsKey(path), contents)
     }
     this.fs = new FakeFs(this.files)
     if (opts.preview) {


### PR DESCRIPTION
Closes #587.

`FakeFs` is the test double for the real runners, but its filesystem stored any path as a map key with no escape guard. A `write('../evil.txt', ...)` that Docker/Local/WebContainer all reject was silently accepted, so code exercised only against `FakeRunner` never saw the escape path (the one most worth exercising) and then threw against a real runner.

## Fix

Route every `FakeFs` path, and the boot-time seeding that shares the same map, through the shared `safeSegments` guard (from #585). It now rejects escapes and resolves `.`/`..` exactly as the real runners do.

## Tests

Mirrors the real runners' `refuses paths that escape the workspace` test in `fake.test.ts` (`../evil.txt`, `../../etc/passwd`, `a/../../b`, `..`), plus a parity test that `.`/in-workspace `..` resolve to the same file. Full suite: 298 pass, 0 fail; typecheck clean.

No existing test wrote an escaping path to the fake, so nothing regresses.