### PR TITLE
fix(framework-dashboard): critical UX paper cuts from the dogfood review (#695)

### DIFF
--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -204,10 +204,13 @@ function WorkingNow({ active, onSelectProject }: { active: ActiveRun[]; onSelect
             className="flex w-full flex-col items-start gap-0.5 py-2 text-left hover:opacity-80"
           >
             <span className="flex w-full items-center gap-1.5">
+              {/* Decorative dot + sr-only status (#695/U33): color alone reaches no screen reader. */}
               <span
+                aria-hidden
                 className={cn('h-2 w-2 shrink-0 rounded-full', run.readyForMerge ? 'bg-emerald-500' : 'animate-pulse bg-amber-500')}
                 title={run.readyForMerge ? 'Ready for merge' : 'Building'}
               />
+              <span className="sr-only">{run.readyForMerge ? 'Ready for merge' : 'Building'}: </span>
               <span className="truncate font-medium">{run.projectName}</span>
               {run.sessionName && <span className="truncate text-xs text-muted-foreground">{run.sessionName}</span>}
             </span>
@@ -288,13 +291,16 @@ function ProjectsTable({ projects, onSelectProject }: { projects: ProjectStat[];
             >
               <td className="py-2 pr-4">
                 <span className="flex items-center gap-2">
+                  {/* Decorative dot + sr-only status (#695/U33): color alone reaches no screen reader. */}
                   <span
+                    aria-hidden
                     className={cn(
                       'h-2 w-2 shrink-0 rounded-full',
                       p.running ? 'animate-pulse bg-primary' : p.activated ? 'bg-emerald-500' : 'bg-muted-foreground',
                     )}
                     title={p.running ? 'Running' : p.activated ? 'Activated' : 'Not activated'}
                   />
+                  <span className="sr-only">{p.running ? 'Running' : p.activated ? 'Activated' : 'Not activated'}: </span>
                   <span className="truncate font-medium">{p.projectName}</span>
                 </span>
               </td>

--- a/packages/framework-dashboard/components/EventList.tsx
+++ b/packages/framework-dashboard/components/EventList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { FrameworkEvent } from '@gemstack/framework'
 import { formatFrameworkEvent } from '@gemstack/framework/client'
 import { Badge } from './ui/badge.js'
@@ -18,35 +18,60 @@ function disclosableText(e: FrameworkEvent): { text: string; label: string } | n
 }
 
 export function EventList({ events, stick = true }: { events: FrameworkEvent[]; stick?: boolean }) {
+  const scrollRef = useRef<HTMLDivElement>(null)
   const bottomRef = useRef<HTMLDivElement>(null)
+  // Stick to the bottom only while the reader is already there (#695/U19): scrolling up to read
+  // an earlier line must not get yanked back down by the next event. `atBottom` tracks that, and
+  // a "Jump to latest" chip appears while it's false so the bottom is one click away.
+  const [atBottom, setAtBottom] = useState(true)
+
+  const onScroll = () => {
+    const el = scrollRef.current
+    if (!el) return
+    setAtBottom(el.scrollHeight - el.scrollTop - el.clientHeight < 48)
+  }
 
   useEffect(() => {
-    if (stick) bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [events.length, stick])
+    if (stick && atBottom) bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [events.length, stick, atBottom])
 
   return (
-    <div className="flex-1 overflow-y-auto p-4">
-      <ol className="space-y-1 font-mono text-xs">
-        {events.map((e, i) => {
-          const disclosable = disclosableText(e)
-          return (
-            <li key={i} className="flex items-start gap-2">
-              <Badge className="mt-0.5 shrink-0 text-[10px] uppercase text-muted-foreground">{e.kind}</Badge>
-              {disclosable ? (
-                <details className="min-w-0 flex-1">
-                  <summary className="cursor-pointer text-foreground marker:text-muted-foreground">
-                    {disclosable.label} ({disclosable.text.length.toLocaleString()} chars) — click to expand
-                  </summary>
-                  <pre className="mt-1 max-h-96 overflow-auto whitespace-pre-wrap break-words rounded bg-muted p-2 text-foreground">{disclosable.text}</pre>
-                </details>
-              ) : (
-                <span className="whitespace-pre-wrap break-words text-foreground">{(formatFrameworkEvent(e) ?? '').trim()}</span>
-              )}
-            </li>
-          )
-        })}
-      </ol>
-      <div ref={bottomRef} />
+    <div className="relative flex min-h-0 flex-1 flex-col">
+      <div ref={scrollRef} onScroll={onScroll} className="flex-1 overflow-y-auto p-4">
+        <ol className="space-y-1 font-mono text-xs">
+          {events.map((e, i) => {
+            const disclosable = disclosableText(e)
+            return (
+              <li key={i} className="flex items-start gap-2">
+                <Badge className="mt-0.5 shrink-0 text-[10px] uppercase text-muted-foreground">{e.kind}</Badge>
+                {disclosable ? (
+                  <details className="min-w-0 flex-1">
+                    <summary className="cursor-pointer text-foreground marker:text-muted-foreground">
+                      {disclosable.label} ({disclosable.text.length.toLocaleString()} chars) — click to expand
+                    </summary>
+                    <pre className="mt-1 max-h-96 overflow-auto whitespace-pre-wrap break-words rounded bg-muted p-2 text-foreground">{disclosable.text}</pre>
+                  </details>
+                ) : (
+                  <span className="whitespace-pre-wrap break-words text-foreground">{(formatFrameworkEvent(e) ?? '').trim()}</span>
+                )}
+              </li>
+            )
+          })}
+        </ol>
+        <div ref={bottomRef} />
+      </div>
+      {stick && !atBottom && (
+        <button
+          type="button"
+          onClick={() => {
+            bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+            setAtBottom(true)
+          }}
+          className="absolute bottom-3 left-1/2 -translate-x-1/2 rounded-full border border-border bg-background/90 px-3 py-1 text-xs text-foreground shadow-sm backdrop-blur hover:bg-accent"
+        >
+          Jump to latest ↓
+        </button>
+      )}
     </div>
   )
 }

--- a/packages/framework-dashboard/components/ProjectsSidebar.tsx
+++ b/packages/framework-dashboard/components/ProjectsSidebar.tsx
@@ -82,10 +82,14 @@ export function ProjectsSidebar({
             onClick={() => onSelect(p.id)}
           >
             <span className="flex w-full items-center gap-2">
+              {/* Status by color alone reads as nothing to a screen reader (#695/U33): hide the
+                  decorative dot and give it an sr-only text alternative. */}
               <span
+                aria-hidden
                 className={cn('h-2 w-2 shrink-0 rounded-full', p.activated ? 'bg-primary' : 'bg-muted-foreground')}
                 title={p.activated ? 'activated' : 'not activated'}
               />
+              <span className="sr-only">{p.activated ? 'Activated' : 'Not activated'}: </span>
               <span className="truncate font-medium">{p.name}</span>
             </span>
             <span className="truncate pl-4 text-xs font-normal text-muted-foreground">

--- a/packages/framework-dashboard/components/PromptEditor.tsx
+++ b/packages/framework-dashboard/components/PromptEditor.tsx
@@ -92,6 +92,9 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
   // markdown out). Takes the editor as an argument so the `/` menu — whose closures are built
   // once, before useEditor resolves — can call it too, not only the imperative handle.
   const loadTemplateInto = (ed: Editor, text: string): void => {
+    // Loading a preset replaces the whole editor, so guard typed work (#695/U11): a non-empty
+    // editor gets one confirm before its content is discarded. An empty editor loads silently.
+    if (!ed.isEmpty && typeof window !== 'undefined' && !window.confirm('Replace your current prompt with this preset?')) return
     applyTemplate(ed, text)
     setIsEmpty(ed.isEmpty)
     onChangeRef.current(ed.storage.markdown.getMarkdown())

--- a/packages/framework-dashboard/components/RightRail.tsx
+++ b/packages/framework-dashboard/components/RightRail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { ChoiceRequest } from '@gemstack/framework'
 import { DocsPanel } from './DocsPanel.js'
 import { ProjectLogPanel } from './ProjectLogPanel.js'
@@ -36,15 +36,32 @@ export function RightRail({
   toggleContext: (path: string) => void
 }) {
   const [tab, setTab] = useState<Tab>('docs')
+  // Once the user picks a tab, stop auto-defaulting (#695/U22) — only a genuinely new choice
+  // gate or the first view may still pull focus after that.
+  const touched = useRef(false)
+  const pickTab = (t: Tab) => {
+    touched.current = true
+    setTab(t)
+  }
   const hasChoices = choices.length > 0
   const hasViews = views.length > 0
   const hasFiles = files.length > 0
 
-  // Pull the rail to the most urgent surface: a choice gate over a view, else the file tree
-  // when just browsing a project (#492), else the docs.
+  // Only pull the rail for something genuinely new (#695/U22): a fresh choice gate (an id we
+  // haven't shown) or the first view. A resolving gate, a second view, or a Files flip no longer
+  // yanks the tab you're reading, and an explicit pick is never overridden by the browse default.
+  const seenChoiceIds = useRef<Set<string>>(new Set())
+  const sawView = useRef(false)
   useEffect(() => {
-    setTab(hasChoices ? 'choices' : hasViews ? 'views' : hasFiles ? 'files' : 'docs')
-  }, [hasChoices, hasViews, hasFiles])
+    const freshChoice = choices.some(c => !seenChoiceIds.current.has(c.id))
+    for (const c of choices) seenChoiceIds.current.add(c.id)
+    const firstView = hasViews && !sawView.current
+    sawView.current = sawView.current || hasViews
+
+    if (freshChoice) setTab('choices')
+    else if (firstView) setTab('views')
+    else if (!touched.current && !hasChoices && !hasViews) setTab(hasFiles ? 'files' : 'docs')
+  }, [choices, hasChoices, hasViews, hasFiles])
 
   if (!projectId) return null
 
@@ -72,7 +89,7 @@ export function RightRail({
             variant="ghost"
             size="sm"
             className={cn('h-7 gap-1.5 text-xs', tab === t && 'bg-accent text-accent-foreground')}
-            onClick={() => setTab(t)}
+            onClick={() => pickTab(t)}
           >
             {label(t)}
             {count(t) > 0 && <Badge className="border-primary/40 text-primary">{count(t)}</Badge>}

--- a/packages/framework-dashboard/components/RunOverview.tsx
+++ b/packages/framework-dashboard/components/RunOverview.tsx
@@ -1,6 +1,7 @@
 import type { FrameworkEvent } from '@gemstack/framework'
 import { loopStatus, sessionInfo, deployPlan, runProgress } from '@gemstack/framework/client'
 import { Badge } from './ui/badge.js'
+import { isRunActive } from '../lib/live-state.js'
 import { cn } from '../lib/utils.js'
 
 // The run overview (#431): the "moat" the wrapped agent's own chat cannot show, rebuilt
@@ -14,6 +15,9 @@ export function RunOverview({ events }: { events: FrameworkEvent[] }) {
   const deploy = deployPlan(events)
   const progress = runProgress(events)
   const hasProgress = Boolean(progress.sessionName) || progress.readyForMerge
+  // A run only pulses "building…" while it's live (#695/U20): once the `end` event lands the
+  // pill must settle to the final state ("ready for merge" or "finished") instead of pulsing on.
+  const active = isRunActive(events)
 
   if (!loop && !deploy && !session?.sessionLink && !hasProgress) return null
 
@@ -22,10 +26,16 @@ export function RunOverview({ events }: { events: FrameworkEvent[] }) {
       {hasProgress && (
         <div className="flex items-center gap-2 text-sm md:col-span-2">
           <span
-            className={cn('h-2.5 w-2.5 shrink-0 rounded-full', progress.readyForMerge ? 'bg-green-500' : 'animate-pulse bg-amber-500')}
+            className={cn(
+              'h-2.5 w-2.5 shrink-0 rounded-full',
+              progress.readyForMerge ? 'bg-green-500' : active ? 'animate-pulse bg-amber-500' : 'bg-muted-foreground',
+            )}
+            aria-hidden
           />
           {progress.sessionName && <span className="font-medium">{progress.sessionName}</span>}
-          <span className="text-xs text-muted-foreground">{progress.readyForMerge ? 'ready for merge' : 'building…'}</span>
+          <span className="text-xs text-muted-foreground">
+            {progress.readyForMerge ? 'ready for merge' : active ? 'building…' : 'finished'}
+          </span>
         </div>
       )}
       {loop && (

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -274,9 +274,19 @@ export function StartRunForm({
           type="submit"
           className="ml-auto"
           disabled={busy || !prompt.trim()}
-          title={!prompt.trim() ? 'Type a prompt to start a run' : undefined}
+          title={!prompt.trim() ? 'Type a prompt to start a run' : 'Start run  (⌘↵ / Ctrl+Enter)'}
         >
-          {busy ? 'Starting…' : 'Start run'}
+          {busy ? (
+            'Starting…'
+          ) : (
+            <>
+              Start run
+              {/* The editor submits on ⌘/Ctrl+Enter (#695/U13): surface the otherwise-hidden shortcut. */}
+              <kbd className="ml-1.5 hidden rounded border border-primary-foreground/30 px-1 text-[10px] font-medium text-primary-foreground/70 sm:inline">
+                ⌘↵
+              </kbd>
+            </>
+          )}
         </Button>
       </div>
 

--- a/packages/framework-dashboard/lib/document-title.test.ts
+++ b/packages/framework-dashboard/lib/document-title.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { frameworkTitle } from './document-title.js'
+
+describe('frameworkTitle', () => {
+  it('is the bare brand with no count and no project', () => {
+    expect(frameworkTitle(0)).toBe('The Framework')
+    expect(frameworkTitle(0, null)).toBe('The Framework')
+  })
+
+  it('prefixes the needs-you count when there is one', () => {
+    expect(frameworkTitle(2)).toBe('(2) The Framework')
+  })
+
+  it('scopes to the selected project', () => {
+    expect(frameworkTitle(0, 'gemstack')).toBe('gemstack — The Framework')
+  })
+
+  it('combines the count and the project', () => {
+    expect(frameworkTitle(2, 'gemstack')).toBe('(2) gemstack — The Framework')
+  })
+
+  it('drops the count when zero', () => {
+    expect(frameworkTitle(0, 'gemstack')).toBe('gemstack — The Framework')
+  })
+})

--- a/packages/framework-dashboard/lib/document-title.ts
+++ b/packages/framework-dashboard/lib/document-title.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react'
+
+// The browser-tab title (#695/U3). A static "The Framework" hides which of several open tabs
+// needs you; fold the "needs you" count and the selected project into document.title so the
+// tab alone tells you, e.g. `(2) gemstack — The Framework`.
+
+/** Compose the tab title from the needs-you count and the selected project name. */
+export function frameworkTitle(needsYou: number, projectName?: string | null): string {
+  const prefix = needsYou > 0 ? `(${needsYou}) ` : ''
+  const scope = projectName ? `${projectName} — ` : ''
+  return `${prefix}${scope}The Framework`
+}
+
+/** Keep document.title in sync with the needs-you count and selected project (client-only). */
+export function useDocumentTitle(needsYou: number, projectName?: string | null): void {
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    document.title = frameworkTitle(needsYou, projectName)
+  }, [needsYou, projectName])
+}

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
-import type { Intervention, Activity } from '@gemstack/framework'
+import type { Intervention, Activity, ProjectSummary } from '@gemstack/framework'
 import { onProjectFiles, onInterventions, onActivity } from '../../server/reads.telefunc.js'
+import { onProjects } from '../../server/projects.telefunc.js'
 import { ProjectsSidebar } from '../../components/ProjectsSidebar.js'
 import { NotificationsMenu } from '../../components/NotificationsMenu.js'
 import { RunHistory } from '../../components/RunHistory.js'
@@ -20,9 +21,13 @@ import { useInterventionNotifications } from '../../lib/use-intervention-notific
 import { useActivityNotifications } from '../../lib/use-activity-notifications.js'
 import { usePreferences, notificationsEnabled, newActivityEnabled, humanInterventionEnabled } from '../../lib/preferences.js'
 import { pendingChoices, agentViews } from '../../lib/live-state.js'
+import { useDocumentTitle } from '../../lib/document-title.js'
 
 /** Stable, so `files` keeps one identity while no project is selected. */
 const EMPTY_FILES: string[] = []
+
+/** Stable initial for the projects load, so it does not churn on every render. */
+const EMPTY_PROJECTS: ProjectSummary[] = []
 
 /** Stable initial for the interventions poll, so it does not churn on every render. */
 const EMPTY_INTERVENTIONS: Intervention[] = []
@@ -64,6 +69,13 @@ export default function Page() {
   // the sidebar badge and the Overview card share one poll. Slow cadence — PRs change rarely and
   // each poll spawns `gh` per project.
   const { value: interventions } = usePolled<Intervention[]>(onInterventions, EMPTY_INTERVENTIONS, 15000, [])
+
+  // The registered projects, loaded once for the browser-tab title (#695/U3): the selected
+  // project's name plus the needs-you count drive `document.title` so a backgrounded tab tells
+  // you which project needs attention. The sidebar keeps its own poll; this is a cheap one-shot.
+  const projects = useLoaded<ProjectSummary[]>(onProjects, EMPTY_PROJECTS, [])
+  const projectName = projectId ? projects.find(p => p.id === projectId)?.name : null
+  useDocumentTitle(interventions.length, projectName)
 
   // Fire a browser notification when a new item lands on the "needs you" queue (#627). Rides the
   // one interventions poll above (the poll stays unconditional — it also feeds the sidebar badge


### PR DESCRIPTION
A focused batch of seven small, high-confidence fixes from the U1-U33 UX review (PR #696), the same shape as the merged #691. Dashboard is a private package, so no changeset.

## Fixes

| Ref | Fix |
|-----|-----|
| **U20** | The project-home pill stops pulsing "building…" once a run ends; it settles to "ready for merge" or "finished" (drives off `isRunActive`). |
| **U11** | Loading a preset now confirms before it discards a non-empty prompt (data-loss guard). |
| **U13** | The Start button surfaces the otherwise-hidden ⌘/Ctrl+Enter submit shortcut (title + small kbd). |
| **U19** | The event log sticks to the bottom only when you are already near it; a "Jump to latest ↓" chip appears when you have scrolled up to read. |
| **U22** | The right rail auto-switches only for a genuinely new choice gate (by id) or the first view, and never overrides a tab you picked. |
| **U3** | The browser-tab title reflects the needs-you count and selected project, e.g. `(2) gemstack — The Framework`. |
| **U33** | Status dots (sidebar, Working now, Projects table, run pill) are `aria-hidden` with sr-only text alternatives instead of color + hover only. |

## Notes for review

- **U5 was intentionally dropped** from this batch. The plan flags it (like U8) for an alternatives round before code — the "Live" launcher rename is a naming decision (Home? house icon?). Left for a design pass.
- **U22 minor behavior change**: the rail no longer force-selects Files/Docs after you've clicked a tab; the browse default still applies until your first pick. Badges signal the rest.
- **U24** (auto-select the newest view within the Views tab) is a natural follow-up to U22 and still open.

## Verify

- `pnpm --filter @gemstack/framework-dashboard typecheck` — clean
- `vitest run` — 82 passed (77 baseline + 5 new `document-title` tests)
- `pnpm build` — clean; all seven new UI strings confirmed present in the shipped client bundle

Closes #695.