### PR TITLE
feat(framework-dashboard): global quick-launch composer in the top navbar (#723)

### DIFF
--- a/packages/framework-dashboard/components/Composer.test.tsx
+++ b/packages/framework-dashboard/components/Composer.test.tsx
@@ -63,6 +63,18 @@ describe('Composer (#721)', () => {
     expect(screen.getByRole('button', { name: /Start run/ })).toBeTruthy()
   })
 
+  test('compact (#723) drops the control row, keeping only the editor + submit', () => {
+    const { onSubmit } = renderComposer({ compact: true, submitLabel: 'Start' })
+    // The redundant control row is gone in compact form.
+    expect(screen.queryByText('Presets')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Run options' })).toBeNull()
+    expect(screen.queryByTitle(/Agent: Claude Code/)).toBeNull()
+    // The editor + submit still work (so `/` `<` `@` `#` triggers remain live in the editor).
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'quick run' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }))
+    expect(onSubmit).toHaveBeenCalledWith('quick run', 'build')
+  })
+
   test('the submit button is disabled until the editor has text, then fires onSubmit', () => {
     const { onSubmit } = renderComposer()
     const submit = screen.getByRole('button', { name: 'Send' })

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -84,8 +84,12 @@ export const Composer = forwardRef<ComposerHandle, {
   placeholder?: string | undefined
   /** Show the ⌘↵ hint on the submit button (the launcher's Start). */
   showShortcutHint?: boolean | undefined
+  /** Compact single-row form for the navbar quick-launch (#723): editor + submit, no control row
+   *  or preset panel. The `/` `<` `@` `#` triggers still work; agent/model + options come from the
+   *  shared prefs the launcher sets. */
+  compact?: boolean | undefined
 }>(function Composer(
-  { projects, files, addContext, onSubmit, onPromptChange, onPreset, busy, submitLabel, submitBusyLabel, placeholder, showShortcutHint = false },
+  { projects, files, addContext, onSubmit, onPromptChange, onPreset, busy, submitLabel, submitBusyLabel, placeholder, showShortcutHint = false, compact = false },
   ref,
 ) {
   const [prompt, setPrompt] = useState('')
@@ -160,21 +164,45 @@ export const Composer = forwardRef<ComposerHandle, {
     { key: 'ecoMaintenance', label: 'Auto maintenance', description: 'Drops the maintenance section.', title: 'Drop the maintenance section', checked: ecoMaintenance },
   ]
 
+  const editorEl = (
+    <PromptEditor
+      ref={editorRef}
+      compact={compact}
+      onChange={onPromptEdit}
+      onSubmit={submit}
+      onPreset={loadPreset}
+      onMentionProject={addContext}
+      onMentionFile={addContext}
+      projects={projects}
+      files={files}
+      presets={PRESETS}
+      disabled={busy}
+      {...(placeholder ? { placeholder } : {})}
+    />
+  )
+
+  // Compact (#723): one row of editor + submit for the navbar. The `/` `<` `@` `#` triggers still
+  // work in the editor; the agent/model + options controls are dropped (they come from prefs).
+  if (compact) {
+    return (
+      <div className="flex items-start gap-2">
+        <div className="min-w-0 flex-1">{editorEl}</div>
+        <Button
+          type="submit"
+          size="sm"
+          onClick={submit}
+          disabled={busy || !prompt.trim()}
+          title={!prompt.trim() ? 'Type a prompt first' : `${submitLabel}  (⌘↵ / Ctrl+Enter)`}
+        >
+          {busy ? submitBusyLabel : submitLabel}
+        </Button>
+      </div>
+    )
+  }
+
   return (
     <>
-      <PromptEditor
-        ref={editorRef}
-        onChange={onPromptEdit}
-        onSubmit={submit}
-        onPreset={loadPreset}
-        onMentionProject={addContext}
-        onMentionFile={addContext}
-        projects={projects}
-        files={files}
-        presets={PRESETS}
-        disabled={busy}
-        {...(placeholder ? { placeholder } : {})}
-      />
+      {editorEl}
 
       {/* Run controls, directly under the editor (#649/#650/#654/#668): agent+model at the start,
           then presets and the options gear, then submit at the end. */}

--- a/packages/framework-dashboard/components/NavbarQuickLaunch.test.tsx
+++ b/packages/framework-dashboard/components/NavbarQuickLaunch.test.tsx
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { Preferences } from '@gemstack/framework'
+
+// Stub the shared prefs + the start RPC.
+let prefs: Preferences = {}
+vi.mock('../lib/preferences.js', () => ({
+  usePreferences: () => prefs,
+  updatePreferences: vi.fn(),
+  autopilotEnabled: (p: Preferences) => p.autopilot ?? true,
+}))
+const sendStart = vi.hoisted(() => vi.fn())
+vi.mock('../server/control.telefunc.js', () => ({ sendStart }))
+
+// Stub the Tiptap editor: an input driving onChange, a ref exposing clear/focus. (Same stub as
+// Composer.test — the quick-launch renders the real Composer, whose editor needs a real DOM.)
+vi.mock('./PromptEditor.js', async () => {
+  const { forwardRef, useImperativeHandle } = await import('react')
+  const PromptEditor = forwardRef((props: any, ref: any) => {
+    useImperativeHandle(ref, () => ({ clear: () => props.onChange(''), focus: () => {}, loadTemplate: () => {} }))
+    return <input aria-label="prompt" onChange={e => props.onChange(e.target.value)} disabled={props.disabled} />
+  })
+  return { PromptEditor }
+})
+
+const { NavbarQuickLaunch } = await import('./NavbarQuickLaunch.js')
+
+function renderQL(over: Partial<Parameters<typeof NavbarQuickLaunch>[0]> = {}) {
+  const onRunStarted = vi.fn()
+  render(
+    <NavbarQuickLaunch
+      projectId="p1"
+      projectName="demo"
+      projects={[]}
+      files={[]}
+      context={new Set()}
+      addContext={vi.fn()}
+      onRunStarted={onRunStarted}
+      {...over}
+    />,
+  )
+  return { onRunStarted }
+}
+
+beforeEach(() => {
+  prefs = {}
+  sendStart.mockReset()
+})
+afterEach(cleanup)
+
+describe('NavbarQuickLaunch (#723)', () => {
+  test('with no project selected, shows a disabled hint and no editor', () => {
+    renderQL({ projectId: null })
+    expect(screen.getByText(/select a project to quick-launch/i)).toBeTruthy()
+    expect(screen.queryByLabelText('prompt')).toBeNull()
+  })
+
+  test('submitting starts a run in the selected project, then clears + jumps to live', async () => {
+    sendStart.mockResolvedValue({ ok: true })
+    const { onRunStarted } = renderQL()
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'add a test' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }))
+    await waitFor(() => expect(sendStart).toHaveBeenCalledTimes(1))
+    const [projectId, text, kind, options] = sendStart.mock.calls[0]!
+    expect(projectId).toBe('p1')
+    expect(text).toBe('add a test')
+    expect(kind).toBe('build')
+    expect(typeof options).toBe('object')
+    await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('add a test'))
+  })
+
+  test('surfaces the busy guard when a run is already active', async () => {
+    sendStart.mockResolvedValue({ ok: false, busy: true })
+    const { onRunStarted } = renderQL()
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'go' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }))
+    await waitFor(() => expect(screen.getByText(/run is already active/i)).toBeTruthy())
+    expect(onRunStarted).not.toHaveBeenCalled()
+  })
+})

