### PR TITLE
feat(framework): Queue "Needs you" list — open PRs across projects (#632)

### DIFF
--- a/.changeset/queue-interventions-632.md
+++ b/.changeset/queue-interventions-632.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Add the Queue's cross-project "needs you" projection (#632, part of #624): `buildInterventions` rolls up every registered project's open, non-draft PRs (via `gh pr list`, degrading to empty with no remote / no gh), newest first, and exposes them over a new `onInterventions()` dashboard read. This is the first slice of the interventions queue — proposals and finished work both surface as PRs to review or close.

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react'
-import type { DashboardData, ActiveRun, ProjectStat, ProjectQueue } from '@gemstack/framework'
-import { FolderGit2, Zap, ListChecks, History } from 'lucide-react'
+import type { DashboardData, ActiveRun, ProjectStat, ProjectQueue, Intervention } from '@gemstack/framework'
+import { FolderGit2, Zap, ListChecks, History, GitPullRequest, Inbox } from 'lucide-react'
 import { onDashboard } from '../server/reads.telefunc.js'
 import { ActivityChart } from './ActivityChart.js'
 import { RunOutcomes } from './RunOutcomes.js'
@@ -14,7 +14,13 @@ import { cn } from '../lib/utils.js'
 // how past runs ended, what the agent is working on right now, and the TODO backlog — all a
 // projection of the same files over the `onDashboard` Telefunc read, polled so it stays live.
 // Selecting anything here jumps into that project. Shown by the shell when no project is picked.
-export function DashboardPage({ onSelectProject }: { onSelectProject: (id: string) => void }) {
+export function DashboardPage({
+  onSelectProject,
+  interventions,
+}: {
+  onSelectProject: (id: string) => void
+  interventions: Intervention[]
+}) {
   const { value: data } = usePolled<DashboardData | null>(onDashboard, null, 5000, [])
 
   return (
@@ -24,6 +30,8 @@ export function DashboardPage({ onSelectProject }: { onSelectProject: (id: strin
           <h1 className="text-xl font-semibold">Overview</h1>
           <p className="text-sm text-muted-foreground">Everything the agent is doing, across every project.</p>
         </div>
+
+        <NeedsYou items={interventions} />
 
         {data === null ? (
           <p className="text-sm text-muted-foreground">Loading…</p>
@@ -93,6 +101,52 @@ export function DashboardPage({ onSelectProject }: { onSelectProject: (id: strin
         )}
       </div>
     </div>
+  )
+}
+
+// The Queue's "needs you" list (#632, part of #624): the cross-project interventions — today
+// the open PRs to review (proposals + finished work both surface as PRs). Merge to confirm,
+// close to reject; both happen on GitHub, so each item links straight out to its PR. Placed at
+// the top of the Overview as the day's actionable inbox; #627 notifications fire off the same set.
+function NeedsYou({ items }: { items: Intervention[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Inbox className="h-4 w-4 text-muted-foreground" />
+          Needs you
+          {items.length > 0 && (
+            <span className="rounded-full bg-primary px-1.5 text-xs font-semibold text-primary-foreground tabular-nums">
+              {items.length}
+            </span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0">
+        {items.length === 0 ? (
+          <p className="py-2 text-sm text-muted-foreground">You&apos;re all caught up — nothing to review.</p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {items.map(item => (
+              <li key={`${item.projectId}#${item.number}`}>
+                <a
+                  href={item.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center gap-2 py-2 hover:opacity-80"
+                  title={`Open PR #${item.number} on GitHub`}
+                >
+                  <GitPullRequest className="h-4 w-4 shrink-0 text-emerald-500" />
+                  <span className="shrink-0 text-xs font-medium tabular-nums text-muted-foreground">#{item.number}</span>
+                  <span className="truncate font-medium">{item.title}</span>
+                  <span className="ml-auto shrink-0 text-xs text-muted-foreground">{item.projectName}</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
   )
 }
 

--- a/packages/framework-dashboard/components/ProjectsSidebar.tsx
+++ b/packages/framework-dashboard/components/ProjectsSidebar.tsx
@@ -16,10 +16,13 @@ export function ProjectsSidebar({
   selectedId,
   onSelect,
   onDashboard,
+  interventionCount = 0,
 }: {
   selectedId: string | null
   onSelect: (id: string) => void
   onDashboard: () => void
+  /** Count for the "needs you" badge on the Overview nav (#632). 0 hides it. */
+  interventionCount?: number
 }) {
   const [projects, setProjects] = useState<ProjectSummary[] | null>(null)
 
@@ -49,6 +52,14 @@ export function ProjectsSidebar({
           )}
         >
           <LayoutDashboard className="h-4 w-4" /> Overview
+          {interventionCount > 0 && (
+            <span
+              className="ml-auto min-w-5 rounded-full bg-primary px-1.5 text-center text-xs font-semibold text-primary-foreground tabular-nums"
+              title={`${interventionCount} item(s) need you`}
+            >
+              {interventionCount}
+            </span>
+          )}
         </button>
       </nav>
       <div className="min-h-0 flex-1 overflow-y-auto">

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import { onProjectFiles } from '../../server/reads.telefunc.js'
+import type { Intervention } from '@gemstack/framework'
+import { onProjectFiles, onInterventions } from '../../server/reads.telefunc.js'
 import { ProjectsSidebar } from '../../components/ProjectsSidebar.js'
 import { RunHistory } from '../../components/RunHistory.js'
 import { ProjectHome } from '../../components/ProjectHome.js'
@@ -11,13 +12,16 @@ import { RelayView } from '../../components/RelayView.js'
 import { Badge } from '../../components/ui/badge.js'
 import { useLiveEvents } from '../../lib/use-live-events.js'
 import { useRuns } from '../../lib/use-runs.js'
-import { useLoaded } from '../../lib/use-async.js'
+import { useLoaded, usePolled } from '../../lib/use-async.js'
 import { usePersistentState } from '../../lib/use-persistent-state.js'
 import { useContextSet } from '../../lib/use-context-set.js'
 import { pendingChoices, agentViews } from '../../lib/live-state.js'
 
 /** Stable, so `files` keeps one identity while no project is selected. */
 const EMPTY_FILES: string[] = []
+
+/** Stable initial for the interventions poll, so it does not churn on every render. */
+const EMPTY_INTERVENTIONS: Intervention[] = []
 
 // The dashboard shell (#405 phase 2): Projects | Runs | main | Docs/Log rail. The main pane
 // is one of three views chosen by the Runs-rail selection: the project home/launcher (Live,
@@ -48,6 +52,11 @@ export default function Page() {
   // The selected project's files (git ls-files), fetched once here and handed to both the
   // `#` picker and the tree. Empty when no project / on the relay (no checkout).
   const files = useLoaded<string[]>(projectId ? () => onProjectFiles(projectId) : null, EMPTY_FILES, [projectId])
+
+  // The cross-project "needs you" queue (#632): open PRs to review. Polled here in the shell so
+  // the sidebar badge and the Overview card share one poll. Slow cadence — PRs change rarely and
+  // each poll spawns `gh` per project.
+  const { value: interventions } = usePolled<Intervention[]>(onInterventions, EMPTY_INTERVENTIONS, 15000, [])
 
   const onRunStarted = (intent: string) => {
     // Stay on the home launcher (it must stay visible so you can launch again); the new run
@@ -87,7 +96,7 @@ export default function Page() {
   // project streams one live feed today; per-run streams land with worktrees, #453.)
   const selectedRun = runId ? runs.find(run => run.id === runId) : undefined
   const renderMain = () => {
-    if (!projectId) return <DashboardPage onSelectProject={selectProject} />
+    if (!projectId) return <DashboardPage onSelectProject={selectProject} interventions={interventions} />
     if (runId === null)
       return (
         <ProjectHome
@@ -112,7 +121,12 @@ export default function Page() {
         <span className="ml-auto text-xs text-muted-foreground">Vike · React · shadcn · Telefunc</span>
       </header>
       <div className="flex min-h-0 flex-1">
-        <ProjectsSidebar selectedId={projectId} onSelect={selectProject} onDashboard={showDashboard} />
+        <ProjectsSidebar
+          selectedId={projectId}
+          onSelect={selectProject}
+          onDashboard={showDashboard}
+          interventionCount={interventions.length}
+        />
         <RunHistory
           projectId={projectId}
           runs={runs}

--- a/packages/framework-dashboard/server/reads.telefunc.ts
+++ b/packages/framework-dashboard/server/reads.telefunc.ts
@@ -3,4 +3,4 @@
 // the client bakes the RPC key `/server/reads.telefunc.ts` — the exact key the daemon
 // registers the impls under (see framework's dashboard-rpc/register.ts). The telefunc
 // Vite transform turns these named re-exports into client RPC stubs.
-export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from '@gemstack/framework/dashboard-rpc'
+export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from '@gemstack/framework/dashboard-rpc'

--- a/packages/framework/src/dashboard-rpc/index.ts
+++ b/packages/framework/src/dashboard-rpc/index.ts
@@ -2,7 +2,7 @@
 // implementations live here in @gemstack/framework so `sendStart` (added with the serve
 // wiring) can reach the daemon's `startRun`; the framework-dashboard client imports
 // these through thin re-export shims so the baked RPC keys stay `/server/*.telefunc.ts`.
-export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from './reads.telefunc.js'
+export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from './reads.telefunc.js'
 export { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
 export { onEvents } from './events.telefunc.js'
 export { onProjects, sendAddProject } from './projects.telefunc.js'

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -3,6 +3,7 @@ import { readLogs, type LogEntry } from '../logs.js'
 import { readDocs, type WorkspaceDoc } from '../dashboard/docs.js'
 import { collectQueue, type ProjectQueue } from '../dashboard/queue.js'
 import { buildOverview, type Overview } from '../dashboard/overview.js'
+import { buildInterventions, type Intervention } from '../dashboard/interventions.js'
 import { buildDashboard, type DashboardData } from '../dashboard/dashboard.js'
 import { githubUrlFor } from '../dashboard/github.js'
 import { readGitStatus, type GitStatus } from '../dashboard/git-status.js'
@@ -75,6 +76,12 @@ export async function onQueue(): Promise<ProjectQueue[]> {
 export async function onOverview(): Promise<Overview> {
   const projects = await contextProjects().list().catch(() => [])
   return buildOverview(projects)
+}
+
+/** The cross-project interventions queue (#632, Queue #624): open PRs that need review, newest first. */
+export async function onInterventions(): Promise<Intervention[]> {
+  const projects = await contextProjects().list().catch(() => [])
+  return buildInterventions(projects)
 }
 
 /** The Overview dashboard page (#471): the {@link onOverview} rollup plus run counts, run-status totals, and activity. */

--- a/packages/framework/src/dashboard-rpc/register.ts
+++ b/packages/framework/src/dashboard-rpc/register.ts
@@ -1,5 +1,5 @@
 import { __decorateTelefunction } from 'telefunc'
-import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from './reads.telefunc.js'
+import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from './reads.telefunc.js'
 import { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
 import { onEvents } from './events.telefunc.js'
 import { onProjects, sendAddProject } from './projects.telefunc.js'
@@ -39,6 +39,7 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(onProjectLog, 'onProjectLog', reads)
   reg(onQueue, 'onQueue', reads)
   reg(onOverview, 'onOverview', reads)
+  reg(onInterventions, 'onInterventions', reads)
   reg(onDashboard, 'onDashboard', reads)
   reg(onGithubUrl, 'onGithubUrl', reads)
   reg(onGitStatus, 'onGitStatus', reads)

--- a/packages/framework/src/dashboard/index.ts
+++ b/packages/framework/src/dashboard/index.ts
@@ -17,3 +17,11 @@ export { collectQueue, parseTodoItems, type ProjectQueue, type QueueItem } from 
 export { buildOverview, type Overview, type ActiveRun, type RecentProject, type OverviewDeps } from './overview.js'
 export { buildDashboard, type DashboardData, type ProjectStat, type ActivityDay, type DashboardDeps } from './dashboard.js'
 export { readGitStatus, type GitStatus, type LinkedPr } from './git-status.js'
+export {
+  buildInterventions,
+  nodeGhPrLister,
+  type Intervention,
+  type OpenPr,
+  type PrLister,
+  type InterventionsDeps,
+} from './interventions.js'

--- a/packages/framework/src/dashboard/interventions.test.ts
+++ b/packages/framework/src/dashboard/interventions.test.ts
@@ -1,0 +1,43 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { buildInterventions, type OpenPr } from './interventions.js'
+import type { ProjectSummary } from './projects.js'
+
+const project = (id: string, path: string): ProjectSummary => ({ id, path, name: id, activated: true })
+
+test('buildInterventions rolls up open non-draft PRs across projects, newest first', async () => {
+  const prsByPath: Record<string, OpenPr[]> = {
+    '/a': [
+      { number: 7, title: 'add cart', url: 'u7', isDraft: false, createdAt: '2026-07-10T00:00:00Z' },
+      { number: 8, title: 'wip spike', url: 'u8', isDraft: true, createdAt: '2026-07-12T00:00:00Z' }, // draft -> excluded
+    ],
+    '/b': [{ number: 3, title: 'fix login', url: 'u3', isDraft: false, createdAt: '2026-07-15T00:00:00Z' }],
+    '/c': [], // no open PRs -> contributes nothing
+  }
+  const prs = async (cwd: string): Promise<OpenPr[]> => prsByPath[cwd] ?? []
+  const items = await buildInterventions([project('a', '/a'), project('b', '/b'), project('c', '/c')], { prs })
+
+  // Newest PR first; the draft is gone.
+  assert.deepEqual(
+    items.map(i => ({ project: i.projectId, number: i.number, title: i.title })),
+    [
+      { project: 'b', number: 3, title: 'fix login' },
+      { project: 'a', number: 7, title: 'add cart' },
+    ],
+  )
+  assert.ok(items.every(i => i.kind === 'pr'))
+})
+
+test('buildInterventions skips a project whose PR lookup throws', async () => {
+  const prs = async (cwd: string): Promise<OpenPr[]> => {
+    if (cwd === '/boom') throw new Error('gh exploded')
+    return [{ number: 1, title: 'ok', url: 'u1', isDraft: false }]
+  }
+  const items = await buildInterventions([project('boom', '/boom'), project('ok', '/ok')], { prs })
+  assert.deepEqual(items.map(i => i.projectId), ['ok'])
+})
+
+test('buildInterventions returns [] when nothing is open anywhere', async () => {
+  const prs = async (): Promise<OpenPr[]> => []
+  assert.deepEqual(await buildInterventions([project('a', '/a')], { prs }), [])
+})

--- a/packages/framework/src/dashboard/interventions.test.ts
+++ b/packages/framework/src/dashboard/interventions.test.ts
@@ -41,3 +41,10 @@ test('buildInterventions returns [] when nothing is open anywhere', async () => 
   const prs = async (): Promise<OpenPr[]> => []
   assert.deepEqual(await buildInterventions([project('a', '/a')], { prs }), [])
 })
+
+test('buildInterventions dedupes a PR shared by two registered projects (same repo), keeping one', async () => {
+  const shared: OpenPr = { number: 285, title: 'release', url: 'https://gh/pr/285', isDraft: false, createdAt: '2026-07-05T00:00:00Z' }
+  const prs = async (): Promise<OpenPr[]> => [shared] // both projects resolve to the same repo
+  const items = await buildInterventions([project('root', '/repo'), project('sub', '/repo/packages/x')], { prs })
+  assert.deepEqual(items.map(i => i.number), [285])
+})

--- a/packages/framework/src/dashboard/interventions.ts
+++ b/packages/framework/src/dashboard/interventions.ts
@@ -82,5 +82,8 @@ export async function buildInterventions(
     }
   }
   items.sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''))
-  return items
+  // The same repo can be registered under two projects (e.g. a monorepo root + a subdir), so a
+  // PR would otherwise appear once per entry. Collapse by URL, keeping the first (newest-sorted).
+  const seen = new Set<string>()
+  return items.filter(item => (seen.has(item.url) ? false : (seen.add(item.url), true)))
 }

--- a/packages/framework/src/dashboard/interventions.ts
+++ b/packages/framework/src/dashboard/interventions.ts
@@ -1,0 +1,86 @@
+import type { ProjectSummary } from './projects.js'
+
+// The interventions queue (#632, part of the Queue #624): the cross-project "needs you" list.
+// Rom's design (#624): proposals and finished work are both just PRs, so the bulk of what
+// needs a human is the set of open PRs across the registered projects — merge to confirm,
+// close to reject. This rolls those up, the same way overview.ts rolls up running runs. The
+// other source, a run paused at an await gate, is a follow-up; #627 notifications rides this.
+
+/** One item awaiting the human. Today always a PR; the shape leaves room for a paused run later. */
+export interface Intervention {
+  projectId: string
+  projectName: string
+  /** What kind of attention this needs. `pr` = an open PR to review/merge or close. */
+  kind: 'pr'
+  number: number
+  title: string
+  url: string
+  /** When the PR was opened (ISO), for ordering. */
+  createdAt?: string
+}
+
+/** An open PR as the lister reports it. */
+export interface OpenPr {
+  number: number
+  title: string
+  url: string
+  /** Draft PRs are not ready for review, so they are left off the queue. */
+  isDraft: boolean
+  createdAt?: string
+}
+
+/** Lists a checkout's open PRs; resolves `[]` when there is no remote / gh is unavailable. */
+export type PrLister = (cwd: string) => Promise<OpenPr[]>
+
+/** A {@link PrLister} via the `gh` CLI; resolves `[]` when gh is missing/unauthed or there is no remote. */
+export function nodeGhPrLister(): PrLister {
+  return cwd =>
+    new Promise(resolve => {
+      void import('node:child_process').then(({ execFile }) => {
+        const args = ['pr', 'list', '--state', 'open', '--limit', '50', '--json', 'number,title,url,isDraft,createdAt']
+        execFile('gh', args, { cwd, timeout: 8_000 }, (err, stdout) => {
+          if (err) return resolve([])
+          try {
+            resolve(JSON.parse(String(stdout)) as OpenPr[])
+          } catch {
+            resolve([])
+          }
+        })
+      })
+    })
+}
+
+/** Injectable seam so {@link buildInterventions} is unit-testable off disk. */
+export interface InterventionsDeps {
+  prs?: PrLister
+}
+
+/**
+ * Build the cross-project interventions queue: every registered project's open, non-draft PRs,
+ * newest first. Forgiving — a project with no remote (or an unreadable one) simply contributes
+ * nothing. Draft PRs are excluded: they are not yet asking for review.
+ */
+export async function buildInterventions(
+  projects: ProjectSummary[],
+  deps: InterventionsDeps = {},
+): Promise<Intervention[]> {
+  const prs = deps.prs ?? nodeGhPrLister()
+  const items: Intervention[] = []
+  for (const project of projects) {
+    const open = await prs(project.path).catch(() => [])
+    for (const pr of open) {
+      if (pr.isDraft) continue
+      items.push({
+        projectId: project.id,
+        projectName: project.name,
+        kind: 'pr',
+        number: pr.number,
+        title: pr.title,
+        url: pr.url,
+        ...(pr.createdAt ? { createdAt: pr.createdAt } : {}),
+      })
+    }
+  }
+  items.sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''))
+  return items
+}

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -130,7 +130,7 @@ export {
   type SweepDeps,
   type MaintenanceFs,
 } from './maintenance.js'
-export { startDashboard, summarizeProject, defaultProjectsProvider, readDocs, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunResult, type AddProjectResult, type PreviewResult, type PreviewStatus, type ProjectSummary, type ProjectsProvider, type SummarizeDeps, type WorkspaceDoc, type ProjectQueue, type QueueItem, type Overview, type ActiveRun, type RecentProject, type DashboardData, type ProjectStat, type ActivityDay, type GitStatus, type LinkedPr } from './dashboard/index.js'
+export { startDashboard, summarizeProject, defaultProjectsProvider, readDocs, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunResult, type AddProjectResult, type PreviewResult, type PreviewStatus, type ProjectSummary, type ProjectsProvider, type SummarizeDeps, type WorkspaceDoc, type ProjectQueue, type QueueItem, type Overview, type ActiveRun, type RecentProject, type DashboardData, type ProjectStat, type ActivityDay, type GitStatus, type LinkedPr, buildInterventions, nodeGhPrLister, type Intervention, type OpenPr, type PrLister, type InterventionsDeps } from './dashboard/index.js'
 export { startPreview, detectDevScript, parsePreviewUrl, PREVIEW_SCRIPTS, type PreviewHandle, type StartPreviewOptions } from './preview.js'
 export {
   RunStore,


### PR DESCRIPTION
Closes #632. Part of #624 (the Queue).

The first slice of Queue A — the cross-project "Needs you" list. Rom's design (#624): proposals and finished work are both just PRs, so the bulk of "needs a human" is the set of open PRs across the registered projects, merge to confirm / close to reject.

**Server**
- `buildInterventions(projects)` — rolls up every registered project's open, non-draft PRs via `gh pr list`, newest first. Deduped by PR url (a monorepo registered at root + a subdir would otherwise list the same PR twice). Degrades to empty when there's no remote / gh is missing / on the relay (no checkout). Injectable PR lister, unit-tested off disk.
- `onInterventions()` read RPC, wired like `onOverview`.

**Dashboard** (client, bundled)
- A "Needs you" card at the top of the Overview page — each item links straight to its PR on GitHub. Empty state when caught up.
- A count badge on the sidebar Overview nav.
- Polled once in the shell and shared by both, so there's a single `gh` poll (slow cadence — PRs change rarely).

**Verification**
- 4 projection unit tests (rollup, draft exclusion, error tolerance, dedup) + framework/dashboard build + typecheck green.
- Dogfooded live through a real daemon: `onInterventions` returned the real open PR #285 once (draft #623 correctly excluded).

**Next** (follow-ups on #624): the second Queue-A source — a run paused at an await gate ("awaiting your answer") — then #627 notifications firing off this same set.
