### PR TITLE
feat(framework-dashboard): reuse the full launcher editor in the run-view composer (#721)

### DIFF
--- a/packages/framework-dashboard/components/Composer.test.tsx
+++ b/packages/framework-dashboard/components/Composer.test.tsx
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { Preferences } from '@gemstack/framework'
+
+// Preferences are the shared daemon store; stub them so the composer reads a fixed value.
+const updatePreferences = vi.hoisted(() => vi.fn())
+let prefs: Preferences = {}
+vi.mock('../lib/preferences.js', () => ({
+  usePreferences: () => prefs,
+  updatePreferences,
+  autopilotEnabled: (p: Preferences) => p.autopilot ?? true,
+}))
+
+// Stub the Tiptap editor (it needs a real DOM/ProseMirror): a plain input driving onChange, a
+// "type-submit" button firing onSubmit, and a ref exposing the same handle the composer calls.
+vi.mock('./PromptEditor.js', async () => {
+  const { forwardRef, useImperativeHandle } = await import('react')
+  const PromptEditor = forwardRef((props: any, ref: any) => {
+    useImperativeHandle(ref, () => ({ clear: () => props.onChange(''), focus: () => {}, loadTemplate: () => {} }))
+    return (
+      <div>
+        <input aria-label="prompt" onChange={e => props.onChange(e.target.value)} disabled={props.disabled} />
+        <button type="button" onClick={() => props.onSubmit()}>
+          editor-submit
+        </button>
+      </div>
+    )
+  })
+  return { PromptEditor }
+})
+
+const { Composer } = await import('./Composer.js')
+
+function renderComposer(over: Partial<Parameters<typeof Composer>[0]> = {}) {
+  const onSubmit = vi.fn()
+  render(
+    <Composer
+      projects={[]}
+      files={[]}
+      addContext={vi.fn()}
+      onSubmit={onSubmit}
+      busy={false}
+      submitLabel="Send"
+      submitBusyLabel="Sending…"
+      {...over}
+    />,
+  )
+  return { onSubmit }
+}
+
+beforeEach(() => {
+  prefs = {}
+  updatePreferences.mockReset()
+})
+afterEach(cleanup)
+
+describe('Composer (#721)', () => {
+  test('renders the full control row: agent/model, presets, options gear, and the submit button', () => {
+    renderComposer({ submitLabel: 'Start run' })
+    expect(screen.getByText('Presets')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Run options' })).toBeTruthy()
+    expect(screen.getByTitle(/Agent: Claude Code/)).toBeTruthy() // the agent/model trigger
+    expect(screen.getByRole('button', { name: /Start run/ })).toBeTruthy()
+  })
+
+  test('the submit button is disabled until the editor has text, then fires onSubmit', () => {
+    const { onSubmit } = renderComposer()
+    const submit = screen.getByRole('button', { name: 'Send' })
+    expect(submit.hasAttribute('disabled')).toBe(true)
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'ship it' } })
+    expect(submit.hasAttribute('disabled')).toBe(false)
+    fireEvent.click(submit)
+    expect(onSubmit).toHaveBeenCalledWith('ship it', 'build')
+  })
+
+  test('the editor shortcut (Cmd/Ctrl+Enter) submits too', () => {
+    const { onSubmit } = renderComposer()
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'go' } })
+    fireEvent.click(screen.getByText('editor-submit'))
+    expect(onSubmit).toHaveBeenCalledWith('go', 'build')
+  })
+
+  test('mirrors prompt changes out via onPromptChange', () => {
+    const onPromptChange = vi.fn()
+    renderComposer({ onPromptChange })
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'hi' } })
+    expect(onPromptChange).toHaveBeenLastCalledWith('hi', 'build')
+  })
+})

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -1,0 +1,241 @@
+import { forwardRef, useImperativeHandle, useRef, useState, type FormEvent } from 'react'
+import type { ProjectSummary } from '@gemstack/framework'
+import {
+  renderResearchPrompt,
+  renderReadabilityPrompt,
+  renderMaintainabilityPrompt,
+  renderSecurityAuditPrompt,
+  renderUxPrompt,
+} from '@gemstack/framework/client'
+import { usePreferences, updatePreferences, autopilotEnabled } from '../lib/preferences.js'
+import { PromptEditor, type PromptEditorHandle } from './PromptEditor.js'
+import { PresetCreatePanel } from './PresetCreatePanel.js'
+import { PresetMenu } from './PresetMenu.js'
+import { AgentModelMenu, type AgentOption } from './AgentModelMenu.js'
+import { OptionsMenu, type OptionRow } from './OptionsMenu.js'
+import { ClaudeLogo, CodexLogo } from './agent-logos.js'
+import { Button } from './ui/button.js'
+
+// The presets (#353/#433): each PREFILLS the editor with a rendered prompt and runs it verbatim
+// (`kind: 'prompt'`). Emptying the box falls back to a normal `build` run.
+const PRESETS: { id: string; label: string; render: () => string }[] = [
+  { id: 'research', label: 'Research', render: renderResearchPrompt },
+  { id: 'readability', label: 'Readability', render: renderReadabilityPrompt },
+  { id: 'maintainability', label: 'Maintainability', render: renderMaintainabilityPrompt },
+  { id: 'security-audit', label: 'Security audit', render: renderSecurityAuditPrompt },
+  { id: 'ux', label: 'UX', render: renderUxPrompt },
+]
+
+// The agent + model tree (#650/#656/#658): each agent lists ONLY its own models, since `--model`
+// passes straight through to that agent's CLI. Picking a model in an agent's submenu sets both, so
+// an incompatible pair can't be chosen. Empty value = the agent's own default (no `--model` flag).
+// Kept as a client const so the dashboard bundle never imports the node-only driver layer.
+const AGENTS: AgentOption[] = [
+  {
+    value: 'claude',
+    label: 'Claude Code',
+    icon: <ClaudeLogo className="h-4 w-4" />,
+    models: [
+      { value: '', label: 'Default model' },
+      { value: 'opus', label: 'Opus' },
+      { value: 'sonnet', label: 'Sonnet' },
+      { value: 'haiku', label: 'Haiku' },
+    ],
+  },
+  {
+    value: 'codex',
+    label: 'Codex',
+    icon: <CodexLogo className="h-4 w-4" />,
+    models: [
+      { value: '', label: 'Default model' },
+      { value: 'gpt-5-codex', label: 'GPT-5 Codex' },
+      { value: 'gpt-5', label: 'GPT-5' },
+      { value: 'o3', label: 'o3' },
+    ],
+  },
+]
+
+export interface ComposerHandle {
+  clear: () => void
+  focus: () => void
+}
+
+// The shared run composer (#721): the Tiptap editor (`/` `<` `@` `#` triggers, presets, mentions)
+// plus the control row — agent/model select, presets menu, Global-options gear, and the submit
+// button. Factored out of the launcher (StartRunForm) so the run-view chat (RunChat) gets the exact
+// same surface, wired to the same data (projects, files, presets, prefs). The caller owns what
+// happens on submit: the launcher starts a run (with collected options), the chat sends a message.
+export const Composer = forwardRef<ComposerHandle, {
+  /** Registered projects for the `@` picker. */
+  projects: ProjectSummary[]
+  /** The current project's files for the `#` picker (#504). */
+  files: string[]
+  /** Add a path to the run Context (from an `@`/`#` mention). */
+  addContext: (path: string) => void
+  /** Run the composed text. `kind` is `prompt` once a preset was loaded, else `build`. */
+  onSubmit: (text: string, kind: 'build' | 'prompt') => void | Promise<void>
+  /** Mirror the live prompt + kind out, so the launcher can drive its disclosure/context UI. */
+  onPromptChange?: ((prompt: string, kind: 'build' | 'prompt') => void) | undefined
+  /** A preset was loaded (so the launcher can flag it in its note). */
+  onPreset?: ((label: string) => void) | undefined
+  busy: boolean
+  submitLabel: string
+  submitBusyLabel: string
+  placeholder?: string | undefined
+  /** Show the ⌘↵ hint on the submit button (the launcher's Start). */
+  showShortcutHint?: boolean | undefined
+}>(function Composer(
+  { projects, files, addContext, onSubmit, onPromptChange, onPreset, busy, submitLabel, submitBusyLabel, placeholder, showShortcutHint = false },
+  ref,
+) {
+  const [prompt, setPrompt] = useState('')
+  const [kind, setKind] = useState<'build' | 'prompt'>('build')
+  const [addingPreset, setAddingPreset] = useState(false)
+  const editorRef = useRef<PromptEditorHandle>(null)
+
+  const preferences = usePreferences()
+  const autopilot = autopilotEnabled(preferences)
+  const technical = preferences.technical ?? false
+  const vanilla = preferences.vanilla ?? false
+  const transparent = preferences.transparent ?? false // #625: the master off-switch (raw Claude Code)
+  const eco = preferences.eco ?? false
+  const ecoPlanning = preferences.ecoPlanning ?? false
+  const ecoResearch = preferences.ecoResearch ?? false
+  const ecoMaintenance = preferences.ecoMaintenance ?? false
+  const onBeforeMergeableQuality = preferences.onBeforeMergeableQuality ?? false
+  const browser = preferences.browser ?? false
+  const model = preferences.model ?? '' // #628: empty = the driver's default model
+  const agent = preferences.agent ?? 'claude' // #650: which coding agent drives the run
+  const customPresets = preferences.customPresets ?? [] // #626: the user's own saved prompts
+
+  // Vanilla removes the system prompt (nothing left for Eco to trim); Transparent turns off the
+  // whole framework, so it overrides the rest too.
+  const ecoDisabled = vanilla || transparent
+
+  useImperativeHandle(ref, () => ({
+    clear: () => {
+      editorRef.current?.clear()
+      setPrompt('')
+      setKind('build')
+    },
+    focus: () => editorRef.current?.focus(),
+  }))
+
+  const submit = (e?: FormEvent) => {
+    e?.preventDefault()
+    const text = prompt.trim()
+    if (!text || busy) return
+    void onSubmit(text, kind)
+  }
+
+  // A preset button (or the `/` menu) loads the rendered template into the editor, which chip-ifies
+  // its tags; the run then goes verbatim as a `prompt` kind.
+  const loadPreset = (label: string) => {
+    setKind('prompt')
+    onPreset?.(label)
+  }
+
+  const onPromptEdit = (value: string) => {
+    setPrompt(value)
+    // An emptied box is a fresh start: back to a normal build run.
+    const nextKind = !value.trim() && kind !== 'build' ? 'build' : kind
+    if (nextKind !== kind) setKind(nextKind)
+    onPromptChange?.(value, nextKind)
+  }
+
+  // The Global options as one table (#314). Autopilot's default-on lives in `autopilotEnabled`; Eco
+  // is disabled + dimmed under Vanilla; the Eco sub-drops show only while Eco is on.
+  const mainOptions: OptionRow[] = [
+    { key: 'transparent', label: 'Transparent', description: 'Raw Claude Code — turns the whole framework off.', title: 'Fully transparent (#625): run the agent exactly like plain Claude Code, with no framework system prompt, controls, dashboard, guard, or TODO loop. Overrides the options below.', checked: transparent },
+    { key: 'autopilot', label: 'Autopilot', description: 'Auto-accepts the recommended choice after a countdown.', title: 'Auto-accept the recommended choice after a countdown; also relaxes the maintenance stance', checked: autopilot && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
+    { key: 'technical', label: 'Technical control', description: 'Surfaces technical detail like tech-stack choices.', title: 'Expose technical detail (e.g. tech-stack choices)', checked: technical && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
+    { key: 'vanilla', label: 'Disable system prompt', description: 'Drops the added system prompt; keeps the run controls.', title: "Remove the built-in system prompt but keep the framework's run controls. For a fully raw run, use Transparent. Expand 'Actual prompt' to read what it removes.", checked: vanilla && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
+    { key: 'eco', label: 'Eco', description: 'Trims the system prompt to save tokens.', title: 'Trim the built-in system prompt to save tokens', checked: eco && !ecoDisabled, disabled: ecoDisabled, disabledReason: 'nothing to trim while the system prompt is off' },
+    { key: 'onBeforeMergeableQuality', label: 'Post-merge cleanup', description: 'Runs quality passes once it is ready to merge.', title: "When the run signals it's ready for merge, run maintainability, readability, and security-audit passes", checked: onBeforeMergeableQuality && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
+    { key: 'browser', label: 'Browser', description: 'Gives the agent a real browser to inspect pages.', title: 'Give the agent a real browser via chrome-devtools-mcp: navigate pages, read console + network, inspect the DOM, and screenshot', checked: browser && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
+  ]
+  const ecoOptions: OptionRow[] = [
+    { key: 'ecoPlanning', label: 'Auto planning', description: 'Drops the planning section; the agent plans itself.', title: 'Drop the planning section, letting the agent plan on its own', checked: ecoPlanning },
+    { key: 'ecoResearch', label: 'Auto research', description: 'Drops the alternatives/variability section.', title: 'Drop the alternatives/variability section', checked: ecoResearch },
+    { key: 'ecoMaintenance', label: 'Auto maintenance', description: 'Drops the maintenance section.', title: 'Drop the maintenance section', checked: ecoMaintenance },
+  ]
+
+  return (
+    <>
+      <PromptEditor
+        ref={editorRef}
+        onChange={onPromptEdit}
+        onSubmit={submit}
+        onPreset={loadPreset}
+        onMentionProject={addContext}
+        onMentionFile={addContext}
+        projects={projects}
+        files={files}
+        presets={PRESETS}
+        disabled={busy}
+        {...(placeholder ? { placeholder } : {})}
+      />
+
+      {/* Run controls, directly under the editor (#649/#650/#654/#668): agent+model at the start,
+          then presets and the options gear, then submit at the end. */}
+      <div className="mt-2 flex flex-wrap items-center gap-1.5">
+        <AgentModelMenu
+          agents={AGENTS}
+          agent={agent}
+          model={model}
+          onChange={(a, m) => updatePreferences({ agent: a, model: m })}
+          busy={busy}
+        />
+        <PresetMenu
+          builtIns={PRESETS}
+          customPresets={customPresets}
+          busy={busy}
+          onLoadBuiltIn={p => {
+            editorRef.current?.loadTemplate(p.render())
+            loadPreset(p.label)
+          }}
+          onUseCustom={preset => {
+            editorRef.current?.loadTemplate(preset.prompt)
+            loadPreset(preset.label)
+          }}
+          onDeleteCustom={id => updatePreferences({ customPresets: customPresets.filter(p => p.id !== id) })}
+          onNewPreset={() => setAddingPreset(true)}
+        />
+        <OptionsMenu options={mainOptions} ecoOptions={ecoOptions} showEco={eco && !ecoDisabled} busy={busy} />
+        <Button
+          type="submit"
+          onClick={submit}
+          className="ml-auto"
+          disabled={busy || !prompt.trim()}
+          title={!prompt.trim() ? 'Type a prompt first' : `${submitLabel}  (⌘↵ / Ctrl+Enter)`}
+        >
+          {busy ? (
+            submitBusyLabel
+          ) : (
+            <>
+              {submitLabel}
+              {showShortcutHint && (
+                // The editor submits on ⌘/Ctrl+Enter (#695/U13): surface the otherwise-hidden shortcut.
+                <kbd className="ml-1.5 hidden rounded border border-primary-foreground/30 px-1 text-[10px] font-medium text-primary-foreground/70 sm:inline">
+                  ⌘↵
+                </kbd>
+              )}
+            </>
+          )}
+        </Button>
+      </div>
+
+      {addingPreset && (
+        <PresetCreatePanel
+          currentPrompt={prompt}
+          busy={busy}
+          onCancel={() => setAddingPreset(false)}
+          onSave={preset => {
+            updatePreferences({ customPresets: [...customPresets, preset] })
+            setAddingPreset(false)
+          }}
+        />
+      )}
+    </>
+  )
+})

--- a/packages/framework-dashboard/components/RunChat.tsx
+++ b/packages/framework-dashboard/components/RunChat.tsx
@@ -1,50 +1,59 @@
 import { useRef, useState } from 'react'
-import { PromptEditor, type PromptEditorHandle } from './PromptEditor.js'
-import { Button } from './ui/button.js'
+import type { ProjectSummary } from '@gemstack/framework'
+import { Composer, type ComposerHandle } from './Composer.js'
 import { sendMessage } from '../server/control.telefunc.js'
+import { onProjects } from '../server/projects.telefunc.js'
+import { useLoaded } from '../lib/use-async.js'
 
-// The live-chat composer (#714): send more messages to a running run. Reuses the same Tiptap
-// PromptEditor the launcher uses, so `/` actions and `<` tags work here too; on submit it writes
-// a `message` control entry that the run drains between turns (continuing the same session via
-// --resume). Only rendered inside RunLive, i.e. while the run is running — a finished run replays
-// without it. Presets/mentions are dropped here (a mid-run message is plain instruction).
-export function RunChat({ projectId }: { projectId: string }) {
-  const editorRef = useRef<PromptEditorHandle>(null)
-  const [text, setText] = useState('')
+// The live-chat composer (#714/#721): send more messages to a running run. Reuses the same shared
+// Composer the launcher uses, so `/` presets, `<` tags, and `@`/`#` mentions work here too, plus the
+// agent/model + options controls. On submit it writes a `message` control entry that the run drains
+// between turns (continuing the same session via --resume); the agent/model + options edit the
+// Global preferences (the defaults for the next run) — a mid-run message itself carries no options.
+// Only rendered inside RunLive, i.e. while the run is running — a finished run replays without it.
+export function RunChat({
+  projectId,
+  files,
+  addContext,
+}: {
+  projectId: string
+  /** The project's files for the `#` picker (#504), owned by the shell. */
+  files: string[]
+  /** Add a path to the run Context (from an `@`/`#` mention). */
+  addContext: (path: string) => void
+}) {
+  const composerRef = useRef<ComposerHandle>(null)
   const [sending, setSending] = useState(false)
+  // The registered projects for the `@` picker — the same list the launcher reads.
+  const projects = useLoaded<ProjectSummary[]>(onProjects, [], [])
 
-  const send = async (): Promise<void> => {
-    const message = text.trim()
-    if (!message || sending) return
+  const send = async (text: string): Promise<void> => {
+    if (sending) return
     setSending(true)
     try {
-      await sendMessage(projectId, message)
-      editorRef.current?.clear()
-      setText('')
+      await sendMessage(projectId, text)
+      composerRef.current?.clear()
     } catch {
       // Leave the text in place so the user can retry; the run may have just ended.
     } finally {
       setSending(false)
-      editorRef.current?.focus()
+      composerRef.current?.focus()
     }
   }
 
   return (
     <div className="border-t border-border p-3">
-      <PromptEditor
-        ref={editorRef}
-        projects={[]}
-        presets={[]}
-        onChange={setText}
+      <Composer
+        ref={composerRef}
+        projects={projects}
+        files={files}
+        addContext={addContext}
         onSubmit={send}
-        placeholder="Message the run…  (Cmd/Ctrl+Enter to send)"
-        disabled={sending}
+        busy={sending}
+        submitLabel="Send"
+        submitBusyLabel="Sending…"
+        placeholder="Message the run…  ( / commands · < tags · @ projects · # files )"
       />
-      <div className="mt-2 flex justify-end">
-        <Button size="sm" onClick={send} disabled={!text.trim() || sending}>
-          {sending ? 'Sending…' : 'Send'}
-        </Button>
-      </div>
     </div>
   )
 }

--- a/packages/framework-dashboard/components/RunLive.tsx
+++ b/packages/framework-dashboard/components/RunLive.tsx
@@ -8,13 +8,24 @@ import { RunFeed } from './RunFeed.js'
 // more messages (#714). Distinct from the home launcher (ProjectHome) and a finished run's replay
 // (RunReplay, which has no composer). Single-run today streams the project's one live feed; per-run
 // streams arrive with worktrees (#453). The session link lives in the action bar now, so the feed's
-// overview drops it (`showSessionLink={false}`).
-export function RunLive({ projectId, events }: { projectId: string; events: FrameworkEvent[] }) {
+// overview drops it (`showSessionLink={false}`). `files`/`addContext` flow through to RunChat's
+// shared Composer for the `#`/`@` pickers (#721).
+export function RunLive({
+  projectId,
+  events,
+  files,
+  addContext,
+}: {
+  projectId: string
+  events: FrameworkEvent[]
+  files: string[]
+  addContext: (path: string) => void
+}) {
   return (
     <>
       <RunActionBar projectId={projectId} events={events} />
       <RunFeed events={events} showSessionLink={false} />
-      <RunChat projectId={projectId} />
+      <RunChat projectId={projectId} files={files} addContext={addContext} />
     </>
   )
 }

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -1,72 +1,19 @@
-import { useRef, useState, type FormEvent, type ReactNode } from 'react'
+import { useRef, useState } from 'react'
 import type { ProjectSummary } from '@gemstack/framework'
-import {
-  renderResearchPrompt,
-  renderReadabilityPrompt,
-  renderMaintainabilityPrompt,
-  renderSecurityAuditPrompt,
-  renderUxPrompt,
-} from '@gemstack/framework/client'
 import { sendStart } from '../server/control.telefunc.js'
 import { onProjects } from '../server/projects.telefunc.js'
 import { usePreferences, updatePreferences, autopilotEnabled } from '../lib/preferences.js'
 import { useLoaded } from '../lib/use-async.js'
-import { PromptEditor, type PromptEditorHandle } from './PromptEditor.js'
-import { PresetMenu } from './PresetMenu.js'
-import { PresetCreatePanel } from './PresetCreatePanel.js'
-import { AgentModelMenu, type AgentOption } from './AgentModelMenu.js'
+import { Composer, type ComposerHandle } from './Composer.js'
 import { ContextFiles } from './ContextFiles.js'
-import { ClaudeLogo, CodexLogo } from './agent-logos.js'
 import { DisclosureToggle } from './DisclosureToggle.js'
 import { SystemPromptDisclosure } from './SystemPromptDisclosure.js'
-import { OptionsMenu, type OptionRow } from './OptionsMenu.js'
-import { Button } from './ui/button.js'
 
-// The presets (#353/#433): each PREFILLS the textarea with a rendered prompt and runs it
-// verbatim (`kind: 'prompt'`), the same as the old page.ts. Emptying the box falls back to
-// a normal `build` run.
-const PRESETS: { id: string; label: string; render: () => string }[] = [
-  { id: 'research', label: 'Research', render: renderResearchPrompt },
-  { id: 'readability', label: 'Readability', render: renderReadabilityPrompt },
-  { id: 'maintainability', label: 'Maintainability', render: renderMaintainabilityPrompt },
-  { id: 'security-audit', label: 'Security audit', render: renderSecurityAuditPrompt },
-  { id: 'ux', label: 'UX', render: renderUxPrompt },
-]
-
-// The agent + model tree (#650/#656/#658): each agent lists ONLY its own models, since `--model`
-// passes straight through to that agent's CLI (Claude aliases vs OpenAI ids). Picking a model in
-// an agent's submenu sets both, so an incompatible pair can't be chosen. Empty value = the
-// agent's own default (no `--model` flag). Kept as a client const so the dashboard bundle never
-// imports the node-only driver layer (mirrors AGENTS in the framework's agent.ts).
-const AGENTS: AgentOption[] = [
-  {
-    value: 'claude',
-    label: 'Claude Code',
-    icon: <ClaudeLogo className="h-4 w-4" />,
-    models: [
-      { value: '', label: 'Default model' },
-      { value: 'opus', label: 'Opus' },
-      { value: 'sonnet', label: 'Sonnet' },
-      { value: 'haiku', label: 'Haiku' },
-    ],
-  },
-  {
-    value: 'codex',
-    label: 'Codex',
-    icon: <CodexLogo className="h-4 w-4" />,
-    models: [
-      { value: '', label: 'Default model' },
-      { value: 'gpt-5-codex', label: 'GPT-5 Codex' },
-      { value: 'gpt-5', label: 'GPT-5' },
-      { value: 'o3', label: 'o3' },
-    ],
-  },
-]
-
-// Start a run in the selected project (#405): the one write that goes through the daemon's
-// own `startRun` (with its one-run-per-project busy guard), posted over Telefunc. The
-// Global options (#314/#433) ride along: Autopilot, Technical control, Vanilla, and Eco
-// (with its section drops). Shown when no run is active; a `busy` result means one already is.
+// Start a run in the selected project (#405): the one write that goes through the daemon's own
+// `startRun` (with its one-run-per-project busy guard), posted over Telefunc. The editor + control
+// row are the shared Composer (#721); this form owns the submit (sendStart with the collected
+// Global options), the system-prompt preview, and the Context selector. Shown when no run is active;
+// a `busy` result means one already is.
 export function StartRunForm({
   projectId,
   onRunStarted,
@@ -87,38 +34,33 @@ export function StartRunForm({
   toggleContext: (path: string) => void
 }) {
   const [prompt, setPrompt] = useState('')
-  const [kind, setKind] = useState<'build' | 'prompt'>('build')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [note, setNote] = useState<string | null>(null)
-  const editorRef = useRef<PromptEditorHandle>(null)
+  const composerRef = useRef<ComposerHandle>(null)
 
   // The Global options persist daemon-side (#410), shared with the choice-gate countdown.
   const preferences = usePreferences()
   const autopilot = autopilotEnabled(preferences)
-  const technical = preferences.technical ?? false
   const vanilla = preferences.vanilla ?? false
   const transparent = preferences.transparent ?? false // #625: the master off-switch (raw Claude Code)
   const eco = preferences.eco ?? false
   const ecoPlanning = preferences.ecoPlanning ?? false
   const ecoResearch = preferences.ecoResearch ?? false
   const ecoMaintenance = preferences.ecoMaintenance ?? false
+  const technical = preferences.technical ?? false
   const onBeforeMergeableQuality = preferences.onBeforeMergeableQuality ?? false
   const browser = preferences.browser ?? false
   const model = preferences.model ?? '' // #628: empty = the driver's default model
   const agent = preferences.agent ?? 'claude' // #650: which coding agent drives the run
-  const customPresets = preferences.customPresets ?? [] // #626: the user's own saved prompts
-  const [addingPreset, setAddingPreset] = useState(false) // #649: the full-width "New preset" panel
 
-  // Context selector (#439/#314): the agent can reach every registered repo, so ticking a
-  // subset narrows its focus — the picked paths become one `Context:` line in the system
-  // prompt. Loaded from the same registry the Projects sidebar shows.
+  // Context selector (#439/#314): the agent can reach every registered repo, so ticking a subset
+  // narrows its focus — the picked paths become one `Context:` line in the system prompt.
   const projects = useLoaded<ProjectSummary[]>(onProjects, [], [])
   const [showContext, setShowContext] = useState(false)
 
   // The Context set mixes whole repos (registered project paths) and individual files (relative
-  // paths from a `#` mention or the file tree). Split out the files so they can be shown + removed,
-  // and count each kind separately for the section header.
+  // paths). Split out the files so they can be shown + removed, and count each kind separately.
   const projectPaths = new Set(projects.map(p => p.path))
   const contextFiles = [...context].filter(path => !projectPaths.has(path))
   // The current project is already the run's workspace, so it isn't offered as a focus target
@@ -132,13 +74,10 @@ export function StartRunForm({
     .filter(Boolean)
     .join(' · ')
 
-  // Vanilla removes the system prompt entirely, so Eco (which only trims it) has nothing
-  // left to act on; Transparent (#625) turns off the whole framework, so it overrides the
-  // rest of the toggles too.
   const ecoDisabled = vanilla || transparent
 
-  // The eco drops, hoisted: the run gets them via collectOptions, and the #520
-  // preview renders with them, so what you read is what gets sent.
+  // The eco drops, hoisted: the run gets them via collectOptions, and the #520 preview renders with
+  // them, so what you read is what gets sent.
   const ecoDrops = {
     ...(ecoPlanning ? { autoPlanning: true } : {}),
     ...(ecoResearch ? { autoResearch: true } : {}),
@@ -160,23 +99,19 @@ export function StartRunForm({
     }
   }
 
-  const submit = async (e?: FormEvent) => {
-    e?.preventDefault()
-    const text = prompt.trim()
-    if (!text || busy) return
+  const submit = async (text: string, submitKind: 'build' | 'prompt') => {
+    if (busy) return
     setBusy(true)
     setError(null)
     setNote('Starting…')
     try {
-      const result = await sendStart(projectId, text, kind, collectOptions())
+      const result = await sendStart(projectId, text, submitKind, collectOptions())
       if (result.ok) {
-        // Show the run in the Runs rail immediately (#405): the spawned process
-        // writes its run.json a beat later, so seed an optimistic row with the
-        // typed prompt until the real running meta takes over.
+        // Show the run in the Runs rail immediately (#405): the spawned process writes its run.json
+        // a beat later, so seed an optimistic row with the typed prompt until the real meta takes over.
         onRunStarted?.(text)
-        editorRef.current?.clear()
+        composerRef.current?.clear()
         setPrompt('')
-        setKind('build')
         setNote(null)
       } else {
         setNote(null)
@@ -190,117 +125,28 @@ export function StartRunForm({
     }
   }
 
-  // A preset button (or the `/` menu) loads the rendered template into the editor, which
-  // chip-ifies its tags; the run then goes verbatim as a `prompt` kind.
-  const loadPreset = (label: string) => {
-    setKind('prompt')
-    setError(null)
-    setNote(`${label} preset loaded — review or edit, then Start`)
-  }
-
-  const onPromptChange = (value: string) => {
-    setPrompt(value)
-    // An emptied box is a fresh start: back to a normal build run.
-    if (!value.trim() && kind !== 'build') {
-      setKind('build')
-      setNote(null)
-    }
-  }
-
-  // The Global options as one table (#314). Autopilot's default-on lives in `autopilotEnabled`;
-  // Eco is disabled + dimmed under Vanilla (nothing left to trim); the Eco sub-drops show only
-  // while Eco is on.
-  const mainOptions: OptionRow[] = [
-    { key: 'transparent', label: 'Transparent', description: 'Raw Claude Code — turns the whole framework off.', title: 'Fully transparent (#625): run the agent exactly like plain Claude Code, with no framework system prompt, controls, dashboard, guard, or TODO loop. Overrides the options below.', checked: transparent },
-    { key: 'autopilot', label: 'Autopilot', description: 'Auto-accepts the recommended choice after a countdown.', title: 'Auto-accept the recommended choice after a countdown; also relaxes the maintenance stance', checked: autopilot && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
-    { key: 'technical', label: 'Technical control', description: 'Surfaces technical detail like tech-stack choices.', title: 'Expose technical detail (e.g. tech-stack choices)', checked: technical && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
-    { key: 'vanilla', label: 'Disable system prompt', description: 'Drops the added system prompt; keeps the run controls.', title: "Remove the built-in system prompt but keep the framework's run controls. For a fully raw run, use Transparent. Expand 'Actual prompt' to read what it removes.", checked: vanilla && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
-    { key: 'eco', label: 'Eco', description: 'Trims the system prompt to save tokens.', title: 'Trim the built-in system prompt to save tokens', checked: eco && !ecoDisabled, disabled: ecoDisabled, disabledReason: 'nothing to trim while the system prompt is off' },
-    { key: 'onBeforeMergeableQuality', label: 'Post-merge cleanup', description: 'Runs quality passes once it is ready to merge.', title: "When the run signals it's ready for merge, run maintainability, readability, and security-audit passes", checked: onBeforeMergeableQuality && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
-    { key: 'browser', label: 'Browser', description: 'Gives the agent a real browser to inspect pages.', title: 'Give the agent a real browser via chrome-devtools-mcp: navigate pages, read console + network, inspect the DOM, and screenshot', checked: browser && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
-  ]
-  const ecoOptions: OptionRow[] = [
-    { key: 'ecoPlanning', label: 'Auto planning', description: 'Drops the planning section; the agent plans itself.', title: 'Drop the planning section, letting the agent plan on its own', checked: ecoPlanning },
-    { key: 'ecoResearch', label: 'Auto research', description: 'Drops the alternatives/variability section.', title: 'Drop the alternatives/variability section', checked: ecoResearch },
-    { key: 'ecoMaintenance', label: 'Auto maintenance', description: 'Drops the maintenance section.', title: 'Drop the maintenance section', checked: ecoMaintenance },
-  ]
-
   return (
-    <form onSubmit={submit} className="border-b border-border p-4">
+    <form onSubmit={e => e.preventDefault()} className="border-b border-border p-4">
       <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Start a run</div>
-      <PromptEditor
-        ref={editorRef}
-        onChange={onPromptChange}
-        onSubmit={() => void submit()}
-        onPreset={loadPreset}
-        onMentionProject={addContext}
-        onMentionFile={addContext}
+      <Composer
+        ref={composerRef}
         projects={projects}
         files={files}
-        presets={PRESETS}
-        disabled={busy}
+        addContext={addContext}
+        onSubmit={submit}
+        onPromptChange={value => {
+          setPrompt(value)
+          if (!value.trim() && note) setNote(null)
+        }}
+        onPreset={label => {
+          setError(null)
+          setNote(`${label} preset loaded — review or edit, then Start`)
+        }}
+        busy={busy}
+        submitLabel="Start run"
+        submitBusyLabel="Starting…"
+        showShortcutHint
       />
-
-      {/* Run controls, directly under the textarea (#649/#650/#654/#668): agent+model at the start,
-          then presets and the options gear, then Start run at the end. */}
-      <div className="mt-2 flex flex-wrap items-center gap-1.5">
-        {/* Agent + model tree (#650/#658), each agent showing only its own models. */}
-        <AgentModelMenu
-          agents={AGENTS}
-          agent={agent}
-          model={model}
-          onChange={(a, m) => updatePreferences({ agent: a, model: m })}
-          busy={busy}
-        />
-        <PresetMenu
-          builtIns={PRESETS}
-          customPresets={customPresets}
-          busy={busy}
-          onLoadBuiltIn={p => {
-            editorRef.current?.loadTemplate(p.render())
-            loadPreset(p.label)
-          }}
-          onUseCustom={preset => {
-            editorRef.current?.loadTemplate(preset.prompt)
-            loadPreset(preset.label)
-          }}
-          onDeleteCustom={id => updatePreferences({ customPresets: customPresets.filter(p => p.id !== id) })}
-          onNewPreset={() => setAddingPreset(true)}
-        />
-        {/* Global options (#314) as a gear-icon checkbox dropdown (#654/#668). */}
-        <OptionsMenu options={mainOptions} ecoOptions={ecoOptions} showEco={eco && !ecoDisabled} busy={busy} />
-        {/* Start run at the end of the row (#668). */}
-        <Button
-          type="submit"
-          className="ml-auto"
-          disabled={busy || !prompt.trim()}
-          title={!prompt.trim() ? 'Type a prompt to start a run' : 'Start run  (⌘↵ / Ctrl+Enter)'}
-        >
-          {busy ? (
-            'Starting…'
-          ) : (
-            <>
-              Start run
-              {/* The editor submits on ⌘/Ctrl+Enter (#695/U13): surface the otherwise-hidden shortcut. */}
-              <kbd className="ml-1.5 hidden rounded border border-primary-foreground/30 px-1 text-[10px] font-medium text-primary-foreground/70 sm:inline">
-                ⌘↵
-              </kbd>
-            </>
-          )}
-        </Button>
-      </div>
-
-      {addingPreset && (
-        <PresetCreatePanel
-          currentPrompt={prompt}
-          busy={busy}
-          onCancel={() => setAddingPreset(false)}
-          onSave={preset => {
-            updatePreferences({ customPresets: [...customPresets, preset] })
-            setAddingPreset(false)
-          }}
-        />
-      )}
 
       <SystemPromptDisclosure
         prompt={prompt}
@@ -320,8 +166,8 @@ export function StartRunForm({
           </DisclosureToggle>
           {showContext && (
             <div className="mt-2 grid grid-cols-1 gap-4 rounded border border-border p-3 sm:grid-cols-2">
-              {/* Projects: repo checkboxes. The agent can still reach every repo; ticking some
-                  just narrows its focus (kept in the heading's tooltip). */}
+              {/* Projects: repo checkboxes. The agent can still reach every repo; ticking some just
+                  narrows its focus (kept in the heading's tooltip). */}
               <div>
                 <p className="mb-1.5 text-muted-foreground/80" title="The agent can still reach every repo; ticking some just narrows its focus.">
                   Projects
@@ -353,7 +199,6 @@ export function StartRunForm({
         </div>
       )}
 
-      {/* Start run moved up into the controls row (#668); the note + error stay below it. */}
       {error && <p className="mt-2 text-xs text-red-500">{error}</p>}
       {note && !error && <p className="mt-2 text-xs text-muted-foreground">{note}</p>}
     </form>

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -159,7 +159,7 @@ export default function Page() {
     if (!projectId) return <DashboardPage onSelectProject={selectProject} interventions={interventions} />
     if (runId === null) {
       // Just pressed Start: follow the run's live output until the poll adopts its real id above.
-      if (followLive) return <RunLive projectId={projectId} events={events} />
+      if (followLive) return <RunLive projectId={projectId} events={events} files={files} addContext={addContext} />
       return (
         <ProjectHome
           projectId={projectId}
@@ -172,7 +172,7 @@ export default function Page() {
         />
       )
     }
-    if (selectedRun?.status === 'running') return <RunLive projectId={projectId} events={events} />
+    if (selectedRun?.status === 'running') return <RunLive projectId={projectId} events={events} files={files} addContext={addContext} />
     return <RunReplay projectId={projectId} runId={runId} />
   }
 


### PR DESCRIPTION
## What

Factors the launcher's Tiptap editor + control row into one reusable **`Composer`** and uses it in both `StartRunForm` (launcher) and `RunChat` (run view).

The run-view chat (`RunChat`, #715) was a stripped `PromptEditor`: it passed `presets={[]}` and `projects={[]}`, so `/` presets and `@` projects were dead, and it had no model/agent select or settings. It now matches the launcher, wired to the same data (projects, files, presets, prefs):

- the same Tiptap editor with `/` `<` `@` `#` triggers + presets + mentions
- the agent/model select (`AgentModelMenu`)
- the presets menu (`PresetMenu`) + New-preset panel
- the Global-options gear (`OptionsMenu`)

Each call site keeps its own submit: the launcher starts a run with the collected options; the chat sends a `message` (agent/model/options edit the shared prefs, i.e. the defaults for the next run, since a mid-run message carries no options).

## Notes

- `RunLive` now threads `files`/`addContext` down to `RunChat` for the `#`/`@` pickers.
- No separate navbar launcher exists in the tree yet; when one lands it can drop in `Composer` too.

## Test

- New `Composer.test.tsx` (control row renders, submit gating + fire, prompt mirroring).
- `framework-dashboard` typecheck clean, all 95 tests pass.

Closes #721