### PR TITLE
chore(framework-dashboard): remove the tech-stack line from the header

### DIFF
--- a/.changeset/remove-header-stack-text.md
+++ b/.changeset/remove-header-stack-text.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Remove the "Vike · React · shadcn · Telefunc" tech-stack line from the dashboard header.

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -127,12 +127,9 @@ export default function Page() {
       <header className="flex items-center gap-3 border-b border-border px-4 py-3">
         <span className="font-semibold">The Framework</span>
         <Badge className="text-muted-foreground">dashboard</Badge>
-        <div className="ml-auto flex items-center gap-3">
-          <div className="flex items-center gap-1">
-            <NotificationBell />
-            <DiscordToggle />
-          </div>
-          <span className="text-xs text-muted-foreground">Vike · React · shadcn · Telefunc</span>
+        <div className="ml-auto flex items-center gap-1">
+          <NotificationBell />
+          <DiscordToggle />
         </div>
       </header>
       <div className="flex min-h-0 flex-1">


### PR DESCRIPTION
Removes the "Vike · React · shadcn · Telefunc" text from the dashboard header (and collapses the now-redundant wrapper div). Client-only; patch changeset.