### PR TITLE
feat(framework-dashboard): adopt shadcn Base message-scroller for the run output

### DIFF
--- a/packages/framework-dashboard/components/EventList.tsx
+++ b/packages/framework-dashboard/components/EventList.tsx
@@ -1,12 +1,22 @@
-import { useEffect, useRef, useState } from 'react'
 import type { FrameworkEvent } from '@gemstack/framework'
 import { formatFrameworkEvent } from '@gemstack/framework/client'
 import { Badge } from './ui/badge.js'
+import {
+  MessageScroller,
+  MessageScrollerButton,
+  MessageScrollerContent,
+  MessageScrollerItem,
+  MessageScrollerProvider,
+  MessageScrollerViewport,
+} from './ui/message-scroller.js'
 
 // Presentational event log, shared by the live stream and past-run replay. Each
 // FrameworkEvent is a kind badge + its human-readable line (the same formatter the
 // terminal uses, so a `driver` turn reads "· Read" / "‹ turn complete" rather than raw
-// JSON); the pane sticks to the bottom as events arrive (live), replay renders at once.
+// JSON). Scrolling rides shadcn's Base UI message-scroller (#712): live follows the edge
+// (`autoScroll`) but yields the moment the reader scrolls up, replay renders static from the
+// top, and the "Jump to latest" chip is the scroller's own inert-when-not-scrollable button —
+// replacing the hand-rolled U19 stick/jump logic.
 // The prompt-disclosure surface (#476/#520): the full text rides on the event, but the
 // one-line formatter reduces it to a char count (a driver `start`'s prompt) or drops it (a
 // system prompt). So the "see every prompt without a script" block renders it here; every
@@ -17,61 +27,39 @@ function disclosableText(e: FrameworkEvent): { text: string; label: string } | n
   return null
 }
 
