### PR TITLE
feat(framework): root tickets/ directory for the backlog (#629)

### DIFF
--- a/.changeset/tickets-dir-629.md
+++ b/.changeset/tickets-dir-629.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Keep the flat backlog under a root `tickets/` directory (`tickets/TODO.md`) instead of the repo root, so The Framework rides on a plain, visible convention (beside `DECISIONS.md`) rather than a proprietary file (#629). New backlogs are created there, the dashboard surfaces it, and a legacy root `TODO.md` is still read so existing repos keep their backlog. Session-scoped `TODO_<slug>.agent.md` files are unchanged.

--- a/packages/framework/src/dashboard/docs.test.ts
+++ b/packages/framework/src/dashboard/docs.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { readDocs, DOC_CATEGORIES } from './docs.js'
@@ -35,6 +35,20 @@ test('readDocs surfaces session-scoped PLAN_/TODO_ .agent.md files (#323/#326)',
   }
 })
 
+test('readDocs surfaces the flat backlog from tickets/TODO.md, after PLAN (#629)', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'framework-docs-'))
+  try {
+    await mkdir(join(cwd, 'tickets'))
+    await writeFile(join(cwd, 'tickets/TODO.md'), '- [ ] roadmap\n')
+    await writeFile(join(cwd, 'PLAN.md'), '# Plan\n')
+    const docs = await readDocs(cwd)
+    assert.deepEqual(docs.map(d => d.name), ['PLAN.md', 'tickets/TODO.md'])
+    assert.equal(docs[1]!.content, '- [ ] roadmap\n')
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
 test('readDocs skips missing and blank docs, and never throws', async () => {
   const cwd = await mkdtemp(join(tmpdir(), 'framework-docs-'))
   try {
@@ -49,11 +63,13 @@ test('readDocs skips missing and blank docs, and never throws', async () => {
 })
 
 test('DOC_CATEGORIES match fixed roots + slug-only scoped names (no traversal)', () => {
-  for (const { flat, scoped } of DOC_CATEGORIES) {
-    assert.doesNotMatch(flat, /[\\/]|\.\./)
+  for (const cat of DOC_CATEGORIES) {
+    assert.doesNotMatch(cat.flat, /[\\/]|\.\./)
+    // The optional `dir` (e.g. tickets/) is a fixed slug, not user input, so no traversal.
+    if ('dir' in cat) assert.match(cat.dir, /^[a-z0-9-]+$/)
     // The scoped pattern only admits a-z0-9- slugs, so no path separators slip in.
-    assert.ok(!scoped.test('PLAN_../evil.agent.md'))
-    assert.ok(!scoped.test('PLAN_a/b.agent.md'))
+    assert.ok(!cat.scoped.test('PLAN_../evil.agent.md'))
+    assert.ok(!cat.scoped.test('PLAN_a/b.agent.md'))
   }
   assert.ok(DOC_CATEGORIES[0]!.scoped.test('PLAN_my-branch.agent.md'))
   assert.ok(DOC_CATEGORIES[1]!.scoped.test('TODO_main-2.agent.md'))

--- a/packages/framework/src/dashboard/docs.ts
+++ b/packages/framework/src/dashboard/docs.ts
@@ -1,5 +1,6 @@
 import { readFile, readdir } from 'node:fs/promises'
 import { join } from 'node:path'
+import { findFlatTodo } from '../tickets.js'
 
 /**
  * The plan/backlog document categories the dashboard surfaces in its sidebar
@@ -7,14 +8,15 @@ import { join } from 'node:path'
  *
  * The Framework's system prompt writes these per session (#323/#326):
  * `PLAN_<SESSION>.agent.md` (the plan for now) and `TODO_<SESSION>.agent.md` (the
- * backlog), where SESSION is a git-branch slug. The flat `PLAN.md` / `TODO.md`
- * stay as a fallback for hand-written docs (and the current #301 prompt). Names are
- * matched against a flat readdir of the root, never taken from user input, so there
+ * backlog), where SESSION is a git-branch slug. The flat fallbacks are `PLAN.md`
+ * (root) and the backlog `tickets/TODO.md` (#629; `dir` marks it lives under the
+ * `tickets/` convention). Scoped and flat-root names are matched against a flat
+ * readdir of the root, never taken from user input; `dir` is a fixed slug, so there
  * is no path traversal to guard against.
  */
 export const DOC_CATEGORIES = [
   { flat: 'PLAN.md', scoped: /^PLAN_[a-z0-9-]+\.agent\.md$/ },
-  { flat: 'TODO.md', scoped: /^TODO_[a-z0-9-]+\.agent\.md$/ },
+  { flat: 'TODO.md', dir: 'tickets', scoped: /^TODO_[a-z0-9-]+\.agent\.md$/ },
 ] as const
 
 /** One surfaced document: its filename and current contents. */
@@ -41,9 +43,15 @@ async function surfacedFilenames(cwd: string): Promise<string[]> {
   }
   const present = new Set(entries)
   const names: string[] = []
-  for (const { flat, scoped } of DOC_CATEGORIES) {
-    if (present.has(flat)) names.push(flat)
-    names.push(...entries.filter(e => scoped.test(e)).sort())
+  for (const cat of DOC_CATEGORIES) {
+    if ('dir' in cat) {
+      // Flat backlog lives under `tickets/` (#629), with a legacy root fallback.
+      const flat = await findFlatTodo(cwd)
+      if (flat) names.push(flat)
+    } else if (present.has(cat.flat)) {
+      names.push(cat.flat)
+    }
+    names.push(...entries.filter(e => cat.scoped.test(e)).sort())
   }
   return names
 }

--- a/packages/framework/src/dashboard/queue.test.ts
+++ b/packages/framework/src/dashboard/queue.test.ts
@@ -17,7 +17,7 @@ test('parseTodoItems extracts task-list entries and their checked state', () => 
 
 test('collectQueue rolls up open TODO items per project, most-open first, skipping empties', async () => {
   const docs: Record<string, WorkspaceDoc[]> = {
-    '/a': [{ name: 'TODO.md', content: '- [ ] one\n- [ ] two\n- [x] gone\n' }],
+    '/a': [{ name: 'tickets/TODO.md', content: '- [ ] one\n- [ ] two\n- [x] gone\n' }], // #629 location, matched by basename
     '/b': [{ name: 'TODO_main.agent.md', content: '- [ ] only\n' }],
     '/c': [{ name: 'PLAN.md', content: '- [ ] not a todo doc\n' }], // no TODO doc -> skipped
     '/d': [{ name: 'TODO.md', content: '# nothing checkable\n' }], // TODO but no items -> skipped

--- a/packages/framework/src/dashboard/queue.ts
+++ b/packages/framework/src/dashboard/queue.ts
@@ -1,3 +1,4 @@
+import { basename } from 'node:path'
 import type { ProjectSummary } from './projects.js'
 import { readDocs, type WorkspaceDoc } from './docs.js'
 
@@ -49,7 +50,7 @@ export async function collectQueue(
   const queues: ProjectQueue[] = []
   for (const project of projects) {
     const docs = await read(project.path).catch(() => [])
-    const items = docs.filter(d => d.name.startsWith('TODO')).flatMap(d => parseTodoItems(d.content))
+    const items = docs.filter(d => basename(d.name).startsWith('TODO')).flatMap(d => parseTodoItems(d.content))
     if (items.length === 0) continue
     const open = items.filter(i => !i.done).length
     queues.push({ projectId: project.id, projectName: project.name, open, total: items.length, items })

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -270,6 +270,8 @@ export {
   parseTodoEntries,
   TODO_FILE_PATTERN,
   FLAT_TODO_FILE,
+  LEGACY_TODO_FILE,
+  TICKETS_DIR,
   DEFAULT_MAX_TODO_ITEMS,
   type TodoBacklog,
   type TodoLoopOptions,

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -743,7 +743,8 @@ test('runFramework leaves a resume note on the backlog when it pauses (#529)', a
       }),
     )
     // The backlog is what a later run drains, so the note needs no machinery of its own.
-    const todo = await readFile(join(cwd, 'TODO.md'), 'utf8')
+    // With no existing backlog, it is created at the #629 location, tickets/TODO.md.
+    const todo = await readFile(join(cwd, 'tickets/TODO.md'), 'utf8')
     assert.match(todo, /^- \[ \] Resume .+$/m)
     assert.ok(events.some(e => e.kind === 'log' && e.message.includes('to pick up when the limit resets')))
   } finally {

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -196,7 +196,7 @@ export interface RunFrameworkOptions {
   consumptionGate?: () => ConsumptionWindow | null
   /**
    * Run the backlog loop (#323) after the build settles: consume the agent's own
-   * `TODO_<slug>.agent.md` / `TODO.md` one entry per turn until empty, gating
+   * `TODO_<slug>.agent.md` / `tickets/TODO.md` one entry per turn until empty, gating
    * before each entry when {@link requestChoice} is wired. Default: on for real
    * drivers, off for the fake one (its scripted demo writes no backlog and must
    * stay deterministic). Set explicitly to force either way.

--- a/packages/framework/src/tickets.test.ts
+++ b/packages/framework/src/tickets.test.ts
@@ -1,0 +1,41 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { FLAT_TODO_FILE, LEGACY_TODO_FILE, TICKETS_DIR, findFlatTodo } from './tickets.js'
+
+test('the flat backlog lives at tickets/TODO.md, with the legacy root file named', () => {
+  assert.equal(TICKETS_DIR, 'tickets')
+  assert.equal(FLAT_TODO_FILE, 'tickets/TODO.md')
+  assert.equal(LEGACY_TODO_FILE, 'TODO.md')
+})
+
+test('findFlatTodo prefers tickets/TODO.md, falls back to legacy root TODO.md, else undefined (#629)', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'framework-tickets-'))
+  try {
+    assert.equal(await findFlatTodo(cwd), undefined)
+
+    // Only a legacy root TODO.md -> that is returned (existing repos keep their backlog).
+    await writeFile(join(cwd, 'TODO.md'), '- [ ] legacy\n')
+    assert.equal(await findFlatTodo(cwd), 'TODO.md')
+
+    // tickets/TODO.md present -> it wins over the legacy root file.
+    await mkdir(join(cwd, TICKETS_DIR))
+    await writeFile(join(cwd, FLAT_TODO_FILE), '- [ ] new\n')
+    assert.equal(await findFlatTodo(cwd), 'tickets/TODO.md')
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('findFlatTodo ignores a tickets/ directory that is not a file', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'framework-tickets-'))
+  try {
+    // A directory named exactly TODO.md must not be mistaken for the backlog file.
+    await mkdir(join(cwd, 'TODO.md'))
+    assert.equal(await findFlatTodo(cwd), undefined)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})

--- a/packages/framework/src/tickets.ts
+++ b/packages/framework/src/tickets.ts
@@ -1,0 +1,39 @@
+import { stat } from 'node:fs/promises'
+import { join } from 'node:path'
+
+/**
+ * The root `tickets/` directory (#629): a plain repo convention where The Framework
+ * keeps its human-facing roadmap files, rather than hiding them in a proprietary
+ * `.the-framework/` dir. It sits beside conventions like a root `DECISIONS.md`, and
+ * is where the durable backlog (`tickets/TODO.md`) and, later, ticket files live.
+ */
+export const TICKETS_DIR = 'tickets'
+
+/**
+ * The flat, durable backlog/roadmap file — the confirmed-task queue. Moved under
+ * `tickets/` in #629 (it used to sit at the repo root). This is the one a run drains
+ * and the dashboard surfaces; the session-scoped `TODO_<slug>.agent.md` files the
+ * system prompt writes are separate and stay at the root.
+ */
+export const FLAT_TODO_FILE = `${TICKETS_DIR}/TODO.md`
+
+/** The pre-#629 root location, still read so an existing repo keeps its backlog. */
+export const LEGACY_TODO_FILE = 'TODO.md'
+
+/** Whether a workspace-relative path is an existing file. Never throws. */
+async function isFile(cwd: string, rel: string): Promise<boolean> {
+  return stat(join(cwd, rel))
+    .then(s => s.isFile())
+    .catch(() => false)
+}
+
+/**
+ * The workspace's flat backlog file: the #629 `tickets/TODO.md` if present, else a
+ * legacy root `TODO.md`. Returns the workspace-relative path, or `undefined` when
+ * neither exists. New backlogs are created at {@link FLAT_TODO_FILE}.
+ */
+export async function findFlatTodo(cwd: string): Promise<string | undefined> {
+  if (await isFile(cwd, FLAT_TODO_FILE)) return FLAT_TODO_FILE
+  if (await isFile(cwd, LEGACY_TODO_FILE)) return LEGACY_TODO_FILE
+  return undefined
+}

--- a/packages/framework/src/todo-loop.test.ts
+++ b/packages/framework/src/todo-loop.test.ts
@@ -1,12 +1,12 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { writeFileSync } from 'node:fs'
-import { mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { FakeDriver } from './driver/fake.js'
 import type { ChoicePick, ChoiceRequest, FrameworkEvent } from './events.js'
-import { findTodoBacklog, parseTodoEntries, runTodoLoop } from './todo-loop.js'
+import { appendTodoEntry, findTodoBacklog, parseTodoEntries, runTodoLoop } from './todo-loop.js'
 
 async function tmpWorkspace(): Promise<string> {
   return mkdtemp(join(tmpdir(), 'framework-todo-'))
@@ -56,6 +56,36 @@ test('findTodoBacklog prefers the newest session-scoped file, falls back to flat
     await writeFile(join(cwd, 'TODO_feat-y.agent.md'), '- [x] all done\n')
     await writeFile(join(cwd, 'TODO_feat-x.agent.md'), '- [x] all done\n')
     assert.equal((await findTodoBacklog(cwd))?.name, 'TODO.md')
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('findTodoBacklog reads the flat backlog from tickets/TODO.md (#629)', async () => {
+  const cwd = await tmpWorkspace()
+  try {
+    await mkdir(join(cwd, 'tickets'))
+    await writeFile(join(cwd, 'tickets/TODO.md'), '- [ ] roadmap entry\n')
+    assert.deepEqual(await findTodoBacklog(cwd), { name: 'tickets/TODO.md', entries: ['roadmap entry'] })
+
+    // A session-scoped backlog still wins over the flat one, wherever the flat one lives.
+    await writeFile(join(cwd, 'TODO_feat-x.agent.md'), '- [ ] scoped entry\n')
+    assert.equal((await findTodoBacklog(cwd))?.name, 'TODO_feat-x.agent.md')
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('appendTodoEntry creates tickets/TODO.md (and its dir) when the workspace has no backlog (#629)', async () => {
+  const cwd = await tmpWorkspace()
+  try {
+    const file = await appendTodoEntry(cwd, 'Resume the paused run')
+    assert.equal(file, 'tickets/TODO.md')
+    assert.equal(await readFile(join(cwd, 'tickets/TODO.md'), 'utf8'), '- [ ] Resume the paused run\n')
+
+    // A second entry appends to the same file, not a new one.
+    await appendTodoEntry(cwd, 'And another')
+    assert.equal(await readFile(join(cwd, 'tickets/TODO.md'), 'utf8'), '- [ ] Resume the paused run\n- [ ] And another\n')
   } finally {
     await rm(cwd, { recursive: true, force: true })
   }

--- a/packages/framework/src/todo-loop.ts
+++ b/packages/framework/src/todo-loop.ts
@@ -1,9 +1,12 @@
-import { readdir, readFile, stat, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
 import type { DriverSession } from './driver/index.js'
 import type { ChoicePick, ChoiceRequest, FrameworkEvent } from './events.js'
 import { requestChoices, runAwaitRounds } from './run.js'
+import { FLAT_TODO_FILE, findFlatTodo } from './tickets.js'
 import { createTurnSignalEmitter } from './turn-gate.js'
+
+export { FLAT_TODO_FILE, LEGACY_TODO_FILE, TICKETS_DIR } from './tickets.js'
 
 /**
  * The backlog loop (#323): once the main work settles, consume the agent's own
@@ -19,9 +22,6 @@ import { createTurnSignalEmitter } from './turn-gate.js'
 
 /** The session-scoped backlog filename the #326 prompt writes. */
 export const TODO_FILE_PATTERN = /^TODO_[a-z0-9-]+\.agent\.md$/
-
-/** The flat fallback the current pill (#301) still writes. */
-export const FLAT_TODO_FILE = 'TODO.md'
 
 /** A located backlog: its filename and the entries still open. */
 export interface TodoBacklog {
@@ -56,8 +56,9 @@ export function parseTodoEntries(md: string): string[] {
 
 /**
  * The workspace's backlog files, best first: the most recently modified
- * session-scoped `TODO_<slug>.agent.md` (#323/#326), then the flat `TODO.md`
- * the current pill writes (#301) — the same dual convention as the doc sidebar.
+ * session-scoped `TODO_<slug>.agent.md` (#323/#326), then the flat backlog
+ * (`tickets/TODO.md`, or a legacy root `TODO.md`) — the same dual convention as
+ * the doc sidebar.
  */
 async function backlogCandidates(cwd: string): Promise<string[]> {
   let names: string[]
@@ -77,7 +78,8 @@ async function backlogCandidates(cwd: string): Promise<string[]> {
   } else {
     candidates.push(...scoped)
   }
-  if (names.includes(FLAT_TODO_FILE)) candidates.push(FLAT_TODO_FILE)
+  const flat = await findFlatTodo(cwd)
+  if (flat) candidates.push(flat)
   return candidates
 }
 
@@ -97,6 +99,7 @@ export async function appendTodoEntry(cwd: string, entry: string): Promise<strin
   try {
     const existing = await readFile(path, 'utf8').catch(() => '')
     const separator = existing === '' || existing.endsWith('\n') ? '' : '\n'
+    await mkdir(dirname(path), { recursive: true }) // fresh tickets/TODO.md needs its dir
     await writeFile(path, `${existing}${separator}- [ ] ${entry}\n`, 'utf8')
     return name
   } catch {
@@ -255,7 +258,7 @@ export async function runTodoLoop(opts: TodoLoopOptions): Promise<TodoLoopResult
     emit({ kind: 'log', message: `Backlog item ${completed + 1}: ${preview}` })
     // Complete exactly the first open entry and check it off, honoring await gates.
     // A declined plan (#358) ends the item turn; the loop's stall check takes it from there.
-    const prompt = `Open \`${backlog.name}\` at the workspace root and work on the FIRST open entry only. Complete it fully and verify your work. Then update \`${backlog.name}\`: check the entry off (or remove it). Do not start any other entry.`
+    const prompt = `Open \`${backlog.name}\` in the workspace and work on the FIRST open entry only. Complete it fully and verify your work. Then update \`${backlog.name}\`: check the entry off (or remove it). Do not start any other entry.`
     await runAwaitRounds({ session, prompt, ...gateDeps })
     completed++
 


### PR DESCRIPTION
Closes #629.

Move the flat backlog to a root `tickets/` directory (`tickets/TODO.md`), so The Framework rides on a plain, visible convention (beside `DECISIONS.md`) instead of a proprietary file.

- New backlogs are created at `tickets/TODO.md` (the dir is made on demand); the dashboard surfaces it.
- A legacy root `TODO.md` is still read, so existing repos keep their backlog. No files are auto-moved.
- The session-scoped `TODO_<slug>.agent.md` files are untouched, so **the system prompt does not change** (only the flat/durable file moves). Reconciling the scoped files with `tickets/` belongs to the Queue work (#624) and would need a prompt tweak.

New leaf module `tickets.ts` (`TICKETS_DIR`, `FLAT_TODO_FILE`, `LEGACY_TODO_FILE`, `findFlatTodo`) is the single source of the location; `todo-loop`, the docs rail, and the queue rollup all read through it.

Tests: new `tickets.test.ts` + added cases to todo-loop/docs/queue. Full framework build + typecheck green; dashboard typecheck green.
