### PR TITLE
fix(framework): reconcile orphaned running runs on daemon start (#642)

### DIFF
--- a/.changeset/reconcile-orphaned-runs-642.md
+++ b/.changeset/reconcile-orphaned-runs-642.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Reconcile orphaned runs on daemon start. A run a dead process left marked `running` (a crash, kill, or daemon restart) no longer shows as active forever with a no-op Stop: a freshly started daemon drives no in-flight run, so at boot any such run across registered projects is flipped to `stopped` (the live one archived first, keeping its history).

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -2,7 +2,7 @@ import { spawn, type ChildProcess } from 'node:child_process'
 import { mkdir, readFile, writeFile, rm, stat } from 'node:fs/promises'
 import { basename, dirname, join, resolve } from 'node:path'
 import type { FrameworkEvent } from './events.js'
-import { FRAMEWORK_DIR } from './store/index.js'
+import { FRAMEWORK_DIR, reconcileOrphanedRuns } from './store/index.js'
 import { startDashboard, type Dashboard, type StartRunKind, type StartRunOptions, type StartRunResult, type AddProjectResult, type PreviewResult, type PreviewStatus } from './dashboard/index.js'
 import { startInterventionWatcher, postDiscord, type InterventionWatcher } from './dashboard/intervention-watcher.js'
 import { buildInterventions } from './dashboard/interventions.js'
@@ -305,6 +305,14 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
 
   // Multi-project (#392): make sure an activated home repo shows up in the Projects list.
   await registerHomeProject(cwd, env)
+
+  // Crash recovery (#642): a fresh daemon drives no in-flight run, so any run a dead
+  // process left marked `running` is orphaned — it would show as active forever with a
+  // no-op Stop. Reconcile them to `stopped` across every registered project at boot.
+  for (const record of await listProjects(undefined, env).catch(() => [])) {
+    const fixed = await reconcileOrphanedRuns(record.path).catch(() => 0)
+    if (fixed > 0) console.log(`[framework] reconciled ${fixed} orphaned run(s) in ${basename(record.path)}`)
+  }
 
   // Everything the dashboard drives per project — run spawning, project install, and app
   // previews — lives in the runtime, so this body stays about the daemon's own lifecycle.

--- a/packages/framework/src/store/index.ts
+++ b/packages/framework/src/store/index.ts
@@ -5,6 +5,7 @@ export {
   metaFromEvents,
   listRuns,
   readLiveMeta,
+  reconcileOrphanedRuns,
   loadRunEvents,
   runIdFromStartedAt,
   isSafeRunId,

--- a/packages/framework/src/store/run-store.test.ts
+++ b/packages/framework/src/store/run-store.test.ts
@@ -7,6 +7,7 @@ import {
   metaFromEvents,
   listRuns,
   readLiveMeta,
+  reconcileOrphanedRuns,
   loadRunEvents,
   RUN_META_VERSION,
   type StoreFs,
@@ -244,4 +245,37 @@ test('a fresh run archives a prior run that never got closed (crash safety) (#30
   const runs = await listRuns(CWD, fs)
   assert.equal(runs.length, 1)
   assert.equal(runs[0]!.intent, 'a blog with comments')
+})
+
+const RUNS = join(CWD, '.the-framework', 'runs')
+const runningMeta = (id: string): string =>
+  JSON.stringify({ version: RUN_META_VERSION, status: 'running', id, startedAt: AT, updatedAt: AT, passes: 0 })
+
+test('reconcileOrphanedRuns flips archived runs stuck at running to stopped (#642)', async () => {
+  const fs = memFs({
+    [join(RUNS, 'a.json')]: runningMeta('a'),
+    [join(RUNS, 'b.json')]: runningMeta('b'),
+    [join(RUNS, 'c.json')]: JSON.stringify({ version: RUN_META_VERSION, status: 'done', id: 'c', startedAt: AT, updatedAt: AT, passes: 0 }),
+  })
+  const fixed = await reconcileOrphanedRuns(CWD, fs)
+  assert.equal(fixed, 2)
+  const runs = await listRuns(CWD, fs)
+  assert.deepEqual(runs.map(r => [r.id, r.status]).sort(), [['a', 'stopped'], ['b', 'stopped'], ['c', 'done']])
+})
+
+test('reconcileOrphanedRuns flips a live run and archives it, counting it once (#642)', async () => {
+  const fs = memFs({ [META]: runningMeta('2026-live') })
+  const fixed = await reconcileOrphanedRuns(CWD, fs)
+  assert.equal(fixed, 1)
+  // The live run.json is now stopped...
+  assert.equal((await readLiveMeta(CWD, fs))!.status, 'stopped')
+  // ...and archived (as stopped) so it stays in the history list.
+  const runs = await listRuns(CWD, fs)
+  assert.deepEqual(runs.map(r => [r.id, r.status]), [['2026-live', 'stopped']])
+})
+
+test('reconcileOrphanedRuns is a no-op on a clean or empty workspace (#642)', async () => {
+  assert.equal(await reconcileOrphanedRuns(CWD, memFs()), 0)
+  const done = memFs({ [META]: JSON.stringify({ version: RUN_META_VERSION, status: 'done', id: 'd', startedAt: AT, updatedAt: AT, passes: 0 }) })
+  assert.equal(await reconcileOrphanedRuns(CWD, done), 0)
 })

--- a/packages/framework/src/store/run-store.ts
+++ b/packages/framework/src/store/run-store.ts
@@ -375,6 +375,45 @@ export async function listRuns(cwd: string, fs: StoreFs = nodeStoreFs()): Promis
 }
 
 /**
+ * Reconcile runs a dead process left marked `running`. A freshly started daemon
+ * drives no in-flight run, so at boot any run still at `running` in this workspace
+ * — the live `run.json` or an archived `runs/*.json` — is orphaned: its owning
+ * process is gone (a crash, kill, or daemon restart), yet it shows as active and
+ * its Stop is a no-op (nothing is left to read `control.jsonl`). Each is flipped to
+ * `stopped`; the live run is archived first (idempotent) so its history is kept.
+ * Returns how many were reconciled. Best-effort: a read/write error skips that run,
+ * never throws.
+ */
+export async function reconcileOrphanedRuns(cwd: string, fs: StoreFs = nodeStoreFs()): Promise<number> {
+  const dir = join(cwd, FRAMEWORK_DIR)
+  let fixed = 0
+  // Archived runs stuck at `running` (e.g. a prior live run the next run never
+  // rescued). Done before the live run so its fresh archive isn't re-counted here.
+  for (const name of await fs.readdir(join(dir, RUNS_DIR))) {
+    if (!name.endsWith('.json')) continue
+    const path = join(dir, RUNS_DIR, name)
+    try {
+      const meta = JSON.parse(await fs.read(path)) as RunMeta
+      if (meta.status !== 'running') continue
+      await fs.write(path, JSON.stringify({ ...meta, status: 'stopped' }, null, 2) + '\n')
+      fixed++
+    } catch {
+      // torn/half-written meta — skip it
+    }
+  }
+  // The live run: flip it, then archive so a crash that skipped close() still
+  // leaves the stopped run in the history list.
+  const live = await readMetaFile(fs, join(dir, META_FILE))
+  if (live?.status === 'running') {
+    const stopped: RunMeta = { ...live, status: 'stopped' }
+    await fs.write(join(dir, META_FILE), JSON.stringify(stopped, null, 2) + '\n').catch(() => {})
+    await archivePriorRun(fs, dir).catch(() => {})
+    fixed++
+  }
+  return fixed
+}
+
+/**
  * The live (in-progress) run's meta snapshot from `.the-framework/run.json`, or
  * `undefined` when none/unreadable. Unlike {@link listRuns} (which reads the
  * archived `runs/` copies written on close), this is the run the daemon is


### PR DESCRIPTION
Closes #642.

## Problem
When the daemon dies mid-run (crash, kill, restart), the run's `run.json` / `runs/*.json` stays at `status: 'running'`. On the next start these show as active runs forever, and Stop is a no-op: it writes `{"kind":"stop"}` to `control.jsonl`, but the process that would read it is gone. Found while dogfooding: three zombie "running" runs, two unconsumed stop signals.

## Fix
A freshly started daemon drives no in-flight run, so at boot any run still at `running` is orphaned. New `reconcileOrphanedRuns(cwd)` flips them to `stopped`: archived `runs/*.json` in place, and the live `run.json` archived first (idempotent) so its history is kept. `runDaemon` calls it for every registered project right after `registerHomeProject`. Mirrors the daemon's existing `process.kill(pid, 0)` staleness check for its own state file.

Reuses the existing `stopped` status (no new run state).

## Tests
- `reconcileOrphanedRuns` flips archived runs, leaves terminal ones, returns the count
- flips + archives the live run, counted once (no double-count of the fresh archive)
- no-op on a clean/empty workspace
- real-disk smoke test through the built dist verified live + archived reconciliation

Store suite 21/21, workspace typecheck 21/21.

## Follow-up (out of scope)
Record a pid on the run so a mid-session crash while the daemon stays up is also detectable.