### PR TITLE
feat(framework): theme preference (system / light / dark)

### DIFF
--- a/.changeset/dashboard-theme-preference.md
+++ b/.changeset/dashboard-theme-preference.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Add a `theme` dashboard preference (#725): `system` (the default, following the OS), `light`, or `dark`. Stored in `the-framework.json` alongside the other preferences and sanitized against the known set. The dashboard applies it by toggling the `.dark` class (following live OS changes while on `system`) and exposes a system/light/dark picker in the Settings gear, replacing the previously hardcoded dark-only mode.

--- a/packages/framework-dashboard/components/Composer.test.tsx
+++ b/packages/framework-dashboard/components/Composer.test.tsx
@@ -9,6 +9,7 @@ vi.mock('../lib/preferences.js', () => ({
   usePreferences: () => prefs,
   updatePreferences,
   autopilotEnabled: (p: Preferences) => p.autopilot ?? true,
+  themePreference: (p: Preferences) => p.theme ?? 'system',
 }))
 
 // Stub the Tiptap editor (it needs a real DOM/ProseMirror): a plain input driving onChange, a

--- a/packages/framework-dashboard/components/OptionsMenu.test.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.test.tsx
@@ -24,27 +24,44 @@ function open() {
 
 describe('OptionsMenu (#654)', () => {
   test('the trigger badges how many options are on', () => {
-    render(<OptionsMenu options={mainOptions()} ecoOptions={ecoOptions()} showEco={false} busy={false} />)
+    render(<OptionsMenu options={mainOptions()} ecoOptions={ecoOptions()} showEco={false} busy={false} theme="system" onThemeChange={() => {}} />)
     // Only Eco is checked -> the gear trigger shows a corner badge "1".
     expect(screen.getByRole('button', { name: /run options/i }).textContent).toContain('1')
   })
 
   test('toggling an item writes the new value through', () => {
-    render(<OptionsMenu options={mainOptions()} ecoOptions={ecoOptions()} showEco={false} busy={false} />)
+    render(<OptionsMenu options={mainOptions()} ecoOptions={ecoOptions()} showEco={false} busy={false} theme="system" onThemeChange={() => {}} />)
     open()
     fireEvent.click(screen.getByText('Autopilot'))
     expect(updatePreferences).toHaveBeenCalledWith({ autopilot: true })
   })
 
   test('hides the Eco sub-drops when Eco does not apply', () => {
-    render(<OptionsMenu options={mainOptions()} ecoOptions={ecoOptions()} showEco={false} busy={false} />)
+    render(<OptionsMenu options={mainOptions()} ecoOptions={ecoOptions()} showEco={false} busy={false} theme="system" onThemeChange={() => {}} />)
     open()
     expect(screen.queryByText('Auto planning')).toBeNull()
   })
 
   test('shows the Eco sub-drops when Eco applies', () => {
-    render(<OptionsMenu options={mainOptions()} ecoOptions={ecoOptions()} showEco={true} busy={false} />)
+    render(<OptionsMenu options={mainOptions()} ecoOptions={ecoOptions()} showEco={true} busy={false} theme="system" onThemeChange={() => {}} />)
     open()
     expect(screen.getByText('Auto planning')).toBeTruthy()
+  })
+
+  test('picking a theme calls onThemeChange with the chosen value (#725)', () => {
+    const onThemeChange = vi.fn()
+    render(
+      <OptionsMenu
+        options={mainOptions()}
+        ecoOptions={ecoOptions()}
+        showEco={false}
+        busy={false}
+        theme="system"
+        onThemeChange={onThemeChange}
+      />,
+    )
+    open()
+    fireEvent.click(screen.getByText('Dark'))
+    expect(onThemeChange).toHaveBeenCalledWith('dark')
   })
 })

--- a/packages/framework-dashboard/components/OptionsMenu.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.tsx
@@ -1,6 +1,6 @@
 import type { Preferences } from '@gemstack/framework'
-import { Settings } from 'lucide-react'
-import { updatePreferences } from '../lib/preferences.js'
+import { Settings, Check, Monitor, Sun, Moon, type LucideIcon } from 'lucide-react'
+import { updatePreferences, type ThemePreference } from '../lib/preferences.js'
 import { cn } from '../lib/utils.js'
 import { buttonVariants } from './ui/button.js'
 import {
@@ -8,6 +8,9 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuCheckboxItem,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
 } from './ui/dropdown-menu.js'
 
@@ -34,6 +37,13 @@ function setOption(key: keyof Preferences, checked: boolean) {
   updatePreferences({ [key]: checked } as Partial<Preferences>)
 }
 
+/** The theme choices (#725), in trigger order; `system` is the default. */
+const THEME_OPTIONS: { value: ThemePreference; label: string; description: string; icon: LucideIcon }[] = [
+  { value: 'system', label: 'System', description: 'Follow your OS setting', icon: Monitor },
+  { value: 'light', label: 'Light', description: '', icon: Sun },
+  { value: 'dark', label: 'Dark', description: '', icon: Moon },
+]
+
 /** An option's label with a short one-line description under it (#654). */
 function OptionLabel({ label, description }: { label: string; description?: string | undefined }) {
   return (
@@ -49,12 +59,18 @@ export function OptionsMenu({
   ecoOptions,
   showEco,
   busy,
+  theme,
+  onThemeChange,
 }: {
   options: OptionRow[]
   ecoOptions: OptionRow[]
   /** Whether Eco's sub-drops apply right now (Eco on and not disabled by Vanilla). */
   showEco: boolean
   busy: boolean
+  /** The current dashboard theme (#725). */
+  theme: ThemePreference
+  /** Pick a new theme; persisted by the caller. */
+  onThemeChange: (theme: ThemePreference) => void
 }) {
   const activeCount = options.filter(o => o.checked && !o.disabled).length
   return (
@@ -109,6 +125,28 @@ export function OptionsMenu({
             ))}
           </>
         )}
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Theme</DropdownMenuLabel>
+          {THEME_OPTIONS.map(t => {
+            const Icon = t.icon
+            return (
+              <DropdownMenuItem
+                key={t.value}
+                disabled={busy}
+                // Keep the menu open so the theme visibly changes underneath the pick.
+                closeOnClick={false}
+                onClick={() => onThemeChange(t.value)}
+                title={`${t.label} theme`}
+                className="items-start"
+              >
+                <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', t.value === theme ? 'opacity-100' : 'opacity-0')} />
+                <Icon className="mt-0.5 h-3.5 w-3.5 shrink-0 opacity-70" />
+                <OptionLabel label={t.label} description={t.description || undefined} />
+              </DropdownMenuItem>
+            )
+          })}
+        </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -9,7 +9,7 @@ import {
 } from '@gemstack/framework/client'
 import { sendStart } from '../server/control.telefunc.js'
 import { onProjects } from '../server/projects.telefunc.js'
-import { usePreferences, updatePreferences, autopilotEnabled } from '../lib/preferences.js'
+import { usePreferences, updatePreferences, autopilotEnabled, themePreference } from '../lib/preferences.js'
 import { useLoaded } from '../lib/use-async.js'
 import { PromptEditor, type PromptEditorHandle } from './PromptEditor.js'
 import { PresetMenu } from './PresetMenu.js'
@@ -107,6 +107,7 @@ export function StartRunForm({
   const browser = preferences.browser ?? false
   const model = preferences.model ?? '' // #628: empty = the driver's default model
   const agent = preferences.agent ?? 'claude' // #650: which coding agent drives the run
+  const theme = themePreference(preferences) // #725: system (default) / light / dark
   const customPresets = preferences.customPresets ?? [] // #626: the user's own saved prompts
   const [addingPreset, setAddingPreset] = useState(false) // #649: the full-width "New preset" panel
 
@@ -268,7 +269,14 @@ export function StartRunForm({
           onNewPreset={() => setAddingPreset(true)}
         />
         {/* Global options (#314) as a gear-icon checkbox dropdown (#654/#668). */}
-        <OptionsMenu options={mainOptions} ecoOptions={ecoOptions} showEco={eco && !ecoDisabled} busy={busy} />
+        <OptionsMenu
+          options={mainOptions}
+          ecoOptions={ecoOptions}
+          showEco={eco && !ecoDisabled}
+          busy={busy}
+          theme={theme}
+          onThemeChange={t => updatePreferences({ theme: t })}
+        />
         {/* Start run at the end of the row (#668). */}
         <Button
           type="submit"

--- a/packages/framework-dashboard/layouts/LayoutDefault.tsx
+++ b/packages/framework-dashboard/layouts/LayoutDefault.tsx
@@ -1,11 +1,21 @@
 import { useEffect, type ReactNode } from 'react'
 import './tailwind.css'
+import { usePreferences, themePreference, resolvedDark } from '../lib/preferences.js'
 
-// The Framework's MVP page is dark-first; match it so the spike reads as the same
-// product. Client-only (ssr:false), so toggling the class in an effect is fine.
+// The dashboard's color theme (#725): system (default, follow the OS), light, or dark. Client-only
+// (ssr:false), so toggling the `.dark` class in an effect is fine. Until the preferences load over
+// Telefunc the choice is `system`, so a dark-OS user still gets dark first paint.
 export default function LayoutDefault({ children }: { children: ReactNode }) {
+  const theme = themePreference(usePreferences())
   useEffect(() => {
-    document.documentElement.classList.add('dark')
-  }, [])
+    const root = document.documentElement
+    const mql = window.matchMedia('(prefers-color-scheme: dark)')
+    const apply = () => root.classList.toggle('dark', resolvedDark(theme, mql.matches))
+    apply()
+    // Only follow live OS changes while on `system`; light/dark are fixed choices.
+    if (theme !== 'system') return
+    mql.addEventListener('change', apply)
+    return () => mql.removeEventListener('change', apply)
+  }, [theme])
   return <div className="min-h-screen bg-background text-foreground">{children}</div>
 }

--- a/packages/framework-dashboard/lib/preferences.test.ts
+++ b/packages/framework-dashboard/lib/preferences.test.ts
@@ -44,4 +44,17 @@ describe('preferences', () => {
     await flush()
     expect(result.current).toEqual({ autopilot: false, technical: true })
   })
+
+  test('themePreference falls back to system and resolvedDark honours the choice (#725)', async () => {
+    const { themePreference, resolvedDark } = await import('./preferences.js')
+
+    expect(themePreference({})).toBe('system')
+    expect(themePreference({ theme: 'light' })).toBe('light')
+
+    // Fixed choices ignore the OS; `system` follows it.
+    expect(resolvedDark('dark', false)).toBe(true)
+    expect(resolvedDark('light', true)).toBe(false)
+    expect(resolvedDark('system', true)).toBe(true)
+    expect(resolvedDark('system', false)).toBe(false)
+  })
 })

--- a/packages/framework-dashboard/lib/preferences.ts
+++ b/packages/framework-dashboard/lib/preferences.ts
@@ -68,6 +68,18 @@ export function autopilotEnabled(preferences: Preferences): boolean {
   return preferences.autopilot ?? true
 }
 
+export type ThemePreference = NonNullable<Preferences['theme']>
+
+/** The chosen dashboard theme (#725); absent follows the OS (`system`). */
+export function themePreference(preferences: Preferences): ThemePreference {
+  return preferences.theme ?? 'system'
+}
+
+/** Whether the dark palette applies, given the theme choice and the OS's dark preference. */
+export function resolvedDark(theme: ThemePreference, systemDark: boolean): boolean {
+  return theme === 'dark' || (theme === 'system' && systemDark)
+}
+
 /** Browser notifications default on (#627); the browser permission is still the real gate. */
 export function notificationsEnabled(preferences: Preferences): boolean {
   return preferences.notifyBrowser ?? true

--- a/packages/framework/src/registry.test.ts
+++ b/packages/framework/src/registry.test.ts
@@ -220,6 +220,14 @@ test('writePreferences keeps a known agent and drops an unknown one (#650)', asy
   assert.deepEqual(await readPreferences(fs, ENV), {}) // dropped
 })
 
+test('writePreferences keeps a known theme and drops an unknown one (#725)', async () => {
+  const fs = memFs({ [FILE]: JSON.stringify([APP_A]) })
+  await writePreferences({ theme: 'dark' }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { theme: 'dark' })
+  await writePreferences({ theme: 'solarized' } as never, fs, ENV) // not in the known set
+  assert.deepEqual(await readPreferences(fs, ENV), {}) // dropped, falls back to system
+})
+
 test('writePreferences keeps well-formed custom presets and drops malformed ones (#626)', async () => {
   const fs = memFs({ [FILE]: JSON.stringify([APP_A]) })
   await writePreferences(

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -82,6 +82,8 @@ export interface Preferences {
   model?: string
   /** Which coding agent drives the run (#650): `claude` or `codex`; maps to `--agent`. Absent = the default (`claude`). */
   agent?: string
+  /** Dashboard color theme (#725): `system` (follow the OS, the default), `light`, or `dark`. Absent = system. */
+  theme?: 'system' | 'light' | 'dark'
   /**
    * Post a Discord message when a new item lands on the "needs you" queue (#627). Absent = off:
    * unlike the in-browser toggle, Discord reaches you when no dashboard is open, so it is opt-in.
@@ -208,6 +210,9 @@ const PREFERENCE_KEYS = [
 /** The coding agents the dashboard offers (#650); mirrors AGENTS in agent.ts, kept local. */
 const KNOWN_AGENTS = ['claude', 'codex']
 
+/** The color themes the dashboard offers (#725); anything else means the default `system`. */
+const KNOWN_THEMES = ['system', 'light', 'dark'] as const
+
 function sanitizePreferences(value: unknown): Preferences {
   if (typeof value !== 'object' || value === null) return {}
   const input = value as Record<string, unknown>
@@ -221,6 +226,10 @@ function sanitizePreferences(value: unknown): Preferences {
   // `agent` (#650) is constrained to the known set so junk never reaches the run; mirrors AGENTS
   // in agent.ts (kept local so the registry doesn't import the driver layer). Default = claude.
   if (typeof input['agent'] === 'string' && KNOWN_AGENTS.includes(input['agent'])) preferences.agent = input['agent']
+  // `theme` (#725) is constrained to the known set; anything else (incl. absent) means the default
+  // `system`, so it is simply dropped rather than persisted.
+  if (typeof input['theme'] === 'string' && (KNOWN_THEMES as readonly string[]).includes(input['theme']))
+    preferences.theme = input['theme'] as (typeof KNOWN_THEMES)[number]
   const customPresets = sanitizeCustomPresets(input['customPresets'])
   if (customPresets.length) preferences.customPresets = customPresets
   const consumptionLimits = sanitizeConsumptionLimits(input['consumptionLimits'])


### PR DESCRIPTION
Adds a **theme** dashboard preference: `system` (default, follows the OS live), `light`, or `dark`.

- `Preferences.theme` in the registry, sanitized against the known set (like `agent`).
- `LayoutDefault` toggles the `.dark` class from the choice (subscribing to OS changes while on `system`) instead of forcing dark. The light palette already existed in `tailwind.css`.
- A system/light/dark picker in the Settings gear (`OptionsMenu`).
- Resolvers (`themePreference`, `resolvedDark`) + tests (registry sanitize, resolver logic, picker click).

Closes #725

## Test plan
- [x] `pnpm build`, `typecheck` green (framework + dashboard)
- [x] Dashboard suite green (93)
- [ ] framework `node:test` suite (running / CI)
