### PR TITLE
feat(framework-dashboard): hide the current project from Context focus (#665)

### DIFF
--- a/.changeset/context-hide-current-project-665.md
+++ b/.changeset/context-hide-current-project-665.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Don't offer the current project as a Context focus target (#665). The Context → Projects list is for pulling *other* repos into the agent's focus; the current project is already the run's workspace, so ticking it was redundant. It's now excluded from the list (and from the "N projects" count), with a "No other repos to add" hint when it's the only registered project.

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -120,7 +120,10 @@ export function StartRunForm({
   // and count each kind separately for the section header.
   const projectPaths = new Set(projects.map(p => p.path))
   const contextFiles = [...context].filter(path => !projectPaths.has(path))
-  const selectedRepos = projects.filter(p => context.has(p.path)).length
+  // The current project is already the run's workspace, so it isn't offered as a focus target
+  // (#665) — only the other registered repos are, and only those count toward the header.
+  const otherProjects = projects.filter(p => p.id !== projectId)
+  const selectedRepos = otherProjects.filter(p => context.has(p.path)).length
   const contextSummary = [
     selectedRepos > 0 ? `${selectedRepos} project${selectedRepos > 1 ? 's' : ''}` : null,
     contextFiles.length > 0 ? `${contextFiles.length} file${contextFiles.length > 1 ? 's' : ''}` : null,
@@ -288,7 +291,7 @@ export function StartRunForm({
         busy={busy}
       />
 
-      {(projects.length > 0 || contextFiles.length > 0) && (
+      {(otherProjects.length > 0 || contextFiles.length > 0) && (
         <div className="mt-3 text-xs text-muted-foreground">
           <DisclosureToggle open={showContext} onToggle={() => setShowContext(s => !s)}>
             Context{contextSummary && <span className="text-primary"> · {contextSummary}</span>}
@@ -301,14 +304,18 @@ export function StartRunForm({
                 <p className="mb-1.5 text-muted-foreground/80" title="The agent can still reach every repo; ticking some just narrows its focus.">
                   Projects
                 </p>
-                <div className="flex flex-col gap-1">
-                  {projects.map(p => (
-                    <label key={p.id} className="flex cursor-pointer items-center gap-1.5" title={p.path}>
-                      <input type="checkbox" checked={context.has(p.path)} onChange={() => toggleContext(p.path)} disabled={busy} />
-                      <span className="truncate">{p.name}</span>
-                    </label>
-                  ))}
-                </div>
+                {otherProjects.length > 0 ? (
+                  <div className="flex flex-col gap-1">
+                    {otherProjects.map(p => (
+                      <label key={p.id} className="flex cursor-pointer items-center gap-1.5" title={p.path}>
+                        <input type="checkbox" checked={context.has(p.path)} onChange={() => toggleContext(p.path)} disabled={busy} />
+                        <span className="truncate">{p.name}</span>
+                      </label>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-muted-foreground/60">No other repos to add.</p>
+                )}
               </div>
               {/* Files picked via a `#` mention or the file tree (#661): removable with an X. */}
               <div>


### PR DESCRIPTION
Closes #665.

The Context → Projects list is for pulling *other* repos into the agent's focus, but it also listed the current/active project — which is already the run's workspace, so ticking it just duplicated it. Now the current project is excluded from the list (and from the "N projects" count), with a "No other repos to add" hint when it's the only registered project.

Client-only; patch changeset. Dashboard 62/62, build + prerender clean.