### PR TITLE
refactor(framework): drop the orphaned system-prompt-file doc comment

### DIFF
--- a/packages/framework/src/system-prompt.ts
+++ b/packages/framework/src/system-prompt.ts
@@ -159,11 +159,6 @@ export function renderSystemPrompt(tf: TfContext = DEFAULT_TF): RenderedSystemPr
   }
 }
 
-/**
- * The canonical user system-prompt file at the workspace root. Its contents are
- * injected into every prompt, so a project's own instructions travel with the
- * code (Rom's repo-as-database model, like the memory files in {@link ./memory}).
- */
 /** Inputs to {@link systemPromptBlock}. */
 export interface SystemPromptOptions {
   /**


### PR DESCRIPTION
Closes #611

A JSDoc block in `system-prompt.ts` describes "the canonical user system-prompt file at the workspace root" but sits above `interface SystemPromptOptions`, which has its own doc. The file it documents (`SYSTEM_PROMPT_FILE` / `loadUserSystemPrompt`) lives in `system-prompt-file.ts`; this comment was left behind and documents nothing here.

Remove it. No behavior change; typecheck and the system-prompt tests stay green.