### PR TITLE
docs(ai-sdk): record the contentToString separator decision (#573)

### DIFF
--- a/packages/ai-sdk/src/util/content.test.ts
+++ b/packages/ai-sdk/src/util/content.test.ts
@@ -14,11 +14,16 @@ describe('contentToString', () => {
     assert.equal(contentToString('already text'), 'already text')
   })
 
-  it('joins text parts with no separator by default, which is what the providers send', () => {
+  // The two separators are an intentional, settled difference (#573), not an oversight:
+  // the provider default reconstructs the wire message with nothing injected, while
+  // memory extraction separates parts so text does not jam across a dropped part.
+  it('joins text parts with no separator by default, reconstructing the wire message', () => {
     assert.equal(contentToString(mixed), 'Helloworld')
   })
 
-  it('takes a separator, which is what memory extraction needs (#572)', () => {
+  it('separates parts with a given separator, which is what memory extraction needs (#573)', () => {
+    // The image between the two text parts is dropped; the separator keeps the
+    // remaining text from jamming into `Helloworld` for the extractor.
     assert.equal(contentToString(mixed, '\n'), 'Hello\nworld')
   })
 

--- a/packages/ai-sdk/src/util/content.ts
+++ b/packages/ai-sdk/src/util/content.ts
@@ -5,10 +5,14 @@ import type { ContentPart } from '../types.js'
  * {@link ContentPart} list contributes its text parts in order. Image and document
  * parts have no text and are dropped.
  *
- * `separator` is explicit because the call sites genuinely disagree: the providers
- * join with `''` (the parts are contiguous chunks of one message) while memory
- * extraction joins with `'\n'`. Whether that difference is intended is #572; this
- * only makes it visible at the call site rather than hidden in a fourth copy.
+ * `separator` is explicit because the two call sites genuinely differ, and the
+ * difference is intentional (#573):
+ * - providers join with `''` (the default): they rebuild the wire message, so the
+ *   text is reconstructed as authored, with nothing injected between parts.
+ * - memory extraction joins with `'\n'`: it feeds the flattened text to an extractor,
+ *   and a separator keeps parts from jamming together where a non-text part (e.g. a
+ *   dropped image) sat between them, so `['Hello', 'world']` reads as two lines rather
+ *   than `Helloworld`.
  */
 export function contentToString(content: string | ContentPart[], separator = ''): string {
   if (typeof content === 'string') return content


### PR DESCRIPTION
Closes #573.

## The question

`contentToString` has one implementation with the join separator as a parameter (#572). Two callers pass different values, and #572 left open whether the difference was intended:

- the three providers join with `''`
- `memory-extract.ts` joins with `'\n'`

## The decision: intentional, keep both

- **Providers (`''`)** rebuild the wire message. The text is reconstructed as authored, with nothing injected between parts.
- **Memory extraction (`'\n'`)** feeds the flattened text to an extractor. A separator keeps parts from jamming together where a non-text part was dropped between them: with an image between two text parts, `['Hello', 'world']` should read as two lines, not `Helloworld`.

Unifying would make one caller worse: `''` everywhere jams the extractor input, and `'\n'` everywhere changes what every provider sends to the wire. So the separator stays a parameter and the two callers keep their values on purpose.

## Change

Doc comment records the decision (was "whether that difference is intended is #572"), and the two tests are renamed to assert the behaviors as intentional, referencing the dropped-image case. No runtime change; nothing to publish (no changeset). Full ai-sdk suite: 872 pass / 0 fail, typecheck clean.

> Judgment call, so flagging it: if you'd rather unify (accepting the extractor-jamming or wire-change tradeoff), say so and I'll switch it.