### PR TITLE
feat(framework-dashboard): two-column Context — Projects | Files (#663)

### DIFF
--- a/.changeset/context-two-col-663.md
+++ b/.changeset/context-two-col-663.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Lay out the expanded Context section as two columns (#663): a "Projects" column (repo checkboxes) beside a "Files" column (removable file rows), each under its own heading. The Files column shows a hint when nothing is picked, and the repos' "can still reach the rest" note moves to the Projects heading tooltip.

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -294,27 +294,31 @@ export function StartRunForm({
             Context{contextSummary && <span className="text-primary"> · {contextSummary}</span>}
           </DisclosureToggle>
           {showContext && (
-            <div className="mt-2 space-y-2 rounded border border-border p-3">
+            <div className="mt-2 grid grid-cols-1 gap-4 rounded border border-border p-3 sm:grid-cols-2">
+              {/* Projects: repo checkboxes. The agent can still reach every repo; ticking some
+                  just narrows its focus (kept in the heading's tooltip). */}
+              <div>
+                <p className="mb-1.5 text-muted-foreground/80" title="The agent can still reach every repo; ticking some just narrows its focus.">
+                  Projects
+                </p>
+                <div className="flex flex-col gap-1">
+                  {projects.map(p => (
+                    <label key={p.id} className="flex cursor-pointer items-center gap-1.5" title={p.path}>
+                      <input type="checkbox" checked={context.has(p.path)} onChange={() => toggleContext(p.path)} disabled={busy} />
+                      <span className="truncate">{p.name}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
               {/* Files picked via a `#` mention or the file tree (#661): removable with an X. */}
-              {contextFiles.length > 0 && (
-                <div>
-                  <p className="mb-1 text-muted-foreground/80">Files</p>
+              <div>
+                <p className="mb-1 text-muted-foreground/80">Files</p>
+                {contextFiles.length > 0 ? (
                   <ContextFiles files={contextFiles} onRemove={toggleContext} busy={busy} />
-                </div>
-              )}
-              {projects.length > 0 && (
-                <div>
-                  <p className="mb-1.5 text-muted-foreground/80">Focus the agent on these repos (it can still reach the rest):</p>
-                  <div className="flex flex-col gap-1">
-                    {projects.map(p => (
-                      <label key={p.id} className="flex cursor-pointer items-center gap-1.5" title={p.path}>
-                        <input type="checkbox" checked={context.has(p.path)} onChange={() => toggleContext(p.path)} disabled={busy} />
-                        <span className="truncate">{p.name}</span>
-                      </label>
-                    ))}
-                  </div>
-                </div>
-              )}
+                ) : (
+                  <p className="text-muted-foreground/60">None yet — add with # or the Files tab.</p>
+                )}
+              </div>
             </div>
           )}
         </div>


### PR DESCRIPTION
Closes #663.

The expanded Context section is now two columns: a **Projects** column (repo checkboxes) on the left, a **Files** column (removable file rows) on the right, each under its own heading. The Files column shows a hint when nothing is picked; the repos' "it can still reach the rest" note moves to the Projects heading tooltip.

Client-only; patch changeset. Dashboard 62/62, build + prerender clean.