### PR TITLE
fix(framework-dashboard): scope the live feed to the current run

### DIFF
--- a/packages/framework-dashboard/lib/live-state.test.ts
+++ b/packages/framework-dashboard/lib/live-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import type { FrameworkEvent } from '@gemstack/framework'
-import { agentViews, pendingChoices, pendingChoice, isRunActive } from './live-state.js'
+import { agentViews, pendingChoices, pendingChoice, isRunActive, currentRunEvents } from './live-state.js'
 
 const view = (id: string, title: string, markdown: string): FrameworkEvent => ({ kind: 'view', id, title, markdown })
 const choice = (id: string, title: string): FrameworkEvent => ({
@@ -62,5 +62,46 @@ describe('isRunActive', () => {
     expect(isRunActive([])).toBe(false)
     expect(isRunActive([{ kind: 'log', message: 'go' }])).toBe(true)
     expect(isRunActive([{ kind: 'log', message: 'go' }, { kind: 'end', ok: true }])).toBe(false)
+  })
+})
+
+describe('currentRunEvents', () => {
+  const session = (workspace: string): FrameworkEvent => ({ kind: 'session', driver: 'claude', workspace, fake: false })
+
+  test('returns the feed whole when no run has opened yet', () => {
+    const events: FrameworkEvent[] = [{ kind: 'log', message: 'warming up' }]
+    expect(currentRunEvents(events)).toEqual(events)
+  })
+
+  test('keeps a single run intact, session-first', () => {
+    const events: FrameworkEvent[] = [session('/repo'), { kind: 'log', message: 'go' }, { kind: 'end', ok: true }]
+    expect(currentRunEvents(events)).toEqual(events)
+  })
+
+  test('drops a previous run once a new run opens (the bug)', () => {
+    const events: FrameworkEvent[] = [
+      session('/repo'),
+      { kind: 'log', message: 'run 1' },
+      { kind: 'end', ok: true },
+      session('/repo'),
+      { kind: 'log', message: 'run 2' },
+    ]
+    expect(currentRunEvents(events)).toEqual([session('/repo'), { kind: 'log', message: 'run 2' }])
+  })
+
+  test('a just-finished second run keeps its own end, not the first run', () => {
+    const events: FrameworkEvent[] = [
+      session('/repo'),
+      { kind: 'log', message: 'run 1' },
+      { kind: 'end', ok: true },
+      session('/repo'),
+      { kind: 'log', message: 'run 2' },
+      { kind: 'end', ok: false, stopped: true },
+    ]
+    expect(currentRunEvents(events)).toEqual([
+      session('/repo'),
+      { kind: 'log', message: 'run 2' },
+      { kind: 'end', ok: false, stopped: true },
+    ])
   })
 })

--- a/packages/framework-dashboard/lib/live-state.ts
+++ b/packages/framework-dashboard/lib/live-state.ts
@@ -68,3 +68,23 @@ export function agentViews(events: readonly FrameworkEvent[]): AgentView[] {
 export function isRunActive(events: readonly FrameworkEvent[]): boolean {
   return events.length > 0 && !events.some(event => event.kind === 'end')
 }
+
+/**
+ * The current run's slice of an accumulated live feed. The dashboard's live channel keeps
+ * one long-lived subscription per project and appends every streamed event, but each run
+ * truncates `events.jsonl` on disk and opens with exactly one `session` event
+ * (`emitSessionStart`). So a subscription that spans a run boundary ends up holding the
+ * previous run's log followed by the new one. Keep only the tail from the last `session`
+ * event — that is the run in progress; a feed with no `session` yet is returned whole. This
+ * stops a fresh run's live view (and the right-rail choices/views) from showing the prior run.
+ */
+export function currentRunEvents(events: readonly FrameworkEvent[]): FrameworkEvent[] {
+  let start = 0
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i]?.kind === 'session') {
+      start = i
+      break
+    }
+  }
+  return events.slice(start)
+}

--- a/packages/framework-dashboard/lib/use-live-events.ts
+++ b/packages/framework-dashboard/lib/use-live-events.ts
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { FrameworkEvent } from '@gemstack/framework'
 import type { ClientChannel } from 'telefunc'
 import { onEvents } from '../server/events.telefunc.js'
+import { currentRunEvents } from './live-state.js'
 
 // The live run feed (#405), shared. The dashboard is a projection of the selected project's
 // `.the-framework/events.jsonl`, streamed over a Telefunc Channel that pushes one
@@ -30,5 +31,8 @@ export function useLiveEvents(projectId: string | null): FrameworkEvent[] {
     }
   }, [projectId])
 
-  return events
+  // Scope the accumulated feed to the run in progress. The subscription lives across run
+  // boundaries (it only resets on a project switch), so without this a second run would show
+  // the previous run's log until it finished. See {@link currentRunEvents}.
+  return useMemo(() => currentRunEvents(events), [events])
 }


### PR DESCRIPTION
Closes #700.

## The bug
A new run's live view (`RunLive`) and the right-rail choices/views showed the **previous** run's log mixed in, until the run finished and the view switched to the archived replay.

## Root cause
On disk each run truncates `events.jsonl`, but the client's `useLiveEvents` keeps one long-lived Telefunc subscription per project and only resets its buffer on a project switch, never on a run boundary. A subscription that spans a run boundary holds the old run's log followed by the new one. The finished view is correct because it reads the run-scoped archive (`onRun`).

## Fix
Every run opens with exactly one `session` event (`emitSessionStart`). New pure helper `currentRunEvents()` (live-state.ts) returns the tail from the last `session` event; applied in `useLiveEvents` so the run view, right-rail gates/views, and the home overview all scope to the run in progress.

- Client-only (private package) → no changeset.
- Robust against subscription/truncation timing (no reliance on a UI run-start signal).

## Verify
- typecheck clean; `vitest run` = 81 passed (77 baseline + 4 new `currentRunEvents` tests); build clean.