--- a/packages/framework-dashboard/components/NavbarQuickLaunch.tsx
+++ b/packages/framework-dashboard/components/NavbarQuickLaunch.tsx
@@ -1,0 +1,86 @@
+import { useRef, useState } from 'react'
+import type { ProjectSummary } from '@gemstack/framework'
+import { sendStart } from '../server/control.telefunc.js'
+import { usePreferences } from '../lib/preferences.js'
+import { collectRunOptions } from '../lib/run-options.js'
+import { Composer, type ComposerHandle } from './Composer.js'
+
+// The global quick-launch (#723): the same shared Composer as the launcher, compact, in the top
+// navbar. Type a prompt, ⌘/Ctrl+Enter, and it starts a run in the SELECTED project and jumps to its
+// live output (the #705 follow-on-start flow via onRunStarted). Options come from the shared prefs
+// the launcher's controls write, so a quick-launch matches what a full Start would send. Targets the
+// selected project only; with none selected it shows a disabled hint (the full launcher is where you
+// pick a project). `@`/`#` mentions add to the shared run Context, same as the launcher.
+export function NavbarQuickLaunch({
+  projectId,
+  projectName,
+  projects,
+  files,
+  context,
+  addContext,
+  onRunStarted,
+  className,
+}: {
+  projectId: string | null
+  projectName?: string | null | undefined
+  projects: ProjectSummary[]
+  files: string[]
+  context: Set<string>
+  addContext: (path: string) => void
+  onRunStarted: (intent: string) => void
+  className?: string
+}) {
+  const composerRef = useRef<ComposerHandle>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const preferences = usePreferences()
+
+  // No project selected: nothing to launch into. Show a muted hint rather than a live editor.
+  if (!projectId) {
+    return (
+      <div className={className}>
+        <div className="rounded-md border border-dashed border-border px-3 py-2 text-sm text-muted-foreground">
+          Select a project to quick-launch a run
+        </div>
+      </div>
+    )
+  }
+
+  const submit = async (text: string, kind: 'build' | 'prompt') => {
+    if (busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await sendStart(projectId, text, kind, collectRunOptions(preferences, [...context]))
+      if (result.ok) {
+        composerRef.current?.clear()
+        onRunStarted(text) // jump to the new run's live output
+      } else {
+        setError(result.busy ? 'A run is already active for this project.' : result.error)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to start the run.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className={className}>
+      <Composer
+        ref={composerRef}
+        compact
+        projects={projects}
+        files={files}
+        addContext={addContext}
+        onSubmit={submit}
+        onPromptChange={() => error && setError(null)}
+        busy={busy}
+        submitLabel="Start"
+        submitBusyLabel="…"
+        placeholder={`Quick-launch a run${projectName ? ` in ${projectName}` : ''}…  ( / commands · @ projects · # files )`}
+      />
+      {error && <p className="mt-1 truncate text-xs text-red-500" title={error}>{error}</p>}
+    </div>
+  )
+}

--- a/packages/framework-dashboard/components/PromptEditor.tsx
+++ b/packages/framework-dashboard/components/PromptEditor.tsx
@@ -39,6 +39,8 @@ interface PromptEditorProps {
   presets: { id: string; label: string; render: () => string }[]
   disabled?: boolean
   placeholder?: string
+  /** A shorter surface for the navbar quick-launch (#723): starts one line tall instead of ~three. */
+  compact?: boolean
 }
 
 /** Insert a token chip at the suggestion range, followed by a space. */
@@ -63,7 +65,7 @@ function applyTemplate(editor: Editor, text: string): void {
 }
 
 export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(function PromptEditor(
-  { onChange, onSubmit, onPreset, onMentionProject, onMentionFile, projects, files = [], presets, disabled = false, placeholder = 'Describe what to build…  ( / commands · < tags · @ projects · # files )' },
+  { onChange, onSubmit, onPreset, onMentionProject, onMentionFile, projects, files = [], presets, disabled = false, placeholder = 'Describe what to build…  ( / commands · < tags · @ projects · # files )', compact = false },
   ref,
 ) {
   const [isEmpty, setIsEmpty] = useState(true)
@@ -227,7 +229,9 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
     <div className="relative">
       <EditorContent
         editor={editor}
-        className="max-h-64 min-h-[4.5rem] w-full overflow-y-auto rounded-md border border-border bg-transparent p-2 text-sm focus-within:ring-2 focus-within:ring-[var(--color-primary)]"
+        className={`w-full overflow-y-auto rounded-md border border-border bg-transparent p-2 text-sm focus-within:ring-2 focus-within:ring-[var(--color-primary)] ${
+          compact ? 'max-h-32 min-h-9' : 'max-h-64 min-h-[4.5rem]'
+        }`}
       />
       {isEmpty && (
         <span className="pointer-events-none absolute left-2 top-2 text-sm text-muted-foreground">{placeholder}</span>

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -3,6 +3,7 @@ import type { ProjectSummary } from '@gemstack/framework'
 import { sendStart } from '../server/control.telefunc.js'
 import { onProjects } from '../server/projects.telefunc.js'
 import { usePreferences, updatePreferences, autopilotEnabled } from '../lib/preferences.js'
+import { collectRunOptions } from '../lib/run-options.js'
 import { useLoaded } from '../lib/use-async.js'
 import { Composer, type ComposerHandle } from './Composer.js'
 import { ContextFiles } from './ContextFiles.js'
@@ -48,11 +49,6 @@ export function StartRunForm({
   const ecoPlanning = preferences.ecoPlanning ?? false
   const ecoResearch = preferences.ecoResearch ?? false
   const ecoMaintenance = preferences.ecoMaintenance ?? false
-  const technical = preferences.technical ?? false
-  const onBeforeMergeableQuality = preferences.onBeforeMergeableQuality ?? false
-  const browser = preferences.browser ?? false
-  const model = preferences.model ?? '' // #628: empty = the driver's default model
-  const agent = preferences.agent ?? 'claude' // #650: which coding agent drives the run
 
   // Context selector (#439/#314): the agent can reach every registered repo, so ticking a subset
   // narrows its focus — the picked paths become one `Context:` line in the system prompt.
@@ -74,29 +70,12 @@ export function StartRunForm({
     .filter(Boolean)
     .join(' · ')
 
-  const ecoDisabled = vanilla || transparent
-
-  // The eco drops, hoisted: the run gets them via collectOptions, and the #520 preview renders with
-  // them, so what you read is what gets sent.
+  // The eco drops for the system-prompt preview (#520): what the run trims is what you read. The run
+  // itself gets them via collectRunOptions (which recomputes them from the same prefs).
   const ecoDrops = {
     ...(ecoPlanning ? { autoPlanning: true } : {}),
     ...(ecoResearch ? { autoResearch: true } : {}),
     ...(ecoMaintenance ? { autoMaintenance: true } : {}),
-  }
-
-  const collectOptions = () => {
-    return {
-      ...(autopilot ? { autopilot: true } : {}),
-      ...(technical ? { technical: true } : {}),
-      ...(vanilla ? { vanilla: true } : {}),
-      ...(transparent ? { transparent: true } : {}),
-      ...(eco && !vanilla && !transparent && Object.keys(ecoDrops).length ? { eco: ecoDrops } : {}),
-      ...(onBeforeMergeableQuality ? { onBeforeMergeable: true } : {}),
-      ...(browser ? { browser: true } : {}),
-      ...(model ? { model } : {}),
-      ...(agent && agent !== 'claude' ? { agent } : {}),
-      ...(context.size ? { context: [...context] } : {}),
-    }
   }
 
   const submit = async (text: string, submitKind: 'build' | 'prompt') => {
@@ -105,7 +84,7 @@ export function StartRunForm({
     setError(null)
     setNote('Starting…')
     try {
-      const result = await sendStart(projectId, text, submitKind, collectOptions())
+      const result = await sendStart(projectId, text, submitKind, collectRunOptions(preferences, [...context]))
       if (result.ok) {
         // Show the run in the Runs rail immediately (#405): the spawned process writes its run.json
         // a beat later, so seed an optimistic row with the typed prompt until the real meta takes over.

--- a/packages/framework-dashboard/lib/run-options.ts
+++ b/packages/framework-dashboard/lib/run-options.ts
@@ -1,0 +1,36 @@
+import type { Preferences } from '@gemstack/framework'
+import { autopilotEnabled } from './preferences.js'
+
+// The Global run options for `sendStart`, derived from the shared preferences (#410) plus the run
+// Context set. Shared by the launcher (StartRunForm) and the navbar quick-launch (#723) so a run
+// starts the same way from either surface. Mirrors the toggles the OptionsMenu + AgentModelMenu
+// write. Returned as an inferred literal, not annotated: `StartRunOptions` isn't re-exported to the
+// client bundle, and `sendStart` type-checks the shape at the call site (as the inline version did).
+export function collectRunOptions(preferences: Preferences, context: string[] = []) {
+  const autopilot = autopilotEnabled(preferences)
+  const vanilla = preferences.vanilla ?? false
+  const transparent = preferences.transparent ?? false
+  const eco = preferences.eco ?? false
+  const technical = preferences.technical ?? false
+  const onBeforeMergeableQuality = preferences.onBeforeMergeableQuality ?? false
+  const browser = preferences.browser ?? false
+  const model = preferences.model ?? ''
+  const agent = preferences.agent ?? 'claude'
+  const ecoDrops = {
+    ...(preferences.ecoPlanning ? { autoPlanning: true } : {}),
+    ...(preferences.ecoResearch ? { autoResearch: true } : {}),
+    ...(preferences.ecoMaintenance ? { autoMaintenance: true } : {}),
+  }
+  return {
+    ...(autopilot ? { autopilot: true } : {}),
+    ...(technical ? { technical: true } : {}),
+    ...(vanilla ? { vanilla: true } : {}),
+    ...(transparent ? { transparent: true } : {}),
+    ...(eco && !vanilla && !transparent && Object.keys(ecoDrops).length ? { eco: ecoDrops } : {}),
+    ...(onBeforeMergeableQuality ? { onBeforeMergeable: true } : {}),
+    ...(browser ? { browser: true } : {}),
+    ...(model ? { model } : {}),
+    ...(agent && agent !== 'claude' ? { agent } : {}),
+    ...(context.length ? { context } : {}),
+  }
+}

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -4,6 +4,7 @@ import { onProjectFiles, onInterventions, onActivity } from '../../server/reads.
 import { onProjects } from '../../server/projects.telefunc.js'
 import { ProjectsSidebar } from '../../components/ProjectsSidebar.js'
 import { NotificationsMenu } from '../../components/NotificationsMenu.js'
+import { NavbarQuickLaunch } from '../../components/NavbarQuickLaunch.js'
 import { RunHistory } from '../../components/RunHistory.js'
 import { ProjectHome } from '../../components/ProjectHome.js'
 import { DashboardPage } from '../../components/DashboardPage.js'
@@ -97,8 +98,11 @@ export default function Page() {
   useActivityNotifications(activity, browserActivity)
 
   const onRunStarted = (intent: string) => {
-    // Jump to the new run's live output (the launcher stays on the "Live" row, one click back).
+    // Jump to the new run's live output. Reset to the home/Live row first (a no-op from the launcher,
+    // where it already is) so a navbar quick-launch (#723) jumps to live even from a finished run's
+    // replay; `followLive` streams the shared feed until the poll adopts the new run's real id below.
     // The new run just appends to the rail; reload so its real row shows up quickly.
+    setRunId(null)
     setRunStart(prev => ({ tick: prev.tick + 1, intent }))
     setFollowLive(true)
     reload()
@@ -179,9 +183,20 @@ export default function Page() {
   return (
     <div className="flex h-screen flex-col">
       <header className="flex items-center gap-3 border-b border-border px-4 py-3">
-        <span className="font-semibold">The Framework</span>
-        <Badge className="text-muted-foreground">dashboard</Badge>
-        <div className="ml-auto flex items-center gap-1">
+        <span className="shrink-0 font-semibold">The Framework</span>
+        <Badge className="shrink-0 text-muted-foreground">dashboard</Badge>
+        {/* Global quick-launch (#723): start a run in the selected project from anywhere. */}
+        <NavbarQuickLaunch
+          className="mx-2 min-w-0 flex-1"
+          projectId={projectId}
+          projectName={projectName}
+          projects={projects}
+          files={files}
+          context={context}
+          addContext={addContext}
+          onRunStarted={onRunStarted}
+        />
+        <div className="flex shrink-0 items-center gap-1">
           <NotificationsMenu />
         </div>
       </header>


### PR DESCRIPTION
## What

Adds a **global quick-launch** to the top navbar (next to the logo): type a prompt, press ⌘/Ctrl+Enter, and it starts a run in the selected project and jumps to its live output (the #705 follow-on-start flow). It **reuses the shared `Composer`** from #721 in a compact form, so the `/` `<` `@` `#` editor triggers all work; agent/model + options come from the shared prefs the launcher's controls write, so a quick-launch sends the same thing a full Start would.

## How

- **`Composer`** gains a `compact` form: editor + submit on one row, no control row or preset panel (the redundant agent/model/options/presets controls are dropped; they live on the launcher).
- **`PromptEditor`** gains a `compact` flag (shorter surface so it fits the header).
- **`collectRunOptions()`** extracted to `lib/run-options.ts` so the launcher and the quick-launch build `sendStart` options identically; `StartRunForm` now uses it (drops its inline `collectOptions`).
- **`NavbarQuickLaunch`** wires it up: target = the selected project; on submit `sendStart` + `onRunStarted` (jump to live). Busy guard surfaced inline.
- **`+Page`** renders it in the header; `onRunStarted` now resets to the Live row first, so a quick-launch jumps to live even from a finished run's replay.

## Decisions / assumptions

- **Target project = the currently selected one.** With no project selected the quick-launch shows a disabled hint ("Select a project…") rather than a project picker — the full launcher is where you choose a project. (The issue floated an inline `@`-mention picker; left out to keep this focused. `@`/`#` still add to the run Context, same as the launcher.)
- Compact form hides the agent/model + options controls; those are set on the launcher and read from the shared prefs.

## Test

- New `NavbarQuickLaunch.test.tsx` (no-project hint · start-in-selected-project + clear/jump · busy guard).
- New compact-mode case in `Composer.test.tsx` (control row dropped, editor+submit still fire).
- Typecheck clean, all **99** dashboard tests pass, Vike build succeeds.

Closes #723