### PR TITLE
fix(framework-dashboard): label the session link honestly

### DIFF
--- a/packages/framework-dashboard/components/RunOverview.tsx
+++ b/packages/framework-dashboard/components/RunOverview.tsx
@@ -2,6 +2,7 @@ import type { FrameworkEvent } from '@gemstack/framework'
 import { loopStatus, sessionInfo, deployPlan, runProgress } from '@gemstack/framework/client'
 import { Badge } from './ui/badge.js'
 import { isRunActive } from '../lib/live-state.js'
+import { describeSessionLink } from '../lib/session-link.js'
 import { cn } from '../lib/utils.js'
 
 // The run overview (#431): the "moat" the wrapped agent's own chat cannot show, rebuilt
@@ -18,6 +19,11 @@ export function RunOverview({ events }: { events: FrameworkEvent[] }) {
   // A run only pulses "building…" while it's live (#695/U20): once the `end` event lands the
   // pill must settle to the final state ("ready for merge" or "finished") instead of pulsing on.
   const active = isRunActive(events)
+
+  // The "Open session" link, labeled honestly: a headless Claude Code run has no per-session
+  // URL, so the generic app entry (claude.ai/code) is shown as "Open Claude Code" with the id
+  // surfaced separately, not as a deep link to that id. See {@link describeSessionLink}.
+  const sessionLink = describeSessionLink(session)
 
   if (!loop && !deploy && !session?.sessionLink && !hasProgress) return null
 
@@ -72,15 +78,17 @@ export function RunOverview({ events }: { events: FrameworkEvent[] }) {
         </section>
       )}
 
-      {session?.sessionLink && (
-        <a
-          href={session.sessionLink}
-          target="_blank"
-          rel="noreferrer"
-          className="text-xs text-primary underline underline-offset-2 md:col-span-2"
-        >
-          Open session{session.sessionId ? ` (${session.sessionId})` : ''} ↗
-        </a>
+      {sessionLink && (
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs md:col-span-2">
+          <a href={sessionLink.href} target="_blank" rel="noreferrer" className="text-primary underline underline-offset-2">
+            {sessionLink.label}
+          </a>
+          {sessionLink.id && (
+            <span className="text-muted-foreground" title="Claude Code session id">
+              session <code className="font-mono text-[11px]">{sessionLink.id}</code>
+            </span>
+          )}
+        </div>
       )}
     </div>
   )

--- a/packages/framework-dashboard/lib/session-link.test.ts
+++ b/packages/framework-dashboard/lib/session-link.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { describeSessionLink } from './session-link.js'
+
+describe('describeSessionLink', () => {
+  it('returns null when there is no link', () => {
+    expect(describeSessionLink(null)).toBeNull()
+    expect(describeSessionLink({})).toBeNull()
+    expect(describeSessionLink({ sessionId: 'abc', driver: 'claude' })).toBeNull()
+  })
+
+  it('labels the generic Claude Code entry honestly and surfaces the id separately (the bug)', () => {
+    const view = describeSessionLink({ sessionLink: 'https://claude.ai/code', sessionId: '532ccc4b', driver: 'claude' })
+    expect(view).toEqual({ href: 'https://claude.ai/code', label: 'Open Claude Code ↗', id: '532ccc4b' })
+  })
+
+  it('keeps "Open session (id)" for a real deep link that encodes the id', () => {
+    const view = describeSessionLink({ sessionLink: 'https://example.com/s/532ccc4b', sessionId: '532ccc4b', driver: 'claude' })
+    expect(view).toEqual({ href: 'https://example.com/s/532ccc4b', label: 'Open session (532ccc4b) ↗', id: null })
+  })
+
+  it('does not claim a session before the id is reported', () => {
+    const view = describeSessionLink({ sessionLink: 'https://claude.ai/code', driver: 'claude' })
+    expect(view).toEqual({ href: 'https://claude.ai/code', label: 'Open Claude Code ↗', id: null })
+  })
+
+  it('for a non-Claude custom link, shows a neutral label plus the id', () => {
+    const view = describeSessionLink({ sessionLink: 'https://foo.test', sessionId: 'x1', driver: 'codex' })
+    expect(view).toEqual({ href: 'https://foo.test', label: 'Open session ↗', id: 'x1' })
+  })
+})

--- a/packages/framework-dashboard/lib/session-link.ts
+++ b/packages/framework-dashboard/lib/session-link.ts
@@ -1,0 +1,37 @@
+// Honest labeling for a run's "Open session" link. Only a URL that actually encodes the
+// session id opens *this* session. A headless Claude Code run has no per-session URL — the
+// framework defaults to the generic app entry point (claude.ai/code) as an "open the app"
+// affordance — so surfacing it as "Open session (<id>)" wrongly implies the link resolves to
+// that id. Here we detect the difference and describe the link honestly; the id, when it is
+// not encoded in the URL, is returned separately so the UI can show it as plain text.
+
+/** The minimal shape of `sessionInfo(events)` this needs, kept structural so it never
+ *  couples to the framework's exact type. */
+export interface SessionLike {
+  sessionLink?: string | undefined
+  sessionId?: string | undefined
+  driver?: string | undefined
+}
+
+export interface SessionLinkView {
+  /** The URL to open. */
+  href: string
+  /** The honest link text. */
+  label: string
+  /** The session id to show as separate text, or null when the link already encodes it. */
+  id: string | null
+}
+
+/** Describe a run's session link, or null when there is no link to show. */
+export function describeSessionLink(session?: SessionLike | null): SessionLinkView | null {
+  const href = session?.sessionLink
+  if (!href) return null
+  const id = session?.sessionId
+  const deep = Boolean(id && href.includes(id))
+  const label = deep
+    ? `Open session (${id}) ↗`
+    : session?.driver === 'claude'
+      ? 'Open Claude Code ↗'
+      : 'Open session ↗'
+  return { href, label, id: !deep && id ? id : null }
+}


### PR DESCRIPTION
Closes #702.

## The bug
On a live run the overview showed `Open session (<id>) ↗`, but clicking it opened the generic `https://claude.ai/code` landing page, not that session.

## Cause
A headless Claude Code run has no per-session URL. The framework intentionally defaults to `CLAUDE_CODE_SESSION_LINK = https://claude.ai/code` as an "open the app" affordance (session-link.ts). `RunOverview` mislabeled that generic link as a per-session deep link.

## Fix
New pure helper `describeSessionLink()` (lib/session-link.ts): claim "Open session (id)" only when the URL actually encodes the id; otherwise label it "Open Claude Code" and surface the id as separate plain text.

- Client-only (private package) → no changeset.

## Verify
- typecheck clean; `vitest run` = 91 passed (+5 new `session-link` tests); build clean.