### PR TITLE
feat(framework): live chat — send more messages to a running run

### DIFF
--- a/.changeset/chat-running-run.md
+++ b/.changeset/chat-running-run.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Live chat: send more messages to a running run. The dashboard's run view gains a composer, and the run stays open after the agent goes idle to take the user's own messages (the "stay-open" lifecycle) until it is stopped. Each message continues the same agent session via `claude --resume <sessionId>`, so the conversation keeps full context, and rides the existing `control.jsonl` steering channel as a new `message` kind next to Stop and choice picks. Wired only for an interactive run (a live dashboard / daemon); a headless run ends when the agent stops asking, exactly as before. The Claude Code driver gains a `resume` prompt option (`DriverPromptOptions.resume`) that continues the retained session and skips the redundant system-prompt re-append.

--- a/packages/framework-dashboard/components/RunChat.tsx
+++ b/packages/framework-dashboard/components/RunChat.tsx
@@ -1,0 +1,50 @@
+import { useRef, useState } from 'react'
+import { PromptEditor, type PromptEditorHandle } from './PromptEditor.js'
+import { Button } from './ui/button.js'
+import { sendMessage } from '../server/control.telefunc.js'
+
+// The live-chat composer (#714): send more messages to a running run. Reuses the same Tiptap
+// PromptEditor the launcher uses, so `/` actions and `<` tags work here too; on submit it writes
+// a `message` control entry that the run drains between turns (continuing the same session via
+// --resume). Only rendered inside RunLive, i.e. while the run is running — a finished run replays
+// without it. Presets/mentions are dropped here (a mid-run message is plain instruction).
+export function RunChat({ projectId }: { projectId: string }) {
+  const editorRef = useRef<PromptEditorHandle>(null)
+  const [text, setText] = useState('')
+  const [sending, setSending] = useState(false)
+
+  const send = async (): Promise<void> => {
+    const message = text.trim()
+    if (!message || sending) return
+    setSending(true)
+    try {
+      await sendMessage(projectId, message)
+      editorRef.current?.clear()
+      setText('')
+    } catch {
+      // Leave the text in place so the user can retry; the run may have just ended.
+    } finally {
+      setSending(false)
+      editorRef.current?.focus()
+    }
+  }
+
+  return (
+    <div className="border-t border-border p-3">
+      <PromptEditor
+        ref={editorRef}
+        projects={[]}
+        presets={[]}
+        onChange={setText}
+        onSubmit={send}
+        placeholder="Message the run…  (Cmd/Ctrl+Enter to send)"
+        disabled={sending}
+      />
+      <div className="mt-2 flex justify-end">
+        <Button size="sm" onClick={send} disabled={!text.trim() || sending}>
+          {sending ? 'Sending…' : 'Send'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/packages/framework-dashboard/components/RunLive.tsx
+++ b/packages/framework-dashboard/components/RunLive.tsx
@@ -1,17 +1,20 @@
 import type { FrameworkEvent } from '@gemstack/framework'
 import { RunActionBar } from './RunActionBar.js'
+import { RunChat } from './RunChat.js'
 import { RunFeed } from './RunFeed.js'
 
-// One running run's own view (its output): the action bar (Serve · Stop · Open session) plus the
-// run overview + live event feed from the shared Telefunc Channel. Distinct from the home launcher
-// (ProjectHome) and a finished run's replay (RunReplay). Single-run today streams the project's
-// one live feed; per-run streams arrive with worktrees (#453). The session link lives in the
-// action bar now, so the feed's overview drops it (`showSessionLink={false}`).
+// One running run's own view (its output): the action bar (Serve · Stop · Open session), the run
+// overview + live event feed from the shared Telefunc Channel, and the chat composer to send it
+// more messages (#714). Distinct from the home launcher (ProjectHome) and a finished run's replay
+// (RunReplay, which has no composer). Single-run today streams the project's one live feed; per-run
+// streams arrive with worktrees (#453). The session link lives in the action bar now, so the feed's
+// overview drops it (`showSessionLink={false}`).
 export function RunLive({ projectId, events }: { projectId: string; events: FrameworkEvent[] }) {
   return (
     <>
       <RunActionBar projectId={projectId} events={events} />
       <RunFeed events={events} showSessionLink={false} />
+      <RunChat projectId={projectId} />
     </>
   )
 }

--- a/packages/framework-dashboard/server/control.telefunc.ts
+++ b/packages/framework-dashboard/server/control.telefunc.ts
@@ -1,4 +1,4 @@
 // Re-export shim (#405): the steering telefunctions live in @gemstack/framework so the
 // daemon serves them in-process. The file path keeps the baked RPC key
 // `/server/control.telefunc.ts`. See framework's dashboard-rpc/register.ts.
-export { sendStop, sendChoice, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp } from '@gemstack/framework/dashboard-rpc'
+export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp } from '@gemstack/framework/dashboard-rpc'

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -41,6 +41,7 @@ import { RunStore, nodeStoreFs, type StoreFs } from './store/index.js'
 import { materializePresets } from './presets.js'
 import { daemonStatus, ensureDaemon, registerHomeProject, runDaemon, stopDaemon, DEFAULT_DAEMON_PORT } from './daemon.js'
 import { resetControl, watchControl, type ControlWatcher } from './control.js'
+import { RunMessageQueue } from './run-messages.js'
 import { nodeGitRunner } from './project.js'
 import { listProjects, readPreferences, resolveConsumptionLimits } from './registry.js'
 import { startConsumptionGuard } from './consumption-guard.js'
@@ -979,9 +980,13 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // to /choice, which resolves it. Aborting the run resolves any pending choice
   // (proceed) so the gate never hangs a stopped run.
   const pendingChoices = new Map<string, (pick: ChoicePick) => void>()
+  // Live-chat messages the user sends to the running run (#714). The control watcher
+  // pushes each here; the run loop drains them between turns and waits here when idle.
+  const messages = new RunMessageQueue()
   controller.signal.addEventListener('abort', () => {
     for (const resolve of pendingChoices.values()) resolve({ picked: 'proceed', by: 'auto' })
     pendingChoices.clear()
+    messages.close()
   })
   // Serve the new Vike + Telefunc dashboard (#405/#427) for this run, in single-project mode:
   // the SPA reads this one `cwd`'s event/control logs without touching the global registry, so
@@ -1024,6 +1029,10 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
       control = watchControl(cwd, entry => {
         if (entry.kind === 'stop') {
           controller.abort()
+          return
+        }
+        if (entry.kind === 'message') {
+          messages.push(entry.text)
           return
         }
         const resolve = pendingChoices.get(entry.id)
@@ -1199,6 +1208,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
         onEvent,
         signal: controller.signal,
         ...(requestChoice ? { requestChoice } : {}),
+        ...(requestChoice ? { messages } : {}),
         ...(opts.model ? { model: opts.model } : {}),
         ...(opts.maxCost ? { budgetUsd: opts.maxCost } : {}),
         ...(guard ? { consumptionGate: guard.gate } : {}),
@@ -1264,6 +1274,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     signals,
     signal: controller.signal,
     ...(requestChoice ? { requestChoice } : {}),
+    ...(requestChoice ? { messages } : {}),
     ...(opts.model ? { model: opts.model } : {}),
     ...(opts.maxPasses ? { maxPasses: opts.maxPasses } : {}),
     ...(opts.maxCost ? { budgetUsd: opts.maxCost } : {}),

--- a/packages/framework/src/control.test.ts
+++ b/packages/framework/src/control.test.ts
@@ -86,3 +86,23 @@ test('watchControl skips malformed and unknown lines', async () => {
     await rm(cwd, { recursive: true, force: true })
   }
 })
+
+test('watchControl delivers live-chat messages and drops empty ones (#714)', async () => {
+  const cwd = await tmpWorkspace()
+  const seen: ControlEntry[] = []
+  const watcher = watchControl(cwd, e => seen.push(e), 20)
+  try {
+    await resetControl(cwd)
+    await appendFile(
+      controlPath(cwd),
+      JSON.stringify({ kind: 'message', text: 'also add dark mode' }) + '\n' +
+        JSON.stringify({ kind: 'message', text: '' }) + '\n' + // empty -> dropped
+        JSON.stringify({ kind: 'message' }) + '\n', // missing text -> dropped
+    )
+    assert.ok(await until(() => seen.length === 1), `saw ${seen.length}`)
+    assert.deepEqual(seen, [{ kind: 'message', text: 'also add dark mode' }])
+  } finally {
+    watcher.close()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})

--- a/packages/framework/src/control.ts
+++ b/packages/framework/src/control.ts
@@ -22,6 +22,8 @@ export type ControlEntry =
   | { kind: 'stop' }
   /** Resolve a parked choice gate: the pick for the pending {@link ChoiceRequest} id. */
   | { kind: 'choice'; id: string; pick: string | string[]; by: ChoiceBy }
+  /** A live-chat message the user sent to the running run (#714). */
+  | { kind: 'message'; text: string }
 
 /** The control log path for a workspace. */
 export function controlPath(cwd: string): string {
@@ -72,6 +74,7 @@ function isControlEntry(value: unknown): value is ControlEntry {
   if (!value || typeof value !== 'object') return false
   const v = value as Record<string, unknown>
   if (v['kind'] === 'stop') return true
+  if (v['kind'] === 'message') return typeof v['text'] === 'string' && v['text'].length > 0
   if (v['kind'] !== 'choice') return false
   if (typeof v['id'] !== 'string' || !v['id']) return false
   const pick = v['pick']

--- a/packages/framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/control.telefunc.ts
@@ -37,6 +37,19 @@ export async function sendChoice(
 }
 
 /**
+ * Send a live-chat message to the project's running run (#714): append a `message` entry
+ * that the run drains between turns, continuing the same session via `--resume`. Empty
+ * messages are dropped. A no-op when the project has no local path (the read-only relay),
+ * so the run channel is only ever written by a host that owns the workspace.
+ */
+export async function sendMessage(projectId: string, text: string): Promise<void> {
+  const message = text.trim()
+  if (!message) return
+  const cwd = await resolveProjectPath(projectId)
+  if (cwd) await appendControl(cwd, { kind: 'message', text: message })
+}
+
+/**
  * Start a run in the project (#405, #345): the one write that needs the daemon, since
  * spawning goes through the daemon's own `startRun` closure (with its one-run-per-
  * project busy guard). The daemon provides `startRun` on the Telefunc request context,

--- a/packages/framework/src/dashboard-rpc/index.ts
+++ b/packages/framework/src/dashboard-rpc/index.ts
@@ -3,7 +3,7 @@
 // wiring) can reach the daemon's `startRun`; the framework-dashboard client imports
 // these through thin re-export shims so the baked RPC keys stay `/server/*.telefunc.ts`.
 export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from './reads.telefunc.js'
-export { sendStop, sendChoice, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
+export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
 export { onEvents } from './events.telefunc.js'
 export { onProjects, sendAddProject } from './projects.telefunc.js'
 export { onPreferences, savePreferences, type SavePreferencesResult } from './preferences.telefunc.js'

--- a/packages/framework/src/dashboard-rpc/register.ts
+++ b/packages/framework/src/dashboard-rpc/register.ts
@@ -1,6 +1,6 @@
 import { __decorateTelefunction } from 'telefunc'
 import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from './reads.telefunc.js'
-import { sendStop, sendChoice, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
+import { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
 import { onEvents } from './events.telefunc.js'
 import { onProjects, sendAddProject } from './projects.telefunc.js'
 import { onPreferences, savePreferences } from './preferences.telefunc.js'
@@ -48,6 +48,7 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(onProjectFileStatus, 'onProjectFileStatus', reads)
   reg(sendStop, 'sendStop', control)
   reg(sendChoice, 'sendChoice', control)
+  reg(sendMessage, 'sendMessage', control)
   reg(sendStart, 'sendStart', control)
   reg(sendPreview, 'sendPreview', control)
   reg(onServeTargets, 'onServeTargets', control)

--- a/packages/framework/src/driver/claude-code.test.ts
+++ b/packages/framework/src/driver/claude-code.test.ts
@@ -205,6 +205,36 @@ test('ClaudeCodeDriver writes an --mcp-config file for mcpServers and cleans it 
   assert.ok(!existsSync(configPath))
 })
 
+test('ClaudeCodeSession resumes the same session for a chat turn (#714)', async () => {
+  let captured: string[] = []
+  const spawn: SpawnLike = (_cmd, args) => {
+    captured = [...args]
+    // The turn reports its session id, which the session retains for a later --resume.
+    return fakeSpawn([JSON.stringify({ type: 'result', result: 'ok', session_id: 'sess-1' })])(_cmd, args, { cwd: '/ws', env: {} })
+  }
+  const session = await new ClaudeCodeDriver({ spawn }).start({ cwd: '/ws', system: 'You are a Vike expert' })
+  // A normal turn: fresh, appends the system prompt, no --resume yet.
+  await session.prompt('go')
+  assert.ok(!captured.includes('--resume'))
+  assert.ok(captured.includes('--append-system-prompt'))
+  // A chat message resumes the captured session and skips the redundant system append.
+  await session.prompt('also add dark mode', { resume: true })
+  assert.equal(captured[captured.indexOf('--resume') + 1], 'sess-1')
+  assert.ok(!captured.includes('--append-system-prompt'))
+})
+
+test('ClaudeCodeSession runs a fresh turn when resume is asked with no prior session (#714)', async () => {
+  let captured: string[] = []
+  const spawn: SpawnLike = (_cmd, args) => {
+    captured = [...args]
+    return fakeSpawn([JSON.stringify({ type: 'result', result: 'ok' })])(_cmd, args, { cwd: '/ws', env: {} })
+  }
+  const session = await new ClaudeCodeDriver({ spawn }).start({ cwd: '/ws', system: 'framing' })
+  await session.prompt('hi', { resume: true })
+  assert.ok(!captured.includes('--resume'))
+  assert.ok(captured.includes('--append-system-prompt'))
+})
+
 test('StreamJsonParser surfaces the rate-limit telemetry the agent emits per turn (#517)', () => {
   const p = new StreamJsonParser()
   // Real payload shape, captured from `claude -p --output-format stream-json`.

--- a/packages/framework/src/driver/claude-code.ts
+++ b/packages/framework/src/driver/claude-code.ts
@@ -82,6 +82,12 @@ export class ClaudeCodeSession implements DriverSession {
   readonly cwd: string
   /** Path to the written `--mcp-config` file, lazily created on first use. */
   private mcpConfigPath: string | undefined
+  /**
+   * The agent's own session id from the last turn (#714). Retained so a
+   * {@link DriverPromptOptions.resume} prompt can `--resume` the same
+   * conversation; resume keeps the id stable, so consecutive chat messages chain.
+   */
+  private lastSessionId: string | undefined
 
   constructor(
     private readonly config: ClaudeCodeDriverOptions,
@@ -91,11 +97,12 @@ export class ClaudeCodeSession implements DriverSession {
     this.id = `claude-code-${++sessionCounter}`
   }
 
-  prompt(text: string, opts: DriverPromptOptions = {}): Promise<DriverTurn> {
+  async prompt(text: string, opts: DriverPromptOptions = {}): Promise<DriverTurn> {
     const system = combineFraming(this.startOpts.system, opts.system)
-    return runClaude({
+    const resumeId = opts.resume ? this.lastSessionId : undefined
+    const turn = await runClaude({
       bin: this.config.bin ?? 'claude',
-      args: this.buildArgs(system),
+      args: this.buildArgs(system, resumeId),
       cwd: this.cwd,
       env: this.config.env ?? process.env,
       prompt: text,
@@ -103,6 +110,9 @@ export class ClaudeCodeSession implements DriverSession {
       emit: makeEmit(this.startOpts.onEvent, 'claude-code'),
       signals: combineSignals(this.startOpts.signal, opts.signal),
     })
+    // Track the agent's session so a later resume continues this exact conversation.
+    if (turn.sessionId) this.lastSessionId = turn.sessionId
+    return turn
   }
 
   readCode(path: string): Promise<string> {
@@ -124,11 +134,14 @@ export class ClaudeCodeSession implements DriverSession {
     return Promise.resolve()
   }
 
-  private buildArgs(system: string): string[] {
+  private buildArgs(system: string, resumeId?: string): string[] {
     const args = ['-p', '--output-format', 'stream-json', '--verbose']
     if (this.config.dangerouslySkipPermissions) args.push('--dangerously-skip-permissions')
     else args.push('--permission-mode', this.config.permissionMode ?? 'acceptEdits')
-    if (system) args.push('--append-system-prompt', system)
+    // Resume the same conversation for a chat turn (#714). Skip the system append then:
+    // the resumed transcript already carries its framing, so re-appending only duplicates it.
+    if (resumeId) args.push('--resume', resumeId)
+    else if (system) args.push('--append-system-prompt', system)
     if (this.startOpts.model) args.push('--model', this.startOpts.model)
     const mcpConfig = this.mcpConfigFile()
     if (mcpConfig) args.push('--mcp-config', mcpConfig)

--- a/packages/framework/src/driver/types.ts
+++ b/packages/framework/src/driver/types.ts
@@ -84,6 +84,14 @@ export interface DriverPromptOptions {
   system?: string
   /** Abort just this prompt (the in-flight invocation). */
   signal?: AbortSignal
+  /**
+   * Continue the agent's *previous* turn instead of starting fresh (#714): the
+   * live-chat path resumes the same session so the message lands in the ongoing
+   * conversation with full context. Best-effort — a driver that can't resume
+   * (or has no prior turn yet) runs a fresh invocation, the normal case. Honored
+   * by the Claude Code driver via `--resume <sessionId>`.
+   */
+  resume?: boolean
 }
 
 /** The outcome of one {@link DriverSession.prompt} turn. */

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -264,6 +264,7 @@ export {
   type ControlEntry,
   type ControlWatcher,
 } from './control.js'
+export { RunMessageQueue, type RunMessages } from './run-messages.js'
 export { runPrompt, type RunPromptOptions, type RunPromptResult } from './prompt-run.js'
 export {
   runTodoLoop,

--- a/packages/framework/src/prompt-run.test.ts
+++ b/packages/framework/src/prompt-run.test.ts
@@ -3,6 +3,7 @@ import { test } from 'node:test'
 import { FakeDriver } from './driver/fake.js'
 import type { ChoicePick, ChoiceRequest, FrameworkEvent } from './events.js'
 import { runPrompt } from './prompt-run.js'
+import { RunMessageQueue } from './run-messages.js'
 
 const multiGateTurn = [
   'I rated the problems and wrote REVIEW-PROBLEMS_feat-x.agent.md.',
@@ -32,6 +33,40 @@ test('runPrompt runs a gateless prompt straight through and emits session + end'
   assert.deepEqual(events.at(-1), { kind: 'end', ok: true })
   // No gate, so nothing paused.
   assert.equal(events.some(e => e.kind === 'choice'), false)
+})
+
+test('runPrompt stays open for a live-chat message and delivers it as a turn (#714)', async () => {
+  const events: FrameworkEvent[] = []
+  // Queue a message and close: the opening prompt settles, the chat phase drains the message
+  // (one more turn), then next() -> undefined ends the run. Deterministic, no timing race.
+  const messages = new RunMessageQueue()
+  messages.push('also add dark mode')
+  messages.close()
+  const driver = new FakeDriver({ turns: [{ text: 'built the base' }, { text: 'added dark mode' }] })
+  const { text } = await runPrompt({
+    prompt: 'build it',
+    driver,
+    cwd: '/ws',
+    messages,
+    onEvent: e => events.push(e),
+  })
+  // The final turn is the chat reply, not the opening turn.
+  assert.equal(text, 'added dark mode')
+  // The message rode a driver `start` event (so it shows in the feed) and was echoed as a log.
+  assert.ok(
+    events.some(e => e.kind === 'driver' && e.event.type === 'start' && e.event.prompt === 'also add dark mode'),
+    'the chat message was delivered as a driver turn',
+  )
+  assert.ok(events.some(e => e.kind === 'log' && e.message === 'You: also add dark mode'))
+  assert.deepEqual(events.at(-1), { kind: 'end', ok: true })
+})
+
+test('runPrompt without a messages source ends when the agent stops (byte-identical, #714)', async () => {
+  const events: FrameworkEvent[] = []
+  const driver = new FakeDriver({ turns: [{ text: 'done' }] })
+  const { text } = await runPrompt({ prompt: 'go', driver, cwd: '/ws', onEvent: e => events.push(e) })
+  assert.equal(text, 'done')
+  assert.deepEqual(events.at(-1), { kind: 'end', ok: true })
 })
 
 test('runPrompt emits the #326 lifecycle signals a turn declares (session name, ready-for-merge)', async () => {

--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -6,6 +6,7 @@ import { createRunControls, emitSessionStart, endStopDetail } from './run-teleme
 import { createTurnSignalEmitter } from './turn-gate.js'
 import { type ConsumptionWindow } from './consumption.js'
 import { leaveResumeNote } from './todo-loop.js'
+import type { RunMessages } from './run-messages.js'
 
 /**
  * The direct prompt path (#331): run *one prompt* through the driver and honor
@@ -58,6 +59,12 @@ export interface RunPromptOptions {
   consumptionGate?: () => ConsumptionWindow | null
   /** Session link template for the dashboard, `{sessionId}` resolved when known. */
   sessionLink?: string
+  /**
+   * Live chat (#714): stay open after the prompt settles and take the user's own
+   * messages, each resuming the same session. Unset for a headless run, which ends
+   * when the agent stops asking — exactly as before.
+   */
+  messages?: RunMessages
 }
 
 /** What {@link runPrompt} resolves with. */
@@ -133,6 +140,7 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
       requestChoice: opts.requestChoice,
       emit,
       signal: runSignal,
+      ...(opts.messages ? { messages: opts.messages } : {}),
     })
     // The agent kept asking past the limit: finish with the latest turn rather than loop.
     if (rounds.exhausted) emit({ kind: 'log', message: 'Finishing the run (await limit reached).' })

--- a/packages/framework/src/run-messages.test.ts
+++ b/packages/framework/src/run-messages.test.ts
@@ -1,0 +1,55 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { RunMessageQueue } from './run-messages.js'
+
+test('RunMessageQueue drains already-queued messages in order (between turns)', async () => {
+  const q = new RunMessageQueue()
+  q.push('one')
+  q.push('two')
+  assert.equal(await q.next(), 'one')
+  assert.equal(await q.next(), 'two')
+})
+
+test('RunMessageQueue hands a message to a parked waiter (stay-open)', async () => {
+  const q = new RunMessageQueue()
+  const pending = q.next() // parks: nothing queued yet
+  q.push('later')
+  assert.equal(await pending, 'later')
+})
+
+test('RunMessageQueue close() wakes a parked waiter with undefined', async () => {
+  const q = new RunMessageQueue()
+  const pending = q.next()
+  q.close()
+  assert.equal(await pending, undefined)
+})
+
+test('RunMessageQueue next() resolves undefined once closed', async () => {
+  const q = new RunMessageQueue()
+  q.close()
+  assert.equal(await q.next(), undefined)
+})
+
+test('RunMessageQueue push() is a no-op after close()', async () => {
+  const q = new RunMessageQueue()
+  q.close()
+  q.push('ignored')
+  assert.equal(await q.next(), undefined)
+})
+
+test('RunMessageQueue next() unblocks on abort (Stop / budget cap)', async () => {
+  const q = new RunMessageQueue()
+  const ac = new AbortController()
+  const pending = q.next(ac.signal)
+  ac.abort()
+  assert.equal(await pending, undefined)
+})
+
+test('RunMessageQueue next() returns a queued message even if the signal is aborted', async () => {
+  const q = new RunMessageQueue()
+  const ac = new AbortController()
+  ac.abort()
+  q.push('queued')
+  // A message already in hand wins over the aborted signal: it is not lost.
+  assert.equal(await q.next(ac.signal), 'queued')
+})

--- a/packages/framework/src/run-messages.ts
+++ b/packages/framework/src/run-messages.ts
@@ -1,0 +1,70 @@
+/**
+ * The live-chat message channel (#714): the user's own turns into a running run.
+ *
+ * A run's await gates (#337) are the agent asking the user; this is the reverse —
+ * the user speaking to the agent unprompted. Each message continues the *same*
+ * agent session (`claude --resume <id>`), so the conversation keeps its full
+ * context. The run loop drains this between turns and, when the agent goes idle,
+ * waits here for the next message (the "stay-open" chat lifecycle): the run stays
+ * running until the user stops it or a budget / await cap trips.
+ *
+ * Wired only when an interactive channel can deliver messages (a live dashboard /
+ * daemon over `control.jsonl`). A headless run gets no {@link RunMessages}, so its
+ * loop ends when the agent stops asking — byte-identical to before this existed.
+ */
+
+/** A source of user chat messages for a running run. */
+export interface RunMessages {
+  /**
+   * The next user message. Returns an already-queued message immediately (drain
+   * between turns); otherwise waits for one (stay-open). Resolves `undefined` when
+   * the run should stop waiting — the signal aborted (Stop / budget cap) or the
+   * source was closed — so the loop ends cleanly rather than hanging.
+   */
+  next(signal?: AbortSignal): Promise<string | undefined>
+}
+
+/**
+ * A {@link RunMessages} the control channel feeds ({@link push}) and the run loop
+ * drains ({@link next}). A message that arrives with a waiter parked hands off
+ * directly; otherwise it queues until the next `next()`. FIFO in both directions.
+ */
+export class RunMessageQueue implements RunMessages {
+  private readonly pending: string[] = []
+  private readonly waiters: Array<(text: string | undefined) => void> = []
+  private closed = false
+
+  /** Enqueue a user message (or hand it to a parked waiter). No-op once closed. */
+  push(text: string): void {
+    if (this.closed) return
+    const waiter = this.waiters.shift()
+    if (waiter) waiter(text)
+    else this.pending.push(text)
+  }
+
+  /** Stop the chat: wake every parked waiter with `undefined` so their loops end. */
+  close(): void {
+    this.closed = true
+    let waiter: ((text: string | undefined) => void) | undefined
+    while ((waiter = this.waiters.shift())) waiter(undefined)
+  }
+
+  next(signal?: AbortSignal): Promise<string | undefined> {
+    const queued = this.pending.shift()
+    if (queued !== undefined) return Promise.resolve(queued)
+    if (this.closed || signal?.aborted) return Promise.resolve(undefined)
+    return new Promise<string | undefined>(resolve => {
+      const waiter = (text: string | undefined): void => {
+        if (signal) signal.removeEventListener('abort', onAbort)
+        resolve(text)
+      }
+      const onAbort = (): void => {
+        const i = this.waiters.indexOf(waiter)
+        if (i >= 0) this.waiters.splice(i, 1)
+        resolve(undefined)
+      }
+      this.waiters.push(waiter)
+      if (signal) signal.addEventListener('abort', onAbort, { once: true })
+    })
+  }
+}

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -23,7 +23,7 @@ import {
 } from '@gemstack/ai-autopilot'
 import { snapshotWorkspace } from './sandbox.js'
 import { type ConsumptionWindow } from './consumption.js'
-import type { Driver, DriverSession } from './driver/index.js'
+import type { Driver, DriverSession, DriverTurn } from './driver/index.js'
 import { composeRunSystem, type EcoOptions, type TfContext } from './system-prompt.js'
 import { createRunControls, emitSessionStart, endStopDetail } from './run-telemetry.js'
 import { AWAIT_PROTOCOL, CONFIRM_APPROVED, CONFIRM_DECLINED, MAX_AWAIT_ROUNDS, PLAN_DECLINED_MESSAGE, continuationPrompt, createTurnSignalEmitter, isDeclinedConfirmation, parseAwaitGate, type ParsedAwaitGate } from './turn-gate.js'
@@ -32,6 +32,7 @@ import { AWAIT_PROTOCOL, CONFIRM_APPROVED, CONFIRM_DECLINED, MAX_AWAIT_ROUNDS, P
 import { leaveResumeNote, runTodoLoop, type TodoLoopResult } from './todo-loop.js'
 import { continueAfterChoice, decideDeploy, deployWith, domainLoopChecklist, driverBuild, driverChecklist, driverImprove, driverLoopPrompts } from './steps.js'
 import { OPEN_LOOP_MODES, pickedIds, type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
+import type { RunMessages } from './run-messages.js'
 
 /**
  * The framework's default full-fledged pass budget. Higher than ai-autopilot's
@@ -206,6 +207,13 @@ export interface RunFrameworkOptions {
   todoLoop?: boolean
   /** Per-run cap on backlog entries worked (#323). Default 25. */
   todoMaxItems?: number
+  /**
+   * Live chat (#714): once the build settles, stay running and take the user's own
+   * messages, each resuming the build session for full context. Ends when the source
+   * resolves `undefined` (Stop / budget cap). Wired only for an interactive run — a
+   * headless run leaves it unset and ends when the build is done, exactly as before.
+   */
+  messages?: RunMessages
   /** Observe the unified event stream. */
   onEvent?: (event: FrameworkEvent) => void
 }
@@ -411,6 +419,16 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     // to boot is non-fatal. Default off, so a programmatic run never leaks a
     // process a caller that ignores `preview` would never stop.
     if (runner && s?.keepAlive) preview = await startAppPreview(runner, s, emit)
+    // Live chat (#714): with the build settled, stay open for the user's own messages,
+    // each continuing the same session. Ends on Stop / budget cap (next -> undefined).
+    if (opts.messages) {
+      await runChatPhase(session, opts.messages, { text: '' }, {
+        ...(opts.requestChoice ? { requestChoice: opts.requestChoice } : {}),
+        emit,
+        emitTurnSignals: createTurnSignalEmitter(emit),
+        signal: runSignal,
+      })
+    }
     emit({ kind: 'end', ok: true })
     return { result, detection, events, ...(preview ? { preview } : {}), ...(loop ? { loop } : {}), ...(todo ? { todo } : {}) }
   } catch (err) {
@@ -624,12 +642,73 @@ export interface AwaitRoundsOptions {
   requestChoice?: ((req: ChoiceRequest) => Promise<ChoicePick>) | undefined
   emit: (event: FrameworkEvent) => void
   signal?: AbortSignal | undefined
+  /**
+   * Live chat (#714): once the agent stops asking, stay open for the user's own
+   * messages, each resuming the same session. Unset for a headless run, which then
+   * ends when the agent stops asking — byte-identical to before this existed.
+   */
+  messages?: RunMessages | undefined
+}
+
+/** The shared deps of a turn that may hit an await gate or a chat message. */
+interface AwaitTurnDeps {
+  requestChoice?: ((req: ChoiceRequest) => Promise<ChoicePick>) | undefined
+  emit: (event: FrameworkEvent) => void
+  emitTurnSignals: (text: string) => void
+  signal?: AbortSignal | undefined
+}
+
+/**
+ * Resolve the await gates (#337/#339) a turn ended on: pick the answer, re-prompt with
+ * it, repeat until the agent stops asking or the {@link MAX_AWAIT_ROUNDS} cap trips. A
+ * declined plan (#358) stops here. Returns the settled turn plus whether it declined /
+ * was still asking at the cap. Shared by the opening prompt and each chat message.
+ */
+async function drainGates(session: DriverSession, turn: DriverTurn, deps: AwaitTurnDeps): Promise<{ turn: DriverTurn; declined: boolean; exhausted: boolean }> {
+  const signalOpt = deps.signal ? { signal: deps.signal } : {}
+  let gate = parseAwaitGate(turn.text)
+  for (let round = 0; round < MAX_AWAIT_ROUNDS && gate; round++) {
+    const answer = await resolveAwaitGate(gate, round, deps)
+    if (isDeclinedConfirmation(gate, answer)) {
+      deps.emit({ kind: 'log', message: PLAN_DECLINED_MESSAGE })
+      return { turn, declined: true, exhausted: false }
+    }
+    deps.emit({ kind: 'log', message: `Continuing with your choice: ${answer}` })
+    turn = await session.prompt(continuationPrompt(gate.title, answer), signalOpt)
+    deps.emitTurnSignals(turn.text)
+    gate = parseAwaitGate(turn.text)
+  }
+  return { turn, declined: false, exhausted: gate !== undefined }
+}
+
+/**
+ * The live-chat loop (#714): wait for the user's next message, deliver it by resuming the
+ * same session (full conversational context), then honor any await gate it produced —
+ * repeat until the source resolves `undefined` (Stop / budget cap). This is the "stay-open"
+ * lifecycle: a run keeps running as a conversation until the user ends it. Shared by the
+ * direct prompt path and the build path, which both reach it once their work has settled.
+ */
+export async function runChatPhase(session: DriverSession, messages: RunMessages, seed: DriverTurn, deps: AwaitTurnDeps): Promise<DriverTurn> {
+  const signalOpt = deps.signal ? { signal: deps.signal } : {}
+  let turn = seed
+  for (;;) {
+    const message = await messages.next(deps.signal)
+    if (message === undefined) return turn // Stop / budget cap: end the conversation.
+    deps.emit({ kind: 'log', message: `You: ${message}` })
+    turn = await session.prompt(message, { ...signalOpt, resume: true })
+    deps.emitTurnSignals(turn.text)
+    const drained = await drainGates(session, turn, deps)
+    turn = drained.turn
+    if (drained.declined) return turn
+  }
 }
 
 /**
  * Prompt the agent and honor its await gates (#337/#339) until it stops asking: resolve each
  * gate to the user's answer, re-prompt with it, and repeat up to {@link MAX_AWAIT_ROUNDS}.
- * A declined plan (#358) ends the exchange rather than re-prompting.
+ * A declined plan (#358) ends the exchange rather than re-prompting. When a live-chat
+ * {@link AwaitRoundsOptions.messages} source is wired, the run then stays open for the
+ * user's own messages (#714) rather than finishing.
  *
  * Every turn here is a turn like any other, so each one's signals are emitted. That is the
  * point of sharing this: the direct prompt path and the backlog loop each had their own copy
@@ -639,25 +718,19 @@ export interface AwaitRoundsOptions {
  * rather than a raw prompt, and skips gates entirely when headless.
  */
 export async function runAwaitRounds(opts: AwaitRoundsOptions): Promise<AwaitRoundsResult> {
-  const { session, emit, emitTurnSignals } = opts
-  const deps = { requestChoice: opts.requestChoice, emit, signal: opts.signal }
+  const { session, emit, emitTurnSignals, messages } = opts
+  const deps: AwaitTurnDeps = { requestChoice: opts.requestChoice, emit, emitTurnSignals, signal: opts.signal }
   const signalOpt = opts.signal ? { signal: opts.signal } : {}
 
-  let turn = await session.prompt(opts.prompt, signalOpt)
-  emitTurnSignals(turn.text)
-  let gate = parseAwaitGate(turn.text)
-  for (let round = 0; round < MAX_AWAIT_ROUNDS && gate; round++) {
-    const answer = await resolveAwaitGate(gate, round, deps)
-    if (isDeclinedConfirmation(gate, answer)) {
-      emit({ kind: 'log', message: PLAN_DECLINED_MESSAGE })
-      return { text: turn.text, declined: true, exhausted: false }
-    }
-    emit({ kind: 'log', message: `Continuing with your choice: ${answer}` })
-    turn = await session.prompt(continuationPrompt(gate.title, answer), signalOpt)
-    emitTurnSignals(turn.text)
-    gate = parseAwaitGate(turn.text)
-  }
-  return { text: turn.text, declined: false, exhausted: gate !== undefined }
+  const opening = await session.prompt(opts.prompt, signalOpt)
+  emitTurnSignals(opening.text)
+  const drained = await drainGates(session, opening, deps)
+  if (drained.declined) return { text: drained.turn.text, declined: true, exhausted: false }
+
+  // Live chat (#714): stay open for the user's messages until Stop. Headless leaves it unset,
+  // so the run ends here exactly as before.
+  const finalTurn = messages ? await runChatPhase(session, messages, drained.turn, deps) : drained.turn
+  return { text: finalTurn.text, declined: false, exhausted: drained.exhausted }
 }
 
 


### PR DESCRIPTION
Closes #714.

Turn the run view into a live chat. The composer (the same Tiptap PromptEditor the launcher uses) renders in a running run, and the run stays open after the agent goes idle to take your messages until you Stop it.

## How it works
Each message continues the **same agent session** via `claude -p --resume <sessionId>` — the id is retained on the session and stays stable across resumes, so the conversation keeps full context. It rides the existing `control.jsonl` steering channel as a new `message` kind (next to Stop / choice). The run loop drains queued messages between turns and, when idle, waits here for the next one (`RunMessageQueue`). One shared `runChatPhase` covers both the prompt path (`runAwaitRounds`) and the build path (`runFramework`, after the build settles).

## Lifecycle: stay-open (per the design call on #714)
The run keeps "running" after the agent goes quiet and waits for the next message; it ends when you Stop it (or a budget / await cap trips). This reproduces Claude Code's *interactive* feel on top of its headless engine (`claude -p` is one-shot; only `--resume` continues it).

- **Wired only for an interactive run** (a live dashboard / daemon, i.e. where `requestChoice` is wired). A headless / CI run leaves `messages` unset and ends when the agent stops asking — **byte-identical to before** (the no-messages path is unchanged, and the existing `runAwaitRounds` tests still pass).
- **@brillout heads-up:** this changes *when a run auto-ends* (an interactive run now ends on Stop rather than when the agent goes idle). That is run-lifecycle territory — flagging for your review. If stay-open proves heavy, the fallback is **drain-only** (run ends when idle; a fresh run re-sends `--resume` for the next message) — same resume plumbing, a cheap switch later.

## Scope note
Mid-build messages are delivered when the build settles (they queue until `runChatPhase` runs), not between individual build steps — draining *during* the pipeline is a follow-up.

## Driver
`DriverPromptOptions.resume` continues the retained session and skips the redundant `--append-system-prompt` re-append (the resumed transcript already carries its framing). Honored by the Claude Code driver; other drivers ignore it and run fresh.

## Verified
- Full `pnpm build` clean; `@gemstack/framework-dashboard` typecheck clean + 91 vitest; framework node:test **546 pass / 0 fail** (new: RunMessageQueue queue/handoff/close/abort; `message` control parse; driver `--resume` args + no-prior-session fallback; runPrompt stay-open delivery + unchanged no-messages path).
- **Live end-to-end** against a real model: opening turn "remember codeword BANANA", then a chat message "what codeword?" delivered through the queue + `runChatPhase` + driver `--resume` — the reply was `BANANA`, i.e. full context continuity across a real resumed turn.
- Live browser eyeball on :4200 pending (use Safari/Firefox — Chrome force-upgrades localhost to HTTPS).

`@gemstack/framework` change → changeset (minor).