### PR TITLE
feat(framework): Discord notifications for the "Needs you" queue (#627)

### DIFF
--- a/.changeset/queue-discord-notify-627.md
+++ b/.changeset/queue-discord-notify-627.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Discord notifications for the Queue's "needs you" list (#627): when `DISCORD_WEBHOOK` is set, the daemon watches the interventions queue and posts a message when a new PR lands — so you are notified even with no dashboard open. The PRs already open when the daemon starts are folded into a baseline (no start-up blast); the env var is the opt-in. Complements the in-browser notifications from the same queue.

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -1,9 +1,10 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { mkdir, readFile, writeFile, rm, stat } from 'node:fs/promises'
-import { dirname, join, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 import type { FrameworkEvent } from './events.js'
 import { FRAMEWORK_DIR } from './store/index.js'
 import { startDashboard, type Dashboard, type StartRunKind, type StartRunOptions, type StartRunResult, type AddProjectResult, type PreviewResult, type PreviewStatus } from './dashboard/index.js'
+import { startInterventionWatcher, postDiscord, type InterventionWatcher } from './dashboard/intervention-watcher.js'
 import { startPreview, type PreviewHandle } from './preview.js'
 import { resolveDashboardBundle } from './dashboard/bundle.js'
 import { isActivated } from './project.js'
@@ -337,8 +338,26 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     throw err
   }
 
+  // Discord notifications (#627): fire on new "needs you" items even when no dashboard is open.
+  // Opt-in by setting DISCORD_WEBHOOK; the browser-notification path needs no daemon watcher.
+  const webhook = env.DISCORD_WEBHOOK
+  let watcher: InterventionWatcher | undefined
+  if (webhook) {
+    watcher = startInterventionWatcher({
+      projects: async () =>
+        (await listProjects(undefined, env).catch(() => [])).map(p => ({
+          id: p.id,
+          path: p.path,
+          name: basename(p.path),
+          activated: true,
+        })),
+      onNew: items => postDiscord(webhook, items).catch(() => {}),
+    })
+  }
+
   await waitForShutdown(opts.signal)
 
+  watcher?.stop()
   await runtime.dispose() // stop live previews (#475) so their dev servers do not outlive us
   await dashboard.close()
   await rm(daemonStatePath(env), { force: true }).catch(() => {})

--- a/packages/framework/src/dashboard/intervention-watcher.test.ts
+++ b/packages/framework/src/dashboard/intervention-watcher.test.ts
@@ -1,0 +1,71 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { InterventionTracker, postDiscord, startInterventionWatcher } from './intervention-watcher.js'
+import type { Intervention } from './interventions.js'
+import type { ProjectSummary } from './projects.js'
+
+const item = (n: number, url: string, project = 'p'): Intervention => ({
+  projectId: project,
+  projectName: project,
+  kind: 'pr',
+  number: n,
+  title: `pr ${n}`,
+  url,
+})
+
+test('InterventionTracker seeds a baseline on the first poll, then returns only new items', () => {
+  const tracker = new InterventionTracker()
+  // First poll = the queue that already existed at start-up: baseline, nothing announced.
+  assert.deepEqual(tracker.observe([item(1, 'u1')]), [])
+  // A new PR appears next poll -> just that one.
+  assert.deepEqual(tracker.observe([item(1, 'u1'), item(2, 'u2')]).map(i => i.number), [2])
+  // Nothing new -> empty.
+  assert.deepEqual(tracker.observe([item(1, 'u1'), item(2, 'u2')]), [])
+})
+
+test('postDiscord posts one item with its number, title, project and url', async () => {
+  let body: unknown
+  const fetchImpl = (async (_url, init) => {
+    body = JSON.parse(String(init!.body))
+    return new Response(null, { status: 204 })
+  }) as typeof fetch
+  await postDiscord('https://discord/hook', [item(285, 'https://gh/pr/285', 'gemstack')], fetchImpl)
+  const content = (body as { content: string }).content
+  assert.match(content, /#285/)
+  assert.match(content, /gemstack/)
+  assert.match(content, /https:\/\/gh\/pr\/285/)
+})
+
+test('postDiscord summarizes multiple items and skips the call when there are none', async () => {
+  const calls: string[] = []
+  const fetchImpl = (async (_url, init) => {
+    calls.push(String(init!.body))
+    return new Response(null, { status: 204 })
+  }) as typeof fetch
+  await postDiscord('https://discord/hook', [item(1, 'u1'), item(2, 'u2')], fetchImpl)
+  assert.match(JSON.parse(calls[0]!).content, /2 items need you/)
+  await postDiscord('https://discord/hook', [], fetchImpl)
+  assert.equal(calls.length, 1) // empty -> no second POST
+})
+
+test('startInterventionWatcher announces only items that appear after the first poll', async () => {
+  const projects = async (): Promise<ProjectSummary[]> => [{ id: 'a', path: '/a', name: 'a', activated: true }]
+  let current: Intervention[] = [item(1, 'u1')]
+  const announced: number[][] = []
+  const watcher = startInterventionWatcher({
+    projects,
+    build: async () => current,
+    onNew: items => void announced.push(items.map(i => i.number)),
+    intervalMs: 1_000_000, // effectively disable the timer; drive via poll()
+  })
+  try {
+    // The constructor fires an immediate baseline poll (u1 already open) — let it settle.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    assert.deepEqual(announced, []) // baseline announces nothing
+    current = [item(1, 'u1'), item(2, 'u2')]
+    await watcher.poll() // u2 is new -> announced
+    assert.deepEqual(announced, [[2]])
+  } finally {
+    watcher.stop()
+  }
+})

--- a/packages/framework/src/dashboard/intervention-watcher.ts
+++ b/packages/framework/src/dashboard/intervention-watcher.ts
@@ -1,0 +1,101 @@
+import type { ProjectSummary } from './projects.js'
+import { buildInterventions, interventionKey, pickNewInterventions, type Intervention } from './interventions.js'
+
+// The daemon-side half of notifications (#627): a background poll of the "needs you" queue that
+// fires even when no dashboard is open (that is what a Discord message buys over the browser
+// notification). Gated on a `DISCORD_WEBHOOK` being set — the env var is the opt-in, per the
+// issue. The tracker below is the same "only genuinely new items" rule the browser side uses,
+// with a baseline so the PRs already open when the daemon starts do not blast the channel.
+
+/** Tracks which interventions have been announced, so only new ones notify. Testable without timers. */
+export class InterventionTracker {
+  private readonly seen = new Set<string>()
+  private warmedUp = false
+
+  /**
+   * Fold a poll's items into the baseline and return the ones not seen before. The first call
+   * only establishes the baseline (returns `[]`), so the queue that already existed at start-up
+   * is never announced.
+   */
+  observe(items: Intervention[]): Intervention[] {
+    const fresh = this.warmedUp ? pickNewInterventions(this.seen, items) : []
+    for (const item of items) this.seen.add(interventionKey(item))
+    this.warmedUp = true
+    return fresh
+  }
+}
+
+/** Post the given interventions to a Discord webhook as one message. `fetch` is injectable for tests. */
+export async function postDiscord(
+  webhook: string,
+  items: Intervention[],
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  if (items.length === 0) return
+  const line = (i: Intervention): string => `#${i.number} ${i.title} — ${i.url}`
+  const content =
+    items.length === 1
+      ? `🔔 Needs you (${items[0]!.projectName}): ${line(items[0]!)}`
+      : `🔔 ${items.length} items need you:\n${items.map(i => `• ${line(i)}`).join('\n')}`
+  await fetchImpl(webhook, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  })
+}
+
+/** A running watcher; call {@link InterventionWatcher.stop} to end it. */
+export interface InterventionWatcher {
+  stop: () => void
+  /** Run one poll now. Exposed so the daemon and tests can drive it deterministically. */
+  poll: () => Promise<void>
+}
+
+/** Options for {@link startInterventionWatcher}. */
+export interface InterventionWatcherOptions {
+  /** The projects to scan each poll (the daemon passes the registry, mapped to summaries). */
+  projects: () => Promise<ProjectSummary[]>
+  /** Called with the genuinely-new interventions each poll (empty polls are skipped). */
+  onNew: (items: Intervention[]) => void | Promise<void>
+  /** Poll cadence, ms. Default 60s — PRs change slowly and each poll spawns `gh` per project. */
+  intervalMs?: number
+  /** Override the projection (tests). */
+  build?: (projects: ProjectSummary[]) => Promise<Intervention[]>
+}
+
+/**
+ * Start polling the interventions queue and hand each poll's new items to `onNew`. The first
+ * poll only seeds the baseline. Forgiving — a failed project scan or projection just yields no
+ * new items that cycle. Runs immediately, then every `intervalMs`; the timer is unref'd so it
+ * never keeps the daemon alive past shutdown.
+ */
+export function startInterventionWatcher(opts: InterventionWatcherOptions): InterventionWatcher {
+  const build = opts.build ?? buildInterventions
+  const tracker = new InterventionTracker()
+  let stopped = false
+  let running = false
+
+  const poll = async (): Promise<void> => {
+    if (stopped || running) return
+    running = true
+    try {
+      const projects = await opts.projects().catch(() => [])
+      const items = await build(projects).catch(() => [])
+      const fresh = tracker.observe(items)
+      if (fresh.length > 0 && !stopped) await opts.onNew(fresh)
+    } finally {
+      running = false
+    }
+  }
+
+  void poll()
+  const timer = setInterval(() => void poll(), opts.intervalMs ?? 60_000)
+  timer.unref?.()
+  return {
+    stop: () => {
+      stopped = true
+      clearInterval(timer)
+    },
+    poll,
+  }
+}

--- a/packages/framework/src/dashboard/interventions.ts
+++ b/packages/framework/src/dashboard/interventions.ts
@@ -87,3 +87,19 @@ export async function buildInterventions(
   const seen = new Set<string>()
   return items.filter(item => (seen.has(item.url) ? false : (seen.add(item.url), true)))
 }
+
+/** The stable identity of an intervention — its PR url, which survives title edits and re-sorts. */
+export function interventionKey(item: Intervention): string {
+  return item.url
+}
+
+/**
+ * The interventions in `current` not already in `seen` (by {@link interventionKey}) — the ones
+ * that just landed on the queue. Drives the daemon's Discord watcher (#627): the watcher keeps
+ * the keys it has already announced, so only genuinely new items notify. (The dashboard keeps a
+ * client-side copy of this for browser notifications; it can't import runtime values from this
+ * package without dragging Node-only modules into the browser bundle.)
+ */
+export function pickNewInterventions(seen: ReadonlySet<string>, current: Intervention[]): Intervention[] {
+  return current.filter(item => !seen.has(interventionKey(item)))
+}


### PR DESCRIPTION
Part of #627 (the away path). Complements the in-browser notifications (#634).

When `DISCORD_WEBHOOK` is set, the daemon watches the "needs you" queue and posts a Discord message when a new PR lands — so you're notified even when no dashboard is open (the real value over a browser toast). The env var is the opt-in, per the issue.

- Daemon-side `startInterventionWatcher` polls `buildInterventions` (default 60s; each poll spawns `gh` per project) and posts only genuinely-new items via `postDiscord`.
- **No start-up blast:** an `InterventionTracker` folds the PRs already open when the daemon starts into a baseline, so only items that appear afterwards notify.
- Wired into `runDaemon`: started after the dashboard binds when the webhook is present, stopped on shutdown.

**Verified end to end on a real daemon:**
- Started with `DISCORD_WEBHOOK` pointed at a local catcher → the existing open PR was baselined, zero posts (no spam), daemon healthy.
- `postDiscord` real network POST delivered the expected payload: `🔔 Needs you (gemstack): #999 a brand new PR — <url>`.
- 4 unit tests (tracker baseline/new, postDiscord single+multi+empty, watcher poll) + build/typecheck green.

**Scope:** env-only opt-in (no settings toggle yet — the webhook's presence is the switch). A per-user Discord toggle and the second trigger source (a run paused awaiting an answer) are the remaining #627 follow-ups.
