### PR TITLE
feat(framework): select the model from the dashboard (#628)

### DIFF
--- a/.changeset/select-model-628.md
+++ b/.changeset/select-model-628.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Select the model from the dashboard (#628): a model picker sits under the prompt textarea (Default / Opus / Sonnet / Haiku) and persists as a `model` preference. It flows through as the run's `--model`, so the wrapped agent runs on the chosen model; empty means the driver's own default (no flag). A full model id set directly in the registry works too — the aliases are just the common Claude Code ones, since it is the default driver.

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -27,6 +27,17 @@ const PRESETS: { id: string; label: string; render: () => string }[] = [
   { id: 'ux', label: 'UX', render: renderUxPrompt },
 ]
 
+// The model picker below the textarea (#628): what the run passes as `--model`. Empty = the
+// driver's own default (no flag). The aliases are Claude Code's, since it is the default driver;
+// the value passes straight through to the wrapped agent, so a full model id typed into the
+// registry works too.
+const MODELS: { value: string; label: string }[] = [
+  { value: '', label: 'Default model' },
+  { value: 'opus', label: 'Opus' },
+  { value: 'sonnet', label: 'Sonnet' },
+  { value: 'haiku', label: 'Haiku' },
+]
+
 // Start a run in the selected project (#405): the one write that goes through the daemon's
 // own `startRun` (with its one-run-per-project busy guard), posted over Telefunc. The
 // Global options (#314/#433) ride along: Autopilot, Technical control, Vanilla, and Eco
@@ -68,6 +79,7 @@ export function StartRunForm({
   const ecoMaintenance = preferences.ecoMaintenance ?? false
   const onBeforeMergeableQuality = preferences.onBeforeMergeableQuality ?? false
   const browser = preferences.browser ?? false
+  const model = preferences.model ?? '' // #628: empty = the driver's default model
 
   // Context selector (#439/#314): the agent can reach every registered repo, so ticking a
   // subset narrows its focus — the picked paths become one `Context:` line in the system
@@ -95,6 +107,7 @@ export function StartRunForm({
       ...(eco && !vanilla && Object.keys(ecoDrops).length ? { eco: ecoDrops } : {}),
       ...(onBeforeMergeableQuality ? { onBeforeMergeable: true } : {}),
       ...(browser ? { browser: true } : {}),
+      ...(model ? { model } : {}),
       ...(context.size ? { context: [...context] } : {}),
     }
   }
@@ -189,7 +202,7 @@ export function StartRunForm({
         busy={busy}
       />
 
-      <div className="mt-2 flex flex-wrap gap-1.5">
+      <div className="mt-2 flex flex-wrap items-center gap-1.5">
         {PRESETS.map(p => (
           <Button
             key={p.id}
@@ -205,6 +218,22 @@ export function StartRunForm({
             {p.label}
           </Button>
         ))}
+        {/* Model picker (#628): sits with the presets under the textarea; persists as a preference. */}
+        <label className="ml-auto flex items-center gap-1.5 text-xs text-muted-foreground" title="Model to run on (passed as --model)">
+          Model
+          <select
+            value={model}
+            disabled={busy}
+            onChange={e => updatePreferences({ model: e.target.value })}
+            className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground disabled:opacity-50"
+          >
+            {MODELS.map(m => (
+              <option key={m.value} value={m.value}>
+                {m.label}
+              </option>
+            ))}
+          </select>
+        </label>
       </div>
 
       <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1.5 text-xs text-muted-foreground">

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -60,6 +60,10 @@ test('startOptionFlags maps only enabled Global options to CLI flags (#314)', ()
   assert.deepEqual(startOptionFlags({ onBeforeMergeable: true }), ['--on-before-mergeable'])
   // Browser via chrome-devtools-mcp (#452): maps to --browser.
   assert.deepEqual(startOptionFlags({ browser: true }), ['--browser'])
+  // Model (#628): maps to --model, trimmed; blank/whitespace is no choice -> no flag.
+  assert.deepEqual(startOptionFlags({ model: 'opus' }), ['--model', 'opus'])
+  assert.deepEqual(startOptionFlags({ model: '  sonnet  ' }), ['--model', 'sonnet'])
+  assert.deepEqual(startOptionFlags({ model: '   ' }), [])
 })
 
 const logEvent = (message: string): FrameworkEvent => ({ kind: 'log', message })

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -106,6 +106,7 @@ export function startOptionFlags(options: StartRunOptions): string[] {
   for (const dir of options.context ?? []) if (typeof dir === 'string' && dir.trim()) flags.push('--context', dir)
   if (options.onBeforeMergeable) flags.push('--on-before-mergeable')
   if (options.browser) flags.push('--browser')
+  if (typeof options.model === 'string' && options.model.trim()) flags.push('--model', options.model.trim())
   return flags
 }
 

--- a/packages/framework/src/dashboard/types.ts
+++ b/packages/framework/src/dashboard/types.ts
@@ -30,6 +30,8 @@ export interface StartRunOptions {
   onBeforeMergeable?: boolean
   /** Give the agent a real browser via chrome-devtools-mcp during the run (#452); maps to `--browser`. */
   browser?: boolean
+  /** The model to run the wrapped agent on (#628); maps to `--model`. Absent = the driver's own default. */
+  model?: string
 }
 
 /**

--- a/packages/framework/src/registry.test.ts
+++ b/packages/framework/src/registry.test.ts
@@ -185,6 +185,14 @@ test('writePreferences round-trips the notifyDiscord toggle (#627)', async () =>
   assert.deepEqual(await readPreferences(fs, ENV), { notifyDiscord: true })
 })
 
+test('writePreferences keeps the model string but drops a blank one (#628)', async () => {
+  const fs = memFs({ [FILE]: JSON.stringify([APP_A]) })
+  await writePreferences({ model: '  opus  ' }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { model: 'opus' }) // trimmed
+  await writePreferences({ model: '   ' }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), {}) // blank -> no choice, dropped
+})
+
 test('addProject preserves existing preferences', async () => {
   const fs = memFs({ [FILE]: JSON.stringify({ projects: [APP_A], preferences: { autopilot: false } }) })
   await addProject('/repos/app-b', APP_B.addedAt, fs, ENV)

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -40,6 +40,8 @@ export interface Preferences {
   browser?: boolean
   /** Fire a browser notification when a new item lands on the "needs you" queue (#627). Absent = on. */
   notifyBrowser?: boolean
+  /** The model to run on (#628), e.g. `opus` / `sonnet`; maps to a run's `--model`. Absent = the driver's default. */
+  model?: string
   /**
    * Post a Discord message when a new item lands on the "needs you" queue (#627). Absent = off:
    * unlike the in-browser toggle, Discord reaches you when no dashboard is open, so it is opt-in.
@@ -165,6 +167,9 @@ function sanitizePreferences(value: unknown): Preferences {
   for (const key of PREFERENCE_KEYS) {
     if (typeof input[key] === 'boolean') preferences[key] = input[key] as boolean
   }
+  // `model` (#628) is the one string preference; the rest are booleans. A blank string is "no
+  // choice", same as absent, so it is dropped rather than persisted.
+  if (typeof input['model'] === 'string' && input['model'].trim()) preferences.model = input['model'].trim()
   const consumptionLimits = sanitizeConsumptionLimits(input['consumptionLimits'])
   if (consumptionLimits) preferences.consumptionLimits = consumptionLimits
   return preferences


### PR DESCRIPTION
Closes #628.

## What

A model picker under the prompt textarea, per Rom's paper-cut ticket. Default / Opus / Sonnet / Haiku; persists as a `model` preference and flows through as the run's `--model`.

## How

- `StartRunOptions.model` -> `startOptionFlags` maps it to `--model <value>` (trimmed; blank = no flag). The rest of the chain already existed: the CLI parses `--model` and the Claude Code / Codex drivers forward it, so nothing new past the flag.
- `Preferences.model` (the one string preference; `sanitizePreferences` trims it and drops a blank). Persisting it means you set the model once for dogfooding, like the other Start options.
- `MODELS` picker in `StartRunForm`, beside the presets under the textarea. Empty = the driver's default. The aliases are Claude Code's (the default driver); a full model id typed into the registry passes straight through too.

Ties into the #610 web-driver model-forwarding Rom noted.

## Tests

- `startOptionFlags`: `model` -> `--model`, trimmed, blank -> no flag.
- registry: the `model` string round-trips (trimmed), a blank one is dropped.
- Root build + both typechecks green.