### PR TITLE
feat(framework-dashboard): one action bar for Serve, Stop, and Open session

### DIFF
--- a/packages/framework-dashboard/components/RunActionBar.tsx
+++ b/packages/framework-dashboard/components/RunActionBar.tsx
@@ -1,0 +1,69 @@
+import type { FrameworkEvent } from '@gemstack/framework'
+import { sessionInfo } from '@gemstack/framework/client'
+import { Square, ExternalLink } from 'lucide-react'
+import { sendStop } from '../server/control.telefunc.js'
+import { useAction } from '../lib/use-action.js'
+import { isRunActive } from '../lib/live-state.js'
+import { describeSessionLink } from '../lib/session-link.js'
+import { PreviewBar } from './PreviewBar.js'
+import { Button, buttonVariants } from './ui/button.js'
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './ui/tooltip.js'
+
+// One run's action bar: Serve, Stop, and Open session as a single row of icon buttons with
+// tooltips, instead of three stacked labeled rows. Shared by the live view (RunLive) and the
+// finished replay (RunReplay), so the controls stay put when a run reaches Done. Serve is a
+// project-level action (always available); Stop shows only while the run is active; Open session
+// appears once the run has reported one (honestly labeled — see describeSessionLink).
+export function RunActionBar({ projectId, events }: { projectId: string; events: FrameworkEvent[] }) {
+  // Stop routes through useAction like every other mutation: a click disables + shows "Stopping…"
+  // and a failed stop surfaces instead of silently doing nothing.
+  const { busy, error, run } = useAction()
+  const active = isRunActive(events)
+  const session = describeSessionLink(sessionInfo(events))
+  // The bar's buttons are icon-only, so the link's label rides in the tooltip (drop its arrow).
+  const sessionTip = session && (session.id ? `${session.label.replace(' ↗', '')} — session ${session.id}` : session.label.replace(' ↗', ''))
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-2">
+      <TooltipProvider delay={300} closeDelay={0}>
+        {/* Serve the project's built result (its own icon button + tooltip). */}
+        <PreviewBar projectId={projectId} inline />
+        {active && (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="outline"
+                  size="icon-sm"
+                  disabled={busy}
+                  onClick={() => void run(() => sendStop(projectId), 'Could not stop the run.')}
+                />
+              }
+            >
+              <Square className="h-3 w-3 fill-current" />
+            </TooltipTrigger>
+            <TooltipContent>{busy ? 'Stopping…' : 'Stop run'}</TooltipContent>
+          </Tooltip>
+        )}
+        {session && (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <a
+                  href={session.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={buttonVariants({ variant: 'outline', size: 'icon-sm' })}
+                />
+              }
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+            </TooltipTrigger>
+            <TooltipContent>{sessionTip}</TooltipContent>
+          </Tooltip>
+        )}
+      </TooltipProvider>
+      {error && <span className="text-xs text-red-500">{error}</span>}
+    </div>
+  )
+}

