### PR TITLE
feat(framework-dashboard): jump to the run's live output on Start

### DIFF
--- a/packages/framework-dashboard/components/RunHistory.tsx
+++ b/packages/framework-dashboard/components/RunHistory.tsx
@@ -24,6 +24,7 @@ export function RunHistory({
   onSelect,
   startTick = 0,
   startIntent = '',
+  followLive = false,
 }: {
   projectId: string | null
   runs: RunMeta[]
@@ -31,6 +32,9 @@ export function RunHistory({
   onSelect: (runId: string | null) => void
   startTick?: number
   startIntent?: string
+  /** Just started a run and following its live output (#705): highlight the running/optimistic
+   *  row at once, not the Live home row, before the poll adopts the run's real id. */
+  followLive?: boolean
 }) {
   const [optimistic, setOptimistic] = useState<string | null>(null)
 
@@ -48,7 +52,9 @@ export function RunHistory({
 
   if (!projectId) return null
 
-  const atHome = selectedRunId === null
+  // While following a just-started run, the highlight belongs on that run (its optimistic row,
+  // then its real row) — not the Live home row, even though no run id is selected yet (#705).
+  const atHome = selectedRunId === null && !followLive
 
   return (
     <aside className="flex w-60 shrink-0 flex-col border-r border-border">
@@ -63,9 +69,9 @@ export function RunHistory({
           <span className="mr-2 inline-block h-2 w-2 rounded-full bg-primary" /> Live
         </Button>
 
-        {/* A just-started run, before its run.json exists. */}
+        {/* A just-started run, before its run.json exists — highlighted while following it. */}
         {optimistic !== null && !hasRunning && (
-          <RunRow status="running" intent={optimistic} subtitle="starting…" active={false} dim onClick={() => onSelect(null)} />
+          <RunRow status="running" intent={optimistic} subtitle="starting…" active={followLive} dim onClick={() => onSelect(null)} />
         )}
 
         {runs.length === 0 && optimistic === null && (
@@ -77,7 +83,7 @@ export function RunHistory({
             status={run.status}
             intent={run.intent}
             subtitle={new Date(run.startedAt).toLocaleString()}
-            active={run.id === selectedRunId}
+            active={run.id === selectedRunId || (followLive && run.status === 'running')}
             onClick={() => onSelect(run.id)}
           />
         ))}

--- a/packages/framework-dashboard/lib/use-live-events.ts
+++ b/packages/framework-dashboard/lib/use-live-events.ts
@@ -9,8 +9,18 @@ import { currentRunEvents } from './live-state.js'
 // `FrameworkEvent` per new line. Both the main event view and the right rail's choice gates
 // (#440) read this same stream, so the subscription lives here and each consumer owns one
 // channel for its project rather than opening a second.
-export function useLiveEvents(projectId: string | null): FrameworkEvent[] {
+export function useLiveEvents(projectId: string | null, resetKey?: unknown): FrameworkEvent[] {
   const [events, setEvents] = useState<FrameworkEvent[]>([])
+
+  // Drop the accumulated feed at a run boundary the caller knows about (a fresh Start bumps
+  // `resetKey`), WITHOUT tearing down the subscription. The new run truncates events.jsonl a
+  // beat later, so until its first line streams the buffer would otherwise still hold the
+  // finished run — which the jump-to-live view (#705) would show. Clearing here means the pane
+  // waits empty for the new run instead. The live tail then re-reads the truncated file on its
+  // own (JsonlTailer rewrite detection) and streams the new run in.
+  useEffect(() => {
+    setEvents([])
+  }, [resetKey])
 
   useEffect(() => {
     setEvents([])

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -140,7 +140,7 @@ export default function Page() {
 
   // The live run feed is owned here so both the main view and the right rail's choice gates
   // (#440) read one shared Telefunc Channel. Hooks run before the relay early return below.
-  const events = useLiveEvents(projectId)
+  const events = useLiveEvents(projectId, runStart.tick)
   const choices = projectId ? pendingChoices(events) : []
   const views = projectId ? agentViews(events) : []
 

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -199,6 +199,7 @@ export default function Page() {
           onSelect={selectRun}
           startTick={runStart.tick}
           startIntent={runStart.intent}
+          followLive={followLive}
         />
         <main className="flex min-w-0 flex-1 flex-col">{renderMain()}</main>
         <RightRail

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { Intervention, Activity, ProjectSummary } from '@gemstack/framework'
 import { onProjectFiles, onInterventions, onActivity } from '../../server/reads.telefunc.js'
 import { onProjects } from '../../server/projects.telefunc.js'
@@ -53,6 +53,10 @@ export default function Page() {
   // A just-started run: bump the tick so the Runs rail shows an optimistic "starting…" row
   // with the typed prompt at once, before the spawned process writes its run.json.
   const [runStart, setRunStart] = useState<{ tick: number; intent: string }>({ tick: 0, intent: '' })
+  // Just pressed Start: jump straight to the run's live output. sendStart returns no id (the
+  // run is a detached process that writes its run.json a beat later), so follow the shared live
+  // feed until the poll surfaces the real run row, which the effect below adopts as the selection.
+  const [followLive, setFollowLive] = useState(false)
 
   const { runs, reload } = useRuns(projectId)
 
@@ -93,15 +97,36 @@ export default function Page() {
   useActivityNotifications(activity, browserActivity)
 
   const onRunStarted = (intent: string) => {
-    // Stay on the home launcher (it must stay visible so you can launch again); the new run
-    // just appends to the rail. Reload so its real row replaces the optimistic one quickly.
+    // Jump to the new run's live output (the launcher stays on the "Live" row, one click back).
+    // The new run just appends to the rail; reload so its real row shows up quickly.
     setRunStart(prev => ({ tick: prev.tick + 1, intent }))
+    setFollowLive(true)
     reload()
+  }
+
+  // Adopt the started run's real id as the selection the moment the poll surfaces it as running,
+  // so the view follows its normal running -> done -> replay lifecycle and the rail highlights the
+  // run's own row. Until then `followLive` shows the shared live output.
+  useEffect(() => {
+    if (!followLive) return
+    const running = runs.find(run => run.status === 'running')
+    if (running) {
+      setRunId(running.id)
+      setFollowLive(false)
+    }
+  }, [followLive, runs])
+
+  // Selecting a run (or the Live/Home row) from the rail is always an explicit choice, so it
+  // ends the just-started follow.
+  const selectRun = (id: string | null) => {
+    setFollowLive(false)
+    setRunId(id)
   }
 
   const selectProject = (id: string) => {
     setProjectId(id) // persisted, so a refresh returns here
     setRunId(null) // switching projects always returns to the home launcher
+    setFollowLive(false)
     resetContext() // the picked context is the old project's — start fresh
   }
 
@@ -110,6 +135,7 @@ export default function Page() {
   const showDashboard = () => {
     setProjectId(null)
     setRunId(null)
+    setFollowLive(false)
   }
 
   // The live run feed is owned here so both the main view and the right rail's choice gates
@@ -131,7 +157,9 @@ export default function Page() {
   const selectedRun = runId ? runs.find(run => run.id === runId) : undefined
   const renderMain = () => {
     if (!projectId) return <DashboardPage onSelectProject={selectProject} interventions={interventions} />
-    if (runId === null)
+    if (runId === null) {
+      // Just pressed Start: follow the run's live output until the poll adopts its real id above.
+      if (followLive) return <RunLive projectId={projectId} events={events} />
       return (
         <ProjectHome
           projectId={projectId}
@@ -143,6 +171,7 @@ export default function Page() {
           toggleContext={toggleContext}
         />
       )
+    }
     if (selectedRun?.status === 'running') return <RunLive projectId={projectId} events={events} />
     return <RunReplay projectId={projectId} runId={runId} />
   }
@@ -167,7 +196,7 @@ export default function Page() {
           projectId={projectId}
           runs={runs}
           selectedRunId={runId}
-          onSelect={setRunId}
+          onSelect={selectRun}
           startTick={runStart.tick}
           startIntent={runStart.intent}
         />


### PR DESCRIPTION
Closes #704.

## What
Pressing **Start run** now navigates straight to the run's live output instead of leaving you on the launcher to hunt for the new row.

## How
`sendStart` returns no run id (the run is a detached process that writes `run.json` a beat later), so the shell:
1. sets a `followLive` flag on Start and renders `RunLive` (the shared live feed — needs no id) right away, and
2. adopts the run's real id the moment the runs poll surfaces it as `running`, after which the view follows the normal **running → done → replay** lifecycle and the rail highlights the run's own row.

Selecting any run/Live, switching projects, or opening the Overview ends the follow.

## Compatible with the "Live is a launcher" model
The launcher is unchanged and stays one click away on the **Live** row; this only changes the default pane after Start (it does not fold Live into the running run).

- Client-only (private package) → no changeset.

## Verify
- typecheck clean; `vitest run` = 86 passed; build clean.
- Live: Start a run → the pane switches to its live output; when it finishes it becomes the replay; clicking **Live** returns to the launcher.