### PR TITLE
fix(framework): stop the CI test suite hanging for 60 min (#729)

### DIFF
--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -54,7 +54,7 @@
     "build": "node scripts/gen-prompts.mjs && tsc -p tsconfig.build.json",
     "dev": "node scripts/gen-prompts.mjs && tsc -p tsconfig.build.json --watch",
     "typecheck": "node scripts/gen-prompts.mjs && tsc --noEmit",
-    "test": "node scripts/gen-prompts.mjs && tsc -p tsconfig.test.json && cd dist-test && node --test",
+    "test": "node scripts/gen-prompts.mjs && tsc -p tsconfig.test.json && cd dist-test && node --test --test-timeout=60000",
     "bundle:dashboard": "node scripts/bundle-dashboard.mjs",
     "clean": "rm -rf dist dist-test src/prompts.generated.ts",
     "gen:prompts": "node scripts/gen-prompts.mjs",

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -691,6 +691,13 @@ test('a live daemon steers a dashboard-less run through its gates via control.js
         answered.add(e.id)
         await appendControl(cwd, { kind: 'choice', id: e.id, pick: e.recommended ?? e.options?.[0]?.id ?? '', by: 'user' })
       }
+      // The steered build now stays open waiting for a chat message or Stop (#714). Once it has
+      // been steered through its gate and produced its output, end it with a Stop, exactly as the
+      // dashboard's Stop button would; otherwise `done` never resolves and the run hangs.
+      if (answered.has('await-choices') && /production-grade/.test(out.join('\n'))) {
+        await appendControl(cwd, { kind: 'stop' })
+        break
+      }
       await new Promise(r => setTimeout(r, 20))
     }
 


### PR DESCRIPTION
Closes #729

## Problem
`@gemstack/framework`'s `pnpm test` hangs for the full **60-minute** CI job timeout on every branch (including `main`), so all PR CI is stuck. Regression from #715 (live-chat stay-open).

Every CI run before #715 finished green in ~2 min; #715 and every push/PR after it hang at ~60 min.

## Root cause
#715 made runs **stay-open**: after the build's gates drain, the run enters `runChatPhase` and waits for a chat message or a Stop (wired whenever a dashboard **or a live daemon** is present). `cli.test.ts:657` — *'a live daemon steers a dashboard-less run through its gates via control.jsonl (#344)'* — fakes a live daemon, starts a run, and `await done` **without ever sending Stop**. The run never ends, so `node --test` never exits and `pnpm test` hangs until the job timeout.

## Fix
1. **Test:** once the run is steered through its gate and has produced its output, send `{ kind: 'stop' }` — exactly what the dashboard's Stop button does. The stay-open run then ends and `done` resolves (the test now runs in ~0.1s instead of hanging).
2. **Hardening:** add `--test-timeout=60000` to the framework `test` script, so any future never-resolving `await` fails in seconds instead of stalling the job for 60 min.

Test-only + script change: **no changeset**.

## Verification
Full `@gemstack/framework` suite: **631 tests, 630 pass, 0 fail, 0 cancelled, exits in 8.2s** (previously never exited). The #344 test passes in ~0.1s.

## Open design question (not addressed here, run-lifecycle = Rom's area)
Stay-open also means a **headless / CLI** run steered by a background daemon no longer returns on its own — `framework \"build X\"` in a terminal would wait after the build if a daemon is up. If a non-interactive run should instead drain-and-exit, that is a separate behavior change (gate the message queue on interactivity); this PR only unblocks CI and keeps #715's intended stay-open behavior.