### PR TITLE
fix(framework-dashboard): keep the log and preferences live

### DIFF
--- a/packages/framework-dashboard/components/ProjectLogPanel.tsx
+++ b/packages/framework-dashboard/components/ProjectLogPanel.tsx
@@ -1,7 +1,7 @@
 import type { LogEntry } from '@gemstack/framework'
 import { onProjectLog } from '../server/reads.telefunc.js'
 import { Badge } from './ui/badge.js'
-import { useLoaded } from '../lib/use-async.js'
+import { usePolled } from '../lib/use-async.js'
 import { cn } from '../lib/utils.js'
 
 const STATUS_TONE: Record<string, string> = {
@@ -13,8 +13,10 @@ const STATUS_TONE: Record<string, string> = {
 
 // The committed project log (#378/#379): `.the-framework/LOGS.md`, every finished
 // loop/prompt/build run newest-first, over a Telefunc RPC (server/reads.telefunc.ts).
+// Polled like the sibling rail panels, so an entry a run appends on finishing shows up
+// without a project switch.
 export function ProjectLogPanel({ projectId }: { projectId: string | null }) {
-  const logs = useLoaded<LogEntry[]>(projectId ? () => onProjectLog(projectId) : null, [], [projectId])
+  const logs = usePolled<LogEntry[]>(projectId ? () => onProjectLog(projectId) : null, [], 10_000, [projectId]).value
 
   if (!projectId) return null
   if (logs.length === 0) return <p className="p-4 text-sm text-muted-foreground">No committed log entries yet.</p>

--- a/packages/framework-dashboard/lib/preferences.test.ts
+++ b/packages/framework-dashboard/lib/preferences.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+
+const onPreferences = vi.hoisted(() => vi.fn())
+const savePreferences = vi.hoisted(() => vi.fn())
+vi.mock('../server/preferences.telefunc.js', () => ({ onPreferences, savePreferences }))
+
+const flush = () => act(async () => {
+  await Promise.resolve()
+  await Promise.resolve()
+})
+
+describe('preferences', () => {
+  beforeEach(() => {
+    // The cache is module state, so each test needs a fresh module instance.
+    vi.resetModules()
+    onPreferences.mockReset()
+    savePreferences.mockReset().mockResolvedValue({ ok: true })
+  })
+
+  test('an optimistic update made during the initial load survives the load resolving', async () => {
+    let resolveLoad: (p: unknown) => void = () => {}
+    onPreferences.mockReturnValue(new Promise(r => (resolveLoad = r)))
+    const { usePreferences, updatePreferences, autopilotEnabled } = await import('./preferences.js')
+
+    const { result } = renderHook(() => usePreferences())
+    // The load is in flight; the user toggles autopilot off before it resolves.
+    act(() => updatePreferences({ autopilot: false }))
+    expect(autopilotEnabled(result.current)).toBe(false)
+
+    // The load now resolves with the server's pre-toggle value; the toggle must win.
+    await act(async () => {
+      resolveLoad({ autopilot: true })
+      await Promise.resolve()
+    })
+    expect(autopilotEnabled(result.current)).toBe(false)
+  })
+
+  test('the initial load populates the cache when no optimistic write raced it', async () => {
+    onPreferences.mockResolvedValue({ autopilot: false, technical: true })
+    const { usePreferences } = await import('./preferences.js')
+
+    const { result } = renderHook(() => usePreferences())
+    await flush()
+    expect(result.current).toEqual({ autopilot: false, technical: true })
+  })
+})

--- a/packages/framework-dashboard/lib/preferences.ts
+++ b/packages/framework-dashboard/lib/preferences.ts
@@ -30,11 +30,13 @@ function snapshot(): Preferences {
 function ensureLoaded(): void {
   if (cache || loading) return
   loading = onPreferences()
+    // `??=`, not `=`: a toggle made while this initial load was in flight already populated
+    // the cache and persisted, so the load must not overwrite it with the pre-toggle value.
     .then(preferences => {
-      cache = preferences
+      cache ??= preferences
     })
     .catch(() => {
-      cache = {}
+      cache ??= {}
     })
     .finally(() => {
       loading = null


### PR DESCRIPTION
Two live-data correctness fixes surfaced by the dashboard quality review.

**Project log went stale.** `ProjectLogPanel` read `.the-framework/LOGS.md` once (`useLoaded`) while its sibling rail panels poll (Docs 4s, FileTree 8s, GitStatus 10s). A run appends a log entry when it finishes, so the Log tab showed stale content until the user switched projects and back. Now it polls every 10s like the others.

**An optimistic preference toggle could revert.** The shared preferences cache loads once on mount; if the user flipped a toggle (e.g. Autopilot) before that load resolved, the load's `cache = preferences` overwrote the just-set value with the server's pre-toggle one, reverting the checkbox with no re-fetch to recover. The load now uses `cache ??= preferences` (and the same on the error path), so a write that raced the load wins. Regression test added (lib/preferences.test.ts).

Behavior-only; no changeset (private package). 31 tests pass, build green.