### PR TITLE
refactor(framework-dashboard): Composer owns its projects load (#743)

### DIFF
--- a/packages/framework-dashboard/components/Composer.test.tsx
+++ b/packages/framework-dashboard/components/Composer.test.tsx
@@ -13,6 +13,8 @@ vi.mock('../lib/preferences.js', () => ({
 }))
 // The editor picker (#727) detects installed editors over Telefunc; stub it to none in the test.
 vi.mock('../lib/editors.js', () => ({ useDetectedEditors: () => [] }))
+// Composer loads its own projects for the `@` picker (#743); stub the read to none.
+vi.mock('../server/projects.telefunc.js', () => ({ onProjects: () => Promise.resolve([]) }))
 
 // Stub the Tiptap editor (it needs a real DOM/ProseMirror): a plain input driving onChange, a
 // "type-submit" button firing onSubmit, and a ref exposing the same handle the composer calls.
@@ -38,7 +40,6 @@ function renderComposer(over: Partial<Parameters<typeof Composer>[0]> = {}) {
   const onSubmit = vi.fn()
   render(
     <Composer
-      projects={[]}
       files={[]}
       addContext={vi.fn()}
       onSubmit={onSubmit}

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -10,6 +10,8 @@ import {
 } from '@gemstack/framework/client'
 import { usePreferences, updatePreferences, autopilotEnabled, themePreference } from '../lib/preferences.js'
 import { useDetectedEditors } from '../lib/editors.js'
+import { useLoaded } from '../lib/use-async.js'
+import { onProjects } from '../server/projects.telefunc.js'
 import { PromptEditor, type PromptEditorHandle } from './PromptEditor.js'
 import { PresetCreatePanel } from './PresetCreatePanel.js'
 import { AgentModelMenu, type AgentOption } from './AgentModelMenu.js'
@@ -65,11 +67,11 @@ export interface ComposerHandle {
 // The shared run composer (#721): the Tiptap editor (`/` `<` `@` `#` triggers, presets, mentions)
 // plus the control row — agent/model select, presets menu, Global-options gear, and the submit
 // button. Factored out of the launcher (StartRunForm) so the run-view chat (RunChat) gets the exact
-// same surface, wired to the same data (projects, files, presets, prefs). The caller owns what
-// happens on submit: the launcher starts a run (with collected options), the chat sends a message.
+// same surface, wired to the same data (files, presets, prefs). The caller owns what happens on
+// submit: the launcher starts a run (with collected options), the chat sends a message. The `@`
+// picker's project list is Composer's own concern, so it loads it here (#743) rather than making
+// every host pass the same list down.
 export const Composer = forwardRef<ComposerHandle, {
-  /** Registered projects for the `@` picker. */
-  projects: ProjectSummary[]
   /** The current project's files for the `#` picker (#504). */
   files: string[]
   /** Add a path to the run Context (from an `@`/`#` mention). */
@@ -91,13 +93,15 @@ export const Composer = forwardRef<ComposerHandle, {
    *  shared prefs the launcher sets. */
   compact?: boolean | undefined
 }>(function Composer(
-  { projects, files, addContext, onSubmit, onPromptChange, onPreset, busy, submitLabel, submitBusyLabel, placeholder, showShortcutHint = false, compact = false },
+  { files, addContext, onSubmit, onPromptChange, onPreset, busy, submitLabel, submitBusyLabel, placeholder, showShortcutHint = false, compact = false },
   ref,
 ) {
   const [prompt, setPrompt] = useState('')
   const [kind, setKind] = useState<'build' | 'prompt'>('build')
   const [addingPreset, setAddingPreset] = useState(false)
   const editorRef = useRef<PromptEditorHandle>(null)
+  // The registered projects for the `@` picker — the same list the launcher reads.
+  const projects = useLoaded<ProjectSummary[]>(onProjects, [], [])
 
   const preferences = usePreferences()
   const autopilot = autopilotEnabled(preferences)

--- a/packages/framework-dashboard/components/NavbarQuickLaunch.test.tsx
+++ b/packages/framework-dashboard/components/NavbarQuickLaunch.test.tsx
@@ -14,6 +14,8 @@ const sendStart = vi.hoisted(() => vi.fn())
 vi.mock('../server/control.telefunc.js', () => ({ sendStart }))
 // The Composer's editor picker (#727) detects editors over Telefunc; stub it to none.
 vi.mock('../lib/editors.js', () => ({ useDetectedEditors: () => [] }))
+// The Composer loads its own projects for the `@` picker (#743); stub the read to none.
+vi.mock('../server/projects.telefunc.js', () => ({ onProjects: () => Promise.resolve([]) }))
 
 // Stub the Tiptap editor: an input driving onChange, a ref exposing clear/focus. (Same stub as
 // Composer.test — the quick-launch renders the real Composer, whose editor needs a real DOM.)
@@ -34,7 +36,6 @@ function renderQL(over: Partial<Parameters<typeof NavbarQuickLaunch>[0]> = {}) {
     <NavbarQuickLaunch
       projectId="p1"
       projectName="demo"
-      projects={[]}
       files={[]}
       context={new Set()}
       addContext={vi.fn()}

--- a/packages/framework-dashboard/components/NavbarQuickLaunch.tsx
+++ b/packages/framework-dashboard/components/NavbarQuickLaunch.tsx
@@ -1,5 +1,4 @@
 import { useRef, useState } from 'react'
-import type { ProjectSummary } from '@gemstack/framework'
 import { sendStart } from '../server/control.telefunc.js'
 import { usePreferences } from '../lib/preferences.js'
 import { collectRunOptions } from '../lib/run-options.js'
@@ -14,7 +13,6 @@ import { Composer, type ComposerHandle } from './Composer.js'
 export function NavbarQuickLaunch({
   projectId,
   projectName,
-  projects,
   files,
   context,
   addContext,
@@ -23,7 +21,6 @@ export function NavbarQuickLaunch({
 }: {
   projectId: string | null
   projectName?: string | null | undefined
-  projects: ProjectSummary[]
   files: string[]
   context: Set<string>
   addContext: (path: string) => void
@@ -70,7 +67,6 @@ export function NavbarQuickLaunch({
       <Composer
         ref={composerRef}
         compact
-        projects={projects}
         files={files}
         addContext={addContext}
         onSubmit={submit}

--- a/packages/framework-dashboard/components/RunChat.tsx
+++ b/packages/framework-dashboard/components/RunChat.tsx
@@ -1,9 +1,6 @@
 import { useRef, useState } from 'react'
-import type { ProjectSummary } from '@gemstack/framework'
 import { Composer, type ComposerHandle } from './Composer.js'
 import { sendMessage } from '../server/control.telefunc.js'
-import { onProjects } from '../server/projects.telefunc.js'
-import { useLoaded } from '../lib/use-async.js'
 
 // The live-chat composer (#714/#721): send more messages to a running run. Reuses the same shared
 // Composer the launcher uses, so `/` presets, `<` tags, and `@`/`#` mentions work here too, plus the
@@ -24,8 +21,6 @@ export function RunChat({
 }) {
   const composerRef = useRef<ComposerHandle>(null)
   const [sending, setSending] = useState(false)
-  // The registered projects for the `@` picker — the same list the launcher reads.
-  const projects = useLoaded<ProjectSummary[]>(onProjects, [], [])
 
   const send = async (text: string): Promise<void> => {
     if (sending) return
@@ -45,7 +40,6 @@ export function RunChat({
     <div className="border-t border-border p-3">
       <Composer
         ref={composerRef}
-        projects={projects}
         files={files}
         addContext={addContext}
         onSubmit={send}

--- a/packages/framework-dashboard/components/RunResumeChat.tsx
+++ b/packages/framework-dashboard/components/RunResumeChat.tsx
@@ -1,10 +1,7 @@
 import { useRef, useState } from 'react'
-import type { ProjectSummary } from '@gemstack/framework'
 import { Composer, type ComposerHandle } from './Composer.js'
 import { sendStart } from '../server/control.telefunc.js'
-import { onProjects } from '../server/projects.telefunc.js'
 import { usePreferences } from '../lib/preferences.js'
-import { useLoaded } from '../lib/use-async.js'
 
 // The finished-run composer (#720): keep talking to a run that has ended. A live run drains
 // messages in-process (RunChat + sendMessage), but a finished run has no process — so sending here
@@ -30,8 +27,6 @@ export function RunResumeChat({
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const preferences = usePreferences()
-  // The registered projects for the `@` picker — the same list the launcher reads.
-  const projects = useLoaded<ProjectSummary[]>(onProjects, [], [])
 
   const send = async (text: string): Promise<void> => {
     if (busy) return
@@ -66,7 +61,6 @@ export function RunResumeChat({
       <p className="mb-2 text-xs text-muted-foreground">Run ended — your next message continues it.</p>
       <Composer
         ref={composerRef}
-        projects={projects}
         files={files}
         addContext={addContext}
         onSubmit={send}

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -109,7 +109,6 @@ export function StartRunForm({
       <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Start a run</div>
       <Composer
         ref={composerRef}
-        projects={projects}
         files={files}
         addContext={addContext}
         onSubmit={submit}

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -191,7 +191,6 @@ export default function Page() {
           className="mx-2 min-w-0 flex-1"
           projectId={projectId}
           projectName={projectName}
-          projects={projects}
           files={files}
           context={context}
           addContext={addContext}


### PR DESCRIPTION
Closes #743.

`projects = useLoaded<ProjectSummary[]>(onProjects, [], [])` was duplicated across every Composer host, but `projects` exists solely for Composer's own `@`-picker. Move the load inside Composer and drop the `projects` prop.

## What changed
- **Composer**: loads its own projects; the `projects` prop is gone.
- **RunChat / RunResumeChat**: dropped their load + the now-unused `onProjects`/`useLoaded`/`ProjectSummary` imports (their only use of the list was feeding Composer).
- **StartRunForm** / **+Page**: keep their load (they use the list for their own project logic - the context selector, the browser-tab title) but stop passing it to Composer.
- **NavbarQuickLaunch**: lost its now-unused `projects` prop (it only forwarded it).

Deferred from the #741 quality pass, where it was blocked because the fix lands in Composer.tsx (then open in #740). Net -12 lines.

## Note
Each mounted Composer now loads independently (as each host did before). A shared, memoized `useProjects()` to collapse concurrent loads is a clean follow-up if it ever matters; at most two Composers mount at once today.

## Verification
- `framework-dashboard` typecheck clean; 105 vitest pass (24 files); production bundle builds.
- Tests updated: Composer.test + NavbarQuickLaunch.test now stub `onProjects` (Composer self-loads) and drop the `projects` prop.

framework-dashboard is private, so no changeset.
