### PR TITLE
feat(framework): git-worktree lifecycle module (#735)

### DIFF
--- a/.changeset/worktree-lifecycle-module.md
+++ b/.changeset/worktree-lifecycle-module.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Add a git-worktree lifecycle module (`addWorktree` / `listWorktrees` / `removeWorktree` / `pruneWorktrees`), the foundation for running multiple tasks concurrently on one repo (#453). Each run will get its own checkout under `.the-framework/worktrees/<runId>` so concurrent runs never fight over the working tree. This slice is the isolated, unit-tested plumbing only; the daemon wiring, per-worktree concurrency, and dashboard changes land in the sibling #453 issues, so nothing changes at runtime yet.

--- a/packages/framework/src/store/index.ts
+++ b/packages/framework/src/store/index.ts
@@ -19,3 +19,15 @@ export {
   type RunStatus,
   type OpenStoreOptions,
 } from './run-store.js'
+export {
+  addWorktree,
+  listWorktrees,
+  parseWorktreeList,
+  removeWorktree,
+  pruneWorktrees,
+  worktreePath,
+  WORKTREES_DIR,
+  type WorktreeInfo,
+  type AddWorktreeOptions,
+  type AddedWorktree,
+} from './worktree.js'

--- a/packages/framework/src/store/worktree.test.ts
+++ b/packages/framework/src/store/worktree.test.ts
@@ -1,0 +1,137 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { join } from 'node:path'
+import { mkdtemp, rm, writeFile, stat, realpath } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import type { GitRunner } from '../project.js'
+import { nodeGitRunner } from '../project.js'
+import {
+  addWorktree,
+  listWorktrees,
+  parseWorktreeList,
+  removeWorktree,
+  pruneWorktrees,
+  worktreePath,
+  FRAMEWORK_DIR,
+} from './index.js'
+
+const REPO = '/repo'
+
+/** A {@link GitRunner} that records its calls and returns a canned stdout. */
+function recordingGit(stdout = ''): GitRunner & { calls: { args: string[]; cwd: string }[] } {
+  const calls: { args: string[]; cwd: string }[] = []
+  const run: GitRunner = async (args, cwd) => {
+    calls.push({ args, cwd })
+    return stdout
+  }
+  return Object.assign(run, { calls })
+}
+
+const failingGit: GitRunner = async () => {
+  throw new Error('not a git repository')
+}
+
+test('worktreePath nests the run under .the-framework/worktrees', () => {
+  assert.equal(worktreePath(REPO, '2026-07-19T10-00-00-000Z'), join(REPO, FRAMEWORK_DIR, 'worktrees', '2026-07-19T10-00-00-000Z'))
+})
+
+test('addWorktree builds `worktree add -b <branch> <path>` and returns the path + branch', async () => {
+  const git = recordingGit()
+  const added = await addWorktree(REPO, { runId: 'run1', branch: 'the-framework/run-run1' }, git)
+  const path = worktreePath(REPO, 'run1')
+  assert.deepEqual(added, { path, branch: 'the-framework/run-run1' })
+  assert.deepEqual(git.calls, [{ args: ['worktree', 'add', '-b', 'the-framework/run-run1', path], cwd: REPO }])
+})
+
+test('addWorktree appends the base ref when given', async () => {
+  const git = recordingGit()
+  await addWorktree(REPO, { runId: 'run1', branch: 'b', base: 'origin/main' }, git)
+  assert.deepEqual(git.calls[0]?.args, ['worktree', 'add', '-b', 'b', worktreePath(REPO, 'run1'), 'origin/main'])
+})
+
+test('addWorktree rejects an unsafe run id before touching git (no traversal out of worktrees/)', async () => {
+  const git = recordingGit()
+  await assert.rejects(() => addWorktree(REPO, { runId: '../evil', branch: 'b' }, git), /unsafe run id/)
+  assert.equal(git.calls.length, 0)
+})
+
+test('parseWorktreeList reads path/head/branch and strips refs/heads/, dropping detached branches', () => {
+  const porcelain = [
+    'worktree /repo',
+    'HEAD aaaa',
+    'branch refs/heads/main',
+    '',
+    'worktree /repo/.the-framework/worktrees/run1',
+    'HEAD bbbb',
+    'branch refs/heads/the-framework/run-run1',
+    '',
+    'worktree /repo/detached',
+    'HEAD cccc',
+    'detached',
+    '',
+  ].join('\n')
+  assert.deepEqual(parseWorktreeList(porcelain), [
+    { path: '/repo', head: 'aaaa', branch: 'main' },
+    { path: '/repo/.the-framework/worktrees/run1', head: 'bbbb', branch: 'the-framework/run-run1' },
+    { path: '/repo/detached', head: 'cccc' },
+  ])
+})
+
+test('parseWorktreeList yields [] for empty output', () => {
+  assert.deepEqual(parseWorktreeList(''), [])
+})
+
+test('listWorktrees passes --porcelain and is forgiving of a git failure', async () => {
+  const git = recordingGit('worktree /repo\nHEAD aaaa\nbranch refs/heads/main\n')
+  const entries = await listWorktrees(REPO, git)
+  assert.deepEqual(git.calls[0]?.args, ['worktree', 'list', '--porcelain'])
+  assert.deepEqual(entries, [{ path: '/repo', head: 'aaaa', branch: 'main' }])
+  assert.deepEqual(await listWorktrees(REPO, failingGit), [])
+})
+
+test('removeWorktree forces the removal and tolerates an already-gone path', async () => {
+  const git = recordingGit()
+  await removeWorktree(REPO, '/repo/wt', git)
+  assert.deepEqual(git.calls[0]?.args, ['worktree', 'remove', '--force', '/repo/wt'])
+  await assert.doesNotReject(() => removeWorktree(REPO, '/repo/gone', failingGit))
+})
+
+test('pruneWorktrees runs `worktree prune` and tolerates failure', async () => {
+  const git = recordingGit()
+  await pruneWorktrees(REPO, git)
+  assert.deepEqual(git.calls[0]?.args, ['worktree', 'prune'])
+  await assert.doesNotReject(() => pruneWorktrees(REPO, failingGit))
+})
+
+// End-to-end against real git: the whole point of the module is that the plumbing
+// works, so add -> list -> remove -> prune is exercised on a temp repo.
+test('add/list/remove round-trips against a real git repo', async () => {
+  const git = nodeGitRunner()
+  // realpath so the mkdtemp path matches what `git worktree list` reports: on
+  // macOS tmpdir is under the /var -> /private/var symlink (same gotcha as
+  // enumerateGitRepos in install.ts).
+  const repo = await realpath(await mkdtemp(join(tmpdir(), 'framework-worktree-')))
+  try {
+    await git(['init'], repo)
+    await git(['config', 'user.email', 't@t'], repo)
+    await git(['config', 'user.name', 't'], repo)
+    await writeFile(join(repo, 'README.md'), '# t\n')
+    await git(['add', '-A'], repo)
+    await git(['commit', '-m', 'init'], repo)
+
+    const { path, branch } = await addWorktree(repo, { runId: 'run1', branch: 'the-framework/run-run1' }, git)
+    assert.equal((await stat(path)).isDirectory(), true, 'worktree checkout dir exists')
+    assert.equal((await stat(join(path, 'README.md'))).isFile(), true, 'checkout has the repo content')
+
+    const listed = await listWorktrees(repo, git)
+    assert.ok(listed.some(w => w.path === path && w.branch === branch), 'new worktree shows up with its branch')
+
+    await removeWorktree(repo, path, git)
+    await assert.rejects(() => stat(path), 'checkout dir is gone after removal')
+    assert.equal((await listWorktrees(repo, git)).some(w => w.path === path), false, 'removed worktree is no longer listed')
+
+    await assert.doesNotReject(() => pruneWorktrees(repo, git))
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})

--- a/packages/framework/src/store/worktree.ts
+++ b/packages/framework/src/store/worktree.ts
@@ -1,0 +1,124 @@
+import { join } from 'node:path'
+import { nodeGitRunner, type GitRunner } from '../project.js'
+import { FRAMEWORK_DIR, isSafeRunId } from './run-store.js'
+
+/**
+ * Git-worktree lifecycle for concurrent runs (#453/#735): give each run its own
+ * checkout so N runs on one repo never fight over the working tree. Pure plumbing
+ * over the existing {@link GitRunner} seam; no daemon wiring, no concurrency, no
+ * dashboard changes (those are the sibling #453 slices). This module only knows
+ * how to add, list, remove, and prune worktrees.
+ */
+
+/** Per-run worktrees live under `<repo>/.the-framework/worktrees/`. Already kept
+ *  out of git by the install-time `.the-framework/.gitignore` (`*` rule, #313), so
+ *  a worktree's checkout never shows up as dirty in the parent. */
+export const WORKTREES_DIR = 'worktrees'
+
+/** The path a run's worktree gets: `<repo>/.the-framework/worktrees/<runId>`. */
+export function worktreePath(repo: string, runId: string): string {
+  return join(repo, FRAMEWORK_DIR, WORKTREES_DIR, runId)
+}
+
+/** One entry parsed from `git worktree list --porcelain`. */
+export interface WorktreeInfo {
+  /** Absolute worktree path (the main checkout included). */
+  path: string
+  /** The checked-out commit. */
+  head: string
+  /** The checked-out branch (short name), or absent when detached. */
+  branch?: string
+}
+
+/** Inputs to {@link addWorktree}. The caller owns branch naming (#736). */
+export interface AddWorktreeOptions {
+  runId: string
+  /** The branch to create for the run. */
+  branch: string
+  /** Base ref to branch from; defaults to the repo's current HEAD. */
+  base?: string
+}
+
+/** The worktree {@link addWorktree} created. */
+export interface AddedWorktree {
+  path: string
+  branch: string
+}
+
+/**
+ * Create a worktree for a run on a fresh branch: `git worktree add -b <branch>
+ * <path> [base]`. Git makes the leaf dir (and any missing parents) itself. The
+ * `runId` is validated as path-safe first so a caller can never traverse out of
+ * `.the-framework/worktrees/`. Rejects on any git failure (a caller that wants a
+ * run needs its checkout, so failure must surface, not be swallowed).
+ */
+export async function addWorktree(
+  repo: string,
+  opts: AddWorktreeOptions,
+  run: GitRunner = nodeGitRunner(),
+): Promise<AddedWorktree> {
+  if (!isSafeRunId(opts.runId)) throw new Error(`unsafe run id: ${opts.runId}`)
+  const path = worktreePath(repo, opts.runId)
+  await run(['worktree', 'add', '-b', opts.branch, path, ...(opts.base ? [opts.base] : [])], repo)
+  return { path, branch: opts.branch }
+}
+
+/**
+ * Every worktree registered for the repo (the main checkout included). Forgiving:
+ * a non-repo / git failure yields `[]` so a reconcile scan never throws.
+ */
+export async function listWorktrees(repo: string, run: GitRunner = nodeGitRunner()): Promise<WorktreeInfo[]> {
+  try {
+    return parseWorktreeList(await run(['worktree', 'list', '--porcelain'], repo))
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Parse `git worktree list --porcelain`: blank-line-separated records, each with
+ * a `worktree <path>` line, a `HEAD <sha>` line, and either `branch refs/heads/...`
+ * or `detached`. Extra attributes (bare/locked/prunable) are ignored. Exported so
+ * the parsing is unit-testable without a real repo.
+ */
+export function parseWorktreeList(porcelain: string): WorktreeInfo[] {
+  const entries: WorktreeInfo[] = []
+  for (const block of porcelain.split(/\n\s*\n/)) {
+    let path: string | undefined
+    let head = ''
+    let branch: string | undefined
+    for (const line of block.split('\n')) {
+      if (line.startsWith('worktree ')) path = line.slice('worktree '.length).trim()
+      else if (line.startsWith('HEAD ')) head = line.slice('HEAD '.length).trim()
+      else if (line.startsWith('branch ')) branch = line.slice('branch '.length).trim().replace(/^refs\/heads\//, '')
+    }
+    if (path) entries.push({ path, head, ...(branch ? { branch } : {}) })
+  }
+  return entries
+}
+
+/**
+ * Remove a run's worktree: `git worktree remove --force <path>` (force so an
+ * in-progress checkout with untracked build output still tears down). Tolerant of
+ * an already-gone / never-registered path so teardown stays idempotent (the run
+ * child is detached; the daemon only holds its pid).
+ */
+export async function removeWorktree(repo: string, path: string, run: GitRunner = nodeGitRunner()): Promise<void> {
+  try {
+    await run(['worktree', 'remove', '--force', path], repo)
+  } catch {
+    // Already removed, or never registered: nothing to do.
+  }
+}
+
+/**
+ * `git worktree prune`: drop administrative entries for worktree dirs a crash left
+ * behind. Never removes a live worktree, so it is always safe. Forgiving.
+ */
+export async function pruneWorktrees(repo: string, run: GitRunner = nodeGitRunner()): Promise<void> {
+  try {
+    await run(['worktree', 'prune'], repo)
+  } catch {
+    // Not a repo / nothing to prune: no-op.
+  }
+}


### PR DESCRIPTION
Closes #735. Part of #453 (git worktrees for concurrent runs).

The foundational, isolated git-worktree lifecycle module. Everything else in #453 builds on this, so it lands first and safely: the MVP one-run-per-project flow is untouched and nothing changes at runtime.

## What

`packages/framework/src/store/worktree.ts`, over the existing `GitRunner` seam (`project.ts:nodeGitRunner`):

- `addWorktree(repo, { runId, branch, base? })` -> `git worktree add -b <branch> <path> [base]`, path under `<repo>/.the-framework/worktrees/<runId>`; returns `{ path, branch }`. Guards `runId` with the store's `isSafeRunId` so a caller can never traverse out of `worktrees/`.
- `listWorktrees(repo)` -> parses `git worktree list --porcelain` into `{ path, head, branch? }[]` (forgiving: non-repo yields `[]`).
- `removeWorktree(repo, path)` -> `git worktree remove --force <path>`, tolerant of an already-gone path so teardown is idempotent.
- `pruneWorktrees(repo)` -> `git worktree prune` for crash-orphaned registrations.

Exported from the store barrel (internal); NOT re-exported from the package's public entry, so no consumer-facing surface yet.

## Notes

- `.the-framework/worktrees/` is already gitignored by the install-time `.the-framework/.gitignore` (`*` rule, #313), so a worktree checkout never shows up as dirty in the parent. No installer change needed.
- Branch naming is left to the caller (the #736 daemon slice owns the run/session-name question).

## Tests

10 tests in `worktree.test.ts`: arg construction + porcelain parsing (fake `GitRunner`), the `isSafeRunId` traversal guard, forgiving failure paths, and an end-to-end add -> list -> remove -> prune round-trip against a real temp git repo.

Full framework typecheck clean; the new file's 10 tests + the existing 28 store tests pass.
