### PR TITLE
fix(framework): transparent mode runs raw, skipping the build flow + prompt wrapping (#678)

### DIFF
--- a/.changeset/transparent-raw-prompt-path.md
+++ b/.changeset/transparent-raw-prompt-path.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Fix transparent mode so it is actually raw Claude Code (#678). Transparent (#625) is meant to run identical to `claude -p <your prompt>`, but a build-kind run (a plain typed prompt, the dashboard default) still went through the full `runFramework` orchestration (scope, plan, dispatch, synthesize, production-grade pass) and sent the wrapped `extendPrompt`/`buildPrompt` text to the agent instead of the raw prompt, because run-path routing keyed only off the `research`/`prompt` subcommands. Transparent now routes any run through the raw prompt path, so the prompt runs verbatim with no build orchestration and no wrapping. Research rendering still applies only to a genuine (non-transparent) research run.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -217,6 +217,8 @@ test('runLogKind maps the run path to a project-log kind (#379)', () => {
   assert.equal(runLogKind({ directPrompt: false, research: false }), 'build')
   assert.equal(runLogKind({ directPrompt: true, research: false }), 'prompt')
   assert.equal(runLogKind({ directPrompt: false, research: true }), 'prompt')
+  // Transparent (#625) routes a build-kind run through the raw prompt path, so it logs as a prompt.
+  assert.equal(runLogKind({ directPrompt: false, research: false }, true), 'prompt')
 })
 
 test('runLogEntry maps the end event to a status and carries the session (#379)', () => {
@@ -630,6 +632,26 @@ test('runCli --fake --no-dashboard runs the whole flow offline to production-gra
   assert.match(text, /checklist pass 1/)
   assert.match(text, /production-grade/)
   assert.match(text, /deploy: SSR/)
+})
+
+test('runCli --transparent runs a bare prompt raw, skipping the build flow + wrapping (#625/#678)', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'framework-transparent-'))
+  try {
+    const { io, out } = capture()
+    const code = await runCli(['make it blue', '--transparent', '--fake', '--no-dashboard', '--cwd', dir], io)
+    assert.equal(code, 0)
+    const text = out.join('\n')
+    // Transparent = raw Claude Code: the build path's markers must NOT appear (contrast the test above).
+    assert.doesNotMatch(text, /scope: full/) // no scope phase
+    assert.doesNotMatch(text, /Build this app end to end/) // no buildPrompt wrapping
+    assert.doesNotMatch(text, /Work within the existing codebase/) // no extendPrompt wrapping
+    assert.doesNotMatch(text, /production-grade/) // no synthesize / production-grade pass
+    // And it records as a prompt run, not a build.
+    const logs = await readLogs(dir)
+    assert.equal(logs[0]!.kind, 'prompt')
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
 })
 
 test('a live daemon steers a dashboard-less run through its gates via control.jsonl (#344)', async () => {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -616,9 +616,11 @@ export function ecoOptions(opts: Pick<CliOptions, 'eco'>): EcoOptions | undefine
   return { autoPlanning, autoResearch, autoMaintenance }
 }
 
-/** The log kind a run records in `.the-framework/LOGS.md` (#379): the direct paths are prompts, a build run is a build. */
-export function runLogKind(opts: Pick<CliOptions, 'directPrompt' | 'research'>): LogEntry['kind'] {
-  return opts.directPrompt || opts.research ? 'prompt' : 'build'
+/** The log kind a run records in `.the-framework/LOGS.md` (#379): the direct paths are prompts, a
+ * build run is a build. Transparent (#625) routes a build-kind run through the raw prompt path too,
+ * so it logs as a prompt. */
+export function runLogKind(opts: Pick<CliOptions, 'directPrompt' | 'research'>, transparent = false): LogEntry['kind'] {
+  return opts.directPrompt || opts.research || transparent ? 'prompt' : 'build'
 }
 
 /**
@@ -1069,7 +1071,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // kind + title are known up front; the session id/link arrive mid-run, and the
   // `end` event (fired once by both run paths) closes the entry. Best-effort: the
   // project DB is committed history, so it must never break a run.
-  const logKind = runLogKind(opts)
+  const logKind = runLogKind(opts, transparent)
   const logTitle = intent || (opts.research ? 'this PR' : '')
   let logSessionId: string | undefined
   let logSessionLink: string | undefined
@@ -1176,14 +1178,19 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // `framework research [what]` (#331) and `framework prompt <text>` (#353): the
   // direct prompt path — run one prompt through runPrompt, which honors its gates
   // (#337/#339) but skips the scope -> build scaffolding entirely.
-  // Research renders its preset template around the "what"; prompt runs the text
+  // Transparent (#625) joins them: "raw Claude Code" must bypass the build orchestration
+  // AND the prompt wrapping too, not just zero the system prompt — so a transparent run
+  // (any kind) runs its prompt verbatim here rather than through runFramework's
+  // scope -> build -> synthesize + extendPrompt. Research renders its preset template
+  // around the "what" (only when it isn't transparent); prompt/transparent run the text
   // verbatim (it may already BE an edited preset, so it must not be re-rendered).
   // Shares all the wiring above (dashboard, store, control channel, budget).
-  if (opts.research || opts.directPrompt) {
+  const isResearch = opts.research && !transparent
+  if (opts.research || opts.directPrompt || transparent) {
     const { userSystemPrompt, noBuiltinPrompt, eco } = promptConfig
-    return settleRun(epilogue(opts.directPrompt ? 'prompt run' : 'research'), async () => {
+    return settleRun(epilogue(isResearch ? 'research' : 'prompt run'), async () => {
       await runPrompt({
-        prompt: opts.directPrompt ? intent : renderResearchPrompt(intent),
+        prompt: isResearch ? renderResearchPrompt(intent) : intent,
         driver,
         cwd,
         onEvent,
@@ -1201,9 +1208,9 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
         ...(sessionLink ? { sessionLink } : {}),
       })
       return {
-        successLine: opts.directPrompt
-          ? '\n✓ prompt run done.'
-          : '\n✓ research done: see the REVIEW-PROBLEMS / TODO files it wrote.',
+        successLine: isResearch
+          ? '\n✓ research done: see the REVIEW-PROBLEMS / TODO files it wrote.'
+          : '\n✓ prompt run done.',
       }
     })
   }


### PR DESCRIPTION
Closes #678. Found by dogfooding: a Transparent-mode run in the dashboard still showed `scope: full`, `build/plan`, `build/synthesize`, a production-grade second pass, and a 449-char wrapped prompt.

## Root cause
Transparent (#625) is meant to be "raw Claude Code" — identical to `claude -p <prompt>`. But run-path routing in `cli.ts` (`if (opts.research || opts.directPrompt)`) keyed only off the `research`/`prompt` subcommands. A plain typed prompt has neither, so a transparent run took the `runFramework` build path. There, `transparent`'s only effect was `composeRunSystem` returning `''` (zeroing the system prompt); the scope→build→synthesize orchestration and the `extendPrompt`/`buildPrompt` wrapping still ran.

## Fix
Route any transparent run through the raw `runPrompt` path, so the prompt runs verbatim with no build orchestration and no wrapping. `renderResearchPrompt` still applies only to a genuine (non-transparent) research run, and `runLogKind` logs a transparent run as a `prompt`.

One line, in the routing branch:
```
- if (opts.research || opts.directPrompt) {
+ const isResearch = opts.research && !transparent
+ if (opts.research || opts.directPrompt || transparent) {
```
plus the prompt/label/successline keying off `isResearch`.

## Tests
- New `runCli --transparent ...` test: a bare prompt under `--transparent` prints **none** of the build-flow markers (`scope: full`, `Build this app end to end`, `Work within the existing codebase`, `production-grade`) and records as a `prompt` — the exact contrast to the existing build-flow test.
- `runLogKind` extended for the transparent case.
- run.test.js 39/39 (runFramework unaffected); routing-relevant cli tests green. (The full cli.test.js wedges on a pre-existing flaky daemon/file-watch test, unrelated.)

Note: this changes the behavior of Rom's #625 transparent mode (now genuinely bypasses the framework), aligning it with its documented "raw Claude Code" intent — worth his awareness.