### PR TITLE
feat(framework): transparent mode, the coarse master off-switch (#625)

### DIFF
--- a/.changeset/transparent-mode-625.md
+++ b/.changeset/transparent-mode-625.md
@@ -1,0 +1,9 @@
+---
+'@gemstack/framework': minor
+---
+
+Transparent mode (#625): a coarse master off-switch that makes a run identical to plain `claude -p <prompt>` — the "only pick what you need" requirement, at its extreme. Turn it on and the wrapped agent runs fully raw: no framework system prompt, no AWAIT/SIGNAL emit protocols, no consumption guard, no dashboard, no TODO loop.
+
+Available at all three tiers: the `--transparent` flag, a `the-framework.yml` `transparent: true` key (per project), and a `transparent` user preference surfaced as the "Transparent" toggle in the dashboard's run options (it overrides the other option toggles, and the "Actual prompt" preview correctly shows an empty channel).
+
+This also closes the gap where `--vanilla` was advertised as "fully transparent" but still injected the AWAIT/SIGNAL protocols into the system channel: `--vanilla` keeps that emit contract (so the agent can still drive the dashboard's gates), and `--transparent` is the new switch that drops everything for a genuinely raw run. `composeRunSystem` now returns an empty string under transparent, the single place the whole system channel is assembled.

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -98,6 +98,7 @@ export function StartRunForm({
   const autopilot = autopilotEnabled(preferences)
   const technical = preferences.technical ?? false
   const vanilla = preferences.vanilla ?? false
+  const transparent = preferences.transparent ?? false // #625: the master off-switch (raw Claude Code)
   const eco = preferences.eco ?? false
   const ecoPlanning = preferences.ecoPlanning ?? false
   const ecoResearch = preferences.ecoResearch ?? false
@@ -132,8 +133,9 @@ export function StartRunForm({
     .join(' · ')
 
   // Vanilla removes the system prompt entirely, so Eco (which only trims it) has nothing
-  // left to act on.
-  const ecoDisabled = vanilla
+  // left to act on; Transparent (#625) turns off the whole framework, so it overrides the
+  // rest of the toggles too.
+  const ecoDisabled = vanilla || transparent
 
   // The eco drops, hoisted: the run gets them via collectOptions, and the #520
   // preview renders with them, so what you read is what gets sent.
@@ -148,7 +150,8 @@ export function StartRunForm({
       ...(autopilot ? { autopilot: true } : {}),
       ...(technical ? { technical: true } : {}),
       ...(vanilla ? { vanilla: true } : {}),
-      ...(eco && !vanilla && Object.keys(ecoDrops).length ? { eco: ecoDrops } : {}),
+      ...(transparent ? { transparent: true } : {}),
+      ...(eco && !vanilla && !transparent && Object.keys(ecoDrops).length ? { eco: ecoDrops } : {}),
       ...(onBeforeMergeableQuality ? { onBeforeMergeable: true } : {}),
       ...(browser ? { browser: true } : {}),
       ...(model ? { model } : {}),
@@ -208,12 +211,13 @@ export function StartRunForm({
   // Eco is disabled + dimmed under Vanilla (nothing left to trim); the Eco sub-drops show only
   // while Eco is on.
   const mainOptions: OptionRow[] = [
-    { key: 'autopilot', label: 'Autopilot', description: 'Auto-accepts the recommended choice after a countdown.', title: 'Auto-accept the recommended choice after a countdown; also relaxes the maintenance stance', checked: autopilot },
-    { key: 'technical', label: 'Technical control', description: 'Surfaces technical detail like tech-stack choices.', title: 'Expose technical detail (e.g. tech-stack choices)', checked: technical },
-    { key: 'vanilla', label: 'Disable system prompt', description: 'Raw Claude Code, with no added system prompt.', title: "Remove all system prompts: the same as raw Claude Code. Expand 'Actual prompt' to read what it removes.", checked: vanilla },
+    { key: 'transparent', label: 'Transparent', description: 'Raw Claude Code — turns the whole framework off.', title: 'Fully transparent (#625): run the agent exactly like plain Claude Code, with no framework system prompt, controls, dashboard, guard, or TODO loop. Overrides the options below.', checked: transparent },
+    { key: 'autopilot', label: 'Autopilot', description: 'Auto-accepts the recommended choice after a countdown.', title: 'Auto-accept the recommended choice after a countdown; also relaxes the maintenance stance', checked: autopilot && !transparent, disabled: transparent },
+    { key: 'technical', label: 'Technical control', description: 'Surfaces technical detail like tech-stack choices.', title: 'Expose technical detail (e.g. tech-stack choices)', checked: technical && !transparent, disabled: transparent },
+    { key: 'vanilla', label: 'Disable system prompt', description: 'Drops the added system prompt; keeps the run controls.', title: "Remove the built-in system prompt but keep the framework's run controls. For a fully raw run, use Transparent. Expand 'Actual prompt' to read what it removes.", checked: vanilla && !transparent, disabled: transparent },
     { key: 'eco', label: 'Eco', description: 'Trims the system prompt to save tokens.', title: 'Trim the built-in system prompt to save tokens', checked: eco && !ecoDisabled, disabled: ecoDisabled },
-    { key: 'onBeforeMergeableQuality', label: 'Post-merge cleanup', description: 'Runs quality passes once it is ready to merge.', title: "When the run signals it's ready for merge, run maintainability, readability, and security-audit passes", checked: onBeforeMergeableQuality },
-    { key: 'browser', label: 'Browser', description: 'Gives the agent a real browser to inspect pages.', title: 'Give the agent a real browser via chrome-devtools-mcp: navigate pages, read console + network, inspect the DOM, and screenshot', checked: browser },
+    { key: 'onBeforeMergeableQuality', label: 'Post-merge cleanup', description: 'Runs quality passes once it is ready to merge.', title: "When the run signals it's ready for merge, run maintainability, readability, and security-audit passes", checked: onBeforeMergeableQuality && !transparent, disabled: transparent },
+    { key: 'browser', label: 'Browser', description: 'Gives the agent a real browser to inspect pages.', title: 'Give the agent a real browser via chrome-devtools-mcp: navigate pages, read console + network, inspect the DOM, and screenshot', checked: browser && !transparent, disabled: transparent },
   ]
   const ecoOptions: OptionRow[] = [
     { key: 'ecoPlanning', label: 'Auto planning', description: 'Drops the planning section; the agent plans itself.', title: 'Drop the planning section, letting the agent plan on its own', checked: ecoPlanning },
@@ -287,6 +291,7 @@ export function StartRunForm({
         prompt={prompt}
         disabled={vanilla}
         onDisabledChange={value => updatePreferences({ vanilla: value })}
+        transparent={transparent}
         autopilot={autopilot}
         eco={eco && !vanilla ? ecoDrops : undefined}
         context={[...context]}

--- a/packages/framework-dashboard/components/SystemPromptDisclosure.test.tsx
+++ b/packages/framework-dashboard/components/SystemPromptDisclosure.test.tsx
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { SystemPromptDisclosure } from './SystemPromptDisclosure.js'
+
+afterEach(cleanup)
+
+// Open the "Actual prompt" disclosure so its body renders.
+function openDisclosure() {
+  fireEvent.click(screen.getByText('Actual prompt'))
+}
+
+const baseProps = {
+  prompt: 'build me a thing',
+  onDisabledChange: () => {},
+  autopilot: false,
+  eco: undefined,
+  context: [],
+  busy: false,
+}
+
+describe('SystemPromptDisclosure transparent mode (#625)', () => {
+  test('with the built-in prompt on, the preview shows the wrapped system prompt', () => {
+    render(<SystemPromptDisclosure {...baseProps} disabled={false} />)
+    openDisclosure()
+    // The real composeRunSystem output is shown; it is a non-empty system channel.
+    expect(screen.queryByText(/The system prompt is off/)).toBeNull()
+    expect(screen.getByText(/whole system prompt/)).toBeTruthy()
+  })
+
+  test('under transparent, the preview is empty — the prompt is sent as written', () => {
+    render(<SystemPromptDisclosure {...baseProps} disabled={false} transparent />)
+    openDisclosure()
+    // Transparent empties the whole channel (protocols included), so the "off" branch renders.
+    expect(screen.getByText(/your prompt is sent to the agent exactly as you wrote it/)).toBeTruthy()
+  })
+})

--- a/packages/framework-dashboard/components/SystemPromptDisclosure.tsx
+++ b/packages/framework-dashboard/components/SystemPromptDisclosure.tsx
@@ -19,6 +19,7 @@ export function SystemPromptDisclosure({
   prompt,
   disabled,
   onDisabledChange,
+  transparent,
   autopilot,
   eco,
   context,
@@ -29,6 +30,8 @@ export function SystemPromptDisclosure({
   /** The Vanilla toggle (#314), under its real name. */
   disabled: boolean
   onDisabledChange: (value: boolean) => void
+  /** Transparent mode (#625): the whole channel is empty, so the preview shows nothing wrapped. */
+  transparent?: boolean
   autopilot: boolean
   eco: EcoOptions | undefined
   context: string[]
@@ -38,6 +41,7 @@ export function SystemPromptDisclosure({
 
   const text = composeRunSystem({
     antiLazyPill: !disabled,
+    ...(transparent ? { transparent: true } : {}),
     tf: { prompt, params: { autopilot, ...(eco ? { eco } : {}) } },
     ...(context.length ? { context } : {}),
   })

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -193,6 +193,11 @@ test('parseArgs reads the Global options flags: vanilla + eco (#314)', () => {
   assert.deepEqual(on.eco, { autoPlanning: true, autoResearch: false, autoMaintenance: true })
 })
 
+test('parseArgs reads --transparent, off by default (#625)', () => {
+  assert.equal(parseArgs(['x']).transparent, false)
+  assert.equal(parseArgs(['--transparent', 'x']).transparent, true)
+})
+
 test('ecoOptions returns undefined when nothing is set, else only the enabled drops (#314)', () => {
   assert.equal(ecoOptions(parseArgs(['x'])), undefined)
   assert.deepEqual(ecoOptions(parseArgs(['--eco-auto-research', 'x'])), {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -145,9 +145,15 @@ Options:
   --technical            Activate the preset's Technical mode variants.
                          (--preset / --autopilot / --technical / --kind can also be
                           set per repo in the-framework.yml; these flags override it.)
-  --vanilla              Remove the built-in system prompt entirely, so the agent
-                         runs as raw Claude Code (fully transparent). Overrides the
-                         Eco flags below (there is no built-in prompt left to trim).
+  --vanilla              Remove the built-in system prompt entirely. The agent still
+                         gets the AWAIT/SIGNAL emit contract, so it can drive the
+                         dashboard's gates; for a fully raw run use --transparent.
+                         Overrides the Eco flags below (no built-in prompt to trim).
+  --transparent          Fully transparent (#625): run the wrapped agent raw, exactly
+                         like plain "claude -p" — no framework system prompt, emit
+                         protocols, consumption guard, dashboard, or TODO loop. The
+                         coarse master off-switch; also settable per repo in
+                         the-framework.yml (transparent: true) or per user.
   --eco-auto-planning    Drop the built-in prompt's "Large scope" (planning) section.
   --eco-auto-research    Drop the built-in prompt's "Alternatives" (research) section.
   --eco-auto-maintenance Drop the built-in prompt's "Maintenance" section.
@@ -227,6 +233,9 @@ export interface CliOptions {
   technical: boolean
   /** `--vanilla`: remove the built-in #326 system prompt entirely (antiLazyPill off, #314). */
   vanilla: boolean
+  /** `--transparent` (#625): run the wrapped agent fully raw — no framework system prompt, emit
+   * protocols, consumption guard, dashboard, or TODO loop, so a run is identical to `claude -p`. */
+  transparent: boolean
   /** `--eco-*`: fine-grained #326 section drops to save tokens (#314). */
   eco: Required<EcoOptions>
   /** `--context <dir>` (repeatable): in-context directories added as one `Context:` line (#439). */
@@ -292,6 +301,7 @@ export function parseArgs(argv: string[]): CliOptions {
     autopilot: false,
     technical: false,
     vanilla: false,
+    transparent: false,
     eco: { autoPlanning: false, autoResearch: false, autoMaintenance: false },
     context: [],
     onBeforeMergeable: false,
@@ -348,6 +358,9 @@ export function parseArgs(argv: string[]): CliOptions {
         break
       case '--vanilla':
         opts.vanilla = true
+        break
+      case '--transparent':
+        opts.transparent = true
         break
       case '--on-before-mergeable':
         opts.onBeforeMergeable = true
@@ -789,12 +802,15 @@ async function resolvePromptConfig(
   fileConfig: FrameworkFileConfig,
   cwd: string,
   io: CliIO,
+  transparent: boolean,
 ): Promise<{ userSystemPrompt?: string; noBuiltinPrompt: boolean; eco?: EcoOptions }> {
   const userSystemPrompt = await loadUserSystemPrompt(cwd)
-  const noBuiltinPrompt = antiLazyPillOff(opts, fileConfig)
+  // Transparent empties the whole channel, which subsumes "no built-in prompt".
+  const noBuiltinPrompt = transparent || antiLazyPillOff(opts, fileConfig)
   const eco = ecoOptions(opts)
   if (userSystemPrompt) io.out(`◆ system prompt: ${SYSTEM_PROMPT_FILE}`)
-  if (noBuiltinPrompt) io.out(`◆ built-in system prompt: off (${opts.vanilla ? 'vanilla' : 'the-framework.yml'})`)
+  // Transparent already announced itself (guard line); don't double-report the prompt being off.
+  if (noBuiltinPrompt && !transparent) io.out(`◆ built-in system prompt: off (${opts.vanilla ? 'vanilla' : 'the-framework.yml'})`)
   else if (eco) io.out(`◆ eco: dropping ${Object.keys(eco).filter(k => eco[k as keyof EcoOptions]).join(', ')}`)
   if (opts.context.length) io.out(`◆ context: ${opts.context.join(', ')}`)
   return { ...(userSystemPrompt ? { userSystemPrompt } : {}), noBuiltinPrompt, ...(eco ? { eco } : {}) }
@@ -876,6 +892,12 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   const fileConfig = await loadFrameworkConfig(cwd, msg => io.err(msg))
   const fromFile = describeConfigSource(opts, fileConfig)
   if (fromFile) io.out(`◆ the-framework.yml: ${fromFile}`)
+
+  // Transparent mode (#625): the coarse master off-switch — `--transparent` or the-framework.yml.
+  // When on, this run is byte-identical to raw `claude -p`: no framework system channel (composed
+  // empty below), no consumption guard, no dashboard, no TODO loop. Resolved once here so every
+  // one of those sites reads the same answer.
+  const transparent = opts.transparent || fileConfig.transparent === true
 
   // Resolve which Open Loop domain preset (+ modes + build event) to run under:
   // --preset / the-framework.yml, or none at all (#545). Nothing infers one.
@@ -963,7 +985,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // the SPA reads this one `cwd`'s event/control logs without touching the global registry, so
   // a one-shot run never pollutes the Projects list. It streams the persisted event log, so a
   // --no-persist run (or an old install missing the built bundle) runs headless.
-  const dashboard = await startRunDashboard(opts.dashboard && opts.persist, cwd, opts.port, io, {
+  const dashboard = await startRunDashboard(opts.dashboard && opts.persist && !transparent, cwd, opts.port, io, {
     headlessNote: 'continuing headless',
   })
   // The new dashboard steers this live run purely through control.jsonl (its Stop / choice
@@ -1123,15 +1145,18 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // a run started from a terminal is guarded exactly like one started from the
   // dashboard. `undefined` when the agent can't report a quota (the fake driver,
   // or Codex), which leaves the run ungated — the fail-open Rom confirmed.
-  const guard = startConsumptionGuard({ driver, limits: resolveConsumptionLimits(await readPreferences()) })
-  if (guard) io.out('◆ consumption limits: on')
+  // Transparent mode (#625) leaves the run fully raw, so the guard is off with it — the run is
+  // `claude -p` with no framework behavior, spend included.
+  const guard = transparent ? undefined : startConsumptionGuard({ driver, limits: resolveConsumptionLimits(await readPreferences()) })
+  if (transparent) io.out(`◆ transparent: on — raw ${AGENT_SPECS[opts.agent].label}, no framework prompt, guard, dashboard, or TODO loop`)
+  else if (guard) io.out('◆ consumption limits: on')
   else if (!fake) {
     io.out(`◆ consumption limits: off — ${AGENT_SPECS[opts.agent].label} reports no quota, so nothing gates your subscription spend.`)
   }
 
   // A user SYSTEM.md + the anti-lazy-pill toggle shape the system prompt (#301), and the eco
   // flags trim the built-in one (#314). Resolve and echo once, shared by both run paths.
-  const promptConfig = await resolvePromptConfig(opts, fileConfig, cwd, io)
+  const promptConfig = await resolvePromptConfig(opts, fileConfig, cwd, io, transparent)
 
   // The run-scoped state both run paths hand to settleRun to close out. stoppedCleanly is a
   // getter because the onEvent sink sets it as the `end` event arrives.
@@ -1169,6 +1194,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
         ...(guard ? { consumptionGate: guard.gate } : {}),
         ...(userSystemPrompt ? { systemPrompt: userSystemPrompt } : {}),
         ...(noBuiltinPrompt ? { antiLazyPill: false } : {}),
+        ...(transparent ? { transparent: true } : {}),
         ...(eco ? { eco } : {}),
         ...(opts.context.length ? { context: opts.context } : {}),
         ...(modeList.includes('autopilot') ? { autopilot: true } : {}),
@@ -1232,7 +1258,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     ...(opts.maxPasses ? { maxPasses: opts.maxPasses } : {}),
     ...(opts.maxCost ? { budgetUsd: opts.maxCost } : {}),
     ...(guard ? { consumptionGate: guard.gate } : {}),
-    ...(opts.todoLoop ? {} : { todoLoop: false }),
+    ...(opts.todoLoop && !transparent ? {} : { todoLoop: false }),
     ...(opts.todoMaxItems ? { todoMaxItems: opts.todoMaxItems } : {}),
     ...(deploy ? { deploy } : {}),
     ...(deployTarget ? { deployTarget } : {}),
@@ -1245,6 +1271,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     ...(buildEvent ? { buildEvent } : {}),
     ...(userSystemPrompt ? { systemPrompt: userSystemPrompt } : {}),
     ...(noBuiltinPrompt ? { antiLazyPill: false } : {}),
+    ...(transparent ? { transparent: true } : {}),
     ...(eco ? { eco } : {}),
     ...(opts.context.length ? { context: opts.context } : {}),
     ...(sessionLink ? { sessionLink } : {}),

--- a/packages/framework/src/config.test.ts
+++ b/packages/framework/src/config.test.ts
@@ -22,6 +22,11 @@ test('parseFrameworkConfig reads the antiLazyPill toggle', () => {
   assert.throws(() => parseFrameworkConfig('antiLazyPill: nope\n'), /"antiLazyPill" must be a boolean/)
 })
 
+test('parseFrameworkConfig reads the transparent toggle (#625)', () => {
+  assert.deepEqual(parseFrameworkConfig('transparent: true\n'), { transparent: true })
+  assert.throws(() => parseFrameworkConfig('transparent: nope\n'), /"transparent" must be a boolean/)
+})
+
 test('parseFrameworkConfig treats an empty document as {}', () => {
   assert.deepEqual(parseFrameworkConfig(''), {})
   assert.deepEqual(parseFrameworkConfig('# just a comment\n'), {})

--- a/packages/framework/src/config.ts
+++ b/packages/framework/src/config.ts
@@ -18,6 +18,12 @@ export interface FrameworkFileConfig {
   event?: string
   /** Inject the built-in system prompt (#326, via #301). Default `true`; set false to remove it. */
   antiLazyPill?: boolean
+  /**
+   * Transparent mode (#625): make every run in this project a raw `claude -p` — no framework
+   * system prompt, no emit protocols, no consumption guard, no dashboard, no TODO loop. The
+   * coarse "only-pick-what-you-need" master off-switch, at the per-project tier. Default `false`.
+   */
+  transparent?: boolean
 }
 
 /** Config file names read from the workspace root, in precedence order. */
@@ -69,7 +75,7 @@ export function parseFrameworkConfig(raw: string, source = 'the-framework.yml'):
       config[key] = obj[key] as string
     }
   }
-  for (const key of ['autopilot', 'technical', 'antiLazyPill'] as const) {
+  for (const key of ['autopilot', 'technical', 'antiLazyPill', 'transparent'] as const) {
     if (obj[key] !== undefined) {
       if (typeof obj[key] !== 'boolean') throw new Error(`${source}: "${key}" must be a boolean`)
       config[key] = obj[key] as boolean

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -62,6 +62,8 @@ test('startOptionFlags maps only enabled Global options to CLI flags (#314)', ()
   assert.deepEqual(startOptionFlags({ onBeforeMergeable: true }), ['--on-before-mergeable'])
   // Browser via chrome-devtools-mcp (#452): maps to --browser.
   assert.deepEqual(startOptionFlags({ browser: true }), ['--browser'])
+  // Transparent (#625): the master off-switch maps to --transparent.
+  assert.deepEqual(startOptionFlags({ transparent: true }), ['--transparent'])
   // Model (#628): maps to --model, trimmed; blank/whitespace is no choice -> no flag.
   assert.deepEqual(startOptionFlags({ model: 'opus' }), ['--model', 'opus'])
   assert.deepEqual(startOptionFlags({ model: '  sonnet  ' }), ['--model', 'sonnet'])

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -112,6 +112,7 @@ export function startOptionFlags(options: StartRunOptions): string[] {
   if (options.autopilot) flags.push('--autopilot')
   if (options.technical) flags.push('--technical')
   if (options.vanilla) flags.push('--vanilla')
+  if (options.transparent) flags.push('--transparent')
   if (options.eco?.autoPlanning) flags.push('--eco-auto-planning')
   if (options.eco?.autoResearch) flags.push('--eco-auto-research')
   if (options.eco?.autoMaintenance) flags.push('--eco-auto-maintenance')

--- a/packages/framework/src/dashboard/types.ts
+++ b/packages/framework/src/dashboard/types.ts
@@ -20,8 +20,10 @@ export interface StartRunOptions {
   autopilot?: boolean
   /** Technical mode: expose technical detail (preset-scoped). */
   technical?: boolean
-  /** Remove the built-in #326 system prompt entirely (raw Claude Code). */
+  /** Remove the built-in #326 system prompt entirely (keeps the emit contract so the dashboard still drives it). */
   vanilla?: boolean
+  /** Transparent mode (#625): run the wrapped agent fully raw (no framework system prompt, guard, dashboard, or TODO loop); maps to `--transparent`. */
+  transparent?: boolean
   /** Fine-grained #326 section drops to save tokens. */
   eco?: EcoOptions
   /** In-context directories (#439): each becomes a `--context <dir>` flag on the spawned run. */

--- a/packages/framework/src/prompt-run.test.ts
+++ b/packages/framework/src/prompt-run.test.ts
@@ -117,6 +117,26 @@ test('runPrompt with antiLazyPill false emits no built-in prompt even with eco s
   assert.ok(!sys.text.includes('## Analyze the user prompt'))
 })
 
+test('runPrompt under transparent emits an empty system channel and sends the prompt verbatim (#625)', async () => {
+  const events: FrameworkEvent[] = []
+  const driver = new FakeDriver({ turns: [{ text: 'done' }] })
+  await runPrompt({
+    prompt: 'just do this',
+    driver,
+    cwd: '/ws',
+    onEvent: e => events.push(e),
+    transparent: true,
+  })
+  const sys = events.find(e => e.kind === 'system-prompt') as { text: string } | undefined
+  assert.ok(sys)
+  assert.equal(sys.text, '') // no framework system channel at all — not even the emit protocols
+  const start = events.find(
+    (e): e is Extract<FrameworkEvent, { kind: 'driver' }> => e.kind === 'driver' && e.event.type === 'start',
+  )
+  assert.ok(start, 'the driver start event carries the user prompt')
+  if (start.event.type === 'start') assert.equal(start.event.prompt, 'just do this') // verbatim, not the template half
+})
+
 test('runPrompt pauses on a multi-select gate and continues with the pick (#331)', async () => {
   const events: FrameworkEvent[] = []
   const picks: ChoiceRequest[] = []

--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -40,6 +40,8 @@ export interface RunPromptOptions {
   systemPrompt?: string
   /** Include the built-in #326 system prompt. Default true (#301; the name is the historical config key). */
   antiLazyPill?: boolean
+  /** Transparent mode (#625): empty the system channel and pass the prompt verbatim (raw `claude -p`). */
+  transparent?: boolean
   /** Whether autopilot mode is on: steers the #326 prompt's maintenance stance (#325). Default false. */
   autopilot?: boolean
   /** Eco fine-grained control (#314): drop the enabled #326 sections to save tokens. */
@@ -87,11 +89,11 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
     prompt: opts.prompt,
     params: { autopilot: opts.autopilot === true, ...(opts.eco ? { eco: opts.eco } : {}) },
   }
-  const system = composeRunSystem({ antiLazyPill: opts.antiLazyPill, user: opts.systemPrompt, tf, context: opts.context })
+  const system = composeRunSystem({ antiLazyPill: opts.antiLazyPill, transparent: opts.transparent, user: opts.systemPrompt, tf, context: opts.context })
   // The template's `# User prompt` half carries the prompt (today it renders to
   // exactly `opts.prompt`; any framing Rom adds around the slot rides along). With
-  // the built-in prompt off, the raw prompt is sent as-is.
-  const firstPrompt = opts.antiLazyPill === false ? opts.prompt : renderSystemPrompt(tf).user
+  // the built-in prompt off (or transparent, #625), the raw prompt is sent as-is.
+  const firstPrompt = opts.transparent || opts.antiLazyPill === false ? opts.prompt : renderSystemPrompt(tf).user
 
   emitSessionStart({ emit, driver: opts.driver, cwd: opts.cwd, sessionLink: opts.sessionLink })
   // Surface the exact system prompt the agent runs under (#343). The user prompts

--- a/packages/framework/src/registry.test.ts
+++ b/packages/framework/src/registry.test.ts
@@ -191,6 +191,12 @@ test('writePreferences round-trips the notifyNewActivity toggle (#627)', async (
   assert.deepEqual(await readPreferences(fs, ENV), { notifyNewActivity: true })
 })
 
+test('writePreferences round-trips the transparent toggle (#625)', async () => {
+  const fs = memFs({ [FILE]: JSON.stringify([APP_A]) })
+  await writePreferences({ transparent: true }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { transparent: true })
+})
+
 test('writePreferences keeps the model string but drops a blank one (#628)', async () => {
   const fs = memFs({ [FILE]: JSON.stringify([APP_A]) })
   await writePreferences({ model: '  opus  ' }, fs, ENV)

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -55,6 +55,12 @@ export interface Preferences {
   onBeforeMergeableQuality?: boolean
   /** Give the agent a real browser via chrome-devtools-mcp during the run (#452); maps to `--browser`. */
   browser?: boolean
+  /**
+   * Transparent mode (#625): run the wrapped agent raw — no framework system prompt, emit
+   * protocols, consumption guard, dashboard, or TODO loop, so a run is identical to `claude -p`.
+   * The coarse master off-switch ("only pick what you need"); maps to `--transparent`. Absent = off.
+   */
+  transparent?: boolean
   /** Fire a browser notification when a new item lands on the "needs you" queue (#627). Absent = on. */
   notifyBrowser?: boolean
   /**
@@ -182,6 +188,7 @@ const PREFERENCE_KEYS = [
   'ecoMaintenance',
   'onBeforeMergeableQuality',
   'browser',
+  'transparent',
   'notifyBrowser',
   'notifyDiscord',
   'notifyNewActivity',

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -179,6 +179,12 @@ test('the run system channel is exactly composeRunSystem, with nothing appended 
   assert.equal(system(), composeRunSystem({ tf: { prompt: FAKE_INTENT, params: { autopilot: false } } }))
 })
 
+test('transparent empties the build-path system channel (#625)', async () => {
+  const { driver, system } = recordingDriver()
+  await runFramework({ intent: FAKE_INTENT, driver, cwd: '/tmp/ws', signals: FAKE_SIGNALS, transparent: true, onEvent: () => {} })
+  assert.equal(system(), '') // raw claude: no #326 block, no emit protocols
+})
+
 test('detected deps never reach the system channel (#547)', async () => {
   const { driver, system } = recordingDriver()
   // FAKE_SIGNALS carries vike-react + @prisma/client; none of it may frame the agent.

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -101,6 +101,8 @@ export interface RunFrameworkOptions {
    * is the historical config key: #326 is the anti-lazy-pill's (#297) successor.
    */
   antiLazyPill?: boolean
+  /** Transparent mode (#625): empty the system channel entirely (raw `claude -p`); overrides antiLazyPill/eco. */
+  transparent?: boolean
   /** Eco fine-grained control (#314): drop the enabled #326 sections to save tokens. */
   eco?: EcoOptions
   /** In-context directories (#439): added as one `Context:` line to the system prompt. */
@@ -284,6 +286,7 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
   // direct-prompt path so the two can never drift (the drift behind #500).
   const system = composeRunSystem({
     antiLazyPill: opts.antiLazyPill,
+    transparent: opts.transparent,
     user: opts.systemPrompt,
     tf,
     context: opts.context,

--- a/packages/framework/src/system-prompt.test.ts
+++ b/packages/framework/src/system-prompt.test.ts
@@ -249,3 +249,13 @@ test('composeRunSystem keeps the emit protocols even with the built-in prompt of
   assert.ok(!system.includes('# System prompt'), 'built-in #326 prompt is off')
   assert.equal(system, [AWAIT_PROTOCOL, SIGNAL_PROTOCOL].join('\n\n'))
 })
+
+test('composeRunSystem is empty under transparent mode — no prompt, no emit protocols (#625)', () => {
+  // Transparent (#625) is stronger than --vanilla: the whole system channel is dropped, protocols
+  // included, so the agent runs as raw `claude -p`. It overrides every other option.
+  assert.equal(composeRunSystem({ transparent: true }), '')
+  assert.equal(
+    composeRunSystem({ transparent: true, antiLazyPill: true, user: 'ignored', context: ['/work/api'] }),
+    '',
+  )
+})

--- a/packages/framework/src/system-prompt.ts
+++ b/packages/framework/src/system-prompt.ts
@@ -177,6 +177,15 @@ export interface SystemPromptOptions {
    * the block. Empty/absent adds nothing.
    */
   context?: readonly string[] | undefined
+  /**
+   * Transparent mode (#625): drop *everything* framework-authored from the system channel —
+   * the built-in prompt, the knowledge docs, AND the emit protocols — so the agent receives an
+   * empty system channel, byte-identical to raw `claude -p <prompt>`. This is stronger than
+   * `--vanilla` (which keeps the AWAIT/SIGNAL emit contract so the agent can still drive the
+   * dashboard's gates); transparent means there is no framework behavior left to signal to.
+   * Short-circuits {@link composeRunSystem}, so it overrides every other option here.
+   */
+  transparent?: boolean | undefined
 }
 
 /**
@@ -221,14 +230,17 @@ export type RunSystemOptions = SystemPromptOptions
  * inside the built-in-prompt branch.
  *
  * Order is fixed: the #326 prompt block (context / built-in prompt / user SYSTEM.md)
- * first, then the always-on emit protocols. Nothing else is appended — a
- * build run's system channel is exactly this (#547), which is what lets the dashboard
- * show the whole prompt before a run starts (#520). The protocols are unconditional —
- * they are the *emit contract* (how the agent signals an awaited choice and the
- * setSessionName()/setReadyForMerge() lifecycle), not prompt content — so the agent
- * needs them even with the built-in prompt off.
+ * first, then the emit protocols. Nothing else is appended — a build run's system channel
+ * is exactly this (#547), which is what lets the dashboard show the whole prompt before a run
+ * starts (#520). The protocols are otherwise unconditional — they are the *emit contract* (how
+ * the agent signals an awaited choice and the setSessionName()/setReadyForMerge() lifecycle),
+ * not prompt content — so the agent needs them even with the built-in prompt off (`--vanilla`).
+ *
+ * The one exception is transparent mode (#625): there is no framework behavior to signal to, so
+ * the whole channel is empty and the agent runs as raw `claude -p`.
  */
 export function composeRunSystem(opts: RunSystemOptions = {}): string {
+  if (opts.transparent) return ''
   const promptBlock = systemPromptBlock(opts)
   return [...(promptBlock ? [promptBlock] : []), AWAIT_PROTOCOL, SIGNAL_PROTOCOL].join('\n\n')
 }


### PR DESCRIPTION
Closes #625.

The 'only pick what you need' requirement at its extreme: a **transparent** mode where all framework features are off and a run is byte-identical to plain `claude -p <prompt>`.

> Heads-up for review: the keystone gates the **AWAIT/SIGNAL emit protocols** in `composeRunSystem` (the system-prompt composition). Flagging since that's the system-channel path.

### What transparent turns off
When `--transparent` (or the-framework.yml / the pref) is on, the run gets: no framework system prompt, **no AWAIT/SIGNAL emit protocols**, no consumption guard, no dashboard, no TODO loop. `composeRunSystem` returns `''` — the single place the whole system channel is assembled, so build and direct-prompt paths can't drift.

### Also fixes: `--vanilla` was mis-advertised
`--vanilla`'s help claimed 'fully transparent', but it still injected AWAIT/SIGNAL (deliberately, per #500/#463 - so the agent can drive the dashboard's gates). That contract stays on `--vanilla`; `--transparent` is the new switch that drops it too. Help text corrected.

### Three tiers (no parallel config system, rides the existing surfaces)
- **Per run**: `--transparent` flag.
- **Per project**: `the-framework.yml` `transparent: true`.
- **Per user**: `transparent` preference -> the **Transparent** toggle in the dashboard run options. It overrides the other option toggles (they grey out), and the 'Actual prompt' preview (#520) shows the empty channel via the same `composeRunSystem`.

### Scope note
Run recording (`.the-framework/`, LOGS.md, event stream) stays on under transparent: it doesn't change what the agent receives, only what we observe. The guarantee is about the agent's input/behavior being raw.

### Tests
- framework: composeRunSystem empty under transparent; the-framework.yml `transparent` parse; parseArgs `--transparent`; registry round-trip; startOptionFlags `--transparent`; end-to-end empty system channel on both the build path (run.test) and direct path (prompt-run.test, incl. prompt sent verbatim). Typecheck + build clean.
- dashboard: SystemPromptDisclosure shows the empty channel under transparent; full vitest 67 green; typecheck clean.

Minor changeset on `@gemstack/framework` (dashboard bundled).