### PR TITLE
fix(framework): no spurious error event when a process closes after abort

### DIFF
--- a/.changeset/agent-cli-abort-no-error.md
+++ b/.changeset/agent-cli-abort-no-error.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Fix the agent-CLI runner emitting a spurious `error` event after a run is aborted. On abort the turn rejects and settles, but the killed child process still fires `close` afterward, and the close handler emitted an `error` (and would have emitted `result`) telemetry event before checking whether the turn had already settled. The dashboard event stream saw a phantom agent error after a clean Stop. The close handler now returns early once the turn has settled, so an abort produces exactly one outcome.

--- a/packages/framework/src/driver/agent-cli.test.ts
+++ b/packages/framework/src/driver/agent-cli.test.ts
@@ -1,0 +1,79 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { Readable, Writable } from 'node:stream'
+import { runAgentCli, type AgentCliParser, type SpawnLike, type SpawnedProcess } from './agent-cli.js'
+import type { DriverEvent } from './types.js'
+
+test('runAgentCli streams the parser events and resolves the final turn', async () => {
+  const events: DriverEvent[] = []
+  const parser: AgentCliParser = {
+    push: line => (line === 'hi' ? [{ type: 'text', text: 'hi' }] : []),
+    result: () => ({ text: 'done', sessionId: 's1' }),
+  }
+  const stdout = Readable.from(['hi\n'])
+  const spawn: SpawnLike = () => {
+    const proc: SpawnedProcess = {
+      stdout,
+      stderr: Readable.from([]),
+      stdin: new Writable({ write: (_c, _e, cb) => cb() }),
+      on(event, listener) {
+        if (event === 'close') stdout.on('end', () => (listener as (c: number | null) => void)(0))
+        return proc
+      },
+      kill: () => undefined,
+    }
+    return proc
+  }
+  const turn = await runAgentCli({
+    bin: 'agent',
+    args: [],
+    cwd: '/ws',
+    env: {},
+    prompt: 'go',
+    spawn,
+    emit: e => events.push(e),
+    signals: [],
+    parser,
+  })
+  assert.deepEqual(turn, { text: 'done', sessionId: 's1' })
+  assert.equal(events[0]!.type, 'start')
+  assert.ok(events.some(e => e.type === 'text'))
+  assert.equal(events.at(-1)!.type, 'result')
+})
+
+test('runAgentCli emits no telemetry when the process closes after an abort', async () => {
+  const events: DriverEvent[] = []
+  const controller = new AbortController()
+  // A process whose `close` fires only when the test triggers it, so we can order
+  // the abort strictly before the (killed) process's late exit.
+  let fireClose: (code: number | null) => void = () => {}
+  const spawn: SpawnLike = () => {
+    const proc: SpawnedProcess = {
+      stdout: Readable.from([]),
+      stderr: Readable.from([]),
+      stdin: new Writable({ write: (_c, _e, cb) => cb() }),
+      on(event, listener) {
+        if (event === 'close') fireClose = listener as (c: number | null) => void
+        return proc
+      },
+      kill: () => undefined,
+    }
+    return proc
+  }
+  const promise = runAgentCli({
+    bin: 'agent',
+    args: [],
+    cwd: '/ws',
+    env: {},
+    prompt: 'go',
+    spawn,
+    emit: e => events.push(e),
+    signals: [controller.signal],
+    parser: { push: () => [], result: () => ({ text: '' }) },
+  })
+  controller.abort()
+  fireClose(null) // the killed process reports its exit after the abort already rejected
+  await assert.rejects(promise, /aborted/)
+  assert.ok(!events.some(e => e.type === 'error'), 'no error event after abort')
+  assert.ok(!events.some(e => e.type === 'result'), 'no result event after abort')
+})

--- a/packages/framework/src/driver/agent-cli.ts
+++ b/packages/framework/src/driver/agent-cli.ts
@@ -144,6 +144,9 @@ export function runAgentCli(opts: RunAgentCliOptions): Promise<DriverTurn> {
 
     child.on('close', code => {
       cleanup()
+      // An abort (or a spawn error) already settled and reported the turn; the process
+      // still closes afterward, but its late exit must not emit a second telemetry event.
+      if (settled) return
       const turn = parser.result()
       // A non-zero exit is a failed turn even when the agent streamed some text
       // first: the loop gates on the outcome, so a crash mid-build must not pass


### PR DESCRIPTION
On abort, `runAgentCli` rejects and settles the turn, but the killed child still fires `close` afterward. The close handler emitted an `error` telemetry event (and would emit `result`) before checking `settled`, so the dashboard event stream saw a phantom agent error after a clean Stop. The close handler now returns early once settled, so an abort produces exactly one outcome.

New `agent-cli.test.ts` with a happy-path run + the regression (abort then a late close emits no error/result). Changeset: patch.