### PR TITLE
fix(framework): label prompt/research runs instead of "(no prompt)"

### DIFF
--- a/.changeset/seed-run-intent.md
+++ b/.changeset/seed-run-intent.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Seed a run's intent (its prompt) when the run store opens, so the dashboard's Runs list labels `prompt` and `research` runs with their prompt instead of "(no prompt)". Only build runs emitted a `bootstrap` scope event carrying the intent; a direct-prompt or research run had none, so its row showed no label. A build run still refines the seeded intent via its scope event; research with no "what" seeds the same "this PR" default the log title uses.

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -1002,7 +1002,10 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   let store: RunStore | undefined
   if (opts.persist) {
     try {
-      store = await RunStore.open(cwd, { fresh: true })
+      // Seed the run's intent (its prompt) so the dashboard's Runs list labels it instead of
+      // showing "(no prompt)". A build run refines this via its scope event; a prompt/research
+      // run keeps it. Research with no "what" defaults to the same "this PR" the log title uses.
+      store = await RunStore.open(cwd, { fresh: true, intent: intent || (opts.research ? 'this PR' : '') })
     } catch (err) {
       io.err(`could not persist run state (${err instanceof Error ? err.message : String(err)}); continuing without it`)
     }

--- a/packages/framework/src/store/run-store.test.ts
+++ b/packages/framework/src/store/run-store.test.ts
@@ -75,6 +75,19 @@ test('fresh open truncates the log and writes an initial meta snapshot', async (
   assert.equal(meta?.startedAt, AT)
 })
 
+test('fresh open seeds the run intent into the snapshot (so prompt runs are not "(no prompt)")', async () => {
+  const fs = memFs()
+  const store = await RunStore.open(CWD, { fs, fresh: true, now: AT, intent: 'what is your name' })
+  assert.equal((await store.readMeta())?.intent, 'what is your name')
+})
+
+test('a scope event still refines a seeded intent (build path)', async () => {
+  const fs = memFs()
+  const store = await RunStore.open(CWD, { fs, fresh: true, now: AT, intent: 'build a blog' })
+  await store.append({ kind: 'bootstrap', event: { type: 'scope', scope: 'full', intent: 'a blog with comments' } })
+  assert.equal(store.snapshot().intent, 'a blog with comments')
+})
+
 test('append writes one JSONL line per event and derives meta', async () => {
   const fs = memFs()
   const store = await RunStore.open(CWD, { fs, fresh: true, now: AT })

--- a/packages/framework/src/store/run-store.ts
+++ b/packages/framework/src/store/run-store.ts
@@ -117,6 +117,12 @@ export interface OpenStoreOptions {
   fresh?: boolean
   /** The wall-clock start, ISO. Injectable so tests are deterministic. */
   now?: string
+  /**
+   * The run's intent (its prompt / request) shown in the dashboard's Runs list. A build run
+   * later refines this via its `bootstrap` scope event; a `prompt`/`research` run has no scope
+   * step, so seeding it here is the only way its row shows the prompt instead of "(no prompt)".
+   */
+  intent?: string
 }
 
 /**
@@ -170,7 +176,7 @@ export function applyEventToMeta(meta: RunMeta, event: FrameworkEvent, at: strin
 }
 
 /** The seed meta a run starts from, before any event is folded in. */
-function freshMeta(startedAt: string): RunMeta {
+function freshMeta(startedAt: string, intent?: string): RunMeta {
   return {
     version: RUN_META_VERSION,
     status: 'running',
@@ -178,6 +184,7 @@ function freshMeta(startedAt: string): RunMeta {
     startedAt,
     updatedAt: startedAt,
     passes: 0,
+    ...(intent ? { intent } : {}),
   }
 }
 
@@ -256,7 +263,7 @@ export class RunStore {
     const dir = join(cwd, FRAMEWORK_DIR)
     const now = opts.now ?? new Date().toISOString()
     await fs.mkdir(dir)
-    const store = new RunStore(fs, dir, now, freshMeta(now))
+    const store = new RunStore(fs, dir, now, freshMeta(now, opts.intent))
     if (opts.fresh) {
       // A new run truncates the live log. First rescue the prior run if it never
       // got archived (e.g. a crash exited before close), so no history is lost.


### PR DESCRIPTION
The Runs list showed **(no prompt)** for `prompt` and `research` runs. `RunMeta.intent` was only set from a build run's `bootstrap` scope event; direct-prompt/research runs have no scope step, so no label.

Seed the run's intent (its prompt) when the store opens for a fresh run. A build run still refines it via its scope event; a prompt/research run keeps it. Research with no "what" seeds the same "this PR" default the log title uses.

Changeset: `@gemstack/framework` patch.

## Verify
- 2 new store tests (intent seeded; scope still refines it); existing suite unaffected.
- e2e: a fake `prompt "what is your name"` run writes `run.json` with `intent: "what is your name"`.