### PR TITLE
feat(framework): per-user Discord notifications toggle (#638)

### DIFF
--- a/.changeset/discord-notify-toggle-627.md
+++ b/.changeset/discord-notify-toggle-627.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Per-user Discord toggle for the "needs you" notifications (#627): Discord was env-only (set `DISCORD_WEBHOOK` and it posted). Now a `notifyDiscord` preference (default off) gates the daemon watcher on top of the webhook — the webhook is *where* to post, the preference is *whether* to. It is checked at post time, so the new header toggle (beside the browser bell) takes effect without restarting the daemon, and the watcher keeps its baseline warm while off so flipping it on starts from now rather than blasting the open backlog.

--- a/packages/framework-dashboard/components/DiscordToggle.tsx
+++ b/packages/framework-dashboard/components/DiscordToggle.tsx
@@ -1,0 +1,29 @@
+import { MessageSquare, MessageSquareOff } from 'lucide-react'
+import { usePreferences, updatePreferences, discordEnabled } from '../lib/preferences.js'
+import { cn } from '../lib/utils.js'
+
+// The Discord notifications toggle in the shell header (#627), beside the browser bell. Unlike
+// the bell (default on, gated on a browser permission), Discord is default off and reaches you
+// with no dashboard open, so it is opt-in. The other gate is the daemon's `DISCORD_WEBHOOK` env
+// var — the toggle can't see it, so the tooltip names it: this only says *whether* to notify,
+// the webhook is *where*.
+export function DiscordToggle() {
+  const preferences = usePreferences()
+  const enabled = discordEnabled(preferences)
+  const title = enabled
+    ? 'Discord notifications on — click to mute (needs DISCORD_WEBHOOK set on the daemon)'
+    : 'Discord notifications off — click to turn on (needs DISCORD_WEBHOOK set on the daemon)'
+
+  return (
+    <button
+      type="button"
+      onClick={() => updatePreferences({ notifyDiscord: !enabled })}
+      title={title}
+      aria-label={title}
+      aria-pressed={enabled}
+      className={cn('rounded-md p-1.5 hover:bg-accent', enabled ? 'text-foreground' : 'text-muted-foreground')}
+    >
+      {enabled ? <MessageSquare className="h-4 w-4" /> : <MessageSquareOff className="h-4 w-4" />}
+    </button>
+  )
+}

--- a/packages/framework-dashboard/lib/preferences.ts
+++ b/packages/framework-dashboard/lib/preferences.ts
@@ -72,3 +72,9 @@ export function autopilotEnabled(preferences: Preferences): boolean {
 export function notificationsEnabled(preferences: Preferences): boolean {
   return preferences.notifyBrowser ?? true
 }
+
+/** Discord notifications default off (#627): they reach you with no dashboard open, so opt-in.
+ * The daemon's `DISCORD_WEBHOOK` is the other gate (where to post; this is whether to). */
+export function discordEnabled(preferences: Preferences): boolean {
+  return preferences.notifyDiscord ?? false
+}

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -3,6 +3,7 @@ import type { Intervention } from '@gemstack/framework'
 import { onProjectFiles, onInterventions } from '../../server/reads.telefunc.js'
 import { ProjectsSidebar } from '../../components/ProjectsSidebar.js'
 import { NotificationBell } from '../../components/NotificationBell.js'
+import { DiscordToggle } from '../../components/DiscordToggle.js'
 import { RunHistory } from '../../components/RunHistory.js'
 import { ProjectHome } from '../../components/ProjectHome.js'
 import { DashboardPage } from '../../components/DashboardPage.js'
@@ -127,7 +128,10 @@ export default function Page() {
         <span className="font-semibold">The Framework</span>
         <Badge className="text-muted-foreground">dashboard</Badge>
         <div className="ml-auto flex items-center gap-3">
-          <NotificationBell />
+          <div className="flex items-center gap-1">
+            <NotificationBell />
+            <DiscordToggle />
+          </div>
           <span className="text-xs text-muted-foreground">Vike · React · shadcn · Telefunc</span>
         </div>
       </header>

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -9,7 +9,7 @@ import { buildInterventions } from './dashboard/interventions.js'
 import { startPreview, type PreviewHandle } from './preview.js'
 import { resolveDashboardBundle } from './dashboard/bundle.js'
 import { isActivated } from './project.js'
-import { addProject, listProjects, projectId } from './registry.js'
+import { addProject, listProjects, projectId, readPreferences } from './registry.js'
 import { installProject, enumerateGitRepos } from './install.js'
 import { JsonlTailer } from './jsonl-tail.js'
 
@@ -340,7 +340,10 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
   }
 
   // Discord notifications (#627): fire on new "needs you" items even when no dashboard is open.
-  // Opt-in by setting DISCORD_WEBHOOK; the browser-notification path needs no daemon watcher.
+  // Two gates: a `DISCORD_WEBHOOK` (where to post) and the per-user `notifyDiscord` preference
+  // (whether to). The pref is checked at post time, not watcher start, so the header toggle takes
+  // effect without a daemon restart — and the watcher keeps observing while off, so flipping it on
+  // starts from now rather than blasting the whole open backlog.
   const webhook = env.DISCORD_WEBHOOK
   let watcher: InterventionWatcher | undefined
   if (webhook) {
@@ -354,7 +357,11 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
         })),
       // Pass the daemon's own URL so a paused-run item (#636) can link back to the dashboard.
       build: projects => buildInterventions(projects, { dashboardUrl: dashboard.url }),
-      onNew: items => postDiscord(webhook, items).catch(() => {}),
+      onNew: async items => {
+        const prefs = await readPreferences(undefined, env).catch(() => ({}) as Awaited<ReturnType<typeof readPreferences>>)
+        if (!prefs.notifyDiscord) return // opted out (default): keep quiet, baseline already advanced
+        await postDiscord(webhook, items).catch(() => {})
+      },
     })
   }
 

