### PR TITLE
chore: import GitHub issues as tickets/ (dogfooding #462)

### DIFF
--- a/tickets/109-ai-autopilot%3A_sandboxed_runner_adapters_(Docker_%2F_WebContainer_%2F_Flue).md
+++ b/tickets/109-ai-autopilot%3A_sandboxed_runner_adapters_(Docker_%2F_WebContainer_%2F_Flue).md
@@ -1,0 +1,12 @@
+# ai-autopilot: sandboxed runner adapters (Docker / WebContainer / Flue)
+
+Follow-up from the ai-autopilot epic (#97). The runner seam and the first real adapter (`LocalRunner`, #106) shipped. What's left are the *sandboxed* adapters that isolate untrusted agent code:
+
+- [x] **Docker** — full-fidelity, background/long-running; needs a Docker daemon. **Shipped** (`DockerRunner`, PR #142; sandboxed boot-and-serve E2E, PR #143).
+- [x] **WebContainer** — instant in-browser Vike preview; needs a browser runtime. **Shipped** (`WebContainerRunner`, PR #223; headless-Chromium boot-and-serve harness under `harness/webcontainer/`, 15/15).
+- [ ] **Flue** — mirror Flue's `sandbox` contract (in-memory / edge / container); needs a live Flue env.
+
+`LocalRunner` is the reference each mirrors; `FakeRunner` covers tests. Docker is done; WebContainer and Flue remain infra-gated (can't be built and honestly verified without provisioning that infra first).
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/109

--- a/tickets/11-Design%3A_optional_TS-first_skill_authoring_(defineSkill)_alongside_SKILL.md.md
+++ b/tickets/11-Design%3A_optional_TS-first_skill_authoring_(defineSkill)_alongside_SKILL.md.md
@@ -1,0 +1,25 @@
+# Design: optional TS-first skill authoring (defineSkill) alongside SKILL.md
+
+Spun out of #8 (Q1). #8 decided the **primary** skill manifest format is `SKILL.md` frontmatter (matches the shipped `boost/skills` convention + Anthropic Agent Skills; portable; natural progressive disclosure). This issue tracks a possible **TS-first authoring path** as an *additional* option later, not a replacement.
+
+## Idea
+Offer a typed `defineSkill({ name, description, instructions, tools, resources })` (or a `Skill` class) that produces the same runtime skill object the `SKILL.md` loader produces. Two front doors, one runtime.
+
+## Why someone might want it
+- Full type safety + IDE support at authoring time.
+- Tools can be real `tool()` objects inline (no name/path resolution).
+- Native composition with the `Agent` class for code-only projects.
+
+## Why it is deferred (not in #8)
+- Diverges from the Anthropic shape, so TS-authored skills are not portable out the way `SKILL.md` bundles are. The markdown path is the moat.
+- Long instructions read poorly as TS template strings.
+- Progressive disclosure is less natural (the module loads at import).
+- Adds a second authoring surface to maintain - only worth it if there is real demand.
+
+## Acceptance (if built)
+`defineSkill(...)` yields a skill object indistinguishable to the runtime/composition layer from one loaded via `SKILL.md`, with tests proving parity. Markdown remains the documented default; TS-first is opt-in.
+
+Gated on the same family alignment as #8; design-only for now.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/11

--- a/tickets/110-Epic%3A_The_AI_framework_—_turnkey_end-to-end_AI_orchestration_for_building_software_(web-app_first).md
+++ b/tickets/110-Epic%3A_The_AI_framework_—_turnkey_end-to-end_AI_orchestration_for_building_software_(web-app_first).md
@@ -1,0 +1,57 @@
+# Epic: The AI framework — turnkey end-to-end AI orchestration for building software (web-app first)
+
+## The bet
+
+A **turnkey** AI framework for building web apps. `npm install` and it works: prompts, personas, and flows already wired, opinionated about the stack (Vike/Next + universal-orm). Claude Code for the web, supercharged, not low-level agent infra you assemble yourself.
+
+This extends the ai-autopilot thesis (#97, closed) from "the seed" (personas + runner + surfaces, all shipped) to the full product. Flue/Pi/Omnigent are generic harnesses we sit on; none ship the web-app-specific layer. That layer is the moat.
+
+## Scope (agreed 2026-07-02)
+
+**Agnostic core + domain presets.** The engine (the loop + the state layer: decisions ledger, CODE-OVERVIEW, review/quality/security triggers) is language- and framework-agnostic and runs on any codebase; most prompts are generic. The web-app-specific value (Vike/Next personas, UI-flow => QA+UX) sits on top as a **preset**. Web-app is the flagship preset and the launch wedge, we lead the story there, not with "works on any code" (the crowded/generic pitch). Non-web presets (e.g. Python) are possible later.
+
+Execution model (updated 2026-07-03, see #165): the shipped product **wraps the Claude Code CLI** and drives it as a black-box **outer loop** — we send prompts, read the code it produced, and gate on outcomes (builds / serves / review-passes / PR-exists); we never reach inside its loop. This lets users spend a Claude Max subscription and keeps us provider-swappable (Codex/opencode behind the same driver adapter). `@gemstack/ai-sdk` remains the lower-level, provider-agnostic engine (pay-per-token) that the orchestration primitives and any non-wrapped paths run on — it is the engine, not the shell. Guardrails (swappable driver, own the event stream) live in #165. (Verify Claude Code ToS before relying on the subscription path.)
+
+## Positioning
+
+- **Turnkey**: zero wiring. `npm install` and go.
+- **Opinionated**: knows Vike/Next + universal-orm. Data stays separate (universal-orm), as agreed.
+- **Open source, collaborative**: the community grows the prompt/flow library via PRs, and it stays turnkey for everyone.
+- Name (decided 2026-07-03): **"The Framework"**, tagline "The (AI) Framework", domain `the-framework.ai`, npm `@gemstack/framework` (`npm i -g`). Positioning shorthand: "Vite for AI" (turnkey/zero-config) vs competitors' "webpack for AI" (low-level).
+
+## Children (buildable, in priority order)
+
+Status (2026-07-02): the whole state layer + loop + bootstrap are built and merged. Only #115 (deliberately scope-open) and the infra-gated pieces remain.
+
+- [x] #111 — **Built-in prompts library** (P0, first): review (TLDR + thorough), code quality, security audit, refactoring, UX, QA, knowledge base / business context. The v1 and the main OSS contribution surface.
+- [x] #112 — **Decisions bookkeeping** (P1): persist rejected ideas so the AI stops re-pitching them. Novel; nobody ships it.
+- [x] #113 — **"The loop"** (P1): event to prompt-chain policy. A major change fires review + code quality + security; a new UI flow fires QA + UX. Runs on the autopilot Supervisor + surfaces.
+- [x] #114 — **Scale mode** (P2): maintain a `CODE-OVERVIEW.md` so the agent navigates a large codebase fast.
+- [x] #115 — **Web-app preset (Next.js + Vike)**: the flagship domain preset on top of the agnostic core; framework-specific personas/prompts at the persona/prompt/loop layer only. (Scope deliberately open pending v1 traction.)
+- [x] #116 — **Bootstrap mode** (P-high): zero to a production-grade app, scope prompt + full-fledged loop + dev-style narration. Likely our best first-run / acquisition hook. (Framework side done #120-123; only the live capstone #124 is infra-gated.)
+- [ ] #165 — **Presentation layer**: headless server + two thin UIs (CLI + localhost web chat) on one backend, over the existing `EventStream`. Open decision: own shell vs. sit on opencode.
+
+## Parked (not children yet)
+
+- **Paid-hosting business model** (decision, not a buildable issue). (Product name decided 2026-07-03 — see Positioning.)
+
+Foundation: #97.
+
+## Landscape + positioning (validated 2026-07-02, competitive scan)
+
+The "prompt collection + workflow + OSS PRs" positioning is already crowded: BMAD, GitHub Spec Kit, OpenSpec, GSD, Superpowers (170k+ combined stars) all sit there, betting on **spec-driven** dev. Cloudflare published their internal review-orchestration system (runs "the loop" at scale in CI; found AGENTS.md-style instruction files rot fast, so they built a reviewer that detects material changes and forces updates). Claude Squad / Baton orchestrate parallelism, not quality loops. LangGraph/CrewAI = infra layer, not competitors.
+
+So: **prompts are table stakes / the on-ramp, not the moat.** Lead the product with the auto-maintained **state layer + the loop**, which is the whitespace:
+- Decisions bookkeeping (#112) — nobody has a rejected-ideas ledger. Most original.
+- Semantic event-triggered loops (#113) — others are command-driven or CI-every-PR, not change-type-aware.
+- Browser-agent QA on UI changes — nobody ships it inside a workflow framework (near-standalone).
+- Auto-maintained CODE-OVERVIEW.md (#114) — validated by Cloudflare's "instructions rot" finding.
+
+Our bet (review/QA loops + persistent state) differs from the spec-driven pack. Lead with it so we don't read as "the sixth spec framework."
+
+**Which agent do we orchestrate?** (updated 2026-07-03) The product **wraps the Claude Code CLI** as an outer loop; `@gemstack/ai-sdk` is the underlying provider-agnostic engine, not the shell. Wrapping a vendor CLI does raise a real "could Anthropic eat this layer" risk — the #165 guardrails are how we mitigate it: (1) the wrapped CLI is a **swappable driver adapter** (Claude Code first, Codex/opencode behind the same seam), so no single vendor is load-bearing; the only hard dependency is the code/outcome seam we own; (2) we **own our own event stream** (the Supervisor already emits it) rather than betting the UX on any one vendor's UI. The defensible value stays in the loop + state layer + team/multiplayer, not the shell.
+
+**Business model:** keep the OSS local version from being so complete that hosting is pointless. The paid wedge is team/multiplayer (shared decision log, review history, org-wide business context), not "we run it for you."
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/110

--- a/tickets/12-Design%3A_optional_skill-scoped_tool_wrapper_(skillTool)_over_tool().md
+++ b/tickets/12-Design%3A_optional_skill-scoped_tool_wrapper_(skillTool)_over_tool().md
@@ -1,0 +1,27 @@
+# Design: optional skill-scoped tool wrapper (skillTool) over tool()
+
+Spun out of #8 (Q2). #8 decided skills declare tools by **reusing `ai-sdk` `tool()` directly** (a co-located `tools.ts` per skill; the loader merges them and handles namespacing/scoping at composition time). One tool API, full typing, skills stay self-contained.
+
+This issue tracks a possible **skill-scoped tool wrapper** as an *additional* future option, to evaluate if a concrete need appears.
+
+## Idea
+A `skillTool()` / `defineSkillTool()` wrapper over `tool()` that bakes skill-level concerns into authoring time:
+- namespacing (collision-safe names when many skills load at once)
+- scoping/lifecycle (a tool active only while its skill is loaded)
+- access to the owning skill's resources/context inside the tool handler
+
+## Why it is deferred (not in #8)
+- It is a second tool API to learn and maintain - violates "one way to do it" unless clearly needed.
+- The concerns it solves (namespacing, active-only-while-loaded) are solvable at **composition time** in the loader, without burdening every tool author.
+- Justified only if tools genuinely need skill context that plain `tool()` cannot carry. Not demonstrated yet.
+
+## Trigger to revisit
+Open evidence here if/when: multi-skill loading produces real tool-name collisions the loader cannot cleanly resolve, or a skill's tools need first-class access to that skill's resources at call time.
+
+## Acceptance (if built)
+`skillTool(...)` produces tools indistinguishable to the runtime from `tool()` outputs, adds the skill-context/namespacing it promises, and `tool()` remains the default. Tests prove parity + the added scoping.
+
+Gated on the same family alignment as #8; design-only for now.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/12

--- a/tickets/13-Design%3A_optional_imperative_agent.use(skill)_runtime_composition.md
+++ b/tickets/13-Design%3A_optional_imperative_agent.use(skill)_runtime_composition.md
@@ -1,0 +1,32 @@
+# Design: optional imperative agent.use(skill) runtime composition
+
+Spun out of #8 (Q4). #8 decided the **primary** composition API is a declarative `skills()` class method (mirrors `tools()`/`middleware()`); the agent's own `instructions()`/`tools()` are authoritative and skills augment + yield on conflict; progressive disclosure is handled lazily by the runtime.
+
+This issue tracks an optional **imperative `agent.use(skill)`** runtime-composition API as an *additional* path later.
+
+## Idea
+Allow attaching skills at runtime, after construction:
+- `agent.use(skill)` for conditional/dynamic composition (e.g. load a skill based on the incoming request or user).
+- Likely also `agent.forUser(id).use(...)` / `agent.continue(convId).use(...)` for per-conversation skill sets.
+
+## Why someone might want it
+- Compose skills based on runtime conditions the class cannot know at definition time.
+- Per-user / per-conversation skill sets.
+
+## Why it is deferred (not in #8)
+- Breaks the declarative class idiom that the rest of `Agent` follows.
+- Introduces mutable agent state (precedence/ordering rules get harder).
+- Not required for progressive disclosure - the declarative `skills()` set already loads lazily at runtime.
+
+## Open design points (if built)
+- Precedence when a runtime-added skill collides with a declared one (last-wins? declared-wins?).
+- Immutability: does `use()` return a derived agent rather than mutating in place?
+- Interaction with `forUser()`/`continue()` scoping.
+
+## Acceptance (if built)
+`agent.use(skill)` composes a skill at runtime with the same merge/precedence semantics as declarative `skills()`, without mutating shared agent state in a surprising way. Declarative `skills()` remains the documented default. Tests prove parity + the scoping rules.
+
+Gated on the same family alignment as #8; design-only for now.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/13

--- a/tickets/291-Dogfooding%3A_publish_the_vike-%2A_packages_to_npm.md
+++ b/tickets/291-Dogfooding%3A_publish_the_vike-%2A_packages_to_npm.md
@@ -1,0 +1,17 @@
+# Dogfooding: publish the vike-* packages to npm
+
+Part of #286 (dogfooding). This is gap 3 from the analysis, and it turns out to be a concrete publish task, not an open design question.
+
+Why `--compose-extensions` only works inside the vike-data workspace: the built-in composers (framework-auth/data/rbac/crud/shell) just frame the agent to build on the vike-* packages. But those packages are all `"private": true` and not on npm, so a generated app can only install them via workspace linking. Outside the monorepo the framework falls back to hand-rolled auth + Prisma.
+
+Confirmed private + unpublished (in the vike-data repo): vike-auth, vike-rbac, vike-crud, vike-admin, vike-themes, vike-layouts, vike-toolbar, plus @vike-data/vike-schema and @universal-orm/core.
+
+To close (work happens in the vike-data repo):
+- decide the public package names first (they are inconsistent today: bare `vike-auth`, scoped `@vike-data/vike-schema`, scoped `@universal-orm/core`). This is the one bit worth a quick alignment before publishing.
+- flip `private`, set real versions, publish via changesets.
+- then verify `--compose-extensions` scaffolds a real app in an empty dir outside the monorepo and it installs the extensions from npm.
+
+Once this lands, the integrated reference app (#288) can be built anywhere, not just inside vike-data.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/291

--- a/tickets/297-[The_Framework]_Bootstrap_mode.md
+++ b/tickets/297-[The_Framework]_Bootstrap_mode.md
@@ -1,0 +1,14 @@
+# [The Framework] Bootstrap mode
+
+In the dashboard, there's a button "Create new project".
+
+Then it all starts with one question/prompt:
+
+"What do you want to build?"
+
+Label: "You can describe what you want approximately (e.g. just a hunch, just a vision, just an idea) and we'll create a plan together. Or you can go ahead with a concrete plan."
+
+Low-prio for now I think (because I ain't sure how well we can make it work, to be tested).
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/297

--- a/tickets/298-[The_Framework]_Background_jobs.md
+++ b/tickets/298-[The_Framework]_Background_jobs.md
@@ -1,0 +1,16 @@
+# [The Framework] Background jobs
+
+Implements:
+- Listeners
+  - Error in production (Sentry, Cloudfalre, ...) => triggers agent
+  - CI is red on `main` (GitHub) => triggers agent
+- The [usage max-out idea](https://github.com/gemstack-land/gemstack/pull/287/changes):
+  - Check the current usage limit + when the limit resets
+    - If usage limit reached (with a configurable margin) => abort, don't do any maintenance
+    - Make sure to also check the usage limit of the current default model => use a fallback model if usage limit is reached (with a configurable margin)
+  - If there's capacity, then check the latest commits of all The Framework repos that weren't reviewed by the maintenance loop yet => apply the maintenance loop
+- Autopilot mode (fully automatic development cycle, including feature requests)
+- More?
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/298

--- a/tickets/312-CLI.md
+++ b/tickets/312-CLI.md
@@ -1,0 +1,17 @@
+# CLI
+
+> [!NOTE]
+> This includes brainstorming ideas (long-term vision). **A lot is out-of-scope for the MVP:** we can only implement the MVP-relevant parts.
+
+I suggest that running `$ framework` does the following:
+- [x] Ensure The background process that runs the localhost dashboard (e.g. `localhost:4200`) is running
+- [ ] Runs [background jobs](https://github.com/gemstack-land/gemstack/issues/298)
+- [x] Prints the list of commands (just convenience commands like `framework run [prompt]`, `framework logs`, ... — not important since the UI already implements all features)
+- [ ] Prints the CLI version
+  - [Only if trivial to implement] Show whether the version is up-to-date (by using `$ npm info`).
+    - Should be async (show static info first, then await npm server and show "up-to-date" label)
+    - The CLI regularly auto-updates itself
+    - Also show `(✅ auto-update enabled)`.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/312

--- a/tickets/313-Database.md
+++ b/tickets/313-Database.md
@@ -1,0 +1,35 @@
+# Database
+
+## Project DB
+
+> [!NOTE]
+> This includes brainstorming ideas (long-term vision). **A lot is out-of-scope for the MVP:** we can only implement the MVP-relevant parts.
+
+I suggest:
+- `.the-framework/LOGS.md` contains the list of AI loops/prompts that were run via The Framework
+  - We therefore don't need any real database, the `.the-framework/` directory *is* the database (it isn't `.gitignore` so it's persisted)
+  - A log entry can be a loop or a standalone prompt
+    - A loop is a list of standalone prompts
+  - Each log entry contains the Claude Code session ID (with a link such as `https://claude.ai/code/session_01MU13ncNmLi5rz2xySmm5rZ`, possible thanks to Claude's [Remote Control](https://code.claude.com/docs/en/remote-control))
+  - We can very effeciently crawl repo files using `$ git ls-files`.
+    - That's [what Vike does](https://github.com/vikejs/vike/blob/8a6511d506a8db32f05944646d52f711eaa1682f/packages/vike/src/node/vite/shared/resolveVikeConfigInternal/crawlPlusFilePaths.ts#L76) and is has been working great. Note that it also lists untracked files.
+- Commit messages authored by The Framework contain data.
+  - For example, if the commit introduces changes that require refactoring, then `TO-DO/maintenance` is appended:
+    ```
+    [The Framework] Commit message
+
+    TO-DO/maintenance
+    ```
+    > E.g. because the PR introduced a bug fix using that applies minimal changes in order to make reviewing easier, but requires refactoring to be clean.
+
+## User DB
+
+A special Git repo named `my-framework` (convention, but the user can save the `my-framework/` directory anywhere) that holds user-specific settings.
+
+
+## See also
+
+- https://github.com/gemstack-land/gemstack/issues/454
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/313

--- a/tickets/326-System_prompt.md
+++ b/tickets/326-System_prompt.md
@@ -1,0 +1,113 @@
+# System prompt
+
+## System prompt
+
+```md
+# System prompt
+
+SHOW_MD: Show it via `showMarkdown()`
+SHOW_CHOICES: Show it via `showChoices()`
+AWAIT: Stop, await user answer before resuming
+SESSION_NAME: the name of the session
+TODO_FILE: `TODO_<SESSION_NAME>.agent.md`
+ADD_ANALYSIS_ENTRY: Add entry to the ANLYSIS_RESULT.md list
+
+## Analyze the user prompt
+
+Analyze the user prompt, follow the instructions, create ANLYSIS_RESULT.md that lists the analysis results, and show it via showMarkdownSecondary()
+
+### Ambiguous prompt
+
+If it isn't clear what you should do (e.g. unclear scope, unclear user prompt), make a list of interpretations sorted by plausibility, <SHOW_CHOICES>, <AWAIT>
+
+<ADD_ANALYSIS_ENTRY> whether YES/NO the prompt is ambiguous
+
+### Scope
+
+- If the scope of what you'll work on is *large*, create a `PLAN_<SESSION_NAME>.agent.md` of what you'll work on, <SHOW_MD>, <AWAIT>
+- If the scope is potentially *very large* (e.g. spans over many hours/days of work), also create a <TODO_FILE> (backlog of follow-up tasks) and <SHOW_MD>
+
+<ADD_ANALYSIS_ENTRY> whether the scope is small, large, or very large
+
+
+## Before starting changes
+
+Do the following before applying your first change.
+
+### Session name
+
+1. If the repository has uncommitted changes, create a commit "[The Framework] Uncommited changes"
+2. Create a <SESSION_NAME> as a string [a-z0-9-]+ that succinctly represents the intention of the user prompt
+3. Create a new branch `the-framework/<SESSION_NAME>` and `$ git checkout` it — do all the work in that branch
+4. Call setSessionName(<SESSION_NAME>)
+
+
+## Before applying changes
+
+Do the following before applying changes — do it again anytime you make new changes.
+
+### Alternatives
+
+Measure "variability":
+- List all high-level problems that you're about to solve
+- Give a rating to each problem (from 0 to 10) following this criteria: is there an obviously optimal way to solve the problem (10), or is it highly unclear whether the problem can be solved in a better way (0)?
+- Explore and suggest alternatives for problems with a low rating
+- For each problem that has alternatives: list all alternatives sorted in a sensible order, <SHOW_CHOICES>, <AWAIT>
+
+
+## After applying changes
+
+After you're done, consider whether <SESSION_NAME> is finished and there isn't any work left to do — if that's the case then call setReadyForMerge()
+
+
+
+# User prompt
+
+${{tf.prompt}}
+```
+
+> [!NOTE]
+> The idea of `showMarkdownSecondary()` is to show the markdown in a less prominent way than `showMarkdown()`. For the MVP, we can make both equivalent.
+
+## Post-merge prompt
+
+```md
+TODO_FILE: `TODO_<SESSION_NAME>.agent.md`
+
+## Maintenance
+
+If the changes introduced by ${{ tf.session_name }} aren't trivial and have refactor potential, add the following to <TODO_FILE>
+- `Apply ${{ tf.presets.maintainability.filePath }} with tf.params.what set to "changes introduced by ${{ tf.session_name }}"`
+${{ !tf.settings.technical_control ? '' : (`
+- `Apply ${{ tf.presets.readability.filePath }} with tf.params.what set to "changes introduced by ${{ tf.session_name }}"`
+`.trim() + '\n') }}
+
+If the changes introduced by ${{ tf.session_name }} can potentially lead to security issues, add the following to <TODO_FILE>
+- `Apply ${{ tf.presets.security_audit.filePath }} with tf.params.what set to "changes introduced by ${{ tf.session_name }}"`
+```
+
+> [!NOTE]
+> Same presets as the buttons show in the UI.
+
+> [!NOTE]
+> I think the best would be:
+> - New user setting `[] Eager post-merge cleanup` => post-merge prompts are fired optimistically as soon as `setReadyForMerge()` is fired (even before human review)
+> - Otherwise, these post-merge prompts are only fired after actual merge
+> 
+> Merge conflicts are easy for AI to resolve — parallelizing the maintenance/readability refactor is worth it, I guess.
+> 
+> MVP shortcuts welcome. For example, we can skip the user setting — or whatever you think can make us move faster.
+
+
+
+## See also
+
+- https://github.com/gemstack-land/gemstack/issues/323
+- https://github.com/gemstack-land/gemstack/issues/297#issuecomment-4913683778
+- https://github.com/gemstack-land/gemstack/issues/331
+- https://github.com/gemstack-land/gemstack/issues/361
+- https://github.com/gemstack-land/gemstack/issues/360
+- https://github.com/gemstack-land/gemstack/issues/461
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/326

--- a/tickets/411-App_instead_of_`localhost`%3F.md
+++ b/tickets/411-App_instead_of_`localhost`%3F.md
@@ -1,0 +1,12 @@
+# App instead of `localhost`?
+
+I wonder whether we should use Electron (or preferably something like Tauri if it's a viable solution).
+
+Downside: bloat.
+
+Upside: looks professional.
+
+I think it's worth it... especially if we can use a solution that doesn't bloat the user's memory. Is Tauri (or some other tool) a good option?
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/411

--- a/tickets/453-Git_worktrees.md
+++ b/tickets/453-Git_worktrees.md
@@ -1,0 +1,8 @@
+# Git worktrees
+
+If we want Claude Code to be able to work on multiple tasks at the same time for the same repo, we'll need to use Git worktress.
+
+We'll probably need it fairly soon, but I ain't sure how complex it is to fully implement, so we can make it post-MVP.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/453

--- a/tickets/454-Syncing_UI%3C-%3Edata.md
+++ b/tickets/454-Syncing_UI%3C-%3Edata.md
@@ -1,0 +1,17 @@
+# Syncing UI<->data
+
+There seem to be fundamental question about how the UI should be synced with the data it shows.
+
+So far, I think the best approach is to treat the filesystem (more precisely speaking, all the Git repos) as the single source-of-truth.
+
+The potential downside is that we'll need filesystem watchers. So far I think it can work reliably though: Vite shows that watching all the files of a project works, and we'll only need to watch The Framework's `.the-framework/*` data (of all Git repos).
+
+The follow up question is about Telefunc. How can we use Telefunc to automatically sync the UI with `.the-framework/*` data? @nitedani Ideas?
+
+@suleimansh In then meantime, for the MVP, I guess it's enough if the UI requests the data at load time (no syncing, user has to F5 the page to get fresh data), while the main view is synced via Telefunc Stream.
+
+See also:
+- https://github.com/gemstack-land/gemstack/issues/313
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/454

--- a/tickets/455-Marketing.md
+++ b/tickets/455-Marketing.md
@@ -1,0 +1,14 @@
+# Marketing
+
+Umbrella ticket for marketing concerns.
+
+Intro text (WIP, I will polish this a *lot*):
+
+> The goal of The Framework is to build a "Vite for agents" that is 100% open source (unlike Claude Code that is closed source).
+>
+> The difference between OpenCode and what we're building is that The Framework takes care of the *entire* AI orchestration pipeline (including open-source prompts, loops, and skills). It's a turnkey solution.
+>
+> It's kinda like open source Autopilot for Software Development: engineers take care of complex decisions, while AI fully and automatically takes care of the rest. The Framework automatically orchestrates the entire lifecycle as an automatic loop of product management, writing code, reviewing, refactoring for high-quality code, bug fixing, security audit, maintenance, ...).
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/455

--- a/tickets/460-Vike_error.md
+++ b/tickets/460-Vike_error.md
@@ -1,0 +1,23 @@
+# Vike error
+
+I'll have a look at it.
+
+```
+~/code/gemstack/packages/framework (main|u=) node dist/bin.js
+◆ dashboard running: http://127.0.0.1:4200
+  Ctrl+C to stop. Server logs stream below.
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/rom/code/gemstack/packages/framework-dashboard/dist/server/entry.mjs' imported from /home/rom/code/gemstack/node_modules/.pnpm/@brillout+vite-plugin-server-entry@0.7.18/node_modules/@brillout/vite-plugin-server-entry/dist/esm/runtime/autoImporter.js
+    at finalizeResolution (node:internal/modules/esm/resolve:275:11)
+    at moduleResolve (node:internal/modules/esm/resolve:860:10)
+    at defaultResolve (node:internal/modules/esm/resolve:984:11)
+    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:685:12)
+    at #cachedDefaultResolve (node:internal/modules/esm/loader:634:25)
+    at ModuleLoader.resolve (node:internal/modules/esm/loader:617:38)
+    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:273:38)
+    at onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:577:36)
+    at TracingChannel.tracePromise (node:diagnostics_channel:344:14)
+    at ModuleLoader.import (node:internal/modules/esm/loader:576:21)
+```
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/460

--- a/tickets/462-Product_Management%3A_ticketing.md
+++ b/tickets/462-Product_Management%3A_ticketing.md
@@ -1,0 +1,35 @@
+# Product Management: ticketing
+
+There might be tremendous value in saving a copy of all the tickets (e.g. GitHub Issues) inside the Git repo.
+
+```
+tickets/1337-Some_Feature_Request.md
+tickets/4200-Some_Other_Feature_Request.md
+```
+
+- We two-way-sync `tickets/*` with GitHub issues
+  - Because humans prefer UIs (e.g. GitHub issues), while agents prefer text
+  - Synced ticket body: `cat 1337-Some_Feature_Request.md` <=> body of `https://github.com/org/repo/issues/1337`
+  - Title encoding: ` ` => `_`, `_` => `%5F`, filesystem problematic chars => `%xx`
+  - Discussions only happen on GitHub (no syncing)
+  - Convention: ticket body includes the approved goal (the consensus)
+- We can then ask AI things like:
+  - "Read all tickets and suggest a PLAN.md" => once PLAN.md approved => materialize into TODO.md
+  - "Read the discussion at #1337 and update the ticket body" => updates both Git ticket and GitHub issue (thanks to auto-sync)
+- When a ticket is done => remove it (it's still available via `git log -p`)
+
+Very tempting to work on it today (big dogfooding potential), but I'll evaluate the priority for this once we're done with the MVP and landing page.
+
+@suleimansh You mentioned that you use GitHub issues as a seam between you and AI — feel free to elaborate. Let me know if you think this ticket doesn't add *that* much value in your experience.
+
+AFAICT, the biggest added value is that AI can fully access all tickets without having to make any GitHub requests. Another massive added value is that the user can use AI to manage tickets ("create new umbrella ticket that lists all product managment ticktes", "correctly label all tickets", "create labels and suggest a PLAN.md"). Also, it's lossless and reviewable (thanks to Git).
+
+Using Git to manage tickets isn't a new idea, but I think AI brings this idea to a whole new level.
+
+Discussion and feedback welcome.
+
+See also:
+- [Script one-way-syncing `CHANGELOG.md` => GitHub releases](https://github.com/vikejs/vike/tree/main/.github/workflows/sync-github-releases) ([permalink](https://github.com/vikejs/vike/tree/15c05abaeae57bc3112702a8faeca36c20ee13ea/.github/workflows/sync-github-releases)) — shows GitHub API usage, including some gotchas
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/462

--- a/tickets/469-Browser_Phase_2%3A_bundle_Chromium_into_the_sandbox_runner_image.md
+++ b/tickets/469-Browser_Phase_2%3A_bundle_Chromium_into_the_sandbox_runner_image.md
@@ -1,0 +1,17 @@
+# Browser Phase 2: bundle Chromium into the sandbox runner image
+
+Phase 2 of #452. Phase 1 (merged, #466) gives the agent a browser on the **host** via chrome-devtools-mcp behind `--browser`. That covers dev-machine runs.
+
+Phase 2 is the sandboxed version: bake Chromium + chrome-devtools-mcp into the Docker runner image so the browser works when the run is isolated in a container.
+
+**Blocked** on the agent-in-container move (#109). Today the agent runs on the host and only the app is served inside the runner, so an in-image browser has nothing pointing at it. This only pays off once the agent itself runs inside the sandbox.
+
+Scope when unblocked:
+- Alpine needs `chromium` + fonts + `--no-sandbox`.
+- MCP config points chrome-devtools-mcp at the in-container browser.
+- Gated on a real Docker env (#109).
+
+Also worth deciding first, from Phase 1 real-world use: is browser access valuable enough to carry into the sandbox story at all?
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/469

--- a/tickets/495-Epic%3A_Bring_your_own_subscription_(BYOS)_—_run_the_user's_own_coding-agent_CLI.md
+++ b/tickets/495-Epic%3A_Bring_your_own_subscription_(BYOS)_—_run_the_user's_own_coding-agent_CLI.md
@@ -1,0 +1,23 @@
+# Epic: Bring your own subscription (BYOS) — run the user's own coding-agent CLI
+
+Bring your own subscription (BYOS): run the AI on the CLI the user already pays for, instead of reselling tokens or asking for API keys.
+
+Idea from Traycer (open source). They don't touch keys. They run the user's already-installed coding-agent CLI (claude-code, codex, gemini), which already holds that subscription's auth. Requests go straight through it.
+
+Fits our existing seams with almost no new concepts. Two plug points already exist:
+- Runner (where code executes) — the local runner spawns the CLI.
+- ai-sdk ProviderAdapter (which model does the work) — a new `cli/*` adapter.
+
+BYOS = a new adapter that spawns the user's CLI through the local runner, plus a small discovery step. Other providers are just more entries: ChatGPT via Codex CLI, Gemini via Gemini CLI, Claude via Claude Code. A plain web subscription with no CLI is not reachable this way.
+
+Plan:
+- [ ] Spike `cli/claude-code` adapter + PATH discovery (child)
+- [ ] Widen discovery to codex + gemini CLI
+- [ ] Provider config: where the pick + custom paths persist (framework config, TBD with Rom)
+
+Open calls for Rom:
+- go/no-go on the spike
+- config location: framework config (env-paths/XDG) vs a separate dotfile
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/495

--- a/tickets/538-Roadmap_(MVP)_🚀.md
+++ b/tickets/538-Roadmap_(MVP)_🚀.md
@@ -1,0 +1,27 @@
+# Roadmap (MVP) 🚀
+
+## 1. MVP v1
+
+- [x] https://github.com/gemstack-land/gemstack/issues/326
+  - [ ] Test: is everything working? Any issues with it?
+    - The result should be: analyzes user prompt, auto-plan, ask user sensible questions, no implicit-laziness
+  - [ ] Test: "Build instgram clone" => high quality AI work (thanks to the system prompt) with zero human intervention?
+- [x] https://github.com/gemstack-land/gemstack/issues/314
+  - [ ] Test: is everything working? Any issues with it? Let's polish quick-win? Big UX paper cuts we should fix (we can fix minor paper cuts in post-MVP)
+- [ ] Dogfooding — the ultimate test here is we start using The Framework ourselves: what missing to get there?
+
+## 2. MVP v2
+
+- [ ] https://github.com/gemstack-land/gemstack/issues/624
+- [ ] Agentic PM (Product Mangement)
+  - [ ] https://github.com/gemstack-land/gemstack/issues/462
+  - [x] https://github.com/gemstack-land/gemstack/issues/537
+  - [ ] New preset "Suggest new features"
+- [ ] https://github.com/gemstack-land/gemstack/issues/625
+- [ ] https://github.com/gemstack-land/gemstack/issues/626
+- [ ] https://github.com/gemstack-land/gemstack/issues/627
+
+The vision here is to automatize as much as possible, with minimal human intervention.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/538

--- a/tickets/554-Open_Skills.md
+++ b/tickets/554-Open_Skills.md
@@ -1,0 +1,10 @@
+# Open Skills
+
+- "Open Skills": Open Source catalog of skills
+- Skills can register "hooks", e.g. if app uses Vike => add `skills/vike.md` to user repo
+- The Framework automatically runs these hooks => a bunch of skills are automatically added to the user repo when the user installs The Framework.
+
+Not sure yet whether post-MVP.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/554

--- a/tickets/605-Epic%3A_Daemon_+_gateway_split_—_headless_24%2F7_runtime,_composable_frontend.md
+++ b/tickets/605-Epic%3A_Daemon_+_gateway_split_—_headless_24%2F7_runtime,_composable_frontend.md
@@ -1,0 +1,30 @@
+# Epic: Daemon + gateway split — headless 24/7 runtime, composable frontend
+
+> Tracked-but-later (**Phase 1**). Do not build before the MVP ships. Direction captured from team discussion so it is not lost; not scheduled work yet.
+
+## Vision
+
+Split the runtime into composable pieces so The Framework can run anywhere from a single local machine to a hosted service:
+
+- **Daemon**: a separately deployable service that runs 24/7, hosts the workspace, and gives agents shell + filesystem access and the local coding-agent CLIs (Claude Code, Codex) so it uses existing subscriptions rather than API-key pricing.
+- **Gateway**: a public forwarding layer (Telefunc server) that joins agents and users into rooms.
+- **Frontend**: the dashboard is just "a" frontend that connects to the daemon. Slack/Discord are other frontends.
+
+## Decided direction
+
+- Composable from the start: daemon + gateway + frontend as separate seams.
+- Git-as-data: persist everything through Git repo(s), so no database and no real server are needed for local use. It can run 100% local as a desktop app, which underpins the "100% open source / free / local" positioning.
+- Current state, for reference: all background jobs run in the same process as the frontend server today (so `Ctrl + C` after `framework` terminates everything). The headless split is the future direction, not a regression to fix now.
+
+## Open questions
+
+- The 24/7 responsibility: exactly one instance must manage the AI chat bot. Options discussed: a paid hosted daemon, a user-run VPS, or a simple lead-designation where one dev-machine instance auto-designates itself as the manager.
+- Where the headless-browser preview runs (most likely on the daemon).
+
+## Related
+
+- #298 (background jobs) and its usage-limit management: the daemon is where these run continuously.
+- #297 (bootstrap mode), #453 (git worktrees), #454 (syncing UI <-> data): all assume a runtime that can host long-lived, multi-repo work.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/605

--- a/tickets/606-Epic%3A_Collaboration_layer_—_agents_as_teammates_in_the_comms_layer.md
+++ b/tickets/606-Epic%3A_Collaboration_layer_—_agents_as_teammates_in_the_comms_layer.md
@@ -1,0 +1,28 @@
+# Epic: Collaboration layer — agents as teammates in the comms layer
+
+> Tracked-but-later (**Phase 1**). Do not build before the MVP ships. This captures a team-discussion direction so it is not lost; it is not scheduled work yet.
+
+## Vision
+
+Agents get real identities and presence and live in the company's communication layer (chat, threads, later voice/video) as peers, not as a passive sidebar assistant. You add an agent to a channel, `@mention` it, or DM it. A manager agent reads a channel, DMs specialist agents, they coordinate, reply in-channel, and maintain the knowledge base, tasks, and issues. This is the "then extend in this direction" step that sits on top of the autonomous core, not instead of it.
+
+## Decided direction
+
+- Keep the integration seam simple and generic so Slack / Discord / others are all easy to add. Start with a single bot user that acts as a channel for multiple agent personas (no per-persona accounts needed).
+- Realtime via Telefunc (Room API).
+- Agentic-PM entry point: a team chats to consensus, then `/plan-from-chat` (or "@ai create a plan from this chat") turns the discussion into a plan/queue. Nudge the agent to be succinct.
+
+## Open questions
+
+- Multi-user chat mapping: how per-user TODO/state maps when one bot user serves many humans.
+- Voice/video participation (hosted-only, needs webrtc infra).
+- Compete vs collaborate with the main competitor (affects how much of this we build ourselves).
+
+## Related
+
+- Depends on #605 (daemon + gateway split) for where the agents actually run.
+- #454 (syncing UI <-> data): the realtime / source-of-truth substrate this rides on.
+- #462 (ticketing / PM): the tasks and issues agents maintain from chat.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/606

--- a/tickets/607-Epic%3A_Org_layer_—_company_%2F_department_%2F_project_scopes.md
+++ b/tickets/607-Epic%3A_Org_layer_—_company_%2F_department_%2F_project_scopes.md
@@ -1,0 +1,24 @@
+# Epic: Org layer — company / department / project scopes
+
+> Tracked-but-later (**Phase 2**, post-investors). Do not build before the MVP and the collaboration layer. Captured from team discussion; deferred by consensus.
+
+## Vision
+
+An organization layer so agents work like scoped teammates inside a company:
+
+- Three nested scopes, each with its own knowledge base: **Company** (shared across everyone), **Department** (e.g. Software / Marketing / Design, with its own members, agents, projects, knowledge), and **Project** (lives in a department, shareable on demand).
+- Agents are scoped members: a Software agent inherits Company + Software knowledge but cannot see another department's private data. Real access boundaries, not one flat context.
+- This is the layer built for companies and teams, and the natural home for a paid tier.
+
+## Open questions / caution
+
+- Do not hard-box agents into fixed roles. This was flagged in discussion as a **security question, not a clearance one**. The scoping above should be expressed as an access/permission model, not rigid role assignments. The exact permission model is TBD.
+- Monetization: agreed this is long-term and likely the paid/hosted tier, deferred until after investors + growth.
+
+## Related
+
+- Depends on #606 (collaboration layer) and #605 (daemon + gateway split).
+- #462 (tickets/knowledge saved in Git per repo): the per-scope knowledge bases build on this.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/607

--- a/tickets/608-Modularity%3A_%22pick_only_the_features_you_need%22_(all_off_=_transparent_Claude_Code_wrapper).md
+++ b/tickets/608-Modularity%3A_%22pick_only_the_features_you_need%22_(all_off_=_transparent_Claude_Code_wrapper).md
@@ -1,0 +1,26 @@
+# Modularity: "pick only the features you need" (all off = transparent Claude Code wrapper)
+
+> Exploration, captured from team discussion. Flagged as "only if clearly worth it" and "don't let architecture slow us down." Not scheduled; this is here to think it through, not to build yet.
+
+## Idea
+
+Make The Framework fully opt-in at the feature level: the user picks only the features they want. Turn everything off and The Framework is 100% exactly like Claude Code, a transparent wrapper that adds nothing. Each feature (built-in system prompt, autopilot / queue, presets, gates, knowledge docs, browser, ...) is an independent toggle on top of that passthrough base. Possibly a little composability too, but only the smallest amount that clearly pays for itself.
+
+## Why it matters
+
+- A transparent-passthrough baseline is the most honest "0% lock-in" story: adopt one feature at a time, always fall back to plain Claude Code.
+- It de-risks adoption and reinforces the open-source positioning.
+
+## Open questions / caution
+
+- Keep it simple. The explicit ask was to avoid complex architecture that slows us down; pursue only if the value is clear.
+- Granularity: what is the right unit of "a feature"? We already have coarse toggles (`--vanilla` drops the built-in prompt, `--eco-*` drop sections, `--no-todo-loop`, ...). This may be mostly unifying and surfacing those as one clean "features" model rather than new machinery.
+- This is a lighter, toggle-level take, not a return to the extension SPI.
+
+## Related
+
+- #190 (closed): the earlier "Vike-style extensions" modularity attempt, since removed.
+- The existing `--vanilla` / `--eco-*` / `--no-todo-loop` flags are the seed of a feature-toggle model.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/608

--- a/tickets/609-Preview%3A_stream_the_agent's_headless_browser_so_a_human_can_step_in_when_it's_blocked.md
+++ b/tickets/609-Preview%3A_stream_the_agent's_headless_browser_so_a_human_can_step_in_when_it's_blocked.md
@@ -1,0 +1,34 @@
+# Preview: stream the agent's headless browser so a human can step in when it's blocked
+
+> Captured from team discussion. This is a preview / human-in-the-loop capability, not a toggleable "feature" and not about running Claude Code itself in a headless browser.
+
+## Idea
+
+The agent works in a headless browser. Stream its view (capture) to the client so a human can watch, and when the agent hits something it should not or cannot handle on its own, the human steps in by clicking on the streamed capture (x,y and keys relayed back to the headless browser), then the agent continues.
+
+The point is not debugging or inspecting elements. The point is to see when the agent's browser is blocked and let a human resolve it.
+
+## Why it matters
+
+- See when the agent gets blocked (e.g. a bot check / reCAPTCHA, a login wall).
+- Human-in-the-loop for sensitive steps: we do not autofill or save sensitive data (passwords, captcha). A reCAPTCHA means something important, so a human approves it manually through the streamed view rather than the agent handling it.
+
+## Mechanism
+
+- Capture + stream + input relay (x,y clicks, scroll, keys) over WebSocket. Reference implementation: the `stream-headless` script (https://github.com/suleimansh/stream-headless).
+- Capture-and-stream is the approach that works. An `<iframe>` of the app was tried and did not work; opening the headless browser via "Share Screen" is not allowed. So capture + stream it is.
+- Browser built in, headless, zero install, zero user configuration (not a Chrome extension). Something Electron-like could give this via a webview + MCP.
+
+## Open questions
+
+- Where it runs (most likely the daemon, #605).
+- Is "preview" the right home for this, or its own capability alongside the agent's browser work?
+
+## Related
+
+- #452 (closed): gave the agent a real Chromium + chrome-devtools-mcp during runs.
+- #469: bundle Chromium into the sandbox runner image.
+- #605 (daemon): the likely host for the headless browser.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/609

--- a/tickets/610-Drive_Claude_Code_on_the_web_instead_of_the_CLI_(MVP_shortcut%3A_free_worktrees_+_PR,_0%25_local_CPU).md
+++ b/tickets/610-Drive_Claude_Code_on_the_web_instead_of_the_CLI_(MVP_shortcut%3A_free_worktrees_+_PR,_0%25_local_CPU).md
@@ -1,0 +1,33 @@
+# Drive Claude Code on the web instead of the CLI (MVP shortcut: free worktrees + PR, 0% local CPU)
+
+> Captured from team discussion. Flagged as a potentially large MVP shortcut. The mechanism (how we drive it) and session/login are open; needs a spike.
+
+## Idea
+
+Add a driver that uses Claude Code on the web instead of the Claude Code CLI. We drive the web UI programmatically and let it run the task, rather than running the CLI locally.
+
+## Why it's a big shortcut
+
+- Claude Code on the web already does the whole Git worktree dance and opens the GitHub PR. We reuse that flow instead of building it (relates to #453).
+- It runs off the user's machine: roughly 0% local CPU, so AI tasks parallelize essentially without limit.
+- It is where at least some of us already work day to day.
+
+## How to drive it (open)
+
+- **Chrome extension**: the first idea. Simple-ish, but an install plus configuration.
+- **Headless browser automation**: drive the web UI in a server-side headless browser (no install, seamless). Could reuse the headless-streaming primitive from the preview capability (#609), though the purpose is different (driving the agent vs previewing the agent's browser).
+- Decision pending; a spike should compare the two on the hard part below.
+
+## The one hard part: session / login
+
+- [ ] Confirm we can drive an authenticated Claude Code web session programmatically (headless or via extension). This is the main unknown and likely decides extension vs headless.
+
+## Related
+
+- #495 (BYOS): the CLI path for "use the user's own agent". This is the web analog.
+- #453 (git worktrees): the web flow does this for us, reducing what we build.
+- #609: a separate idea, but shares the possible headless-browser mechanism.
+- #605 (daemon): where a server-side headless driver would run.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/610

--- a/tickets/624-Queue.md
+++ b/tickets/624-Queue.md
@@ -1,0 +1,15 @@
+# Queue
+
+Two queues:
+- Queue of human interventions needed
+  - AI in-progress tasks awaiting user answer
+  - AI finished tasks (ready to merge) requiring user review
+  - New tickets pending user confirmation (agentic PM automatically proposes new tickets => user confirms)
+  - New tasks pending user confirmation (agentic PM automatically proposes new tasks from ticketing => user confirms)
+- Queue of confirmed tasks
+  - pending tasks
+  - future task confirmed by user
+  - finished tasks (i.e. history)
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/624

--- a/tickets/625-Modular%3A_only-pick-what-you-need.md
+++ b/tickets/625-Modular%3A_only-pick-what-you-need.md
@@ -1,0 +1,12 @@
+# Modular: only-pick-what-you-need
+
+Enable the user to opt-out of all functionalities. (Only coarse and high-level opt-out, the goal here isn't fine-grained configurability.)
+
+If the user disables all features => 100% exactly like Claude Code (The Framework becomes just a transparent wrapper).
+
+This isn't a feature per-se — it's more a constant requirement: let's met sure everything is opt-out-able.
+
+For example, The Framework presets are already very valuable in themselves. Some users might user The Framework only for its presets.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/625

--- a/tickets/626-Custom_presets.md
+++ b/tickets/626-Custom_presets.md
@@ -1,0 +1,12 @@
+# Custom presets
+
+Enable users to define custom presets.
+
+@nitedani and myself consistently create new prompts for squeeze out maximum performance from AI.
+
+Custom presets might already be a reason enough for us to use The Framework.
+
+If it's a quick-win (I think it is?) then I'd say let's do it now.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/626

--- a/tickets/627-Notifications.md
+++ b/tickets/627-Notifications.md
@@ -1,0 +1,23 @@
+# Notifications
+
+When human intervention is required (e.g. task is done and ready to merge, or AI is waiting for user answer), fire a browser notification (and/or a Discord message).
+
+Settings:
+- Notifications
+  - [ ] Human intervention (default: true)
+  - [ ] New activity (default: false)
+- Notification methods
+  - [ ] Browser (default: true)
+  - [ ] Discord (default: false, requires DISCORD_WEBWOOK)
+
+> [!NOTE]
+> The Discord integration is simple: the only secret is just a Discord webhook the user can get via the Discord UI.
+> - https://github.com/vikejs/vike/blob/15c05abaeae57bc3112702a8faeca36c20ee13ea/.github/workflows/discord-notification.yml
+> <img width="937" height="131" alt="Image" src="https://github.com/user-attachments/assets/2653c6cd-034d-4ade-96ee-abf929bde1c5" />
+
+For me, that would be a feature enough to start using The Framework.
+
+If it's a quick-win (I think it is), then I'd say let's do it now.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/627

--- a/tickets/628-Select_Model.md
+++ b/tickets/628-Select_Model.md
@@ -1,0 +1,8 @@
+# Select Model
+
+Setting (below the texatrea prompt) to select the model.
+
+@suleimansh Feel free to create such tickets when you see such major paper cut (a road blocker actually). FYI that's one major motivation for dogfooding.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/628

--- a/tickets/629-New_root_directory_`tickets%2F`.md
+++ b/tickets/629-New_root_directory_`tickets%2F`.md
@@ -1,0 +1,10 @@
+# New root directory `tickets/`
+
+Let's move `TODO.md` in there.
+
+Only if it's a quick-win (I think it is?), otherwise post-MVP.
+
+The general idea here is that TF rides on conventions like a root `DECISIONS.md` instead of using "proprietary" files.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/629

--- a/tickets/63-Attach_gemstack.land_custom_domain_to_the_docs_site.md
+++ b/tickets/63-Attach_gemstack.land_custom_domain_to_the_docs_site.md
@@ -1,0 +1,20 @@
+# Attach gemstack.land custom domain to the docs site
+
+The docs site is live on GitHub Pages at https://gemstack-land.github.io/gemstack/ (deployed via `deploy-docs.yml`). Once the `gemstack.land` domain is in place (transfer Hover -> Cloudflare in progress), cut the site over to it.
+
+### Cutover checklist
+- [ ] DNS: point `gemstack.land` at GitHub Pages (CNAME/ALIAS to `gemstack-land.github.io`, or per the hosting decision below)
+- [ ] Set the Pages custom domain (`gh api -X PUT repos/gemstack-land/gemstack/pages -f cname=gemstack.land`) and wait for GitHub to provision TLS
+- [ ] Drop `DOCS_BASE=/gemstack/` from `.github/workflows/deploy-docs.yml` so the VitePress base returns to `/`
+- [ ] Re-swap the interim `github.io` links to `gemstack.land`:
+  - rudder `docs/guide/ai.md` + `docs/guide/mcp.md` (currently github.io, rudder PR #1465)
+  - the package README "Docs" column links
+- [ ] Verify the deep pages resolve at the new root
+
+### Out of scope (decided in Discord)
+The governance questions (whose Cloudflare account owns the domain, GitHub Pages vs Cloudflare Pages, who controls deploys) are being settled in chat. This issue only tracks the mechanical cutover once that's resolved.
+
+Non-urgent: the github.io URL works today and will redirect once the custom domain is attached.
+
+---
+Source: https://github.com/gemstack-land/gemstack/issues/63


### PR DESCRIPTION
Part of #462 (the dogfooding import Rom suggested). Not the sync feature, which stays post-MVP.

One-time import of all 34 open issues into `tickets/*.md`, so The Framework can read the whole roadmap straight from the repo (no GitHub calls). This populates the `tickets/` convention from #629.

- One file per open issue: `tickets/<num>-<Title>.md` (per #462 naming: ` ` -> `_`, `_` -> `%5F`, filesystem-problematic chars -> `%XX`, `%` -> `%25`).
- Content: the issue title as an H1, the issue body verbatim (the agreed goal), and a source link back to the GitHub issue.
- Body only, no comments (discussions stay on GitHub). No syncing: from here The Framework writes `tickets/*` and does not touch GitHub issues.

Seeing the full backlog as files is itself useful for flushing stale tickets (e.g. #11/#12/#13, #63) to close.
