### PR TITLE
refactor(framework): one shared continuation prompt for all gate paths

### DIFF
--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -135,8 +135,6 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
     const rounds = await runAwaitRounds({
       session,
       prompt: firstPrompt,
-      continuation: (gate, answer) =>
-        `You paused to ask: "${gate.title}". The user chose: ${answer}. Continue with that decision, and do not ask again unless a genuinely new choice comes up.`,
       emitTurnSignals,
       requestChoice: opts.requestChoice,
       emit,

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -10,7 +10,7 @@ import { FAKE_DEPLOY, FAKE_INTENT, FAKE_SIGNALS, fakeDriver } from './fake-scrip
 import { FakeDriver, type Driver, type DriverSession } from './driver/index.js'
 import { composeRunSystem } from './system-prompt.js'
 import type { ChoiceRequest, FrameworkEvent } from './events.js'
-import { MAX_AWAIT_ROUNDS, PLAN_DECLINED_MESSAGE } from './turn-gate.js'
+import { MAX_AWAIT_ROUNDS, PLAN_DECLINED_MESSAGE, continuationPrompt } from './turn-gate.js'
 
 /** A driver that records the `system` framing it is started with, delegating the run to the fake. */
 function recordingDriver(): { driver: Driver; system: () => string } {
@@ -829,14 +829,14 @@ test('runAwaitRounds resolves a gate, re-prompts with the answer, and emits ever
   const result = await runAwaitRounds({
     session,
     prompt: 'open',
-    continuation: (gate, answer) => `resume: ${gate.title} -> ${answer}`,
     emitTurnSignals: text => void signalled.push(text),
     requestChoice: async () => ({ picked: 'b' }),
     emit: e => void events.push(e),
   })
 
   assert.deepEqual(result, { text: 'All done.', declined: false, exhausted: false })
-  assert.deepEqual(prompts, ['open', 'resume: Which way? -> Option B']) // the caller owns the wording
+  // One shared continuation wording for every path (#570), built from the gate title + pick.
+  assert.deepEqual(prompts, ['open', continuationPrompt('Which way?', 'Option B')])
   assert.ok(events.some(e => e.kind === 'log' && e.message === 'Continuing with your choice: Option B'))
   // Every turn goes through the signal emitter, the gate turn included (#563).
   assert.equal(signalled.length, 2)
@@ -852,7 +852,6 @@ test('runAwaitRounds reports a declined plan and stops instead of re-prompting (
   const result = await runAwaitRounds({
     session,
     prompt: 'open',
-    continuation: () => 'should never be sent',
     emitTurnSignals: () => {},
     requestChoice: async () => ({ picked: 'decline' }),
     emit: e => void events.push(e),
@@ -872,7 +871,6 @@ test('runAwaitRounds gives up after MAX_AWAIT_ROUNDS and reports it exhausted', 
   const result = await runAwaitRounds({
     session,
     prompt: 'open',
-    continuation: () => 'again',
     emitTurnSignals: () => {},
     requestChoice: async () => ({ picked: 'a' }),
     emit: () => {},

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -26,7 +26,7 @@ import { CONSUMPTION_LIMIT_LABEL, type ConsumptionWindow } from './consumption.j
 import type { Driver, DriverSession } from './driver/index.js'
 import { composeRunSystem, type EcoOptions, type TfContext } from './system-prompt.js'
 import { createDriverEventHandler, emitSessionStart } from './run-telemetry.js'
-import { AWAIT_PROTOCOL, CONFIRM_APPROVED, CONFIRM_DECLINED, MAX_AWAIT_ROUNDS, PLAN_DECLINED_MESSAGE, createTurnSignalEmitter, isDeclinedConfirmation, parseAwaitGate, type ParsedAwaitGate } from './turn-gate.js'
+import { AWAIT_PROTOCOL, CONFIRM_APPROVED, CONFIRM_DECLINED, MAX_AWAIT_ROUNDS, PLAN_DECLINED_MESSAGE, continuationPrompt, createTurnSignalEmitter, isDeclinedConfirmation, parseAwaitGate, type ParsedAwaitGate } from './turn-gate.js'
 // Value import from todo-loop.js is a benign cycle: todo-loop.js only calls
 // run.js's hoisted function declarations (requestChoices / resolveAwaitGate).
 import { leaveResumeNote, runTodoLoop, type TodoLoopResult } from './todo-loop.js'
@@ -618,12 +618,6 @@ export interface AwaitRoundsOptions {
   session: DriverSession
   /** The prompt that opens the exchange. */
   prompt: string
-  /**
-   * The prompt that resumes the agent once the user has answered a gate. The caller owns
-   * the wording (it is agent-facing text, and each path says something different), so this
-   * takes it rather than templating it here.
-   */
-  continuation: (gate: ParsedAwaitGate, answer: string) => string
   /** Emit the signals each turn carries (#563). */
   emitTurnSignals: (text: string) => void
   requestChoice?: ((req: ChoiceRequest) => Promise<ChoicePick>) | undefined
@@ -658,7 +652,7 @@ export async function runAwaitRounds(opts: AwaitRoundsOptions): Promise<AwaitRou
       return { text: turn.text, declined: true, exhausted: false }
     }
     emit({ kind: 'log', message: `Continuing with your choice: ${answer}` })
-    turn = await session.prompt(opts.continuation(gate, answer), signalOpt)
+    turn = await session.prompt(continuationPrompt(gate.title, answer), signalOpt)
     emitTurnSignals(turn.text)
     gate = parseAwaitGate(turn.text)
   }

--- a/packages/framework/src/steps.ts
+++ b/packages/framework/src/steps.ts
@@ -17,7 +17,7 @@ import type {
   Verdict,
 } from '@gemstack/ai-autopilot'
 import type { DriverSession } from './driver/index.js'
-import { parseAwaitGate, type ParsedAwaitGate } from './turn-gate.js'
+import { continuationPrompt, parseAwaitGate, type ParsedAwaitGate } from './turn-gate.js'
 
 /**
  * Driver-backed {@link https://github.com/gemstack-land/gemstack | Bootstrap} steps.
@@ -163,7 +163,7 @@ export function continueAfterChoice(
   question: string,
   answer: string,
 ): Promise<SupervisorRun> {
-  const prompt = `You paused to ask: "${question}". The user chose: ${answer}. Continue building "${ctx.intent}" with that decision, and do not ask again unless a genuinely new choice comes up.`
+  const prompt = continuationPrompt(question, answer)
   return session
     .prompt(prompt, { ...(ctx.signal ? { signal: ctx.signal } : {}) })
     .then(turn => {

--- a/packages/framework/src/todo-loop.ts
+++ b/packages/framework/src/todo-loop.ts
@@ -300,8 +300,6 @@ async function promptItem(
   await runAwaitRounds({
     session,
     prompt,
-    continuation: (gate, answer) =>
-      `You paused to ask: "${gate.title}". The user chose: ${answer}. Continue the backlog entry with that decision, and do not ask again unless a genuinely new choice comes up.`,
     emitTurnSignals: deps.emitTurnSignals,
     requestChoice: deps.requestChoice,
     emit: deps.emit,

--- a/packages/framework/src/turn-gate.test.ts
+++ b/packages/framework/src/turn-gate.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { isDeclinedConfirmation, parseAwaitGate, parseChoicesGate, parseConfirmationGate, parseMarkdownViews, parseMultiSelectGate, parseSessionName, parseReadyForMerge } from './turn-gate.js'
+import { continuationPrompt, isDeclinedConfirmation, parseAwaitGate, parseChoicesGate, parseConfirmationGate, parseMarkdownViews, parseMultiSelectGate, parseSessionName, parseReadyForMerge } from './turn-gate.js'
 
 const block = (json: string): string => 'Here are the options.\n```await-choices\n' + json + '\n```'
 const multiBlock = (json: string): string => 'Pick some.\n```await-multiselect\n' + json + '\n```'
@@ -8,6 +8,15 @@ const confirmBlock = (json: string): string => 'Wrote the plan.\n```await-confir
 
 test('parseChoicesGate returns undefined when the agent did not stop to ask (#337)', () => {
   assert.equal(parseChoicesGate('Built the whole app. Done.'), undefined)
+})
+
+test('continuationPrompt is one wording for every path, carrying the title and the pick (#570)', () => {
+  const prompt = continuationPrompt('Which data store?', 'Postgres')
+  assert.match(prompt, /You paused to ask: "Which data store\?"/)
+  assert.match(prompt, /The user chose: Postgres/)
+  // No caller-specific clause ("backlog entry" / "building X"): the same string everywhere.
+  assert.equal(prompt, continuationPrompt('Which data store?', 'Postgres'))
+  assert.doesNotMatch(prompt, /backlog entry|Continue building/)
 })
 
 test('parseChoicesGate parses a well-formed await-choices block (#337)', () => {

--- a/packages/framework/src/turn-gate.test.ts
+++ b/packages/framework/src/turn-gate.test.ts
@@ -17,6 +17,8 @@ test('continuationPrompt is one wording for every path, carrying the title and t
   // No caller-specific clause ("backlog entry" / "building X"): the same string everywhere.
   assert.equal(prompt, continuationPrompt('Which data store?', 'Postgres'))
   assert.doesNotMatch(prompt, /backlog entry|Continue building/)
+  // No "do not ask again" babysitting tail (#570 review): a capable agent handles that itself.
+  assert.doesNotMatch(prompt, /do not ask again/)
 })
 
 test('parseChoicesGate parses a well-formed await-choices block (#337)', () => {

--- a/packages/framework/src/turn-gate.ts
+++ b/packages/framework/src/turn-gate.ts
@@ -69,6 +69,18 @@ export const CONFIRM_DECLINED = 'Decline'
  */
 export const MAX_AWAIT_ROUNDS = 5
 
+/**
+ * The prompt that resumes the agent after the user answers a gate. One wording for
+ * every path that runs gates (a direct prompt, the backlog loop, a build): the agent
+ * already knows what it is working on from the session, so the clause that used to
+ * vary per caller ("Continue" / "Continue the backlog entry" / "Continue building X")
+ * carried no distinct meaning to it. One constant so a reword lands everywhere at once
+ * instead of one path and not the others (#570).
+ */
+export function continuationPrompt(question: string, answer: string): string {
+  return `You paused to ask: "${question}". The user chose: ${answer}. Continue with that decision, and do not ask again unless a genuinely new choice comes up.`
+}
+
 /** The log line printed when a confirmation gate is declined (#358). */
 export const PLAN_DECLINED_MESSAGE = 'Plan declined, awaiting user instructions.'
 

--- a/packages/framework/src/turn-gate.ts
+++ b/packages/framework/src/turn-gate.ts
@@ -76,9 +76,13 @@ export const MAX_AWAIT_ROUNDS = 5
  * vary per caller ("Continue" / "Continue the backlog entry" / "Continue building X")
  * carried no distinct meaning to it. One constant so a reword lands everywhere at once
  * instead of one path and not the others (#570).
+ *
+ * No "do not ask again" tail: a capable agent does not re-ask a settled question on
+ * its own, so spelling it out is babysitting we leave off until a run shows it is
+ * needed (#570 review).
  */
 export function continuationPrompt(question: string, answer: string): string {
-  return `You paused to ask: "${question}". The user chose: ${answer}. Continue with that decision, and do not ask again unless a genuinely new choice comes up.`
+  return `You paused to ask: "${question}". The user chose: ${answer}. Continue with that decision.`
 }
 
 /** The log line printed when a confirmation gate is declined (#358). */


### PR DESCRIPTION
Draft: previews the #570 fix.

## What

The prompt that resumes the agent after it stops to ask lived in three places, identical but for one clause:

- `prompt-run.ts` "**Continue** with that decision, ..."
- `todo-loop.ts` "**Continue the backlog entry** with that decision, ..."
- `steps.ts` "**Continue building \"X\"** with that decision, ..."

Three copies means a reword lands in one path and skips the other two, the #563 drift risk applied to wording.

## Fix

One `continuationPrompt(question, answer)` in `turn-gate.ts` (the leaf module both `run.ts` and `steps.ts` already import, so no cycle). The clause did not need to vary: the agent already knows what it is working on from the session, so `Continue` / `Continue the backlog entry` / `Continue building X` all carry the same meaning to it. `runAwaitRounds` no longer takes a `continuation` callback and builds the prompt itself.

Also trimmed the trailing "do not ask again unless a genuinely new choice comes up" clause per review: a capable agent does not re-ask a settled question on its own, so that instruction was babysitting. Left off until a run shows it is needed; its absence is pinned in the unit test. The shared prompt is now just the decision hand-off.

## Scope / notes

- Five source files. `runAwaitRounds` / `AwaitRoundsOptions` are package-internal (not in `index.ts`), so no changeset.
- Loop mechanics untouched, so this decides on its own.
- Tests: updated the three `runAwaitRounds` call sites, added a `continuationPrompt` unit test asserting one wording, no caller-specific clause, and no "do not ask again" tail. Typecheck clean; turn-gate + run suites green.

Closes #570