--- a/packages/framework/src/registry.test.ts
+++ b/packages/framework/src/registry.test.ts
@@ -179,6 +179,12 @@ test('writePreferences persists sanitized prefs and preserves the project list',
   assert.deepEqual(await listProjects(fs, ENV), [APP_A, APP_B])
 })
 
+test('writePreferences round-trips the notifyDiscord toggle (#627)', async () => {
+  const fs = memFs({ [FILE]: JSON.stringify([APP_A]) })
+  await writePreferences({ notifyDiscord: true }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { notifyDiscord: true })
+})
+
 test('addProject preserves existing preferences', async () => {
   const fs = memFs({ [FILE]: JSON.stringify({ projects: [APP_A], preferences: { autopilot: false } }) })
   await addProject('/repos/app-b', APP_B.addedAt, fs, ENV)

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -41,6 +41,13 @@ export interface Preferences {
   /** Fire a browser notification when a new item lands on the "needs you" queue (#627). Absent = on. */
   notifyBrowser?: boolean
   /**
+   * Post a Discord message when a new item lands on the "needs you" queue (#627). Absent = off:
+   * unlike the in-browser toggle, Discord reaches you when no dashboard is open, so it is opt-in.
+   * Gates the daemon watcher *on top of* a `DISCORD_WEBHOOK` being set (the webhook is where to
+   * post; this is whether to).
+   */
+  notifyDiscord?: boolean
+  /**
    * How much of the subscription The Framework may burn before it pauses itself
    * (#527, the settings behind #519).
    *
@@ -146,6 +153,7 @@ const PREFERENCE_KEYS = [
   'onBeforeMergeableQuality',
   'browser',
   'notifyBrowser',
+  'notifyDiscord',
 ] as const
 
 /** Keep only the known preference fields, so a hand-edited or browser-supplied


### PR DESCRIPTION
Closes #638. Follow-up to #627 / #635.

## What

Discord notifications were env-only: set `DISCORD_WEBHOOK` and the daemon posts. This adds a per-user `notifyDiscord` preference (default **off**) that gates the daemon watcher **on top of** the webhook — the webhook is *where* to post, the preference is *whether* to.

## How

- `Preferences.notifyDiscord` + `PREFERENCE_KEYS` (registry.ts). Default off: Discord reaches you with no dashboard open, so it is opt-in (the browser bell stays default on).
- The daemon checks the pref in the watcher's `onNew` (post time, not watcher start), so the header toggle takes effect **without a daemon restart**. The watcher keeps observing while off, so the baseline stays warm — turning it on starts from now, not a blast of the whole open backlog.
- `DiscordToggle` in the shell header beside the browser bell; `discordEnabled()` helper. The toggle can't see the daemon's env, so its tooltip names `DISCORD_WEBHOOK` as the other gate.

## Tests + verification

- registry: `notifyDiscord` round-trips through write/read + sanitize.
- Verified the gate end-to-end against the real `readPreferences` + a local webhook catcher: default (unset) posts nothing, `notifyDiscord=true` posts, `false` goes quiet again.
- Root build + both typechecks green.