### PR TITLE
fix(framework): last activity reflects runs, not just LOGS.md (#645)

### DIFF
--- a/.changeset/last-activity-includes-runs-645.md
+++ b/.changeset/last-activity-includes-runs-645.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Fix "last activity" so it reflects runs, not just `LOGS.md`. A project's `lastActivityAt` is now the newest of its latest `LOGS.md` entry and its most recent run (live or archived), so a project with runs no longer reads "no activity yet" just because a run stopped before writing to `LOGS.md`.

--- a/packages/framework/src/dashboard/projects.test.ts
+++ b/packages/framework/src/dashboard/projects.test.ts
@@ -3,12 +3,22 @@ import { test } from 'node:test'
 import { summarizeProject, singleProjectProvider, type SummarizeDeps } from './projects.js'
 import type { ProjectRecord } from '../registry.js'
 import type { LogEntry } from '../logs.js'
+import { RUN_META_VERSION, type RunMeta } from '../store/index.js'
 
 const RECORD: ProjectRecord = { id: 'app-a-1', path: '/repos/app-a', addedAt: '2026-07-11T00:00:00.000Z' }
 
 function deps(over: SummarizeDeps): SummarizeDeps {
-  return { isActivated: async () => true, readLogs: async () => [], ...over }
+  return { isActivated: async () => true, readLogs: async () => [], readRuns: async () => [], ...over }
 }
+
+const run = (id: string, updatedAt: string): RunMeta => ({
+  version: RUN_META_VERSION,
+  status: 'stopped',
+  id,
+  startedAt: updatedAt,
+  updatedAt,
+  passes: 0,
+})
 
 test('summarizeProject derives name from the path basename', async () => {
   const summary = await summarizeProject(RECORD, deps({}))
@@ -29,6 +39,28 @@ test('lastActivityAt is the newest LOGS.md entry (readLogs is newest-first)', as
 test('no log entries means no lastActivityAt key at all', async () => {
   const summary = await summarizeProject(RECORD, deps({ readLogs: async () => [] }))
   assert.equal('lastActivityAt' in summary, false)
+})
+
+test('lastActivityAt falls back to the newest run when there are no LOGS.md entries (#645)', async () => {
+  const summary = await summarizeProject(
+    RECORD,
+    deps({ readRuns: async () => [run('b', '2026-07-12T00:00:00.000Z'), run('a', '2026-07-10T00:00:00.000Z')] }),
+  )
+  assert.equal(summary.lastActivityAt, '2026-07-12T00:00:00.000Z')
+})
+
+test('lastActivityAt is the newest of LOGS.md and runs, either way (#645)', async () => {
+  const newerRun = deps({
+    readLogs: async () => [{ at: '2026-07-11T00:00:00.000Z', kind: 'build', title: 'log', status: 'done' }],
+    readRuns: async () => [run('x', '2026-07-14T00:00:00.000Z')],
+  })
+  assert.equal((await summarizeProject(RECORD, newerRun)).lastActivityAt, '2026-07-14T00:00:00.000Z')
+
+  const newerLog = deps({
+    readLogs: async () => [{ at: '2026-07-20T00:00:00.000Z', kind: 'build', title: 'log', status: 'done' }],
+    readRuns: async () => [run('x', '2026-07-14T00:00:00.000Z')],
+  })
+  assert.equal((await summarizeProject(RECORD, newerLog)).lastActivityAt, '2026-07-20T00:00:00.000Z')
 })
 
 test('activation reflects the injected check', async () => {

--- a/packages/framework/src/dashboard/projects.ts
+++ b/packages/framework/src/dashboard/projects.ts
@@ -2,6 +2,7 @@ import { basename } from 'node:path'
 import { listProjects, type ProjectRecord } from '../registry.js'
 import { isActivated } from '../project.js'
 import { readLogs, type LogEntry } from '../logs.js'
+import { listRuns, readLiveMeta, type RunMeta } from '../store/index.js'
 
 /**
  * The multi-project read side (#392): projects the daemon serves come from the
@@ -21,7 +22,7 @@ export interface ProjectSummary {
   name: string
   /** True when the repo still has its `.the-framework/` marker. */
   activated: boolean
-  /** ISO timestamp of the newest `LOGS.md` entry, when any. */
+  /** ISO timestamp of the project's newest activity: the latest `LOGS.md` entry or run, whichever is newer. */
   lastActivityAt?: string
 }
 
@@ -29,6 +30,17 @@ export interface ProjectSummary {
 export interface SummarizeDeps {
   isActivated?: (path: string) => Promise<boolean>
   readLogs?: (path: string) => Promise<LogEntry[]>
+  /** The project's runs (live + archived), newest-first. Defaults to {@link readAllRuns}. */
+  readRuns?: (path: string) => Promise<RunMeta[]>
+}
+
+/** A project's runs, live prepended to the archived history. Forgiving: a failed read is `[]`. */
+async function readAllRuns(path: string): Promise<RunMeta[]> {
+  const [archived, live] = await Promise.all([
+    listRuns(path).catch(() => [] as RunMeta[]),
+    readLiveMeta(path).catch(() => undefined),
+  ])
+  return live ? [live, ...archived] : archived
 }
 
 /**
@@ -40,9 +52,16 @@ export interface SummarizeDeps {
 export async function summarizeProject(record: ProjectRecord, deps: SummarizeDeps = {}): Promise<ProjectSummary> {
   const checkActivated = deps.isActivated ?? isActivated
   const loadLogs = deps.readLogs ?? readLogs
+  const loadRuns = deps.readRuns ?? readAllRuns
   const activated = await checkActivated(record.path).catch(() => false)
-  const logs = await loadLogs(record.path).catch(() => [] as LogEntry[])
-  const lastActivityAt = logs[0]?.at
+  const [logs, runs] = await Promise.all([
+    loadLogs(record.path).catch(() => [] as LogEntry[]),
+    loadRuns(record.path).catch(() => [] as RunMeta[]),
+  ])
+  // Newest of the latest LOGS.md entry and the latest run: a run is activity even
+  // when it stopped before writing to LOGS.md. ISO timestamps sort chronologically.
+  const runActivity = runs.map(r => r.updatedAt || r.startedAt).filter(Boolean)
+  const lastActivityAt = [logs[0]?.at, ...runActivity].filter((a): a is string => !!a).sort().at(-1)
   const summary: ProjectSummary = {
     id: record.id,
     path: record.path,


### PR DESCRIPTION
Closes #645.

## Problem
The Projects sidebar and Overview table derived `lastActivityAt` only from the newest `LOGS.md` entry. Runs that stop early (or never reach the step that writes LOGS.md) leave no entry, so a project with a dozen runs still read "no activity yet" (seen dogfooding: the framework project had 12 runs in the rail but "no activity yet" in the sidebar).

## Fix
`summarizeProject` now takes the newest of the latest `LOGS.md` entry and the most recent run (its `updatedAt`/`startedAt`, from `runs/` plus the live `run.json`). New `readRuns` dep (defaults to live + archived) keeps it unit-testable off disk. ISO timestamps sort chronologically.

## Tests
- falls back to the newest run when there are no LOGS.md entries
- takes whichever of LOGS.md / runs is newer, both directions
- existing cases (LOGS-only, none, forgiving reads) still green

Projects suite 10/10, workspace typecheck 21/21, overview + dashboard consumers green.