+// A driver `start` opens a fresh prompt turn — the natural anchor the scroller keeps in view.
+function isTurnBoundary(e: FrameworkEvent): boolean {
+  return e.kind === 'driver' && e.event.type === 'start'
+}
+
 export function EventList({ events, stick = true }: { events: FrameworkEvent[]; stick?: boolean }) {
-  const scrollRef = useRef<HTMLDivElement>(null)
-  const bottomRef = useRef<HTMLDivElement>(null)
-  // Stick to the bottom only while the reader is already there (#695/U19): scrolling up to read
-  // an earlier line must not get yanked back down by the next event. `atBottom` tracks that, and
-  // a "Jump to latest" chip appears while it's false so the bottom is one click away.
-  const [atBottom, setAtBottom] = useState(true)
-
-  const onScroll = () => {
-    const el = scrollRef.current
-    if (!el) return
-    setAtBottom(el.scrollHeight - el.scrollTop - el.clientHeight < 48)
-  }
-
-  useEffect(() => {
-    if (stick && atBottom) bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [events.length, stick, atBottom])
-
   return (
-    <div className="relative flex min-h-0 flex-1 flex-col">
-      <div ref={scrollRef} onScroll={onScroll} className="flex-1 overflow-y-auto p-4">
-        <ol className="space-y-1 font-mono text-xs">
-          {events.map((e, i) => {
-            const disclosable = disclosableText(e)
-            return (
-              <li key={i} className="flex items-start gap-2">
-                <Badge className="mt-0.5 shrink-0 text-[10px] uppercase text-muted-foreground">{e.kind}</Badge>
-                {disclosable ? (
-                  <details className="min-w-0 flex-1">
-                    <summary className="cursor-pointer text-foreground marker:text-muted-foreground">
-                      {disclosable.label} ({disclosable.text.length.toLocaleString()} chars) — click to expand
-                    </summary>
-                    <pre className="mt-1 max-h-96 overflow-auto whitespace-pre-wrap break-words rounded bg-muted p-2 text-foreground">{disclosable.text}</pre>
-                  </details>
-                ) : (
-                  <span className="whitespace-pre-wrap break-words text-foreground">{(formatFrameworkEvent(e) ?? '').trim()}</span>
-                )}
-              </li>
-            )
-          })}
-        </ol>
-        <div ref={bottomRef} />
-      </div>
-      {stick && !atBottom && (
-        <button
-          type="button"
-          onClick={() => {
-            bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-            setAtBottom(true)
-          }}
-          className="absolute bottom-3 left-1/2 -translate-x-1/2 rounded-full border border-border bg-background/90 px-3 py-1 text-xs text-foreground shadow-sm backdrop-blur hover:bg-accent"
-        >
-          Jump to latest ↓
-        </button>
-      )}
-    </div>
+    <MessageScrollerProvider autoScroll={stick} defaultScrollPosition={stick ? 'end' : 'start'}>
+      <MessageScroller className="flex-1">
+        <MessageScrollerViewport aria-label="Run output">
+          <MessageScrollerContent className="gap-1 p-4 font-mono text-xs">
+            {events.map((e, i) => {
+              const disclosable = disclosableText(e)
+              return (
+                <MessageScrollerItem key={i} messageId={String(i)} scrollAnchor={isTurnBoundary(e)} className="flex items-start gap-2">
+                  <Badge className="mt-0.5 shrink-0 text-[10px] uppercase text-muted-foreground">{e.kind}</Badge>
+                  {disclosable ? (
+                    <details className="min-w-0 flex-1">
+                      <summary className="cursor-pointer text-foreground marker:text-muted-foreground">
+                        {disclosable.label} ({disclosable.text.length.toLocaleString()} chars) — click to expand
+                      </summary>
+                      <pre className="mt-1 max-h-96 overflow-auto whitespace-pre-wrap break-words rounded bg-muted p-2 text-foreground">{disclosable.text}</pre>
+                    </details>
+                  ) : (
+                    <span className="whitespace-pre-wrap break-words text-foreground">{(formatFrameworkEvent(e) ?? '').trim()}</span>
+                  )}
+                </MessageScrollerItem>
+              )
+            })}
+          </MessageScrollerContent>
+        </MessageScrollerViewport>
+        <MessageScrollerButton />
+      </MessageScroller>
+    </MessageScrollerProvider>
   )
 }

--- a/packages/framework-dashboard/components/ui/message-scroller.tsx
+++ b/packages/framework-dashboard/components/ui/message-scroller.tsx
@@ -1,0 +1,90 @@
+import type { ComponentProps } from 'react'
+import { ArrowDown } from 'lucide-react'
+import {
+  MessageScroller as MessageScrollerPrimitive,
+  useMessageScroller,
+  useMessageScrollerScrollable,
+  useMessageScrollerVisibility,
+} from '@shadcn/react/message-scroller'
+import { cn } from '../../lib/utils.js'
+
+// shadcn's Base UI `message-scroller`, ported (no components.json here, #712). The behavior —
+// follow the live edge, preserve visible rows, anchor on turn boundaries, an inert-when-not-
+// scrollable scroll button — lives in the dependency-free @shadcn/react primitive; these are the
+// styled wrappers. Adapted from the upstream `bases/base` variant: our own `cn`, a native button
+// (our Button is not Base-UI render-ready) rather than `render={<Button/>}`, lucide instead of the
+// icon placeholder, and the scrollbar-plugin utilities dropped (the app paints native scrollbars
+// via color-scheme, #710).
+
+export function MessageScrollerProvider(props: ComponentProps<typeof MessageScrollerPrimitive.Provider>) {
+  return <MessageScrollerPrimitive.Provider {...props} />
+}
+
+export function MessageScroller({ className, ...props }: ComponentProps<typeof MessageScrollerPrimitive.Root>) {
+  return (
+    <MessageScrollerPrimitive.Root
+      data-slot="message-scroller"
+      className={cn('group/message-scroller relative flex size-full min-h-0 flex-col overflow-hidden', className)}
+      {...props}
+    />
+  )
+}
+
+export function MessageScrollerViewport({ className, ...props }: ComponentProps<typeof MessageScrollerPrimitive.Viewport>) {
+  return (
+    <MessageScrollerPrimitive.Viewport
+      data-slot="message-scroller-viewport"
+      className={cn('size-full min-h-0 min-w-0 overflow-y-auto overscroll-contain', className)}
+      {...props}
+    />
+  )
+}
+
+export function MessageScrollerContent({ className, ...props }: ComponentProps<typeof MessageScrollerPrimitive.Content>) {
+  return (
+    <MessageScrollerPrimitive.Content
+      data-slot="message-scroller-content"
+      className={cn('flex h-max min-h-full flex-col', className)}
+      {...props}
+    />
+  )
+}
+
+export function MessageScrollerItem({ className, scrollAnchor = false, ...props }: ComponentProps<typeof MessageScrollerPrimitive.Item>) {
+  return (
+    <MessageScrollerPrimitive.Item
+      data-slot="message-scroller-item"
+      scrollAnchor={scrollAnchor}
+      className={cn('min-w-0 shrink-0', className)}
+      {...props}
+    />
+  )
+}
+
+export function MessageScrollerButton({ direction = 'end', className, children, ...props }: ComponentProps<typeof MessageScrollerPrimitive.Button>) {
+  return (
+    <MessageScrollerPrimitive.Button
+      data-slot="message-scroller-button"
+      data-direction={direction}
+      direction={direction}
+      className={cn(
+        'absolute left-1/2 z-10 flex -translate-x-1/2 items-center gap-1 rounded-full border border-border bg-background/90 px-3 py-1 text-xs text-foreground shadow-sm backdrop-blur transition-[translate,scale,opacity] duration-200 hover:bg-accent',
+        'data-[active=false]:pointer-events-none data-[active=false]:scale-95 data-[active=false]:opacity-0',
+        'data-[active=true]:translate-y-0 data-[active=true]:scale-100 data-[active=true]:opacity-100',
+        'data-[direction=end]:bottom-3 data-[direction=end]:data-[active=false]:translate-y-full',
+        'data-[direction=start]:top-3 data-[direction=start]:data-[active=false]:-translate-y-full',
+        className,
+      )}
+      {...props}
+    >
+      {children ?? (
+        <>
+          Jump to latest
+          <ArrowDown className="size-3.5" aria-hidden />
+        </>
+      )}
+    </MessageScrollerPrimitive.Button>
+  )
+}
+
+export { useMessageScroller, useMessageScrollerScrollable, useMessageScrollerVisibility }

--- a/packages/framework-dashboard/package.json
+++ b/packages/framework-dashboard/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@base-ui-components/react": "1.0.0-rc.0",
     "@gemstack/framework": "workspace:^",
+    "@shadcn/react": "^0.2.1",
     "@tiptap/core": "^2.10.0",
     "@tiptap/pm": "^2.10.0",
     "@tiptap/react": "^2.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,9 @@ importers:
       '@gemstack/framework':
         specifier: workspace:^
         version: link:../framework
+      '@shadcn/react':
+        specifier: ^0.2.1
+        version: 0.2.1(@types/react@19.2.17)(react@19.2.7)
       '@tiptap/core':
         specifier: ^2.10.0
         version: 2.27.2(@tiptap/pm@2.27.2)
@@ -1328,6 +1331,17 @@ packages:
     resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
+
+  '@shadcn/react@0.2.1':
+    resolution: {integrity: sha512-5krgi3dRMKb5jH6a+qPzVJUy/54s0kKE4Rw4LjDfLqOdVQTWKUgxWf1kW8r912I0jX/Lzxqc+pgjkjWxUIK5BQ==}
+    peerDependencies:
+      '@types/react': '>=19'
+      react: '>=19'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   '@shikijs/core@3.23.0':
     resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
@@ -4779,6 +4793,11 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
+
+  '@shadcn/react@0.2.1(@types/react@19.2.17)(react@19.2.7)':
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 19.2.7
 
   '@shikijs/core@3.23.0':
     dependencies:


### PR DESCRIPTION
Closes #712.

The run output pane hand-rolled stick-to-bottom + a "Jump to latest" chip (#695/U19). This swaps that for shadcn's Base UI `message-scroller` — a clean fit since the dashboard is built on Base UI.

## What
- Add `@shadcn/react` (dependency-free, peer react >=19) and a ported styled wrapper `components/ui/message-scroller.tsx` (upstream `bases/base` variant, adapted to our `cn`/lucide + a native button, since our `Button` is not Base-UI render-ready, and native scrollbars per #710).
- Rewrite `EventList.tsx` on top of it: each `FrameworkEvent` is a `MessageScrollerItem`, live follows the edge (`autoScroll`) and yields when the reader scrolls up, replay renders static from the top (`stick=false`), the chip is `MessageScrollerButton`. Driver `start` rows are marked `scrollAnchor` (turn boundaries). The prompt-disclosure rows (#476/#520) and the shared line formatter are unchanged.

Private `framework-dashboard` package: no changeset.

## Verified
- `pnpm --filter @gemstack/framework-dashboard typecheck` clean; 91 vitest pass; full `pnpm build` (dashboard bundle) clean.
- jsdom smoke render (throwaway): EventList mounts in both live and replay modes without throwing (the scroll primitive is jsdom-safe).
- Live browser eyeball on :4200 still pending (use Safari/Firefox — Chrome force-upgrades localhost to HTTPS).