### PR TITLE
refactor(framework): quality pass over the rest of the package

### DIFF
--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -18,7 +18,9 @@ import { hostExecutor } from './host-exec.js'
 import { startDashboard, singleProjectProvider, resolveDashboardBundle, type Dashboard } from './dashboard/index.js'
 import { startRelay, relayPublisher, type RelayPublisher } from './relay.js'
 import { randomUUID } from 'node:crypto'
-import { formatFrameworkEvent, CLAUDE_CODE_SESSION_LINK, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
+import { formatFrameworkEvent } from './terminal.js'
+import { CLAUDE_CODE_SESSION_LINK } from './session-link.js'
+import { type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
 import {
   runFramework,
   type AppPreview,

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -2,7 +2,8 @@
 // here — `formatFrameworkEvent` and the run-view derivations — with no Node imports, so
 // the client can import these at runtime without dragging the server barrel (relay,
 // sandbox, node:fs/http, …) into the browser bundle. Types come from the root entry.
-export { formatFrameworkEvent, pickedIds } from './events.js'
+export { formatFrameworkEvent } from './terminal.js'
+export { pickedIds } from './events.js'
 export {
   loopStatus,
   sessionInfo,

--- a/packages/framework/src/dashboard-rpc/context.ts
+++ b/packages/framework/src/dashboard-rpc/context.ts
@@ -1,8 +1,22 @@
 import { getContext } from 'telefunc'
 import { defaultProjectsProvider, type ProjectsProvider } from '../dashboard/projects.js'
-import type { EventsSource } from '../dashboard/telefunc-serve.js'
+import type { DashboardContext, EventsSource } from '../dashboard/telefunc-serve.js'
 import type { PreferencesStore } from '../registry.js'
 import type { QuotaSource } from '../dashboard/quota.js'
+
+/**
+ * Read one field off the Telefunc request context, or undefined when it is unset. Every
+ * real call runs inside `serve({ context })`; the try/catch is the defensive fallback for
+ * a call made outside a request. The named accessors below add each field's meaning; this
+ * is the shared plumbing they all sit on.
+ */
+function fromContext<T>(pick: (ctx: DashboardContext) => T | undefined): T | undefined {
+  try {
+    return pick(getContext<DashboardContext>())
+  } catch {
+    return undefined
+  }
+}
 
 /**
  * The {@link ProjectsProvider} a telefunction should read a project id against (#427).
@@ -12,12 +26,12 @@ import type { QuotaSource } from '../dashboard/quota.js'
  * no context is set (defensive — every real call runs inside `serve({ context })`).
  */
 export function contextProjects(): ProjectsProvider {
-  try {
-    const ctx = getContext<{ projects?: ProjectsProvider }>()
-    return ctx?.projects ?? defaultProjectsProvider()
-  } catch {
-    return defaultProjectsProvider()
-  }
+  return fromContext(ctx => ctx.projects) ?? defaultProjectsProvider()
+}
+
+/** The workspace path for a project id (registry, or single-project #427), else undefined. */
+export function resolveProjectPath(projectId: string): Promise<string | undefined> {
+  return contextProjects().resolvePath(projectId)
 }
 
 /**
@@ -27,11 +41,7 @@ export function contextProjects(): ProjectsProvider {
  * tails the file as before.
  */
 export function contextEventsSource(): EventsSource | undefined {
-  try {
-    return getContext<{ eventsSource?: EventsSource }>()?.eventsSource
-  } catch {
-    return undefined
-  }
+  return fromContext(ctx => ctx.eventsSource)
 }
 
 /**
@@ -40,11 +50,7 @@ export function contextEventsSource(): EventsSource | undefined {
  * degrade to a read-only default / a no-op write on a shared host.
  */
 export function contextPreferences(): PreferencesStore | undefined {
-  try {
-    return getContext<{ preferences?: PreferencesStore }>()?.preferences
-  } catch {
-    return undefined
-  }
+  return fromContext(ctx => ctx.preferences)
 }
 
 /**
@@ -53,9 +59,5 @@ export function contextPreferences(): PreferencesStore | undefined {
  * and no business reading someone else's account.
  */
 export function contextQuota(): QuotaSource | undefined {
-  try {
-    return getContext<{ quota?: QuotaSource }>()?.quota
-  } catch {
-    return undefined
-  }
+  return fromContext(ctx => ctx.quota)
 }

--- a/packages/framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/control.telefunc.ts
@@ -3,7 +3,7 @@ import { appendControl } from '../control.js'
 import { openInApp, type OpenTarget, type OpenResult } from '../dashboard/open-in-app.js'
 import { resolveProjectPath } from './context.js'
 import type { ChoiceBy } from '../events.js'
-import type { PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from '../dashboard/server.js'
+import type { PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from '../dashboard/types.js'
 import type { DashboardContext } from '../dashboard/telefunc-serve.js'
 
 // The write side behind the new dashboard (#405): steering a live run. The reverse of

--- a/packages/framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/control.telefunc.ts
@@ -1,7 +1,7 @@
 import { getContext } from 'telefunc'
 import { appendControl } from '../control.js'
 import { openInApp, type OpenTarget, type OpenResult } from '../dashboard/open-in-app.js'
-import { contextProjects } from './context.js'
+import { resolveProjectPath } from './context.js'
 import type { ChoiceBy } from '../events.js'
 import type { PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from '../dashboard/server.js'
 import type { DashboardContext } from '../dashboard/telefunc-serve.js'
@@ -14,14 +14,9 @@ import type { DashboardContext } from '../dashboard/telefunc-serve.js'
 // steerable. (Starting a run needs a spawn + the daemon's busy guard, so `sendStart`
 // lands with the daemon-serves-the-bundle wiring, not here.)
 
-/** The path for a project id (registry, or single-project #427), else undefined (no-op steer). */
-async function projectPath(projectId: string): Promise<string | undefined> {
-  return contextProjects().resolvePath(projectId)
-}
-
 /** Stop the project's live run (the Stop button): append a stop entry to its control log. */
 export async function sendStop(projectId: string): Promise<void> {
-  const cwd = await projectPath(projectId)
+  const cwd = await resolveProjectPath(projectId)
   if (cwd) await appendControl(cwd, { kind: 'stop' })
 }
 
@@ -36,7 +31,7 @@ export async function sendChoice(
   pick: string | string[],
   by: ChoiceBy = 'user',
 ): Promise<void> {
-  const cwd = await projectPath(projectId)
+  const cwd = await resolveProjectPath(projectId)
   if (cwd) await appendControl(cwd, { kind: 'choice', id, pick, by })
 }
 
@@ -92,7 +87,7 @@ export async function onPreviewStatus(projectId: string): Promise<PreviewStatus>
  * local path to resolve, so it returns an error rather than spawning anything.
  */
 export async function sendOpenInApp(projectId: string, target: OpenTarget): Promise<OpenResult> {
-  const cwd = await projectPath(projectId)
+  const cwd = await resolveProjectPath(projectId)
   if (!cwd) return { ok: false, error: 'this project has no local path on this server' }
   return openInApp(cwd, target)
 }

--- a/packages/framework/src/dashboard-rpc/events.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/events.telefunc.ts
@@ -1,10 +1,10 @@
 import { join } from 'node:path'
-import { Channel, type ClientChannel } from 'telefunc'
+import type { ClientChannel } from 'telefunc'
 import { FRAMEWORK_DIR, EVENTS_FILE } from '../store/index.js'
 import { contextEventsSource, resolveProjectPath } from './context.js'
 import type { FrameworkEvent } from '../events.js'
 import { tailEvents } from './events-tail.js'
-import { forwardStream } from './stream-channel.js'
+import { forwardStream, streamChannel } from './stream-channel.js'
 
 // The live event stream behind the new dashboard (#405): the selected project's run,
 // read straight from the same `.the-framework/events.jsonl` the daemon writes. Each new
@@ -32,24 +32,12 @@ export async function onEvents(projectId: string): Promise<ClientChannel<never, 
   const source = contextEventsSource()
   if (source) {
     // The relay: replay + follow its in-memory run, mirroring how serveSSE consumes it.
-    const stream = source(projectId)
-    const channel = new Channel<never, FrameworkEvent>()
-    if (!stream) {
-      void channel.close()
-      return channel.client
-    }
-    const stop = forwardStream(stream, event => void channel.send(event))
-    channel.onClose(stop)
-    return channel.client
+    return streamChannel<FrameworkEvent>(send => {
+      const stream = source(projectId)
+      return stream ? forwardStream(stream, send) : undefined
+    })
   }
-
-  const channel = new Channel<never, FrameworkEvent>()
+  // Everywhere else: tail the project's on-disk events.jsonl (undefined path -> closed channel).
   const path = await resolveEventsPath(projectId)
-  if (!path) {
-    void channel.close()
-    return channel.client
-  }
-  const stop = tailEvents<FrameworkEvent>(path, event => void channel.send(event))
-  channel.onClose(stop)
-  return channel.client
+  return streamChannel<FrameworkEvent>(send => (path ? tailEvents(path, send) : undefined))
 }

--- a/packages/framework/src/dashboard-rpc/events.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/events.telefunc.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { Channel, type ClientChannel } from 'telefunc'
 import { FRAMEWORK_DIR, EVENTS_FILE } from '../store/index.js'
-import { contextProjects, contextEventsSource } from './context.js'
+import { contextEventsSource, resolveProjectPath } from './context.js'
 import type { FrameworkEvent } from '../events.js'
 import { tailEvents } from './events-tail.js'
 import { forwardStream } from './stream-channel.js'
@@ -14,7 +14,7 @@ import { forwardStream } from './stream-channel.js'
 
 /** The events file for a project id, or undefined when the project is unknown. */
 async function resolveEventsPath(projectId: string): Promise<string | undefined> {
-  const path = await contextProjects().resolvePath(projectId)
+  const path = await resolveProjectPath(projectId)
   return path ? join(path, FRAMEWORK_DIR, EVENTS_FILE) : undefined
 }
 

--- a/packages/framework/src/dashboard-rpc/projects.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/projects.telefunc.ts
@@ -1,7 +1,7 @@
 import { getContext } from 'telefunc'
 import { contextProjects } from './context.js'
 import type { ProjectSummary } from '../dashboard/projects.js'
-import type { AddProjectResult } from '../dashboard/server.js'
+import type { AddProjectResult } from '../dashboard/types.js'
 import type { DashboardContext } from '../dashboard/telefunc-serve.js'
 
 // The Projects sidebar behind the new dashboard (#405): the global registry (#390) the

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -8,7 +8,7 @@ import { githubUrlFor } from '../dashboard/github.js'
 import { readGitStatus, type GitStatus } from '../dashboard/git-status.js'
 import { crawlRepoFiles } from '../project.js'
 import { readFileStatuses, type FileGitStatus } from '../dashboard/file-status.js'
-import { contextProjects } from './context.js'
+import { contextProjects, resolveProjectPath } from './context.js'
 import type { FrameworkEvent } from '../events.js'
 
 // The read model behind the new dashboard (#405): the run history, a run's replay, the
@@ -19,9 +19,15 @@ import type { FrameworkEvent } from '../events.js'
 // in framework-dashboard, keeping the baked RPC keys `/server/reads.telefunc.ts`). The
 // live run stream is its own Telefunc Channel (events.telefunc.ts).
 
-/** The path for a project id (registry, or single-project #427), else undefined -> empty. */
-async function projectPath(projectId: string): Promise<string | undefined> {
-  return contextProjects().resolvePath(projectId)
+/**
+ * Resolve a project id and run a forgiving read against its workspace: an unknown project
+ * or a failing read both fall back to `empty`. The uniform readers below are one call each
+ * over this; the run history and null-returning git readers stay bespoke (extra logic or a
+ * distinct empty).
+ */
+async function withProject<T>(projectId: string, read: (cwd: string) => Promise<T>, empty: T): Promise<T> {
+  const cwd = await resolveProjectPath(projectId)
+  return cwd ? read(cwd).catch(() => empty) : empty
 }
 
 /**
@@ -32,7 +38,7 @@ async function projectPath(projectId: string): Promise<string | undefined> {
  * the same id (it then appears from `listRuns` instead), so there is no double.
  */
 export async function onRuns(projectId: string): Promise<RunMeta[]> {
-  const cwd = await projectPath(projectId)
+  const cwd = await resolveProjectPath(projectId)
   if (!cwd) return []
   const archived = await listRuns(cwd).catch(() => [])
   const live = await readLiveMeta(cwd).catch(() => undefined)
@@ -44,21 +50,19 @@ export async function onRuns(projectId: string): Promise<RunMeta[]> {
 
 /** One archived run's event log for replay (or `[]` when the run or project is gone). */
 export async function onRun(projectId: string, runId: string): Promise<FrameworkEvent[]> {
-  const cwd = await projectPath(projectId)
+  const cwd = await resolveProjectPath(projectId)
   if (!cwd) return []
   return (await loadRunEvents(cwd, runId).catch(() => undefined)) ?? []
 }
 
 /** The surfaced PLAN/TODO docs at the workspace root, in sidebar order (or `[]`). */
 export async function onDocs(projectId: string): Promise<WorkspaceDoc[]> {
-  const cwd = await projectPath(projectId)
-  return cwd ? readDocs(cwd).catch(() => []) : []
+  return withProject(projectId, readDocs, [])
 }
 
 /** The committed `.the-framework/LOGS.md` entries, newest-first (or `[]`). */
 export async function onProjectLog(projectId: string): Promise<LogEntry[]> {
-  const cwd = await projectPath(projectId)
-  return cwd ? readLogs(cwd).catch(() => []) : []
+  return withProject(projectId, readLogs, [])
 }
 
 /** The aggregated open TODO queue across every registered project (#438), most-open first. */
@@ -85,8 +89,7 @@ export async function onDashboard(): Promise<DashboardData> {
  * `git ls-files`. Localhost-only by nature — the relay has no checkout, so it resolves `[]`.
  */
 export async function onProjectFiles(projectId: string): Promise<string[]> {
-  const cwd = await projectPath(projectId)
-  return cwd ? crawlRepoFiles(cwd).catch(() => []) : []
+  return withProject(projectId, crawlRepoFiles, [])
 }
 
 /**
@@ -94,20 +97,19 @@ export async function onProjectFiles(projectId: string): Promise<string[]> {
  * deleted, from `git status --porcelain`. `{}` when not a repo / on the relay (no checkout).
  */
 export async function onProjectFileStatus(projectId: string): Promise<Record<string, FileGitStatus>> {
-  const cwd = await projectPath(projectId)
-  return cwd ? readFileStatuses(cwd).catch(() => ({})) : {}
+  return withProject(projectId, readFileStatuses, {})
 }
 
 /** The project's GitHub URL from its `origin` remote (#489), or null (no remote / not GitHub / relay). */
 export async function onGithubUrl(projectId: string): Promise<string | null> {
-  const cwd = await projectPath(projectId)
+  const cwd = await resolveProjectPath(projectId)
   if (!cwd) return null
   return (await githubUrlFor(cwd)) ?? null
 }
 
 /** The project's git status (#491): active branch, dirty flag, linked PR. Null when not a repo / relay. */
 export async function onGitStatus(projectId: string): Promise<GitStatus | null> {
-  const cwd = await projectPath(projectId)
+  const cwd = await resolveProjectPath(projectId)
   if (!cwd) return null
   return (await readGitStatus(cwd)) ?? null
 }

--- a/packages/framework/src/dashboard-rpc/stream-channel.ts
+++ b/packages/framework/src/dashboard-rpc/stream-channel.ts
@@ -1,10 +1,30 @@
+import { Channel, type ClientChannel } from 'telefunc'
+
+/**
+ * Wrap a live source in a Telefunc Channel (#405/#426): open the channel, hand `start` a
+ * `send` sink, and let it wire the source and hand back a stop function. When `start`
+ * returns undefined — an unknown project with nothing to stream — the channel closes
+ * immediately, mirroring the read model's empty results rather than throwing at the client;
+ * otherwise the stop runs on `.close()`. This owns the whole Channel lifecycle so the
+ * callers (events.telefunc.ts) read as "stream from this source" with no channel plumbing.
+ */
+export function streamChannel<T>(start: (send: (value: T) => void) => (() => void) | undefined): ClientChannel<never, T> {
+  const channel = new Channel<never, T>()
+  // `as never`: telefunc's ChannelData<T> wrapper doesn't resolve for a free type param
+  // (it does for a concrete event type); the sink is plain `T` for every caller.
+  const stop = start(value => void channel.send(value as never))
+  if (stop) channel.onClose(stop)
+  else void channel.close()
+  return channel.client
+}
+
 /**
  * Forward an async-iterable of events to a `send` sink until the source is exhausted or
  * the returned stop function is called (#426). This is the bridge behind the relay's
  * `onEvents`: the relay's in-memory run is an `AsyncIterable` that replays its buffered
  * history then follows live (exactly what `serveSSE` consumes), and each value becomes a
  * `channel.send(event)`. Kept transport-agnostic (a plain `send` callback, not a Channel)
- * so the pump can be driven and tested on its own; events.telefunc.ts wires the Channel.
+ * so the pump can be driven and tested on its own; {@link streamChannel} wires the Channel.
  *
  * Returns a stop function that halts forwarding and cancels the iterator, releasing the
  * follower waiting on the next event. Idempotent. An absent source is a no-op.
@@ -16,7 +36,7 @@ export function forwardStream<T>(iterable: AsyncIterable<T> | undefined, send: (
   void (async () => {
     try {
       for (let next = await iterator.next(); !next.done && !stopped; next = await iterator.next()) {
-        if (!stopped) send(next.value)
+        send(next.value)
       }
     } catch {
       // the stream closed or the consumer went away

--- a/packages/framework/src/dashboard/content-type.ts
+++ b/packages/framework/src/dashboard/content-type.ts
@@ -1,0 +1,32 @@
+import { extname } from 'node:path'
+
+/**
+ * Content types for the files the framework's two static servers hand out — the dashboard
+ * bundle (static.ts) and a project's on-demand Preview (preview.ts). One table so the two
+ * cannot drift apart, which they had: each was missing extensions the other listed. The two
+ * servers keep their own policies (SPA fallback + immutable cache vs 403 + stream); only this
+ * lookup is shared. Unknown extensions fall back to `application/octet-stream`.
+ */
+const CONTENT_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.map': 'application/json; charset=utf-8',
+  '.webmanifest': 'application/manifest+json',
+}
+
+/** The content type for a file path (by its extension), or `application/octet-stream`. */
+export function contentTypeFor(path: string): string {
+  return CONTENT_TYPES[extname(path).toLowerCase()] ?? 'application/octet-stream'
+}

--- a/packages/framework/src/dashboard/index.ts
+++ b/packages/framework/src/dashboard/index.ts
@@ -1,4 +1,5 @@
-export { startDashboard, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunOptions, type StartRunResult, type AddProjectResult, type PreviewResult, type PreviewStatus } from './server.js'
+export { startDashboard, type Dashboard, type DashboardOptions } from './server.js'
+export type { StartRunKind, StartRunOptions, StartRunResult, AddProjectResult, PreviewResult, PreviewStatus } from './types.js'
 export {
   summarizeProject,
   defaultProjectsProvider,

--- a/packages/framework/src/dashboard/index.ts
+++ b/packages/framework/src/dashboard/index.ts
@@ -1,4 +1,4 @@
-export { startDashboard, isSameOriginRequest, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunOptions, type StartRunResult, type AddProjectResult, type PreviewResult, type PreviewStatus } from './server.js'
+export { startDashboard, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunOptions, type StartRunResult, type AddProjectResult, type PreviewResult, type PreviewStatus } from './server.js'
 export {
   summarizeProject,
   defaultProjectsProvider,
@@ -9,7 +9,7 @@ export {
   type SummarizeDeps,
 } from './projects.js'
 export { resolveDashboardBundle } from './bundle.js'
-export { makeTelefuncMount, type EventsSource } from './telefunc-serve.js'
+export { makeTelefuncMount, isSameOriginRequest, type EventsSource } from './telefunc-serve.js'
 export { serveClientBundle } from './static.js'
 export { readDocs, DOC_CATEGORIES, type WorkspaceDoc } from './docs.js'
 export { collectQueue, parseTodoItems, type ProjectQueue, type QueueItem } from './queue.js'

--- a/packages/framework/src/dashboard/overview.ts
+++ b/packages/framework/src/dashboard/overview.ts
@@ -1,6 +1,4 @@
-import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
-import { FRAMEWORK_DIR, META_FILE, type RunMeta, type RunStatus } from '../store/index.js'
+import { readLiveMeta, type RunMeta, type RunStatus } from '../store/index.js'
 import type { ProjectSummary } from './projects.js'
 import { collectQueue, type ProjectQueue } from './queue.js'
 
@@ -45,15 +43,6 @@ export interface Overview {
 
 /** How many recent projects the Overview surfaces. */
 const RECENT_LIMIT = 5
-
-/** Read a project's live run meta (`.the-framework/run.json`), or undefined when absent/unreadable. */
-async function readLiveMeta(cwd: string): Promise<RunMeta | undefined> {
-  try {
-    return JSON.parse(await readFile(join(cwd, FRAMEWORK_DIR, META_FILE), 'utf8')) as RunMeta
-  } catch {
-    return undefined
-  }
-}
 
 /** Injectable readers so {@link buildOverview} is unit-testable off disk. */
 export interface OverviewDeps {

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -4,7 +4,8 @@ import { get, request } from 'node:http'
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { startDashboard, isSameOriginRequest } from './server.js'
+import { startDashboard } from './server.js'
+import { isSameOriginRequest } from './telefunc-serve.js'
 import type { IncomingMessage } from 'node:http'
 
 function fetchText(url: string): Promise<{ status: number; body: string; type: string }> {

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -117,15 +117,14 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
   // `projects` is passed raw (may be undefined) so the mount falls back to the global
   // registry, byte-identical to the daemon default; the per-run dashboard passes a
   // single-project provider, the relay an empty one.
-  const telefuncMount = makeTelefuncMount(
-    opts.onStart,
-    opts.projects,
-    undefined,
-    opts.onAddProject,
-    opts.preferences ?? registryPreferencesStore(),
-    preview,
+  const telefuncMount = makeTelefuncMount({
+    ...(opts.onStart ? { startRun: opts.onStart } : {}),
+    ...(opts.projects ? { projects: opts.projects } : {}),
+    ...(opts.onAddProject ? { addProject: opts.onAddProject } : {}),
+    ...(preview ? { preview } : {}),
+    preferences: opts.preferences ?? registryPreferencesStore(),
     quota,
-  )
+  })
 
   const server = createServer((req, res) => {
     const { pathname } = new URL(req.url ?? '/', 'http://localhost')

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -7,8 +7,6 @@ import { serveClientBundle } from './static.js'
 import { makeTelefuncMount } from './telefunc-serve.js'
 import type { AddProjectResult, PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from './types.js'
 
-export type { AddProjectResult, PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from './types.js'
-
 /** Options for {@link startDashboard}. */
 export interface DashboardOptions {
   /** Port to bind. Default `4200`; pass `0` for an ephemeral port. */

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -1,11 +1,13 @@
-import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import { createServer, type Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
-import type { EcoOptions } from '../system-prompt.js'
 import type { ProjectsProvider } from './projects.js'
 import { registryPreferencesStore, type PreferencesStore } from '../registry.js'
 import { defaultQuotaSource, type QuotaSource } from './quota.js'
 import { serveClientBundle } from './static.js'
 import { makeTelefuncMount } from './telefunc-serve.js'
+import type { AddProjectResult, PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from './types.js'
+
+export type { AddProjectResult, PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from './types.js'
 
 /** Options for {@link startDashboard}. */
 export interface DashboardOptions {
@@ -69,60 +71,6 @@ export interface DashboardOptions {
    * no built bundle, where the server reports the bundle is missing.
    */
   clientBundleDir?: string
-}
-
-/** The outcome of an {@link DashboardOptions.onAddProject} attempt (#396). */
-export type AddProjectResult =
-  | { ok: true; added: number; alreadyActivated: number }
-  | { ok: false; error: string }
-
-/**
- * The dashboard's Global options (#314), posted alongside a Start. Each maps to a
- * run flag: Autopilot + Technical to modes, Vanilla to removing the built-in
- * system prompt, and Eco to the fine-grained #326 section drops. Absent fields
- * default off, i.e. today's behavior.
- */
-export interface StartRunOptions {
-  /** Auto-accept mode; also steers the #326 maintenance stance. */
-  autopilot?: boolean
-  /** Technical mode: expose technical detail (preset-scoped). */
-  technical?: boolean
-  /** Remove the built-in #326 system prompt entirely (raw Claude Code). */
-  vanilla?: boolean
-  /** Fine-grained #326 section drops to save tokens. */
-  eco?: EcoOptions
-  /** In-context directories (#439): each becomes a `--context <dir>` flag on the spawned run. */
-  context?: string[]
-  /** On-before-mergeable prompt (#326): on setReadyForMerge(), queue the quality follow-ups as TODO entries; maps to `--on-before-mergeable`. */
-  onBeforeMergeable?: boolean
-  /** Give the agent a real browser via chrome-devtools-mcp during the run (#452); maps to `--browser`. */
-  browser?: boolean
-}
-
-/**
- * What a dashboard Start spawns (#345/#331/#353): `build` is the normal framework
- * run; `prompt` runs the posted text verbatim through the direct path — what the
- * page sends after a preset prefilled (and the user possibly edited) the textarea;
- * `research` renders the [Research] preset around the posted "what" server-side
- * (empty allowed, defaults to `this PR`) and remains for API callers.
- */
-export type StartRunKind = 'build' | 'research' | 'prompt'
-
-/** The outcome of an {@link DashboardOptions.onStart} attempt (#345). */
-export type StartRunResult =
-  | { ok: true }
-  | { ok: false; busy?: boolean; error: string }
-
-/** The outcome of an {@link DashboardOptions.onPreview} attempt (#475): the live URL, or why not. */
-export type PreviewResult =
-  | { ok: true; url: string; command: string }
-  | { ok: false; error: string }
-
-/** Whether a project's Preview is running, and where (#475). */
-export interface PreviewStatus {
-  running: boolean
-  url?: string
-  command?: string
 }
 
 /** A running localhost dashboard: the prerendered SPA + its Telefunc mount. */
@@ -205,27 +153,6 @@ function listenDashboard(server: Server, host: string, port: number, close: () =
       resolvePromise({ url: `http://${host}:${address.port}`, close })
     })
   })
-}
-
-/**
- * CSRF guard for the state-changing Telefunc calls. A browser attaches an `Origin`
- * header to every cross-site request, so we reject any POST whose Origin is not this
- * same server (or a loopback host) — otherwise a page on `evil.com` could `fetch()` the
- * localhost dashboard and spawn/steer a run. An absent Origin means a non-browser caller
- * (curl, the test suite) with no ambient session to abuse, so it passes.
- */
-export function isSameOriginRequest(req: IncomingMessage): boolean {
-  const origin = req.headers.origin
-  if (!origin) return true
-  const host = req.headers.host
-  if (host && (origin === `http://${host}` || origin === `https://${host}`)) return true
-  let hostname: string
-  try {
-    hostname = new URL(origin).hostname
-  } catch {
-    return false // malformed Origin: treat as cross-origin
-  }
-  return hostname === 'localhost' || hostname === '::1' || hostname === '[::1]' || hostname.startsWith('127.')
 }
 
 function closeServer(server: Server): Promise<void> {

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -146,9 +146,18 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
   const host = opts.host ?? '127.0.0.1'
   const port = opts.port ?? 4200
   const clientBundleDir = opts.clientBundleDir
-  // `projects` is passed raw (may be undefined) so the mount falls back to the global
-  // registry, byte-identical to the daemon default; the per-run dashboard passes a
-  // single-project provider, the relay an empty one.
+
+  // A broken install ships no built bundle (the published package always does), so serve
+  // 503 for everything rather than stand up a half-wired mount. Returning here lets the
+  // main path below treat the bundle, mount, and quota as present with no re-checks.
+  if (!clientBundleDir) {
+    const server = createServer((_req, res) => {
+      res.writeHead(503, { 'content-type': 'text/plain' })
+      res.end('the dashboard bundle is not installed')
+    })
+    return listenDashboard(server, host, port, () => closeServer(server))
+  }
+
   // Bundle the three Preview callbacks (#475) into one context handler set, present only
   // when the host wired a Preview (the daemon does; the relay/per-run dashboard do not).
   const preview = opts.onPreview
@@ -156,49 +165,44 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
     : undefined
   // The usage panel polls for the dashboard's whole life, not just during a run:
   // it has to show where the account stands while nothing is running (#533).
-  const quota = clientBundleDir ? (opts.quota ?? defaultQuotaSource()) : undefined
-  const telefuncMount = clientBundleDir
-    ? makeTelefuncMount(
-        opts.onStart,
-        opts.projects,
-        undefined,
-        opts.onAddProject,
-        opts.preferences ?? registryPreferencesStore(),
-        preview,
-        quota,
-      )
-    : undefined
+  const quota = opts.quota ?? defaultQuotaSource()
+  // `projects` is passed raw (may be undefined) so the mount falls back to the global
+  // registry, byte-identical to the daemon default; the per-run dashboard passes a
+  // single-project provider, the relay an empty one.
+  const telefuncMount = makeTelefuncMount(
+    opts.onStart,
+    opts.projects,
+    undefined,
+    opts.onAddProject,
+    opts.preferences ?? registryPreferencesStore(),
+    preview,
+    quota,
+  )
 
   const server = createServer((req, res) => {
-    if (!clientBundleDir) {
-      // A broken install with no built bundle (the published package ships it).
-      res.writeHead(503, { 'content-type': 'text/plain' })
-      res.end('the dashboard bundle is not installed')
-      return
-    }
     const { pathname } = new URL(req.url ?? '/', 'http://localhost')
     if (pathname === '/_telefunc' || pathname.startsWith('/_telefunc/')) {
-      void telefuncMount!(req, res)
+      void telefuncMount(req, res)
       return
     }
     void serveClientBundle(req, res, clientBundleDir)
   })
+  return listenDashboard(server, host, port, async () => {
+    // Stop polling with the server: the poller outlives every run by design,
+    // so nothing else would ever end it.
+    quota.stop()
+    await closeServer(server)
+  })
+}
 
+/** Bind the server and resolve a {@link Dashboard} handle; rejects if the port is already taken. */
+function listenDashboard(server: Server, host: string, port: number, close: () => Promise<void>): Promise<Dashboard> {
   return new Promise<Dashboard>((resolvePromise, rejectPromise) => {
     server.once('error', rejectPromise)
     server.listen(port, host, () => {
       server.removeListener('error', rejectPromise)
       const address = server.address() as AddressInfo
-      const url = `http://${host}:${address.port}`
-      resolvePromise({
-        url,
-        close: async () => {
-          // Stop polling with the server: the poller outlives every run by design,
-          // so nothing else would ever end it.
-          quota?.stop()
-          await closeServer(server)
-        },
-      })
+      resolvePromise({ url: `http://${host}:${address.port}`, close })
     })
   })
 }

--- a/packages/framework/src/dashboard/static.ts
+++ b/packages/framework/src/dashboard/static.ts
@@ -1,29 +1,13 @@
 import { readFile, stat } from 'node:fs/promises'
-import { extname, join, normalize, sep } from 'node:path'
+import { join, normalize, sep } from 'node:path'
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import { contentTypeFor } from './content-type.js'
 
 // Serve the prerendered dashboard bundle (#405). The new dashboard is a Vike `ssr:false`
 // SPA prerendered to a static `index.html` + `assets/**`, so the daemon serves it as
 // plain files with an SPA fallback (any non-asset path yields `index.html`, which boots
 // the client router) — no Vike runtime in the daemon. Assets are copied into the
 // framework package at build time (see scripts/bundle-dashboard.mjs).
-
-const CONTENT_TYPES: Record<string, string> = {
-  '.html': 'text/html; charset=utf-8',
-  '.js': 'text/javascript; charset=utf-8',
-  '.mjs': 'text/javascript; charset=utf-8',
-  '.css': 'text/css; charset=utf-8',
-  '.json': 'application/json; charset=utf-8',
-  '.svg': 'image/svg+xml',
-  '.ico': 'image/x-icon',
-  '.png': 'image/png',
-  '.jpg': 'image/jpeg',
-  '.webp': 'image/webp',
-  '.woff': 'font/woff',
-  '.woff2': 'font/woff2',
-  '.map': 'application/json; charset=utf-8',
-  '.webmanifest': 'application/manifest+json',
-}
 
 /** Whether a real, readable file exists at `path`. */
 async function isFile(path: string): Promise<boolean> {
@@ -50,7 +34,7 @@ export async function serveClientBundle(req: IncomingMessage, res: ServerRespons
     res.end('dashboard bundle not built')
     return
   }
-  const type = CONTENT_TYPES[extname(target)] ?? 'application/octet-stream'
+  const type = contentTypeFor(target)
   // Fingerprinted assets are immutable; index.html must always revalidate.
   const cacheControl = target.endsWith('index.html') ? 'no-cache' : 'public, max-age=31536000, immutable'
   res.writeHead(200, { 'content-type': type, 'cache-control': cacheControl })

--- a/packages/framework/src/dashboard/telefunc-serve.ts
+++ b/packages/framework/src/dashboard/telefunc-serve.ts
@@ -93,17 +93,14 @@ export function isSameOriginRequest(req: IncomingMessage): boolean {
  * Mount the dashboard's Telefunc surface (#405) on the daemon's `node:http` server: one
  * `serve()` handles both the RPCs and the Channel SSE stream at `/_telefunc`. Telefunc
  * runs in the daemon process, so a `sendStart` telefunction can call the daemon's own
- * `startRun` via the request context. Cross-origin POSTs are rejected (CSRF: a page on
- * evil.com must not steer or start a run). Returns whether the request was Telefunc's.
+ * `startRun` via the request context. The `context` is exactly what each telefunction
+ * reaches through {@link getContext} (see {@link DashboardContext}): the daemon wires the
+ * full set, the relay passes only an events source plus an empty projects provider. Cross-
+ * origin POSTs are rejected (CSRF: a page on evil.com must not steer or start a run).
+ * Returns whether the request was Telefunc's.
  */
 export function makeTelefuncMount(
-  startRun?: StartRunHandler,
-  projects?: ProjectsProvider,
-  eventsSource?: EventsSource,
-  addProject?: AddProjectHandler,
-  preferences?: PreferencesStore,
-  preview?: PreviewHandlers,
-  quota?: QuotaSource,
+  context: DashboardContext = {},
 ): (req: IncomingMessage, res: ServerResponse) => Promise<boolean> {
   return async (req, res) => {
     if (!isSameOriginRequest(req)) {
@@ -112,15 +109,6 @@ export function makeTelefuncMount(
       return true
     }
     const tf = setup()
-    const context: DashboardContext = {
-      ...(startRun ? { startRun } : {}),
-      ...(addProject ? { addProject } : {}),
-      ...(preview ? { preview } : {}),
-      ...(projects ? { projects } : {}),
-      ...(eventsSource ? { eventsSource } : {}),
-      ...(preferences ? { preferences } : {}),
-      ...(quota ? { quota } : {}),
-    }
     // Never let a telefunc failure become an unhandled rejection that kills the daemon:
     // telefunc 0.2.22 throws on a bare `GET /_telefunc` (it passes the request as a body,
     // which `new Request()` rejects for GET), and a browser tab hits that on reconnect.

--- a/packages/framework/src/dashboard/telefunc-serve.ts
+++ b/packages/framework/src/dashboard/telefunc-serve.ts
@@ -6,7 +6,7 @@ import type { ProjectsProvider } from './projects.js'
 import type { FrameworkEvent } from '../events.js'
 import type { PreferencesStore } from '../registry.js'
 import type { QuotaSource } from './quota.js'
-import { isSameOriginRequest, type AddProjectResult, type PreviewResult, type PreviewStatus, type StartRunKind, type StartRunOptions, type StartRunResult } from './server.js'
+import type { AddProjectResult, PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from './types.js'
 
 /** Wired by the daemon so `sendStart` can reach the daemon's own `startRun` closure. */
 export type StartRunHandler = (
@@ -65,6 +65,28 @@ function setup(): Telefunc {
   registerDashboardTelefunctions()
   instance = new Telefunc()
   return instance
+}
+
+/**
+ * CSRF guard for the state-changing Telefunc calls. A browser attaches an `Origin`
+ * header to every cross-site request, so we reject any POST whose Origin is not this
+ * same server (or a loopback host) — otherwise a page on `evil.com` could `fetch()` the
+ * localhost dashboard and spawn/steer a run. An absent Origin means a non-browser caller
+ * (curl, the test suite) with no ambient session to abuse, so it passes. Lives here beside
+ * the mount, its only caller.
+ */
+export function isSameOriginRequest(req: IncomingMessage): boolean {
+  const origin = req.headers.origin
+  if (!origin) return true
+  const host = req.headers.host
+  if (host && (origin === `http://${host}` || origin === `https://${host}`)) return true
+  let hostname: string
+  try {
+    hostname = new URL(origin).hostname
+  } catch {
+    return false // malformed Origin: treat as cross-origin
+  }
+  return hostname === 'localhost' || hostname === '::1' || hostname === '[::1]' || hostname.startsWith('127.')
 }
 
 /**

--- a/packages/framework/src/dashboard/types.ts
+++ b/packages/framework/src/dashboard/types.ts
@@ -1,0 +1,59 @@
+import type { EcoOptions } from '../system-prompt.js'
+
+// The dashboard's request/result vocabulary (#345/#396/#475): the shapes the Start / Add /
+// Preview RPCs speak. They live here, on neither the HTTP server nor the Telefunc mount, so
+// both — plus the telefunctions themselves — depend on this leaf rather than on each other.
+
+/** The outcome of an add-project attempt (#396). */
+export type AddProjectResult =
+  | { ok: true; added: number; alreadyActivated: number }
+  | { ok: false; error: string }
+
+/**
+ * The dashboard's Global options (#314), posted alongside a Start. Each maps to a
+ * run flag: Autopilot + Technical to modes, Vanilla to removing the built-in
+ * system prompt, and Eco to the fine-grained #326 section drops. Absent fields
+ * default off, i.e. today's behavior.
+ */
+export interface StartRunOptions {
+  /** Auto-accept mode; also steers the #326 maintenance stance. */
+  autopilot?: boolean
+  /** Technical mode: expose technical detail (preset-scoped). */
+  technical?: boolean
+  /** Remove the built-in #326 system prompt entirely (raw Claude Code). */
+  vanilla?: boolean
+  /** Fine-grained #326 section drops to save tokens. */
+  eco?: EcoOptions
+  /** In-context directories (#439): each becomes a `--context <dir>` flag on the spawned run. */
+  context?: string[]
+  /** On-before-mergeable prompt (#326): on setReadyForMerge(), queue the quality follow-ups as TODO entries; maps to `--on-before-mergeable`. */
+  onBeforeMergeable?: boolean
+  /** Give the agent a real browser via chrome-devtools-mcp during the run (#452); maps to `--browser`. */
+  browser?: boolean
+}
+
+/**
+ * What a dashboard Start spawns (#345/#331/#353): `build` is the normal framework
+ * run; `prompt` runs the posted text verbatim through the direct path — what the
+ * page sends after a preset prefilled (and the user possibly edited) the textarea;
+ * `research` renders the [Research] preset around the posted "what" server-side
+ * (empty allowed, defaults to `this PR`) and remains for API callers.
+ */
+export type StartRunKind = 'build' | 'research' | 'prompt'
+
+/** The outcome of a Start attempt (#345). */
+export type StartRunResult =
+  | { ok: true }
+  | { ok: false; busy?: boolean; error: string }
+
+/** The outcome of a Preview attempt (#475): the live URL, or why not. */
+export type PreviewResult =
+  | { ok: true; url: string; command: string }
+  | { ok: false; error: string }
+
+/** Whether a project's Preview is running, and where (#475). */
+export interface PreviewStatus {
+  running: boolean
+  url?: string
+  command?: string
+}

--- a/packages/framework/src/driver/agent-cli.ts
+++ b/packages/framework/src/driver/agent-cli.ts
@@ -1,0 +1,172 @@
+import { createInterface } from 'node:readline'
+import { killTree, registerChild, unregisterChild } from './child-registry.js'
+import type { DriverEvent, DriverTurn } from './types.js'
+
+// The agent-agnostic core for running one wrapped coding-agent CLI: spawn it in its own
+// process group, stream its output through a parser, and gate the turn on its exit. Each
+// concrete driver (claude-code, codex) supplies the argv and an AgentCliParser for its own
+// output dialect; everything about the *process* lives here, so a second driver reuses it
+// rather than reaching into the first driver's file for it.
+
+/** Grace between SIGTERM and the SIGKILL that forces a hung agent tree down. */
+const TERMINATE_GRACE_MS = 5000
+
+/** The slice of `child_process.spawn` a driver needs. Injectable for tests. */
+export type SpawnLike = (
+  command: string,
+  args: readonly string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv; detached?: boolean },
+) => SpawnedProcess
+
+/** The slice of a spawned process a driver reads. */
+export interface SpawnedProcess {
+  /** OS pid; present for a real child, absent for in-memory test fakes. */
+  pid?: number | undefined
+  stdout: NodeJS.ReadableStream | null
+  stderr: NodeJS.ReadableStream | null
+  stdin: NodeJS.WritableStream | null
+  on(event: 'close', listener: (code: number | null) => void): unknown
+  on(event: 'error', listener: (err: Error) => void): unknown
+  kill(signal?: NodeJS.Signals): unknown
+}
+
+/**
+ * The slice of a driver's output parser {@link runAgentCli} drives: fed one line
+ * at a time, asked for the turn at the end. Each wrapped agent speaks its own
+ * dialect ({@link StreamJsonParser} for Claude Code, `CodexJsonParser` for
+ * Codex), but the process handling around it is identical.
+ */
+export interface AgentCliParser {
+  /** Fold one line of the agent's output in, and surface anything worth emitting. */
+  push(line: string): DriverEvent[]
+  /** The turn the lines added up to. */
+  result(): DriverTurn
+}
+
+/** How to run one agent-CLI invocation. */
+export interface RunAgentCliOptions {
+  bin: string
+  args: string[]
+  cwd: string
+  env: NodeJS.ProcessEnv
+  prompt: string
+  spawn: SpawnLike
+  emit: (event: DriverEvent) => void
+  signals: AbortSignal[]
+  /** The agent's own output dialect. */
+  parser: AgentCliParser
+  /** The agent's name, for error messages. Default `"claude-code"`. */
+  agent?: string
+}
+
+/**
+ * Spawn one agent-CLI invocation and resolve with its final turn.
+ *
+ * Everything here is about the *process*, not the agent: its own process group
+ * so an interrupt kills the whole tree rather than orphaning it, a SIGTERM/
+ * SIGKILL grace window, abort wiring, and a non-zero exit failing the turn even
+ * when text was streamed first. Only {@link RunAgentCliOptions.parser} knows
+ * which agent is on the other end — a second agent gets all of this for free
+ * rather than a second copy of it.
+ */
+export function runAgentCli(opts: RunAgentCliOptions): Promise<DriverTurn> {
+  return new Promise<DriverTurn>((resolvePromise, rejectPromise) => {
+    for (const s of opts.signals) {
+      if (s.aborted) {
+        rejectPromise(new Error(`[framework] ${opts.agent ?? 'claude-code'} prompt aborted`))
+        return
+      }
+    }
+
+    opts.emit({ type: 'start', prompt: opts.prompt })
+    // `detached` makes the child its own process-group leader so we can kill the
+    // whole agent subtree (claude + node workers + tool calls) at once, not just
+    // the top process — otherwise an interrupt orphans the tree (the leak).
+    const child = opts.spawn(opts.bin, opts.args, { cwd: opts.cwd, env: opts.env, detached: true })
+    const pid = child.pid
+    if (pid != null) registerChild(pid)
+    const parser = opts.parser
+    const agent = opts.agent ?? 'claude-code'
+    let settled = false
+    let hardKillTimer: ReturnType<typeof setTimeout> | undefined
+    const stderrChunks: string[] = []
+
+    // Kill the agent's whole process group: SIGTERM to let it flush, then a
+    // SIGKILL after a grace window in case it ignores the term (mid tool-call).
+    const terminate = () => {
+      if (pid != null) killTree(pid, 'SIGTERM')
+      else child.kill('SIGTERM')
+      hardKillTimer = setTimeout(() => {
+        if (pid != null) killTree(pid, 'SIGKILL')
+        else child.kill('SIGKILL')
+      }, TERMINATE_GRACE_MS)
+      hardKillTimer.unref?.()
+    }
+
+    // Runs exactly once the process is done with (closed, errored, or killed):
+    // stop tracking it and cancel any pending hard-kill.
+    const cleanup = () => {
+      if (pid != null) unregisterChild(pid)
+      if (hardKillTimer) clearTimeout(hardKillTimer)
+    }
+
+    const finish = (fn: () => void) => {
+      if (settled) return
+      settled = true
+      for (const { signal, handler } of aborts) signal.removeEventListener('abort', handler)
+      fn()
+    }
+
+    const aborts = opts.signals.map(signal => {
+      const handler = () => {
+        if (settled) return
+        terminate()
+        finish(() => rejectPromise(new Error(`[framework] ${agent} prompt aborted`)))
+      }
+      signal.addEventListener('abort', handler)
+      return { signal, handler }
+    })
+
+    child.on('error', err => {
+      cleanup()
+      finish(() => rejectPromise(err))
+    })
+
+    if (child.stdout) {
+      const rl = createInterface({ input: child.stdout })
+      rl.on('line', line => {
+        for (const event of parser.push(line)) opts.emit(event)
+      })
+    }
+    if (child.stderr) {
+      child.stderr.on('data', (chunk: Buffer | string) => stderrChunks.push(String(chunk)))
+    }
+
+    child.on('close', code => {
+      cleanup()
+      const turn = parser.result()
+      // A non-zero exit is a failed turn even when the agent streamed some text
+      // first: the loop gates on the outcome, so a crash mid-build must not pass
+      // as a result. Surface stderr, else the partial text, as context.
+      if (code !== 0) {
+        const detail = stderrChunks.join('').trim() || turn.text.trim() || `exit code ${code ?? 'null'}`
+        opts.emit({ type: 'error', message: detail })
+        finish(() => rejectPromise(new Error(`[framework] ${agent} exited (${code ?? 'null'}): ${detail}`)))
+        return
+      }
+      opts.emit({
+        type: 'result',
+        text: turn.text,
+        ...(turn.sessionId ? { sessionId: turn.sessionId } : {}),
+        ...(turn.usage ? { usage: turn.usage } : {}),
+      })
+      finish(() => resolvePromise(turn))
+    })
+
+    // Feed the prompt over stdin so long prompts never hit arg-length limits.
+    if (child.stdin) {
+      child.stdin.write(opts.prompt)
+      child.stdin.end()
+    }
+  })
+}

--- a/packages/framework/src/driver/claude-code-quota.test.ts
+++ b/packages/framework/src/driver/claude-code-quota.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { Readable, Writable } from 'node:stream'
 import { parseQuotaReadout, readClaudeQuota } from './claude-code-quota.js'
-import type { SpawnLike, SpawnedProcess } from './claude-code.js'
+import type { SpawnLike, SpawnedProcess } from './agent-cli.js'
 import { isTransientQuotaReason } from './types.js'
 
 /**

--- a/packages/framework/src/driver/claude-code-quota.ts
+++ b/packages/framework/src/driver/claude-code-quota.ts
@@ -1,6 +1,6 @@
 import { spawn as nodeSpawn } from 'node:child_process'
 import type { DriverQuota, DriverQuotaWindow } from './types.js'
-import type { SpawnLike } from './claude-code.js'
+import type { SpawnLike } from './agent-cli.js'
 
 /** How long we wait for the readout before calling it a timeout. */
 const READ_TIMEOUT_MS = 20_000

--- a/packages/framework/src/driver/claude-code.test.ts
+++ b/packages/framework/src/driver/claude-code.test.ts
@@ -2,7 +2,8 @@ import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { Readable, Writable } from 'node:stream'
 import { existsSync, readFileSync } from 'node:fs'
-import { ClaudeCodeDriver, StreamJsonParser, runClaude, type SpawnLike, type SpawnedProcess } from './claude-code.js'
+import { ClaudeCodeDriver, StreamJsonParser, runClaude } from './claude-code.js'
+import type { SpawnLike, SpawnedProcess } from './agent-cli.js'
 import type { DriverEvent } from './types.js'
 
 test('StreamJsonParser surfaces assistant text + tool names, keeps the result', () => {

--- a/packages/framework/src/driver/claude-code.ts
+++ b/packages/framework/src/driver/claude-code.ts
@@ -1,15 +1,11 @@
 import { spawn as nodeSpawn } from 'node:child_process'
-import { createInterface } from 'node:readline'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { killTree, registerChild, unregisterChild } from './child-registry.js'
 import { readClaudeQuota } from './claude-code-quota.js'
 import { combineFraming, combineSignals, makeEmit, readWorkspaceFile } from './session-support.js'
+import { runAgentCli, type RunAgentCliOptions, type SpawnLike } from './agent-cli.js'
 import type { Driver, DriverEvent, DriverPromptOptions, DriverQuota, DriverRateLimit, DriverSession, DriverStartOptions, DriverTurn, DriverUsage } from './types.js'
-
-/** Grace between SIGTERM and the SIGKILL that forces a hung agent tree down. */
-const TERMINATE_GRACE_MS = 5000
 
 /** Claude Code permission modes we pass through to the CLI. */
 export type PermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan'
@@ -19,25 +15,6 @@ export interface McpServerSpec {
   command: string
   args?: string[]
   env?: Record<string, string>
-}
-
-/** The slice of `child_process.spawn` this driver needs. Injectable for tests. */
-export type SpawnLike = (
-  command: string,
-  args: readonly string[],
-  options: { cwd: string; env: NodeJS.ProcessEnv; detached?: boolean },
-) => SpawnedProcess
-
-/** The slice of a spawned process this driver reads. */
-export interface SpawnedProcess {
-  /** OS pid; present for a real child, absent for in-memory test fakes. */
-  pid?: number | undefined
-  stdout: NodeJS.ReadableStream | null
-  stderr: NodeJS.ReadableStream | null
-  stdin: NodeJS.WritableStream | null
-  on(event: 'close', listener: (code: number | null) => void): unknown
-  on(event: 'error', listener: (err: Error) => void): unknown
-  kill(signal?: NodeJS.Signals): unknown
 }
 
 /** Options for {@link ClaudeCodeDriver}. */
@@ -177,153 +154,12 @@ export class ClaudeCodeSession implements DriverSession {
   }
 }
 
-/**
- * The slice of a driver's output parser {@link runAgentCli} drives: fed one line
- * at a time, asked for the turn at the end. Each wrapped agent speaks its own
- * dialect ({@link StreamJsonParser} for Claude Code, `CodexJsonParser` for
- * Codex), but the process handling around it is identical.
- */
-export interface AgentCliParser {
-  /** Fold one line of the agent's output in, and surface anything worth emitting. */
-  push(line: string): DriverEvent[]
-  /** The turn the lines added up to. */
-  result(): DriverTurn
-}
-
-/** How to run one agent-CLI invocation. */
-export interface RunAgentCliOptions {
-  bin: string
-  args: string[]
-  cwd: string
-  env: NodeJS.ProcessEnv
-  prompt: string
-  spawn: SpawnLike
-  emit: (event: DriverEvent) => void
-  signals: AbortSignal[]
-  /** The agent's own output dialect. */
-  parser: AgentCliParser
-  /** The agent's name, for error messages. Default `"claude-code"`. */
-  agent?: string
-}
-
 /** @deprecated Use {@link RunAgentCliOptions}. */
 export type RunClaudeOptions = Omit<RunAgentCliOptions, 'parser' | 'agent'>
 
 /** Spawn one Claude Code invocation and resolve with its final turn. */
 export function runClaude(opts: RunClaudeOptions): Promise<DriverTurn> {
   return runAgentCli({ ...opts, parser: new StreamJsonParser() })
-}
-
-/**
- * Spawn one agent-CLI invocation and resolve with its final turn.
- *
- * Everything here is about the *process*, not the agent: its own process group
- * so an interrupt kills the whole tree rather than orphaning it, a SIGTERM/
- * SIGKILL grace window, abort wiring, and a non-zero exit failing the turn even
- * when text was streamed first. Only {@link RunAgentCliOptions.parser} knows
- * which agent is on the other end — a second agent gets all of this for free
- * rather than a second copy of it.
- */
-export function runAgentCli(opts: RunAgentCliOptions): Promise<DriverTurn> {
-  return new Promise<DriverTurn>((resolvePromise, rejectPromise) => {
-    for (const s of opts.signals) {
-      if (s.aborted) {
-        rejectPromise(new Error(`[framework] ${opts.agent ?? 'claude-code'} prompt aborted`))
-        return
-      }
-    }
-
-    opts.emit({ type: 'start', prompt: opts.prompt })
-    // `detached` makes the child its own process-group leader so we can kill the
-    // whole agent subtree (claude + node workers + tool calls) at once, not just
-    // the top process — otherwise an interrupt orphans the tree (the leak).
-    const child = opts.spawn(opts.bin, opts.args, { cwd: opts.cwd, env: opts.env, detached: true })
-    const pid = child.pid
-    if (pid != null) registerChild(pid)
-    const parser = opts.parser
-    const agent = opts.agent ?? 'claude-code'
-    let settled = false
-    let hardKillTimer: ReturnType<typeof setTimeout> | undefined
-    const stderrChunks: string[] = []
-
-    // Kill the agent's whole process group: SIGTERM to let it flush, then a
-    // SIGKILL after a grace window in case it ignores the term (mid tool-call).
-    const terminate = () => {
-      if (pid != null) killTree(pid, 'SIGTERM')
-      else child.kill('SIGTERM')
-      hardKillTimer = setTimeout(() => {
-        if (pid != null) killTree(pid, 'SIGKILL')
-        else child.kill('SIGKILL')
-      }, TERMINATE_GRACE_MS)
-      hardKillTimer.unref?.()
-    }
-
-    // Runs exactly once the process is done with (closed, errored, or killed):
-    // stop tracking it and cancel any pending hard-kill.
-    const cleanup = () => {
-      if (pid != null) unregisterChild(pid)
-      if (hardKillTimer) clearTimeout(hardKillTimer)
-    }
-
-    const finish = (fn: () => void) => {
-      if (settled) return
-      settled = true
-      for (const { signal, handler } of aborts) signal.removeEventListener('abort', handler)
-      fn()
-    }
-
-    const aborts = opts.signals.map(signal => {
-      const handler = () => {
-        if (settled) return
-        terminate()
-        finish(() => rejectPromise(new Error(`[framework] ${agent} prompt aborted`)))
-      }
-      signal.addEventListener('abort', handler)
-      return { signal, handler }
-    })
-
-    child.on('error', err => {
-      cleanup()
-      finish(() => rejectPromise(err))
-    })
-
-    if (child.stdout) {
-      const rl = createInterface({ input: child.stdout })
-      rl.on('line', line => {
-        for (const event of parser.push(line)) opts.emit(event)
-      })
-    }
-    if (child.stderr) {
-      child.stderr.on('data', (chunk: Buffer | string) => stderrChunks.push(String(chunk)))
-    }
-
-    child.on('close', code => {
-      cleanup()
-      const turn = parser.result()
-      // A non-zero exit is a failed turn even when the agent streamed some text
-      // first: the loop gates on the outcome, so a crash mid-build must not pass
-      // as a result. Surface stderr, else the partial text, as context.
-      if (code !== 0) {
-        const detail = stderrChunks.join('').trim() || turn.text.trim() || `exit code ${code ?? 'null'}`
-        opts.emit({ type: 'error', message: detail })
-        finish(() => rejectPromise(new Error(`[framework] ${agent} exited (${code ?? 'null'}): ${detail}`)))
-        return
-      }
-      opts.emit({
-        type: 'result',
-        text: turn.text,
-        ...(turn.sessionId ? { sessionId: turn.sessionId } : {}),
-        ...(turn.usage ? { usage: turn.usage } : {}),
-      })
-      finish(() => resolvePromise(turn))
-    })
-
-    // Feed the prompt over stdin so long prompts never hit arg-length limits.
-    if (child.stdin) {
-      child.stdin.write(opts.prompt)
-      child.stdin.end()
-    }
-  })
 }
 
 /**

--- a/packages/framework/src/driver/claude-code.ts
+++ b/packages/framework/src/driver/claude-code.ts
@@ -1,11 +1,11 @@
 import { spawn as nodeSpawn } from 'node:child_process'
 import { createInterface } from 'node:readline'
-import { readFile } from 'node:fs/promises'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, join } from 'node:path'
 import { killTree, registerChild, unregisterChild } from './child-registry.js'
 import { readClaudeQuota } from './claude-code-quota.js'
+import { combineFraming, combineSignals, makeEmit, readWorkspaceFile } from './session-support.js'
 import type { Driver, DriverEvent, DriverPromptOptions, DriverQuota, DriverRateLimit, DriverSession, DriverStartOptions, DriverTurn, DriverUsage } from './types.js'
 
 /** Grace between SIGTERM and the SIGKILL that forces a hung agent tree down. */
@@ -115,32 +115,21 @@ export class ClaudeCodeSession implements DriverSession {
   }
 
   prompt(text: string, opts: DriverPromptOptions = {}): Promise<DriverTurn> {
-    const system = [this.startOpts.system, opts.system].filter(Boolean).join('\n\n')
-    const args = this.buildArgs(system)
-    const emit = (event: DriverEvent) => {
-      const on = this.startOpts.onEvent
-      if (!on) return
-      try {
-        on(event)
-      } catch (err) {
-        console.error('[framework] claude-code onEvent threw; ignoring:', err)
-      }
-    }
-    const signals = [this.startOpts.signal, opts.signal].filter((s): s is AbortSignal => s != null)
+    const system = combineFraming(this.startOpts.system, opts.system)
     return runClaude({
       bin: this.config.bin ?? 'claude',
-      args,
+      args: this.buildArgs(system),
       cwd: this.cwd,
       env: this.config.env ?? process.env,
       prompt: text,
       spawn: this.config.spawn ?? (nodeSpawn as unknown as SpawnLike),
-      emit,
-      signals,
+      emit: makeEmit(this.startOpts.onEvent, 'claude-code'),
+      signals: combineSignals(this.startOpts.signal, opts.signal),
     })
   }
 
-  async readCode(path: string): Promise<string> {
-    return readFile(resolve(this.cwd, path), 'utf8')
+  readCode(path: string): Promise<string> {
+    return readWorkspaceFile(this.cwd, path)
   }
 
   dispose(): Promise<void> {

--- a/packages/framework/src/driver/codex.test.ts
+++ b/packages/framework/src/driver/codex.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { Readable, Writable } from 'node:stream'
 import { CodexDriver, CodexJsonParser, parseCodexUsage } from './codex.js'
-import type { SpawnLike, SpawnedProcess } from './claude-code.js'
+import type { SpawnLike, SpawnedProcess } from './agent-cli.js'
 import type { Driver, DriverEvent } from './types.js'
 
 /** A real codex-cli 0.144.4 run, verbatim: "Create a file hello.txt containing exactly: hi". */

--- a/packages/framework/src/driver/codex.ts
+++ b/packages/framework/src/driver/codex.ts
@@ -1,5 +1,5 @@
 import { spawn as nodeSpawn } from 'node:child_process'
-import { runAgentCli, type AgentCliParser, type SpawnLike } from './claude-code.js'
+import { runAgentCli, type AgentCliParser, type SpawnLike } from './agent-cli.js'
 import { combineFraming, combineSignals, makeEmit, readWorkspaceFile } from './session-support.js'
 import type { Driver, DriverEvent, DriverPromptOptions, DriverSession, DriverStartOptions, DriverTurn, DriverUsage } from './types.js'
 

--- a/packages/framework/src/driver/codex.ts
+++ b/packages/framework/src/driver/codex.ts
@@ -1,7 +1,6 @@
 import { spawn as nodeSpawn } from 'node:child_process'
-import { readFile } from 'node:fs/promises'
-import { resolve } from 'node:path'
 import { runAgentCli, type AgentCliParser, type SpawnLike } from './claude-code.js'
+import { combineFraming, combineSignals, makeEmit, readWorkspaceFile } from './session-support.js'
 import type { Driver, DriverEvent, DriverPromptOptions, DriverSession, DriverStartOptions, DriverTurn, DriverUsage } from './types.js'
 
 /**
@@ -74,18 +73,8 @@ export class CodexSession implements DriverSession {
   prompt(text: string, opts: DriverPromptOptions = {}): Promise<DriverTurn> {
     // Codex takes no system-prompt flag, so the framing rides in front of the
     // prompt. Blank-line separated, so it reads as its own block.
-    const framing = [this.startOpts.system, opts.system].filter(Boolean).join('\n\n')
+    const framing = combineFraming(this.startOpts.system, opts.system)
     const prompt = framing ? `${framing}\n\n${text}` : text
-    const emit = (event: DriverEvent) => {
-      const on = this.startOpts.onEvent
-      if (!on) return
-      try {
-        on(event)
-      } catch (err) {
-        console.error('[framework] codex onEvent threw; ignoring:', err)
-      }
-    }
-    const signals = [this.startOpts.signal, opts.signal].filter((s): s is AbortSignal => s != null)
     return runAgentCli({
       bin: this.config.bin ?? 'codex',
       args: this.buildArgs(),
@@ -93,15 +82,15 @@ export class CodexSession implements DriverSession {
       env: this.config.env ?? process.env,
       prompt,
       spawn: this.config.spawn ?? (nodeSpawn as unknown as SpawnLike),
-      emit,
-      signals,
+      emit: makeEmit(this.startOpts.onEvent, 'codex'),
+      signals: combineSignals(this.startOpts.signal, opts.signal),
       parser: new CodexJsonParser(),
       agent: 'codex',
     })
   }
 
-  async readCode(path: string): Promise<string> {
-    return readFile(resolve(this.cwd, path), 'utf8')
+  readCode(path: string): Promise<string> {
+    return readWorkspaceFile(this.cwd, path)
   }
 
   dispose(): Promise<void> {

--- a/packages/framework/src/driver/fake.ts
+++ b/packages/framework/src/driver/fake.ts
@@ -1,4 +1,5 @@
 import type { Driver, DriverEvent, DriverPromptOptions, DriverSession, DriverStartOptions, DriverTurn, DriverUsage } from './types.js'
+import { makeEmit } from './session-support.js'
 
 /** One scripted turn the {@link FakeDriver} replays. */
 export interface FakeTurn {
@@ -96,12 +97,6 @@ export class FakeDriverSession implements DriverSession {
   }
 
   private emit(event: DriverEvent): void {
-    const on = this.startOpts.onEvent
-    if (!on) return
-    try {
-      on(event)
-    } catch (err) {
-      console.error('[framework] fake driver onEvent threw; ignoring:', err)
-    }
+    makeEmit(this.startOpts.onEvent, 'fake driver')(event)
   }
 }

--- a/packages/framework/src/driver/index.ts
+++ b/packages/framework/src/driver/index.ts
@@ -23,9 +23,11 @@ export {
   type ClaudeCodeDriverOptions,
   type McpServerSpec,
   type PermissionMode,
-  type SpawnLike,
-  type SpawnedProcess,
+} from './claude-code.js'
+export {
   runAgentCli,
   type AgentCliParser,
   type RunAgentCliOptions,
-} from './claude-code.js'
+  type SpawnLike,
+  type SpawnedProcess,
+} from './agent-cli.js'

--- a/packages/framework/src/driver/session-support.ts
+++ b/packages/framework/src/driver/session-support.ts
@@ -1,0 +1,40 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import type { DriverEvent } from './types.js'
+
+// The pieces every driver session needs but that are not agent-specific: emitting events
+// without letting a listener throw into the run, folding the session + per-call signals and
+// framing, and reading a workspace file. The agent-specific parts (argv, the output parser,
+// how framing is delivered) stay in each driver; these do not, so a second driver reuses
+// them rather than copying them.
+
+/**
+ * A {@link DriverStartOptions.onEvent} caller that never lets a listener throw into the
+ * driver — a throwing dashboard handler must not abort the agent run. An absent `onEvent`
+ * is a no-op. `agent` names the driver in the swallow log so a thrown handler stays traceable.
+ */
+export function makeEmit(onEvent: ((event: DriverEvent) => void) | undefined, agent: string): (event: DriverEvent) => void {
+  if (!onEvent) return () => {}
+  return event => {
+    try {
+      onEvent(event)
+    } catch (err) {
+      console.error(`[framework] ${agent} onEvent threw; ignoring:`, err)
+    }
+  }
+}
+
+/** The live AbortSignals for a prompt — the session's and the per-call one, minus the absent. */
+export function combineSignals(...signals: (AbortSignal | undefined)[]): AbortSignal[] {
+  return signals.filter((s): s is AbortSignal => s != null)
+}
+
+/** Fold a session's framing and a per-call system prompt into one blank-line-separated block. */
+export function combineFraming(...parts: (string | undefined)[]): string {
+  return parts.filter(Boolean).join('\n\n')
+}
+
+/** Read a workspace file relative to the session cwd — the driver's `readCode`. */
+export function readWorkspaceFile(cwd: string, path: string): Promise<string> {
+  return readFile(resolve(cwd, path), 'utf8')
+}

--- a/packages/framework/src/events.test.ts
+++ b/packages/framework/src/events.test.ts
@@ -1,13 +1,8 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import {
-  OPEN_LOOP_MODES,
-  SESSION_ID_PLACEHOLDER,
-  formatFrameworkEvent,
-  hasSessionIdPlaceholder,
-  pickedIds,
-  resolveSessionLink,
-} from './events.js'
+import { OPEN_LOOP_MODES, pickedIds } from './events.js'
+import { formatFrameworkEvent } from './terminal.js'
+import { SESSION_ID_PLACEHOLDER, hasSessionIdPlaceholder, resolveSessionLink } from './session-link.js'
 
 test('hasSessionIdPlaceholder distinguishes templates from literal URLs', () => {
   assert.equal(hasSessionIdPlaceholder(`https://x.dev/s/${SESSION_ID_PLACEHOLDER}`), true)

--- a/packages/framework/src/events.ts
+++ b/packages/framework/src/events.ts
@@ -1,5 +1,5 @@
 import type { BootstrapEvent } from '@gemstack/ai-autopilot'
-import type { DriverEvent, DriverRateLimit } from './driver/index.js'
+import type { DriverEvent } from './driver/index.js'
 
 /** One selectable option in an interactive {@link ChoiceRequest} (#304). */
 export interface ChoiceOption {
@@ -163,137 +163,8 @@ export type FrameworkEvent =
    */
   | { kind: 'end'; ok: boolean; stopped?: boolean; detail?: string }
 
-/** Render a {@link FrameworkEvent} as one human-readable line (terminal surface). */
-export function formatFrameworkEvent(event: FrameworkEvent): string {
-  switch (event.kind) {
-    case 'session':
-      return `◆ ${event.fake ? 'fake' : event.driver} in ${event.workspace}${
-        event.sessionLink ? ` — ${event.sessionLink}` : ''
-      }`
-    case 'session-update':
-      return `  session ${event.sessionId}${event.sessionLink ? ` — ${event.sessionLink}` : ''}`
-    case 'system-prompt':
-      return `  system prompt sent (${event.text.length} chars)`
-    case 'preview':
-      return `▶ your app is running at ${event.url}`
-    case 'log':
-      return `  ${event.message}`
-    case 'view':
-      return `▶ view: ${event.title}`
-    case 'session-name':
-      return `  session: ${event.name}`
-    case 'ready-for-merge':
-      return `✓ ready for merge`
-    case 'usage': {
-      const turns = `over ${event.turns} turn${event.turns === 1 ? '' : 's'}`
-      // No price to show: report the tokens the agent *did* report, rather than a
-      // `$0.0000` that would read as free (#540).
-      if (event.costUsd === undefined) {
-        const tokens = event.inputTokens + event.cacheReadTokens + event.outputTokens
-        return `  tokens: ${tokens.toLocaleString('en-US')} (${event.outputTokens.toLocaleString('en-US')} out) ${turns} — no price reported`
-      }
-      return `  spend: $${event.costUsd.toFixed(4)}${event.budgetUsd ? ` / $${event.budgetUsd}` : ''} ${turns}`
-    }
-    case 'modes': {
-      const shown = event.all.map(m => `${event.active.includes(m) ? '[x]' : '[ ]'} ${m}`).join('  ')
-      return `  modes: ${shown}`
-    }
-    case 'choice': {
-      const mark = (o: ChoiceOption) =>
-        event.multi ? (o.default ? '[x]' : '[ ]') : o.id === event.recommended ? '●' : '○'
-      const opts = event.options.map(o => `    ${mark(o)} ${o.label}`).join('\n')
-      return `? ${event.title}\n${opts}`
-    }
-    case 'choice-resolved':
-      return `  ✓ chose ${pickedIds(event.picked).join(', ') || '(none)'} (${event.by})`
-    case 'driver':
-      return formatDriverEvent(event.event)
-    case 'bootstrap':
-      return formatBootstrapEvent(event.event)
-    case 'end':
-      return event.ok ? '✓ finished' : event.stopped ? '■ stopped' : `✗ failed: ${event.detail ?? 'unknown error'}`
-  }
-}
-
-function formatDriverEvent(event: DriverEvent): string {
-  switch (event.type) {
-    case 'start':
-      return `  › prompt: ${truncate(event.prompt, 140)}`
-    case 'text':
-      return `    ${truncate(event.text)}`
-    case 'action':
-      return `    · ${event.label}`
-    case 'result':
-      return `  ‹ turn complete`
-    case 'rate-limit':
-      return `    ${formatRateLimit(event.limit)}`
-    case 'error':
-      return `  ! agent error: ${event.message}`
-  }
-}
-
-/** Quiet on the happy path: only worth a line when the quota is actually tight. */
-function formatRateLimit(limit: DriverRateLimit): string {
-  const resets = new Date(limit.resetsAt).toISOString()
-  if (limit.status === 'rejected') return `✗ quota exhausted (${limit.window}), resets ${resets}`
-  if (limit.status === 'allowed_warning') return `! quota running low (${limit.window}), resets ${resets}`
-  return `· quota ${limit.status} (${limit.window}), resets ${resets}`
-}
-
-function formatBootstrapEvent(event: BootstrapEvent): string {
-  switch (event.type) {
-    case 'scope':
-      return `▶ scope: ${event.scope} — "${event.intent}"`
-    case 'narrate':
-      return `  ${event.message}`
-    case 'build':
-      return `    build/${event.event.type}`
-    case 'checklist':
-      return event.passing
-        ? `  ✓ checklist pass ${event.pass}: production-grade`
-        : `  ✗ checklist pass ${event.pass}: ${event.blockers.join('; ')}`
-    case 'improve':
-      return `  → improving: ${event.blockers.join('; ')}`
-    case 'deploy':
-      return `▶ deploy: ${event.plan.render.toUpperCase()} → ${event.plan.target} (${event.plan.reason})`
-    case 'done':
-      return `✓ ${event.result.productionGrade ? 'production-grade' : 'prototype'} in ${event.result.passes} pass(es)`
-  }
-}
-
-function truncate(text: string, max = 100): string {
-  const flat = text.replace(/\s+/g, ' ').trim()
-  return flat.length > max ? flat.slice(0, max - 1) + '…' : flat
-}
-
 /**
  * The Open Loop modes a run can activate, in the order the dashboard shows them.
  * The single source of truth for the mode checkboxes (#272).
  */
 export const OPEN_LOOP_MODES = ['autopilot', 'technical'] as const
-
-/**
- * The placeholder a `--session-link` template uses for the real session id.
- * Remote Control does not expose a URL you can build from a session id, so we
- * surface the honest id and let a template drop a real URL in when there is one:
- * `--session-link "https://example.com/s/{sessionId}"`.
- */
-export const SESSION_ID_PLACEHOLDER = '{sessionId}'
-
-/** Whether a `--session-link` value is a template (needs the id) vs a literal URL. */
-export function hasSessionIdPlaceholder(template: string): boolean {
-  return template.includes(SESSION_ID_PLACEHOLDER)
-}
-
-/** Fill a `--session-link` template with the real session id (no-op for a literal). */
-export function resolveSessionLink(template: string, sessionId: string): string {
-  return template.split(SESSION_ID_PLACEHOLDER).join(sessionId)
-}
-
-/**
- * The generic Claude Code entry point. It is NOT a per-run live session: a
- * headless run is not Remote-Controlled, so there is no deep link to build (see
- * #214). We surface this only as an "Open Claude Code" affordance; a real live
- * link comes from an explicit `--session-link`.
- */
-export const CLAUDE_CODE_SESSION_LINK = 'https://claude.ai/code'

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -103,12 +103,10 @@ export {
   type ChoicePick,
   type ChoiceBy,
   pickedIds,
-  formatFrameworkEvent,
-  resolveSessionLink,
-  hasSessionIdPlaceholder,
-  SESSION_ID_PLACEHOLDER,
   OPEN_LOOP_MODES,
 } from './events.js'
+export { formatFrameworkEvent } from './terminal.js'
+export { resolveSessionLink, hasSessionIdPlaceholder, SESSION_ID_PLACEHOLDER } from './session-link.js'
 export {
   loopStatus,
   sessionInfo,

--- a/packages/framework/src/install.ts
+++ b/packages/framework/src/install.ts
@@ -51,8 +51,8 @@ export async function installProject(cwd: string, deps: InstallDeps = {}): Promi
     }
 
     await fs.mkdir(join(cwd, THE_FRAMEWORK_DIR))
-    const path = logsPath(cwd)
-    if (!(await fs.exists(path))) await fs.write(path, LOGS_HEADER)
+    // The early return above already established LOGS.md is absent, so write it unconditionally.
+    await fs.write(logsPath(cwd), LOGS_HEADER)
     // Keep the transient run state (events.jsonl / run.json / runs/) out of git;
     // only LOGS.md is the committed DB (#313).
     const ignore = gitignorePath(cwd)

--- a/packages/framework/src/maintainability-preset.ts
+++ b/packages/framework/src/maintainability-preset.ts
@@ -1,4 +1,4 @@
-import { renderTemplate } from './prompt-template.js'
+import { definePreset } from './preset-prompt.js'
 import { PRESETS_MAINTAINABILITY } from './prompts.generated.js'
 
 /**
@@ -7,23 +7,13 @@ import { PRESETS_MAINTAINABILITY } from './prompts.generated.js'
  * deliberately minimal — Rom wants to see how it performs before developing a
  * more explicit one, so keep it in sync with the issue rather than growing it here.
  */
+const maintainability = definePreset('maintainability', PRESETS_MAINTAINABILITY, 'What to refactor for maintainability')
 
 /** The preset's name, as the dashboard button uses it. */
-export const MAINTAINABILITY_PRESET_NAME = 'maintainability'
-
+export const MAINTAINABILITY_PRESET_NAME = maintainability.name
 /** The one user param: what to refactor. Defaults to `this PR`, like the others. */
-export const MAINTAINABILITY_PARAMS = [
-  { name: 'what', default: 'this PR', description: 'What to refactor for maintainability' },
-] as const
-
+export const MAINTAINABILITY_PARAMS = maintainability.params
 /** The prompt template, verbatim from #361, in `prompts/presets/maintainability.md` (#551). */
-export const MAINTAINABILITY_PROMPT_TEMPLATE = PRESETS_MAINTAINABILITY
-
-/**
- * Render the Maintainability prompt for a target, filling its `${{ tf.params.what }}`
- * blank (#326). A blank / omitted `what` falls back to the declared default (`this PR`).
- */
-export function renderMaintainabilityPrompt(what?: string): string {
-  const value = what?.trim() || MAINTAINABILITY_PARAMS[0].default
-  return renderTemplate(MAINTAINABILITY_PROMPT_TEMPLATE, { tf: { params: { what: value } } })
-}
+export const MAINTAINABILITY_PROMPT_TEMPLATE = maintainability.template
+/** Render the Maintainability prompt, filling its `${{ tf.params.what }}` blank (defaults to `this PR`). */
+export const renderMaintainabilityPrompt = maintainability.render

--- a/packages/framework/src/preset-prompt.ts
+++ b/packages/framework/src/preset-prompt.ts
@@ -1,0 +1,35 @@
+import { renderTemplate } from './prompt-template.js'
+
+/** A quality preset's single user param: the target to run against. */
+export interface PresetParam {
+  name: 'what'
+  default: string
+  description: string
+}
+
+/** A quality preset's public shape: its run-kind name, the `what` param, its template, and a renderer. */
+export interface PresetDef {
+  name: string
+  params: readonly [PresetParam]
+  template: string
+  /** Render the template, filling `${{ tf.params.what }}`; a blank/omitted `what` falls back to the default. */
+  render: (what?: string) => string
+}
+
+/**
+ * Define a quality preset (#326/#330) from the three things that actually differ between them:
+ * the run-kind name, the prompt template, and what the one `what` param means. Every preset
+ * has the identical shape — a single `what` param defaulting to `this PR`, rendered by filling
+ * the `${{ tf.params.what }}` blank — so that shape lives here once instead of in each preset
+ * file. A blank/omitted `what` falls back to the default, so a dashboard button runs with zero
+ * input; a passed value is trimmed first.
+ */
+export function definePreset(name: string, template: string, whatDescription: string): PresetDef {
+  const params = [{ name: 'what', default: 'this PR', description: whatDescription }] as const
+  return {
+    name,
+    params,
+    template,
+    render: what => renderTemplate(template, { tf: { params: { what: what?.trim() || params[0].default } } }),
+  }
+}

--- a/packages/framework/src/preview.ts
+++ b/packages/framework/src/preview.ts
@@ -2,9 +2,10 @@ import { spawn, type ChildProcess } from 'node:child_process'
 import { createServer } from 'node:http'
 import { createReadStream } from 'node:fs'
 import { readFile, stat } from 'node:fs/promises'
-import { extname, join, normalize, sep } from 'node:path'
+import { join, normalize, sep } from 'node:path'
 import type { ServerResponse } from 'node:http'
 import type { AddressInfo } from 'node:net'
+import { contentTypeFor } from './dashboard/content-type.js'
 
 /**
  * On-demand app preview (#475): serve a project's built result from the dashboard
@@ -174,22 +175,6 @@ async function startStaticServer(cwd: string): Promise<PreviewHandle> {
   }
 }
 
-const CONTENT_TYPES: Record<string, string> = {
-  '.html': 'text/html; charset=utf-8',
-  '.js': 'text/javascript; charset=utf-8',
-  '.mjs': 'text/javascript; charset=utf-8',
-  '.css': 'text/css; charset=utf-8',
-  '.json': 'application/json; charset=utf-8',
-  '.svg': 'image/svg+xml',
-  '.png': 'image/png',
-  '.jpg': 'image/jpeg',
-  '.jpeg': 'image/jpeg',
-  '.gif': 'image/gif',
-  '.ico': 'image/x-icon',
-  '.woff': 'font/woff',
-  '.woff2': 'font/woff2',
-}
-
 /** Serve one file from `root`, defaulting `/` to `index.html`, refusing path traversal. */
 async function serveStaticFile(root: string, urlPath: string, res: ServerResponse): Promise<void> {
   const rel = normalize(decodeURIComponent(urlPath.split('?')[0]!)).replace(/^(\.\.[/\\])+/, '')
@@ -206,6 +191,6 @@ async function serveStaticFile(root: string, urlPath: string, res: ServerRespons
     res.writeHead(404, { 'content-type': 'text/plain' }).end('not found')
     return
   }
-  res.writeHead(200, { 'content-type': CONTENT_TYPES[extname(file).toLowerCase()] ?? 'application/octet-stream' })
+  res.writeHead(200, { 'content-type': contentTypeFor(file) })
   createReadStream(file).pipe(res)
 }

--- a/packages/framework/src/readability-preset.ts
+++ b/packages/framework/src/readability-preset.ts
@@ -1,4 +1,4 @@
-import { renderTemplate } from './prompt-template.js'
+import { definePreset } from './preset-prompt.js'
 import { PRESETS_READABILITY } from './prompts.generated.js'
 
 /**
@@ -8,24 +8,13 @@ import { PRESETS_READABILITY } from './prompts.generated.js'
  * user-facing blank (#330); `<FUNCTION>` is an agent-facing macro defined at the
  * bottom of the prompt itself, like the Research preset's CAPS tokens.
  */
+const readability = definePreset('readability', PRESETS_READABILITY, 'What to refactor for readability')
 
 /** The preset's name, as the dashboard button uses it. */
-export const READABILITY_PRESET_NAME = 'readability'
-
+export const READABILITY_PRESET_NAME = readability.name
 /** The one user param: what to refactor. Defaults to `this PR`, like Research. */
-export const READABILITY_PARAMS = [
-  { name: 'what', default: 'this PR', description: 'What to refactor for readability' },
-] as const
-
+export const READABILITY_PARAMS = readability.params
 /** The prompt template, verbatim from #360 (with `${{ tf.params.what }}` as the blank). */
-export const READABILITY_PROMPT_TEMPLATE = PRESETS_READABILITY
-
-/**
- * Render the Readability prompt for a target, filling its `${{ tf.params.what }}`
- * blank (#326). A blank / omitted `what` falls back to the declared default
- * (`this PR`), so the dashboard button runs with zero input.
- */
-export function renderReadabilityPrompt(what?: string): string {
-  const value = what?.trim() || READABILITY_PARAMS[0].default
-  return renderTemplate(READABILITY_PROMPT_TEMPLATE, { tf: { params: { what: value } } })
-}
+export const READABILITY_PROMPT_TEMPLATE = readability.template
+/** Render the Readability prompt, filling its `${{ tf.params.what }}` blank (defaults to `this PR`). */
+export const renderReadabilityPrompt = readability.render

--- a/packages/framework/src/relay.ts
+++ b/packages/framework/src/relay.ts
@@ -113,7 +113,7 @@ export async function startRelay(opts: RelayOptions = {}): Promise<Relay> {
   // the relay's own in-memory run (create-on-access, so a viewer can connect before the
   // publisher), and an empty projects provider neutralizes every file/registry RPC on
   // this public host. No `startRun`, so a start is never enabled here.
-  const telefunc = makeTelefuncMount(undefined, emptyProjectsProvider(), id => run(id).stream)
+  const telefunc = makeTelefuncMount({ projects: emptyProjectsProvider(), eventsSource: id => run(id).stream })
   const server = createServer((req, res) => handle(req, res, { run, maxBody, clientBundleDir, telefunc }))
 
   return new Promise<Relay>((resolvePromise, rejectPromise) => {

--- a/packages/framework/src/research-preset.ts
+++ b/packages/framework/src/research-preset.ts
@@ -1,4 +1,4 @@
-import { renderTemplate } from './prompt-template.js'
+import { definePreset } from './preset-prompt.js'
 import { PRESETS_RESEARCH } from './prompts.generated.js'
 
 /**
@@ -10,25 +10,13 @@ import { PRESETS_RESEARCH } from './prompts.generated.js'
  * of the prompt itself, and `showMultiSelect()` + `<AWAIT>` becomes a live
  * turn-boundary gate (#339/#340) the dashboard resolves.
  */
+const research = definePreset('research', PRESETS_RESEARCH, 'What to measure problem variability of')
 
 /** The preset's name, as the CLI subcommand and the dashboard button use it. */
-export const RESEARCH_PRESET_NAME = 'research'
-
+export const RESEARCH_PRESET_NAME = research.name
 /** The one user param: what to measure. Defaults to `this PR`, per the issue. */
-export const RESEARCH_PARAMS = [
-  { name: 'what', default: 'this PR', description: 'What to measure problem variability of' },
-] as const
-
+export const RESEARCH_PARAMS = research.params
 /** The prompt template, verbatim from #331 (with `${{ tf.params.what }}` as the blank). */
-export const RESEARCH_PROMPT_TEMPLATE = PRESETS_RESEARCH
-
-/**
- * Render the Research prompt for a target, filling its `${{ tf.params.what }}`
- * blank (#326). A blank / omitted `what` falls back to the declared default
- * (`this PR`), so the dashboard button and a bare `framework research` both run
- * with zero input.
- */
-export function renderResearchPrompt(what?: string): string {
-  const value = what?.trim() || RESEARCH_PARAMS[0].default
-  return renderTemplate(RESEARCH_PROMPT_TEMPLATE, { tf: { params: { what: value } } })
-}
+export const RESEARCH_PROMPT_TEMPLATE = research.template
+/** Render the Research prompt, filling its `${{ tf.params.what }}` blank (defaults to `this PR`). */
+export const renderResearchPrompt = research.render

--- a/packages/framework/src/run-telemetry.ts
+++ b/packages/framework/src/run-telemetry.ts
@@ -1,6 +1,7 @@
 import { CONSUMPTION_LIMIT_LABEL, type ConsumptionWindow } from './consumption.js'
 import type { Driver, DriverEvent } from './driver/index.js'
-import { hasSessionIdPlaceholder, resolveSessionLink, type FrameworkEvent } from './events.js'
+import { hasSessionIdPlaceholder, resolveSessionLink } from './session-link.js'
+import { type FrameworkEvent } from './events.js'
 import { UsageMeter } from './usage.js'
 
 // The telemetry both entry paths share. A build (`run.ts`) and a direct prompt

--- a/packages/framework/src/security-audit-preset.ts
+++ b/packages/framework/src/security-audit-preset.ts
@@ -1,4 +1,4 @@
-import { renderTemplate } from './prompt-template.js'
+import { definePreset } from './preset-prompt.js'
 import { PRESETS_SECURITY_AUDIT } from './prompts.generated.js'
 
 /**
@@ -8,24 +8,13 @@ import { PRESETS_SECURITY_AUDIT } from './prompts.generated.js'
  * It is also one of the on-before-mergeable quality prompts #326 fires on
  * `setReadyForMerge()`. Keep it in sync with the issue rather than growing it here.
  */
+const securityAudit = definePreset('security-audit', PRESETS_SECURITY_AUDIT, 'What to security-audit')
 
 /** The preset's name, as the dashboard button uses it. */
-export const SECURITY_AUDIT_PRESET_NAME = 'security-audit'
-
+export const SECURITY_AUDIT_PRESET_NAME = securityAudit.name
 /** The one user param: what to audit. Defaults to `this PR`, like the others. */
-export const SECURITY_AUDIT_PARAMS = [
-  { name: 'what', default: 'this PR', description: 'What to security-audit' },
-] as const
-
+export const SECURITY_AUDIT_PARAMS = securityAudit.params
 /** The prompt template, verbatim from #461 (with `${{ tf.params.what }}` as the blank). */
-export const SECURITY_AUDIT_PROMPT_TEMPLATE = PRESETS_SECURITY_AUDIT
-
-/**
- * Render the Security audit prompt for a target, filling its `${{ tf.params.what }}`
- * blank (#326). A blank / omitted `what` falls back to the declared default
- * (`this PR`), so the dashboard button runs with zero input.
- */
-export function renderSecurityAuditPrompt(what?: string): string {
-  const value = what?.trim() || SECURITY_AUDIT_PARAMS[0].default
-  return renderTemplate(SECURITY_AUDIT_PROMPT_TEMPLATE, { tf: { params: { what: value } } })
-}
+export const SECURITY_AUDIT_PROMPT_TEMPLATE = securityAudit.template
+/** Render the Security audit prompt, filling its `${{ tf.params.what }}` blank (defaults to `this PR`). */
+export const renderSecurityAuditPrompt = securityAudit.render

--- a/packages/framework/src/session-link.ts
+++ b/packages/framework/src/session-link.ts
@@ -1,0 +1,29 @@
+// The `--session-link` plumbing: turn a link template into a real URL for the wrapped
+// agent's session. Kept apart from the event contract (events.ts) and the terminal
+// formatter (terminal.ts) — it is about session URLs, not event shapes or rendering.
+
+/**
+ * The placeholder a `--session-link` template uses for the real session id.
+ * Remote Control does not expose a URL you can build from a session id, so we
+ * surface the honest id and let a template drop a real URL in when there is one:
+ * `--session-link "https://example.com/s/{sessionId}"`.
+ */
+export const SESSION_ID_PLACEHOLDER = '{sessionId}'
+
+/** Whether a `--session-link` value is a template (needs the id) vs a literal URL. */
+export function hasSessionIdPlaceholder(template: string): boolean {
+  return template.includes(SESSION_ID_PLACEHOLDER)
+}
+
+/** Fill a `--session-link` template with the real session id (no-op for a literal). */
+export function resolveSessionLink(template: string, sessionId: string): string {
+  return template.split(SESSION_ID_PLACEHOLDER).join(sessionId)
+}
+
+/**
+ * The generic Claude Code entry point. It is NOT a per-run live session: a
+ * headless run is not Remote-Controlled, so there is no deep link to build (see
+ * #214). We surface this only as an "Open Claude Code" affordance; a real live
+ * link comes from an explicit `--session-link`.
+ */
+export const CLAUDE_CODE_SESSION_LINK = 'https://claude.ai/code'

--- a/packages/framework/src/system-prompt.ts
+++ b/packages/framework/src/system-prompt.ts
@@ -195,13 +195,16 @@ export function systemPromptBlock(opts: SystemPromptOptions = {}): string {
   // The knowledge docs ride with the built-in prompt, not with the user's dirs: they are
   // ours, and `--vanilla` means no framework-authored prompt at all (#547 rule 3). They
   // render as commented bullets under the dirs (#559), so the agent sees what each is for.
-  const docs = opts.antiLazyPill === false ? [] : KNOWLEDGE_DOCS
+  // `--vanilla` (antiLazyPill === false) drops both the framework's knowledge docs and its
+  // built-in prompt; one boolean drives both so they can't fall out of step.
+  const includeBuiltin = opts.antiLazyPill !== false
+  const docs = includeBuiltin ? KNOWLEDGE_DOCS : []
   if (dirs.length || docs.length) {
     const head = `Context:${dirs.length ? ` ${dirs.join(', ')}` : ''}`
     const bullets = docs.map(d => `- \`${d.path}\` (${d.comment})`)
     parts.push([head, ...bullets].join('\n'))
   }
-  if (opts.antiLazyPill !== false) parts.push(renderSystemPrompt(opts.tf).system)
+  if (includeBuiltin) parts.push(renderSystemPrompt(opts.tf).system)
   const user = opts.user?.trim()
   if (user) parts.push(user)
   return parts.join('\n\n')

--- a/packages/framework/src/terminal.ts
+++ b/packages/framework/src/terminal.ts
@@ -1,0 +1,111 @@
+import type { BootstrapEvent } from '@gemstack/ai-autopilot'
+import type { DriverEvent, DriverRateLimit } from './driver/index.js'
+import { pickedIds, type ChoiceOption, type FrameworkEvent } from './events.js'
+
+// The terminal surface for the run's event stream: render one {@link FrameworkEvent} as one
+// human-readable line. This is the CLI's counterpart to the dashboard's read-model
+// projections (run-view.ts) — a pure formatter over the same union, kept out of events.ts so
+// the event contract stays a plain data module (and browser-safe for the client bundle).
+
+/** Render a {@link FrameworkEvent} as one human-readable line (terminal surface). */
+export function formatFrameworkEvent(event: FrameworkEvent): string {
+  switch (event.kind) {
+    case 'session':
+      return `◆ ${event.fake ? 'fake' : event.driver} in ${event.workspace}${
+        event.sessionLink ? ` — ${event.sessionLink}` : ''
+      }`
+    case 'session-update':
+      return `  session ${event.sessionId}${event.sessionLink ? ` — ${event.sessionLink}` : ''}`
+    case 'system-prompt':
+      return `  system prompt sent (${event.text.length} chars)`
+    case 'preview':
+      return `▶ your app is running at ${event.url}`
+    case 'log':
+      return `  ${event.message}`
+    case 'view':
+      return `▶ view: ${event.title}`
+    case 'session-name':
+      return `  session: ${event.name}`
+    case 'ready-for-merge':
+      return `✓ ready for merge`
+    case 'usage': {
+      const turns = `over ${event.turns} turn${event.turns === 1 ? '' : 's'}`
+      // No price to show: report the tokens the agent *did* report, rather than a
+      // `$0.0000` that would read as free (#540).
+      if (event.costUsd === undefined) {
+        const tokens = event.inputTokens + event.cacheReadTokens + event.outputTokens
+        return `  tokens: ${tokens.toLocaleString('en-US')} (${event.outputTokens.toLocaleString('en-US')} out) ${turns} — no price reported`
+      }
+      return `  spend: $${event.costUsd.toFixed(4)}${event.budgetUsd ? ` / $${event.budgetUsd}` : ''} ${turns}`
+    }
+    case 'modes': {
+      const shown = event.all.map(m => `${event.active.includes(m) ? '[x]' : '[ ]'} ${m}`).join('  ')
+      return `  modes: ${shown}`
+    }
+    case 'choice': {
+      const mark = (o: ChoiceOption) =>
+        event.multi ? (o.default ? '[x]' : '[ ]') : o.id === event.recommended ? '●' : '○'
+      const opts = event.options.map(o => `    ${mark(o)} ${o.label}`).join('\n')
+      return `? ${event.title}\n${opts}`
+    }
+    case 'choice-resolved':
+      return `  ✓ chose ${pickedIds(event.picked).join(', ') || '(none)'} (${event.by})`
+    case 'driver':
+      return formatDriverEvent(event.event)
+    case 'bootstrap':
+      return formatBootstrapEvent(event.event)
+    case 'end':
+      return event.ok ? '✓ finished' : event.stopped ? '■ stopped' : `✗ failed: ${event.detail ?? 'unknown error'}`
+  }
+}
+
+function formatDriverEvent(event: DriverEvent): string {
+  switch (event.type) {
+    case 'start':
+      return `  › prompt: ${truncate(event.prompt, 140)}`
+    case 'text':
+      return `    ${truncate(event.text)}`
+    case 'action':
+      return `    · ${event.label}`
+    case 'result':
+      return `  ‹ turn complete`
+    case 'rate-limit':
+      return `    ${formatRateLimit(event.limit)}`
+    case 'error':
+      return `  ! agent error: ${event.message}`
+  }
+}
+
+/** Quiet on the happy path: only worth a line when the quota is actually tight. */
+function formatRateLimit(limit: DriverRateLimit): string {
+  const resets = new Date(limit.resetsAt).toISOString()
+  if (limit.status === 'rejected') return `✗ quota exhausted (${limit.window}), resets ${resets}`
+  if (limit.status === 'allowed_warning') return `! quota running low (${limit.window}), resets ${resets}`
+  return `· quota ${limit.status} (${limit.window}), resets ${resets}`
+}
+
+function formatBootstrapEvent(event: BootstrapEvent): string {
+  switch (event.type) {
+    case 'scope':
+      return `▶ scope: ${event.scope} — "${event.intent}"`
+    case 'narrate':
+      return `  ${event.message}`
+    case 'build':
+      return `    build/${event.event.type}`
+    case 'checklist':
+      return event.passing
+        ? `  ✓ checklist pass ${event.pass}: production-grade`
+        : `  ✗ checklist pass ${event.pass}: ${event.blockers.join('; ')}`
+    case 'improve':
+      return `  → improving: ${event.blockers.join('; ')}`
+    case 'deploy':
+      return `▶ deploy: ${event.plan.render.toUpperCase()} → ${event.plan.target} (${event.plan.reason})`
+    case 'done':
+      return `✓ ${event.result.productionGrade ? 'production-grade' : 'prototype'} in ${event.result.passes} pass(es)`
+  }
+}
+
+function truncate(text: string, max = 100): string {
+  const flat = text.replace(/\s+/g, ' ').trim()
+  return flat.length > max ? flat.slice(0, max - 1) + '…' : flat
+}

--- a/packages/framework/src/todo-loop.ts
+++ b/packages/framework/src/todo-loop.ts
@@ -213,13 +213,17 @@ export async function runTodoLoop(opts: TodoLoopOptions): Promise<TodoLoopResult
   let stalls = 0
   let file: string | undefined
 
+  // The backlog emptied: announce it if we did any work, and report a clean finish.
+  // Both the mid-loop find and the post-loop re-check funnel through here.
+  const finishEmpty = (): TodoLoopResult => {
+    if (completed > 0) emit({ kind: 'log', message: `Backlog done: ${file ?? 'TODO'} is empty after ${completed} item(s).` })
+    return { completed, reason: 'empty', ...(file ? { file } : {}) }
+  }
+
   for (let item = 0; item < maxItems; item++) {
     if (opts.signal?.aborted) break
     const backlog = await findTodoBacklog(cwd)
-    if (!backlog) {
-      if (completed > 0) emit({ kind: 'log', message: `Backlog done: ${file ?? 'TODO'} is empty after ${completed} item(s).` })
-      return { completed, reason: 'empty', ...(file ? { file } : {}) }
-    }
+    if (!backlog) return finishEmpty()
     file = backlog.name
     const next = backlog.entries[0]!
     const preview = next.length > 100 ? `${next.slice(0, 100)}…` : next
@@ -276,10 +280,7 @@ export async function runTodoLoop(opts: TodoLoopOptions): Promise<TodoLoopResult
   if (opts.signal?.aborted) return { completed, reason: 'stopped', ...(file ? { file } : {}) }
 
   const remaining = await findTodoBacklog(cwd)
-  if (!remaining) {
-    if (completed > 0) emit({ kind: 'log', message: `Backlog done: ${file ?? 'TODO'} is empty after ${completed} item(s).` })
-    return { completed, reason: 'empty', ...(file ? { file } : {}) }
-  }
+  if (!remaining) return finishEmpty()
   emit({
     kind: 'log',
     message: `Backlog loop stopped at the ${maxItems}-item cap; ${remaining.entries.length} item(s) left in ${remaining.name}.`,

--- a/packages/framework/src/todo-loop.ts
+++ b/packages/framework/src/todo-loop.ts
@@ -249,7 +249,10 @@ export async function runTodoLoop(opts: TodoLoopOptions): Promise<TodoLoopResult
     }
 
     emit({ kind: 'log', message: `Backlog item ${completed + 1}: ${preview}` })
-    await promptItem(session, backlog.name, gateDeps)
+    // Complete exactly the first open entry and check it off, honoring await gates.
+    // A declined plan (#358) ends the item turn; the loop's stall check takes it from there.
+    const prompt = `Open \`${backlog.name}\` at the workspace root and work on the FIRST open entry only. Complete it fully and verify your work. Then update \`${backlog.name}\`: check the entry off (or remove it). Do not start any other entry.`
+    await runAwaitRounds({ session, prompt, ...gateDeps })
     completed++
 
     // Progress check: the item turn must have retired the entry it was given
@@ -284,25 +287,3 @@ export async function runTodoLoop(opts: TodoLoopOptions): Promise<TodoLoopResult
   return { completed, reason: 'max-items', ...(file ? { file } : {}) }
 }
 
-/** One backlog item's turn: complete the first open entry, honoring await gates. */
-async function promptItem(
-  session: DriverSession,
-  fileName: string,
-  deps: {
-    requestChoice?: ((req: ChoiceRequest) => Promise<ChoicePick>) | undefined
-    emit: (event: FrameworkEvent) => void
-    signal?: AbortSignal | undefined
-    emitTurnSignals: (text: string) => void
-  },
-): Promise<void> {
-  const prompt = `Open \`${fileName}\` at the workspace root and work on the FIRST open entry only. Complete it fully and verify your work. Then update \`${fileName}\`: check the entry off (or remove it). Do not start any other entry.`
-  // A declined plan (#358) ends the item turn; the loop's stall check takes it from there.
-  await runAwaitRounds({
-    session,
-    prompt,
-    emitTurnSignals: deps.emitTurnSignals,
-    requestChoice: deps.requestChoice,
-    emit: deps.emit,
-    signal: deps.signal,
-  })
-}

--- a/packages/framework/src/ux-preset.ts
+++ b/packages/framework/src/ux-preset.ts
@@ -1,4 +1,4 @@
-import { renderTemplate } from './prompt-template.js'
+import { definePreset } from './preset-prompt.js'
 import { PRESETS_UX } from './prompts.generated.js'
 
 /**
@@ -10,24 +10,13 @@ import { PRESETS_UX } from './prompts.generated.js'
  * agent-facing turn-gate macro (#339/#340) the dashboard resolves. Keep it in sync
  * with the issue rather than growing it here.
  */
+const ux = definePreset('ux', PRESETS_UX, 'What to review the UX of')
 
 /** The preset's name, as the dashboard button uses it. */
-export const UX_PRESET_NAME = 'ux'
-
+export const UX_PRESET_NAME = ux.name
 /** The one user param: what to review. Defaults to `this PR`, like the others. */
-export const UX_PARAMS = [
-  { name: 'what', default: 'this PR', description: 'What to review the UX of' },
-] as const
-
+export const UX_PARAMS = ux.params
 /** The prompt template, from #472 (with `${{ tf.params.what }}` as the blank, `<AWAIT>` as the gate). */
-export const UX_PROMPT_TEMPLATE = PRESETS_UX
-
-/**
- * Render the UX prompt for a target, filling its `${{ tf.params.what }}` blank
- * (#326). A blank / omitted `what` falls back to the declared default (`this PR`),
- * so the dashboard button runs with zero input.
- */
-export function renderUxPrompt(what?: string): string {
-  const value = what?.trim() || UX_PARAMS[0].default
-  return renderTemplate(UX_PROMPT_TEMPLATE, { tf: { params: { what: value } } })
-}
+export const UX_PROMPT_TEMPLATE = ux.template
+/** Render the UX prompt, filling its `${{ tf.params.what }}` blank (defaults to `this PR`). */
+export const renderUxPrompt = ux.render


### PR DESCRIPTION
Rom-method quality pass over the **rest** of `@gemstack/framework`, picking up where #615 (the big/complex files) left off. Every remaining file (~65) and every function was rated across 7 independent review slices before any edit; only the significant refactors were applied, one commit each, build + full suite green at each step (544 tests, 543 pass, 0 fail, unchanged from baseline). Behavior-preserving throughout: no public export removed, no user-facing string changed.

Net `-17` lines across 36 files.

## Duplication folded to one (DRY)

| What was duplicated | old -> new | commit |
|---|---|---|
| The five `*-preset.ts` files: identical render body + params shape x5, now derived from one `definePreset` | 4 -> 8 | [`553c14b`](https://github.com/gemstack-land/gemstack/commit/553c14b) |
| The drivers' `emit` / signal-filter / framing-combine / `readCode` (copied across claude-code, codex, fake) -> `driver/session-support.ts` | 6 -> 8 | [`0f7b983`](https://github.com/gemstack-land/gemstack/commit/0f7b983) |
| dashboard-rpc context accessors (4x `try/getContext`) + `projectPath` (defined 2x, inlined once) -> `fromContext` + `resolveProjectPath` | 6 -> 8 | [`ed380d4`](https://github.com/gemstack-land/gemstack/commit/ed380d4) |
| `reads.telefunc` resolve+guard+catch skeleton (x8 uniform readers) -> `withProject` | 7 -> 8 | [`98c515f`](https://github.com/gemstack-land/gemstack/commit/98c515f) |
| Overview's private `readLiveMeta` was a byte copy of the store's | 5 -> 8 | [`69d69e5`](https://github.com/gemstack-land/gemstack/commit/69d69e5) |
| Two static servers, two content-type maps that had drifted -> one table | 7 -> 8 | [`c66d0b0`](https://github.com/gemstack-land/gemstack/commit/c66d0b0) |
| Backlog loop's empty-finish written verbatim twice -> one `finishEmpty` | 6 -> 8 | [`a41756e`](https://github.com/gemstack-land/gemstack/commit/a41756e) |
| `--vanilla` built-in/docs decision spelled two ways -> one boolean | 6 -> 8 | [`500daa8`](https://github.com/gemstack-land/gemstack/commit/500daa8) |

## Seams (right side of the boundary)

| Move | old -> new | commit |
|---|---|---|
| Terminal formatter + session-link plumbing out of `events.ts` (a data module now); the formatter is its own surface, paralleling `run-view.ts` | 7 -> 8 | [`316cf14`](https://github.com/gemstack-land/gemstack/commit/316cf14) |
| `onEvents` Channel lifecycle into `stream-channel.ts` (the file named for it); `onEvents` reads as "stream from this source" | 6 -> 8 | [`11ea07f`](https://github.com/gemstack-land/gemstack/commit/11ea07f) |
| `isSameOriginRequest` down into its only caller + shared request/result types into a leaf `dashboard/types.ts`, breaking the `server` <-> `telefunc-serve` import cycle | 8 -> 9 | [`27b5b82`](https://github.com/gemstack-land/gemstack/commit/27b5b82) |

## Altitude / simplify

| Change | old -> new | commit |
|---|---|---|
| `startDashboard`: early-return the broken-install 503 stub, so the main path drops the triple `clientBundleDir` gate and the `telefuncMount!` non-null assertion | 7 -> 8 | [`30bd2a6`](https://github.com/gemstack-land/gemstack/commit/30bd2a6) |
| `makeTelefuncMount`: one request-context object instead of 7 positional args (callers no longer pass an `undefined` placeholder) | 6 -> 8 | [`00a4a67`](https://github.com/gemstack-land/gemstack/commit/00a4a67) |
| Inline the single-call `promptItem`, dropping its re-declared deps type | 5 -> 8 | [`5ff2aa3`](https://github.com/gemstack-land/gemstack/commit/5ff2aa3) |
| Drop the provably-dead LOGS.md existence re-check on install | 7 -> 8 | [`682345d`](https://github.com/gemstack-land/gemstack/commit/682345d) |

## Coverage checklist

100% of the remaining package was rated before editing, in 7 slices. Each slice produced a per-file + per-function rating list and a tick list to prove nothing was skipped.

- ✅ run / lifecycle: `index`, `todo-loop`, `maintenance`, `control`, `agent`, `sandbox`, `preflight`, `host-exec`
- ✅ events / telemetry: `events`, `relay`, `preview`, `logs`, `run-view`, `jsonl-tail`
- ✅ system-prompt / presets / config: `system-prompt`, `system-prompt-file`, `prompt-template`, `presets`, `config`, the five `*-preset`
- ✅ quota / install / fs: `quota-poller`, `consumption-guard`, `usage`, `update-check`, `install`, `project`, `fake-script`, `node-fs`, `client`
- ✅ `driver/`: `claude-code`, `types`, `codex`, `claude-code-quota`, `fake`, `child-registry`, `index`
- ✅ `dashboard/`: `server`, `dashboard`, `telefunc-serve`, `projects`, `overview`, `quota`, `docs`, `git-status`, `open-in-app`, `static`, `queue`, `file-status`, `github`, `bundle`, `index`
- ✅ `dashboard-rpc/` + `store/index`: the 6 `*.telefunc`, `context`, `register`, `stream-channel`, `events-tail`, `index`

Ratings clustered 4-9 (the five preset files were the one 4). Nothing rated a lazy 10.

## Considered, deliberately not done

Kept out to honor "significant only" and behavior-preserving:

- `nodeMaintenanceFs` / the `RegistryFs`+`MaintenanceFs` merge: these fight the deliberate four-factory `node-fs` convention (#584) and would couple two contracts that only happen to coincide today.
- Relocating `GitRunner` out of `project.ts`: wide churn (7 importers) for low payoff.
- Deleting the five unused `*_PRESET_NAME` exports: they are public API; folded into the `definePreset` table instead of removed.
- Merging the two static servers into one flag-driven `serveFile`: their policies genuinely differ (SPA-fallback + immutable cache + buffered read vs 403 + streamed), so only the content-type table was shared.

## Deferred: behavior-changing fixes (need changesets, separate PRs)

Surfaced by the review but out of scope for a behavior-preserving refactor:

- `relay.ts` `ingestBody` decodes per-chunk (multibyte UTF-8 can corrupt at a chunk boundary) and caps on UTF-16 length, not bytes.
- `claude-code` `parseUsage` sets `costUsd: 0` when the line has usage but no cost, violating the `DriverUsage` contract ("omit, never 0") and diverging from codex.
- `runAgentCli` emits a spurious `error` event after an abort already rejected the turn.
- `preferences` `savePreferences` rejects on a failed write instead of returning the advertised `{ ok: false }`.

No changeset: refactor only.
