### PR TITLE
feat(framework): browser notifications for the "Needs you" queue (#627)

### DIFF
--- a/.changeset/queue-notifications-627.md
+++ b/.changeset/queue-notifications-627.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Browser notifications for the Queue's "needs you" list (#627): when a new PR lands on the interventions queue, the dashboard fires a browser notification that opens the PR on click. A bell in the header toggles it and requests permission; the preference (`notifyBrowser`, on by default) persists with the others. Existing PRs at page load are folded into a baseline, so you are only told about items that appear while you are watching. (Discord delivery and the paused-run trigger are follow-ups.)

--- a/packages/framework-dashboard/components/NotificationBell.tsx
+++ b/packages/framework-dashboard/components/NotificationBell.tsx
@@ -1,0 +1,64 @@
+import { useSyncExternalStore } from 'react'
+import { Bell, BellOff } from 'lucide-react'
+import { usePreferences, updatePreferences, notificationsEnabled } from '../lib/preferences.js'
+import { cn } from '../lib/utils.js'
+
+// The notifications toggle in the shell header (#627). One click controls the whole "needs you"
+// notification path: it flips the preference and, when turning on for the first time, asks the
+// browser for permission (which must come from this user gesture). The icon reflects the real
+// state — on, off, or blocked at the browser level — so it never claims to notify when it can't.
+
+/** Subscribe to `Notification.permission` changes where the browser supports it, else 'unsupported'. */
+function usePermission(): NotificationPermission | 'unsupported' {
+  return useSyncExternalStore(
+    subscribePermission,
+    () => (typeof Notification === 'undefined' ? 'unsupported' : Notification.permission),
+    () => 'unsupported',
+  )
+}
+
+function subscribePermission(onChange: () => void): () => void {
+  // There is no permission-change event on all browsers; the value also changes right after our
+  // own requestPermission() resolves, which re-renders anyway. Poll lightly as a backstop.
+  const timer = setInterval(onChange, 3000)
+  return () => clearInterval(timer)
+}
+
+export function NotificationBell() {
+  const preferences = usePreferences()
+  const enabled = notificationsEnabled(preferences)
+  const permission = usePermission()
+  if (permission === 'unsupported') return null
+
+  const blocked = permission === 'denied'
+  const active = enabled && permission === 'granted'
+  const title = blocked
+    ? 'Notifications are blocked in your browser settings'
+    : !enabled
+      ? 'Notifications off — click to turn on'
+      : permission === 'default'
+        ? 'Click to allow browser notifications'
+        : 'Notifications on — click to mute'
+
+  const onClick = () => {
+    const next = !enabled
+    updatePreferences({ notifyBrowser: next })
+    if (next && permission === 'default') void Notification.requestPermission()
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-label={title}
+      className={cn(
+        'rounded-md p-1.5 hover:bg-accent',
+        active ? 'text-foreground' : 'text-muted-foreground',
+        blocked && 'opacity-50',
+      )}
+    >
+      {active ? <Bell className="h-4 w-4" /> : <BellOff className="h-4 w-4" />}
+    </button>
+  )
+}

--- a/packages/framework-dashboard/lib/interventions.test.ts
+++ b/packages/framework-dashboard/lib/interventions.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest'
+import type { Intervention } from '@gemstack/framework'
+import { interventionKey, pickNewInterventions } from './interventions.js'
+
+const item = (number: number, url: string): Intervention => ({ projectId: 'p', projectName: 'p', kind: 'pr', number, title: `pr ${number}`, url })
+
+describe('interventions helpers (#627)', () => {
+  test('interventionKey is the PR url', () => {
+    expect(interventionKey(item(7, 'https://gh/pr/7'))).toBe('https://gh/pr/7')
+  })
+
+  test('pickNewInterventions returns only items whose key is not already seen', () => {
+    const current = [item(7, 'https://gh/pr/7'), item(8, 'https://gh/pr/8')]
+    expect(pickNewInterventions(new Set(['https://gh/pr/7']), current).map(i => i.number)).toEqual([8])
+    // Nothing new when every current item is already seen.
+    expect(pickNewInterventions(new Set(['https://gh/pr/7', 'https://gh/pr/8']), current)).toEqual([])
+  })
+})

--- a/packages/framework-dashboard/lib/interventions.ts
+++ b/packages/framework-dashboard/lib/interventions.ts
@@ -1,0 +1,20 @@
+import type { Intervention } from '@gemstack/framework'
+
+// Client-side helpers for the interventions notification trigger (#627). These live in the
+// dashboard rather than @gemstack/framework on purpose: importing runtime values from the
+// framework barrel would drag its Node-only + telefunc modules into the browser bundle. Only
+// the `Intervention` type is borrowed (types are erased), and that logic is a couple of lines.
+
+/** The stable identity of an intervention — its PR url, which survives title edits and re-sorts. */
+export function interventionKey(item: Intervention): string {
+  return item.url
+}
+
+/**
+ * The interventions in `current` not already in `seen` (by {@link interventionKey}) — the ones
+ * that just landed on the queue. The shell keeps the keys it has already told the user about,
+ * so only genuinely new items fire a notification.
+ */
+export function pickNewInterventions(seen: ReadonlySet<string>, current: Intervention[]): Intervention[] {
+  return current.filter(item => !seen.has(interventionKey(item)))
+}

--- a/packages/framework-dashboard/lib/preferences.ts
+++ b/packages/framework-dashboard/lib/preferences.ts
@@ -67,3 +67,8 @@ export function usePreferences(): Preferences {
 export function autopilotEnabled(preferences: Preferences): boolean {
   return preferences.autopilot ?? true
 }
+
+/** Browser notifications default on (#627); the browser permission is still the real gate. */
+export function notificationsEnabled(preferences: Preferences): boolean {
+  return preferences.notifyBrowser ?? true
+}

--- a/packages/framework-dashboard/lib/use-intervention-notifications.test.ts
+++ b/packages/framework-dashboard/lib/use-intervention-notifications.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { Intervention } from '@gemstack/framework'
+import { useInterventionNotifications } from './use-intervention-notifications.js'
+
+const item = (n: number, url: string): Intervention => ({ projectId: 'p', projectName: 'p', kind: 'pr', number: n, title: `pr ${n}`, url })
+
+const ctor = vi.fn()
+
+describe('useInterventionNotifications (#627)', () => {
+  beforeEach(() => {
+    ctor.mockReset()
+    class FakeNotification {
+      static permission = 'granted'
+      onclick: (() => void) | null = null
+      constructor(title: string, opts?: NotificationOptions) {
+        ctor(title, opts)
+      }
+      close(): void {}
+    }
+    vi.stubGlobal('Notification', FakeNotification)
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  const render = (enabled: boolean) =>
+    renderHook(({ items }) => useInterventionNotifications(items, enabled), { initialProps: { items: [] as Intervention[] } })
+
+  test('stays quiet for PRs already open at load, then fires for one that appears later', () => {
+    const { rerender } = render(true)
+    rerender({ items: [item(1, 'u1')] }) // first fetch of an already-open PR -> baseline, no notify
+    expect(ctor).not.toHaveBeenCalled()
+    rerender({ items: [item(1, 'u1'), item(2, 'u2')] }) // a genuinely new PR -> notify once
+    expect(ctor).toHaveBeenCalledTimes(1)
+    expect(ctor.mock.calls[0]![0]).toContain('Needs you')
+  })
+
+  test('never fires when notifications are disabled', () => {
+    const { rerender } = render(false)
+    rerender({ items: [item(1, 'u1')] })
+    rerender({ items: [item(1, 'u1'), item(2, 'u2')] })
+    expect(ctor).not.toHaveBeenCalled()
+  })
+})

--- a/packages/framework-dashboard/lib/use-intervention-notifications.ts
+++ b/packages/framework-dashboard/lib/use-intervention-notifications.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from 'react'
+import type { Intervention } from '@gemstack/framework'
+import { interventionKey, pickNewInterventions } from './interventions.js'
+
+// Browser notifications for the "needs you" queue (#627). The interventions list is already
+// polled once in the shell; this watches it and fires a notification when a new PR lands. Two
+// guards keep it quiet: it never fires unless enabled AND the browser permission is granted,
+// and it absorbs the first couple of observations (the initial empty value, then the first
+// fetch of already-open PRs) as a baseline — you only get told about items that show up while
+// you are watching, not the backlog that existed when the page loaded.
+
+/** Observations to treat as baseline before notifying: the initial `[]` plus the first fetch. */
+const WARMUP = 2
+
+function fire(items: Intervention[]): void {
+  if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return
+  const first = items[0]
+  if (!first) return
+  const single = items.length === 1
+  const title = single ? `Needs you · ${first.projectName}` : `${items.length} items need you`
+  const body = single ? `#${first.number} ${first.title}` : items.map(i => `#${i.number} ${i.title}`).join('\n')
+  const notification = new Notification(title, { body })
+  notification.onclick = () => {
+    window.open(first.url, '_blank', 'noopener')
+    notification.close()
+  }
+}
+
+/**
+ * Fire a browser notification when a new intervention appears. `enabled` is the user's
+ * preference; the browser permission is the other gate (checked in {@link fire}). No-op on the
+ * server (no `window`), and harmless when notifications are unsupported.
+ */
+export function useInterventionNotifications(interventions: Intervention[], enabled: boolean): void {
+  const seen = useRef<Set<string>>(new Set())
+  const observations = useRef(0)
+
+  useEffect(() => {
+    const fresh = pickNewInterventions(seen.current, interventions)
+    if (observations.current < WARMUP) {
+      observations.current += 1 // still warming up: fold these into the baseline, don't notify
+    } else if (enabled && fresh.length > 0) {
+      fire(fresh)
+    }
+    for (const item of interventions) seen.current.add(interventionKey(item))
+  }, [interventions, enabled])
+}

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import type { Intervention } from '@gemstack/framework'
 import { onProjectFiles, onInterventions } from '../../server/reads.telefunc.js'
 import { ProjectsSidebar } from '../../components/ProjectsSidebar.js'
+import { NotificationBell } from '../../components/NotificationBell.js'
 import { RunHistory } from '../../components/RunHistory.js'
 import { ProjectHome } from '../../components/ProjectHome.js'
 import { DashboardPage } from '../../components/DashboardPage.js'
@@ -15,6 +16,8 @@ import { useRuns } from '../../lib/use-runs.js'
 import { useLoaded, usePolled } from '../../lib/use-async.js'
 import { usePersistentState } from '../../lib/use-persistent-state.js'
 import { useContextSet } from '../../lib/use-context-set.js'
+import { useInterventionNotifications } from '../../lib/use-intervention-notifications.js'
+import { usePreferences, notificationsEnabled } from '../../lib/preferences.js'
 import { pendingChoices, agentViews } from '../../lib/live-state.js'
 
 /** Stable, so `files` keeps one identity while no project is selected. */
@@ -57,6 +60,11 @@ export default function Page() {
   // the sidebar badge and the Overview card share one poll. Slow cadence — PRs change rarely and
   // each poll spawns `gh` per project.
   const { value: interventions } = usePolled<Intervention[]>(onInterventions, EMPTY_INTERVENTIONS, 15000, [])
+
+  // Fire a browser notification when a new item lands on the "needs you" queue (#627). Rides the
+  // one interventions poll above; the browser permission is the real gate (see the header bell).
+  const preferences = usePreferences()
+  useInterventionNotifications(interventions, notificationsEnabled(preferences))
 
   const onRunStarted = (intent: string) => {
     // Stay on the home launcher (it must stay visible so you can launch again); the new run
@@ -118,7 +126,10 @@ export default function Page() {
       <header className="flex items-center gap-3 border-b border-border px-4 py-3">
         <span className="font-semibold">The Framework</span>
         <Badge className="text-muted-foreground">dashboard</Badge>
-        <span className="ml-auto text-xs text-muted-foreground">Vike · React · shadcn · Telefunc</span>
+        <div className="ml-auto flex items-center gap-3">
+          <NotificationBell />
+          <span className="text-xs text-muted-foreground">Vike · React · shadcn · Telefunc</span>
+        </div>
       </header>
       <div className="flex min-h-0 flex-1">
         <ProjectsSidebar

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -38,6 +38,8 @@ export interface Preferences {
   onBeforeMergeableQuality?: boolean
   /** Give the agent a real browser via chrome-devtools-mcp during the run (#452); maps to `--browser`. */
   browser?: boolean
+  /** Fire a browser notification when a new item lands on the "needs you" queue (#627). Absent = on. */
+  notifyBrowser?: boolean
   /**
    * How much of the subscription The Framework may burn before it pauses itself
    * (#527, the settings behind #519).
@@ -143,6 +145,7 @@ const PREFERENCE_KEYS = [
   'ecoMaintenance',
   'onBeforeMergeableQuality',
   'browser',
+  'notifyBrowser',
 ] as const
 
 /** Keep only the known preference fields, so a hand-edited or browser-supplied


### PR DESCRIPTION
Part of #627 (browser path; Discord + the paused-run trigger are follow-ups).

Browser notifications for the Queue's "Needs you" list. When a new PR lands on the interventions queue, the dashboard fires a browser notification that opens the PR on click.

- **Bell in the header** toggles it and, on first enable, requests browser permission (from that click, as browsers require). The icon reflects the real state — on / off / blocked — so it never claims to notify when it can't.
- **Preference `notifyBrowser`** (on by default, per Rom's spec) persists with the other Global options; the browser permission is the real gate.
- **No load spam:** the PRs already open when the page loads are folded into a baseline, so you're only told about items that appear while you're watching. The "what's new" diff and the warmup are unit-tested.

Rides the single interventions poll already in the shell (no extra polling).

**Scope note:** default-on matches Rom's "Browser (default: true)", but nothing actually fires until the user grants permission via the bell (auto-requesting on load hurts UX and browsers penalize it).

**Verified:** dashboard vitest (helpers + hook warmup/disabled) + framework build/typecheck + dashboard build/typecheck green; dogfooded on a real daemon (bell bundled, `onInterventions` serving).

**Next on #627:** Discord webhook delivery (daemon-side, fires when no dashboard is open) + the second trigger source (a run paused awaiting your answer).
