### PR TITLE
fix(framework): report chat-phase exhaustion, not the opening drain's (#742)

### DIFF
--- a/.changeset/fix-742-chat-exhausted.md
+++ b/.changeset/fix-742-chat-exhausted.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Fix a spurious "await limit reached" notice after a live-chat run (#742). `runAwaitRounds` reported the opening prompt's await-round exhaustion even when a live-chat phase followed and the run actually ended because chat was stopped. `runChatPhase` now reports its own settled `exhausted`, and a run that ends on Stop/close after chat is no longer treated as having hit the await limit.

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -7,6 +7,7 @@ import { defineDomainPreset, defineLoop } from '@gemstack/ai-autopilot'
 import type { Prompt } from '@gemstack/ai-autopilot'
 import { DEFAULT_MAX_PASSES, requestChoices, requestMultiSelect, runAwaitRounds, runFramework, type ChoicesOption, type MultiSelectOption } from './run.js'
 import { FAKE_DEPLOY, FAKE_INTENT, FAKE_SIGNALS, fakeDriver } from './fake-script.js'
+import { RunMessageQueue } from './run-messages.js'
 import { FakeDriver, type Driver, type DriverSession } from './driver/index.js'
 import { composeRunSystem } from './system-prompt.js'
 import type { ChoiceRequest, FrameworkEvent } from './events.js'
@@ -886,4 +887,25 @@ test('runAwaitRounds gives up after MAX_AWAIT_ROUNDS and reports it exhausted', 
   assert.equal(result.exhausted, true)
   assert.equal(result.declined, false)
   assert.equal(prompts.length, MAX_AWAIT_ROUNDS + 1) // the opener, then one per round
+})
+
+test('runAwaitRounds does not report exhausted when a chat phase follows the opening cap (#742)', async () => {
+  // The opening prompt asks forever and hits the cap, but live chat is wired: the run stays open
+  // and ends because chat closes (Stop), not "at the await limit". So exhausted must be false —
+  // before #742 the opening drain's `exhausted: true` leaked through into a spurious end log.
+  const driver = new FakeDriver({ respond: () => choicesGate('Again?') })
+  const session = await driver.start({ cwd: '/tmp/ws' })
+  const messages = new RunMessageQueue()
+  messages.close() // no messages: the stay-open phase ends immediately.
+  const result = await runAwaitRounds({
+    session,
+    prompt: 'open',
+    emitTurnSignals: () => {},
+    requestChoice: async () => ({ picked: 'a' }),
+    emit: () => {},
+    messages,
+  })
+
+  assert.equal(result.exhausted, false)
+  assert.equal(result.declined, false)
 })

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -693,19 +693,25 @@ async function drainGates(session: DriverSession, turn: DriverTurn, deps: AwaitT
  * repeat until the source resolves `undefined` (Stop / budget cap). This is the "stay-open"
  * lifecycle: a run keeps running as a conversation until the user ends it. Shared by the
  * direct prompt path and the build path, which both reach it once their work has settled.
+ *
+ * Reports the settled `exhausted` of the *last* chat turn (#742): entering chat means the
+ * opening prompt's await-round cap is no longer the run's end reason, and a phase that ends
+ * on Stop / close is not exhausted at all.
  */
-export async function runChatPhase(session: DriverSession, messages: RunMessages, seed: DriverTurn, deps: AwaitTurnDeps): Promise<DriverTurn> {
+export async function runChatPhase(session: DriverSession, messages: RunMessages, seed: DriverTurn, deps: AwaitTurnDeps): Promise<{ turn: DriverTurn; exhausted: boolean }> {
   const signalOpt = deps.signal ? { signal: deps.signal } : {}
   let turn = seed
+  let exhausted = false
   for (;;) {
     const message = await messages.next(deps.signal)
-    if (message === undefined) return turn // Stop / budget cap: end the conversation.
+    if (message === undefined) return { turn, exhausted } // Stop / budget cap: end the conversation.
     deps.emit({ kind: 'log', message: `You: ${message}` })
     turn = await session.prompt(message, { ...signalOpt, resume: true })
     deps.emitTurnSignals(turn.text)
     const drained = await drainGates(session, turn, deps)
     turn = drained.turn
-    if (drained.declined) return turn
+    exhausted = drained.exhausted
+    if (drained.declined) return { turn, exhausted }
   }
 }
 
@@ -736,9 +742,14 @@ export async function runAwaitRounds(opts: AwaitRoundsOptions): Promise<AwaitRou
   if (drained.declined) return { text: drained.turn.text, declined: true, exhausted: false }
 
   // Live chat (#714): stay open for the user's messages until Stop. Headless leaves it unset,
-  // so the run ends here exactly as before.
-  const finalTurn = messages ? await runChatPhase(session, messages, drained.turn, deps) : drained.turn
-  return { text: finalTurn.text, declined: false, exhausted: drained.exhausted }
+  // so the run ends here exactly as before. Once chat runs, its settled state is the run's end
+  // reason, not the opening drain's (#742) — otherwise a chat closed by Stop would still be
+  // reported "exhausted" and log a spurious await-limit notice.
+  if (messages) {
+    const chat = await runChatPhase(session, messages, drained.turn, deps)
+    return { text: chat.turn.text, declined: false, exhausted: chat.exhausted }
+  }
+  return { text: drained.turn.text, declined: false, exhausted: drained.exhausted }
 }
 
 


### PR DESCRIPTION
Closes #742.

`runAwaitRounds` returned `exhausted: drained.exhausted`, where `drained` is the **opening** prompt's gate drain. When a live-chat `messages` source is wired, `runChatPhase` runs after the opening and the run ends via Stop/close, but the result still carried the opening drain's `exhausted`. So `prompt-run.ts` could log "Finishing the run (await limit reached)." even though the run actually ended because chat closed.

## Fix
- `runChatPhase` now returns `{ turn, exhausted }` and tracks the last chat turn's settled `exhausted` (false when the phase ends on Stop/close).
- `runAwaitRounds` reports the chat phase's `exhausted` once chat runs, and the opening drain's only when no chat is wired (headless, unchanged).

Entering chat means the opening prompt's await-round cap is no longer the run's end reason; only a chat turn that itself hits the cap is.

## Verification
- New regression test: opening prompt hits `MAX_AWAIT_ROUNDS` with live chat wired that closes immediately -> `exhausted` is false (was true before this fix). The existing no-chat exhausted test is unchanged.
- Framework full suite: 655 pass / 0 fail (656 total), built dashboard bundle so `daemon.test` runs.
- Patch changeset for `@gemstack/framework`.
