### PR TITLE
feat(framework): self-heal a run whose process died (#716)

### DIFF
--- a/.changeset/716-run-liveness-check.md
+++ b/.changeset/716-run-liveness-check.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Self-heal a run whose process died without writing its `end` event (#716). A crash, `kill -9`, or the machine sleeping used to leave `.the-framework/run.json` stuck at `status: running` forever: the dashboard showed a permanently RUNNING row whose Stop was a no-op (nothing was left to consume `control.jsonl`), and it only cleared on a daemon restart. The run now records its owning pid and host in `run.json`, and `readLiveMeta` flips a `running` run to `stopped` (and archives it) on read when that owning process is gone on this host, so the dashboard clears the stuck row on the next poll. Runs whose meta predates this field are left to the existing boot-time reconcile.

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -34,17 +34,20 @@ async function withProject<T>(projectId: string, read: (cwd: string) => Promise<
 
 /**
  * The project's runs, most-recent first (or `[]`). The archived (finished) runs
- * from `runs/`, plus the live run prepended when one is going — so the sidebar
+ * from `runs/`, plus the live run prepended when one is present — so the sidebar
  * shows the in-progress run with a `running` status the moment it starts, not
  * only after it closes. The live run is skipped once it has been archived under
  * the same id (it then appears from `listRuns` instead), so there is no double.
+ * The status is not filtered on: `readLiveMeta` may have just self-healed a dead
+ * run to `stopped` (#716), and that freshly-archived row can lag `listRuns` by a
+ * poll — prepending it regardless keeps the row visible (as stopped) with no flicker.
  */
 export async function onRuns(projectId: string): Promise<RunMeta[]> {
   const cwd = await resolveProjectPath(projectId)
   if (!cwd) return []
   const archived = await listRuns(cwd).catch(() => [])
   const live = await readLiveMeta(cwd).catch(() => undefined)
-  if (live && live.status === 'running' && !archived.some(r => r.id === live.id)) {
+  if (live && !archived.some(r => r.id === live.id)) {
     return [live, ...archived]
   }
   return archived

--- a/packages/framework/src/store/run-store.test.ts
+++ b/packages/framework/src/store/run-store.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { join } from 'node:path'
+import { hostname } from 'node:os'
 import {
   RunStore,
   applyEventToMeta,
@@ -291,4 +292,47 @@ test('reconcileOrphanedRuns is a no-op on a clean or empty workspace (#642)', as
   assert.equal(await reconcileOrphanedRuns(CWD, memFs()), 0)
   const done = memFs({ [META]: JSON.stringify({ version: RUN_META_VERSION, status: 'done', id: 'd', startedAt: AT, updatedAt: AT, passes: 0 }) })
   assert.equal(await reconcileOrphanedRuns(CWD, done), 0)
+})
+
+// #716: a run whose process dies without writing `end`. The owning pid+host are persisted so a
+// reader can flip it to `stopped` (and archive it) without waiting for a daemon-restart reconcile.
+const HERE = hostname()
+const ownedMeta = (id: string, pid: number, host: string): string =>
+  JSON.stringify({ version: RUN_META_VERSION, status: 'running', id, startedAt: AT, updatedAt: AT, passes: 0, pid, host })
+
+test('a fresh open records the owning pid + host so a dead run can be detected (#716)', async () => {
+  const fs = memFs()
+  await RunStore.open(CWD, { fs, fresh: true, now: AT, owner: { pid: 4242, host: 'box-a' } })
+  const meta = JSON.parse(fs.files.get(META)!) as RunMeta
+  assert.equal(meta.pid, 4242)
+  assert.equal(meta.host, 'box-a')
+})
+
+test('readLiveMeta self-heals a running run whose owning process is gone: stopped + archived (#716)', async () => {
+  const fs = memFs({ [META]: ownedMeta('2026-dead', 999999, HERE) })
+  const live = await readLiveMeta(CWD, fs, () => false) // pid probe says the owner is gone
+  assert.equal(live!.status, 'stopped')
+  // The on-disk run.json is flipped, and the run is archived (as stopped) so it stays in history.
+  assert.equal((JSON.parse(fs.files.get(META)!) as RunMeta).status, 'stopped')
+  const runs = await listRuns(CWD, fs)
+  assert.deepEqual(runs.map(r => [r.id, r.status]), [['2026-dead', 'stopped']])
+})
+
+test('readLiveMeta leaves a running run alone while its owning process is alive (#716)', async () => {
+  const fs = memFs({ [META]: ownedMeta('2026-live', process.pid, HERE) })
+  const live = await readLiveMeta(CWD, fs, () => true)
+  assert.equal(live!.status, 'running')
+  assert.equal((JSON.parse(fs.files.get(META)!) as RunMeta).status, 'running')
+})
+
+test('readLiveMeta leaves a pre-pid run untouched — the boot reconcile still catches it (#716)', async () => {
+  const fs = memFs({ [META]: runningMeta('2026-old') }) // no pid recorded
+  const live = await readLiveMeta(CWD, fs, () => false)
+  assert.equal(live!.status, 'running')
+})
+
+test('readLiveMeta does not trust a pid from a different host (#716)', async () => {
+  const fs = memFs({ [META]: ownedMeta('2026-remote', 4242, 'other-box') })
+  const live = await readLiveMeta(CWD, fs, () => false)
+  assert.equal(live!.status, 'running') // a dead-looking pid on another host is unknowable here
 })

--- a/packages/framework/src/store/run-store.ts
+++ b/packages/framework/src/store/run-store.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path'
+import { hostname } from 'node:os'
 import type { FrameworkEvent } from '../events.js'
 import { nodeFs } from '../node-fs.js'
 
@@ -67,6 +68,14 @@ export interface RunMeta {
   updatedAt: string
   /** Full-fledged loop passes performed so far. */
   passes: number
+  /**
+   * The OS pid of the process that owns this run (the one tailing `control.jsonl`), on {@link host}.
+   * Persisted so a reader can tell a live run from one whose process died without writing `end`
+   * (#716): a `running` meta whose owning pid is gone is stale and gets flipped to `stopped`.
+   */
+  pid?: number
+  /** The host the owning {@link pid} lives on, so a pid probe only trusts a match (#716). */
+  host?: string
   /** What the user asked to build (from the `scope` event). */
   intent?: string
   scope?: string
@@ -123,6 +132,11 @@ export interface OpenStoreOptions {
    * step, so seeding it here is the only way its row shows the prompt instead of "(no prompt)".
    */
   intent?: string
+  /**
+   * Who owns this run (#716). Defaults to the current process on this host — the process opening a
+   * fresh store *is* the run's owner. Injectable so tests can seed a specific (dead) pid.
+   */
+  owner?: RunOwner
 }
 
 /**
@@ -175,8 +189,14 @@ export function applyEventToMeta(meta: RunMeta, event: FrameworkEvent, at: strin
   return next
 }
 
+/** Who owns a live run: its OS pid and the host that pid lives on (#716). */
+export interface RunOwner {
+  pid: number
+  host: string
+}
+
 /** The seed meta a run starts from, before any event is folded in. */
-function freshMeta(startedAt: string, intent?: string): RunMeta {
+function freshMeta(startedAt: string, intent?: string, owner?: RunOwner): RunMeta {
   return {
     version: RUN_META_VERSION,
     status: 'running',
@@ -184,6 +204,7 @@ function freshMeta(startedAt: string, intent?: string): RunMeta {
     startedAt,
     updatedAt: startedAt,
     passes: 0,
+    ...(owner ? { pid: owner.pid, host: owner.host } : {}),
     ...(intent ? { intent } : {}),
   }
 }
@@ -263,7 +284,8 @@ export class RunStore {
     const dir = join(cwd, FRAMEWORK_DIR)
     const now = opts.now ?? new Date().toISOString()
     await fs.mkdir(dir)
-    const store = new RunStore(fs, dir, now, freshMeta(now, opts.intent))
+    const owner = opts.owner ?? { pid: process.pid, host: hostname() }
+    const store = new RunStore(fs, dir, now, freshMeta(now, opts.intent, owner))
     if (opts.fresh) {
       // A new run truncates the live log. First rescue the prior run if it never
       // got archived (e.g. a crash exited before close), so no history is lost.
@@ -421,14 +443,55 @@ export async function reconcileOrphanedRuns(cwd: string, fs: StoreFs = nodeStore
 }
 
 /**
+ * Whether `pid` is a live process on this host. `process.kill(pid, 0)` sends no signal but
+ * throws `ESRCH` once the process is gone; `EPERM` means it exists under another user (still
+ * alive). A pid on a *different* host is unknowable here, so callers guard on {@link RunMeta.host}
+ * before trusting a result. A recycled pid (another process reusing a dead run's number) reads as
+ * alive — an accepted, vanishingly rare miss on a single dev box.
+ */
+export function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+/** A `running` meta whose owning process is gone (same host, dead pid) — its state is stale (#716). */
+function isDeadRun(meta: RunMeta, isAlive: (pid: number) => boolean): boolean {
+  return meta.status === 'running' && meta.pid !== undefined && meta.host === hostname() && !isAlive(meta.pid)
+}
+
+/**
  * The live (in-progress) run's meta snapshot from `.the-framework/run.json`, or
  * `undefined` when none/unreadable. Unlike {@link listRuns} (which reads the
  * archived `runs/` copies written on close), this is the run the daemon is
  * tailing right now — so the dashboard can list it with a `running` status
  * before it finishes. Missing or torn file yields `undefined`, never throws.
+ *
+ * Self-heals a stale run on read (#716): if the meta says `running` but its owning process died
+ * without writing `end` (a crash, `kill -9`, or the machine sleeping), nothing is left to consume
+ * `control.jsonl` — so Stop is a no-op and the row is stuck. When the owning pid is gone on this
+ * host, flip it to `stopped` and archive it, so the dashboard clears the row on the next poll
+ * instead of only after a daemon restart's boot-time {@link reconcileOrphanedRuns}. A run whose
+ * meta predates this field (no `pid`) is left untouched — the boot reconcile still catches it.
  */
-export function readLiveMeta(cwd: string, fs: StoreFs = nodeStoreFs()): Promise<RunMeta | undefined> {
-  return readMetaFile(fs, join(cwd, FRAMEWORK_DIR, META_FILE))
+export async function readLiveMeta(
+  cwd: string,
+  fs: StoreFs = nodeStoreFs(),
+  isAlive: (pid: number) => boolean = isPidAlive,
+): Promise<RunMeta | undefined> {
+  const dir = join(cwd, FRAMEWORK_DIR)
+  const meta = await readMetaFile(fs, join(dir, META_FILE))
+  if (!meta) return undefined
+  if (isDeadRun(meta, isAlive)) {
+    const stopped: RunMeta = { ...meta, status: 'stopped' }
+    await fs.write(join(dir, META_FILE), JSON.stringify(stopped, null, 2) + '\n').catch(() => {})
+    await archivePriorRun(fs, dir).catch(() => {})
+    return stopped
+  }
+  return meta
 }
 
 /**


### PR DESCRIPTION
Closes #716

## Problem
If a run's process ends without writing its `end` event (crash, `kill -9`, machine sleep), `.the-framework/run.json` is left at `status: running` forever. The dashboard shows a permanently RUNNING row, and its Stop is a no-op: nothing is left to consume `control.jsonl`. The row only cleared on a daemon restart (boot-time `reconcileOrphanedRuns`).

## Fix (liveness check)
- Record the run's owning `pid` + `host` in `run.json` (`RunMeta`). The process that opens a fresh store is the run's owner, so `process.pid`/`hostname()` are in scope there.
- `readLiveMeta` self-heals on read: a `running` meta whose owning pid is gone on this host is flipped to `stopped` and archived, so the dashboard clears the stuck row on the next poll rather than waiting for a daemon restart.
- `onRuns` prepends the live meta regardless of status (dedup by id unchanged), so a just-healed `stopped` run stays visible without a one-poll flicker.
- A host guard means a pid is only trusted on the host that recorded it. A meta that predates the `pid` field is left untouched: the existing boot reconcile still catches it.

## Tests
5 new store cases (fresh open records owner; self-heal dead run -> stopped + archived; alive run left running; pre-pid run untouched; foreign-host pid not trusted). Full `@gemstack/framework` suite green.

## Notes
A recycled pid (another process reusing a dead run's number) reads as alive and would keep such a run marked running: an accepted, vanishingly rare miss on a single dev box.