### PR TITLE
refactor(framework): quality pass over the big/complex files

### DIFF
--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -309,6 +309,14 @@ export function parseArgs(argv: string[]): CliOptions {
   }
   const PERMISSION_MODES: PermissionMode[] = ['default', 'acceptEdits', 'bypassPermissions', 'plan']
   const words: string[] = []
+  // Parse an integer flag's value, recording opts.error (naming the flag) on a bad one. The
+  // integer flags all share this shape; only the lower bound (0 for --port, else 1) varies.
+  const intFlag = (value: string | undefined, label: string, min: number): number | undefined => {
+    const n = Number(value)
+    if (Number.isInteger(n) && n >= min) return n
+    opts.error = `invalid ${label}: must be a ${min > 0 ? 'positive' : 'non-negative'} integer`
+    return undefined
+  }
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!
     switch (arg) {
@@ -426,9 +434,8 @@ export function parseArgs(argv: string[]): CliOptions {
         opts.servePath = argv[++i]
         break
       case '--serve-port': {
-        const n = Number(argv[++i])
-        if (!Number.isInteger(n) || n < 1) opts.error = `invalid --serve-port: must be a positive integer`
-        else opts.servePort = n
+        const n = intFlag(argv[++i], '--serve-port', 1)
+        if (n !== undefined) opts.servePort = n
         break
       }
       case '--sandbox': {
@@ -450,9 +457,8 @@ export function parseArgs(argv: string[]): CliOptions {
         break
       }
       case '--max-passes': {
-        const n = Number(argv[++i])
-        if (!Number.isInteger(n) || n < 1) opts.error = `invalid --max-passes: must be a positive integer`
-        else opts.maxPasses = n
+        const n = intFlag(argv[++i], '--max-passes', 1)
+        if (n !== undefined) opts.maxPasses = n
         break
       }
       case '--max-cost': {
@@ -468,21 +474,18 @@ export function parseArgs(argv: string[]): CliOptions {
         opts.dryRun = true
         break
       case '--max-repos': {
-        const n = Number(argv[++i])
-        if (!Number.isInteger(n) || n < 1) opts.error = `invalid --max-repos: must be a positive integer`
-        else opts.maxRepos = n
+        const n = intFlag(argv[++i], '--max-repos', 1)
+        if (n !== undefined) opts.maxRepos = n
         break
       }
       case '--max-todo-items': {
-        const n = Number(argv[++i])
-        if (!Number.isInteger(n) || n < 1) opts.error = `invalid --max-todo-items: must be a positive integer`
-        else opts.todoMaxItems = n
+        const n = intFlag(argv[++i], '--max-todo-items', 1)
+        if (n !== undefined) opts.todoMaxItems = n
         break
       }
       case '--port': {
-        const n = Number(argv[++i])
-        if (!Number.isInteger(n) || n < 0) opts.error = `invalid --port: must be a non-negative integer`
-        else opts.port = n
+        const n = intFlag(argv[++i], '--port', 0)
+        if (n !== undefined) opts.port = n
         break
       }
       default:

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -1225,12 +1225,6 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
 }
 
 /**
- * `framework relay`: host the run relay (#230). Teammates open a run's URL
- * (printed when a run uses `--share <this-url>`) and watch it live with full
- * history replay. Runs until interrupted. Unauthenticated by design — anyone with
- * a run URL can watch; accounts/teams/steering come later.
- */
-/**
  * Bare `framework` (no prompt): run the dashboard server in the foreground (#456), so its
  * logs and any server-thrown errors are visible and Ctrl+C stops it. If a background daemon
  * (`framework --daemon`) already owns the port, defer to it rather than fight for the bind.
@@ -1377,13 +1371,6 @@ function spawnMaintenanceRun(review: RepoReview, binPath: string, maxCost?: numb
 }
 
 /**
- * Run one direct prompt by spawning `framework prompt "<prompt>" --cwd <dir> --no-dashboard`,
- * reusing the whole run path (preflight, driver, budget cap, LOGS.md). The child inherits
- * stdio so its run streams to the terminal. Note it carries no `--on-before-mergeable`, so a quality
- * pass never triggers its own on-before-mergeable prompt (the recursion guard). Resolves true on a
- * clean exit (0). Never re-execs a test entry (fork-bomb guard).
- */
-/**
  * The argv a spawned `framework prompt` child runs with. Pure so a test can assert it:
  * note it carries **no** `--on-before-mergeable`, which is the on-before-mergeable recursion guard (a quality
  * pass must not trigger its own suite).
@@ -1401,6 +1388,13 @@ export function promptRunArgs(prompt: string, cwd: string, binPath: string, maxC
   return args
 }
 
+/**
+ * Run one direct prompt by spawning `framework prompt "<prompt>" --cwd <dir> --no-dashboard`,
+ * reusing the whole run path (preflight, driver, budget cap, LOGS.md). The child inherits
+ * stdio so its run streams to the terminal. Note it carries no `--on-before-mergeable`, so a quality
+ * pass never triggers its own on-before-mergeable prompt (the recursion guard). Resolves true on a
+ * clean exit (0). Never re-execs a test entry (fork-bomb guard).
+ */
 function spawnPromptRun(prompt: string, cwd: string, binPath: string, maxCost?: number, vanilla = false): Promise<boolean> {
   if (process.env.NODE_TEST_CONTEXT || /\.test\.[cm]?[jt]s$/.test(binPath)) {
     return Promise.resolve(false) // refuse to spawn from a test entry
@@ -1450,6 +1444,12 @@ export async function runOnBeforeMergeable(
   if (!ok) io.out(`  ! on-before-mergeable queueing did not complete cleanly.`)
 }
 
+/**
+ * `framework relay`: host the run relay (#230). Teammates open a run's URL
+ * (printed when a run uses `--share <this-url>`) and watch it live with full
+ * history replay. Runs until interrupted. Unauthenticated by design — anyone with
+ * a run URL can watch; accounts/teams/steering come later.
+ */
 async function runRelayServer(opts: CliOptions, io: CliIO): Promise<number> {
   const relay = await startRelay(opts.port !== undefined ? { port: opts.port } : {})
   io.out(`◆ relay listening at ${relay.url}`)

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -913,6 +913,18 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     io.out(`◆ shared run: ${publisher.url}`)
   }
 
+  // Pause the choice gates when someone can answer: this run's own dashboard, or the
+  // workspace daemon's via the control channel (#344). With neither, the gates auto-accept
+  // the recommended option (#304). The run's requestChoice parks a resolver in pendingChoices
+  // keyed by the choice id; a dashboard/daemon pick (or an abort) resolves it.
+  const requestChoice =
+    dashboard || control
+      ? (req: ChoiceRequest): Promise<ChoicePick> => new Promise(resolve => pendingChoices.set(req.id, resolve))
+      : undefined
+  // The session link shown on the dashboard: --session-link, else Claude Code's own entry for
+  // a live Claude run, else nothing (#212/#542). Same for both run paths.
+  const sessionLink = chooseSessionLink(opts, fake)
+
   // The framework's own verdict that the run stopped cleanly rather than failed —
   // set by a user interrupt or a budget cap (#322). Trusted over which signal
   // aborted, since a budget stop trips an internal signal the CLI never sees.
@@ -1032,12 +1044,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
         cwd,
         onEvent,
         signal: controller.signal,
-        ...(dashboard || control
-          ? {
-              requestChoice: (req: ChoiceRequest) =>
-                new Promise<ChoicePick>(resolve => pendingChoices.set(req.id, resolve)),
-            }
-          : {}),
+        ...(requestChoice ? { requestChoice } : {}),
         ...(opts.model ? { model: opts.model } : {}),
         ...(opts.maxCost ? { budgetUsd: opts.maxCost } : {}),
         ...(guard ? { consumptionGate: guard.gate } : {}),
@@ -1046,10 +1053,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
         ...(eco ? { eco } : {}),
         ...(opts.context.length ? { context: opts.context } : {}),
         ...(modeList.includes('autopilot') ? { autopilot: true } : {}),
-        ...((): { sessionLink?: string } => {
-          const link = chooseSessionLink(opts, fake)
-          return link ? { sessionLink: link } : {}
-        })(),
+        ...(sessionLink ? { sessionLink } : {}),
       })
       clearInterrupt()
       io.out(
@@ -1133,15 +1137,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     onEvent,
     signals,
     signal: controller.signal,
-    // Pause the choice gates when someone can answer: this run's own dashboard, or
-    // the workspace daemon's via the control channel (#344). With neither, the gates
-    // auto-accept the recommended option as before (#304).
-    ...(dashboard || control
-      ? {
-          requestChoice: (req: ChoiceRequest) =>
-            new Promise<ChoicePick>(resolve => pendingChoices.set(req.id, resolve)),
-        }
-      : {}),
+    ...(requestChoice ? { requestChoice } : {}),
     ...(opts.model ? { model: opts.model } : {}),
     ...(opts.maxPasses ? { maxPasses: opts.maxPasses } : {}),
     ...(opts.maxCost ? { budgetUsd: opts.maxCost } : {}),
@@ -1161,10 +1157,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     ...(noBuiltinPrompt ? { antiLazyPill: false } : {}),
     ...(eco ? { eco } : {}),
     ...(opts.context.length ? { context: opts.context } : {}),
-    ...((): { sessionLink?: string } => {
-      const link = chooseSessionLink(opts, fake)
-      return link ? { sessionLink: link } : {}
-    })(),
+    ...(sessionLink ? { sessionLink } : {}),
   }
 
   try {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -1059,22 +1059,14 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
       )
       await store?.close()
       await maybeFireOnBeforeMergeable()
-      if (dashboard) {
-        io.out(`\nDashboard still live at ${dashboard.url}. Press Ctrl+C to exit.`)
-        await waitForInterrupt()
-        await dashboard.close()
-      }
+      if (dashboard) await keepDashboardUp(dashboard, io)
       return 0
     } catch (err) {
       clearInterrupt()
       await store?.close()
       if (controller.signal.aborted || stoppedCleanly) {
         io.out('\n■ Stopped.')
-        if (dashboard) {
-          io.out(`\nDashboard still live at ${dashboard.url}. Press Ctrl+C to exit.`)
-          await waitForInterrupt()
-          await dashboard.close()
-        }
+        if (dashboard) await keepDashboardUp(dashboard, io)
         return 0
       }
       io.err(`\n✗ ${kindLabel} failed: ${err instanceof Error ? err.message : String(err)}`)
@@ -1205,11 +1197,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     // visible, and exit 0.
     if (controller.signal.aborted || stoppedCleanly) {
       io.out('\n■ Stopped.')
-      if (dashboard) {
-        io.out(`\nDashboard still live at ${dashboard.url}. Press Ctrl+C to exit.`)
-        await waitForInterrupt()
-        await dashboard.close()
-      }
+      if (dashboard) await keepDashboardUp(dashboard, io)
       return 0
     }
     io.err(`\n✗ run failed: ${err instanceof Error ? err.message : String(err)}`)
@@ -1541,6 +1529,13 @@ export function buildDeployTarget(
     return { target: dokployTarget({ serverUrl: opts.dokployUrl, applicationId: opts.dokployApp }) }
   }
   return {} // Unknown target: narrate the decision only.
+}
+
+/** The post-run wait: keep the dashboard up until Ctrl+C, then close it. */
+async function keepDashboardUp(dashboard: Dashboard, io: CliIO): Promise<void> {
+  io.out(`\nDashboard still live at ${dashboard.url}. Press Ctrl+C to exit.`)
+  await waitForInterrupt()
+  await dashboard.close()
 }
 
 /** Resolve when the process is interrupted (Ctrl+C), so the dashboard stays up. */

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -36,10 +36,10 @@ import { appendLog, type LogEntry } from './logs.js'
 import { preflight } from './preflight.js'
 import { RunStore, nodeStoreFs, type StoreFs } from './store/index.js'
 import { materializePresets } from './presets.js'
-import { daemonStatus, ensureDaemon, runDaemon, stopDaemon, DEFAULT_DAEMON_PORT } from './daemon.js'
+import { daemonStatus, ensureDaemon, registerHomeProject, runDaemon, stopDaemon, DEFAULT_DAEMON_PORT } from './daemon.js'
 import { resetControl, watchControl, type ControlWatcher } from './control.js'
-import { isActivated, nodeGitRunner } from './project.js'
-import { addProject, listProjects, readPreferences, resolveConsumptionLimits } from './registry.js'
+import { nodeGitRunner } from './project.js'
+import { listProjects, readPreferences, resolveConsumptionLimits } from './registry.js'
 import { startConsumptionGuard } from './consumption-guard.js'
 import {
   planMaintenanceSweep,
@@ -1273,13 +1273,10 @@ async function ensureDaemonCmd(opts: CliOptions, io: CliIO): Promise<number> {
     io.err(`could not start the dashboard daemon (${err instanceof Error ? err.message : String(err)}).`)
     return 1
   }
-  // One daemon per machine (#393): when it is already running, `framework` in a new
-  // repo would not otherwise register that repo (only the daemon's own cwd is added
-  // on startup). Register it here too, best-effort, so it shows up in the Projects
-  // list either way. Idempotent (addProject dedupes by path).
-  if (await isActivated(cwd).catch(() => false)) {
-    await addProject(cwd, new Date().toISOString()).catch(() => {})
-  }
+  // One daemon per machine (#393): when it is already running, `framework` in a new repo
+  // would not otherwise register that repo (only the daemon's own cwd is added on startup).
+  // Register it here too, best-effort, so it shows up in the Projects list either way.
+  await registerHomeProject(cwd)
 
   const { state, alreadyRunning } = result
   io.out(`◆ dashboard ${alreadyRunning ? 'already running' : 'started'}: ${state.url}`)

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -21,6 +21,7 @@ import { randomUUID } from 'node:crypto'
 import { formatFrameworkEvent, CLAUDE_CODE_SESSION_LINK, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 import {
   runFramework,
+  type AppPreview,
   type DeployDecision,
   type RunFrameworkOptions,
   type RunFrameworkResult,
@@ -678,6 +679,74 @@ export async function resolveDomainPreset(
   return { preset }
 }
 
+/** The run-scoped state {@link settleRun} needs to close out either run path. */
+interface RunEpilogue {
+  io: CliIO
+  dashboard: Dashboard | undefined
+  store: RunStore | undefined
+  control: ControlWatcher | undefined
+  guard: { stop: () => void } | undefined
+  publisher: RelayPublisher | undefined
+  clearInterrupt: () => void
+  maybeFireOnBeforeMergeable: () => Promise<void>
+  /** True once the run stopped cleanly (interrupt / budget cap) rather than failed. */
+  isStopped: () => boolean
+  /** How a real failure is labelled: "run", "research", or "prompt run". */
+  failLabel: string
+}
+
+/**
+ * Run one engine (a build or a direct prompt) and settle it identically: on success print its
+ * line and keep the dashboard (and any app preview) up until Ctrl+C; on a clean stop (interrupt
+ * / budget cap #322) report it and stay up; on a real failure report it and close. The teardown
+ * — flush the store, close the control channel + consumption guard, flush the relay — runs
+ * either way. Returns the exit code (0 on success or a clean stop, 1 on a failure). Shared by
+ * both run paths so their epilogues cannot drift.
+ */
+async function settleRun(
+  ctx: RunEpilogue,
+  run: () => Promise<{ successLine: string; preview?: AppPreview }>,
+): Promise<number> {
+  const { io, dashboard } = ctx
+  try {
+    const { successLine, preview } = await run()
+    // Run settled: hand Ctrl+C back to the post-run dashboard/app wait below.
+    ctx.clearInterrupt()
+    io.out(successLine)
+    if (preview) io.out(`\n▶ Your app is running at ${preview.url} — open it in a browser.`)
+    await ctx.store?.close() // flush the event log; best-effort
+    await ctx.maybeFireOnBeforeMergeable()
+    // Stay up while the dashboard and/or the app are live, then tear both down.
+    if (dashboard || preview) {
+      if (dashboard) io.out(`\nDashboard still live at ${dashboard.url}. Press Ctrl+C to exit.`)
+      else io.out(`\nPress Ctrl+C to stop the app.`)
+      await waitForInterrupt()
+      if (preview) await preview.stop()
+      await dashboard?.close()
+    }
+    return 0
+  } catch (err) {
+    ctx.clearInterrupt()
+    await ctx.store?.close()
+    // A clean stop (Stop button, Ctrl+C, or a budget cap #322) is not a failure: report it,
+    // keep the dashboard up so the stopped state stays visible, and exit 0.
+    if (ctx.isStopped()) {
+      io.out('\n■ Stopped.')
+      if (dashboard) await keepDashboardUp(dashboard, io)
+      return 0
+    }
+    io.err(`\n✗ ${ctx.failLabel} failed: ${err instanceof Error ? err.message : String(err)}`)
+    await dashboard?.close()
+    return 1
+  } finally {
+    ctx.clearInterrupt()
+    ctx.control?.close()
+    ctx.guard?.stop()
+    // Make sure every event (including the final `end`) reached the relay before exit.
+    if (ctx.publisher) await ctx.publisher.flush()
+  }
+}
+
 /**
  * Start this run's single-project dashboard on `cwd` (#427), or return undefined to run
  * headless. `enabled` gates it (a --no-persist run has no event log to stream); a missing
@@ -1062,6 +1131,21 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // flags trim the built-in one (#314). Resolve and echo once, shared by both run paths.
   const promptConfig = await resolvePromptConfig(opts, fileConfig, cwd, io)
 
+  // The run-scoped state both run paths hand to settleRun to close out. stoppedCleanly is a
+  // getter because the onEvent sink sets it as the `end` event arrives.
+  const epilogue = (failLabel: string): RunEpilogue => ({
+    io,
+    dashboard,
+    store,
+    control,
+    guard,
+    publisher,
+    clearInterrupt,
+    maybeFireOnBeforeMergeable,
+    isStopped: () => controller.signal.aborted || stoppedCleanly,
+    failLabel,
+  })
+
   // `framework research [what]` (#331) and `framework prompt <text>` (#353): the
   // direct prompt path — run one prompt through runPrompt, which honors its gates
   // (#337/#339) but skips the scope -> build scaffolding entirely.
@@ -1069,9 +1153,8 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // verbatim (it may already BE an edited preset, so it must not be re-rendered).
   // Shares all the wiring above (dashboard, store, control channel, budget).
   if (opts.research || opts.directPrompt) {
-    const kindLabel = opts.directPrompt ? 'prompt run' : 'research'
     const { userSystemPrompt, noBuiltinPrompt, eco } = promptConfig
-    try {
+    return settleRun(epilogue(opts.directPrompt ? 'prompt run' : 'research'), async () => {
       await runPrompt({
         prompt: opts.directPrompt ? intent : renderResearchPrompt(intent),
         driver,
@@ -1089,33 +1172,12 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
         ...(modeList.includes('autopilot') ? { autopilot: true } : {}),
         ...(sessionLink ? { sessionLink } : {}),
       })
-      clearInterrupt()
-      io.out(
-        opts.directPrompt
+      return {
+        successLine: opts.directPrompt
           ? '\n✓ prompt run done.'
           : '\n✓ research done: see the REVIEW-PROBLEMS / TODO files it wrote.',
-      )
-      await store?.close()
-      await maybeFireOnBeforeMergeable()
-      if (dashboard) await keepDashboardUp(dashboard, io)
-      return 0
-    } catch (err) {
-      clearInterrupt()
-      await store?.close()
-      if (controller.signal.aborted || stoppedCleanly) {
-        io.out('\n■ Stopped.')
-        if (dashboard) await keepDashboardUp(dashboard, io)
-        return 0
       }
-      io.err(`\n✗ ${kindLabel} failed: ${err instanceof Error ? err.message : String(err)}`)
-      await dashboard?.close()
-      return 1
-    } finally {
-      clearInterrupt()
-      control?.close()
-      guard?.stop()
-      if (publisher) await publisher.flush()
-    }
+    })
   }
 
   // The fake demo defaults to a Cloudflare deploy decision so the flow ends with
@@ -1186,49 +1248,13 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     ...(sessionLink ? { sessionLink } : {}),
   }
 
-  try {
+  return settleRun(epilogue('run'), async () => {
     const { result, preview } = await runFramework(runOpts)
-    // Run settled: hand Ctrl+C back to the post-run dashboard/app wait below.
-    clearInterrupt()
-    io.out(
-      result.productionGrade
-        ? `\n✓ production-grade in ${result.passes} pass(es).`
-        : `\n• prototype ready${result.stoppedEarly ? ` (stopped with ${result.blockers.length} blocker(s))` : ''}.`,
-    )
-    if (preview) io.out(`\n▶ Your app is running at ${preview.url} — open it in a browser.`)
-    // Flush the event log. Best-effort.
-    await store?.close()
-    await maybeFireOnBeforeMergeable()
-    // Stay up while the dashboard and/or the app are live, then tear both down.
-    if (dashboard || preview) {
-      if (dashboard) io.out(`\nDashboard still live at ${dashboard.url}. Press Ctrl+C to exit.`)
-      else io.out(`\nPress Ctrl+C to stop the app.`)
-      await waitForInterrupt()
-      if (preview) await preview.stop()
-      await dashboard?.close()
-    }
-    return 0
-  } catch (err) {
-    clearInterrupt()
-    await store?.close()
-    // A clean stop (dashboard Stop button, Ctrl+C, or a budget cap #322) is not a
-    // failure: report it cleanly, keep the dashboard up so the stopped state is
-    // visible, and exit 0.
-    if (controller.signal.aborted || stoppedCleanly) {
-      io.out('\n■ Stopped.')
-      if (dashboard) await keepDashboardUp(dashboard, io)
-      return 0
-    }
-    io.err(`\n✗ run failed: ${err instanceof Error ? err.message : String(err)}`)
-    await dashboard?.close()
-    return 1
-  } finally {
-    clearInterrupt()
-    control?.close()
-    guard?.stop()
-    // Make sure every event (including the final `end`) reached the relay before exit.
-    if (publisher) await publisher.flush()
-  }
+    const successLine = result.productionGrade
+      ? `\n✓ production-grade in ${result.passes} pass(es).`
+      : `\n• prototype ready${result.stoppedEarly ? ` (stopped with ${result.blockers.length} blocker(s))` : ''}.`
+    return { successLine, ...(preview ? { preview } : {}) }
+  })
 }
 
 /**

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -679,6 +679,27 @@ export async function resolveDomainPreset(
 }
 
 /**
+ * Resolve the system-prompt configuration both run paths share (#301/#314), echoing what
+ * is in effect: a user SYSTEM.md, the built-in prompt toggle, the eco section drops, and the
+ * in-context dirs. Reads SYSTEM.md once, so call it on the shared path before either run.
+ */
+async function resolvePromptConfig(
+  opts: CliOptions,
+  fileConfig: FrameworkFileConfig,
+  cwd: string,
+  io: CliIO,
+): Promise<{ userSystemPrompt?: string; noBuiltinPrompt: boolean; eco?: EcoOptions }> {
+  const userSystemPrompt = await loadUserSystemPrompt(cwd)
+  const noBuiltinPrompt = antiLazyPillOff(opts, fileConfig)
+  const eco = ecoOptions(opts)
+  if (userSystemPrompt) io.out(`◆ system prompt: ${SYSTEM_PROMPT_FILE}`)
+  if (noBuiltinPrompt) io.out(`◆ built-in system prompt: off (${opts.vanilla ? 'vanilla' : 'the-framework.yml'})`)
+  else if (eco) io.out(`◆ eco: dropping ${Object.keys(eco).filter(k => eco[k as keyof EcoOptions]).join(', ')}`)
+  if (opts.context.length) io.out(`◆ context: ${opts.context.join(', ')}`)
+  return { ...(userSystemPrompt ? { userSystemPrompt } : {}), noBuiltinPrompt, ...(eco ? { eco } : {}) }
+}
+
+/**
  * The `framework` command. Wires the parsed options into {@link runFramework}
  * over a live dashboard + terminal narration, and resolves with an exit code.
  * Returns 0 on success, 1 on a run error, 2 on a usage error.
@@ -1022,6 +1043,10 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     io.out(`◆ consumption limits: off — ${AGENT_SPECS[opts.agent].label} reports no quota, so nothing gates your subscription spend.`)
   }
 
+  // A user SYSTEM.md + the anti-lazy-pill toggle shape the system prompt (#301), and the eco
+  // flags trim the built-in one (#314). Resolve and echo once, shared by both run paths.
+  const promptConfig = await resolvePromptConfig(opts, fileConfig, cwd, io)
+
   // `framework research [what]` (#331) and `framework prompt <text>` (#353): the
   // direct prompt path — run one prompt through runPrompt, which honors its gates
   // (#337/#339) but skips the scope -> build scaffolding entirely.
@@ -1030,13 +1055,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // Shares all the wiring above (dashboard, store, control channel, budget).
   if (opts.research || opts.directPrompt) {
     const kindLabel = opts.directPrompt ? 'prompt run' : 'research'
-    const userSystemPrompt = await loadUserSystemPrompt(cwd)
-    const noBuiltinPrompt = antiLazyPillOff(opts, fileConfig)
-    const eco = ecoOptions(opts)
-    if (userSystemPrompt) io.out(`◆ system prompt: ${SYSTEM_PROMPT_FILE}`)
-    if (noBuiltinPrompt) io.out(`◆ built-in system prompt: off (${opts.vanilla ? 'vanilla' : 'the-framework.yml'})`)
-    else if (eco) io.out(`◆ eco: dropping ${Object.keys(eco).filter(k => eco[k as keyof EcoOptions]).join(', ')}`)
-    if (opts.context.length) io.out(`◆ context: ${opts.context.join(', ')}`)
+    const { userSystemPrompt, noBuiltinPrompt, eco } = promptConfig
     try {
       await runPrompt({
         prompt: opts.directPrompt ? intent : renderResearchPrompt(intent),
@@ -1119,15 +1138,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
       }
     : undefined
 
-  // A user SYSTEM.md and the-framework.yml's anti-lazy-pill toggle shape the system
-  // prompt injected into every prompt (#301). The built-in pill is on unless removed.
-  const userSystemPrompt = await loadUserSystemPrompt(cwd)
-  const noBuiltinPrompt = antiLazyPillOff(opts, fileConfig)
-  const eco = ecoOptions(opts)
-  if (userSystemPrompt) io.out(`◆ system prompt: ${SYSTEM_PROMPT_FILE}`)
-  if (noBuiltinPrompt) io.out(`◆ built-in system prompt: off (${opts.vanilla ? 'vanilla' : 'the-framework.yml'})`)
-  else if (eco) io.out(`◆ eco: dropping ${Object.keys(eco).filter(k => eco[k as keyof EcoOptions]).join(', ')}`)
-  if (opts.context.length) io.out(`◆ context: ${opts.context.join(', ')}`)
+  const { userSystemPrompt, noBuiltinPrompt, eco } = promptConfig
 
   const runOpts: RunFrameworkOptions = {
     intent,

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -679,6 +679,36 @@ export async function resolveDomainPreset(
 }
 
 /**
+ * Start this run's single-project dashboard on `cwd` (#427), or return undefined to run
+ * headless. `enabled` gates it (a --no-persist run has no event log to stream); a missing
+ * bundle (an old install) or a startup error also fall back to headless. `resumed` tags the
+ * URL line, and `headlessNote` is the fallback message's tail.
+ */
+async function startRunDashboard(
+  enabled: boolean,
+  cwd: string,
+  port: number | undefined,
+  io: CliIO,
+  labels: { resumed?: boolean; headlessNote: string },
+): Promise<Dashboard | undefined> {
+  if (!enabled) return undefined
+  const clientBundleDir = await resolveDashboardBundle()
+  if (!clientBundleDir) return undefined
+  try {
+    const dashboard = await startDashboard({
+      ...(port !== undefined ? { port } : {}),
+      clientBundleDir,
+      projects: singleProjectProvider(cwd),
+    })
+    io.out(`◆ dashboard${labels.resumed ? ' (resumed)' : ''}: ${dashboard.url}`)
+    return dashboard
+  } catch (err) {
+    io.err(`could not start dashboard (${err instanceof Error ? err.message : String(err)}); ${labels.headlessNote}`)
+    return undefined
+  }
+}
+
+/**
  * Resolve the system-prompt configuration both run paths share (#301/#314), echoing what
  * is in effect: a user SYSTEM.md, the built-in prompt toggle, the eco section drops, and the
  * in-context dirs. Reads SYSTEM.md once, so call it on the shared path before either run.
@@ -858,28 +888,13 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     for (const resolve of pendingChoices.values()) resolve({ picked: 'proceed', by: 'auto' })
     pendingChoices.clear()
   })
-  // Serve the new Vike + Telefunc dashboard (#405/#427) for this run, in single-project
-  // mode: the SPA reads this one `cwd` (its own `.the-framework/events.jsonl` +
-  // control.jsonl) without touching the global registry, so a one-shot run never pollutes
-  // the Projects list. It streams the persisted event log, so a --no-persist run (or an
-  // old install missing the built bundle) runs headless.
-  let dashboard: Dashboard | undefined
-  let clientBundleDir: string | undefined
-  if (opts.dashboard && opts.persist) clientBundleDir = await resolveDashboardBundle()
-  if (clientBundleDir) {
-    try {
-      dashboard = await startDashboard({
-        ...(opts.port !== undefined ? { port: opts.port } : {}),
-        clientBundleDir,
-        projects: singleProjectProvider(cwd),
-      })
-      io.out(`◆ dashboard: ${dashboard.url}`)
-    } catch (err) {
-      dashboard = undefined
-      clientBundleDir = undefined
-      io.err(`could not start dashboard (${err instanceof Error ? err.message : String(err)}); continuing headless`)
-    }
-  }
+  // Serve the new Vike + Telefunc dashboard (#405/#427) for this run, in single-project mode:
+  // the SPA reads this one `cwd`'s event/control logs without touching the global registry, so
+  // a one-shot run never pollutes the Projects list. It streams the persisted event log, so a
+  // --no-persist run (or an old install missing the built bundle) runs headless.
+  const dashboard = await startRunDashboard(opts.dashboard && opts.persist, cwd, opts.port, io, {
+    headlessNote: 'continuing headless',
+  })
   // The new dashboard steers this live run purely through control.jsonl (its Stop / choice
   // picks are Telefunc writes to that file, #427), which the watcher below tails whenever
   // the dashboard is up — not only when a daemon is.
@@ -1477,22 +1492,10 @@ async function resumeRun(opts: CliOptions, io: CliIO): Promise<number> {
   // `.the-framework/events.jsonl` is exactly what the SPA's event Channel tails, so the
   // past run replays with no extra wiring (it is finished, so there is nothing to steer).
   // A missing bundle (an old install) replays to the terminal only.
-  let dashboard: Dashboard | undefined
-  if (opts.dashboard) {
-    const clientBundleDir = await resolveDashboardBundle()
-    if (clientBundleDir) {
-      try {
-        dashboard = await startDashboard({
-          ...(opts.port !== undefined ? { port: opts.port } : {}),
-          clientBundleDir,
-          projects: singleProjectProvider(cwd),
-        })
-        io.out(`◆ dashboard (resumed): ${dashboard.url}`)
-      } catch (err) {
-        io.err(`could not start dashboard (${err instanceof Error ? err.message : String(err)}); replaying to terminal only`)
-      }
-    }
-  }
+  const dashboard = await startRunDashboard(opts.dashboard, cwd, opts.port, io, {
+    resumed: true,
+    headlessNote: 'replaying to terminal only',
+  })
 
   for (const event of events) {
     io.out(formatFrameworkEvent(event))

--- a/packages/framework/src/consumption.ts
+++ b/packages/framework/src/consumption.ts
@@ -173,6 +173,39 @@ export const DEFAULT_CONSUMPTION_LIMITS: ConsumptionLimits = {
   session: { enabled: true, percent: 40 },
 }
 
+const CONSUMPTION_LIMIT_KEYS = ['daily', 'fiveHour', 'session'] as const
+
+/**
+ * Read one limit out of a hand-edited or browser-supplied object.
+ *
+ * `undefined` for anything we can't trust, so the caller falls back to the
+ * default rather than to an unguarded account. The percentage is clamped rather
+ * than rejected: a plausible-but-out-of-range number is a slip, and honouring
+ * the nearest legal value beats silently reverting to something else entirely.
+ */
+function sanitizeConsumptionLimit(value: unknown): ConsumptionLimit | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+  const input = value as Record<string, unknown>
+  const percent = input['percent']
+  if (typeof input['enabled'] !== 'boolean') return undefined
+  if (typeof percent !== 'number' || !Number.isFinite(percent)) return undefined
+  return { enabled: input['enabled'], percent: Math.min(100, Math.max(0, percent)) }
+}
+
+/** Read the three limits, falling back per-limit so one bad entry can't unguard the rest. */
+export function sanitizeConsumptionLimits(value: unknown): ConsumptionLimits | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+  const input = value as Record<string, unknown>
+  const limits = {} as ConsumptionLimits
+  let any = false
+  for (const key of CONSUMPTION_LIMIT_KEYS) {
+    const limit = sanitizeConsumptionLimit(input[key])
+    if (limit) any = true
+    limits[key] = limit ?? DEFAULT_CONSUMPTION_LIMITS[key]
+  }
+  return any ? limits : undefined
+}
+
 /** What each limit works out to, in points of the weekly meter. */
 export interface ConsumptionBudgets {
   daily: number

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process'
+import { spawn, type ChildProcess } from 'node:child_process'
 import { mkdir, readFile, writeFile, rm, stat } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import type { FrameworkEvent } from './events.js'
@@ -52,6 +52,40 @@ export interface DaemonState {
 /** The `.the-framework/` directory for a workspace. */
 export function daemonDir(cwd: string): string {
   return join(cwd, FRAMEWORK_DIR)
+}
+
+/**
+ * Locate the CLI entry to re-invoke for a detached child, refusing to re-exec a test
+ * file. Under `node --test` (or a direct `node foo.test.js`) `process.argv[1]` is the test
+ * file, which re-runs the whole suite instead of the daemon/run body — and that suite calls
+ * back here, so each spawn spawns another: a fork bomb. A real run passes the compiled bin
+ * (or an explicit `binPath`), so the guard only ever trips in tests.
+ */
+function resolveSpawnBin(explicitBinPath: string | undefined): string {
+  const binPath = explicitBinPath ?? process.argv[1]
+  if (!binPath) throw new Error('cannot locate the framework CLI entry')
+  if (!explicitBinPath && (process.env.NODE_TEST_CONTEXT || /\.test\.[cm]?[jt]s$/.test(binPath))) {
+    throw new Error('refusing to spawn a framework process from a test entry; pass an explicit binPath')
+  }
+  return binPath
+}
+
+/** Spawn a detached, unref'd framework child (`node <binPath> <args...>`) that outlives us. */
+function spawnDetached(binPath: string, args: string[]): ChildProcess {
+  const child = spawn(process.execPath, [binPath, ...args], { detached: true, stdio: 'ignore' })
+  child.unref()
+  return child
+}
+
+/**
+ * Make sure an activated home workspace shows up in the Projects list (#392). Best-effort
+ * and idempotent (addProject dedupes by path), so it never blocks the daemon coming up.
+ * Called both by the foreground daemon and by `framework --daemon`'s launcher.
+ */
+export async function registerHomeProject(cwd: string, env: NodeJS.ProcessEnv = process.env): Promise<void> {
+  if (await isActivated(cwd).catch(() => false)) {
+    await addProject(cwd, new Date().toISOString(), undefined, env).catch(() => {})
+  }
 }
 
 /**
@@ -153,23 +187,7 @@ export async function ensureDaemon(cwd: string, opts: EnsureDaemonOptions = {}):
   if (existing) return { state: existing, alreadyRunning: true }
 
   const port = opts.port ?? DEFAULT_DAEMON_PORT
-  const binPath = opts.binPath ?? process.argv[1]
-  if (!binPath) throw new Error('cannot locate the framework CLI entry to spawn the daemon')
-
-  // Never re-exec a test file as the daemon. Under `node --test` (or a direct
-  // `node foo.test.js`), process.argv[1] is the test file, which re-runs the whole
-  // suite instead of the daemon body — and that suite calls back here, so each spawn
-  // spawns another: a fork bomb. A real run passes the compiled bin as argv[1] (or an
-  // explicit binPath), so this only ever trips in tests.
-  if (!opts.binPath && (process.env.NODE_TEST_CONTEXT || /\.test\.[cm]?[jt]s$/.test(binPath))) {
-    throw new Error('refusing to spawn the dashboard daemon from a test entry; pass an explicit binPath')
-  }
-
-  const child = spawn(process.execPath, [binPath, '--daemon-serve', '--cwd', cwd, '--port', String(port)], {
-    detached: true,
-    stdio: 'ignore',
-  })
-  child.unref()
+  spawnDetached(resolveSpawnBin(opts.binPath), ['--daemon-serve', '--cwd', cwd, '--port', String(port)])
 
   const state = await waitForDaemon(opts.env, opts.timeoutMs ?? 5000)
   if (!state) throw new Error('the daemon did not come up in time')
@@ -282,20 +300,84 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
   // command in a fresh workspace (before any run made the dir).
   await mkdir(daemonDir(cwd), { recursive: true })
 
-  // Multi-project (#392): when the daemon starts in an activated repo, make sure
-  // it shows up in the Projects list. Best-effort and idempotent (addProject
-  // dedupes by path), so it never blocks the daemon coming up.
-  if (await isActivated(cwd).catch(() => false)) {
-    await addProject(cwd, new Date().toISOString(), undefined, env).catch(() => {})
+  // Multi-project (#392): make sure an activated home repo shows up in the Projects list.
+  await registerHomeProject(cwd, env)
+
+  // Everything the dashboard drives per project — run spawning, project install, and app
+  // previews — lives in the runtime, so this body stays about the daemon's own lifecycle.
+  const runtime = createProjectRuntime({ cwd, env, ...(opts.binPath !== undefined ? { binPath: opts.binPath } : {}) })
+
+  // The daemon serves the prerendered Vike + Telefunc dashboard (#405/#426): the SPA reads
+  // each project's `.the-framework/events.jsonl` over a Telefunc Channel and steers over
+  // control.jsonl, so there is no in-process event stream to feed here. The runtime's RPCs
+  // reach the browser through the Telefunc request context. A missing bundle (a broken
+  // install) surfaces as a 503 from the server.
+  const clientBundleDir = await resolveDashboardBundle()
+  const dashboard: Dashboard = await startDashboard({
+    port,
+    onStart: runtime.onStart,
+    onAddProject: runtime.onAddProject,
+    onPreview: runtime.onPreview,
+    onStopPreview: runtime.onStopPreview,
+    onPreviewStatus: runtime.onPreviewStatus,
+    ...(clientBundleDir ? { clientBundleDir } : {}),
+  })
+
+  try {
+    const actualPort = Number(new URL(dashboard.url).port) || port
+    const state: DaemonState = { pid: process.pid, port: actualPort, url: dashboard.url, startedAt: new Date().toISOString() }
+    await mkdir(dirname(daemonStatePath(env)), { recursive: true })
+    await writeFile(daemonStatePath(env), JSON.stringify(state, null, 2))
+    opts.onListening?.(state)
+  } catch (err) {
+    // Startup failed after the port was bound. Tear the server down, or it keeps the
+    // event loop alive: a zombie daemon squatting the port with no state file, which
+    // also wedges every later `framework` start.
+    await dashboard.close()
+    throw err
   }
 
-  // Per-project run state (#393). The one global run became a map keyed by project
-  // id, so each project runs at most one run at a time independently. The daemon's
-  // own `cwd` is the home project; a run started without a project id targets it, and
-  // the browser passes the home project's id or omits it (both resolve to `homeId`).
+  await waitForShutdown(opts.signal)
+
+  await runtime.dispose() // stop live previews (#475) so their dev servers do not outlive us
+  await dashboard.close()
+  await rm(daemonStatePath(env), { force: true }).catch(() => {})
+}
+
+/** Inputs to {@link createProjectRuntime}. */
+interface ProjectRuntimeOptions {
+  /** The daemon's home workspace; a run/preview with no project id targets it. */
+  cwd: string
+  /** Env for the registry lookups (#393). */
+  env: NodeJS.ProcessEnv
+  /** The CLI entry to spawn runs with (#345); undefined uses `process.argv[1]`. */
+  binPath?: string | undefined
+}
+
+/** The per-project run + preview surface the dashboard drives, plus its teardown. */
+interface ProjectRuntime {
+  onStart: (prompt: string, kind: StartRunKind, options?: StartRunOptions, targetProjectId?: string) => Promise<StartRunResult>
+  onAddProject: (path: string, directory: boolean) => Promise<AddProjectResult>
+  onPreview: (targetProjectId?: string) => Promise<PreviewResult>
+  onStopPreview: (targetProjectId?: string) => Promise<void>
+  onPreviewStatus: (targetProjectId?: string) => PreviewStatus
+  /** Stop every live preview so their dev servers do not outlive the daemon (#475). */
+  dispose: () => Promise<void>
+}
+
+/**
+ * The daemon's per-project runtime (#393): the run and preview state keyed by project id,
+ * plus the RPCs the dashboard invokes over Telefunc. Each project runs at most one run and
+ * one preview at a time, independently. The home `cwd` is the default target — a request
+ * with no project id (or the home id) resolves to it without a registry lookup. Split out of
+ * {@link runDaemon} so the daemon body reads as lifecycle and this reads as business logic.
+ */
+function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): ProjectRuntime {
   const homeId = projectId(resolve(cwd))
   const activeRuns = new Map<string, number>()
   const starting = new Set<string>() // reserved keys mid-spawn, to close the async gap
+  const activePreviews = new Map<string, PreviewHandle>()
+
   // A project id resolves to its repo path via the registry; the home id (or none)
   // resolves to the daemon's own `cwd` without a lookup.
   const resolveProject = async (id: string | undefined): Promise<string | undefined> => {
@@ -304,13 +386,12 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     return records.find(record => record.id === id)?.path
   }
 
-  // Start-from-dashboard (#345): POST /api/start spawns `framework "<prompt>"
-  // --no-dashboard --cwd <project>` as a detached child — the same spawn pattern
-  // ensureDaemon uses for the daemon itself. The run streams into this page via the
-  // tailed event log, and its gates + Stop steer through the control channel (#344),
-  // which the run wires whenever a daemon is live. One run per project (#393): while
-  // that project's child is alive, Start for it is refused (the #322 runaway concern).
-  const startRun = async (
+  // Start-from-dashboard (#345): spawn `framework "<prompt>" --no-dashboard --cwd <project>`
+  // as a detached child — the same spawn ensureDaemon uses for the daemon itself. The run
+  // streams into the page via its tailed event log, and its gates + Stop steer through the
+  // control channel (#344). One run per project (#393): while that project's child is alive,
+  // Start for it is refused (the #322 runaway concern).
+  const onStart = async (
     prompt: string,
     kind: StartRunKind,
     options: StartRunOptions = {},
@@ -326,11 +407,11 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     try {
       const projectCwd = await resolveProject(targetProjectId)
       if (!projectCwd) return { ok: false, error: `unknown project: ${targetProjectId}` }
-      const binPath = opts.binPath ?? process.argv[1]
-      if (!binPath) return { ok: false, error: 'cannot locate the framework CLI entry to spawn a run' }
-      // Same fork-bomb guard as ensureDaemon: never re-exec a test file as a run.
-      if (!opts.binPath && (process.env.NODE_TEST_CONTEXT || /\.test\.[cm]?[jt]s$/.test(binPath))) {
-        return { ok: false, error: 'refusing to spawn a run from a test entry; pass an explicit binPath' }
+      let realBin: string
+      try {
+        realBin = resolveSpawnBin(binPath)
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) }
       }
       // [Research] (#331) runs the research subcommand; its empty prompt is fine
       // (the "what" defaults to `this PR` in the CLI). A `prompt` kind (#353) is a
@@ -341,11 +422,7 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
           : kind === 'prompt'
             ? ['prompt', prompt]
             : [prompt]
-      const child = spawn(process.execPath, [binPath, ...runArgs, ...startOptionFlags(options), '--no-dashboard', '--cwd', projectCwd], {
-        detached: true,
-        stdio: 'ignore',
-      })
-      child.unref()
+      const child = spawnDetached(realBin, [...runArgs, ...startOptionFlags(options), '--no-dashboard', '--cwd', projectCwd])
       // The run narrates itself through its own `.the-framework/events.jsonl`, which the
       // dashboard streams over a Telefunc Channel; the daemon just tracks liveness.
       child.once('error', () => activeRuns.delete(key))
@@ -357,11 +434,11 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     }
   }
 
-  // Add project(s) (#396): install a single repo, or every git repo directly under
-  // a directory, then register each so it appears in the Projects list. installProject
-  // is idempotent (an already-activated repo is a no-op success); a git failure on any
-  // target aborts and surfaces as an error the dialog shows.
-  const addProjects = async (path: string, directory: boolean): Promise<AddProjectResult> => {
+  // Add project(s) (#396): install a single repo, or every git repo directly under a
+  // directory, then register each so it appears in the Projects list. installProject is
+  // idempotent (an already-activated repo is a no-op success); a git failure on any target
+  // aborts and surfaces as an error the dialog shows.
+  const onAddProject = async (path: string, directory: boolean): Promise<AddProjectResult> => {
     // Resolve relative input against the daemon cwd, and check the directory really
     // exists first: without this a bad path reaches git as a missing cwd, which
     // surfaces as the confusing "spawn git ENOENT" rather than a path error.
@@ -382,22 +459,18 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     return { ok: true, added, alreadyActivated }
   }
 
-  // On-demand app preview (#475): one long-lived preview process per project, kept in the
-  // daemon so it outlives the request that opened it and the Stop that closes it. Opening is
-  // idempotent (a live preview is returned as-is); the browser polls `previewStatus` on load
-  // to rehydrate the button after a reload.
-  const activePreviews = new Map<string, PreviewHandle>()
-  // Track a preview under its key and evict it the moment it stops serving (stop, or a
-  // self-exit: crash / build error / the user killing it). Without this a dead preview
-  // lingers, so `previewStatus` reports a dead URL and the idempotent open below hands it
-  // back instead of restarting (#475).
+  // On-demand app preview (#475): one long-lived preview process per project, kept here so it
+  // outlives the request that opened it and the Stop that closes it. Track a preview under its
+  // key and evict it the moment it stops serving (stop, or a self-exit: crash / build error /
+  // the user killing it), so previewStatus never reports a dead URL and the idempotent open
+  // below never hands back a corpse instead of restarting.
   const trackPreview = (key: string, handle: PreviewHandle): void => {
     activePreviews.set(key, handle)
     void handle.exited.then(() => {
       if (activePreviews.get(key) === handle) activePreviews.delete(key)
     })
   }
-  const openPreview = async (targetProjectId?: string): Promise<PreviewResult> => {
+  const onPreview = async (targetProjectId?: string): Promise<PreviewResult> => {
     const key = targetProjectId ?? homeId
     const existing = activePreviews.get(key)
     if (existing) return { ok: true, url: existing.url, command: existing.command }
@@ -417,55 +490,24 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
       return { ok: false, error: err instanceof Error ? err.message : String(err) }
     }
   }
-  const closePreview = async (targetProjectId?: string): Promise<void> => {
+  const onStopPreview = async (targetProjectId?: string): Promise<void> => {
     const key = targetProjectId ?? homeId
     const handle = activePreviews.get(key)
     if (!handle) return
     activePreviews.delete(key)
     await handle.stop().catch(() => {})
   }
-  const previewStatus = (targetProjectId?: string): PreviewStatus => {
+  const onPreviewStatus = (targetProjectId?: string): PreviewStatus => {
     const handle = activePreviews.get(targetProjectId ?? homeId)
     return handle ? { running: true, url: handle.url, command: handle.command } : { running: false }
   }
 
-  // The daemon serves the prerendered Vike + Telefunc dashboard (#405/#426): the SPA reads
-  // each project's `.the-framework/events.jsonl` over a Telefunc Channel and steers over
-  // control.jsonl, so there is no in-process event stream to feed here. `sendStart` /
-  // `sendAddProject` / the Preview RPCs reach the closures above through the Telefunc request
-  // context. A missing bundle (a broken install) surfaces as a 503 from the server.
-  const clientBundleDir = await resolveDashboardBundle()
-  const dashboard: Dashboard = await startDashboard({
-    port,
-    onStart: startRun,
-    onAddProject: addProjects,
-    onPreview: openPreview,
-    onStopPreview: closePreview,
-    onPreviewStatus: previewStatus,
-    ...(clientBundleDir ? { clientBundleDir } : {}),
-  })
-
-  try {
-    const actualPort = Number(new URL(dashboard.url).port) || port
-    const state: DaemonState = { pid: process.pid, port: actualPort, url: dashboard.url, startedAt: new Date().toISOString() }
-    await mkdir(dirname(daemonStatePath(env)), { recursive: true })
-    await writeFile(daemonStatePath(env), JSON.stringify(state, null, 2))
-    opts.onListening?.(state)
-  } catch (err) {
-    // Startup failed after the port was bound. Tear the server down, or it keeps the
-    // event loop alive: a zombie daemon squatting the port with no state file, which
-    // also wedges every later `framework` start.
-    await dashboard.close()
-    throw err
+  const dispose = async (): Promise<void> => {
+    await Promise.all([...activePreviews.values()].map(p => p.stop().catch(() => {})))
+    activePreviews.clear()
   }
 
-  await waitForShutdown(opts.signal)
-
-  // Tear down any live previews (#475) so their dev servers do not outlive the daemon.
-  await Promise.all([...activePreviews.values()].map(p => p.stop().catch(() => {})))
-  activePreviews.clear()
-  await dashboard.close()
-  await rm(daemonStatePath(env), { force: true }).catch(() => {})
+  return { onStart, onAddProject, onPreview, onStopPreview, onPreviewStatus, dispose }
 }
 
 /** Resolve on SIGINT/SIGTERM, or when the optional abort signal fires. */

--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -2,9 +2,9 @@ import type { Driver, DriverSession } from './driver/index.js'
 import { type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 import { runAwaitRounds } from './run.js'
 import { composeRunSystem, renderSystemPrompt, type EcoOptions, type TfContext } from './system-prompt.js'
-import { createDriverEventHandler, emitSessionStart } from './run-telemetry.js'
+import { createRunControls, emitSessionStart, endStopDetail } from './run-telemetry.js'
 import { createTurnSignalEmitter } from './turn-gate.js'
-import { CONSUMPTION_LIMIT_LABEL, type ConsumptionWindow } from './consumption.js'
+import { type ConsumptionWindow } from './consumption.js'
 import { leaveResumeNote } from './todo-loop.js'
 
 /**
@@ -98,25 +98,17 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
   // ride along as `driver` `start` events, so the dashboard can show them all.
   emit({ kind: 'system-prompt', text: system })
 
-  // Usage accounting + the self-stopping budget cap, the same wiring as a build
-  // run (#322): the run signal composes the caller's abort with the budget abort.
-  const budgetController = new AbortController()
-  // A consumption limit (#531) is the other self-stop: the account's quota ran
-  // out rather than this run's spend.
-  const consumptionController = new AbortController()
-  const runSignal = AbortSignal.any([
-    ...(opts.signal ? [opts.signal] : []),
-    budgetController.signal,
-    consumptionController.signal,
-  ])
-  const { onDriverEvent, consumptionTrip } = createDriverEventHandler({
-    emit,
-    sessionLink: opts.sessionLink,
-    budgetUsd: opts.budgetUsd,
-    consumptionGate: opts.consumptionGate,
-    budgetController,
-    consumptionController,
-  })
+  // Usage accounting + the self-stops, the same wiring as a build run (#322/#529):
+  // the run signal composes the caller's abort with the budget/consumption aborts.
+  // (The decline controller is inert here — this path finishes a declined plan cleanly.)
+  const { runSignal, onDriverEvent, consumptionTrip, budgetController, consumptionController, declineController } =
+    createRunControls({
+      emit,
+      ...(opts.signal ? { signal: opts.signal } : {}),
+      ...(opts.sessionLink ? { sessionLink: opts.sessionLink } : {}),
+      ...(opts.budgetUsd != null ? { budgetUsd: opts.budgetUsd } : {}),
+      ...(opts.consumptionGate ? { consumptionGate: opts.consumptionGate } : {}),
+    })
 
   const session: DriverSession = await opts.driver.start({
     cwd: opts.cwd,
@@ -145,21 +137,16 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
     emit({ kind: 'end', ok: true })
     return { text: rounds.text, events }
   } catch (err) {
-    // A user interrupt or the budget cap is a clean stop, not a failure (#322).
-    const budgetStopped = budgetController.signal.aborted && opts.signal?.aborted !== true
-    const paused = consumptionController.signal.aborted && opts.signal?.aborted !== true
-    const stopped = opts.signal?.aborted === true || budgetController.signal.aborted || consumptionController.signal.aborted
-    // Written here, not at the trip: the note is file I/O and the trip is a sync
-    // event handler, so a fire-and-forget write could lose the race with the run
-    // unwinding.
-    const resumeNote = paused ? await leaveResumeNote(opts.cwd, events, emit) : undefined
-    const detail = budgetStopped
-      ? `budget reached ($${opts.budgetUsd})`
-      : paused
-        ? `${CONSUMPTION_LIMIT_LABEL[consumptionTrip() ?? 'session']} consumption limit reached${resumeNote ? `; will resume from ${resumeNote}` : ''}`
-        : err instanceof Error
-          ? err.message
-          : String(err)
+    const { stopped, detail } = await endStopDetail({
+      err,
+      ...(opts.signal ? { signal: opts.signal } : {}),
+      budgetController,
+      consumptionController,
+      declineController,
+      consumptionTrip,
+      ...(opts.budgetUsd != null ? { budgetUsd: opts.budgetUsd } : {}),
+      leaveResumeNote: () => leaveResumeNote(opts.cwd, events, emit),
+    })
     emit({ kind: 'end', ok: false, ...(stopped ? { stopped: true } : {}), detail })
     throw err
   } finally {

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -1,5 +1,5 @@
 import { basename, dirname, join, resolve } from 'node:path'
-import { DEFAULT_CONSUMPTION_LIMITS, type ConsumptionLimit, type ConsumptionLimits } from './consumption.js'
+import { DEFAULT_CONSUMPTION_LIMITS, sanitizeConsumptionLimits, type ConsumptionLimits } from './consumption.js'
 import { nodeFs } from './node-fs.js'
 
 /**
@@ -145,39 +145,6 @@ const PREFERENCE_KEYS = [
   'browser',
 ] as const
 
-const CONSUMPTION_LIMIT_KEYS = ['daily', 'fiveHour', 'session'] as const
-
-/**
- * Read one limit out of a hand-edited or browser-supplied object.
- *
- * `undefined` for anything we can't trust, so the caller falls back to the
- * default rather than to an unguarded account. The percentage is clamped rather
- * than rejected: a plausible-but-out-of-range number is a slip, and honouring
- * the nearest legal value beats silently reverting to something else entirely.
- */
-function sanitizeConsumptionLimit(value: unknown): ConsumptionLimit | undefined {
-  if (typeof value !== 'object' || value === null) return undefined
-  const input = value as Record<string, unknown>
-  const percent = input['percent']
-  if (typeof input['enabled'] !== 'boolean') return undefined
-  if (typeof percent !== 'number' || !Number.isFinite(percent)) return undefined
-  return { enabled: input['enabled'], percent: Math.min(100, Math.max(0, percent)) }
-}
-
-/** Read the three limits, falling back per-limit so one bad entry can't unguard the rest. */
-function sanitizeConsumptionLimits(value: unknown): ConsumptionLimits | undefined {
-  if (typeof value !== 'object' || value === null) return undefined
-  const input = value as Record<string, unknown>
-  const limits = {} as ConsumptionLimits
-  let any = false
-  for (const key of CONSUMPTION_LIMIT_KEYS) {
-    const limit = sanitizeConsumptionLimit(input[key])
-    if (limit) any = true
-    limits[key] = limit ?? DEFAULT_CONSUMPTION_LIMITS[key]
-  }
-  return any ? limits : undefined
-}
-
 /** Keep only the known preference fields, so a hand-edited or browser-supplied
  * object never lands junk (or the wrong type) in the user's home file. */
 function sanitizePreferences(value: unknown): Preferences {
@@ -200,13 +167,9 @@ function sanitizePreferences(value: unknown): Preferences {
  * the settings is still guarded (#519).
  */
 export function resolveConsumptionLimits(preferences: Preferences | undefined): ConsumptionLimits {
-  const set = preferences?.consumptionLimits
-  if (!set) return DEFAULT_CONSUMPTION_LIMITS
-  return {
-    daily: set.daily ?? DEFAULT_CONSUMPTION_LIMITS.daily,
-    fiveHour: set.fiveHour ?? DEFAULT_CONSUMPTION_LIMITS.fiveHour,
-    session: set.session ?? DEFAULT_CONSUMPTION_LIMITS.session,
-  }
+  // sanitizeConsumptionLimits already fills every window, so a stored value is
+  // whole: the only gap left to default is an absent one.
+  return preferences?.consumptionLimits ?? DEFAULT_CONSUMPTION_LIMITS
 }
 
 /**

--- a/packages/framework/src/run-telemetry.ts
+++ b/packages/framework/src/run-telemetry.ts
@@ -111,3 +111,99 @@ export function createDriverEventHandler(opts: DriverEventHandlerOptions): Drive
 
   return { onDriverEvent, consumptionTrip: () => consumptionTrip }
 }
+
+/** Inputs to {@link createRunControls}. */
+export interface RunControlsOptions {
+  emit: (event: FrameworkEvent) => void
+  /** The caller's abort signal (Stop button / Ctrl+C / control channel), if any. */
+  signal?: AbortSignal | undefined
+  sessionLink?: string | undefined
+  budgetUsd?: number | undefined
+  consumptionGate?: (() => ConsumptionWindow | null) | undefined
+}
+
+/** The run's abort plumbing plus its driver-event sink. */
+export interface RunControls extends DriverEventHandler {
+  /** The composed signal every driver turn runs under. */
+  runSignal: AbortSignal
+  /** Trips a clean stop once this run has spent its budget cap (#322). */
+  budgetController: AbortController
+  /** Trips a clean pause once the account's quota window is spent (#529). */
+  consumptionController: AbortController
+  /** Trips a clean stop when the user declines a plan (#358); inert on the direct path. */
+  declineController: AbortController
+}
+
+/**
+ * Compose the run's signal and wire its driver-event handler in one place. The caller's
+ * signal is OR'd (via {@link AbortSignal.any}) with three self-stops — the budget cap
+ * (#322), a spent consumption window (#529), and a declined plan (#358) — so anything
+ * downstream that watches `runSignal` stops the same way regardless of which fired.
+ * Shared by the build (`run.ts`) and direct-prompt (`prompt-run.ts`) paths.
+ */
+export function createRunControls(opts: RunControlsOptions): RunControls {
+  const budgetController = new AbortController()
+  const declineController = new AbortController()
+  const consumptionController = new AbortController()
+  const runSignal = AbortSignal.any([
+    ...(opts.signal ? [opts.signal] : []),
+    budgetController.signal,
+    declineController.signal,
+    consumptionController.signal,
+  ])
+  const handler = createDriverEventHandler({
+    emit: opts.emit,
+    sessionLink: opts.sessionLink,
+    budgetUsd: opts.budgetUsd,
+    consumptionGate: opts.consumptionGate,
+    budgetController,
+    consumptionController,
+  })
+  return { ...handler, runSignal, budgetController, consumptionController, declineController }
+}
+
+/** Inputs to {@link endStopDetail}. */
+export interface StopDetailOptions {
+  /** The error the run's turn loop threw. */
+  err: unknown
+  /** The caller's own signal, to tell a caller stop from a self-stop. */
+  signal?: AbortSignal | undefined
+  budgetController: AbortController
+  consumptionController: AbortController
+  declineController: AbortController
+  consumptionTrip: () => ConsumptionWindow | undefined
+  budgetUsd?: number | undefined
+  /**
+   * Leave a resume note when the run paused on a consumption limit, returning where
+   * it will resume from. Injected (not imported) so this module stays free of the
+   * todo loop it would otherwise import in a cycle.
+   */
+  leaveResumeNote: () => Promise<string | undefined>
+}
+
+/**
+ * Classify why a run's turn loop threw and render the `end` event's `detail`. A caller
+ * interrupt, a budget cap (#322), a declined plan (#358), or a spent consumption window
+ * (#529) are all clean stops; anything else is a real failure. The resume note is written
+ * here (once `paused` is known) rather than at the trip, because it is file I/O racing the
+ * run unwinding. Shared so the two run paths can never disagree on what "stopped" means.
+ */
+export async function endStopDetail(opts: StopDetailOptions): Promise<{ stopped: boolean; detail: string }> {
+  const callerAborted = opts.signal?.aborted === true
+  const budgetStopped = opts.budgetController.signal.aborted && !callerAborted
+  const declined = opts.declineController.signal.aborted
+  const paused = opts.consumptionController.signal.aborted && !callerAborted
+  const stopped =
+    callerAborted || opts.budgetController.signal.aborted || declined || opts.consumptionController.signal.aborted
+  const resumeNote = paused ? await opts.leaveResumeNote() : undefined
+  const detail = declined
+    ? 'plan declined'
+    : budgetStopped
+      ? `budget reached ($${opts.budgetUsd})`
+      : paused
+        ? `${CONSUMPTION_LIMIT_LABEL[opts.consumptionTrip() ?? 'session']} consumption limit reached${resumeNote ? `; will resume from ${resumeNote}` : ''}`
+        : opts.err instanceof Error
+          ? opts.err.message
+          : String(opts.err)
+  return { stopped, detail }
+}

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -329,60 +329,27 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     onEvent: onDriverEvent,
   })
 
-  // Materialize the domain preset's review policy against this run's driver: its
-  // loops, with its prompts as driver-backed passes sharing the run's abort signal.
-  // Exposed on the result, and driven as the review phase below (#252).
-  const loop = domainPreset
-    ? new LoopEngine({
-        loops: [...domainPreset.loops],
-        prompts: driverLoopPrompts(session, domainPreset.prompts, {
-          signal: runSignal,
-        }),
-      })
-    : undefined
-
-  // The production-grade review phase. Default: the built-in checklist. With a
-  // domain preset, its loop *replaces* the checklist (#252) — each pass fires the
-  // preset's review chain through the driver — falling back to the built-in when
-  // the preset has no loop for the build event, so a run is never left unreviewed.
-  // The build event kind: an explicit run choice wins, else the preset's own
-  // default, else `major-change`. This is how a `bug-fix` run reaches the preset's
-  // bug-fix loop (#265).
-  const buildEvent = opts.buildEvent ?? domainPreset?.defaultEvent ?? 'major-change'
-  const reviewChecklist = loop
-    ? domainLoopChecklist(loop, { kind: buildEvent, fallback: driverChecklist(session) })
-    : driverChecklist(session)
-  if (loop)
-    emit({
-      kind: 'log',
-      message: `Review policy: the ${domainPreset!.title} loop drives the ${buildEvent} review`,
-    })
+  // The domain preset's review policy (exposed on the result) and the production-grade
+  // review checklist it drives.
+  const { loop, reviewChecklist } = buildReview(session, domainPreset, {
+    ...(opts.buildEvent ? { buildEvent: opts.buildEvent } : {}),
+    signal: runSignal,
+    emit,
+  })
 
   // Boot-and-serve gate: provision a runner so the checklist can gate on the app
-  // actually running (mergeChecklists unions the review with a real serveCheck).
-  // Local adopts (never deletes) the driver's cwd in place; docker sandboxes the
-  // check in a throwaway container (#229). An injected runner wins over both.
+  // actually running. Local adopts (never deletes) the driver's cwd in place; docker
+  // sandboxes the check in a throwaway container (#229). An injected runner wins over both.
   const sandbox = opts.sandbox ?? 'local'
-  let runner: RunnerSession | undefined
-  if (opts.serve) runner = opts.runner ?? (await provisionServeRunner(sandbox, opts.cwd, opts.serve, emit))
   const s = opts.serve
-  let checklist: NonNullable<BootstrapSteps['checklist']> = reviewChecklist
-  if (runner && s) {
-    const check = serveCheck(runner, {
-      serve: s.command,
-      ...(s.install ? { install: s.install } : {}),
-      ...(s.build ? { build: s.build } : {}),
-      ...(s.port !== undefined ? { port: s.port } : {}),
-      ...(s.waitMs !== undefined ? { waitMs: s.waitMs } : {}),
-      ...(s.healthPath ? { healthPath: s.healthPath } : {}),
-      onProgress: message => emit({ kind: 'log', message: `serve: ${message}` }),
-    })
-    // The build runs on the host, so a sandboxed container must be re-seeded with
-    // the latest host source before every check (each pass changes it). Local reads
-    // the host dir live, so it needs no sync.
-    const serveStep = sandbox === 'docker' && !opts.runner ? syncThenServe(runner, opts.cwd, check, emit) : check
-    checklist = mergeChecklists(reviewChecklist, serveStep)
-  }
+  let runner: RunnerSession | undefined
+  if (s) runner = opts.runner ?? (await provisionServeRunner(sandbox, opts.cwd, s, emit))
+  const checklist = withServeCheck(reviewChecklist, runner, s, {
+    sandbox,
+    cwd: opts.cwd,
+    injectedRunner: opts.runner !== undefined,
+    emit,
+  })
 
   // A real driver writes files to the workspace, so the build/improve steps can
   // detect an empty workspace and hard-scaffold it (#182). The fake driver writes
@@ -461,6 +428,64 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     // Keep the runner alive only when it owns a live preview handed to the caller.
     if (runner && !preview) await runner.dispose()
   }
+}
+
+/**
+ * Materialize the domain preset's review policy against the run's driver, and the
+ * production-grade review checklist it drives. Default: the built-in checklist. With a
+ * domain preset, its loop *replaces* the checklist (#252) — each pass fires the preset's
+ * review chain through the driver — falling back to the built-in when the preset has no
+ * loop for the build event, so a run is never left unreviewed. The build event kind: an
+ * explicit run choice wins, else the preset's own default, else `major-change` — how a
+ * `bug-fix` run reaches the preset's bug-fix loop (#265). The `loop` is returned so the
+ * caller can expose it on the result.
+ */
+function buildReview(
+  session: DriverSession,
+  domainPreset: DomainPreset | undefined,
+  ctx: { buildEvent?: string; signal: AbortSignal; emit: (event: FrameworkEvent) => void },
+): { loop: LoopEngine | undefined; reviewChecklist: NonNullable<BootstrapSteps['checklist']> } {
+  const loop = domainPreset
+    ? new LoopEngine({
+        loops: [...domainPreset.loops],
+        prompts: driverLoopPrompts(session, domainPreset.prompts, { signal: ctx.signal }),
+      })
+    : undefined
+  const buildEvent = ctx.buildEvent ?? domainPreset?.defaultEvent ?? 'major-change'
+  const reviewChecklist = loop
+    ? domainLoopChecklist(loop, { kind: buildEvent, fallback: driverChecklist(session) })
+    : driverChecklist(session)
+  if (loop && domainPreset) {
+    ctx.emit({ kind: 'log', message: `Review policy: the ${domainPreset.title} loop drives the ${buildEvent} review` })
+  }
+  return { loop, reviewChecklist }
+}
+
+/**
+ * Union the review checklist with a boot-and-serve gate (#229) when the run has a runner:
+ * `serveCheck` verifies the app actually boots, and `mergeChecklists` runs it alongside
+ * the review. A docker sandbox re-seeds the container from the host source before every
+ * check (the build writes to the host each pass); local reads the host dir live, so it
+ * needs no sync. Without a runner/serve the review checklist stands alone.
+ */
+function withServeCheck(
+  review: NonNullable<BootstrapSteps['checklist']>,
+  runner: RunnerSession | undefined,
+  serve: ServeConfig | undefined,
+  ctx: { sandbox: 'local' | 'docker'; cwd: string; injectedRunner: boolean; emit: (event: FrameworkEvent) => void },
+): NonNullable<BootstrapSteps['checklist']> {
+  if (!runner || !serve) return review
+  const check = serveCheck(runner, {
+    serve: serve.command,
+    ...(serve.install ? { install: serve.install } : {}),
+    ...(serve.build ? { build: serve.build } : {}),
+    ...(serve.port !== undefined ? { port: serve.port } : {}),
+    ...(serve.waitMs !== undefined ? { waitMs: serve.waitMs } : {}),
+    ...(serve.healthPath ? { healthPath: serve.healthPath } : {}),
+    onProgress: message => ctx.emit({ kind: 'log', message: `serve: ${message}` }),
+  })
+  const serveStep = ctx.sandbox === 'docker' && !ctx.injectedRunner ? syncThenServe(runner, ctx.cwd, check, ctx.emit) : check
+  return mergeChecklists(review, serveStep)
 }
 
 

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -22,10 +22,10 @@ import {
   type Verdict,
 } from '@gemstack/ai-autopilot'
 import { snapshotWorkspace } from './sandbox.js'
-import { CONSUMPTION_LIMIT_LABEL, type ConsumptionWindow } from './consumption.js'
+import { type ConsumptionWindow } from './consumption.js'
 import type { Driver, DriverSession } from './driver/index.js'
 import { composeRunSystem, type EcoOptions, type TfContext } from './system-prompt.js'
-import { createDriverEventHandler, emitSessionStart } from './run-telemetry.js'
+import { createRunControls, emitSessionStart, endStopDetail } from './run-telemetry.js'
 import { AWAIT_PROTOCOL, CONFIRM_APPROVED, CONFIRM_DECLINED, MAX_AWAIT_ROUNDS, PLAN_DECLINED_MESSAGE, continuationPrompt, createTurnSignalEmitter, isDeclinedConfirmation, parseAwaitGate, type ParsedAwaitGate } from './turn-gate.js'
 // Value import from todo-loop.js is a benign cycle: todo-loop.js only calls
 // run.js's hoisted function declarations (requestChoices / resolveAwaitGate).
@@ -309,32 +309,16 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     emit({ kind: 'modes', all: OPEN_LOOP_MODES, active: opts.modes ?? [] })
   }
 
-  // Compose the caller's signal with a budget-triggered abort (#322) so the run can
-  // stop *itself* once it has spent too much, without the caller having to watch
-  // usage. Everything downstream aborts on `runSignal`; only the budget path (or a
-  // caller abort) trips it. With no caller signal this is just the budget signal.
-  const budgetController = new AbortController()
-  // A declined plan (#358) also stops the run cleanly, like the budget cap: nothing
-  // downstream should review or improve work the user just declined.
-  const declineController = new AbortController()
-  // A consumption limit (#529) is the third clean stop: the account's quota, not
-  // this run's spend, is what ran out.
-  const consumptionController = new AbortController()
-  const runSignal = AbortSignal.any([
-    ...(opts.signal ? [opts.signal] : []),
-    budgetController.signal,
-    declineController.signal,
-    consumptionController.signal,
-  ])
-
-  const { onDriverEvent, consumptionTrip } = createDriverEventHandler({
-    emit,
-    sessionLink: opts.sessionLink,
-    budgetUsd: opts.budgetUsd,
-    consumptionGate: opts.consumptionGate,
-    budgetController,
-    consumptionController,
-  })
+  // The run's abort plumbing and driver-event sink: the caller's signal composed with
+  // the budget (#322), consumption (#529), and plan-decline (#358) self-stops.
+  const { runSignal, onDriverEvent, consumptionTrip, budgetController, consumptionController, declineController } =
+    createRunControls({
+      emit,
+      ...(opts.signal ? { signal: opts.signal } : {}),
+      ...(opts.sessionLink ? { sessionLink: opts.sessionLink } : {}),
+      ...(opts.budgetUsd != null ? { budgetUsd: opts.budgetUsd } : {}),
+      ...(opts.consumptionGate ? { consumptionGate: opts.consumptionGate } : {}),
+    })
 
   // 2. One driver session for the whole run; each prompt is a fresh invocation.
   const session: DriverSession = await opts.driver.start({
@@ -460,27 +444,16 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     emit({ kind: 'end', ok: true })
     return { result, detection, events, ...(preview ? { preview } : {}), ...(loop ? { loop } : {}), ...(todo ? { todo } : {}) }
   } catch (err) {
-    // A user interrupt (the dashboard Stop button / Ctrl+C) or a budget cap (#322)
-    // is a clean stop, not a failure — mark it so surfaces show "stopped". Budget is
-    // its own signal, so it trips when the caller's signal did not.
-    const budgetStopped = budgetController.signal.aborted && opts.signal?.aborted !== true
-    const declined = declineController.signal.aborted
-    const paused = consumptionController.signal.aborted && opts.signal?.aborted !== true
-    const stopped =
-      opts.signal?.aborted === true || budgetController.signal.aborted || declined || consumptionController.signal.aborted
-    // Leave word to pick this up again (#529). Written here rather than at the
-    // trip because the note is file I/O and the trip is a sync event handler; a
-    // fire-and-forget write could lose the race with the run unwinding.
-    const resumeNote = paused ? await leaveResumeNote(opts.cwd, events, emit) : undefined
-    const detail = declined
-      ? 'plan declined'
-      : budgetStopped
-        ? `budget reached ($${opts.budgetUsd})`
-        : paused
-          ? `${CONSUMPTION_LIMIT_LABEL[consumptionTrip() ?? 'session']} consumption limit reached${resumeNote ? `; will resume from ${resumeNote}` : ''}`
-          : err instanceof Error
-            ? err.message
-            : String(err)
+    const { stopped, detail } = await endStopDetail({
+      err,
+      ...(opts.signal ? { signal: opts.signal } : {}),
+      budgetController,
+      consumptionController,
+      declineController,
+      consumptionTrip,
+      ...(opts.budgetUsd != null ? { budgetUsd: opts.budgetUsd } : {}),
+      leaveResumeNote: () => leaveResumeNote(opts.cwd, events, emit),
+    })
     emit({ kind: 'end', ok: false, ...(stopped ? { stopped: true } : {}), detail })
     throw err
   } finally {

--- a/packages/framework/src/steps.ts
+++ b/packages/framework/src/steps.ts
@@ -144,10 +144,36 @@ function hasSourceFile(dir: string, depth: number): boolean {
   return false
 }
 
+/**
+ * Whether a step should hard-scaffold rather than build/improve normally (#182): the
+ * workspace is still empty and this driver verifies its output (a real driver; the fake
+ * one writes nothing, so it opts out to stay deterministic). Read at the moment the step
+ * decides, since the workspace changes as the agent works.
+ */
+function shouldScaffold(session: DriverSession, verifyWorkspace: boolean | undefined): boolean {
+  return verifyWorkspace === true && isWorkspaceEmpty(session.cwd)
+}
+
 /** Options shared by the driver-backed steps. */
 export interface DriverStepOptions {
   /** Extra per-step framing appended to the session system prompt. */
   system?: string
+}
+
+/** One synthetic subtask result: a driver turn's text, always "ok" (the driver owns pass/fail). */
+function subtaskResult(subtask: PlannedSubtask, text: string): SubtaskResult {
+  return { subtask, text, ok: true, usage: ZERO_USAGE }
+}
+
+/** Wrap driver-turn results in a {@link SupervisorRun} so the bootstrap narration shows a phase. */
+function supervisorRun(results: SubtaskResult[]): SupervisorRun {
+  return {
+    text: results[results.length - 1]!.text,
+    plan: results.map(r => r.subtask),
+    results,
+    usage: ZERO_USAGE,
+    stoppedEarly: false,
+  }
 }
 
 /**
@@ -168,8 +194,7 @@ export function continueAfterChoice(
     .prompt(prompt, { ...(ctx.signal ? { signal: ctx.signal } : {}) })
     .then(turn => {
       const subtask: PlannedSubtask = { id: 'build-resume', description: 'Continue after the user picked' }
-      const result: SubtaskResult = { subtask, text: turn.text, ok: true, usage: ZERO_USAGE }
-      return { text: turn.text, plan: [subtask], results: [result], usage: ZERO_USAGE, stoppedEarly: false }
+      return supervisorRun([subtaskResult(subtask, turn.text)])
     })
 }
 
@@ -216,7 +241,7 @@ export function driverBuild(
     ctx.onEvent({ type: 'dispatch-start', subtask })
 
     let turn = await session.prompt(firstPrompt, { ...promptOpts, ...signalOpt })
-    const results: SubtaskResult[] = [{ subtask, text: turn.text, ok: true, usage: ZERO_USAGE }]
+    const results: SubtaskResult[] = [subtaskResult(subtask, turn.text)]
     ctx.onEvent({ type: 'dispatch-result', result: results[0]! })
 
     // #182: the build must actually produce an app. If nothing landed on disk,
@@ -225,23 +250,17 @@ export function driverBuild(
     // Exception (#337 / #339): an empty workspace plus an await block means the agent
     // stopped *on purpose* to ask; the await gate handles it, so don't clobber the
     // question with a scaffold directive.
-    if (opts.verifyWorkspace && isWorkspaceEmpty(session.cwd) && !parseAwaitGate(turn.text)) {
+    if (shouldScaffold(session, opts.verifyWorkspace) && !parseAwaitGate(turn.text)) {
       const retry: PlannedSubtask = { id: 'build-2', description: 'Scaffold the app from scratch (workspace was empty)' }
       ctx.onEvent({ type: 'dispatch-start', subtask: retry })
       turn = await session.prompt(scaffoldPrompt(ctx.intent), { ...promptOpts, ...signalOpt })
-      const retryResult: SubtaskResult = { subtask: retry, text: turn.text, ok: true, usage: ZERO_USAGE }
+      const retryResult = subtaskResult(retry, turn.text)
       results.push(retryResult)
       ctx.onEvent({ type: 'dispatch-result', result: retryResult })
     }
 
     ctx.onEvent({ type: 'synthesize', results })
-    return {
-      text: turn.text,
-      plan: results.map(r => r.subtask),
-      results,
-      usage: ZERO_USAGE,
-      stoppedEarly: false,
-    }
+    return supervisorRun(results)
   }
 }
 
@@ -329,8 +348,7 @@ export function driverImprove(
 ): (ctx: LoopPassContext) => Promise<void> {
   const compose = opts.prompt ?? improvePrompt
   return async ctx => {
-    const scaffold = opts.verifyWorkspace && isWorkspaceEmpty(session.cwd)
-    const text = scaffold ? scaffoldPrompt(ctx.intent) : compose(ctx.blockers)
+    const text = shouldScaffold(session, opts.verifyWorkspace) ? scaffoldPrompt(ctx.intent) : compose(ctx.blockers)
     await session.prompt(text, {
       ...(opts.system ? { system: opts.system } : {}),
       ...(ctx.signal ? { signal: ctx.signal } : {}),

--- a/packages/framework/src/store/run-store.ts
+++ b/packages/framework/src/store/run-store.ts
@@ -156,9 +156,9 @@ export function applyEventToMeta(meta: RunMeta, event: FrameworkEvent, at: strin
   return next
 }
 
-/** Rebuild {@link RunMeta} from a full event log (used when resuming). */
-export function metaFromEvents(events: readonly FrameworkEvent[], startedAt: string): RunMeta {
-  let meta: RunMeta = {
+/** The seed meta a run starts from, before any event is folded in. */
+function freshMeta(startedAt: string): RunMeta {
+  return {
     version: RUN_META_VERSION,
     status: 'running',
     id: runIdFromStartedAt(startedAt),
@@ -166,6 +166,40 @@ export function metaFromEvents(events: readonly FrameworkEvent[], startedAt: str
     updatedAt: startedAt,
     passes: 0,
   }
+}
+
+/**
+ * Parse a JSONL event log. A blank or malformed trailing line (e.g. a crash
+ * mid-write) stops the read rather than throwing, so a partial run still replays
+ * everything up to the cut.
+ */
+function parseEventLog(raw: string): FrameworkEvent[] {
+  const events: FrameworkEvent[] = []
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    try {
+      events.push(JSON.parse(trimmed) as FrameworkEvent)
+    } catch {
+      break // a torn last line from an interrupted write; keep what we have
+    }
+  }
+  return events
+}
+
+/** Read + parse a persisted {@link RunMeta} file, or `undefined` if missing/unreadable. */
+async function readMetaFile(fs: StoreFs, path: string): Promise<RunMeta | undefined> {
+  if (!(await fs.exists(path))) return undefined
+  try {
+    return JSON.parse(await fs.read(path)) as RunMeta
+  } catch {
+    return undefined
+  }
+}
+
+/** Rebuild {@link RunMeta} from a full event log (used when resuming). */
+export function metaFromEvents(events: readonly FrameworkEvent[], startedAt: string): RunMeta {
+  let meta = freshMeta(startedAt)
   for (const event of events) meta = applyEventToMeta(meta, event, startedAt)
   return meta
 }
@@ -209,14 +243,7 @@ export class RunStore {
     const dir = join(cwd, FRAMEWORK_DIR)
     const now = opts.now ?? new Date().toISOString()
     await fs.mkdir(dir)
-    const store = new RunStore(fs, dir, now, {
-      version: RUN_META_VERSION,
-      status: 'running',
-      id: runIdFromStartedAt(now),
-      startedAt: now,
-      updatedAt: now,
-      passes: 0,
-    })
+    const store = new RunStore(fs, dir, now, freshMeta(now))
     if (opts.fresh) {
       // A new run truncates the live log. First rescue the prior run if it never
       // got archived (e.g. a crash exited before close), so no history is lost.
@@ -269,29 +296,12 @@ export class RunStore {
    */
   async loadEvents(): Promise<FrameworkEvent[]> {
     if (!(await this.fs.exists(this.eventsPath))) return []
-    const raw = await this.fs.read(this.eventsPath)
-    const events: FrameworkEvent[] = []
-    for (const line of raw.split('\n')) {
-      const trimmed = line.trim()
-      if (!trimmed) continue
-      try {
-        events.push(JSON.parse(trimmed) as FrameworkEvent)
-      } catch {
-        // A torn last line from an interrupted write; stop, keep what we have.
-        break
-      }
-    }
-    return events
+    return parseEventLog(await this.fs.read(this.eventsPath))
   }
 
   /** Read the persisted meta snapshot, or `undefined` if none/unreadable. */
-  async readMeta(): Promise<RunMeta | undefined> {
-    if (!(await this.fs.exists(this.metaPath))) return undefined
-    try {
-      return JSON.parse(await this.fs.read(this.metaPath)) as RunMeta
-    } catch {
-      return undefined
-    }
+  readMeta(): Promise<RunMeta | undefined> {
+    return readMetaFile(this.fs, this.metaPath)
   }
 
   private writeMeta(): Promise<void> {
@@ -325,14 +335,7 @@ async function archiveRun(fs: StoreFs, dir: string, meta: RunMeta, eventsPath: s
  * {@link RunStore.close} still leaves its history behind.
  */
 async function archivePriorRun(fs: StoreFs, dir: string): Promise<void> {
-  const metaPath = join(dir, META_FILE)
-  if (!(await fs.exists(metaPath))) return
-  let meta: RunMeta
-  try {
-    meta = JSON.parse(await fs.read(metaPath)) as RunMeta
-  } catch {
-    return
-  }
+  const meta = await readMetaFile(fs, join(dir, META_FILE))
   if (!meta?.id || !isSafeRunId(meta.id)) return
   if (await fs.exists(archivePaths(dir, meta.id).meta)) return
   await archiveRun(fs, dir, meta, join(dir, EVENTS_FILE))
@@ -365,14 +368,8 @@ export async function listRuns(cwd: string, fs: StoreFs = nodeStoreFs()): Promis
  * tailing right now — so the dashboard can list it with a `running` status
  * before it finishes. Missing or torn file yields `undefined`, never throws.
  */
-export async function readLiveMeta(cwd: string, fs: StoreFs = nodeStoreFs()): Promise<RunMeta | undefined> {
-  const path = join(cwd, FRAMEWORK_DIR, META_FILE)
-  if (!(await fs.exists(path))) return undefined
-  try {
-    return JSON.parse(await fs.read(path)) as RunMeta
-  } catch {
-    return undefined
-  }
+export function readLiveMeta(cwd: string, fs: StoreFs = nodeStoreFs()): Promise<RunMeta | undefined> {
+  return readMetaFile(fs, join(cwd, FRAMEWORK_DIR, META_FILE))
 }
 
 /**
@@ -388,17 +385,7 @@ export async function loadRunEvents(
   if (!isSafeRunId(id)) return undefined
   const path = archivePaths(join(cwd, FRAMEWORK_DIR), id).events
   if (!(await fs.exists(path))) return undefined
-  const events: FrameworkEvent[] = []
-  for (const line of (await fs.read(path)).split('\n')) {
-    const trimmed = line.trim()
-    if (!trimmed) continue
-    try {
-      events.push(JSON.parse(trimmed) as FrameworkEvent)
-    } catch {
-      break
-    }
-  }
-  return events
+  return parseEventLog(await fs.read(path))
 }
 
 /** A {@link StoreFs} backed by `node:fs/promises`. See {@link nodeFs}. */


### PR DESCRIPTION
Quality pass over the big/complex files in `packages/framework`, applying the rate-everything-then-refactor method. I rated every file, function, and logic block across the target files first (via four independent reviewers), then applied only the significant refactors, one per commit. Items already rated 8+ and on the right side of their boundary were left alone; the three the reviewers themselves flagged as minor (a daemon `pollUntil` merge, a steps optional-options spread, a `nodeRegistryFs` re-wrap) were dropped rather than shipped as noise.

Scope: `cli.ts`, `run.ts`, `run-store.ts`, `daemon.ts`, `steps.ts`, `registry.ts`, `run-telemetry.ts`, `prompt-run.ts`, `consumption.ts`. `turn-gate.ts` was left out on purpose (it is being refactored in #614).

**Verification:** `pnpm build` green; framework suite 543 pass / 1 skip (docker) / 0 fail, identical to the pre-refactor baseline; all downstream packages (`framework-dashboard`, examples) build. Every commit type-checks and passes tests on its own.

## What changed (old rating => new)

Ratings are the reviewers' scores for the item before the change vs after.

### Seams (responsibility moved to the right side of its boundary)

| Item | old => new | Commit |
|---|---|---|
| Consumption-limit validation living inside the persistence module (`registry.ts` cohesion) | 6 => 9 | 5fcf77c |
| `resolveConsumptionLimits` dead per-field fallback | 5 => 8 | 5fcf77c |
| `runDaemon` (195-line lifecycle + a whole project runtime in one body) | 6 => 9 | c35aad6 |
| `runCli` (540-line orchestrator, two duplicated run-body epilogues) | 5 => 7 | a788826 |

### Duplication removed (DRY, one home each)

| Item | old => new | Commit |
|---|---|---|
| run-signal composition + clean-stop teardown, duplicated `run.ts` <-> `prompt-run.ts` | 5 => 8 | 544b8bc |
| run-store JSONL parse / read-meta / seed-meta (3 dup pairs) | 6/7 => 8 | b507dd3 |
| daemon fork-bomb guard + detached spawn (2 copies) + `registerHomeProject` (cross-file) | 5/6 => 8 | c35aad6 |
| steps synthetic `SupervisorRun` builder + empty-workspace scaffold predicate | 6 => 8 | 7e633c4 |
| `parseArgs` integer-flag validate/assign (6 copies) | 7 => 8 | f136bd1 |
| `keepDashboardUp` for the repeated post-run wait (4 sites) | 6 => 9 | 7d24db9 |
| shared `requestChoice` handler + session link (2 copies + an IIFE wart) | 7 => 9 | 2aceb54 |
| `resolvePromptConfig` (2 copies + a redundant SYSTEM.md read) | 6 => 9 | 912b100 |
| `startRunDashboard` (dashboard start duplicated `runCli` <-> `resumeRun`) | 7 => 9 | ff53bc6 |
| two run-body epilogues collapsed into `settleRun` | 5/6 => 8 | a788826 |

### Altitude (orchestrators read at one level)

| Item | old => new | Commit |
|---|---|---|
| `runFramework` review-checklist + serve-checklist assembly lifted into `buildReview` / `withServeCheck` | 6 => 8 | 02b2a41 |

### Docs

| Item | old => new | Commit |
|---|---|---|
| two JSDoc blocks describing the wrong function (relay doc, spawn doc) | 4 => 9 | b06c7d4 |

## Coverage check

- [x] `cli.ts` — every function and the run-body logic rated; refactors: 7d24db9, 2aceb54, 912b100, ff53bc6, a788826, f136bd1, b06c7d4
- [x] `run.ts` / `prompt-run.ts` / `run-telemetry.ts` — rated; refactors: 544b8bc, 02b2a41
- [x] `run-store.ts` — every function rated; refactor: b507dd3
- [x] `daemon.ts` — every function rated; refactor: c35aad6
- [x] `steps.ts` — every function rated; refactor: 7e633c4
- [x] `registry.ts` / `consumption.ts` — every function rated; refactor: 5fcf77c
- [x] `index.ts` — rated (healthy barrel, nothing significant to change)

No behavior changes intended anywhere; this is location / DRY / altitude only.
