### PR TITLE
fix(framework): on-before-mergeable run stays on the session branch (#560)

### DIFF
--- a/.changeset/on-before-mergeable-no-branch.md
+++ b/.changeset/on-before-mergeable-no-branch.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+The on-before-mergeable follow-up no longer strands its output on a branch nothing merges. It was spawned as a plain `framework prompt` run, so it inherited the #326 system prompt's `### Session name` step and committed + created + checked out a fresh `the-framework/<name>` branch before writing anything. Its output (the queued quality TODO entries and the business-knowledge docs, `DECISIONS.md` / `KNOWLEDGE-BASE.md`) landed on that branch, which nothing merges, so the next run branched from main and could not see it. The follow-up is a follow-up to a session, not a session of its own, so it now runs `--vanilla` (no built-in prompt, hence no session-name step) and stays on the session's current branch, where its output rides to review and merge with the work.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -100,6 +100,15 @@ test('promptRunArgs runs a headless prompt and carries NO --on-before-mergeable 
   assert.equal(args.includes('--on-before-mergeable'), false)
   // maxCost is optional.
   assert.equal(promptRunArgs('x', '/w', '/bin/f').includes('--max-cost'), false)
+  // Not vanilla by default: a normal direct/quality run keeps the built-in #326 prompt.
+  assert.equal(args.includes('--vanilla'), false)
+})
+
+test('promptRunArgs adds --vanilla so the on-before-mergeable follow-up skips the session-name branch step (#560)', () => {
+  // The follow-up is not a session; --vanilla drops the #326 prompt (and its `### Session
+  // name` step), so the run stays on the session branch instead of stranding its output.
+  const args = promptRunArgs('queue follow-ups', '/work/app', '/bin/framework', 3, true)
+  assert.ok(args.includes('--vanilla'))
 })
 
 test('runOnBeforeMergeable queues the follow-ups in ONE run instead of running the presets (#326/#556)', async () => {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -1388,17 +1388,24 @@ function spawnMaintenanceRun(review: RepoReview, binPath: string, maxCost?: numb
  * note it carries **no** `--on-before-mergeable`, which is the on-before-mergeable recursion guard (a quality
  * pass must not trigger its own suite).
  */
-export function promptRunArgs(prompt: string, cwd: string, binPath: string, maxCost?: number): string[] {
+export function promptRunArgs(prompt: string, cwd: string, binPath: string, maxCost?: number, vanilla = false): string[] {
   const args = [binPath, 'prompt', prompt, '--no-dashboard', '--cwd', cwd]
   if (maxCost !== undefined) args.push('--max-cost', String(maxCost))
+  // The on-before-mergeable follow-up runs `--vanilla` so it skips the #326 prompt's
+  // `### Session name` step: it is a follow-up to a session, not a session of its own,
+  // so it must not commit + branch + checkout a new `the-framework/<name>` branch. That
+  // stranded its output (the #556 TODO entries and #537 knowledge docs) on a branch
+  // nothing merges (#560). Vanilla keeps it on the session's current branch, where its
+  // output rides to review and merge with the work. The follow-up prompt is self-contained.
+  if (vanilla) args.push('--vanilla')
   return args
 }
 
-function spawnPromptRun(prompt: string, cwd: string, binPath: string, maxCost?: number): Promise<boolean> {
+function spawnPromptRun(prompt: string, cwd: string, binPath: string, maxCost?: number, vanilla = false): Promise<boolean> {
   if (process.env.NODE_TEST_CONTEXT || /\.test\.[cm]?[jt]s$/.test(binPath)) {
     return Promise.resolve(false) // refuse to spawn from a test entry
   }
-  const args = promptRunArgs(prompt, cwd, binPath, maxCost)
+  const args = promptRunArgs(prompt, cwd, binPath, maxCost, vanilla)
   return new Promise<boolean>(resolvePromise => {
     const child = spawn(process.execPath, args, { stdio: 'inherit' })
     child.once('error', () => resolvePromise(false))
@@ -1426,7 +1433,8 @@ export async function runOnBeforeMergeable(
   tf: OnBeforeMergeableContext,
   maxCost?: number,
   eco?: EcoOptions,
-  run: PromptRunner = spawnPromptRun,
+  // Vanilla by default: the follow-up must not run the session-name step and branch (#560).
+  run: PromptRunner = (prompt, cwd, binPath, maxCost) => spawnPromptRun(prompt, cwd, binPath, maxCost, true),
   fs: StoreFs = nodeStoreFs(),
 ): Promise<void> {
   // Ensure the presets exist so the queued entries' filePaths resolve, even in a repo


### PR DESCRIPTION
Closes #560. Draft: the fix is a judgment call in a design area, flagging before it leaves draft.

## The bug

The on-before-mergeable follow-up (fired after `setReadyForMerge()`) strands its output on a branch nothing merges:

```
* the-framework/surge-pricing-followup
  22be1cf  Record surge pricing decision and business knowledge   <- DECISIONS.md + KNOWLEDGE-BASE.md
  main: has neither file
```

So the #556 quality TODO entries and the #537 knowledge docs live only on a stranded branch. The next run branches from `main` and cannot read them, which defeats #537.

## Why

The follow-up is spawned as a plain `framework prompt` child, so it gets the full #326 system prompt including the `### Session name` step (commit dirty tree -> create `the-framework/<name>` -> checkout). It branches before writing anything, and writes its output on the new branch. That step is right for a session; the follow-up is a follow-up to one, not a session itself.

## Fix

Spawn the follow-up `--vanilla`, which drops the built-in #326 prompt and with it the session-name step, so it stays on the session's current branch where its output rides to review and merge with the work. The follow-up prompt is self-contained (it names the TODO file and knowledge docs itself) and the always-on emit protocols remain.

Scoped to the on-before-mergeable spawn only. The maintainability/security preset spawns share `spawnPromptRun` but are left branching: each is a separate focused refactor that arguably wants its own branch/PR.

## Alternatives / decision

- **MVP (this PR):** `--vanilla`. One flag, drops the whole built-in prompt.
- **Targeted:** drop only the `## Before starting changes` section, keeping the rest of the built-in prompt. More precise, a little more plumbing. Happy to switch if you prefer keeping the rest of the #326 framing for the follow-up.

One thing to confirm: the intended landing spot is the session's current branch (so output merges with the work). Both #556 and #537 read that way; the eager-vs-after-merge setting is orthogonal (lands correctly either way on the session branch).

## Tests

`promptRunArgs` gains a `vanilla` param; new test locks that the follow-up path carries `--vanilla` and a normal run does not. Framework suite: 542 pass / 0 fail, typecheck clean. Changeset: `@gemstack/framework` patch.