### PR TITLE
fix(framework): don't register the daemon's cwd as a nested duplicate project (#647)

### DIFF
--- a/.changeset/daemon-no-nested-self-register-647.md
+++ b/.changeset/daemon-no-nested-self-register-647.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Stop the daemon from registering its own cwd as a duplicate project. When the daemon runs from a subfolder of an already-tracked repo (e.g. the package dir the binary lives in), it created `.the-framework/` for its own state and then re-added that subfolder as a nested project on every boot. `registerHomeProject` now skips a cwd that lives inside an already-registered project.

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -14,10 +14,12 @@ import {
   runDaemon,
   daemonStatePath,
   startOptionFlags,
+  registerHomeProject,
+  isNestedWithin,
 } from './daemon.js'
 import { EVENTS_FILE, FRAMEWORK_DIR } from './store/index.js'
 import { controlPath } from './control.js'
-import { projectId } from './registry.js'
+import { projectId, listProjects, addProject } from './registry.js'
 
 // The new dashboard steers + starts over Telefunc (#405/#426), not the retired /api/* HTTP
 // routes. Post an RPC to the daemon's in-process `/_telefunc` mount (same-origin), keyed by
@@ -475,5 +477,48 @@ test('runDaemon steers through the control log: sendStop / sendChoice append ent
     if (prevXdg === undefined) delete process.env['XDG_CONFIG_HOME']
     else process.env['XDG_CONFIG_HOME'] = prevXdg
     await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('isNestedWithin flags a child path, not equal/sibling/parent (#647)', () => {
+  assert.equal(isNestedWithin('/repo/packages/framework', '/repo'), true)
+  assert.equal(isNestedWithin('/repo', '/repo'), false) // equal is not nested
+  assert.equal(isNestedWithin('/repo', '/repo/packages'), false) // parent is not nested
+  assert.equal(isNestedWithin('/other/framework', '/repo'), false) // sibling tree
+  assert.equal(isNestedWithin('/repo-x', '/repo'), false) // prefix but not a path child
+})
+
+test('registerHomeProject skips a cwd nested inside an already-tracked project (#647)', async () => {
+  const parent = await mkdtemp(join(tmpdir(), 'framework-parent-'))
+  const env = await configEnv(parent)
+  try {
+    await addProject(parent, new Date().toISOString(), undefined, env)
+    // A nested, activated subfolder (like packages/framework inside the repo).
+    const nested = join(parent, 'packages', 'framework')
+    await mkdir(join(nested, FRAMEWORK_DIR), { recursive: true })
+
+    await registerHomeProject(nested, env)
+
+    const projects = await listProjects(undefined, env)
+    assert.deepEqual(
+      projects.map(p => p.path),
+      [parent],
+      'the nested subfolder must not be added as a second project',
+    )
+  } finally {
+    await rm(parent, { recursive: true, force: true })
+  }
+})
+
+test('registerHomeProject still adds an activated cwd that is not nested (#647)', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'framework-home-'))
+  const env = await configEnv(home)
+  try {
+    await mkdir(join(home, FRAMEWORK_DIR), { recursive: true })
+    await registerHomeProject(home, env)
+    const projects = await listProjects(undefined, env)
+    assert.deepEqual(projects.map(p => p.path), [home])
+  } finally {
+    await rm(home, { recursive: true, force: true })
   }
 })

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { mkdir, readFile, writeFile, rm, stat } from 'node:fs/promises'
-import { basename, dirname, join, resolve } from 'node:path'
+import { basename, dirname, join, resolve, relative, isAbsolute } from 'node:path'
 import type { FrameworkEvent } from './events.js'
 import { FRAMEWORK_DIR, reconcileOrphanedRuns } from './store/index.js'
 import { startDashboard, type Dashboard, type StartRunKind, type StartRunOptions, type StartRunResult, type AddProjectResult, type PreviewResult, type PreviewStatus } from './dashboard/index.js'
@@ -79,15 +79,26 @@ function spawnDetached(binPath: string, args: string[]): ChildProcess {
   return child
 }
 
+/** True when `child` lives strictly inside `parent` (not equal, not outside). */
+export function isNestedWithin(child: string, parent: string): boolean {
+  const rel = relative(parent, child)
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel)
+}
+
 /**
  * Make sure an activated home workspace shows up in the Projects list (#392). Best-effort
  * and idempotent (addProject dedupes by path), so it never blocks the daemon coming up.
  * Called both by the foreground daemon and by `framework --daemon`'s launcher.
+ *
+ * Skips a cwd that lives inside an already-tracked project (#647): the daemon creates
+ * `.the-framework/` for its own state, so running it from a subfolder of a repo (e.g. the
+ * package dir the binary lives in) would otherwise keep re-adding a nested duplicate.
  */
 export async function registerHomeProject(cwd: string, env: NodeJS.ProcessEnv = process.env): Promise<void> {
-  if (await isActivated(cwd).catch(() => false)) {
-    await addProject(cwd, new Date().toISOString(), undefined, env).catch(() => {})
-  }
+  if (!(await isActivated(cwd).catch(() => false))) return
+  const existing = await listProjects(undefined, env).catch(() => [])
+  if (existing.some(p => isNestedWithin(cwd, p.path))) return
+  await addProject(cwd, new Date().toISOString(), undefined, env).catch(() => {})
 }
 
 /**


### PR DESCRIPTION
Closes #647.

## Problem
`isActivated(cwd)` is just "does `.the-framework/` exist", and the daemon creates `.the-framework/` for its own state at boot before `registerHomeProject` runs. So running `node dist/bin.js` from `packages/framework` (inside the `gemstack` repo) re-added `packages/framework` as a project on every boot, and its state dir persists, so it stayed "activated" and the nested duplicate kept coming back. Seen dogfooding: `framework` + `gemstack` as two entries for the same repo.

## Fix
`registerHomeProject` now skips a cwd that lives strictly inside an already-registered project (new `isNestedWithin` helper). A subfolder of a tracked repo is never added as a second project. Explicit adds (the discovery / "Add project" path) are unchanged.

## Tests
- `isNestedWithin`: child true; equal/parent/sibling/prefix-not-child false
- `registerHomeProject` skips a nested activated cwd (registry keeps only the parent)
- `registerHomeProject` still adds a non-nested activated cwd

Workspace typecheck 21/21; new tests green.