### PR TITLE
feat(framework-dashboard): unify the run-form disclosure toggles (#659)

### DIFF
--- a/.changeset/unify-disclosure-toggle-659.md
+++ b/.changeset/unify-disclosure-toggle-659.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Give the run-form disclosures one consistent style (#659). "See actual prompt sent" and "Context" were styled differently (different triangle glyph, weight, and indent); both now use a shared `DisclosureToggle` — a chevron that rotates when open, then the label — so they read as the same control.

--- a/packages/framework-dashboard/components/DisclosureToggle.test.tsx
+++ b/packages/framework-dashboard/components/DisclosureToggle.test.tsx
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { DisclosureToggle } from './DisclosureToggle.js'
+
+afterEach(cleanup)
+
+describe('DisclosureToggle (#659)', () => {
+  test('renders its label and toggles on click, reflecting open in aria-expanded', () => {
+    const onToggle = vi.fn()
+    const { rerender } = render(
+      <DisclosureToggle open={false} onToggle={onToggle}>
+        Context
+      </DisclosureToggle>,
+    )
+    const button = screen.getByRole('button', { name: /Context/ })
+    expect(button.getAttribute('aria-expanded')).toBe('false')
+    fireEvent.click(button)
+    expect(onToggle).toHaveBeenCalledTimes(1)
+    rerender(
+      <DisclosureToggle open={true} onToggle={onToggle}>
+        Context
+      </DisclosureToggle>,
+    )
+    expect(screen.getByRole('button', { name: /Context/ }).getAttribute('aria-expanded')).toBe('true')
+  })
+})

--- a/packages/framework-dashboard/components/DisclosureToggle.tsx
+++ b/packages/framework-dashboard/components/DisclosureToggle.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react'
+import { ChevronRight } from 'lucide-react'
+import { cn } from '../lib/utils.js'
+
+// One collapsible-section toggle (#659), shared so every disclosure under the run controls
+// ("See actual prompt sent", "Context") reads the same: a chevron that rotates when open, then
+// the label, muted until hovered. Keeping them in one place stops the styles drifting apart.
+export function DisclosureToggle({
+  open,
+  onToggle,
+  children,
+  className,
+}: {
+  open: boolean
+  onToggle: () => void
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={open}
+      className={cn('flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground', className)}
+    >
+      <ChevronRight className={cn('h-3.5 w-3.5 shrink-0 transition-transform', open && 'rotate-90')} />
+      {children}
+    </button>
+  )
+}

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -16,6 +16,7 @@ import { PresetMenu } from './PresetMenu.js'
 import { PresetCreatePanel } from './PresetCreatePanel.js'
 import { AgentModelMenu, type AgentOption } from './AgentModelMenu.js'
 import { ClaudeLogo, CodexLogo } from './agent-logos.js'
+import { DisclosureToggle } from './DisclosureToggle.js'
 import { SystemPromptDisclosure } from './SystemPromptDisclosure.js'
 import { OptionsMenu, type OptionRow } from './OptionsMenu.js'
 import { Button } from './ui/button.js'
@@ -275,14 +276,9 @@ export function StartRunForm({
 
       {projects.length > 0 && (
         <div className="mt-3 text-xs text-muted-foreground">
-          <button
-            type="button"
-            onClick={() => setShowContext(s => !s)}
-            className="flex items-center gap-1 font-medium hover:text-foreground"
-          >
-            <span className="inline-block w-3">{showContext ? '▾' : '▸'}</span>
+          <DisclosureToggle open={showContext} onToggle={() => setShowContext(s => !s)}>
             Context{context.size > 0 && <span className="text-primary"> · {context.size} selected</span>}
-          </button>
+          </DisclosureToggle>
           {showContext && (
             <div className="mt-1.5 pl-4">
               <p className="mb-1.5 text-muted-foreground/80">Focus the agent on these repos (it can still reach the rest):</p>

--- a/packages/framework-dashboard/components/SystemPromptDisclosure.tsx
+++ b/packages/framework-dashboard/components/SystemPromptDisclosure.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { composeRunSystem, type EcoOptions } from '@gemstack/framework/client'
+import { DisclosureToggle } from './DisclosureToggle.js'
 
 /**
  * "See actual prompt sent" (#520): the built-in system prompt, shown in full,
@@ -42,14 +43,10 @@ export function SystemPromptDisclosure({
   })
 
   return (
-    <div className="mt-2 text-xs">
-      <button
-        type="button"
-        onClick={() => setOpen(o => !o)}
-        className="cursor-pointer text-muted-foreground hover:text-foreground"
-      >
-        {open ? '▾' : '▶'} See actual prompt sent (see system prompt)
-      </button>
+    <div className="mt-3 text-xs">
+      <DisclosureToggle open={open} onToggle={() => setOpen(o => !o)}>
+        See actual prompt sent (see system prompt)
+      </DisclosureToggle>
 
       {open && (
         <div className="mt-2 space-y-2 rounded border border-border p-3 text-muted-foreground">


### PR DESCRIPTION
Closes #659.

The two collapsible toggles under the run controls were styled differently: "See actual prompt sent" used a filled ▶ with normal weight and no gap; "Context" used a thin ▸ in a fixed-width span with medium weight. Now both use one shared `DisclosureToggle` — a chevron that rotates 90° when open, then the label, muted until hover — so they read as the same control and can't drift apart.

Client-only; patch changeset. Dashboard 59/59 (new DisclosureToggle test), build + prerender clean.