### PR TITLE
feat(framework): resume a finished run by messaging it (#720)

### DIFF
--- a/.changeset/720-auto-resume-finished-run.md
+++ b/.changeset/720-auto-resume-finished-run.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Resume a finished run by messaging it (#720). After a run ends (Stop, or it finishes) the dashboard used to drop the chat composer, so the conversation was a dead end. The finished-run view now keeps a composer, and sending a message spins a fresh run whose opening prompt `--resume`s the ended run's captured session id, continuing the same conversation with full prior context. New plumbing: `DriverStartOptions.resumeSessionId` seeds the Claude Code session so its very first prompt resumes (the framing is skipped, since the resumed transcript already carries it); `AwaitRoundsOptions.resume` / `RunPromptOptions.resumeSessionId` carry it through `runPrompt`; and it threads from the dashboard as `StartRunOptions.resumeSession` -> the `--resume-session <id>` CLI flag. A continuation is sent as a `prompt` run; a fresh run is byte-identical to before.

--- a/packages/framework-dashboard/components/RunReplay.tsx
+++ b/packages/framework-dashboard/components/RunReplay.tsx
@@ -1,17 +1,36 @@
 import type { FrameworkEvent } from '@gemstack/framework'
+import { sessionInfo } from '@gemstack/framework/client'
 import { onRun } from '../server/reads.telefunc.js'
 import { EventList } from './EventList.js'
 import { RunActionBar } from './RunActionBar.js'
+import { RunResumeChat } from './RunResumeChat.js'
 import { useLoaded } from '../lib/use-async.js'
 
 // Replay one archived run: load its event log over a Telefunc RPC and render it in the same
 // EventList the live stream uses (no auto-scroll — it is a static log). The action bar rides
 // along so Serve + Open session stay put once the run is Done (Stop drops out — it is not active).
-export function RunReplay({ projectId, runId }: { projectId: string; runId: string }) {
+// A finished run that captured a session id also gets a composer (#720): sending a message spins a
+// fresh run that resumes that conversation, so a stopped/ended run isn't a dead end.
+export function RunReplay({
+  projectId,
+  runId,
+  files,
+  addContext,
+  onRunStarted,
+}: {
+  projectId: string
+  runId: string
+  files: string[]
+  addContext: (path: string) => void
+  onRunStarted: (intent: string) => void
+}) {
   // null until the first answer: "Loading run…" and "no events" are different things.
   const events = useLoaded<FrameworkEvent[] | null>(() => onRun(projectId, runId), null, [projectId, runId])
 
   if (events === null) return <div className="grid flex-1 place-items-center text-sm text-muted-foreground">Loading run…</div>
+  // The agent session this run ran under (from its `session-update` events): present once the
+  // agent reported it, so a run that never got that far simply can't be resumed.
+  const sessionId = sessionInfo(events)?.sessionId
   return (
     <>
       <RunActionBar projectId={projectId} events={events} />
@@ -19,6 +38,9 @@ export function RunReplay({ projectId, runId }: { projectId: string; runId: stri
         <div className="grid flex-1 place-items-center text-sm text-muted-foreground">This run has no events.</div>
       ) : (
         <EventList events={events} stick={false} />
+      )}
+      {sessionId && (
+        <RunResumeChat projectId={projectId} sessionId={sessionId} files={files} addContext={addContext} onRunStarted={onRunStarted} />
       )}
     </>
   )

--- a/packages/framework-dashboard/components/RunResumeChat.test.tsx
+++ b/packages/framework-dashboard/components/RunResumeChat.test.tsx
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { Preferences } from '@gemstack/framework'
+
+// Stub the shared prefs + the start RPC.
+let prefs: Preferences = {}
+vi.mock('../lib/preferences.js', () => ({
+  usePreferences: () => prefs,
+  updatePreferences: vi.fn(),
+  autopilotEnabled: (p: Preferences) => p.autopilot ?? true,
+}))
+const sendStart = vi.hoisted(() => vi.fn())
+vi.mock('../server/control.telefunc.js', () => ({ sendStart }))
+// The `@` project picker loads over Telefunc; stub the RPC so this stays a unit test.
+vi.mock('../server/projects.telefunc.js', () => ({ onProjects: () => Promise.resolve([]) }))
+
+// Stub the Tiptap editor (needs a real DOM): an input driving onChange + a ref exposing clear/focus.
+vi.mock('./PromptEditor.js', async () => {
+  const { forwardRef, useImperativeHandle } = await import('react')
+  const PromptEditor = forwardRef((props: any, ref: any) => {
+    useImperativeHandle(ref, () => ({ clear: () => props.onChange(''), focus: () => {}, loadTemplate: () => {} }))
+    return <input aria-label="prompt" onChange={e => props.onChange(e.target.value)} disabled={props.disabled} />
+  })
+  return { PromptEditor }
+})
+
+const { RunResumeChat } = await import('./RunResumeChat.js')
+
+function renderChat(over: Partial<Parameters<typeof RunResumeChat>[0]> = {}) {
+  const onRunStarted = vi.fn()
+  render(
+    <RunResumeChat
+      projectId="p1"
+      sessionId="sess-42"
+      files={[]}
+      addContext={vi.fn()}
+      onRunStarted={onRunStarted}
+      {...over}
+    />,
+  )
+  return { onRunStarted }
+}
+
+beforeEach(() => {
+  prefs = {}
+  sendStart.mockReset()
+})
+afterEach(cleanup)
+
+describe('RunResumeChat (#720)', () => {
+  test('shows the "run ended" hint so the finished run is not a dead end', () => {
+    renderChat()
+    expect(screen.getByText(/run ended.*continues it/i)).toBeTruthy()
+  })
+
+  test('sending spins a resumed prompt run carrying the captured session id, then jumps to live', async () => {
+    sendStart.mockResolvedValue({ ok: true })
+    const { onRunStarted } = renderChat()
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'and now dark mode' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    await waitFor(() => expect(sendStart).toHaveBeenCalledTimes(1))
+    const [projectId, text, kind, options] = sendStart.mock.calls[0]!
+    expect(projectId).toBe('p1')
+    expect(text).toBe('and now dark mode')
+    expect(kind).toBe('prompt') // a continuation is a prompt run
+    expect(options.resumeSession).toBe('sess-42') // seeded with the finished run's session
+    await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('and now dark mode'))
+  })
+
+  test('surfaces the busy guard instead of jumping', async () => {
+    sendStart.mockResolvedValue({ ok: false, busy: true })
+    const { onRunStarted } = renderChat()
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'go' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    await waitFor(() => expect(screen.getByText(/run is already active/i)).toBeTruthy())
+    expect(onRunStarted).not.toHaveBeenCalled()
+  })
+})

--- a/packages/framework-dashboard/components/RunResumeChat.tsx
+++ b/packages/framework-dashboard/components/RunResumeChat.tsx
@@ -1,0 +1,81 @@
+import { useRef, useState } from 'react'
+import type { ProjectSummary } from '@gemstack/framework'
+import { Composer, type ComposerHandle } from './Composer.js'
+import { sendStart } from '../server/control.telefunc.js'
+import { onProjects } from '../server/projects.telefunc.js'
+import { usePreferences } from '../lib/preferences.js'
+import { useLoaded } from '../lib/use-async.js'
+
+// The finished-run composer (#720): keep talking to a run that has ended. A live run drains
+// messages in-process (RunChat + sendMessage), but a finished run has no process — so sending here
+// spins a FRESH run whose opening prompt `--resume`s the captured session id, continuing the same
+// conversation with full prior context. Reuses the shared Composer, then jumps to the new run's live
+// output (onRunStarted). Options come from the shared prefs, same as the launcher; the agent should
+// match the one the run used (resume is per-agent). Only rendered when the run has a session id.
+export function RunResumeChat({
+  projectId,
+  sessionId,
+  files,
+  addContext,
+  onRunStarted,
+}: {
+  projectId: string
+  /** The finished run's agent session id, to resume. */
+  sessionId: string
+  files: string[]
+  addContext: (path: string) => void
+  onRunStarted: (intent: string) => void
+}) {
+  const composerRef = useRef<ComposerHandle>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const preferences = usePreferences()
+  // The registered projects for the `@` picker — the same list the launcher reads.
+  const projects = useLoaded<ProjectSummary[]>(onProjects, [], [])
+
+  const send = async (text: string): Promise<void> => {
+    if (busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      // A continuation is a `prompt` run seeded with the finished run's session id (#720). Carry the
+      // model/agent from the shared prefs (resume is per-agent, so keep the same one the run used);
+      // the system-prompt options are moot here — the resumed transcript keeps its own framing.
+      const model = preferences.model ?? ''
+      const agent = preferences.agent ?? 'claude'
+      const result = await sendStart(projectId, text, 'prompt', {
+        resumeSession: sessionId,
+        ...(model ? { model } : {}),
+        ...(agent && agent !== 'claude' ? { agent } : {}),
+      })
+      if (result.ok) {
+        composerRef.current?.clear()
+        onRunStarted(text) // jump to the new (resumed) run's live output
+      } else {
+        setError(result.busy ? 'A run is already active for this project.' : result.error)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to continue the run.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="border-t border-border p-3">
+      <p className="mb-2 text-xs text-muted-foreground">Run ended — your next message continues it.</p>
+      <Composer
+        ref={composerRef}
+        projects={projects}
+        files={files}
+        addContext={addContext}
+        onSubmit={send}
+        busy={busy}
+        submitLabel="Send"
+        submitBusyLabel="Resuming…"
+        placeholder="Message the run to continue it…  ( / commands · < tags · @ projects · # files )"
+      />
+      {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
+    </div>
+  )
+}

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -97,8 +97,12 @@ export default function Page() {
   useActivityNotifications(activity, browserActivity)
 
   const onRunStarted = (intent: string) => {
-    // Jump to the new run's live output (the launcher stays on the "Live" row, one click back).
-    // The new run just appends to the rail; reload so its real row shows up quickly.
+    // Jump to the new run's live output. Reset to the home/Live row first (a no-op from the launcher,
+    // where it already is) so resuming a finished run (#720) jumps to the fresh run's live output
+    // instead of staying on the old replay; `followLive` streams the shared feed until the poll
+    // adopts the new run's real id below. The new run just appends to the rail; reload so its real
+    // row shows up quickly.
+    setRunId(null)
     setRunStart(prev => ({ tick: prev.tick + 1, intent }))
     setFollowLive(true)
     reload()
@@ -173,7 +177,7 @@ export default function Page() {
       )
     }
     if (selectedRun?.status === 'running') return <RunLive projectId={projectId} events={events} files={files} addContext={addContext} />
-    return <RunReplay projectId={projectId} runId={runId} />
+    return <RunReplay projectId={projectId} runId={runId} files={files} addContext={addContext} onRunStarted={onRunStarted} />
   }
 
   return (

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -84,6 +84,11 @@ test('parseArgs reads --browser (#452)', () => {
   assert.equal(parseArgs(['--browser', 'x']).browser, true)
 })
 
+test('parseArgs reads --resume-session to continue a finished run (#720)', () => {
+  assert.equal(parseArgs(['x']).resumeSession, undefined)
+  assert.equal(parseArgs(['prompt', 'keep going', '--resume-session', 'sess-42']).resumeSession, 'sess-42')
+})
+
 test('withBrowser folds chrome-devtools-mcp into driver options only when enabled (#452)', () => {
   const base = claudeDriverOptions({ skipPermissions: false })
   assert.equal(withBrowser(base, false).mcpServers, undefined)

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -228,6 +228,8 @@ export interface CliOptions {
   agent: AgentName
   cwd?: string | undefined
   model?: string | undefined
+  /** `--resume-session <id>` (#720): continue a finished run's agent session — the prompt resumes that conversation (full prior context). Set by the dashboard when you message a run that has ended. */
+  resumeSession?: string | undefined
   scope: 'prototype' | 'full'
   preset?: string | undefined
   autopilot: boolean
@@ -425,6 +427,9 @@ export function parseArgs(argv: string[]): CliOptions {
         break
       case '--model':
         opts.model = argv[++i]
+        break
+      case '--resume-session':
+        opts.resumeSession = argv[++i]
         break
       case '--deploy':
         opts.deploy = argv[++i]
@@ -1219,6 +1224,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
         ...(opts.context.length ? { context: opts.context } : {}),
         ...(modeList.includes('autopilot') ? { autopilot: true } : {}),
         ...(sessionLink ? { sessionLink } : {}),
+        ...(opts.resumeSession ? { resumeSessionId: opts.resumeSession } : {}),
       })
       return {
         successLine: isResearch

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -72,6 +72,10 @@ test('startOptionFlags maps only enabled Global options to CLI flags (#314)', ()
   assert.deepEqual(startOptionFlags({ agent: 'codex' }), ['--agent', 'codex'])
   assert.deepEqual(startOptionFlags({ agent: 'claude' }), [])
   assert.deepEqual(startOptionFlags({ agent: '   ' }), [])
+  // Resume a finished run's session (#720): maps to --resume-session, trimmed; blank -> no flag.
+  assert.deepEqual(startOptionFlags({ resumeSession: 'sess-42' }), ['--resume-session', 'sess-42'])
+  assert.deepEqual(startOptionFlags({ resumeSession: '  sess-7  ' }), ['--resume-session', 'sess-7'])
+  assert.deepEqual(startOptionFlags({ resumeSession: '   ' }), [])
 })
 
 const logEvent = (message: string): FrameworkEvent => ({ kind: 'log', message })

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -124,6 +124,10 @@ export function startOptionFlags(options: StartRunOptions): string[] {
   if (typeof options.agent === 'string' && options.agent.trim() && options.agent !== 'claude') {
     flags.push('--agent', options.agent.trim())
   }
+  // Resume a finished run's session (#720): the spawned run continues that conversation.
+  if (typeof options.resumeSession === 'string' && options.resumeSession.trim()) {
+    flags.push('--resume-session', options.resumeSession.trim())
+  }
   return flags
 }
 

--- a/packages/framework/src/dashboard/types.ts
+++ b/packages/framework/src/dashboard/types.ts
@@ -36,6 +36,8 @@ export interface StartRunOptions {
   model?: string
   /** Which coding agent drives the run (#650): `claude` or `codex`; maps to `--agent`. Absent = the default (`claude`). */
   agent?: string
+  /** Resume a finished run's conversation (#720): its captured agent session id; maps to `--resume-session`. The run's prompt continues that session (full prior context) instead of starting fresh. Sent with `kind: 'prompt'` when you message a run that has ended. */
+  resumeSession?: string
 }
 
 /**

--- a/packages/framework/src/driver/claude-code.test.ts
+++ b/packages/framework/src/driver/claude-code.test.ts
@@ -223,6 +223,19 @@ test('ClaudeCodeSession resumes the same session for a chat turn (#714)', async 
   assert.ok(!captured.includes('--append-system-prompt'))
 })
 
+test('ClaudeCodeSession seeds a given session id so the opening prompt resumes it (#720)', async () => {
+  let captured: string[] = []
+  const spawn: SpawnLike = (_cmd, args) => {
+    captured = [...args]
+    return fakeSpawn([JSON.stringify({ type: 'result', result: 'ok', session_id: 'sess-42' })])(_cmd, args, { cwd: '/ws', env: {} })
+  }
+  // A finished run's session id is threaded in at start; the very first `resume` prompt continues it.
+  const session = await new ClaudeCodeDriver({ spawn }).start({ cwd: '/ws', system: 'framing', resumeSessionId: 'sess-42' })
+  await session.prompt('keep going', { resume: true })
+  assert.equal(captured[captured.indexOf('--resume') + 1], 'sess-42')
+  assert.ok(!captured.includes('--append-system-prompt')) // the resumed transcript already carries its framing
+})
+
 test('ClaudeCodeSession runs a fresh turn when resume is asked with no prior session (#714)', async () => {
   let captured: string[] = []
   const spawn: SpawnLike = (_cmd, args) => {

--- a/packages/framework/src/driver/claude-code.ts
+++ b/packages/framework/src/driver/claude-code.ts
@@ -95,6 +95,9 @@ export class ClaudeCodeSession implements DriverSession {
   ) {
     this.cwd = startOpts.cwd
     this.id = `claude-code-${++sessionCounter}`
+    // Resume a finished run (#720): seeding lastSessionId makes the very first `resume` prompt
+    // `--resume` this conversation, exactly as a mid-run chat turn continues its own session.
+    this.lastSessionId = startOpts.resumeSessionId
   }
 
   async prompt(text: string, opts: DriverPromptOptions = {}): Promise<DriverTurn> {

--- a/packages/framework/src/driver/types.ts
+++ b/packages/framework/src/driver/types.ts
@@ -50,6 +50,14 @@ export interface DriverStartOptions {
   /** Abort the whole session; disposing kills the underlying process. */
   signal?: AbortSignal
   /**
+   * Resume a prior agent session id (#720): seed the session so its very first
+   * prompt (with `resume`) continues that conversation instead of starting fresh.
+   * This is how a finished run is revived from the dashboard — its captured session
+   * id is threaded here so the opening message lands with the full prior context.
+   * A driver that can't resume ignores it and runs fresh (the best-effort contract).
+   */
+  resumeSessionId?: string
+  /**
    * Observe the agent's *own* progress as it works. Black-box granularity: we
    * forward these for visibility (the dashboard) but never branch control flow
    * on them. Isolated: a throwing callback must not break the run.

--- a/packages/framework/src/prompt-run.test.ts
+++ b/packages/framework/src/prompt-run.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { FakeDriver } from './driver/fake.js'
+import type { Driver, DriverSession, DriverStartOptions } from './driver/types.js'
 import type { ChoicePick, ChoiceRequest, FrameworkEvent } from './events.js'
 import { runPrompt } from './prompt-run.js'
 import { RunMessageQueue } from './run-messages.js'
@@ -33,6 +34,40 @@ test('runPrompt runs a gateless prompt straight through and emits session + end'
   assert.deepEqual(events.at(-1), { kind: 'end', ok: true })
   // No gate, so nothing paused.
   assert.equal(events.some(e => e.kind === 'choice'), false)
+})
+
+test('runPrompt seeds the driver and resumes the opening prompt for a finished-run session (#720)', async () => {
+  let startOpts: DriverStartOptions | undefined
+  let openingResume: boolean | undefined
+  let openingText: string | undefined
+  // A capturing driver: the fake records prompt text but not its options, and we need to see the
+  // start seed + the opening prompt's `resume` flag — the whole point of the auto-resume path.
+  const driver: Driver = {
+    name: 'capture',
+    start(opts) {
+      startOpts = opts
+      let first = true
+      const session: DriverSession = {
+        id: 'x',
+        cwd: opts.cwd,
+        prompt(text, o = {}) {
+          if (first) {
+            first = false
+            openingResume = o.resume
+            openingText = text
+          }
+          return Promise.resolve({ text: 'continued', sessionId: 'sess-42' })
+        },
+        dispose: () => Promise.resolve(),
+      }
+      return Promise.resolve(session)
+    },
+  }
+  const { text } = await runPrompt({ prompt: 'keep going', driver, cwd: '/ws', resumeSessionId: 'sess-42', onEvent: () => {} })
+  assert.equal(text, 'continued')
+  assert.equal(startOpts?.resumeSessionId, 'sess-42') // the session is seeded with the finished run's id
+  assert.equal(openingResume, true) // the opening message --resumes it
+  assert.equal(openingText, 'keep going') // sent raw: the resumed transcript already carries its framing
 })
 
 test('runPrompt stays open for a live-chat message and delivers it as a turn (#714)', async () => {

--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -65,6 +65,14 @@ export interface RunPromptOptions {
    * when the agent stops asking — exactly as before.
    */
   messages?: RunMessages
+  /**
+   * Resume a finished run's conversation (#720): the captured agent session id to
+   * continue. When set, the prompt is sent as a plain continuation message that
+   * `--resume`s that session (full prior context), and the built-in system framing
+   * is skipped (the resumed transcript already carries it). This is what the
+   * dashboard sends when you message a run that has already ended.
+   */
+  resumeSessionId?: string
 }
 
 /** What {@link runPrompt} resolves with. */
@@ -100,7 +108,10 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
   // The template's `# User prompt` half carries the prompt (today it renders to
   // exactly `opts.prompt`; any framing Rom adds around the slot rides along). With
   // the built-in prompt off (or transparent, #625), the raw prompt is sent as-is.
-  const firstPrompt = opts.transparent || opts.antiLazyPill === false ? opts.prompt : renderSystemPrompt(tf).user
+  // Resuming a finished run (#720) also sends it raw: the `--resume`d transcript already
+  // carries the framing, so re-wrapping it would only duplicate the system template.
+  const resuming = typeof opts.resumeSessionId === 'string' && opts.resumeSessionId.length > 0
+  const firstPrompt = resuming || opts.transparent || opts.antiLazyPill === false ? opts.prompt : renderSystemPrompt(tf).user
 
   emitSessionStart({ emit, driver: opts.driver, cwd: opts.cwd, sessionLink: opts.sessionLink })
   // Surface the exact system prompt the agent runs under (#343). The user prompts
@@ -123,6 +134,7 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
     cwd: opts.cwd,
     system,
     ...(opts.model ? { model: opts.model } : {}),
+    ...(resuming ? { resumeSessionId: opts.resumeSessionId } : {}),
     signal: runSignal,
     onEvent: onDriverEvent,
   })
@@ -140,6 +152,7 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
       requestChoice: opts.requestChoice,
       emit,
       signal: runSignal,
+      ...(resuming ? { resume: true } : {}),
       ...(opts.messages ? { messages: opts.messages } : {}),
     })
     // The agent kept asking past the limit: finish with the latest turn rather than loop.

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -648,6 +648,12 @@ export interface AwaitRoundsOptions {
    * ends when the agent stops asking — byte-identical to before this existed.
    */
   messages?: RunMessages | undefined
+  /**
+   * Resume a prior session on the OPENING prompt (#720): when the driver session was
+   * seeded with a finished run's id, this makes the first message `--resume` that
+   * conversation (full prior context) instead of starting fresh. Default off.
+   */
+  resume?: boolean | undefined
 }
 
 /** The shared deps of a turn that may hit an await gate or a chat message. */
@@ -722,7 +728,9 @@ export async function runAwaitRounds(opts: AwaitRoundsOptions): Promise<AwaitRou
   const deps: AwaitTurnDeps = { requestChoice: opts.requestChoice, emit, emitTurnSignals, signal: opts.signal }
   const signalOpt = opts.signal ? { signal: opts.signal } : {}
 
-  const opening = await session.prompt(opts.prompt, signalOpt)
+  // Resuming a finished run (#720): the opening message continues the seeded session, so the
+  // agent replies with full prior context. A fresh run leaves `resume` unset — unchanged.
+  const opening = await session.prompt(opts.prompt, { ...signalOpt, ...(opts.resume ? { resume: true } : {}) })
   emitTurnSignals(opening.text)
   const drained = await drainGates(session, opening, deps)
   if (drained.declined) return { text: drained.turn.text, declined: true, exhausted: false }


### PR DESCRIPTION
## What

After a run ends (Stop, or it finishes), the dashboard used to drop the chat composer, so the conversation was a **dead end** (the pain from dogfooding: *"after I Stop, the message box vanishes and I'm stuck"*). Now the finished-run view keeps a composer, and **sending a message spins a fresh run whose opening prompt `--resume`s the ended run's captured session id** — continuing the same conversation with full prior context. This is the auto-resume decision from the issue (no Resume button).

## How

**Framework (`@gemstack/framework`, changeset: minor):**
- `DriverStartOptions.resumeSessionId` seeds `ClaudeCodeSession.lastSessionId` so its *very first* prompt `--resume`s that session (and skips `--append-system-prompt` — the resumed transcript already carries its framing).
- `AwaitRoundsOptions.resume` makes the opening prompt resume; `RunPromptOptions.resumeSessionId` threads it through `runPrompt` and sends the message raw (no system-prompt re-wrap).
- `StartRunOptions.resumeSession` -> `--resume-session <id>` (`startOptionFlags`), parsed back in `parseArgs` and wired into the `runPrompt` call.

**Dashboard (`framework-dashboard`, private, no changeset):**
- `RunReplay` renders a new `RunResumeChat` when the finished run has a session id (derived from its `session-update` events). On send it `sendStart`s a `prompt` run seeded with `resumeSession` and jumps to the new run's live output.
- `onRunStarted` resets to the Live row first so the jump works from a finished-run replay.

A fresh (non-resumed) run is byte-identical to before — `resume` stays unset.

## Notes / limitations

- A continuation is always sent as a **`prompt`** run (a message is a prompt), regardless of the original run's kind.
- **Same-project busy guard still applies:** if a run is already active in that project, resume is refused (surfaced inline). True parallel runs are the worktrees track (#453), intentionally out of scope here.
- **Agent match:** resume carries the current prefs' model/agent. Resuming is per-agent, so it assumes you're on the same agent the run used (the common case); cross-agent resume isn't handled.

## Test

- Framework (node:test, **638 pass**): driver seeds a given session id and the opening prompt `--resume`s it; `startOptionFlags` + `parseArgs` handle `--resume-session`; `runPrompt` seeds the driver, resumes the opening, and sends the raw message.
- Dashboard (vitest, **98 pass**): `RunResumeChat` shows the "run ended" hint, sends a `prompt` run carrying the session id + jumps to live, and surfaces the busy guard.
- Typecheck clean (framework + dashboard).

Closes #720