### PR TITLE
tickets: 4 agentic-PM feature proposals, in the #684 format (#462)

### DIFF
--- a/tickets/2026-07-18_discord-two-way-gate-replies.md
+++ b/tickets/2026-07-18_discord-two-way-gate-replies.md
@@ -1,0 +1,25 @@
+# Two-way Discord replies to answer awaiting-gates
+
+## TLDR
+
+Answer an awaiting-gate (pick a choice, approve a merge) directly from a Discord reply, so the human-intervention queue is chat-native instead of dashboard-only.
+
+## Why it matters
+
+Discord notifications (#627) are outbound-only today: a plain webhook `POST` of `{ content }` when a run needs attention (an `await`/`showChoices()` gate, or a ready-to-merge run). To actually answer that gate — pick a choice, approve a merge — the user still has to leave Discord and open the dashboard. For anyone who lives in chat day-to-day (the explicit motivation behind #606's "agents as teammates in the comms layer"), that round-trip is the friction that keeps the human-intervention queue (#624) from being a true chat-native workflow.
+
+This is a deliberately small slice of that bigger collaboration-layer epic (#606) — it does not need the daemon/gateway split (#605) or channel-presence/manager-agent work #606 describes. It only needs the run to be resumable from an out-of-band answer, which the existing control-channel (`.the-framework/control.jsonl`, `watchControl()`, #313) already supports for the dashboard's own choice UI.
+
+## Rough shape
+
+- Switch the Discord integration from a plain incoming webhook to a minimal bot (needed to *read* replies, which incoming webhooks can't do) — or, as a lighter first cut, require the user to react/reply in the same thread the notification posted to, polled via the webhook channel's message history.
+- Notification message includes the numbered options exactly as `showChoices()`/`showMultiSelect()` would render them in the dashboard, plus the run/project id.
+- A reply like `2` or `merge` in that thread resolves to a control-channel write (`appendControl()` or whatever `watchControl()` consumes) equivalent to clicking that same choice in `ChoicesRail`/`NeedsYou` — same code path, different input surface.
+- Scope to the two gate kinds already modeled: `awaiting` (a choice pick) and ready-to-merge (approve/merge). No open-ended chat, no @mentioning agents — that's #606's job.
+- Setting: reuse the existing per-user `notifyDiscord` toggle (#627); two-way is opt-in on top of that, since it requires a bot token instead of just a webhook URL.
+
+## Related
+
+- #627 (Notifications / Discord) — the outbound half this extends into two-way.
+- #606 (Collaboration layer epic) — the long-term direction; this ticket is an intentionally small, standalone slice that doesn't wait on #605/#606's daemon+gateway prerequisite.
+- #624 (Queue) — what a Discord reply is actually resolving.

--- a/tickets/2026-07-18_multi-agent-race-runs.md
+++ b/tickets/2026-07-18_multi-agent-race-runs.md
@@ -1,0 +1,28 @@
+# Multi-agent race / tournament runs
+
+## TLDR
+
+Run the same intent across N agent/model combos in parallel and isolated, then compare the results and pick a winner from the dashboard.
+
+## Why it matters
+
+`AgentModelMenu` already lets a user pick one agent+model pair (`claude`/`codex`, #628) per run. For an ambiguous or high-stakes task, "which agent/model handles this best" is itself a real open question users have today, and there's no way to answer it except running the task twice, by hand, in two different checkouts, and eyeballing the diffs. A built-in "race" mode — run the same intent across N agent/model combos in parallel, isolated, and let the user compare and pick a winner — turns that manual chore into a first-class dashboard feature and is a differentiator no competitor mentioned in #110's landscape scan ships.
+
+## Rough shape
+
+- Start-run form: an "Compare agents" option next to the existing single `AgentModelMenu` pick — select 2–3 agent/model combos instead of one.
+- Isolation: each combo needs its own workspace so the runs don't clobber each other's edits. Natural fit once git worktrees (#453) land; until then, a naive fallback (temp clone per combo) is acceptable and should be called out as the interim approach in the implementation.
+- Execution: reuses the existing per-run pipeline (`run.ts`) unchanged, just invoked once per combo with its own workspace/branch; runs proceed concurrently, each streaming its own `EventList`/`RunFeed` as today.
+- Comparison UI: a side-by-side view once all runs finish (or reach a mergeable/awaiting state) — diff stat, run duration, cost (where `reportsCost` is available, #628's `AgentSpec`), and pass/fail on the same review/security checklist (`steps.ts`) applied identically to every candidate so the comparison is apples-to-apples.
+- Resolution: user picks a winner branch to open as the real PR; losing branches/worktrees are discarded (with a confirmation, since discarding is the one destructive step here).
+
+## Open questions
+
+- Cost: running N combos multiplies spend — needs its own `--max-cost` semantics (per-combo cap, not shared) and a clear estimate up front (dovetails with the pre-run cost estimate idea).
+- Whether "race" is scoped to agent/model choice only, or later extended to competing *prompts* (e.g. two custom presets attacking the same intent) — start narrow (agent/model only).
+
+## Related
+
+- #628 (Select Model) / `AgentModelMenu` — the existing single-pick UI this extends.
+- #453 (git worktrees) — the clean isolation mechanism; can ship with a temp-clone fallback first.
+- #624 (queue), `dashboard/interventions.ts` — a race run surfaces as one queue item ("pick a winner") once all candidates settle.

--- a/tickets/2026-07-18_pr-review-bot-for-human-prs.md
+++ b/tickets/2026-07-18_pr-review-bot-for-human-prs.md
@@ -1,0 +1,25 @@
+# PR review bot for human-authored PRs
+
+## TLDR
+
+Automatically run the `review` + `security-audit` presets on human-authored PRs (not just the agent's own output), posting findings as inline PR comments.
+
+## Why it matters
+
+Today every quality preset (`review`, `security-audit`, `readability`, `maintainability`, `ux`) only ever runs against work the agent itself just produced — triggered from inside a `framework` run. A human engineer who opens a PR by hand gets none of this: no automatic review, no security pass, nothing. That's a big share of the value left on the table for teams that don't (yet) let the agent write all their code, and it's a natural "whole team benefits, not just the person who typed `framework ...`" story for the open-source pitch (#455).
+
+Concretely: watch each registered project (the same registry `~/.the-framework.json` already tracks, #313/#462) for newly opened or updated **human** PRs (author isn't the framework's own bot/commit pattern), and automatically run the `review` + `security-audit` presets against the diff, posting findings as inline PR review comments on GitHub — the same posture `/code-review --comment` already has for an interactive session, just fired automatically instead of on request.
+
+## Rough shape
+
+- Trigger: extend the existing background-jobs listener idea (#298, "CI is red on main => triggers agent") with a sibling listener — "human PR opened/synced => triggers agent" — polling `gh pr list` per registered project (the interventions queue, `dashboard/interventions.ts`, already polls PRs, so the plumbing to watch PRs exists).
+- Guard: skip PRs authored by the framework's own runs (avoid reviewing its own output twice) and respect the existing usage-limit/margin guard from #298 before firing.
+- Output: inline `gh pr review`/comment API calls per finding (reuse whatever comment-posting the `--comment` review flow already implements), plus a summary comment. No auto-merge, no auto-fix — purely advisory, same trust level as a human reviewer leaving comments.
+- Surfacing: reviewed PRs show up as "reviewed by The Framework" in the dashboard's per-project PR list; a failed/blocking finding could optionally push the PR into the "Needs you" queue (#624) as "reviewed, N blocking comments."
+- Settings: per-project opt-in toggle (default off) plus which presets to run on human PRs (start with `review` + `security-audit`; `readability`/`maintainability`/`ux` optional).
+
+## Related
+
+- #298 (background jobs / listeners) — sibling listener, same usage-guard machinery.
+- #624 (queue) / `dashboard/interventions.ts` — where a blocking review result should surface.
+- #625/#608 (modular opt-out) — must be an explicit per-project opt-in, not on by default.

--- a/tickets/2026-07-18_pre-run-cost-estimate.md
+++ b/tickets/2026-07-18_pre-run-cost-estimate.md
@@ -1,0 +1,24 @@
+# Pre-run cost & duration estimate
+
+## TLDR
+
+Show a rough cost and duration estimate before a run starts, derived from past runs already sitting in the run store.
+
+## Why it matters
+
+The start-run form lets a user set a hard `--max-cost` cap and the dashboard's `UsagePanel` shows quota consumed so far, but nothing today answers the question a user actually has *before* clicking start: "roughly how long will this take, and what will it cost?" Every past run's cost/duration is already sitting in the run store (`.the-framework/runs/*.json`, `run-store.ts`) — this is a matter of surfacing data that's already collected, not new instrumentation.
+
+A rough estimate up front (e.g. "similar `security-audit` runs on this project: ~12 min, ~$1.80") makes `--max-cost` a much easier number to set, and lowers the anxiety of an unbounded-feeling `framework <intent>` invocation for a first-time user — a real paper-cut in the "why would I trust this" first-run trust curve #297's bootstrap-mode ticket is also trying to solve.
+
+## Rough shape
+
+- Data source: aggregate existing per-run records in the run store, grouped by a similarity key — same preset id (or same `--kind`/domain preset for open-ended intents), same project. Nothing new to persist; this reads history that's already written.
+- Display: in `StartRunForm.tsx`, once a preset/agent/model is selected, show a small inline estimate ("based on N past runs") with a range (e.g. p25–p75), not a false-precision single number. No history for this preset/project yet → show nothing rather than a misleading guess.
+- Live refinement: once a run starts, replace the static pre-run estimate with the running actual (cost/time so far vs. the estimate), reusing whatever `RunFeed`/`EventList` already streams.
+- Cross-agent caveat: cost only exists for agents where `reportsCost` is true (#628's `AgentSpec`) — for others (e.g. Codex today, per the "unguarded" notice in `cli.ts`), show duration-only estimates and skip cost.
+
+## Related
+
+- #628 (Select Model) — the `AgentSpec.reportsCost` flag this estimate depends on.
+- #313 (Database) / run store — the historical data source, already written today.
+- #297 (Bootstrap mode) — same "lower the first-run trust barrier" motivation.


### PR DESCRIPTION
Rebased on main after #689 (TODO-AGENTS.md move) + #684 format. Refs #462; the closer is the preset PR #674.

The first dogfood output of the Agentic PM ideation preset. Under the #624 model **a proposal is just a PR: merge accepts, close rejects.** So this is now purely the 4 ticket-file proposals, in the #684 format (`tickets/<DATE>_<SLUG>.md`, each with a `## TLDR`) - no `TODO-AGENTS.md` edit, since proposed tickets are just the ticket-file PRs:

- **PR review bot for human-authored PRs**
- **Multi-agent race / tournament runs**
- **Two-way Discord replies to answer awaiting-gates**
- **Pre-run cost & duration estimate**

No changeset (repo backlog data, not a package). **Merge to accept these into the backlog, or close to reject.**