### PR TITLE
fix(framework-dashboard): batch of UX paper cuts (#690)

### DIFF
--- a/packages/framework-dashboard/components/ChoicePanel.tsx
+++ b/packages/framework-dashboard/components/ChoicePanel.tsx
@@ -23,6 +23,7 @@ export function ChoicePanel({
   active?: boolean
 }) {
   const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
   const [checked, setChecked] = useState<Set<string>>(
     () => new Set(choice.multi ? choice.options.filter(o => o.default).map(o => o.id) : []),
   )
@@ -32,7 +33,11 @@ export function ChoicePanel({
 
   const post = (pick: string | string[], by: 'user' | 'autopilot' = 'user') => {
     setBusy(true)
-    void sendChoice(projectId, choice.id, pick, by).catch(() => setBusy(false))
+    setError(null)
+    void sendChoice(projectId, choice.id, pick, by).catch(() => {
+      setBusy(false)
+      setError('Could not send your choice — try again.')
+    })
   }
 
   const toggle = (id: string) =>
@@ -155,6 +160,8 @@ export function ChoicePanel({
           ))}
         </div>
       )}
+
+      {error && <p className="mt-2 text-xs text-red-500">{error}</p>}
 
       <div className="mt-3 flex items-center gap-3 text-xs text-muted-foreground">
         <label className="flex cursor-pointer items-center gap-1.5">

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -275,8 +275,16 @@ function ProjectsTable({ projects, onSelectProject }: { projects: ProjectStat[];
           {projects.map(p => (
             <tr
               key={p.projectId}
+              role="button"
+              tabIndex={0}
               onClick={() => onSelectProject(p.projectId)}
-              className="cursor-pointer border-b border-border/60 last:border-0 hover:bg-accent"
+              onKeyDown={e => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  onSelectProject(p.projectId)
+                }
+              }}
+              className="cursor-pointer border-b border-border/60 last:border-0 hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
             >
               <td className="py-2 pr-4">
                 <span className="flex items-center gap-2">

--- a/packages/framework-dashboard/components/OptionsMenu.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.tsx
@@ -25,6 +25,9 @@ export type OptionRow = {
   checked: boolean
   /** Disabled beyond the form-wide busy flag (e.g. Eco has nothing to trim under Vanilla). */
   disabled?: boolean
+  /** Why it's disabled, shown in the description so a greyed row isn't a mystery (the `title`
+   * tooltip is suppressed on disabled dropdown items). Only rendered while {@link disabled}. */
+  disabledReason?: string
 }
 
 function setOption(key: keyof Preferences, checked: boolean) {
@@ -80,7 +83,10 @@ export function OptionsMenu({
             title={o.title}
             className="items-start"
           >
-            <OptionLabel label={o.label} description={o.description} />
+            <OptionLabel
+              label={o.label}
+              description={o.disabled && o.disabledReason ? [o.description, `— ${o.disabledReason}`].filter(Boolean).join(' ') : o.description}
+            />
           </DropdownMenuCheckboxItem>
         ))}
         {showEco && (
@@ -95,7 +101,10 @@ export function OptionsMenu({
                 title={o.title}
                 className="items-start pl-8"
               >
-                <OptionLabel label={o.label} description={o.description} />
+                <OptionLabel
+              label={o.label}
+              description={o.disabled && o.disabledReason ? [o.description, `— ${o.disabledReason}`].filter(Boolean).join(' ') : o.description}
+            />
               </DropdownMenuCheckboxItem>
             ))}
           </>

--- a/packages/framework-dashboard/components/ProjectsSidebar.tsx
+++ b/packages/framework-dashboard/components/ProjectsSidebar.tsx
@@ -55,7 +55,7 @@ export function ProjectsSidebar({
           {interventionCount > 0 && (
             <span
               className="ml-auto min-w-5 rounded-full bg-primary px-1.5 text-center text-xs font-semibold text-primary-foreground tabular-nums"
-              title={`${interventionCount} item(s) need you`}
+              title={`${interventionCount} item${interventionCount === 1 ? '' : 's'} need${interventionCount === 1 ? 's' : ''} you`}
             >
               {interventionCount}
             </span>

--- a/packages/framework-dashboard/components/RunLive.tsx
+++ b/packages/framework-dashboard/components/RunLive.tsx
@@ -1,5 +1,6 @@
 import type { FrameworkEvent } from '@gemstack/framework'
 import { sendStop } from '../server/control.telefunc.js'
+import { useAction } from '../lib/use-action.js'
 import { PreviewBar } from './PreviewBar.js'
 import { RunFeed } from './RunFeed.js'
 import { Button } from './ui/button.js'
@@ -9,12 +10,21 @@ import { Button } from './ui/button.js'
 // and a finished run's replay (RunReplay). Single-run today streams the project's one live
 // feed; per-run streams arrive with worktrees (#453).
 export function RunLive({ projectId, events }: { projectId: string; events: FrameworkEvent[] }) {
+  // Stop routes through useAction like every other mutation, so a click disables + shows
+  // "Stopping…" and a failed stop surfaces instead of silently doing nothing (#627-adjacent UX).
+  const { busy, error, run } = useAction()
   return (
     <>
       <PreviewBar projectId={projectId} />
-      <div className="flex items-center justify-end border-b border-border px-4 py-2">
-        <Button variant="outline" size="sm" onClick={() => void sendStop(projectId)}>
-          Stop run
+      <div className="flex items-center justify-end gap-3 border-b border-border px-4 py-2">
+        {error && <span className="text-xs text-red-500">{error}</span>}
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={busy}
+          onClick={() => void run(() => sendStop(projectId), 'Could not stop the run.')}
+        >
+          {busy ? 'Stopping…' : 'Stop run'}
         </Button>
       </div>
       <RunFeed events={events} />

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -212,12 +212,12 @@ export function StartRunForm({
   // while Eco is on.
   const mainOptions: OptionRow[] = [
     { key: 'transparent', label: 'Transparent', description: 'Raw Claude Code — turns the whole framework off.', title: 'Fully transparent (#625): run the agent exactly like plain Claude Code, with no framework system prompt, controls, dashboard, guard, or TODO loop. Overrides the options below.', checked: transparent },
-    { key: 'autopilot', label: 'Autopilot', description: 'Auto-accepts the recommended choice after a countdown.', title: 'Auto-accept the recommended choice after a countdown; also relaxes the maintenance stance', checked: autopilot && !transparent, disabled: transparent },
-    { key: 'technical', label: 'Technical control', description: 'Surfaces technical detail like tech-stack choices.', title: 'Expose technical detail (e.g. tech-stack choices)', checked: technical && !transparent, disabled: transparent },
-    { key: 'vanilla', label: 'Disable system prompt', description: 'Drops the added system prompt; keeps the run controls.', title: "Remove the built-in system prompt but keep the framework's run controls. For a fully raw run, use Transparent. Expand 'Actual prompt' to read what it removes.", checked: vanilla && !transparent, disabled: transparent },
-    { key: 'eco', label: 'Eco', description: 'Trims the system prompt to save tokens.', title: 'Trim the built-in system prompt to save tokens', checked: eco && !ecoDisabled, disabled: ecoDisabled },
-    { key: 'onBeforeMergeableQuality', label: 'Post-merge cleanup', description: 'Runs quality passes once it is ready to merge.', title: "When the run signals it's ready for merge, run maintainability, readability, and security-audit passes", checked: onBeforeMergeableQuality && !transparent, disabled: transparent },
-    { key: 'browser', label: 'Browser', description: 'Gives the agent a real browser to inspect pages.', title: 'Give the agent a real browser via chrome-devtools-mcp: navigate pages, read console + network, inspect the DOM, and screenshot', checked: browser && !transparent, disabled: transparent },
+    { key: 'autopilot', label: 'Autopilot', description: 'Auto-accepts the recommended choice after a countdown.', title: 'Auto-accept the recommended choice after a countdown; also relaxes the maintenance stance', checked: autopilot && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
+    { key: 'technical', label: 'Technical control', description: 'Surfaces technical detail like tech-stack choices.', title: 'Expose technical detail (e.g. tech-stack choices)', checked: technical && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
+    { key: 'vanilla', label: 'Disable system prompt', description: 'Drops the added system prompt; keeps the run controls.', title: "Remove the built-in system prompt but keep the framework's run controls. For a fully raw run, use Transparent. Expand 'Actual prompt' to read what it removes.", checked: vanilla && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
+    { key: 'eco', label: 'Eco', description: 'Trims the system prompt to save tokens.', title: 'Trim the built-in system prompt to save tokens', checked: eco && !ecoDisabled, disabled: ecoDisabled, disabledReason: 'nothing to trim while the system prompt is off' },
+    { key: 'onBeforeMergeableQuality', label: 'Post-merge cleanup', description: 'Runs quality passes once it is ready to merge.', title: "When the run signals it's ready for merge, run maintainability, readability, and security-audit passes", checked: onBeforeMergeableQuality && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
+    { key: 'browser', label: 'Browser', description: 'Gives the agent a real browser to inspect pages.', title: 'Give the agent a real browser via chrome-devtools-mcp: navigate pages, read console + network, inspect the DOM, and screenshot', checked: browser && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
   ]
   const ecoOptions: OptionRow[] = [
     { key: 'ecoPlanning', label: 'Auto planning', description: 'Drops the planning section; the agent plans itself.', title: 'Drop the planning section, letting the agent plan on its own', checked: ecoPlanning },
@@ -270,7 +270,12 @@ export function StartRunForm({
         {/* Global options (#314) as a gear-icon checkbox dropdown (#654/#668). */}
         <OptionsMenu options={mainOptions} ecoOptions={ecoOptions} showEco={eco && !ecoDisabled} busy={busy} />
         {/* Start run at the end of the row (#668). */}
-        <Button type="submit" className="ml-auto" disabled={busy || !prompt.trim()}>
+        <Button
+          type="submit"
+          className="ml-auto"
+          disabled={busy || !prompt.trim()}
+          title={!prompt.trim() ? 'Type a prompt to start a run' : undefined}
+        >
           {busy ? 'Starting…' : 'Start run'}
         </Button>
       </div>

--- a/packages/framework-dashboard/components/UsagePanel.tsx
+++ b/packages/framework-dashboard/components/UsagePanel.tsx
@@ -119,6 +119,8 @@ export function UsagePanel() {
         <CardTitle>Usage</CardTitle>
       </CardHeader>
       <CardContent className="space-y-5">
+        {!view && <p className="text-sm text-muted-foreground">Reading your usage…</p>}
+
         {view?.windows.length ? (
           <div className="space-y-3">{view.windows.map(w => <AccountWindow key={w.label} window={w} />)}</div>
         ) : null}


### PR DESCRIPTION
Closes #690. Seven small, high-confidence dashboard UX fixes from a two-pass audit (states/feedback + copy/affordances). No behavior beyond the fix; each uses an existing pattern.

| Fix | Before | After |
|---|---|---|
| **RunLive** Stop run | fire-and-forget: no pending, silent on failure, re-clickable | routes through `useAction` — disables, "Stopping…", surfaces errors |
| **ChoicePanel** submit | failed choice silently re-enabled the button | shows an error line on failure (the run's main steering action) |
| **UsagePanel** | blank card body during the slower initial quota load | "Reading your usage…" while it loads |
| **DashboardPage** Overview rows | clickable `<tr>`, mouse-only | keyboard-operable (`role`/`tabIndex`/Enter+Space) |
| **ProjectsSidebar** badge | "1 item(s) need you" | correct singular/plural + verb |
| **StartRunForm** Start button | disabled on empty prompt, no hint | `title="Type a prompt to start a run"` |
| **OptionsMenu** | disabled option = dead checkbox, no reason (tooltip suppressed) | reason shown in the description ("— off while Transparent is on") |

**Deferred** (follow-up): FileTree rows are mouse-only for keyboard toggling — it routes through vendored animate-ui internals, so it is out of scope for this paper-cut batch.

No changeset: `framework-dashboard` is private (bundled into `@gemstack/framework`).

## Tests
Dashboard typecheck clean, 77/77 vitest pass, bundle builds.