### PR TITLE
feat(framework): make the 'Needs you' notification a real toggle (#627)

### DIFF
--- a/.changeset/human-intervention-toggle.md
+++ b/.changeset/human-intervention-toggle.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Make the "Needs you" (human intervention) notifications a real toggle (#627). It was always-on before; now it is a default-on `notifyHumanIntervention` preference, so it can be turned off like the other categories. Gates both the browser notification and the daemon's Discord delivery on the category (default on) in addition to the delivery method.

--- a/packages/framework-dashboard/components/NotificationsMenu.test.tsx
+++ b/packages/framework-dashboard/components/NotificationsMenu.test.tsx
@@ -10,6 +10,7 @@ vi.mock('../lib/preferences.js', () => ({
   notificationsEnabled: (p: Preferences) => p.notifyBrowser ?? true,
   discordEnabled: (p: Preferences) => p.notifyDiscord ?? false,
   newActivityEnabled: (p: Preferences) => p.notifyNewActivity ?? false,
+  humanInterventionEnabled: (p: Preferences) => p.notifyHumanIntervention ?? true,
 }))
 
 const { NotificationsMenu } = await import('./NotificationsMenu.js')
@@ -27,7 +28,7 @@ afterEach(() => {
 const open = () => fireEvent.click(screen.getByRole('button', { name: /notifications/i }))
 
 describe('NotificationsMenu (#676)', () => {
-  test('the popover groups methods and categories, with "Needs you" always on', () => {
+  test('the popover groups methods and categories, both "Needs you" and "New activity" toggleable', () => {
     render(<NotificationsMenu />)
     open()
     expect(screen.getByText('Deliver to')).toBeTruthy()
@@ -35,17 +36,20 @@ describe('NotificationsMenu (#676)', () => {
     expect(screen.getByText('Discord')).toBeTruthy()
     expect(screen.getByText('Notify me about')).toBeTruthy()
     expect(screen.getByText('Needs you')).toBeTruthy()
-    expect(screen.getByText('Always on')).toBeTruthy() // baseline shown as static, not a toggle
+    expect(screen.queryByText('Always on')).toBeNull() // #627: now a real toggle, no static row
     expect(screen.getByText('New activity')).toBeTruthy()
   })
 
-  test('toggling Discord and New activity writes each preference through', () => {
+  test('toggling Discord, New activity, and Needs you writes each preference through', () => {
     render(<NotificationsMenu />)
     open()
     fireEvent.click(screen.getByText('Discord'))
     expect(updatePreferences).toHaveBeenCalledWith({ notifyDiscord: true })
     fireEvent.click(screen.getByText('New activity'))
     expect(updatePreferences).toHaveBeenCalledWith({ notifyNewActivity: true })
+    // Defaults on, so the click turns it OFF (#627).
+    fireEvent.click(screen.getByText('Needs you'))
+    expect(updatePreferences).toHaveBeenCalledWith({ notifyHumanIntervention: false })
   })
 
   test('enabling Browser asks for permission when it has not been granted yet', () => {

--- a/packages/framework-dashboard/components/NotificationsMenu.tsx
+++ b/packages/framework-dashboard/components/NotificationsMenu.tsx
@@ -1,6 +1,6 @@
 import { useSyncExternalStore } from 'react'
 import { Bell, BellOff } from 'lucide-react'
-import { usePreferences, updatePreferences, notificationsEnabled, discordEnabled, newActivityEnabled } from '../lib/preferences.js'
+import { usePreferences, updatePreferences, notificationsEnabled, discordEnabled, newActivityEnabled, humanInterventionEnabled } from '../lib/preferences.js'
 import { cn } from '../lib/utils.js'
 import {
   DropdownMenu,
@@ -50,6 +50,7 @@ export function NotificationsMenu() {
   const browser = notificationsEnabled(preferences)
   const discord = discordEnabled(preferences)
   const activity = newActivityEnabled(preferences)
+  const needsYou = humanInterventionEnabled(preferences)
   const permission = usePermission()
   const browserSupported = permission !== 'unsupported'
   const blocked = permission === 'denied'
@@ -112,15 +113,16 @@ export function NotificationsMenu() {
         <DropdownMenuSeparator />
         <DropdownMenuGroup>
           <DropdownMenuLabel>Notify me about</DropdownMenuLabel>
-          {/* "Needs you" is always on — a run awaiting an answer or a PR ready to review. Shown as
-              a static row so the baseline is visible, not a toggle. */}
-          <div className="flex items-start justify-between gap-2 px-2 py-1.5 pl-8 text-sm">
-            <span className="flex flex-col gap-0.5">
-              <span className="leading-tight">Needs you</span>
-              <span className="text-xs text-[var(--color-muted-foreground)]">A run awaiting you, or a PR to review</span>
-            </span>
-            <span className="shrink-0 text-xs text-[var(--color-muted-foreground)]">Always on</span>
-          </div>
+          {/* "Needs you" (#627): a run awaiting an answer or a PR ready to review. Defaults on — the
+              baseline category — but now a real toggle, so it can be turned off like any other. */}
+          <DropdownMenuCheckboxItem
+            checked={needsYou}
+            onCheckedChange={next => updatePreferences({ notifyHumanIntervention: next })}
+            title="A run awaiting your answer, or a PR ready to review"
+            className="items-start"
+          >
+            <NotifLabel label="Needs you" hint="A run awaiting you, or a PR to review" />
+          </DropdownMenuCheckboxItem>
           <DropdownMenuCheckboxItem
             checked={activity}
             onCheckedChange={next => updatePreferences({ notifyNewActivity: next })}

--- a/packages/framework-dashboard/lib/preferences.ts
+++ b/packages/framework-dashboard/lib/preferences.ts
@@ -85,3 +85,10 @@ export function discordEnabled(preferences: Preferences): boolean {
 export function newActivityEnabled(preferences: Preferences): boolean {
   return preferences.notifyNewActivity ?? false
 }
+
+/** The "needs you" category (#627): a run awaiting your answer, or a PR to review. Composes with
+ * the method toggles like {@link newActivityEnabled}, but **defaults on** — these are the baseline
+ * notifications, so an unset preference keeps them firing. */
+export function humanInterventionEnabled(preferences: Preferences): boolean {
+  return preferences.notifyHumanIntervention ?? true
+}

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -18,7 +18,7 @@ import { usePersistentState } from '../../lib/use-persistent-state.js'
 import { useContextSet } from '../../lib/use-context-set.js'
 import { useInterventionNotifications } from '../../lib/use-intervention-notifications.js'
 import { useActivityNotifications } from '../../lib/use-activity-notifications.js'
-import { usePreferences, notificationsEnabled, newActivityEnabled } from '../../lib/preferences.js'
+import { usePreferences, notificationsEnabled, newActivityEnabled, humanInterventionEnabled } from '../../lib/preferences.js'
 import { pendingChoices, agentViews } from '../../lib/live-state.js'
 
 /** Stable, so `files` keeps one identity while no project is selected. */
@@ -66,9 +66,11 @@ export default function Page() {
   const { value: interventions } = usePolled<Intervention[]>(onInterventions, EMPTY_INTERVENTIONS, 15000, [])
 
   // Fire a browser notification when a new item lands on the "needs you" queue (#627). Rides the
-  // one interventions poll above; the browser permission is the real gate (see the header bell).
+  // one interventions poll above (the poll stays unconditional — it also feeds the sidebar badge
+  // and Overview card); only the notification is gated, on both the category (`notifyHumanIntervention`,
+  // default on) and the browser method (`notifyBrowser`).
   const preferences = usePreferences()
-  useInterventionNotifications(interventions, notificationsEnabled(preferences))
+  useInterventionNotifications(interventions, humanInterventionEnabled(preferences) && notificationsEnabled(preferences))
 
   // The "New activity" category (#627): the default-off feed of runs starting/finishing. Its only
   // client consumer is the browser notification below, so it is polled exactly when that will fire —

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -390,7 +390,10 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
       build: projects => buildInterventions(projects, { dashboardUrl: dashboard.url }),
       onNew: async items => {
         const prefs = await readPrefs()
-        if (!prefs.notifyDiscord) return // opted out (default): keep quiet, baseline already advanced
+        // Double-gated like activity below: the method (`notifyDiscord`) AND the category
+        // (`notifyHumanIntervention`) must both be on. The category defaults on, so `?? true` —
+        // do NOT copy activity's plain `!prefs.x`, which would silence the baseline by default.
+        if (!prefs.notifyDiscord || (prefs.notifyHumanIntervention ?? true) === false) return
         await postDiscord(webhook, items).catch(() => {})
       },
     })

--- a/packages/framework/src/registry.test.ts
+++ b/packages/framework/src/registry.test.ts
@@ -191,6 +191,13 @@ test('writePreferences round-trips the notifyNewActivity toggle (#627)', async (
   assert.deepEqual(await readPreferences(fs, ENV), { notifyNewActivity: true })
 })
 
+test('writePreferences round-trips the notifyHumanIntervention toggle (#627)', async () => {
+  const fs = memFs({ [FILE]: JSON.stringify([APP_A]) })
+  // Default is on, so the persisted value that matters is the explicit opt-out.
+  await writePreferences({ notifyHumanIntervention: false }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { notifyHumanIntervention: false })
+})
+
 test('writePreferences round-trips the transparent toggle (#625)', async () => {
   const fs = memFs({ [FILE]: JSON.stringify([APP_A]) })
   await writePreferences({ transparent: true }, fs, ENV)

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -70,6 +70,14 @@ export interface Preferences {
    * toggles ({@link notifyBrowser} / {@link notifyDiscord}), so activity reaches whichever are on.
    */
   notifyNewActivity?: boolean
+  /**
+   * The "needs you" category (#627): notify when a run is awaiting your answer or a PR is ready
+   * to review. A *category* toggle, like {@link notifyNewActivity}, composing with the method
+   * toggles ({@link notifyBrowser} / {@link notifyDiscord}). **Absent = on**: unlike the other
+   * flat opt-in booleans, human-intervention pings are the baseline The Framework leans on, so an
+   * unset preference keeps them firing; a user turns them off explicitly.
+   */
+  notifyHumanIntervention?: boolean
   /** The model to run on (#628), e.g. `opus` / `sonnet`; maps to a run's `--model`. Absent = the driver's default. */
   model?: string
   /** Which coding agent drives the run (#650): `claude` or `codex`; maps to `--agent`. Absent = the default (`claude`). */
@@ -192,6 +200,7 @@ const PREFERENCE_KEYS = [
   'notifyBrowser',
   'notifyDiscord',
   'notifyNewActivity',
+  'notifyHumanIntervention',
 ] as const
 
 /** Keep only the known preference fields, so a hand-edited or browser-supplied


### PR DESCRIPTION
Closes #627 (the last unchecked category: **Human intervention, default on**). The other three categories (New activity, Browser, Discord) already shipped in #670/#671/#676.

## What
Human-intervention ("Needs you") notifications were the always-on baseline. #627 specs them as a **default-on category the user can turn off**. So:

- New `notifyHumanIntervention` preference (**absent = on** — the one notify-category whose default is on, so it keeps firing out of the box), added to the registry + the persisted-keys allowlist.
- `humanInterventionEnabled(prefs)` helper (`?? true`).
- The browser notification hook now gates on the category AND the browser method (the interventions *poll* stays unconditional — it also feeds the sidebar badge + Overview card).
- The daemon Discord delivery gates on the category (`?? true`) on top of `notifyDiscord`.
- The popover's static "Needs you … Always on" row becomes a real checkbox.

## Behavior change (intentional)
For the first time "Needs you" can be turned off. Thats exactly what #627's default-true checkbox asks for.

## Tests
`NotificationsMenu.test.tsx` (toggle writes `notifyHumanIntervention: false`; no more static "Always on" row) and a `registry.test.ts` round-trip. Framework + dashboard typecheck clean; NotificationsMenu 5/5, registry 35/35.