### PR TITLE
feat(framework): "New activity" notifications category (#627)

### DIFF
--- a/.changeset/new-activity-notifications-627.md
+++ b/.changeset/new-activity-notifications-627.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+"New activity" notifications (#627): a default-off notification *category* alongside the always-on "needs you" one. Turn it on (the new Activity toggle in the header, beside the browser bell and Discord toggle) and you get a ping when a run starts and when it finishes, not just when something needs you. It is a category, not a method, so it rides whichever delivery methods are on: browser notifications when the bell is on. A cross-project `onActivity` feed (`buildActivity`) drives it, diffed the same way as the interventions queue, so the runs already going when the page loads are folded into a baseline rather than announced.

--- a/packages/framework-dashboard/components/ActivityToggle.tsx
+++ b/packages/framework-dashboard/components/ActivityToggle.tsx
@@ -1,0 +1,29 @@
+import { Activity } from 'lucide-react'
+import { usePreferences, updatePreferences, newActivityEnabled } from '../lib/preferences.js'
+import { cn } from '../lib/utils.js'
+
+// The "New activity" toggle in the shell header (#627), beside the browser bell and Discord toggle.
+// Those two are the *methods* (where a notification goes); this is a *category* (what is worth one).
+// Default off: it adds run started/finished pings on top of the always-on "needs you" notifications,
+// and rides whichever methods are on — so with the bell on you get them in the browser, and with
+// Discord on they reach you there too.
+export function ActivityToggle() {
+  const preferences = usePreferences()
+  const enabled = newActivityEnabled(preferences)
+  const title = enabled
+    ? 'New-activity notifications on — click to mute (pings when a run starts or finishes)'
+    : 'New-activity notifications off — click to turn on (pings when a run starts or finishes)'
+
+  return (
+    <button
+      type="button"
+      onClick={() => updatePreferences({ notifyNewActivity: !enabled })}
+      title={title}
+      aria-label={title}
+      aria-pressed={enabled}
+      className={cn('rounded-md p-1.5 hover:bg-accent', enabled ? 'text-foreground' : 'text-muted-foreground')}
+    >
+      <Activity className="h-4 w-4" />
+    </button>
+  )
+}

--- a/packages/framework-dashboard/lib/activity.test.ts
+++ b/packages/framework-dashboard/lib/activity.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest'
+import type { Activity } from '@gemstack/framework'
+import { activityKey, pickNewActivity } from './activity.js'
+
+const started: Activity = { projectId: 'a', projectName: 'a', runId: 'r1', kind: 'started' }
+const finished: Activity = { projectId: 'a', projectName: 'a', runId: 'r1', kind: 'finished' }
+
+describe('activity helpers (#627)', () => {
+  test('activityKey separates a run start from its finish', () => {
+    expect(activityKey(started)).toBe('started:a:r1')
+    expect(activityKey(finished)).toBe('finished:a:r1')
+  })
+
+  test('pickNewActivity returns only unseen keys', () => {
+    const seen = new Set([activityKey(started)])
+    expect(pickNewActivity(seen, [started, finished])).toEqual([finished])
+  })
+})

--- a/packages/framework-dashboard/lib/activity.ts
+++ b/packages/framework-dashboard/lib/activity.ts
@@ -1,0 +1,23 @@
+import type { Activity } from '@gemstack/framework'
+
+// Client-side helpers for the "New activity" notification trigger (#627). Like lib/interventions.ts,
+// these live in the dashboard rather than @gemstack/framework on purpose: importing runtime values
+// from the framework barrel would drag its Node-only + telefunc modules into the browser bundle.
+// Only the `Activity` type is borrowed (types are erased), and the logic is a couple of lines.
+
+/**
+ * The stable identity of an activity item: kind + project + run. Mirrors the server's `activityKey`.
+ * The kind is part of the key so a run's `started` and `finished` are two separate announcements.
+ */
+export function activityKey(item: Activity): string {
+  return `${item.kind}:${item.projectId}:${item.runId}`
+}
+
+/**
+ * The activity items in `current` not already in `seen` (by {@link activityKey}) — the transitions
+ * that just happened. The shell keeps the keys it has already told the user about, so only genuinely
+ * new run started/finished events fire a notification.
+ */
+export function pickNewActivity(seen: ReadonlySet<string>, current: Activity[]): Activity[] {
+  return current.filter(item => !seen.has(activityKey(item)))
+}

--- a/packages/framework-dashboard/lib/preferences.ts
+++ b/packages/framework-dashboard/lib/preferences.ts
@@ -78,3 +78,10 @@ export function notificationsEnabled(preferences: Preferences): boolean {
 export function discordEnabled(preferences: Preferences): boolean {
   return preferences.notifyDiscord ?? false
 }
+
+/** "New activity" notifications default off (#627): the category that pings on a run starting or
+ * finishing, not just on things that need you. Composes with the method toggles above — activity
+ * reaches the browser when {@link notificationsEnabled}, Discord when {@link discordEnabled}. */
+export function newActivityEnabled(preferences: Preferences): boolean {
+  return preferences.notifyNewActivity ?? false
+}

--- a/packages/framework-dashboard/lib/use-activity-notifications.test.ts
+++ b/packages/framework-dashboard/lib/use-activity-notifications.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { Activity } from '@gemstack/framework'
+import { useActivityNotifications } from './use-activity-notifications.js'
+
+const startedRun = (runId: string, title?: string): Activity => ({ projectId: 'p', projectName: 'p', runId, kind: 'started', ...(title ? { title } : {}) })
+const finishedRun = (runId: string, title?: string): Activity => ({ projectId: 'p', projectName: 'p', runId, kind: 'finished', ...(title ? { title } : {}) })
+
+const ctor = vi.fn()
+
+describe('useActivityNotifications (#627)', () => {
+  beforeEach(() => {
+    ctor.mockReset()
+    class FakeNotification {
+      static permission = 'granted'
+      onclick: (() => void) | null = null
+      constructor(title: string, opts?: NotificationOptions) {
+        ctor(title, opts)
+      }
+      close(): void {}
+    }
+    vi.stubGlobal('Notification', FakeNotification)
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  const render = (enabled: boolean) =>
+    renderHook(({ items }) => useActivityNotifications(items, enabled), { initialProps: { items: [] as Activity[] } })
+
+  test('stays quiet for runs already present at load, then fires when a run starts', () => {
+    const { rerender } = render(true)
+    rerender({ items: [finishedRun('r1', 'seed')] }) // first fetch of an existing run -> baseline, no notify
+    expect(ctor).not.toHaveBeenCalled()
+    rerender({ items: [startedRun('r2', 'add cart'), finishedRun('r1', 'seed')] }) // a run just started -> notify
+    expect(ctor).toHaveBeenCalledTimes(1)
+    expect(ctor.mock.calls[0]![0]).toContain('Run started')
+    expect(ctor.mock.calls[0]![1]?.body).toContain('add cart')
+  })
+
+  test('fires again when the same run finishes (distinct key)', () => {
+    const { rerender } = render(true)
+    rerender({ items: [] }) // baseline
+    rerender({ items: [startedRun('r1', 'work')] }) // started
+    rerender({ items: [finishedRun('r1', 'work')] }) // finished -> a new key
+    expect(ctor).toHaveBeenCalledTimes(2)
+    expect(ctor.mock.calls[1]![0]).toContain('Run finished')
+  })
+
+  test('never fires when disabled', () => {
+    const { rerender } = render(false)
+    rerender({ items: [startedRun('r1')] })
+    rerender({ items: [startedRun('r1'), startedRun('r2')] })
+    expect(ctor).not.toHaveBeenCalled()
+  })
+})

--- a/packages/framework-dashboard/lib/use-activity-notifications.ts
+++ b/packages/framework-dashboard/lib/use-activity-notifications.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react'
+import type { Activity } from '@gemstack/framework'
+import { activityKey, pickNewActivity } from './activity.js'
+
+// Browser notifications for the "New activity" category (#627). Mirrors use-intervention-
+// notifications.ts: the activity feed is polled once in the shell; this watches it and fires a
+// notification when a run starts or finishes. Same two guards — never fires unless enabled AND the
+// browser permission is granted, and it absorbs the first couple of observations (the initial `[]`
+// then the first fetch of already-known runs) as a baseline, so the runs that already exist when the
+// page loads are never announced. You only hear about transitions that happen while you are watching.
+
+/** Observations to treat as baseline before notifying: the initial `[]` plus the first fetch. */
+const WARMUP = 2
+
+/** How one activity item reads in a notification body: a started run vs a finished one. */
+function label(item: Activity): string {
+  const what = item.title ?? 'a run'
+  return item.kind === 'started' ? `Started: ${what}` : `Finished: ${what}`
+}
+
+function title(item: Activity, count: number): string {
+  if (count > 1) return `${count} run updates`
+  const verb = item.kind === 'started' ? 'Run started' : 'Run finished'
+  return `${verb} · ${item.projectName}`
+}
+
+function fire(items: Activity[]): void {
+  if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return
+  const first = items[0]
+  if (!first) return
+  const single = items.length === 1
+  const body = single ? label(first) : items.map(label).join('\n')
+  // Activity lives in this dashboard (no external URL like a PR), so a click just brings the tab
+  // forward — the runs rail takes it from there.
+  const notification = new Notification(title(first, items.length), { body })
+  notification.onclick = () => {
+    window.focus()
+    notification.close()
+  }
+}
+
+/**
+ * Fire a browser notification when a run starts or finishes. `enabled` folds both gates the caller
+ * owns: the "New activity" category being on AND the browser method being on. The browser permission
+ * is the remaining gate (checked in {@link fire}). No-op on the server (no `window`), and harmless
+ * when notifications are unsupported.
+ */
+export function useActivityNotifications(activity: Activity[], enabled: boolean): void {
+  const seen = useRef<Set<string>>(new Set())
+  const observations = useRef(0)
+
+  useEffect(() => {
+    const fresh = pickNewActivity(seen.current, activity)
+    if (observations.current < WARMUP) {
+      observations.current += 1 // still warming up: fold these into the baseline, don't notify
+    } else if (enabled && fresh.length > 0) {
+      fire(fresh)
+    }
+    for (const item of activity) seen.current.add(activityKey(item))
+  }, [activity, enabled])
+}

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react'
-import type { Intervention } from '@gemstack/framework'
-import { onProjectFiles, onInterventions } from '../../server/reads.telefunc.js'
+import type { Intervention, Activity } from '@gemstack/framework'
+import { onProjectFiles, onInterventions, onActivity } from '../../server/reads.telefunc.js'
 import { ProjectsSidebar } from '../../components/ProjectsSidebar.js'
 import { NotificationBell } from '../../components/NotificationBell.js'
 import { DiscordToggle } from '../../components/DiscordToggle.js'
+import { ActivityToggle } from '../../components/ActivityToggle.js'
 import { RunHistory } from '../../components/RunHistory.js'
 import { ProjectHome } from '../../components/ProjectHome.js'
 import { DashboardPage } from '../../components/DashboardPage.js'
@@ -18,7 +19,8 @@ import { useLoaded, usePolled } from '../../lib/use-async.js'
 import { usePersistentState } from '../../lib/use-persistent-state.js'
 import { useContextSet } from '../../lib/use-context-set.js'
 import { useInterventionNotifications } from '../../lib/use-intervention-notifications.js'
-import { usePreferences, notificationsEnabled } from '../../lib/preferences.js'
+import { useActivityNotifications } from '../../lib/use-activity-notifications.js'
+import { usePreferences, notificationsEnabled, newActivityEnabled } from '../../lib/preferences.js'
 import { pendingChoices, agentViews } from '../../lib/live-state.js'
 
 /** Stable, so `files` keeps one identity while no project is selected. */
@@ -26,6 +28,9 @@ const EMPTY_FILES: string[] = []
 
 /** Stable initial for the interventions poll, so it does not churn on every render. */
 const EMPTY_INTERVENTIONS: Intervention[] = []
+
+/** Stable initial for the activity poll (#627), so it does not churn on every render. */
+const EMPTY_ACTIVITY: Activity[] = []
 
 // The dashboard shell (#405 phase 2): Projects | Runs | main | Docs/Log rail. The main pane
 // is one of three views chosen by the Runs-rail selection: the project home/launcher (Live,
@@ -66,6 +71,14 @@ export default function Page() {
   // one interventions poll above; the browser permission is the real gate (see the header bell).
   const preferences = usePreferences()
   useInterventionNotifications(interventions, notificationsEnabled(preferences))
+
+  // The "New activity" category (#627): the default-off feed of runs starting/finishing. Its only
+  // client consumer is the browser notification below, so it is polled exactly when that will fire —
+  // both the category (`notifyNewActivity`) and the browser method (`notifyBrowser`) on. (Discord
+  // delivery, if enabled, is the daemon's own watcher, independent of this poll.)
+  const browserActivity = newActivityEnabled(preferences) && notificationsEnabled(preferences)
+  const { value: activity } = usePolled<Activity[]>(browserActivity ? onActivity : null, EMPTY_ACTIVITY, 15000, [browserActivity])
+  useActivityNotifications(activity, browserActivity)
 
   const onRunStarted = (intent: string) => {
     // Stay on the home launcher (it must stay visible so you can launch again); the new run
@@ -130,6 +143,7 @@ export default function Page() {
         <div className="ml-auto flex items-center gap-1">
           <NotificationBell />
           <DiscordToggle />
+          <ActivityToggle />
         </div>
       </header>
       <div className="flex min-h-0 flex-1">

--- a/packages/framework-dashboard/server/reads.telefunc.ts
+++ b/packages/framework-dashboard/server/reads.telefunc.ts
@@ -3,4 +3,4 @@
 // the client bakes the RPC key `/server/reads.telefunc.ts` — the exact key the daemon
 // registers the impls under (see framework's dashboard-rpc/register.ts). The telefunc
 // Vite transform turns these named re-exports into client RPC stubs.
-export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from '@gemstack/framework/dashboard-rpc'
+export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from '@gemstack/framework/dashboard-rpc'

--- a/packages/framework/src/dashboard-rpc/index.ts
+++ b/packages/framework/src/dashboard-rpc/index.ts
@@ -2,7 +2,7 @@
 // implementations live here in @gemstack/framework so `sendStart` (added with the serve
 // wiring) can reach the daemon's `startRun`; the framework-dashboard client imports
 // these through thin re-export shims so the baked RPC keys stay `/server/*.telefunc.ts`.
-export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from './reads.telefunc.js'
+export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from './reads.telefunc.js'
 export { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
 export { onEvents } from './events.telefunc.js'
 export { onProjects, sendAddProject } from './projects.telefunc.js'

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -4,6 +4,7 @@ import { readDocs, type WorkspaceDoc } from '../dashboard/docs.js'
 import { collectQueue, type ProjectQueue } from '../dashboard/queue.js'
 import { buildOverview, type Overview } from '../dashboard/overview.js'
 import { buildInterventions, type Intervention } from '../dashboard/interventions.js'
+import { buildActivity, type Activity } from '../dashboard/activity.js'
 import { buildDashboard, type DashboardData } from '../dashboard/dashboard.js'
 import { githubUrlFor } from '../dashboard/github.js'
 import { readGitStatus, type GitStatus } from '../dashboard/git-status.js'
@@ -82,6 +83,12 @@ export async function onOverview(): Promise<Overview> {
 export async function onInterventions(): Promise<Intervention[]> {
   const projects = await contextProjects().list().catch(() => [])
   return buildInterventions(projects)
+}
+
+/** The cross-project "New activity" feed (#627): recent run started/finished transitions, newest first. */
+export async function onActivity(): Promise<Activity[]> {
+  const projects = await contextProjects().list().catch(() => [])
+  return buildActivity(projects)
 }
 
 /** The Overview dashboard page (#471): the {@link onOverview} rollup plus run counts, run-status totals, and activity. */

--- a/packages/framework/src/dashboard-rpc/register.ts
+++ b/packages/framework/src/dashboard-rpc/register.ts
@@ -1,5 +1,5 @@
 import { __decorateTelefunction } from 'telefunc'
-import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from './reads.telefunc.js'
+import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from './reads.telefunc.js'
 import { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
 import { onEvents } from './events.telefunc.js'
 import { onProjects, sendAddProject } from './projects.telefunc.js'
@@ -40,6 +40,7 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(onQueue, 'onQueue', reads)
   reg(onOverview, 'onOverview', reads)
   reg(onInterventions, 'onInterventions', reads)
+  reg(onActivity, 'onActivity', reads)
   reg(onDashboard, 'onDashboard', reads)
   reg(onGithubUrl, 'onGithubUrl', reads)
   reg(onGitStatus, 'onGitStatus', reads)

--- a/packages/framework/src/dashboard/activity.test.ts
+++ b/packages/framework/src/dashboard/activity.test.ts
@@ -1,0 +1,82 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { buildActivity, activityKey, pickNewActivity, type Activity } from './activity.js'
+import type { ProjectSummary } from './projects.js'
+import type { RunMeta } from '../store/index.js'
+
+const project = (id: string, path: string): ProjectSummary => ({ id, path, name: id, activated: true })
+
+const run = (over: Partial<RunMeta> = {}): RunMeta => ({
+  version: 1,
+  status: 'running',
+  id: 'r1',
+  startedAt: '2026-07-16T00:00:00Z',
+  updatedAt: '2026-07-16T00:00:00Z',
+  passes: 0,
+  ...over,
+})
+
+test('buildActivity maps a running run to started and a terminal run to finished', async () => {
+  const runsByPath: Record<string, RunMeta[]> = {
+    '/a': [run({ id: 'r1', status: 'running', intent: 'add cart', updatedAt: '2026-07-16T03:00:00Z' })],
+    '/b': [run({ id: 'r2', status: 'done', intent: 'fix login', updatedAt: '2026-07-16T01:00:00Z' })],
+  }
+  const readRuns = async (cwd: string): Promise<RunMeta[]> => runsByPath[cwd] ?? []
+  const items = await buildActivity([project('a', '/a'), project('b', '/b')], { readRuns })
+
+  // Newest first.
+  assert.deepEqual(
+    items.map(i => ({ project: i.projectId, kind: i.kind, title: i.title, status: i.status })),
+    [
+      { project: 'a', kind: 'started', title: 'add cart', status: undefined },
+      { project: 'b', kind: 'finished', title: 'fix login', status: 'done' },
+    ],
+  )
+})
+
+test('buildActivity carries the terminal status so a stop reads differently from a done', async () => {
+  const readRuns = async (): Promise<RunMeta[]> => [run({ status: 'stopped', updatedAt: '2026-07-16T02:00:00Z' })]
+  const items = await buildActivity([project('a', '/a')], { readRuns })
+  assert.deepEqual({ kind: items[0]!.kind, status: items[0]!.status }, { kind: 'finished', status: 'stopped' })
+})
+
+test('buildActivity emits one item per run across a project history', async () => {
+  const readRuns = async (): Promise<RunMeta[]> => [
+    run({ id: 'live', status: 'running', updatedAt: '2026-07-16T05:00:00Z' }),
+    run({ id: 'old', status: 'done', updatedAt: '2026-07-15T00:00:00Z' }),
+  ]
+  const items = await buildActivity([project('a', '/a')], { readRuns })
+  assert.deepEqual(items.map(i => [i.runId, i.kind]), [['live', 'started'], ['old', 'finished']])
+})
+
+test('buildActivity caps each project to the most recent runs', async () => {
+  const many = Array.from({ length: 30 }, (_, i) =>
+    run({ id: `r${i}`, status: 'done', updatedAt: `2026-07-16T00:${String(i).padStart(2, '0')}:00Z` }),
+  )
+  const readRuns = async (): Promise<RunMeta[]> => many
+  const items = await buildActivity([project('a', '/a')], { readRuns })
+  assert.equal(items.length, 20)
+})
+
+test('buildActivity skips a project whose run read throws', async () => {
+  const readRuns = async (cwd: string): Promise<RunMeta[]> => {
+    if (cwd === '/boom') throw new Error('disk exploded')
+    return [run({ id: 'ok', status: 'done' })]
+  }
+  const items = await buildActivity([project('boom', '/boom'), project('ok', '/ok')], { readRuns })
+  assert.deepEqual(items.map(i => i.projectId), ['ok'])
+})
+
+test('activityKey separates a run start from its finish', () => {
+  const base = { projectId: 'a', projectName: 'a', runId: 'r1' } as const
+  assert.equal(activityKey({ ...base, kind: 'started' }), 'started:a:r1')
+  assert.equal(activityKey({ ...base, kind: 'finished' }), 'finished:a:r1')
+})
+
+test('pickNewActivity returns only items whose key is unseen', () => {
+  const started: Activity = { projectId: 'a', projectName: 'a', runId: 'r1', kind: 'started' }
+  const finished: Activity = { projectId: 'a', projectName: 'a', runId: 'r1', kind: 'finished' }
+  const seen = new Set([activityKey(started)])
+  // The same run finishing is a new key, so it is picked up even though its start was already seen.
+  assert.deepEqual(pickNewActivity(seen, [started, finished]), [finished])
+})

--- a/packages/framework/src/dashboard/activity.ts
+++ b/packages/framework/src/dashboard/activity.ts
@@ -1,0 +1,106 @@
+import { listRuns, readLiveMeta, type RunMeta, type RunStatus } from '../store/index.js'
+import type { ProjectSummary } from './projects.js'
+
+// The "New activity" feed (#627): the cross-project stream of run lifecycle transitions that
+// do NOT need the human — a run started, a run finished. It is the default-off notification
+// category, the counterpart to the interventions queue (which is the always-on "needs you"
+// half). Same shape and same "only genuinely new" diff as interventions.ts, so the browser
+// hook and the Discord watcher fold it into a baseline on first look and then notify once per
+// transition — you hear a run kick off and a run land, nothing when the page/daemon starts.
+
+/** How many recent runs per project to consider. Bounds the finished-set — older runs rolled off
+ * long ago and were already baselined, so they never fire. A running run is always newest (live
+ * meta is prepended), so it is always in range. */
+const RECENT_RUNS = 20
+
+/**
+ * One run lifecycle event worth a passing mention. Two kinds: a run `started` (entered
+ * `running`) or `finished` (reached a terminal status). The card is not shown for these — they
+ * only drive notifications — so the fields are just what a notification line needs.
+ */
+export interface Activity {
+  projectId: string
+  projectName: string
+  /** The run this is about. */
+  runId: string
+  /** `started` = the run entered `running`; `finished` = it reached a terminal status. */
+  kind: 'started' | 'finished'
+  /** What the run is building (its `intent`), for the notification body; may be absent. */
+  title?: string
+  /** The finished run's terminal status (`finished` only), so a stop reads differently from a done. */
+  status?: RunStatus
+  /** When the run last changed, ISO, for ordering and the baseline diff. */
+  updatedAt?: string
+}
+
+/** Injectable seam so {@link buildActivity} is unit-testable off disk. */
+export interface ActivityDeps {
+  /** A project's runs, live prepended to the archived history, newest-first. Defaults to disk. */
+  readRuns?: (cwd: string) => Promise<RunMeta[]>
+}
+
+/** A project's runs, live prepended to the archived history. Forgiving: a failed read is `[]`. */
+async function readAllRuns(cwd: string): Promise<RunMeta[]> {
+  const [archived, live] = await Promise.all([
+    listRuns(cwd).catch(() => [] as RunMeta[]),
+    readLiveMeta(cwd).catch(() => undefined),
+  ])
+  // Skip the live run when it is already archived under the same id, so it is not counted twice.
+  if (live && !archived.some(r => r.id === live.id)) return [live, ...archived]
+  return archived
+}
+
+/** Map one run to its current activity item: `started` while running, else `finished`. */
+function activityFor(project: ProjectSummary, run: RunMeta): Activity {
+  const kind = run.status === 'running' ? 'started' : 'finished'
+  return {
+    projectId: project.id,
+    projectName: project.name,
+    runId: run.id,
+    kind,
+    ...(run.intent ? { title: run.intent } : {}),
+    ...(kind === 'finished' ? { status: run.status } : {}),
+    ...(run.updatedAt ? { updatedAt: run.updatedAt } : {}),
+  }
+}
+
+/**
+ * Build the cross-project activity feed: for each registered project's most recent runs, one
+ * item per run reflecting where it is now (`started` while it runs, `finished` once it lands),
+ * newest first. Forgiving — a project whose runs cannot be read simply contributes nothing.
+ *
+ * The `started` and `finished` items for one run carry distinct keys ({@link activityKey}), so a
+ * run that is still going notifies once (started) and again when it lands (finished). A run that
+ * both starts and finishes between two polls is only ever seen terminal, so it notifies once
+ * (finished) — one quick run, one line.
+ */
+export async function buildActivity(projects: ProjectSummary[], deps: ActivityDeps = {}): Promise<Activity[]> {
+  const readRuns = deps.readRuns ?? readAllRuns
+  const items: Activity[] = []
+  for (const project of projects) {
+    const runs = (await readRuns(project.path).catch(() => [])).slice(0, RECENT_RUNS)
+    for (const run of runs) items.push(activityFor(project, run))
+  }
+  items.sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''))
+  return items
+}
+
+/**
+ * The stable identity of an activity item: its kind + project + run. The kind is part of the key
+ * so a run's `started` and `finished` are two separate announcements (one when it kicks off, one
+ * when it lands), each firing exactly once.
+ */
+export function activityKey(item: Activity): string {
+  return `${item.kind}:${item.projectId}:${item.runId}`
+}
+
+/**
+ * The activity items in `current` not already in `seen` (by {@link activityKey}) — the transitions
+ * that just happened. Drives both the browser hook and the daemon's Discord watcher: each keeps the
+ * keys it has already announced, so only genuinely new transitions notify. (The dashboard keeps a
+ * client-side copy of this; it can't import runtime values from this package without dragging
+ * Node-only modules into the browser bundle.)
+ */
+export function pickNewActivity(seen: ReadonlySet<string>, current: Activity[]): Activity[] {
+  return current.filter(item => !seen.has(activityKey(item)))
+}

--- a/packages/framework/src/dashboard/index.ts
+++ b/packages/framework/src/dashboard/index.ts
@@ -25,3 +25,4 @@ export {
   type PrLister,
   type InterventionsDeps,
 } from './interventions.js'
+export { buildActivity, activityKey, pickNewActivity, type Activity, type ActivityDeps } from './activity.js'

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -130,7 +130,7 @@ export {
   type SweepDeps,
   type MaintenanceFs,
 } from './maintenance.js'
-export { startDashboard, summarizeProject, defaultProjectsProvider, readDocs, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunResult, type AddProjectResult, type PreviewResult, type PreviewStatus, type ProjectSummary, type ProjectsProvider, type SummarizeDeps, type WorkspaceDoc, type ProjectQueue, type QueueItem, type Overview, type ActiveRun, type RecentProject, type DashboardData, type ProjectStat, type ActivityDay, type GitStatus, type LinkedPr, buildInterventions, nodeGhPrLister, type Intervention, type OpenPr, type PrLister, type InterventionsDeps } from './dashboard/index.js'
+export { startDashboard, summarizeProject, defaultProjectsProvider, readDocs, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunResult, type AddProjectResult, type PreviewResult, type PreviewStatus, type ProjectSummary, type ProjectsProvider, type SummarizeDeps, type WorkspaceDoc, type ProjectQueue, type QueueItem, type Overview, type ActiveRun, type RecentProject, type DashboardData, type ProjectStat, type ActivityDay, type GitStatus, type LinkedPr, buildInterventions, nodeGhPrLister, type Intervention, type OpenPr, type PrLister, type InterventionsDeps, buildActivity, activityKey, pickNewActivity, type Activity, type ActivityDeps } from './dashboard/index.js'
 export { startPreview, detectDevScript, parsePreviewUrl, PREVIEW_SCRIPTS, type PreviewHandle, type StartPreviewOptions } from './preview.js'
 export {
   RunStore,

--- a/packages/framework/src/registry.test.ts
+++ b/packages/framework/src/registry.test.ts
@@ -185,6 +185,12 @@ test('writePreferences round-trips the notifyDiscord toggle (#627)', async () =>
   assert.deepEqual(await readPreferences(fs, ENV), { notifyDiscord: true })
 })
 
+test('writePreferences round-trips the notifyNewActivity toggle (#627)', async () => {
+  const fs = memFs({ [FILE]: JSON.stringify([APP_A]) })
+  await writePreferences({ notifyNewActivity: true }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { notifyNewActivity: true })
+})
+
 test('writePreferences keeps the model string but drops a blank one (#628)', async () => {
   const fs = memFs({ [FILE]: JSON.stringify([APP_A]) })
   await writePreferences({ model: '  opus  ' }, fs, ENV)

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -57,6 +57,13 @@ export interface Preferences {
   browser?: boolean
   /** Fire a browser notification when a new item lands on the "needs you" queue (#627). Absent = on. */
   notifyBrowser?: boolean
+  /**
+   * Also notify on plain run activity — a run started, a run finished (#627). The default-off
+   * counterpart to the always-on "needs you" notifications: it keeps you loosely informed of the
+   * pipeline moving even when nothing needs you. A *category* toggle: it composes with the method
+   * toggles ({@link notifyBrowser} / {@link notifyDiscord}), so activity reaches whichever are on.
+   */
+  notifyNewActivity?: boolean
   /** The model to run on (#628), e.g. `opus` / `sonnet`; maps to a run's `--model`. Absent = the driver's default. */
   model?: string
   /** Which coding agent drives the run (#650): `claude` or `codex`; maps to `--agent`. Absent = the default (`claude`). */
@@ -177,6 +184,7 @@ const PREFERENCE_KEYS = [
   'browser',
   'notifyBrowser',
   'notifyDiscord',
+  'notifyNewActivity',
 ] as const
 
 /** Keep only the known preference fields, so a hand-edited or browser-supplied


### PR DESCRIPTION
Part of #627.

Adds the **"New activity"** notification *category*, the default-off counterpart to the always-on "needs you" notifications. Turn it on and you get a browser notification when a run **starts** and when it **finishes** — not just when something needs your review.

### Why
The #627 spec has two notification categories — *Human intervention* (default on, already shipped) and *New activity* (default off). Only the first existed; this adds the second. It is the one item left under Notifications in `tickets/TODO.md`.

### How it composes
Category, not method. It rides the existing delivery-method toggles:
- **Browser** (`notifyBrowser`, the bell): activity pings the browser when the bell is on.
- **Discord** (`notifyDiscord`): daemon-side delivery is a fast follow (mirrors how interventions shipped browser #634 then Discord #635).

### What's here
- `buildActivity(projects)` + `onActivity` RPC: a cross-project feed mapping each recent run to a `started` (while running) or `finished` (terminal) item, newest first, capped per project.
- Diffed by `activityKey` (`kind:project:run`) exactly like the interventions queue: a run's start and finish are distinct keys (one ping each), and runs already going at page load are folded into a baseline instead of announced.
- Client hook `useActivityNotifications` + header `ActivityToggle` (beside the bell and Discord toggle). The client feed is polled only when it will actually notify (category **and** browser method on).
- `notifyNewActivity` preference (default off), sanitized + round-tripped.

### Tests
- framework: `activity.test.ts` (7) + registry round-trip; reads/preferences/server (9) green; typecheck + build clean.
- dashboard: `lib/activity.test.ts` + `use-activity-notifications.test.ts`; full vitest 67 green; typecheck clean.

Minor changeset on `@gemstack/framework` (dashboard bundled).