### PR TITLE
feat(framework-dashboard): tidy the run controls row (#668)

### DIFF
--- a/.changeset/controls-row-layout-668.md
+++ b/.changeset/controls-row-layout-668.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Tidy the run controls row (#668): the Global-options button becomes a gear icon with the on-count as a small corner badge (no "Options" text), the agent/model picker moves to the start of the row, and the "Start run" button sits at the end of that same row (the note/error stay below).

--- a/packages/framework-dashboard/components/OptionsMenu.test.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.test.tsx
@@ -19,14 +19,14 @@ const mainOptions = (): OptionRow[] => [
 const ecoOptions = (): OptionRow[] => [{ key: 'ecoPlanning', label: 'Auto planning', title: 't', checked: false }]
 
 function open() {
-  fireEvent.click(screen.getByRole('button', { name: /Options/ }))
+  fireEvent.click(screen.getByRole('button', { name: /run options/i }))
 }
 
 describe('OptionsMenu (#654)', () => {
   test('the trigger badges how many options are on', () => {
     render(<OptionsMenu options={mainOptions()} ecoOptions={ecoOptions()} showEco={false} busy={false} />)
-    // Only Eco is checked -> the trigger reads "Options 1".
-    expect(screen.getByRole('button', { name: /Options/ }).textContent).toContain('1')
+    // Only Eco is checked -> the gear trigger shows a corner badge "1".
+    expect(screen.getByRole('button', { name: /run options/i }).textContent).toContain('1')
   })
 
   test('toggling an item writes the new value through', () => {

--- a/packages/framework-dashboard/components/OptionsMenu.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.tsx
@@ -1,5 +1,5 @@
 import type { Preferences } from '@gemstack/framework'
-import { ChevronDown } from 'lucide-react'
+import { Settings } from 'lucide-react'
 import { updatePreferences } from '../lib/preferences.js'
 import { cn } from '../lib/utils.js'
 import { buttonVariants } from './ui/button.js'
@@ -59,16 +59,16 @@ export function OptionsMenu({
       <DropdownMenuTrigger
         type="button"
         disabled={busy}
-        title="Run options"
-        className={cn(buttonVariants({ variant: 'outline', size: 'xs' }), 'font-normal')}
+        title={activeCount > 0 ? `Run options — ${activeCount} on` : 'Run options'}
+        aria-label="Run options"
+        className={cn(buttonVariants({ variant: 'outline', size: 'icon-sm' }), 'relative')}
       >
-        Options
+        <Settings className="h-4 w-4" />
         {activeCount > 0 && (
-          <span className="rounded-full bg-[var(--color-primary)] px-1.5 text-[10px] leading-4 text-[var(--color-primary-foreground)]">
+          <span className="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-[var(--color-primary)] px-1 text-[10px] font-medium leading-none text-[var(--color-primary-foreground)]">
             {activeCount}
           </span>
         )}
-        <ChevronDown className="h-3.5 w-3.5 opacity-70" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="min-w-[19rem] max-w-[22rem]">
         {options.map(o => (

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -237,9 +237,17 @@ export function StartRunForm({
         disabled={busy}
       />
 
-      {/* Run controls, directly under the textarea (#649/#650/#654): presets and options on the
-          left, agent+model at the end — all compact matching dropdowns. */}
+      {/* Run controls, directly under the textarea (#649/#650/#654/#668): agent+model at the start,
+          then presets and the options gear, then Start run at the end. */}
       <div className="mt-2 flex flex-wrap items-center gap-1.5">
+        {/* Agent + model tree (#650/#658), each agent showing only its own models. */}
+        <AgentModelMenu
+          agents={AGENTS}
+          agent={agent}
+          model={model}
+          onChange={(a, m) => updatePreferences({ agent: a, model: m })}
+          busy={busy}
+        />
         <PresetMenu
           builtIns={PRESETS}
           customPresets={customPresets}
@@ -255,18 +263,12 @@ export function StartRunForm({
           onDeleteCustom={id => updatePreferences({ customPresets: customPresets.filter(p => p.id !== id) })}
           onNewPreset={() => setAddingPreset(true)}
         />
-        {/* Global options (#314) as a checkbox dropdown (#654). */}
+        {/* Global options (#314) as a gear-icon checkbox dropdown (#654/#668). */}
         <OptionsMenu options={mainOptions} ecoOptions={ecoOptions} showEco={eco && !ecoDisabled} busy={busy} />
-        {/* Agent + model as one tree (#650/#658), each agent showing only its own models — at the end. */}
-        <div className="ml-auto">
-          <AgentModelMenu
-            agents={AGENTS}
-            agent={agent}
-            model={model}
-            onChange={(a, m) => updatePreferences({ agent: a, model: m })}
-            busy={busy}
-          />
-        </div>
+        {/* Start run at the end of the row (#668). */}
+        <Button type="submit" className="ml-auto" disabled={busy || !prompt.trim()}>
+          {busy ? 'Starting…' : 'Start run'}
+        </Button>
       </div>
 
       {addingPreset && (
@@ -331,13 +333,9 @@ export function StartRunForm({
         </div>
       )}
 
+      {/* Start run moved up into the controls row (#668); the note + error stay below it. */}
       {error && <p className="mt-2 text-xs text-red-500">{error}</p>}
-      <div className="mt-2 flex items-center justify-end gap-2">
-        {note && <span className="text-xs text-muted-foreground">{note}</span>}
-        <Button type="submit" disabled={busy || !prompt.trim()}>
-          {busy ? 'Starting…' : 'Start run'}
-        </Button>
-      </div>
+      {note && !error && <p className="mt-2 text-xs text-muted-foreground">{note}</p>}
     </form>
   )
 }


### PR DESCRIPTION
Closes #668.

- The Global-options button is now a **gear icon** with the on-count as a small **corner badge** (no 'Options' text).
- The **agent/model** picker moves to the **start** (left) of the controls row.
- **Start run** moves to the **end** of that same row; the note + error stay on a line below.

Row is now: `[Agent·Model] [Presets] [⚙²]  …  [Start run]`.

Client-only; patch changeset. Dashboard 62/62 (OptionsMenu test updated for the gear's aria-label), build + prerender clean.