### PR TITLE
fix(framework-dashboard): stop the page scrolling horizontally

### DIFF
--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -185,7 +185,9 @@ export default function Page() {
           <NotificationsMenu />
         </div>
       </header>
-      <div className="flex min-h-0 flex-1">
+      {/* The workspace row is fixed-height: each column scrolls internally, so the row itself
+          must never scroll. overflow-hidden clips any stray horizontal bleed (no page X-scroll). */}
+      <div className="flex min-h-0 flex-1 overflow-hidden">
         <ProjectsSidebar
           selectedId={projectId}
           onSelect={selectProject}


### PR DESCRIPTION
Closes #717.

The dashboard had a stray horizontal page scrollbar (body scrolls on X), visible even on the launcher — so it is the app-shell layout, not the run output/chat. The 4-column workspace row is fixed-height with each column scrolling internally; a stray element bled it wider than the viewport. Clip the row with `overflow-hidden` so the page never scrolls sideways (columns keep their own vertical scroll).

Private `framework-dashboard` package: no changeset. Verified: full build + dashboard typecheck clean. (Pre-existing on main, unrelated to #713/#715.)