### PR TITLE
refactor: quality pass over the chat-UX + preferences + worktree cluster

### DIFF
--- a/packages/framework-dashboard/components/AgentModelMenu.tsx
+++ b/packages/framework-dashboard/components/AgentModelMenu.tsx
@@ -56,12 +56,13 @@ export function AgentModelMenu({
   busy: boolean
 }) {
   const current = agentOf(agents, agent)
+  const currentModelLabel = modelLabel(current, model)
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
         type="button"
         disabled={busy}
-        title={`Agent: ${current?.label ?? ''} · Model: ${modelLabel(current, model)}`}
+        title={`Agent: ${current?.label ?? ''} · Model: ${currentModelLabel}`}
         className={cn(buttonVariants({ variant: 'outline', size: 'xs' }), 'gap-1.5 font-normal')}
       >
         {current?.icon ? (
@@ -70,7 +71,7 @@ export function AgentModelMenu({
           current?.label
         )}
         <span className="text-[var(--color-muted-foreground)]">·</span>
-        {modelLabel(current, model)}
+        {currentModelLabel}
         <ChevronDown className="h-3.5 w-3.5 opacity-70" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">

--- a/packages/framework-dashboard/components/ui/message-scroller.tsx
+++ b/packages/framework-dashboard/components/ui/message-scroller.tsx
@@ -16,9 +16,9 @@ import { cn } from '../../lib/utils.js'
 // icon placeholder, and the scrollbar-plugin utilities dropped (the app paints native scrollbars
 // via color-scheme, #710).
 
-export function MessageScrollerProvider(props: ComponentProps<typeof MessageScrollerPrimitive.Provider>) {
-  return <MessageScrollerPrimitive.Provider {...props} />
-}
+// The Provider needs no styling (no data-slot / className), so it is the primitive's directly,
+// re-exported for a uniform `message-scroller` import site rather than wrapped for nothing.
+export const MessageScrollerProvider = MessageScrollerPrimitive.Provider
 
 export function MessageScroller({ className, ...props }: ComponentProps<typeof MessageScrollerPrimitive.Root>) {
   return (

--- a/packages/framework-dashboard/lib/run-options.ts
+++ b/packages/framework-dashboard/lib/run-options.ts
@@ -30,7 +30,7 @@ export function collectRunOptions(preferences: Preferences, context: string[] = 
     ...(onBeforeMergeableQuality ? { onBeforeMergeable: true } : {}),
     ...(browser ? { browser: true } : {}),
     ...(model ? { model } : {}),
-    ...(agent && agent !== 'claude' ? { agent } : {}),
+    ...(agent !== 'claude' ? { agent } : {}),
     ...(context.length ? { context } : {}),
   }
 }

--- a/packages/framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/control.telefunc.ts
@@ -1,5 +1,5 @@
 import { getContext } from 'telefunc'
-import { appendControl } from '../control.js'
+import { appendControl, type ControlEntry } from '../control.js'
 import { openInApp, type OpenTarget, type OpenResult } from '../dashboard/open-in-app.js'
 import { resolveProjectPath, contextPreferences } from './context.js'
 import type { ChoiceBy } from '../events.js'
@@ -16,10 +16,19 @@ import type { Preferences } from '../registry.js'
 // steerable. (Starting a run needs a spawn + the daemon's busy guard, so `sendStart`
 // lands with the daemon-serves-the-bundle wiring, not here.)
 
+/**
+ * Resolve the project's local path and append one steering entry to its `control.jsonl`.
+ * A no-op when the project has no local path (the read-only relay), so the run channel is
+ * only ever written by a host that owns the workspace.
+ */
+async function appendControlFor(projectId: string, entry: ControlEntry): Promise<void> {
+  const cwd = await resolveProjectPath(projectId)
+  if (cwd) await appendControl(cwd, entry)
+}
+
 /** Stop the project's live run (the Stop button): append a stop entry to its control log. */
 export async function sendStop(projectId: string): Promise<void> {
-  const cwd = await resolveProjectPath(projectId)
-  if (cwd) await appendControl(cwd, { kind: 'stop' })
+  await appendControlFor(projectId, { kind: 'stop' })
 }
 
 /**
@@ -33,21 +42,18 @@ export async function sendChoice(
   pick: string | string[],
   by: ChoiceBy = 'user',
 ): Promise<void> {
-  const cwd = await resolveProjectPath(projectId)
-  if (cwd) await appendControl(cwd, { kind: 'choice', id, pick, by })
+  await appendControlFor(projectId, { kind: 'choice', id, pick, by })
 }
 
 /**
  * Send a live-chat message to the project's running run (#714): append a `message` entry
  * that the run drains between turns, continuing the same session via `--resume`. Empty
- * messages are dropped. A no-op when the project has no local path (the read-only relay),
- * so the run channel is only ever written by a host that owns the workspace.
+ * messages are dropped.
  */
 export async function sendMessage(projectId: string, text: string): Promise<void> {
   const message = text.trim()
   if (!message) return
-  const cwd = await resolveProjectPath(projectId)
-  if (cwd) await appendControl(cwd, { kind: 'message', text: message })
+  await appendControlFor(projectId, { kind: 'message', text: message })
 }
 
 /**


### PR DESCRIPTION
Code-quality pass over the chat-UX + preferences + worktree cluster that landed after the last quality pass (#616 / #621), applying Rom's rate-everything-first method: four independent reviewers rated every function/component in the slice on both axes (seams and simplify/altitude) before any edit, then only significant, output-identical refactors were applied. The slice is genuinely clean (it was written under the #616 bar), so the applied set is small and the rejected/deferred lists are explicit rather than padded.

No changeset: the `framework` change is an internal `refactor:` (public API unchanged) and `framework-dashboard` is private.

## Applied (old -> new)

| Theme | Change | File | old -> new | Commit |
|---|---|---|---|---|
| Duplication (seam) | Extract `appendControlFor` so the three steering writes (`sendStop`/`sendChoice`/`sendMessage`) share resolve -> guard -> append, and the no-op-on-relay rule lives once | `dashboard-rpc/control.telefunc.ts` | 9 -> 9 | b1936dd |
| Duplication | Hoist the twice-computed `modelLabel(current, model)` into one `currentModelLabel` | `components/AgentModelMenu.tsx` | 8 -> 9 | 2213903 |
| Dead code | Drop the dead `agent &&` half of the guard (`agent` is `?? 'claude'` and the sanitizer only stores a known-set agent, so it is never empty) | `lib/run-options.ts` | 8 -> 8.5 | b6a9fea |
| Frivolous indirection | Re-export the primitive's `Provider` instead of a pure `{...props}` wrapper component | `components/ui/message-scroller.tsx` | 9 -> 9.5 | ebe2a00 |

The `agent &&` removal was audited before applying (Rom's "comments/justifications are claims"): confirmed at `registry.ts:231` that `agent` is only stored when it is in the known set, so `?? 'claude'` always yields a truthy value.

## Coverage (100% of the slice, rated before editing)

- Framework runtime: `RunMessageQueue` (push/close/next), `runPrompt` resume plumbing, `control.ts` (`message` kind, watchControl, isControlEntry), `sendMessage`/`sendStop`/`sendChoice`, `drainGates`, `runChatPhase`, `runAwaitRounds`, both chat call sites.
- Driver + worktree: `claude-code.ts` resume additions, `driver/types.ts` resume surface, `session-support.combineFraming`, all of `store/worktree.ts` (add/list/remove/prune/parse) + `isSafeRunId`.
- Dashboard chat: `RunChat`, `RunResumeChat`, `message-scroller` wrappers, `RunLive`/`RunReplay` mounts.
- Dashboard launcher/prefs: `NavbarQuickLaunch`, `collectRunOptions`, `AgentModelMenu` (+ `agentOf`/`modelLabel`), `themePreference`/`resolvedDark`, `useDetectedEditors`, `agent-logos`.

## Considered and rejected (below the bar)

- **`run.ts` shared `stayOpenForChat` helper** for the two chat-phase call sites. Once each caller keeps its own per-span `emitTurnSignals` instance (required — the emitter is stateful), the helper dedupes only a 4-field `AwaitTurnDeps` literal that is already a named type, at the cost of churn in the hottest file. Not worth it.
- **The `signalOpt = signal ? { signal } : {}` idiom** repeated across `drainGates`/`runChatPhase`/`runAwaitRounds` - it is a file-wide `exactOptionalPropertyTypes` convention, not duplication to fold.
- **A shared `ComposerHost`** for `RunChat`/`RunResumeChat` - their send bodies genuinely diverge (fire-and-forget + silent catch vs result-object + error state), so a wrapper would cost more than it saves.

## Deferred (behavior-changing or open-draft region - not in this PR)

- **`projects` load duplicated across four Composer hosts** belongs inside `Composer` (its own `@`-picker is the only consumer). Deferred: the fix lands in `Composer.tsx`, which PR #740 already has open, and it changes effect ownership. Follow-up after #740 merges.
- **`worktree.ts` hardening**: guard `worktreePath` (the primitive, not just `addWorktree`) and add `--` end-of-options before the caller-owned `branch`/`base` positionals in `addWorktree`. Both fit naturally when #736 wires the real branch names and #737 adds the reconcile callers.
- **`runAwaitRounds` returns a stale `exhausted`** after a chat phase: it reports the opening prompt's drain, so a run that ends via Stop after a chat can still log "await limit reached". Low severity (needs the opening prompt to hit `MAX_AWAIT_ROUNDS` and live chat wired). Behavior fix -> its own PR + changeset + regression test.
- Two comment-accuracy narrowings (the resume path drops per-call `opts.system`; the dark first-paint claim under `ssr:false`) - cosmetic, folded into whatever next touches those files.

## Verification

- `pnpm typecheck` clean (framework build + dashboard).
- Framework full suite: 654 pass / 0 fail (incl. `daemon.test` against a freshly built dashboard bundle).
- Dashboard vitest: 107 pass (25 files).
- Dashboard bundle builds; downstream build green.
