### PR TITLE
feat(framework): user-defined custom presets (#626)

### DIFF
--- a/.changeset/custom-presets-626.md
+++ b/.changeset/custom-presets-626.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Custom presets (#626): save your own prompts as reusable presets beside the built-in ones. A "＋ Preset" button under the prompt textarea captures the current editor text (or a fresh one) under a name; saved presets render as buttons that load their prompt back into the editor, and each has a delete. They persist in the daemon preferences (`customPresets`), sanitized and capped so a hand-edited registry can't bloat the home file. For the users (Rom, nitedani) who keep hand-crafting high-signal prompts, this makes them one click to re-run.

--- a/packages/framework-dashboard/components/CustomPresets.test.tsx
+++ b/packages/framework-dashboard/components/CustomPresets.test.tsx
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { CustomPreset } from '@gemstack/framework'
+import { CustomPresets } from './CustomPresets.js'
+
+afterEach(cleanup)
+
+const preset = (id: string, label: string, prompt: string): CustomPreset => ({ id, label, prompt })
+
+describe('CustomPresets (#626)', () => {
+  test('loads a saved preset into the editor when its button is clicked', () => {
+    const onUse = vi.fn()
+    render(<CustomPresets presets={[preset('a', 'Deep review', 'Audit this.')]} currentPrompt="" busy={false} onUse={onUse} onChange={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Deep review' }))
+    expect(onUse).toHaveBeenCalledWith(preset('a', 'Deep review', 'Audit this.'))
+  })
+
+  test('saves a new preset, prefilling the prompt from the current editor text', () => {
+    const onChange = vi.fn()
+    render(<CustomPresets presets={[]} currentPrompt="my crafted prompt" busy={false} onUse={() => {}} onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button', { name: /Preset/ })) // opens the add panel
+    // The prompt textarea is prefilled with the current editor content.
+    expect((screen.getByPlaceholderText(/prompt this preset runs/i) as HTMLTextAreaElement).value).toBe('my crafted prompt')
+    fireEvent.change(screen.getByPlaceholderText('Preset name'), { target: { value: 'My preset' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save preset' }))
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const saved = onChange.mock.calls[0]![0] as CustomPreset[]
+    expect(saved).toHaveLength(1)
+    expect({ label: saved[0]!.label, prompt: saved[0]!.prompt }).toEqual({ label: 'My preset', prompt: 'my crafted prompt' })
+    expect(saved[0]!.id).toBeTruthy()
+  })
+
+  test('will not save without both a name and a prompt', () => {
+    const onChange = vi.fn()
+    render(<CustomPresets presets={[]} currentPrompt="" busy={false} onUse={() => {}} onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button', { name: /Preset/ }))
+    expect((screen.getByRole('button', { name: 'Save preset' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  test('deletes a preset by id', () => {
+    const onChange = vi.fn()
+    render(
+      <CustomPresets
+        presets={[preset('a', 'One', 'x'), preset('b', 'Two', 'y')]}
+        currentPrompt=""
+        busy={false}
+        onUse={() => {}}
+        onChange={onChange}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Delete preset One' }))
+    expect(onChange).toHaveBeenCalledWith([preset('b', 'Two', 'y')])
+  })
+})

--- a/packages/framework-dashboard/components/CustomPresets.tsx
+++ b/packages/framework-dashboard/components/CustomPresets.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react'
+import type { CustomPreset } from '@gemstack/framework'
+import { Plus, X } from 'lucide-react'
+import { Button } from './ui/button.js'
+
+// User-defined presets (#626): the user's own saved prompts, shown beside the built-in preset
+// buttons in the Start form. A preset is just a label + a prompt; clicking it loads the prompt
+// into the editor (run as a `prompt` kind, same as a built-in). Rom + nitedani keep hand-crafting
+// high-signal prompts — this lets them save and re-run them. Persisted in the daemon preferences.
+
+const LABEL_MAX = 80
+
+/** A fresh id for a saved preset. `crypto.randomUUID` is present in the dashboard's browser + prerender runtime. */
+function newId(): string {
+  return typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `p-${Date.now()}`
+}
+
+export function CustomPresets({
+  presets,
+  currentPrompt,
+  busy,
+  onUse,
+  onChange,
+}: {
+  presets: CustomPreset[]
+  /** The Start form's current textarea text, so "Save as preset" can capture what you just wrote. */
+  currentPrompt: string
+  busy: boolean
+  /** Load a saved preset's prompt into the editor. */
+  onUse: (preset: CustomPreset) => void
+  /** Persist the next preset list (add / delete). */
+  onChange: (next: CustomPreset[]) => void
+}) {
+  const [adding, setAdding] = useState(false)
+  const [label, setLabel] = useState('')
+  const [prompt, setPrompt] = useState('')
+
+  const openAdd = () => {
+    setLabel('')
+    setPrompt(currentPrompt) // prefill with what's in the editor — the common "save what I just wrote" path
+    setAdding(true)
+  }
+
+  const save = () => {
+    const trimmedLabel = label.trim()
+    const trimmedPrompt = prompt.trim()
+    if (!trimmedLabel || !trimmedPrompt) return
+    onChange([...presets, { id: newId(), label: trimmedLabel, prompt: trimmedPrompt }])
+    setAdding(false)
+  }
+
+  const remove = (id: string) => onChange(presets.filter(p => p.id !== id))
+
+  return (
+    <div className="mt-1.5 flex flex-col gap-1.5">
+      <div className="flex flex-wrap items-center gap-1.5">
+        {presets.map(preset => (
+          <span key={preset.id} className="group inline-flex items-center">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={busy}
+              className="rounded-r-none border-r-0"
+              title="Load this saved prompt"
+              onClick={() => onUse(preset)}
+            >
+              {preset.label}
+            </Button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => remove(preset.id)}
+              title={`Delete "${preset.label}"`}
+              aria-label={`Delete preset ${preset.label}`}
+              className="flex h-8 items-center rounded-md rounded-l-none border border-border px-1 text-muted-foreground hover:text-red-500 disabled:opacity-50"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </span>
+        ))}
+        {!adding && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={busy}
+            onClick={openAdd}
+            title="Save a prompt as a reusable preset"
+            className="text-muted-foreground"
+          >
+            <Plus className="mr-1 h-3.5 w-3.5" />
+            Preset
+          </Button>
+        )}
+      </div>
+
+      {adding && (
+        <div className="flex flex-col gap-1.5 rounded-md border border-border p-2">
+          <input
+            type="text"
+            value={label}
+            maxLength={LABEL_MAX}
+            placeholder="Preset name"
+            disabled={busy}
+            onChange={e => setLabel(e.target.value)}
+            className="rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground"
+          />
+          <textarea
+            value={prompt}
+            placeholder="The prompt this preset runs…"
+            disabled={busy}
+            rows={4}
+            onChange={e => setPrompt(e.target.value)}
+            className="resize-y rounded-md border border-border bg-background px-2 py-1 font-mono text-xs text-foreground"
+          />
+          <div className="flex items-center justify-end gap-2">
+            <Button type="button" variant="ghost" size="sm" onClick={() => setAdding(false)}>
+              Cancel
+            </Button>
+            <Button type="button" size="sm" disabled={busy || !label.trim() || !prompt.trim()} onClick={save}>
+              Save preset
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -12,6 +12,7 @@ import { onProjects } from '../server/projects.telefunc.js'
 import { usePreferences, updatePreferences, autopilotEnabled } from '../lib/preferences.js'
 import { useLoaded } from '../lib/use-async.js'
 import { PromptEditor, type PromptEditorHandle } from './PromptEditor.js'
+import { CustomPresets } from './CustomPresets.js'
 import { SystemPromptDisclosure } from './SystemPromptDisclosure.js'
 import { OptionToggle, type OptionRow } from './OptionToggle.js'
 import { Button } from './ui/button.js'
@@ -80,6 +81,7 @@ export function StartRunForm({
   const onBeforeMergeableQuality = preferences.onBeforeMergeableQuality ?? false
   const browser = preferences.browser ?? false
   const model = preferences.model ?? '' // #628: empty = the driver's default model
+  const customPresets = preferences.customPresets ?? [] // #626: the user's own saved prompts
 
   // Context selector (#439/#314): the agent can reach every registered repo, so ticking a
   // subset narrows its focus — the picked paths become one `Context:` line in the system
@@ -235,6 +237,17 @@ export function StartRunForm({
           </select>
         </label>
       </div>
+
+      <CustomPresets
+        presets={customPresets}
+        currentPrompt={prompt}
+        busy={busy}
+        onUse={preset => {
+          editorRef.current?.loadTemplate(preset.prompt)
+          loadPreset(preset.label)
+        }}
+        onChange={next => updatePreferences({ customPresets: next })}
+      />
 
       <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1.5 text-xs text-muted-foreground">
         {mainOptions.map(o => (

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -190,6 +190,7 @@ export {
   resolveConsumptionLimits,
   type Preferences,
   type PreferencesStore,
+  type CustomPreset,
   type RegistryFs,
 } from './registry.js'
 export {

--- a/packages/framework/src/registry.test.ts
+++ b/packages/framework/src/registry.test.ts
@@ -193,6 +193,33 @@ test('writePreferences keeps the model string but drops a blank one (#628)', asy
   assert.deepEqual(await readPreferences(fs, ENV), {}) // blank -> no choice, dropped
 })
 
+test('writePreferences keeps well-formed custom presets and drops malformed ones (#626)', async () => {
+  const fs = memFs({ [FILE]: JSON.stringify([APP_A]) })
+  await writePreferences(
+    {
+      customPresets: [
+        { id: 'a', label: '  Deep review  ', prompt: '  Audit this PR.  ' }, // trimmed
+        { id: 'b', label: '', prompt: 'no label' }, // dropped (empty label)
+        { id: 'c', label: 'no prompt', prompt: '  ' }, // dropped (empty prompt)
+        { id: 'a', label: 'dup id', prompt: 'x' }, // dropped (duplicate id)
+        { label: 'no id', prompt: 'x' }, // dropped (missing id)
+        'nonsense', // dropped (not an object)
+      ],
+    } as never,
+    fs,
+    ENV,
+  )
+  assert.deepEqual(await readPreferences(fs, ENV), {
+    customPresets: [{ id: 'a', label: 'Deep review', prompt: 'Audit this PR.' }],
+  })
+})
+
+test('writePreferences omits customPresets entirely when none survive (#626)', async () => {
+  const fs = memFs({ [FILE]: JSON.stringify([APP_A]) })
+  await writePreferences({ customPresets: [{ id: '', label: 'x', prompt: 'y' }] } as never, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), {}) // empty list -> field left off
+})
+
 test('addProject preserves existing preferences', async () => {
   const fs = memFs({ [FILE]: JSON.stringify({ projects: [APP_A], preferences: { autopilot: false } }) })
   await addProject('/repos/app-b', APP_B.addedAt, fs, ENV)

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -26,6 +26,23 @@ export interface ProjectRecord {
  * them over Telefunc. Flat booleans mirroring the Start form's toggles; every field is
  * optional and absent means off (Autopilot still defaults on in the UI).
  */
+
+/**
+ * A user-defined preset (#626): a named prompt the user saved to re-run their own high-signal
+ * prompts, sitting beside the built-in presets in the Start form. Just data — the label is the
+ * button, the prompt is loaded verbatim into the editor and run as a `prompt` kind (unlike the
+ * built-ins, whose text is a compiled render function). `id` is stable so edits/deletes address one.
+ */
+export interface CustomPreset {
+  id: string
+  label: string
+  prompt: string
+}
+
+/** The cap on saved custom presets, and the per-field lengths — enough for real prompts, bounded
+ * so a hand-edited or hostile registry can't bloat the home file. */
+export const CUSTOM_PRESET_LIMITS = { count: 30, label: 80, prompt: 20_000 } as const
+
 export interface Preferences {
   autopilot?: boolean
   technical?: boolean
@@ -49,6 +66,8 @@ export interface Preferences {
    * post; this is whether to).
    */
   notifyDiscord?: boolean
+  /** User-defined presets (#626): the user's own saved prompts, shown beside the built-in presets. */
+  customPresets?: CustomPreset[]
   /**
    * How much of the subscription The Framework may burn before it pauses itself
    * (#527, the settings behind #519).
@@ -170,9 +189,35 @@ function sanitizePreferences(value: unknown): Preferences {
   // `model` (#628) is the one string preference; the rest are booleans. A blank string is "no
   // choice", same as absent, so it is dropped rather than persisted.
   if (typeof input['model'] === 'string' && input['model'].trim()) preferences.model = input['model'].trim()
+  const customPresets = sanitizeCustomPresets(input['customPresets'])
+  if (customPresets.length) preferences.customPresets = customPresets
   const consumptionLimits = sanitizeConsumptionLimits(input['consumptionLimits'])
   if (consumptionLimits) preferences.consumptionLimits = consumptionLimits
   return preferences
+}
+
+/**
+ * Keep only well-formed custom presets (#626): each needs a non-empty id, label, and prompt;
+ * label/prompt are trimmed and length-capped, the list capped at {@link CUSTOM_PRESET_LIMITS.count},
+ * and duplicate ids dropped. A malformed entry is skipped, not thrown — a bad registry never breaks the read.
+ */
+function sanitizeCustomPresets(value: unknown): CustomPreset[] {
+  if (!Array.isArray(value)) return []
+  const out: CustomPreset[] = []
+  const seen = new Set<string>()
+  for (const raw of value) {
+    if (out.length >= CUSTOM_PRESET_LIMITS.count) break
+    if (typeof raw !== 'object' || raw === null) continue
+    const { id, label, prompt } = raw as Record<string, unknown>
+    if (typeof id !== 'string' || typeof label !== 'string' || typeof prompt !== 'string') continue
+    const trimmedId = id.trim()
+    const trimmedLabel = label.trim().slice(0, CUSTOM_PRESET_LIMITS.label)
+    const trimmedPrompt = prompt.trim().slice(0, CUSTOM_PRESET_LIMITS.prompt)
+    if (!trimmedId || !trimmedLabel || !trimmedPrompt || seen.has(trimmedId)) continue
+    seen.add(trimmedId)
+    out.push({ id: trimmedId, label: trimmedLabel, prompt: trimmedPrompt })
+  }
+  return out
 }
 
 /**


### PR DESCRIPTION
Closes #626.

## What

Rom + nitedani keep hand-crafting high-signal prompts. This lets them save those as reusable presets, beside the built-in ones — one click to re-run.

## How

- **`CustomPreset` = { id, label, prompt }** on `Preferences.customPresets`, persisted in the daemon preferences (same store as the other Start options). `sanitizeCustomPresets` trims label/prompt, drops malformed/blank/duplicate-id entries, and caps count + field lengths (`CUSTOM_PRESET_LIMITS`) so a hand-edited or hostile registry can't bloat the home file.
- **`CustomPresets` component** under the prompt textarea: saved presets render as buttons (each with a delete ×) that load their prompt into the editor and run as a `prompt` kind, exactly like a built-in. A "＋ Preset" button opens a small inline panel (name + prompt), prefilled with the current editor text — the common "save what I just wrote" path — or a fresh prompt.

Unlike the built-in presets (compiled render functions, the 6-file recipe), custom presets are pure runtime data, so nothing new server-side beyond the preference + its sanitizer.

## Tests

- registry: custom presets round-trip; malformed / blank / duplicate-id / non-object entries dropped; empty list omits the field.
- `CustomPresets` component (Testing Library): clicking a preset loads it; "＋ Preset" prefills from the current prompt and saves a well-formed entry; Save is disabled without both name + prompt; delete removes by id.
- Root build + both typechecks green; full dashboard vitest (48) green.