### PR TITLE
feat(framework): surface paused runs awaiting an answer in the Queue (#636)

### DIFF
--- a/.changeset/queue-awaiting-intervention-636.md
+++ b/.changeset/queue-awaiting-intervention-636.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Queue "needs you" now surfaces paused runs, not just PRs (#636, part of #624): a live run that stopped mid-flight to ask a question shows up alongside open PRs in the Overview card, the sidebar badge, and the #627 browser + Discord notifications. `RunMeta` folds a `pendingChoice` from the `choice`/`choice-resolved` events, and `Intervention` gains a second `kind: 'awaiting'` — the card jumps into that project to answer, and the Discord message reads "awaiting your answer" with a link back to the dashboard.

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -1,7 +1,8 @@
 import { type ReactNode } from 'react'
 import type { DashboardData, ActiveRun, ProjectStat, ProjectQueue, Intervention } from '@gemstack/framework'
-import { FolderGit2, Zap, ListChecks, History, GitPullRequest, Inbox } from 'lucide-react'
+import { FolderGit2, Zap, ListChecks, History, GitPullRequest, Inbox, MessageCircleQuestion } from 'lucide-react'
 import { onDashboard } from '../server/reads.telefunc.js'
+import { interventionKey } from '../lib/interventions.js'
 import { ActivityChart } from './ActivityChart.js'
 import { RunOutcomes } from './RunOutcomes.js'
 import { UsagePanel } from './UsagePanel.js'
@@ -31,7 +32,7 @@ export function DashboardPage({
           <p className="text-sm text-muted-foreground">Everything the agent is doing, across every project.</p>
         </div>
 
-        <NeedsYou items={interventions} />
+        <NeedsYou items={interventions} onSelectProject={onSelectProject} />
 
         {data === null ? (
           <p className="text-sm text-muted-foreground">Loading…</p>
@@ -104,11 +105,12 @@ export function DashboardPage({
   )
 }
 
-// The Queue's "needs you" list (#632, part of #624): the cross-project interventions — today
-// the open PRs to review (proposals + finished work both surface as PRs). Merge to confirm,
-// close to reject; both happen on GitHub, so each item links straight out to its PR. Placed at
-// the top of the Overview as the day's actionable inbox; #627 notifications fire off the same set.
-function NeedsYou({ items }: { items: Intervention[] }) {
+// The Queue's "needs you" list (#632, part of #624): the cross-project interventions. Two kinds:
+// open PRs to review (proposals + finished work both surface as PRs) — merge to confirm, close to
+// reject, so each links straight out to its PR; and runs paused mid-flight on a question (#636),
+// which jump into that project's live view to answer. Placed at the top of the Overview as the
+// day's actionable inbox; #627 notifications fire off the same set.
+function NeedsYou({ items, onSelectProject }: { items: Intervention[]; onSelectProject: (id: string) => void }) {
   return (
     <Card>
       <CardHeader>
@@ -128,19 +130,33 @@ function NeedsYou({ items }: { items: Intervention[] }) {
         ) : (
           <ul className="divide-y divide-border">
             {items.map(item => (
-              <li key={`${item.projectId}#${item.number}`}>
-                <a
-                  href={item.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="flex items-center gap-2 py-2 hover:opacity-80"
-                  title={`Open PR #${item.number} on GitHub`}
-                >
-                  <GitPullRequest className="h-4 w-4 shrink-0 text-emerald-500" />
-                  <span className="shrink-0 text-xs font-medium tabular-nums text-muted-foreground">#{item.number}</span>
-                  <span className="truncate font-medium">{item.title}</span>
-                  <span className="ml-auto shrink-0 text-xs text-muted-foreground">{item.projectName}</span>
-                </a>
+              <li key={interventionKey(item)}>
+                {item.kind === 'awaiting' ? (
+                  <button
+                    type="button"
+                    onClick={() => onSelectProject(item.projectId)}
+                    className="flex w-full items-center gap-2 py-2 text-left hover:opacity-80"
+                    title="Open the run to answer"
+                  >
+                    <MessageCircleQuestion className="h-4 w-4 shrink-0 text-amber-500" />
+                    <span className="shrink-0 text-xs font-medium text-amber-500">Awaiting</span>
+                    <span className="truncate font-medium">{item.title}</span>
+                    <span className="ml-auto shrink-0 text-xs text-muted-foreground">{item.projectName}</span>
+                  </button>
+                ) : (
+                  <a
+                    href={item.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="flex items-center gap-2 py-2 hover:opacity-80"
+                    title={`Open PR #${item.number} on GitHub`}
+                  >
+                    <GitPullRequest className="h-4 w-4 shrink-0 text-emerald-500" />
+                    <span className="shrink-0 text-xs font-medium tabular-nums text-muted-foreground">#{item.number}</span>
+                    <span className="truncate font-medium">{item.title}</span>
+                    <span className="ml-auto shrink-0 text-xs text-muted-foreground">{item.projectName}</span>
+                  </a>
+                )}
               </li>
             ))}
           </ul>

--- a/packages/framework-dashboard/lib/interventions.test.ts
+++ b/packages/framework-dashboard/lib/interventions.test.ts
@@ -3,10 +3,17 @@ import type { Intervention } from '@gemstack/framework'
 import { interventionKey, pickNewInterventions } from './interventions.js'
 
 const item = (number: number, url: string): Intervention => ({ projectId: 'p', projectName: 'p', kind: 'pr', number, title: `pr ${number}`, url })
+const awaiting = (projectId: string, awaitId: string): Intervention => ({ projectId, projectName: projectId, kind: 'awaiting', title: 'q?', url: '', awaitId })
 
 describe('interventions helpers (#627)', () => {
   test('interventionKey is the PR url', () => {
     expect(interventionKey(item(7, 'https://gh/pr/7'))).toBe('https://gh/pr/7')
+  })
+
+  test('interventionKey is project+gate for an awaiting run, so it survives an empty/shared url (#636)', () => {
+    expect(interventionKey(awaiting('a', 'g1'))).toBe('awaiting:a:g1')
+    // Two projects paused on same-id gates stay distinct despite an identical (empty) url.
+    expect(interventionKey(awaiting('a', 'g1'))).not.toBe(interventionKey(awaiting('b', 'g1')))
   })
 
   test('pickNewInterventions returns only items whose key is not already seen', () => {

--- a/packages/framework-dashboard/lib/interventions.ts
+++ b/packages/framework-dashboard/lib/interventions.ts
@@ -5,9 +5,13 @@ import type { Intervention } from '@gemstack/framework'
 // framework barrel would drag its Node-only + telefunc modules into the browser bundle. Only
 // the `Intervention` type is borrowed (types are erased), and that logic is a couple of lines.
 
-/** The stable identity of an intervention — its PR url, which survives title edits and re-sorts. */
+/**
+ * The stable identity of an intervention. A PR is its url (survives title edits and re-sorts);
+ * an awaiting run (#636) is its project + gate id, since its url is the shared dashboard URL and
+ * would otherwise collide across projects. Mirrors the server's `interventionKey`.
+ */
 export function interventionKey(item: Intervention): string {
-  return item.url
+  return item.kind === 'awaiting' ? `awaiting:${item.projectId}:${item.awaitId ?? ''}` : item.url
 }
 
 /**

--- a/packages/framework-dashboard/lib/use-intervention-notifications.test.ts
+++ b/packages/framework-dashboard/lib/use-intervention-notifications.test.ts
@@ -4,6 +4,7 @@ import type { Intervention } from '@gemstack/framework'
 import { useInterventionNotifications } from './use-intervention-notifications.js'
 
 const item = (n: number, url: string): Intervention => ({ projectId: 'p', projectName: 'p', kind: 'pr', number: n, title: `pr ${n}`, url })
+const awaiting = (awaitId: string, title: string): Intervention => ({ projectId: 'p', projectName: 'p', kind: 'awaiting', title, url: '', awaitId })
 
 const ctor = vi.fn()
 
@@ -32,6 +33,14 @@ describe('useInterventionNotifications (#627)', () => {
     rerender({ items: [item(1, 'u1'), item(2, 'u2')] }) // a genuinely new PR -> notify once
     expect(ctor).toHaveBeenCalledTimes(1)
     expect(ctor.mock.calls[0]![0]).toContain('Needs you')
+  })
+
+  test('fires for a paused run that appears later, showing its question (#636)', () => {
+    const { rerender } = render(true)
+    rerender({ items: [] }) // baseline
+    rerender({ items: [awaiting('g1', 'Cache the auth store?')] })
+    expect(ctor).toHaveBeenCalledTimes(1)
+    expect(ctor.mock.calls[0]![1]?.body).toContain('Cache the auth store?')
   })
 
   test('never fires when notifications are disabled', () => {

--- a/packages/framework-dashboard/lib/use-intervention-notifications.ts
+++ b/packages/framework-dashboard/lib/use-intervention-notifications.ts
@@ -12,16 +12,24 @@ import { interventionKey, pickNewInterventions } from './interventions.js'
 /** Observations to treat as baseline before notifying: the initial `[]` plus the first fetch. */
 const WARMUP = 2
 
+/** How a single intervention reads in a notification body: a PR by number, a paused run by its question (#636). */
+function label(item: Intervention): string {
+  return item.kind === 'awaiting' ? item.title : `#${item.number} ${item.title}`
+}
+
 function fire(items: Intervention[]): void {
   if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return
   const first = items[0]
   if (!first) return
   const single = items.length === 1
   const title = single ? `Needs you · ${first.projectName}` : `${items.length} items need you`
-  const body = single ? `#${first.number} ${first.title}` : items.map(i => `#${i.number} ${i.title}`).join('\n')
+  const body = single ? label(first) : items.map(label).join('\n')
   const notification = new Notification(title, { body })
   notification.onclick = () => {
-    window.open(first.url, '_blank', 'noopener')
+    // A PR opens on GitHub; a paused run lives in this dashboard, so just bring the tab forward
+    // (project selection is client state, not a URL) — the "needs you" card takes it from there.
+    if (first.kind === 'awaiting') window.focus()
+    else window.open(first.url, '_blank', 'noopener')
     notification.close()
   }
 }

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -5,6 +5,7 @@ import type { FrameworkEvent } from './events.js'
 import { FRAMEWORK_DIR } from './store/index.js'
 import { startDashboard, type Dashboard, type StartRunKind, type StartRunOptions, type StartRunResult, type AddProjectResult, type PreviewResult, type PreviewStatus } from './dashboard/index.js'
 import { startInterventionWatcher, postDiscord, type InterventionWatcher } from './dashboard/intervention-watcher.js'
+import { buildInterventions } from './dashboard/interventions.js'
 import { startPreview, type PreviewHandle } from './preview.js'
 import { resolveDashboardBundle } from './dashboard/bundle.js'
 import { isActivated } from './project.js'
@@ -351,6 +352,8 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
           name: basename(p.path),
           activated: true,
         })),
+      // Pass the daemon's own URL so a paused-run item (#636) can link back to the dashboard.
+      build: projects => buildInterventions(projects, { dashboardUrl: dashboard.url }),
       onNew: items => postDiscord(webhook, items).catch(() => {}),
     })
   }

--- a/packages/framework/src/dashboard/intervention-watcher.test.ts
+++ b/packages/framework/src/dashboard/intervention-watcher.test.ts
@@ -36,6 +36,28 @@ test('postDiscord posts one item with its number, title, project and url', async
   assert.match(content, /https:\/\/gh\/pr\/285/)
 })
 
+test('postDiscord phrases a paused-run item as awaiting, with no PR number (#636)', async () => {
+  const awaiting: Intervention = {
+    projectId: 'p',
+    projectName: 'gemstack',
+    kind: 'awaiting',
+    title: 'Cache the auth store?',
+    url: 'http://localhost:4200',
+    awaitId: 'g1',
+  }
+  let body: unknown
+  const fetchImpl = (async (_url, init) => {
+    body = JSON.parse(String(init!.body))
+    return new Response(null, { status: 204 })
+  }) as typeof fetch
+  await postDiscord('https://discord/hook', [awaiting], fetchImpl)
+  const content = (body as { content: string }).content
+  assert.match(content, /Cache the auth store\?/)
+  assert.match(content, /awaiting your answer/)
+  assert.match(content, /http:\/\/localhost:4200/)
+  assert.doesNotMatch(content, /#undefined/) // no phantom PR number
+})
+
 test('postDiscord summarizes multiple items and skips the call when there are none', async () => {
   const calls: string[] = []
   const fetchImpl = (async (_url, init) => {
@@ -55,7 +77,7 @@ test('startInterventionWatcher announces only items that appear after the first 
   const watcher = startInterventionWatcher({
     projects,
     build: async () => current,
-    onNew: items => void announced.push(items.map(i => i.number)),
+    onNew: items => void announced.push(items.map(i => i.number!)),
     intervalMs: 1_000_000, // effectively disable the timer; drive via poll()
   })
   try {

--- a/packages/framework/src/dashboard/intervention-watcher.ts
+++ b/packages/framework/src/dashboard/intervention-watcher.ts
@@ -32,7 +32,12 @@ export async function postDiscord(
   fetchImpl: typeof fetch = fetch,
 ): Promise<void> {
   if (items.length === 0) return
-  const line = (i: Intervention): string => `#${i.number} ${i.title} — ${i.url}`
+  // A PR reads `#123 Title — url`; a paused run (#636) has no number and only the dashboard url,
+  // so it reads `Title — awaiting your answer` with the link appended when the daemon knows it.
+  const line = (i: Intervention): string =>
+    i.kind === 'awaiting'
+      ? `${i.title} — awaiting your answer${i.url ? ` — ${i.url}` : ''}`
+      : `#${i.number} ${i.title} — ${i.url}`
   const content =
     items.length === 1
       ? `🔔 Needs you (${items[0]!.projectName}): ${line(items[0]!)}`

--- a/packages/framework/src/dashboard/interventions.test.ts
+++ b/packages/framework/src/dashboard/interventions.test.ts
@@ -1,9 +1,23 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { buildInterventions, type OpenPr } from './interventions.js'
+import { buildInterventions, interventionKey, type OpenPr } from './interventions.js'
 import type { ProjectSummary } from './projects.js'
+import type { RunMeta } from '../store/index.js'
 
 const project = (id: string, path: string): ProjectSummary => ({ id, path, name: id, activated: true })
+
+/** No paused run anywhere — keeps the PR-only tests hermetic (no disk read). */
+const noRuns = async (): Promise<RunMeta | undefined> => undefined
+
+const runningMeta = (over: Partial<RunMeta> = {}): RunMeta => ({
+  version: 1,
+  status: 'running',
+  id: 'r1',
+  startedAt: '2026-07-16T00:00:00Z',
+  updatedAt: '2026-07-16T00:00:00Z',
+  passes: 0,
+  ...over,
+})
 
 test('buildInterventions rolls up open non-draft PRs across projects, newest first', async () => {
   const prsByPath: Record<string, OpenPr[]> = {
@@ -15,7 +29,7 @@ test('buildInterventions rolls up open non-draft PRs across projects, newest fir
     '/c': [], // no open PRs -> contributes nothing
   }
   const prs = async (cwd: string): Promise<OpenPr[]> => prsByPath[cwd] ?? []
-  const items = await buildInterventions([project('a', '/a'), project('b', '/b'), project('c', '/c')], { prs })
+  const items = await buildInterventions([project('a', '/a'), project('b', '/b'), project('c', '/c')], { prs, liveMeta: noRuns })
 
   // Newest PR first; the draft is gone.
   assert.deepEqual(
@@ -33,18 +47,66 @@ test('buildInterventions skips a project whose PR lookup throws', async () => {
     if (cwd === '/boom') throw new Error('gh exploded')
     return [{ number: 1, title: 'ok', url: 'u1', isDraft: false }]
   }
-  const items = await buildInterventions([project('boom', '/boom'), project('ok', '/ok')], { prs })
+  const items = await buildInterventions([project('boom', '/boom'), project('ok', '/ok')], { prs, liveMeta: noRuns })
   assert.deepEqual(items.map(i => i.projectId), ['ok'])
 })
 
 test('buildInterventions returns [] when nothing is open anywhere', async () => {
   const prs = async (): Promise<OpenPr[]> => []
-  assert.deepEqual(await buildInterventions([project('a', '/a')], { prs }), [])
+  assert.deepEqual(await buildInterventions([project('a', '/a')], { prs, liveMeta: noRuns }), [])
 })
 
 test('buildInterventions dedupes a PR shared by two registered projects (same repo), keeping one', async () => {
   const shared: OpenPr = { number: 285, title: 'release', url: 'https://gh/pr/285', isDraft: false, createdAt: '2026-07-05T00:00:00Z' }
   const prs = async (): Promise<OpenPr[]> => [shared] // both projects resolve to the same repo
-  const items = await buildInterventions([project('root', '/repo'), project('sub', '/repo/packages/x')], { prs })
+  const items = await buildInterventions([project('root', '/repo'), project('sub', '/repo/packages/x')], { prs, liveMeta: noRuns })
   assert.deepEqual(items.map(i => i.number), [285])
+})
+
+const noPrs = async (): Promise<OpenPr[]> => []
+
+test('buildInterventions adds an awaiting item for a running run parked on a choice (#636)', async () => {
+  const liveMeta = async (cwd: string): Promise<RunMeta | undefined> =>
+    cwd === '/a' ? runningMeta({ pendingChoice: { id: 'gate-1', title: 'Cache the auth store?' } }) : undefined
+  const items = await buildInterventions([project('a', '/a'), project('b', '/b')], { prs: noPrs, liveMeta })
+
+  assert.equal(items.length, 1)
+  assert.deepEqual(
+    { kind: items[0]!.kind, project: items[0]!.projectId, title: items[0]!.title, awaitId: items[0]!.awaitId },
+    { kind: 'awaiting', project: 'a', title: 'Cache the auth store?', awaitId: 'gate-1' },
+  )
+})
+
+test('buildInterventions ignores a pendingChoice on a run that is no longer running', async () => {
+  const liveMeta = async (): Promise<RunMeta | undefined> =>
+    runningMeta({ status: 'done', pendingChoice: { id: 'gate-1', title: 'stale' } })
+  assert.deepEqual(await buildInterventions([project('a', '/a')], { prs: noPrs, liveMeta }), [])
+})
+
+test('buildInterventions links an awaiting item to the dashboard URL when given, else empty', async () => {
+  const liveMeta = async (): Promise<RunMeta | undefined> => runningMeta({ pendingChoice: { id: 'g', title: 'q?' } })
+  const withUrl = await buildInterventions([project('a', '/a')], { prs: noPrs, liveMeta, dashboardUrl: 'http://localhost:4200' })
+  assert.equal(withUrl[0]!.url, 'http://localhost:4200')
+  const withoutUrl = await buildInterventions([project('a', '/a')], { prs: noPrs, liveMeta })
+  assert.equal(withoutUrl[0]!.url, '')
+})
+
+test('buildInterventions surfaces PRs and awaiting runs together, newest first', async () => {
+  const prs = async (cwd: string): Promise<OpenPr[]> =>
+    cwd === '/a' ? [{ number: 5, title: 'pr', url: 'u5', isDraft: false, createdAt: '2026-07-10T00:00:00Z' }] : []
+  const liveMeta = async (cwd: string): Promise<RunMeta | undefined> =>
+    cwd === '/b' ? runningMeta({ updatedAt: '2026-07-16T00:00:00Z', pendingChoice: { id: 'g', title: 'q?' } }) : undefined
+  const items = await buildInterventions([project('a', '/a'), project('b', '/b')], { prs, liveMeta })
+  assert.deepEqual(items.map(i => i.kind), ['awaiting', 'pr']) // awaiting is newer
+})
+
+test('interventionKey is the url for a PR and project+gate for an awaiting run', () => {
+  assert.equal(
+    interventionKey({ projectId: 'a', projectName: 'a', kind: 'pr', title: 't', url: 'https://gh/pr/1', number: 1 }),
+    'https://gh/pr/1',
+  )
+  assert.equal(
+    interventionKey({ projectId: 'a', projectName: 'a', kind: 'awaiting', title: 't', url: '', awaitId: 'g1' }),
+    'awaiting:a:g1',
+  )
 })

--- a/packages/framework/src/dashboard/interventions.ts
+++ b/packages/framework/src/dashboard/interventions.ts
@@ -1,21 +1,31 @@
+import { readLiveMeta, type RunMeta } from '../store/index.js'
 import type { ProjectSummary } from './projects.js'
 
 // The interventions queue (#632, part of the Queue #624): the cross-project "needs you" list.
 // Rom's design (#624): proposals and finished work are both just PRs, so the bulk of what
 // needs a human is the set of open PRs across the registered projects — merge to confirm,
 // close to reject. This rolls those up, the same way overview.ts rolls up running runs. The
-// other source, a run paused at an await gate, is a follow-up; #627 notifications rides this.
+// second source (#636) is a run paused at an await gate — a live run whose latest state is an
+// unresolved choice, waiting for the user's answer. #627 notifications ride this whole set.
 
-/** One item awaiting the human. Today always a PR; the shape leaves room for a paused run later. */
+/**
+ * One item awaiting the human. Two kinds: an open `pr` to review/merge or close, and an
+ * `awaiting` run paused on a choice gate. The card, the browser hook, and the Discord watcher
+ * all iterate the flat list, branching on `kind` for the fields that differ.
+ */
 export interface Intervention {
   projectId: string
   projectName: string
-  /** What kind of attention this needs. `pr` = an open PR to review/merge or close. */
-  kind: 'pr'
-  number: number
+  /** `pr` = an open PR to review/merge or close; `awaiting` = a run paused on a choice gate (#636). */
+  kind: 'pr' | 'awaiting'
   title: string
+  /** Where to act: the PR on GitHub (`pr`), or the dashboard (`awaiting`, when the URL is known). */
   url: string
-  /** When the PR was opened (ISO), for ordering. */
+  /** The PR number (`pr` only). */
+  number?: number
+  /** The parked gate's id (`awaiting` only) — its stable identity, so it notifies exactly once. */
+  awaitId?: string
+  /** When the PR was opened (`pr`) or the run last updated (`awaiting`), ISO, for ordering. */
   createdAt?: string
 }
 
@@ -53,18 +63,28 @@ export function nodeGhPrLister(): PrLister {
 /** Injectable seam so {@link buildInterventions} is unit-testable off disk. */
 export interface InterventionsDeps {
   prs?: PrLister
+  /** The live-run meta reader (default {@link readLiveMeta}); drives the `awaiting` source (#636). */
+  liveMeta?: (cwd: string) => Promise<RunMeta | undefined>
+  /**
+   * The dashboard's own URL, so an `awaiting` item can link back to it. Only the daemon knows
+   * it (the card path resolves the project client-side and needs no URL), so it is optional; an
+   * awaiting item's `url` is empty when it is unset.
+   */
+  dashboardUrl?: string
 }
 
 /**
  * Build the cross-project interventions queue: every registered project's open, non-draft PRs,
- * newest first. Forgiving — a project with no remote (or an unreadable one) simply contributes
- * nothing. Draft PRs are excluded: they are not yet asking for review.
+ * plus any run currently paused on a choice gate (#636), newest first. Forgiving — a project
+ * with no remote (or an unreadable one) simply contributes nothing. Draft PRs are excluded:
+ * they are not yet asking for review.
  */
 export async function buildInterventions(
   projects: ProjectSummary[],
   deps: InterventionsDeps = {},
 ): Promise<Intervention[]> {
   const prs = deps.prs ?? nodeGhPrLister()
+  const liveMeta = deps.liveMeta ?? readLiveMeta
   const items: Intervention[] = []
   for (const project of projects) {
     const open = await prs(project.path).catch(() => [])
@@ -80,17 +100,36 @@ export async function buildInterventions(
         ...(pr.createdAt ? { createdAt: pr.createdAt } : {}),
       })
     }
+    // A run paused mid-flight to ask the user is a "needs you" too (#636): a live run that is
+    // still `running` and has an unresolved choice gate. One per project (a run parks on one
+    // gate at a time), keyed on the gate id so it notifies once.
+    const meta = await liveMeta(project.path).catch(() => undefined)
+    if (meta?.status === 'running' && meta.pendingChoice) {
+      items.push({
+        projectId: project.id,
+        projectName: project.name,
+        kind: 'awaiting',
+        title: meta.pendingChoice.title,
+        url: deps.dashboardUrl ?? '',
+        awaitId: meta.pendingChoice.id,
+        ...(meta.updatedAt ? { createdAt: meta.updatedAt } : {}),
+      })
+    }
   }
   items.sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''))
   // The same repo can be registered under two projects (e.g. a monorepo root + a subdir), so a
-  // PR would otherwise appear once per entry. Collapse by URL, keeping the first (newest-sorted).
+  // PR would otherwise appear once per entry. Collapse by identity, keeping the first (newest-sorted).
   const seen = new Set<string>()
-  return items.filter(item => (seen.has(item.url) ? false : (seen.add(item.url), true)))
+  return items.filter(item => (seen.has(interventionKey(item)) ? false : (seen.add(interventionKey(item)), true)))
 }
 
-/** The stable identity of an intervention — its PR url, which survives title edits and re-sorts. */
+/**
+ * The stable identity of an intervention. A PR is its url (survives title edits and re-sorts);
+ * an awaiting run is its project + gate id, since its url is the shared dashboard URL and would
+ * otherwise collide across projects.
+ */
 export function interventionKey(item: Intervention): string {
-  return item.url
+  return item.kind === 'awaiting' ? `awaiting:${item.projectId}:${item.awaitId ?? ''}` : item.url
 }
 
 /**

--- a/packages/framework/src/store/run-store.test.ts
+++ b/packages/framework/src/store/run-store.test.ts
@@ -155,6 +155,25 @@ test('applyEventToMeta records the session name + ready-for-merge lifecycle sign
   assert.equal(ready.sessionName, 'add-comments') // ready doesn't clobber the name
 })
 
+test('applyEventToMeta tracks the pending choice gate a run is parked on (#636)', () => {
+  const base = metaFromEvents(RUN.slice(0, 4), AT)
+  assert.equal(base.pendingChoice, undefined)
+  const asked = applyEventToMeta(base, { kind: 'choice', id: 'g1', title: 'Cache the auth store?', options: [{ id: 'y', label: 'Yes' }] }, AT)
+  assert.deepEqual(asked.pendingChoice, { id: 'g1', title: 'Cache the auth store?' })
+  // A resolve for a different gate id leaves it parked; the matching resolve clears it.
+  const other = applyEventToMeta(asked, { kind: 'choice-resolved', id: 'other', picked: 'y', by: 'user' }, AT)
+  assert.deepEqual(other.pendingChoice, { id: 'g1', title: 'Cache the auth store?' })
+  const resolved = applyEventToMeta(asked, { kind: 'choice-resolved', id: 'g1', picked: 'y', by: 'user' }, AT)
+  assert.equal(resolved.pendingChoice, undefined)
+})
+
+test('applyEventToMeta clears a pending choice when the run ends (#636)', () => {
+  const base = metaFromEvents(RUN.slice(0, 4), AT)
+  const asked = applyEventToMeta(base, { kind: 'choice', id: 'g1', title: 'q?', options: [{ id: 'y', label: 'Yes' }] }, AT)
+  const ended = applyEventToMeta(asked, { kind: 'end', ok: true }, AT)
+  assert.equal(ended.pendingChoice, undefined)
+})
+
 test('close archives the run into runs/<id>.json + .jsonl for history (#303)', async () => {
   const fs = memFs()
   const store = await RunStore.open(CWD, { fs, fresh: true, now: AT })

--- a/packages/framework/src/store/run-store.ts
+++ b/packages/framework/src/store/run-store.ts
@@ -82,6 +82,12 @@ export interface RunMeta {
   sessionName?: string
   /** Whether the agent signalled `setReadyForMerge()` (#326): building (false/absent) vs ready (true). */
   readyForMerge?: boolean
+  /**
+   * The choice gate the run is currently parked on (#636): set when a `choice` event fires and
+   * cleared when its `choice-resolved` (or the run's `end`) arrives. Present means the run is
+   * paused waiting for the user's answer — the second "needs you" source after open PRs (#624).
+   */
+  pendingChoice?: { id: string; title: string }
 }
 
 /**
@@ -135,6 +141,12 @@ export function applyEventToMeta(meta: RunMeta, event: FrameworkEvent, at: strin
     case 'ready-for-merge':
       next.readyForMerge = true
       break
+    case 'choice':
+      next.pendingChoice = { id: event.id, title: event.title }
+      break
+    case 'choice-resolved':
+      if (next.pendingChoice?.id === event.id) delete next.pendingChoice
+      break
     case 'bootstrap': {
       const b = event.event
       if (b.type === 'scope') {
@@ -149,6 +161,7 @@ export function applyEventToMeta(meta: RunMeta, event: FrameworkEvent, at: strin
     }
     case 'end':
       next.status = event.ok ? 'done' : event.stopped ? 'stopped' : 'failed'
+      delete next.pendingChoice // a finished run is not awaiting anything
       break
     default:
       break


### PR DESCRIPTION
Closes #636. Part of #624 (the Queue), follow-up to #632/#627.

## What

Today "Needs you" (and the #634 browser + #635 Discord notifications) only surface open PRs. A run that paused mid-flight to ask the user a question is just as much a "needs you", but it was invisible unless you happened to be looking at that project's live view. This adds it as a second intervention source.

## How

- **`RunMeta.pendingChoice`** — folded from the `choice` / `choice-resolved` events (set on `choice`, cleared on the matching resolve and on `end`). `run.json` is already a pure projection of the event stream, so this is one more folded field.
- **`Intervention` gains `kind: 'awaiting'`** (was `'pr'` only). `buildInterventions` reads each project's live meta and adds an awaiting item when a run is `running` with a `pendingChoice`. Identity is `awaiting:<project>:<gateId>` (its url is the shared dashboard URL, so it can't key on url).
- **Card**: an awaiting item renders as a button that jumps into the project to answer (no PR to open); a PR still links out to GitHub.
- **Browser notification**: shows the question; click brings the dashboard tab forward.
- **Discord**: the daemon passes its own URL so the message reads `<question> — awaiting your answer — <dashboard url>`, no phantom `#number`.

Additive: the card, the browser hook, and the Discord watcher already iterate a flat list, so the new kind just flows through.

## Tests

- `run-store`: pendingChoice set/cleared across choice / mismatched-resolve / matching-resolve / end.
- `interventions`: awaiting item built for a running+parked run, ignored when not running, links to the dashboard URL when given (else empty), interleaves with PRs newest-first, and the kind-aware `interventionKey`.
- `intervention-watcher`: Discord phrasing for a paused run (no `#undefined`).
- dashboard `interventions` + `use-intervention-notifications`: awaiting key + a notification firing for a paused run.

Verified end-to-end on real disk: a written `run.json` with a `pendingChoice` surfaces through the default `readLiveMeta` path. Root build + both typechecks green.