### PR TITLE
fix(framework): relay reads the publish body as bytes, decoded once

### DIFF
--- a/.changeset/relay-body-bytes.md
+++ b/.changeset/relay-body-bytes.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Fix the relay's publish-body reader corrupting multibyte payloads and mis-applying its size cap. It decoded each TCP chunk independently (`body += chunk`), so a multibyte UTF-8 codepoint split across a chunk boundary decoded to replacement characters; and it compared the running string's `.length` (UTF-16 code units) against `maxBodyBytes`, so the cap was wrong for any non-ASCII body. It now accumulates raw `Buffer`s, caps on the byte count, and decodes once at the end.

--- a/packages/framework/src/relay.test.ts
+++ b/packages/framework/src/relay.test.ts
@@ -194,6 +194,29 @@ test('relayPublisher keeps publishing after a rejected event, and stays quiet wh
   }
 })
 
+test('the body cap counts bytes, not UTF-16 length: a multibyte body over the byte cap is rejected', async () => {
+  const relay = await startRelay({ ...local, maxBodyBytes: 100, clientBundleDir: '/no/such/bundle' })
+  try {
+    const body = JSON.stringify({ kind: 'log', message: '料'.repeat(40) }) // 40 three-byte chars
+    // Char length is under the cap, byte length is over it: the old char-count would wrongly accept.
+    assert.ok(body.length <= 100 && Buffer.byteLength(body) > 100)
+    assert.equal((await send(`${relay.url}/r/multibyte/publish`, 'POST', body)).status, 413)
+  } finally {
+    await relay.close()
+  }
+})
+
+test('a multibyte body under the cap is accepted and parses cleanly (decoded once, not per chunk)', async () => {
+  const relay = await startRelay({ ...local, clientBundleDir: '/no/such/bundle' })
+  try {
+    const body = JSON.stringify({ kind: 'log', message: 'café ☕ 日本語 🚀' })
+    assert.equal((await send(`${relay.url}/r/utf8/publish`, 'POST', body)).status, 202)
+    assert.deepEqual(relay.runIds(), ['utf8']) // it parsed as JSON and landed in the run
+  } finally {
+    await relay.close()
+  }
+})
+
 test('healthz is 200; a bad publish is rejected without crashing the run', async () => {
   const relay = await startRelay({ ...local, clientBundleDir: '/no/such/bundle' })
   try {

--- a/packages/framework/src/relay.ts
+++ b/packages/framework/src/relay.ts
@@ -182,23 +182,29 @@ function handle(req: IncomingMessage, res: ServerResponse, ctx: HandleCtx): void
 
 /** Read a JSON body (one event or an array) and push each event into the run's stream. */
 function ingestBody(req: IncomingMessage, res: ServerResponse, r: Run, maxBody: number): void {
-  let body = ''
+  // Collect raw bytes and decode once at the end: a per-chunk `String(chunk)` corrupts a
+  // multibyte UTF-8 codepoint split across two chunks, and the cap is in bytes, not the
+  // UTF-16 code units a string length would count.
+  const chunks: Buffer[] = []
+  let bytes = 0
   let tooBig = false
   req.on('data', (chunk: Buffer) => {
     if (tooBig) return
-    body += chunk
-    if (body.length > maxBody) {
+    bytes += chunk.length
+    if (bytes > maxBody) {
       tooBig = true
       res.writeHead(413, { 'content-type': 'text/plain' })
       res.end('payload too large')
       req.destroy()
+      return
     }
+    chunks.push(chunk)
   })
   req.on('end', () => {
     if (tooBig) return
     let parsed: unknown
     try {
-      parsed = JSON.parse(body)
+      parsed = JSON.parse(Buffer.concat(chunks).toString('utf8'))
     } catch {
       res.writeHead(400, { 'content-type': 'text/plain' })
       res.end('invalid json')


### PR DESCRIPTION
The relay's publish-body reader (`ingestBody`) had two UTF-8 defects. It did `body += chunk` per TCP chunk, so a multibyte codepoint split across a chunk boundary decoded to replacement characters; and it capped on the running string's `.length` (UTF-16 code units) against `maxBodyBytes`, so the size limit was wrong for any non-ASCII body. It now accumulates raw Buffers, caps on the byte count, and decodes once with `Buffer.concat(...).toString('utf8')`.

Tests: a multibyte body whose char length is under the cap but byte length is over it is now correctly rejected (413) where the old char-count accepted it; and a multibyte body under the cap is accepted and parses. Changeset: patch.