### PR TITLE
chore: seed tickets/TODO.md as the durable backlog (#624)

### DIFF
--- a/tickets/TODO.md
+++ b/tickets/TODO.md
@@ -1,0 +1,17 @@
+# Backlog
+
+The durable roadmap for The Framework (Queue B, #624). Open items are drawn from
+the MVP roadmap (#538). Runs drain this file one entry at a time; the dashboard
+surfaces it in the Overview Backlog.
+
+## MVP v1
+
+- [ ] Dogfooding: start using The Framework on our own repos, close the gaps that block it
+- [ ] Test the system prompt end to end: analyze, auto-plan, ask sensible questions, no implicit laziness (#326)
+- [ ] Test "build an Instagram clone" produces high-quality work with zero human intervention
+
+## MVP v2
+
+- [ ] Agentic PM: "Suggest new features" preset (#462, #538)
+- [ ] Notifications: "New activity" toggle (the default-off half of #627)
+- [ ] Modular: only-pick-what-you-need, all off = transparent Claude Code wrapper (#625)


### PR DESCRIPTION
Part of #624.

Gives gemstack its own Queue B backlog file (`tickets/TODO.md`, the #629 location) so the dashboard Overview Backlog card populates instead of showing "No open TODOs". Seeded from the open MVP items in the #538 roadmap.

No changeset (repo data, not a package). The projection that renders it was already in place (#630) and is covered by tests; this just gives it content to show.

Verified: `collectQueue` returns 6 open items for the gemstack path.