### PR TITLE
feat(framework): Serve action picks a server in a multi-package repo (#651)

### DIFF
--- a/.changeset/serve-multi-server-picker.md
+++ b/.changeset/serve-multi-server-picker.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Serve action: pick a server in a multi-package repo (#651). The dashboard's Serve button previously ran the first `dev`/`start`/`preview`/`serve` script from the repo root, which serves nothing (or the wrong thing) in a monorepo where the apps live in workspace packages. It now lists the servable apps across the repo, the root plus each workspace package that has a serve script (resolved from `pnpm-workspace.yaml` or the package.json `workspaces` field), and offers a picker when there is more than one. The daemon remembers the last pick per project so re-serving is one click. A single-app repo is unchanged.

--- a/packages/framework-dashboard/components/PreviewBar.test.tsx
+++ b/packages/framework-dashboard/components/PreviewBar.test.tsx
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+// Mock the telefunc shim so the component's RPCs are observable without a daemon.
+const sendPreview = vi.fn(async () => ({ ok: true as const, url: 'http://localhost:5173', command: 'dev' }))
+const onServeTargets = vi.fn(async () => [] as { id: string; label: string; dir: string; script: string }[])
+const onPreviewStatus = vi.fn(async () => ({ running: false }))
+const sendStopPreview = vi.fn(async () => {})
+vi.mock('../server/control.telefunc.js', () => ({ sendPreview, onServeTargets, onPreviewStatus, sendStopPreview }))
+
+const { PreviewBar } = await import('./PreviewBar.js')
+
+beforeEach(() => {
+  sendPreview.mockClear()
+  onServeTargets.mockClear()
+  onPreviewStatus.mockClear()
+})
+afterEach(cleanup)
+
+const twoTargets = [
+  { id: 'apps/web', label: 'web', dir: 'apps/web', script: 'dev' },
+  { id: 'apps/api', label: 'api', dir: 'apps/api', script: 'start' },
+]
+
+describe('PreviewBar serve picker (#651)', () => {
+  test('a single-target repo shows one plain Serve button that serves the default', async () => {
+    onServeTargets.mockResolvedValueOnce([{ id: '.', label: 'app', dir: '', script: 'dev' }])
+    render(<PreviewBar projectId="p1" inline />)
+    await waitFor(() => expect(onServeTargets).toHaveBeenCalled())
+    // One target → a single Serve button (no caret split control).
+    expect(screen.getAllByRole('button')).toHaveLength(1)
+    fireEvent.click(screen.getByRole('button'))
+    // No target id → the daemon serves the root/remembered default.
+    await waitFor(() => expect(sendPreview).toHaveBeenCalledWith('p1', undefined))
+  })
+
+  test('a multi-target repo offers a picker; choosing an app serves that target', async () => {
+    onServeTargets.mockResolvedValueOnce(twoTargets)
+    render(<PreviewBar projectId="p2" inline />)
+    // >1 target → a split control: [primary Serve, caret picker].
+    await waitFor(() => expect(screen.getAllByRole('button')).toHaveLength(2))
+    fireEvent.click(screen.getAllByRole('button')[1]!) // open the caret dropdown
+    fireEvent.click(await screen.findByText('api'))
+    await waitFor(() => expect(sendPreview).toHaveBeenCalledWith('p2', 'apps/api'))
+  })
+
+  test('the multi-target primary button serves the last pick (no explicit id)', async () => {
+    onServeTargets.mockResolvedValueOnce(twoTargets)
+    render(<PreviewBar projectId="p3" inline />)
+    await waitFor(() => expect(screen.getAllByRole('button')).toHaveLength(2))
+    fireEvent.click(screen.getAllByRole('button')[0]!) // the primary Serve
+    await waitFor(() => expect(sendPreview).toHaveBeenCalledWith('p3', undefined))
+  })
+})

--- a/packages/framework-dashboard/components/PreviewBar.tsx
+++ b/packages/framework-dashboard/components/PreviewBar.tsx
@@ -1,38 +1,51 @@
 import { useEffect, useState } from 'react'
-import { Play, ExternalLink, Square } from 'lucide-react'
-import { sendPreview, sendStopPreview, onPreviewStatus } from '../server/control.telefunc.js'
+import { Play, ExternalLink, Square, ChevronDown } from 'lucide-react'
+import type { ServeTarget } from '@gemstack/framework'
+import { sendPreview, onServeTargets, sendStopPreview, onPreviewStatus } from '../server/control.telefunc.js'
 import { useAction } from '../lib/use-action.js'
 import { Button } from './ui/button.js'
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './ui/tooltip.js'
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuGroup, DropdownMenuLabel } from './ui/dropdown-menu.js'
 
 // On-demand app Serve (#475): a per-project button that serves the project's built result
 // (its dev script, else a static server) and surfaces the live URL + a Stop. Independent of
 // any agent run — it closes the "let me see what it produced" loop with one click, useful for
 // non-technical users too. State lives daemon-side, so a reload rehydrates via onPreviewStatus.
 // `inline` renders just the control (for the project action bar); otherwise a full labelled row.
+//
+// Multi-package repos (#651): a monorepo has several servable apps, so onServeTargets lists them
+// and the Serve button becomes a split control — the primary serves the last pick (the daemon
+// remembers), a caret opens the picker. A single-app repo keeps the plain one-click button.
 export function PreviewBar({ projectId, inline = false }: { projectId: string; inline?: boolean }) {
   const [url, setUrl] = useState<string | null>(null)
   const [command, setCommand] = useState<string | null>(null)
+  const [targets, setTargets] = useState<ServeTarget[]>([])
   const { busy, error, reset, run } = useAction()
 
-  // Rehydrate on load / project switch: reflect a preview the daemon is already serving.
+  // Rehydrate on load / project switch: reflect a preview the daemon is already serving, and
+  // list the project's servable apps so the picker knows whether to offer a choice.
   useEffect(() => {
     let live = true
     setUrl(null)
     setCommand(null)
+    setTargets([])
     reset()
     void onPreviewStatus(projectId).then(status => {
       if (!live || !status.running) return
       setUrl(status.url ?? null)
       setCommand(status.command ?? null)
     })
+    void onServeTargets(projectId).then(list => {
+      if (live) setTargets(list)
+    })
     return () => {
       live = false
     }
   }, [projectId, reset])
 
-  const open = async () => {
-    const result = await run(() => sendPreview(projectId), 'Failed to start the preview.')
+  // Serve the given app (or the daemon's remembered/default one when no id is passed).
+  const open = async (targetId?: string) => {
+    const result = await run(() => sendPreview(projectId, targetId), 'Failed to start the preview.')
     if (result?.ok) {
       setUrl(result.url)
       setCommand(result.command)
@@ -50,9 +63,9 @@ export function PreviewBar({ projectId, inline = false }: { projectId: string; i
     }
   }
 
-  // The control (all icon-only, h-9 to match the other actions): a single Serve button when
-  // stopped; once serving, a segmented pair — Open (the live URL ↗) joined to a Stop (⏹) that
-  // collapses it back to Serve. Each segment carries a tooltip.
+  // The control (all icon-only, h-7 to match the other actions): once serving, a segmented pair —
+  // Open (the live URL ↗) joined to a Stop (⏹). When stopped, a plain Serve button, or — in a
+  // multi-package repo — a split Serve + caret picker over the servable apps.
   const controls = (
     <TooltipProvider delay={300} closeDelay={0}>
       {url ? (
@@ -88,6 +101,51 @@ export function PreviewBar({ projectId, inline = false }: { projectId: string; i
             </TooltipTrigger>
             <TooltipContent>Stop serving</TooltipContent>
           </Tooltip>
+        </div>
+      ) : targets.length > 1 ? (
+        <div className="inline-flex h-7 items-center overflow-hidden rounded-md border border-border">
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  onClick={() => void open()}
+                  disabled={busy}
+                  className="flex h-full items-center px-2 hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+                />
+              }
+            >
+              <Play className="h-3.5 w-3.5" />
+            </TooltipTrigger>
+            <TooltipContent>{busy ? 'Starting…' : 'Serve the last app'}</TooltipContent>
+          </Tooltip>
+          <span className="h-full w-px bg-border" />
+          <DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <DropdownMenuTrigger
+                    disabled={busy}
+                    className="flex h-full items-center px-1.5 hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+                  />
+                }
+              >
+                <ChevronDown className="h-3.5 w-3.5" />
+              </TooltipTrigger>
+              <TooltipContent>Pick an app to serve</TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent align="end">
+              <DropdownMenuGroup>
+                <DropdownMenuLabel>Serve which app</DropdownMenuLabel>
+                {targets.map(t => (
+                  <DropdownMenuItem key={t.id} onClick={() => void open(t.id)}>
+                    <span className="truncate">{t.label}</span>
+                    <span className="ml-auto pl-3 text-xs text-muted-foreground">{t.script}</span>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       ) : (
         <Tooltip>

--- a/packages/framework-dashboard/server/control.telefunc.ts
+++ b/packages/framework-dashboard/server/control.telefunc.ts
@@ -1,4 +1,4 @@
 // Re-export shim (#405): the steering telefunctions live in @gemstack/framework so the
 // daemon serves them in-process. The file path keeps the baked RPC key
 // `/server/control.telefunc.ts`. See framework's dashboard-rpc/register.ts.
-export { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus, sendOpenInApp } from '@gemstack/framework/dashboard-rpc'
+export { sendStop, sendChoice, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp } from '@gemstack/framework/dashboard-rpc'

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -286,6 +286,43 @@ test('runDaemon comes up on a fresh workspace with no .the-framework yet', async
   }
 })
 
+test('onServeTargets lists a monorepo\'s servable apps over telefunc (#651)', async () => {
+  const cwd = await tmpWorkspace()
+  // A monorepo whose root has no serve script; two workspace apps do, one package does not.
+  await writeFile(join(cwd, 'package.json'), JSON.stringify({ name: 'mono', scripts: { build: 'turbo build' } }))
+  await writeFile(join(cwd, 'pnpm-workspace.yaml'), 'packages:\n  - "apps/*"\n  - "packages/*"\n')
+  await mkdir(join(cwd, 'apps', 'web'), { recursive: true })
+  await writeFile(join(cwd, 'apps', 'web', 'package.json'), JSON.stringify({ name: 'web', scripts: { dev: 'vite' } }))
+  await mkdir(join(cwd, 'apps', 'api'), { recursive: true })
+  await writeFile(join(cwd, 'apps', 'api', 'package.json'), JSON.stringify({ name: 'api', scripts: { start: 'node .' } }))
+  await mkdir(join(cwd, 'packages', 'lib'), { recursive: true })
+  await writeFile(join(cwd, 'packages', 'lib', 'package.json'), JSON.stringify({ name: 'lib', scripts: { build: 'tsc' } }))
+  const env = await configEnv(cwd)
+  const ac = new AbortController()
+  try {
+    const done = runDaemon(cwd, { port: 0, signal: ac.signal, env })
+    let state = await readDaemonState(env)
+    for (let i = 0; i < 100 && !state; i++) {
+      await new Promise(r => setTimeout(r, 20))
+      state = await readDaemonState(env)
+    }
+    assert.ok(state, 'daemon wrote its state file')
+    const targets = (await callTelefunc(state!.url, '/server/control.telefunc.ts', 'onServeTargets', [
+      homeId(cwd),
+    ])) as Array<{ id: string; label: string; script: string }>
+    assert.deepEqual(
+      targets.map(t => `${t.id}:${t.script}`),
+      ['apps/api:start', 'apps/web:dev'],
+      'lists only servable workspace apps, sorted; the non-servable package is excluded',
+    )
+    ac.abort()
+    await done
+  } finally {
+    ac.abort()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
 test('sendStart spawns the run child (prompt, --no-dashboard, --cwd) one at a time (#345)', async () => {
   const cwd = await tmpWorkspace()
   // A stub CLI standing in for the framework bin: it records its argv, then

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -7,7 +7,7 @@ import { startDashboard, type Dashboard, type StartRunKind, type StartRunOptions
 import { startInterventionWatcher, postDiscord, type InterventionWatcher } from './dashboard/intervention-watcher.js'
 import { buildInterventions } from './dashboard/interventions.js'
 import { startActivityWatcher, postActivityDiscord, type ActivityWatcher } from './dashboard/activity-watcher.js'
-import { startPreview, type PreviewHandle } from './preview.js'
+import { startPreview, detectServeTargets, type PreviewHandle, type ServeTarget } from './preview.js'
 import { resolveDashboardBundle } from './dashboard/bundle.js'
 import { isActivated } from './project.js'
 import { addProject, listProjects, projectId, readPreferences } from './registry.js'
@@ -346,6 +346,7 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     onStart: runtime.onStart,
     onAddProject: runtime.onAddProject,
     onPreview: runtime.onPreview,
+    onServeTargets: runtime.onServeTargets,
     onStopPreview: runtime.onStopPreview,
     onPreviewStatus: runtime.onPreviewStatus,
     ...(clientBundleDir ? { clientBundleDir } : {}),
@@ -430,7 +431,8 @@ interface ProjectRuntimeOptions {
 interface ProjectRuntime {
   onStart: (prompt: string, kind: StartRunKind, options?: StartRunOptions, targetProjectId?: string) => Promise<StartRunResult>
   onAddProject: (path: string, directory: boolean) => Promise<AddProjectResult>
-  onPreview: (targetProjectId?: string) => Promise<PreviewResult>
+  onPreview: (targetProjectId?: string, targetId?: string) => Promise<PreviewResult>
+  onServeTargets: (targetProjectId?: string) => Promise<ServeTarget[]>
   onStopPreview: (targetProjectId?: string) => Promise<void>
   onPreviewStatus: (targetProjectId?: string) => PreviewStatus
   /** Stop every live preview so their dev servers do not outlive the daemon (#475). */
@@ -542,20 +544,33 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
       if (activePreviews.get(key) === handle) activePreviews.delete(key)
     })
   }
-  const onPreview = async (targetProjectId?: string): Promise<PreviewResult> => {
+  // The app the user last served per project (#651), so re-serving a monorepo picks it again
+  // without re-choosing. In-memory: a live preview already rehydrates via onPreviewStatus, and
+  // the pick resets on daemon restart (the picker still lists everything).
+  const lastServeTarget = new Map<string, string>()
+  const onServeTargets = async (targetProjectId?: string): Promise<ServeTarget[]> => {
+    const projectCwd = await resolveProject(targetProjectId)
+    return projectCwd ? detectServeTargets(projectCwd).catch(() => []) : []
+  }
+  const onPreview = async (targetProjectId?: string, targetId?: string): Promise<PreviewResult> => {
     const key = targetProjectId ?? homeId
     const existing = activePreviews.get(key)
     if (existing) return { ok: true, url: existing.url, command: existing.command }
     const projectCwd = await resolveProject(targetProjectId)
     if (!projectCwd) return { ok: false, error: `unknown project: ${targetProjectId}` }
     try {
-      const handle = await startPreview({ cwd: projectCwd })
+      // Resolve the pick: an explicit choice, else the one remembered from last time. Both are
+      // matched against the live target list so a stale/unknown id falls back to the root default.
+      const wantId = targetId ?? lastServeTarget.get(key)
+      const target = wantId ? (await detectServeTargets(projectCwd).catch(() => [])).find(t => t.id === wantId) : undefined
+      const handle = await startPreview(target ? { cwd: projectCwd, target } : { cwd: projectCwd })
       // A racing second open won the slot while we were booting: keep theirs, drop ours.
       const raced = activePreviews.get(key)
       if (raced) {
         await handle.stop().catch(() => {})
         return { ok: true, url: raced.url, command: raced.command }
       }
+      if (target) lastServeTarget.set(key, target.id)
       trackPreview(key, handle)
       return { ok: true, url: handle.url, command: handle.command }
     } catch (err) {
@@ -579,7 +594,7 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
     activePreviews.clear()
   }
 
-  return { onStart, onAddProject, onPreview, onStopPreview, onPreviewStatus, dispose }
+  return { onStart, onAddProject, onPreview, onServeTargets, onStopPreview, onPreviewStatus, dispose }
 }
 
 /** Resolve on SIGINT/SIGTERM, or when the optional abort signal fires. */

--- a/packages/framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/control.telefunc.ts
@@ -4,6 +4,7 @@ import { openInApp, type OpenTarget, type OpenResult } from '../dashboard/open-i
 import { resolveProjectPath } from './context.js'
 import type { ChoiceBy } from '../events.js'
 import type { PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from '../dashboard/types.js'
+import type { ServeTarget } from '../preview.js'
 import type { DashboardContext } from '../dashboard/telefunc-serve.js'
 
 // The write side behind the new dashboard (#405): steering a live run. The reverse of
@@ -62,10 +63,21 @@ export async function sendStart(
  * (like `sendStart`). Idempotent — opening while a preview is up returns the running one.
  * Returns an error result when Preview is not enabled on this host (the relay/per-run view).
  */
-export async function sendPreview(projectId: string): Promise<PreviewResult> {
+export async function sendPreview(projectId: string, targetId?: string): Promise<PreviewResult> {
   const { preview } = getContext<DashboardContext>()
   if (!preview) return { ok: false, error: 'preview is not enabled on this server' }
-  return preview.start(projectId)
+  return preview.start(projectId, targetId)
+}
+
+/**
+ * List a project's servable apps (#651) for the Serve picker: the root plus each workspace package
+ * that has a dev/serve script. A single-package repo returns at most one, so the button stays a
+ * plain Serve; a monorepo returns several to choose from. Empty when Preview is not enabled.
+ */
+export async function onServeTargets(projectId: string): Promise<ServeTarget[]> {
+  const { preview } = getContext<DashboardContext>()
+  if (!preview) return []
+  return preview.targets(projectId)
 }
 
 /** Stop a project's Preview (#475). A no-op when none is running, or Preview is not enabled. */

--- a/packages/framework/src/dashboard-rpc/index.ts
+++ b/packages/framework/src/dashboard-rpc/index.ts
@@ -3,7 +3,7 @@
 // wiring) can reach the daemon's `startRun`; the framework-dashboard client imports
 // these through thin re-export shims so the baked RPC keys stay `/server/*.telefunc.ts`.
 export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from './reads.telefunc.js'
-export { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
+export { sendStop, sendChoice, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
 export { onEvents } from './events.telefunc.js'
 export { onProjects, sendAddProject } from './projects.telefunc.js'
 export { onPreferences, savePreferences, type SavePreferencesResult } from './preferences.telefunc.js'

--- a/packages/framework/src/dashboard-rpc/register.ts
+++ b/packages/framework/src/dashboard-rpc/register.ts
@@ -1,6 +1,6 @@
 import { __decorateTelefunction } from 'telefunc'
 import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from './reads.telefunc.js'
-import { sendStop, sendChoice, sendStart, sendPreview, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
+import { sendStop, sendChoice, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
 import { onEvents } from './events.telefunc.js'
 import { onProjects, sendAddProject } from './projects.telefunc.js'
 import { onPreferences, savePreferences } from './preferences.telefunc.js'
@@ -50,6 +50,7 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(sendChoice, 'sendChoice', control)
   reg(sendStart, 'sendStart', control)
   reg(sendPreview, 'sendPreview', control)
+  reg(onServeTargets, 'onServeTargets', control)
   reg(sendStopPreview, 'sendStopPreview', control)
   reg(onPreviewStatus, 'onPreviewStatus', control)
   reg(sendOpenInApp, 'sendOpenInApp', control)

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -6,6 +6,7 @@ import { defaultQuotaSource, type QuotaSource } from './quota.js'
 import { serveClientBundle } from './static.js'
 import { makeTelefuncMount } from './telefunc-serve.js'
 import type { AddProjectResult, PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from './types.js'
+import type { ServeTarget } from '../preview.js'
 
 /** Options for {@link startDashboard}. */
 export interface DashboardOptions {
@@ -45,7 +46,10 @@ export interface DashboardOptions {
    * per-run dashboard and the relay never serve one). {@link onStopPreview} tears it down and
    * {@link onPreviewStatus} rehydrates the button after a reload.
    */
-  onPreview?: (projectId?: string) => PreviewResult | Promise<PreviewResult>
+  onPreview?: (projectId?: string, targetId?: string) => PreviewResult | Promise<PreviewResult>
+  /** Called to list a project's servable apps (#651) so the Serve button can offer a picker in a
+   * multi-package repo. Omit alongside {@link onPreview} to disable Preview entirely. */
+  onServeTargets?: (projectId?: string) => ServeTarget[] | Promise<ServeTarget[]>
   /** Called when the browser stops a project's Preview (#475). No-op when none is running. */
   onStopPreview?: (projectId?: string) => void | Promise<void>
   /** Called on load to reflect whether a project's Preview is already running (#475). */
@@ -107,7 +111,12 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
   // Bundle the three Preview callbacks (#475) into one context handler set, present only
   // when the host wired a Preview (the daemon does; the relay/per-run dashboard do not).
   const preview = opts.onPreview
-    ? { start: opts.onPreview, stop: opts.onStopPreview ?? (() => {}), status: opts.onPreviewStatus ?? (() => ({ running: false })) }
+    ? {
+        start: opts.onPreview,
+        targets: opts.onServeTargets ?? (() => []),
+        stop: opts.onStopPreview ?? (() => {}),
+        status: opts.onPreviewStatus ?? (() => ({ running: false })),
+      }
     : undefined
   // The usage panel polls for the dashboard's whole life, not just during a run:
   // it has to show where the account stands while nothing is running (#533).

--- a/packages/framework/src/dashboard/telefunc-serve.ts
+++ b/packages/framework/src/dashboard/telefunc-serve.ts
@@ -7,6 +7,7 @@ import type { FrameworkEvent } from '../events.js'
 import type { PreferencesStore } from '../registry.js'
 import type { QuotaSource } from './quota.js'
 import type { AddProjectResult, PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from './types.js'
+import type { ServeTarget } from '../preview.js'
 
 /** Wired by the daemon so `sendStart` can reach the daemon's own `startRun` closure. */
 export type StartRunHandler = (
@@ -21,7 +22,9 @@ export type AddProjectHandler = (path: string, directory: boolean) => AddProject
 
 /** Wired by the daemon so the Preview RPCs can serve/stop/report a project's app (#475). */
 export interface PreviewHandlers {
-  start: (projectId?: string) => PreviewResult | Promise<PreviewResult>
+  start: (projectId?: string, targetId?: string) => PreviewResult | Promise<PreviewResult>
+  /** List the project's servable apps (#651) for the Serve picker in a multi-package repo. */
+  targets: (projectId?: string) => ServeTarget[] | Promise<ServeTarget[]>
   stop: (projectId?: string) => void | Promise<void>
   status: (projectId?: string) => PreviewStatus | Promise<PreviewStatus>
 }

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -131,7 +131,7 @@ export {
   type MaintenanceFs,
 } from './maintenance.js'
 export { startDashboard, summarizeProject, defaultProjectsProvider, readDocs, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunResult, type AddProjectResult, type PreviewResult, type PreviewStatus, type ProjectSummary, type ProjectsProvider, type SummarizeDeps, type WorkspaceDoc, type ProjectQueue, type QueueItem, type Overview, type ActiveRun, type RecentProject, type DashboardData, type ProjectStat, type ActivityDay, type GitStatus, type LinkedPr, buildInterventions, nodeGhPrLister, type Intervention, type OpenPr, type PrLister, type InterventionsDeps, buildActivity, activityKey, pickNewActivity, type Activity, type ActivityDeps } from './dashboard/index.js'
-export { startPreview, detectDevScript, parsePreviewUrl, PREVIEW_SCRIPTS, type PreviewHandle, type StartPreviewOptions } from './preview.js'
+export { startPreview, detectDevScript, detectServeTargets, parsePreviewUrl, PREVIEW_SCRIPTS, type PreviewHandle, type StartPreviewOptions, type ServeTarget } from './preview.js'
 export {
   RunStore,
   nodeStoreFs,

--- a/packages/framework/src/preview.test.ts
+++ b/packages/framework/src/preview.test.ts
@@ -1,9 +1,9 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { detectDevScript, parsePreviewUrl, startPreview, PREVIEW_SCRIPTS } from './preview.js'
+import { detectDevScript, detectServeTargets, parsePreviewUrl, startPreview, PREVIEW_SCRIPTS } from './preview.js'
 
 async function withTmp(prefix: string, fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await mkdtemp(join(tmpdir(), `framework-${prefix}-`))
@@ -12,6 +12,12 @@ async function withTmp(prefix: string, fn: (dir: string) => Promise<void>): Prom
   } finally {
     await rm(dir, { recursive: true, force: true })
   }
+}
+
+/** Write a `package.json` (creating the dir) with the given fields. */
+async function writePkg(dir: string, pkg: Record<string, unknown>): Promise<void> {
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, 'package.json'), JSON.stringify(pkg))
 }
 
 test('parsePreviewUrl reads the first localhost URL a dev server prints', () => {
@@ -83,5 +89,80 @@ test('a preview handle resolves `exited` on stop, and reopening rebinds cleanly'
 test('startPreview throws when there is nothing to serve', async () => {
   await withTmp('empty', async dir => {
     await assert.rejects(startPreview({ cwd: dir }), /nothing to preview/)
+  })
+})
+
+test('detectServeTargets: a single-package repo yields just the root, labelled by name', async () => {
+  await withTmp('targets-single', async dir => {
+    await writePkg(dir, { name: 'my-app', scripts: { dev: 'vite' } })
+    const targets = await detectServeTargets(dir)
+    assert.deepEqual(targets, [{ id: '.', label: 'my-app', dir: '', script: 'dev' }])
+  })
+})
+
+test('detectServeTargets: a root with no serve script yields nothing', async () => {
+  await withTmp('targets-noroot', async dir => {
+    await writePkg(dir, { name: 'x', scripts: { build: 'tsc', test: 'node' } })
+    assert.deepEqual(await detectServeTargets(dir), [])
+  })
+})
+
+test('detectServeTargets: pnpm workspaces list each servable package, root first then sorted', async () => {
+  await withTmp('targets-pnpm', async dir => {
+    // Root has no serve script; the two workspace apps do (one lacks a name → dir basename label).
+    await writePkg(dir, { name: 'monorepo', scripts: { build: 'turbo build' } })
+    await writeFile(join(dir, 'pnpm-workspace.yaml'), 'packages:\n  - "apps/*"\n  - "packages/*"\n')
+    await writePkg(join(dir, 'apps', 'web'), { name: '@acme/web', scripts: { dev: 'vite' } })
+    await writePkg(join(dir, 'apps', 'api'), { scripts: { start: 'node server.js' } })
+    await writePkg(join(dir, 'packages', 'lib'), { name: '@acme/lib', scripts: { build: 'tsc' } }) // no serve script → excluded
+    const targets = await detectServeTargets(dir)
+    assert.deepEqual(targets, [
+      { id: 'apps/api', label: 'api', dir: 'apps/api', script: 'start' },
+      { id: 'apps/web', label: '@acme/web', dir: 'apps/web', script: 'dev' },
+    ])
+  })
+})
+
+test('detectServeTargets: root with its own serve script comes first, ahead of workspaces', async () => {
+  await withTmp('targets-rootfirst', async dir => {
+    await writePkg(dir, { name: 'root-app', scripts: { dev: 'vite' } })
+    await writeFile(join(dir, 'pnpm-workspace.yaml'), 'packages:\n  - "apps/*"\n')
+    await writePkg(join(dir, 'apps', 'web'), { name: 'web', scripts: { dev: 'vite' } })
+    const targets = await detectServeTargets(dir)
+    assert.deepEqual(targets.map(t => t.id), ['.', 'apps/web'])
+  })
+})
+
+test('detectServeTargets: npm/yarn `workspaces` field (array and {packages})', async () => {
+  await withTmp('targets-npm-array', async dir => {
+    await writePkg(dir, { name: 'r', workspaces: ['apps/*'], scripts: { build: 'x' } })
+    await writePkg(join(dir, 'apps', 'site'), { name: 'site', scripts: { serve: 'http-server' } })
+    assert.deepEqual((await detectServeTargets(dir)).map(t => t.id), ['apps/site'])
+  })
+  await withTmp('targets-npm-obj', async dir => {
+    await writePkg(dir, { name: 'r', workspaces: { packages: ['apps/*'] }, scripts: { build: 'x' } })
+    await writePkg(join(dir, 'apps', 'site'), { name: 'site', scripts: { preview: 'vite preview' } })
+    assert.deepEqual((await detectServeTargets(dir)).map(t => t.script), ['preview'])
+  })
+})
+
+test('detectServeTargets: a trailing ** glob matches nested packages, node_modules skipped', async () => {
+  await withTmp('targets-globstar', async dir => {
+    await writePkg(dir, { name: 'r', scripts: { build: 'x' } })
+    await writeFile(join(dir, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/**"\n')
+    await writePkg(join(dir, 'packages', 'a'), { name: 'a', scripts: { dev: 'vite' } })
+    await writePkg(join(dir, 'packages', 'group', 'b'), { name: 'b', scripts: { dev: 'vite' } })
+    await writePkg(join(dir, 'packages', 'node_modules', 'dep'), { name: 'dep', scripts: { dev: 'x' } }) // must be skipped
+    const ids = (await detectServeTargets(dir)).map(t => t.id).sort()
+    assert.deepEqual(ids, ['packages/a', 'packages/group/b'])
+  })
+})
+
+test('detectServeTargets: a literal (non-glob) workspace entry resolves directly', async () => {
+  await withTmp('targets-literal', async dir => {
+    await writePkg(dir, { name: 'r', scripts: { build: 'x' } })
+    await writeFile(join(dir, 'pnpm-workspace.yaml'), 'packages:\n  - "docs"\n')
+    await writePkg(join(dir, 'docs'), { name: 'docs', scripts: { dev: 'vitepress' } })
+    assert.deepEqual((await detectServeTargets(dir)).map(t => t.id), ['docs'])
   })
 })

--- a/packages/framework/src/preview.ts
+++ b/packages/framework/src/preview.ts
@@ -1,8 +1,9 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { createServer } from 'node:http'
 import { createReadStream } from 'node:fs'
-import { readFile, stat } from 'node:fs/promises'
-import { join, normalize, sep } from 'node:path'
+import { readFile, readdir, stat } from 'node:fs/promises'
+import { basename, join, normalize, sep } from 'node:path'
+import { parse as parseYaml } from 'yaml'
 import type { ServerResponse } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { contentTypeFor } from './dashboard/content-type.js'
@@ -37,6 +38,11 @@ export interface PreviewHandle {
 export interface StartPreviewOptions {
   /** The project directory to serve. */
   cwd: string
+  /**
+   * Which app to serve in a multi-package repo (#651), from {@link detectServeTargets}. Absent
+   * serves the root package (the single-package default), preserving the original behavior.
+   */
+  target?: ServeTarget
   /** How long to wait for a dev script to print its localhost URL before giving up. Default 20s. */
   waitMs?: number
 }
@@ -44,16 +50,160 @@ export interface StartPreviewOptions {
 /** The npm scripts we try, best-first, when serving a project's dev preview. */
 export const PREVIEW_SCRIPTS = ['dev', 'start', 'preview', 'serve'] as const
 
+/** The first {@link PREVIEW_SCRIPTS} entry a `package.json`'s `scripts` defines, else undefined. */
+function pickScript(scripts: Record<string, unknown> | undefined): string | undefined {
+  const s = scripts ?? {}
+  return PREVIEW_SCRIPTS.find(name => typeof s[name] === 'string' && (s[name] as string).trim() !== '')
+}
+
 /** The first {@link PREVIEW_SCRIPTS} entry the project's `package.json` defines, else undefined. */
 export async function detectDevScript(cwd: string): Promise<string | undefined> {
-  let pkg: { scripts?: Record<string, unknown> }
-  try {
-    pkg = JSON.parse(await readFile(join(cwd, 'package.json'), 'utf8')) as { scripts?: Record<string, unknown> }
-  } catch {
-    return undefined // no package.json, or it is unreadable/malformed
+  return pickScript((await readPkg(cwd))?.scripts)
+}
+
+/**
+ * One servable app in a repo (#651): a package that defines a dev/serve script. Plain repos
+ * have exactly one (the root); a monorepo has one per workspace package that can serve, and
+ * the dashboard offers a picker over them.
+ */
+export interface ServeTarget {
+  /** Stable id = the dir relative to the repo root, or `.` for the root package itself. */
+  id: string
+  /** Human label: the package.json `name`, else the directory basename (`.` → `root`). */
+  label: string
+  /** The dir to run the script in, relative to the repo root (`''` = the root). */
+  dir: string
+  /** The npm script that serves it (a {@link PREVIEW_SCRIPTS} entry). */
+  script: string
+}
+
+/** How many workspace packages we scan / offer, so a pathological monorepo can't hang or flood the picker. */
+const MAX_SERVE_TARGETS = 50
+
+/**
+ * Enumerate the repo's servable apps (#651), best-first: the root package (when it has a serve
+ * script) followed by each workspace package that has one, in path order. A plain single-package
+ * repo yields at most one target (the root); a monorepo yields one per servable workspace so the
+ * Serve button can offer a pick. Workspaces come from `pnpm-workspace.yaml` or the package.json
+ * `workspaces` field; unreadable/absent config just yields the root (or nothing).
+ */
+export async function detectServeTargets(cwd: string): Promise<ServeTarget[]> {
+  const targets: ServeTarget[] = []
+  const seen = new Set<string>()
+  const add = async (dir: string): Promise<void> => {
+    const abs = dir === '' ? cwd : join(cwd, dir)
+    if (seen.has(abs)) return
+    seen.add(abs)
+    const pkg = await readPkg(abs)
+    const script = pickScript(pkg?.scripts)
+    if (!script) return
+    targets.push({ id: dir === '' ? '.' : dir, label: serveLabel(pkg?.name, dir), dir, script })
   }
-  const scripts = pkg.scripts ?? {}
-  return PREVIEW_SCRIPTS.find(name => typeof scripts[name] === 'string' && (scripts[name] as string).trim() !== '')
+  await add('')
+  const rootPkg = await readPkg(cwd)
+  for (const dir of await workspaceDirs(cwd, rootPkg)) {
+    if (targets.length >= MAX_SERVE_TARGETS) break
+    await add(dir)
+  }
+  return targets
+}
+
+/** A target's display label: its package name, else the dir basename (`.`/root → `root`). */
+function serveLabel(name: unknown, dir: string): string {
+  if (typeof name === 'string' && name.trim() !== '') return name.trim()
+  const base = basename(dir)
+  return base === '' || base === '.' ? 'root' : base
+}
+
+interface PkgJson {
+  name?: unknown
+  scripts?: Record<string, unknown>
+  workspaces?: unknown
+}
+
+/** Read and parse a directory's `package.json`, or undefined when absent/unreadable/malformed. */
+async function readPkg(dir: string): Promise<PkgJson | undefined> {
+  try {
+    return JSON.parse(await readFile(join(dir, 'package.json'), 'utf8')) as PkgJson
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * The workspace package directories (relative to `cwd`), from `pnpm-workspace.yaml` `packages:`
+ * or the package.json `workspaces` field, expanded from their globs. Order is stable (sorted).
+ */
+async function workspaceDirs(cwd: string, rootPkg: PkgJson | undefined): Promise<string[]> {
+  const globs = await workspaceGlobs(cwd, rootPkg)
+  const dirs = new Set<string>()
+  for (const glob of globs) {
+    for (const dir of await expandWorkspaceGlob(cwd, glob)) dirs.add(dir)
+  }
+  return [...dirs].sort()
+}
+
+/** The raw workspace globs: pnpm's `pnpm-workspace.yaml` wins, else npm/yarn's `workspaces`. */
+async function workspaceGlobs(cwd: string, rootPkg: PkgJson | undefined): Promise<string[]> {
+  try {
+    const doc = parseYaml(await readFile(join(cwd, 'pnpm-workspace.yaml'), 'utf8')) as { packages?: unknown }
+    const pkgs = doc?.packages
+    if (Array.isArray(pkgs)) return pkgs.filter((g): g is string => typeof g === 'string')
+  } catch {
+    // no pnpm-workspace.yaml — fall through to the package.json workspaces field
+  }
+  const ws = rootPkg?.workspaces
+  const list = Array.isArray(ws) ? ws : Array.isArray((ws as { packages?: unknown })?.packages) ? (ws as { packages: unknown[] }).packages : []
+  return list.filter((g): g is string => typeof g === 'string')
+}
+
+/**
+ * Expand one workspace glob to the package dirs it matches (relative to `cwd`). Handles the shapes
+ * real workspaces use — a literal dir, a single `*` segment (`packages/*`), and a trailing `**`
+ * (`packages/**`) — by walking the directory tree rather than pulling in a glob dependency. Negations
+ * (`!`) and dirs without a `package.json` are skipped; the walk is depth-bounded for `**`.
+ */
+async function expandWorkspaceGlob(cwd: string, glob: string): Promise<string[]> {
+  if (glob.startsWith('!')) return [] // exclusion patterns: skip, we only add positives
+  const parts = glob.replace(/\/+$/, '').split('/')
+  const out: string[] = []
+  let visited = 0
+  const walk = async (relDir: string, i: number): Promise<void> => {
+    if (++visited > 2000) return // bound the tree walk so a pathological repo can't hang the picker
+    if (i === parts.length) {
+      if (await hasPkg(join(cwd, relDir))) out.push(relDir)
+      return
+    }
+    const seg = parts[i]!
+    if (seg === '**') {
+      // Match this dir and any descendant (bounded), then continue past the `**`.
+      await walk(relDir, i + 1)
+      for (const child of await subdirs(join(cwd, relDir))) await walk(join(relDir, child), i)
+      return
+    }
+    if (seg === '*') {
+      for (const child of await subdirs(join(cwd, relDir))) await walk(join(relDir, child), i + 1)
+      return
+    }
+    await walk(relDir === '' ? seg : join(relDir, seg), i + 1)
+  }
+  await walk('', 0)
+  return out
+}
+
+/** The immediate child directory names of `dir` (excluding dotfiles and `node_modules`), or []. */
+async function subdirs(dir: string): Promise<string[]> {
+  try {
+    const entries = await readdir(dir, { withFileTypes: true })
+    return entries.filter(e => e.isDirectory() && e.name !== 'node_modules' && !e.name.startsWith('.')).map(e => e.name)
+  } catch {
+    return []
+  }
+}
+
+/** Whether `dir` holds a `package.json` (marking a workspace package). */
+async function hasPkg(dir: string): Promise<boolean> {
+  return stat(join(dir, 'package.json')).then(s => s.isFile()).catch(() => false)
 }
 
 // Strip ANSI color codes (dev servers print their URL in color) before matching.
@@ -79,6 +229,11 @@ export function parsePreviewUrl(output: string): string | undefined {
  * is nothing to serve, or the dev script never announces a URL.
  */
 export async function startPreview(opts: StartPreviewOptions): Promise<PreviewHandle> {
+  // A picked target (#651) serves that workspace package; otherwise fall back to the root package.
+  if (opts.target) {
+    const dir = opts.target.dir === '' ? opts.cwd : join(opts.cwd, opts.target.dir)
+    return startDevServer(dir, opts.target.script, opts.waitMs ?? 20_000)
+  }
   const script = await detectDevScript(opts.cwd)
   if (script) return startDevServer(opts.cwd, script, opts.waitMs ?? 20_000)
   const hasIndex = await stat(join(opts.cwd, 'index.html')).then(s => s.isFile()).catch(() => false)


### PR DESCRIPTION
Closes #651. The last of the three dogfood prompt-area paper cuts (#649/#650 already shipped).

## Problem
The dashboard Serve button ran the first \`dev\`/\`start\`/\`preview\`/\`serve\` script from the **repo root**. In a monorepo the root has no single server (or a turbo \`dev\` that runs everything), and the real apps live in workspace packages, so Serve fails or serves the wrong thing.

## Change
- **\`detectServeTargets(cwd)\`** enumerates the repo's servable apps: the root (when it has a serve script) plus each workspace package that has one, resolved from \`pnpm-workspace.yaml\` or the package.json \`workspaces\` field. Bounded directory walk, no new dependency.
- **\`startPreview({ cwd, target? })\`** serves a picked target's script in its subdir; no target keeps today's root behavior (single-package repos unchanged).
- **Daemon** gains an \`onServeTargets\` RPC and threads an optional \`targetId\` through \`onPreview\`, **remembering the last pick per project** (in-memory; a live preview already rehydrates via \`onPreviewStatus\`).
- **\`PreviewBar\`**: >1 target turns the Serve button into a split control (primary serves the last pick, a caret opens the picker); ≤1 target stays a plain one-click button.

## Tests
- \`preview.test.ts\`: \`detectServeTargets\` across single-package, no-serve-script, pnpm workspaces, root-first ordering, npm \`workspaces\` (array and \`{packages}\`), \`**\` globs (node_modules skipped), and literal entries.
- \`daemon.test.ts\`: \`onServeTargets\` end-to-end over the live telefunc mount on a monorepo fixture.
- \`PreviewBar.test.tsx\`: single-target plain button, multi-target picker, and primary-serves-last-pick.

Framework preview+daemon 32/32, dashboard 72/72, both typechecks clean; the dashboard bundle builds SSR-safe.