--- a/packages/framework-dashboard/components/RunActionBar.tsx
+++ b/packages/framework-dashboard/components/RunActionBar.tsx
@@ -19,9 +19,9 @@ export function RunActionBar({ projectId, events }: { projectId: string; events:
   // and a failed stop surfaces instead of silently doing nothing.
   const { busy, error, run } = useAction()
   const active = isRunActive(events)
+  // Only a real per-session deep link is shown; the generic claude.ai/code entry is a dead end,
+  // so Claude Code runs get no Open button (the session id is still in the event log).
   const session = describeSessionLink(sessionInfo(events))
-  // The bar's buttons are icon-only, so the link's label rides in the tooltip (drop its arrow).
-  const sessionTip = session && (session.id ? `${session.label.replace(' ↗', '')} — session ${session.id}` : session.label.replace(' ↗', ''))
 
   return (
     <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-2">
@@ -59,7 +59,7 @@ export function RunActionBar({ projectId, events }: { projectId: string; events:
             >
               <ExternalLink className="h-3.5 w-3.5" />
             </TooltipTrigger>
-            <TooltipContent>{sessionTip}</TooltipContent>
+            <TooltipContent>{session.label.replace(' ↗', '')}</TooltipContent>
           </Tooltip>
         )}
       </TooltipProvider>

--- a/packages/framework-dashboard/components/RunFeed.tsx
+++ b/packages/framework-dashboard/components/RunFeed.tsx
@@ -3,15 +3,16 @@ import { EventList } from './EventList.js'
 import { RunOverview } from './RunOverview.js'
 
 // One run's feed: the run overview plus the live/replayed event log, or a waiting placeholder
-// before anything has streamed. Shared by the run's own view (RunLive, with its Stop control)
-// and the read-only relay watch view (RelayView).
-export function RunFeed({ events }: { events: FrameworkEvent[] }) {
+// before anything has streamed. Shared by the run's own view (RunLive, which shows the session
+// link in its action bar instead — `showSessionLink={false}`) and the read-only relay watch view
+// (RelayView, which keeps it since it has no action bar).
+export function RunFeed({ events, showSessionLink = true }: { events: FrameworkEvent[]; showSessionLink?: boolean }) {
   if (events.length === 0) {
     return <div className="grid flex-1 place-items-center text-sm text-muted-foreground">Waiting for the run to start…</div>
   }
   return (
     <>
-      <RunOverview events={events} />
+      <RunOverview events={events} showSessionLink={showSessionLink} />
       <EventList events={events} />
     </>
   )

--- a/packages/framework-dashboard/components/RunLive.tsx
+++ b/packages/framework-dashboard/components/RunLive.tsx
@@ -1,33 +1,17 @@
 import type { FrameworkEvent } from '@gemstack/framework'
-import { sendStop } from '../server/control.telefunc.js'
-import { useAction } from '../lib/use-action.js'
-import { PreviewBar } from './PreviewBar.js'
+import { RunActionBar } from './RunActionBar.js'
 import { RunFeed } from './RunFeed.js'
-import { Button } from './ui/button.js'
 
-// One running run's own view (its output): the run overview + the live event feed from the
-// shared Telefunc Channel, plus a Stop control. Distinct from the home launcher (ProjectHome)
-// and a finished run's replay (RunReplay). Single-run today streams the project's one live
-// feed; per-run streams arrive with worktrees (#453).
+// One running run's own view (its output): the action bar (Serve · Stop · Open session) plus the
+// run overview + live event feed from the shared Telefunc Channel. Distinct from the home launcher
+// (ProjectHome) and a finished run's replay (RunReplay). Single-run today streams the project's
+// one live feed; per-run streams arrive with worktrees (#453). The session link lives in the
+// action bar now, so the feed's overview drops it (`showSessionLink={false}`).
 export function RunLive({ projectId, events }: { projectId: string; events: FrameworkEvent[] }) {
-  // Stop routes through useAction like every other mutation, so a click disables + shows
-  // "Stopping…" and a failed stop surfaces instead of silently doing nothing (#627-adjacent UX).
-  const { busy, error, run } = useAction()
   return (
     <>
-      <PreviewBar projectId={projectId} />
-      <div className="flex items-center justify-end gap-3 border-b border-border px-4 py-2">
-        {error && <span className="text-xs text-red-500">{error}</span>}
-        <Button
-          variant="outline"
-          size="sm"
-          disabled={busy}
-          onClick={() => void run(() => sendStop(projectId), 'Could not stop the run.')}
-        >
-          {busy ? 'Stopping…' : 'Stop run'}
-        </Button>
-      </div>
-      <RunFeed events={events} />
+      <RunActionBar projectId={projectId} events={events} />
+      <RunFeed events={events} showSessionLink={false} />
     </>
   )
 }

--- a/packages/framework-dashboard/components/RunOverview.tsx
+++ b/packages/framework-dashboard/components/RunOverview.tsx
@@ -80,16 +80,14 @@ export function RunOverview({ events, showSessionLink = true }: { events: Framew
       )}
 
       {sessionLink && (
-        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs md:col-span-2">
-          <a href={sessionLink.href} target="_blank" rel="noreferrer" className="text-primary underline underline-offset-2">
-            {sessionLink.label}
-          </a>
-          {sessionLink.id && (
-            <span className="text-muted-foreground" title="Claude Code session id">
-              session <code className="font-mono text-[11px]">{sessionLink.id}</code>
-            </span>
-          )}
-        </div>
+        <a
+          href={sessionLink.href}
+          target="_blank"
+          rel="noreferrer"
+          className="text-xs text-primary underline underline-offset-2 md:col-span-2"
+        >
+          {sessionLink.label}
+        </a>
       )}
     </div>
   )

--- a/packages/framework-dashboard/components/RunOverview.tsx
+++ b/packages/framework-dashboard/components/RunOverview.tsx
@@ -10,7 +10,7 @@ import { cn } from '../lib/utils.js'
 // in @gemstack/framework) — the production-grade loop status, the deploy plan, and a link
 // to the live session. Cards render only when their data has arrived, so an early run
 // shows nothing extra.
-export function RunOverview({ events }: { events: FrameworkEvent[] }) {
+export function RunOverview({ events, showSessionLink = true }: { events: FrameworkEvent[]; showSessionLink?: boolean }) {
   const loop = loopStatus(events)
   const session = sessionInfo(events)
   const deploy = deployPlan(events)
@@ -22,10 +22,11 @@ export function RunOverview({ events }: { events: FrameworkEvent[] }) {
 
   // The "Open session" link, labeled honestly: a headless Claude Code run has no per-session
   // URL, so the generic app entry (claude.ai/code) is shown as "Open Claude Code" with the id
-  // surfaced separately, not as a deep link to that id. See {@link describeSessionLink}.
-  const sessionLink = describeSessionLink(session)
+  // surfaced separately, not as a deep link to that id. See {@link describeSessionLink}. The
+  // run's own view moves this into its action bar, so it opts out via `showSessionLink={false}`.
+  const sessionLink = showSessionLink ? describeSessionLink(session) : null
 
-  if (!loop && !deploy && !session?.sessionLink && !hasProgress) return null
+  if (!loop && !deploy && !sessionLink && !hasProgress) return null
 
   return (
     <div className="grid gap-3 border-b border-border p-4 md:grid-cols-2">

--- a/packages/framework-dashboard/components/RunReplay.tsx
+++ b/packages/framework-dashboard/components/RunReplay.tsx
@@ -1,15 +1,25 @@
 import type { FrameworkEvent } from '@gemstack/framework'
 import { onRun } from '../server/reads.telefunc.js'
 import { EventList } from './EventList.js'
+import { RunActionBar } from './RunActionBar.js'
 import { useLoaded } from '../lib/use-async.js'
 
-// Replay one archived run: load its event log over a Telefunc RPC and render it in the
-// same EventList the live stream uses (no auto-scroll — it is a static log).
+// Replay one archived run: load its event log over a Telefunc RPC and render it in the same
+// EventList the live stream uses (no auto-scroll — it is a static log). The action bar rides
+// along so Serve + Open session stay put once the run is Done (Stop drops out — it is not active).
 export function RunReplay({ projectId, runId }: { projectId: string; runId: string }) {
   // null until the first answer: "Loading run…" and "no events" are different things.
   const events = useLoaded<FrameworkEvent[] | null>(() => onRun(projectId, runId), null, [projectId, runId])
 
   if (events === null) return <div className="grid flex-1 place-items-center text-sm text-muted-foreground">Loading run…</div>
-  if (events.length === 0) return <div className="grid flex-1 place-items-center text-sm text-muted-foreground">This run has no events.</div>
-  return <EventList events={events} stick={false} />
+  return (
+    <>
+      <RunActionBar projectId={projectId} events={events} />
+      {events.length === 0 ? (
+        <div className="grid flex-1 place-items-center text-sm text-muted-foreground">This run has no events.</div>
+      ) : (
+        <EventList events={events} stick={false} />
+      )}
+    </>
+  )
 }

--- a/packages/framework-dashboard/lib/session-link.test.ts
+++ b/packages/framework-dashboard/lib/session-link.test.ts
@@ -5,26 +5,23 @@ describe('describeSessionLink', () => {
   it('returns null when there is no link', () => {
     expect(describeSessionLink(null)).toBeNull()
     expect(describeSessionLink({})).toBeNull()
-    expect(describeSessionLink({ sessionId: 'abc', driver: 'claude' })).toBeNull()
+    expect(describeSessionLink({ sessionId: 'abc' })).toBeNull()
   })
 
-  it('labels the generic Claude Code entry honestly and surfaces the id separately (the bug)', () => {
-    const view = describeSessionLink({ sessionLink: 'https://claude.ai/code', sessionId: '532ccc4b', driver: 'claude' })
-    expect(view).toEqual({ href: 'https://claude.ai/code', label: 'Open Claude Code ↗', id: '532ccc4b' })
+  it('returns null for the generic Claude Code entry (opens the product page, not the session)', () => {
+    expect(describeSessionLink({ sessionLink: 'https://claude.ai/code', sessionId: '532ccc4b' })).toBeNull()
   })
 
-  it('keeps "Open session (id)" for a real deep link that encodes the id', () => {
-    const view = describeSessionLink({ sessionLink: 'https://example.com/s/532ccc4b', sessionId: '532ccc4b', driver: 'claude' })
-    expect(view).toEqual({ href: 'https://example.com/s/532ccc4b', label: 'Open session (532ccc4b) ↗', id: null })
+  it('returns null for a literal link that does not encode the id', () => {
+    expect(describeSessionLink({ sessionLink: 'https://foo.test', sessionId: 'x1' })).toBeNull()
   })
 
-  it('does not claim a session before the id is reported', () => {
-    const view = describeSessionLink({ sessionLink: 'https://claude.ai/code', driver: 'claude' })
-    expect(view).toEqual({ href: 'https://claude.ai/code', label: 'Open Claude Code ↗', id: null })
+  it('returns null before the id is reported', () => {
+    expect(describeSessionLink({ sessionLink: 'https://claude.ai/code' })).toBeNull()
   })
 
-  it('for a non-Claude custom link, shows a neutral label plus the id', () => {
-    const view = describeSessionLink({ sessionLink: 'https://foo.test', sessionId: 'x1', driver: 'codex' })
-    expect(view).toEqual({ href: 'https://foo.test', label: 'Open session ↗', id: 'x1' })
+  it('returns a link only for a real deep link that encodes the id', () => {
+    const view = describeSessionLink({ sessionLink: 'https://example.com/s/532ccc4b', sessionId: '532ccc4b' })
+    expect(view).toEqual({ href: 'https://example.com/s/532ccc4b', label: 'Open session (532ccc4b) ↗' })
   })
 })

--- a/packages/framework-dashboard/lib/session-link.ts
+++ b/packages/framework-dashboard/lib/session-link.ts
@@ -1,37 +1,29 @@
-// Honest labeling for a run's "Open session" link. Only a URL that actually encodes the
-// session id opens *this* session. A headless Claude Code run has no per-session URL — the
-// framework defaults to the generic app entry point (claude.ai/code) as an "open the app"
-// affordance — so surfacing it as "Open session (<id>)" wrongly implies the link resolves to
-// that id. Here we detect the difference and describe the link honestly; the id, when it is
-// not encoded in the URL, is returned separately so the UI can show it as plain text.
+// A run's "Open session" link — offered only when it actually opens the run. A headless Claude
+// Code run has no per-session URL: the framework defaults to the generic claude.ai/code entry,
+// which opens the product page, not the session, so it isn't worth an action (the session id is
+// still visible in the event log). A link is returned only when the URL genuinely encodes the id —
+// a per-session deep link the user configured via `--session-link "…/{sessionId}"`.
 
 /** The minimal shape of `sessionInfo(events)` this needs, kept structural so it never
  *  couples to the framework's exact type. */
 export interface SessionLike {
   sessionLink?: string | undefined
   sessionId?: string | undefined
-  driver?: string | undefined
 }
 
 export interface SessionLinkView {
-  /** The URL to open. */
+  /** A real per-session deep link to open. */
   href: string
-  /** The honest link text. */
+  /** The link text. */
   label: string
-  /** The session id to show as separate text, or null when the link already encodes it. */
-  id: string | null
 }
 
-/** Describe a run's session link, or null when there is no link to show. */
+/** A run's per-session deep link, or null when there is none worth showing. */
 export function describeSessionLink(session?: SessionLike | null): SessionLinkView | null {
   const href = session?.sessionLink
-  if (!href) return null
   const id = session?.sessionId
-  const deep = Boolean(id && href.includes(id))
-  const label = deep
-    ? `Open session (${id}) ↗`
-    : session?.driver === 'claude'
-      ? 'Open Claude Code ↗'
-      : 'Open session ↗'
-  return { href, label, id: !deep && id ? id : null }
+  // Only a URL that actually encodes the id opens *this* session; anything else (the generic
+  // claude.ai/code entry, or a literal link) is a dead end, so show nothing.
+  if (!href || !id || !href.includes(id)) return null
+  return { href, label: `Open session (${id}) ↗` }
 }


### PR DESCRIPTION
Closes #706.

## What
The run view stacked three labeled rows (Serve · Stop run · Open session). This folds them into a single **RunActionBar** of icon buttons with tooltips, and renders it on the finished replay too, so the actions stay put once a run is **Done**.

- **Serve** — the existing `PreviewBar` inline control (icon + tooltip).
- **Stop run** — shown only while the run is active; drops out on a finished run.
- **Open session** — shown once the run reports one, honestly labeled (Open Claude Code / Open session (id)); the id rides in the tooltip.

The session link moves out of the run overview into the bar: `RunFeed`/`RunOverview` gain a `showSessionLink` flag (default on, so the read-only relay keeps it in the overview since it has no action bar).

Builds on #703 (session-link honest labeling), now merged.

## Verify
- typecheck clean; `vitest run` = 91 passed; build clean.
- Live: the three controls sit in one row with tooltips; on a finished run, Serve + Open session remain and Stop is gone.