### PR TITLE
feat(framework): show every live run of a project, not just one (#738)

### DIFF
--- a/.changeset/feat-738-aggregate-live-runs.md
+++ b/.changeset/feat-738-aggregate-live-runs.md
@@ -1,0 +1,11 @@
+---
+"@gemstack/framework": minor
+---
+
+Show every live run of a project, not just one (#738). Since #736 each run lives in its own worktree and writes its `run.json` there, so `readLiveMeta(projectPath)` stopped seeing any of them and the dashboard went blind to dashboard-started runs. A new `readLiveMetas(cwd)` discovers the live run in each `.the-framework/worktrees/*` checkout plus the project root (where a non-git project still runs, and where pre-#736 runs live), self-healing a stale one exactly as the single reader did.
+
+Every reader now aggregates: the runs list, the "working now" overview, the awaiting-you queue, the activity feed, and the project summaries. Each live run carries the `cwd` of the checkout it is editing, and `ActiveRun` and an `awaiting` intervention now carry a `runId`, so two concurrent runs of one project are told apart. `onGitStatus`, `onProjectFileStatus`, and `onProjectFiles` take an optional `runId` and read that run's worktree rather than the user's checkout.
+
+Also fixes a #736 bug found on the way: a repo's `.gitignore` says `node_modules/`, and a trailing slash matches a directory, not the symlink the worktree gets. The links were therefore untracked in every run's worktree, so a run's `git add -A` would commit dangling absolute symlinks onto its branch. The rule now goes into the repository's `info/exclude`, which is where git resolves excludes from for a linked worktree.
+
+Two dashboard fixes fall out: the "working now" list keyed its rows by project id alone, which produced duplicate React keys with two live runs in one project, and following live highlighted every running row at once instead of the newest.

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -197,7 +197,8 @@ function WorkingNow({ active, onSelectProject }: { active: ActiveRun[]; onSelect
   return (
     <ul className="divide-y divide-border">
       {active.map(run => (
-        <li key={run.projectId}>
+        // Keyed by project + run (#738): one project can have several runs in flight.
+        <li key={`${run.projectId}:${run.runId}`}>
           <button
             type="button"
             onClick={() => onSelectProject(run.projectId)}

--- a/packages/framework-dashboard/components/RunHistory.tsx
+++ b/packages/framework-dashboard/components/RunHistory.tsx
@@ -43,6 +43,7 @@ export function RunHistory({
   }, [startTick]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const hasRunning = runs.some(run => run.status === 'running')
+  const newestRunningId = runs.find(run => run.status === 'running')?.id
   useEffect(() => {
     if (hasRunning) setOptimistic(null)
   }, [hasRunning])
@@ -83,7 +84,9 @@ export function RunHistory({
             status={run.status}
             intent={run.intent}
             subtitle={new Date(run.startedAt).toLocaleString()}
-            active={run.id === selectedRunId || (followLive && run.status === 'running')}
+            // Following live highlights the newest running run, not every one of them (#738):
+            // `runs` is newest-first, so that is the first with a running status.
+            active={run.id === selectedRunId || (followLive && run.id === newestRunningId)}
             onClick={() => onSelect(run.id)}
           />
         ))}

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -9,6 +9,7 @@ import {
   addWorktree,
   runBranchName,
   linkDependencies,
+  excludeDependencyLinks,
 } from './store/index.js'
 import { startDashboard, type Dashboard, type StartRunKind, type StartRunOptions, type StartRunResult, type AddProjectResult, type PreviewResult, type PreviewStatus } from './dashboard/index.js'
 import { startInterventionWatcher, postDiscord, type InterventionWatcher } from './dashboard/intervention-watcher.js'
@@ -488,8 +489,10 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
   const allocateWorkspace = async (projectCwd: string, runId: string): Promise<{ cwd: string; runId?: string }> => {
     try {
       const worktree = await addWorktree(projectCwd, { runId, branch: runBranchName(runId) })
-      // `node_modules` is gitignored, so a fresh worktree has none: link the parent's in.
+      // `node_modules` is gitignored, so a fresh worktree has none: link the parent's in, and
+      // make git ignore the links (a `node_modules/` rule does not match a symlink, #738).
       await linkDependencies(projectCwd, worktree.path).catch(() => [])
+      await excludeDependencyLinks(projectCwd).catch(() => {})
       return { cwd: worktree.path, runId }
     } catch (err) {
       console.log(`[framework] no worktree for ${basename(projectCwd)} (${err instanceof Error ? err.message : String(err)}); running in the main checkout`)

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -1,4 +1,4 @@
-import { listRuns, readLiveMeta, loadRunEvents, type RunMeta } from '../store/index.js'
+import { listRuns, readLiveMetas, loadRunEvents, type RunMeta } from '../store/index.js'
 import { readLogs, type LogEntry } from '../logs.js'
 import { readDocs, type WorkspaceDoc } from '../dashboard/docs.js'
 import { collectQueue, type ProjectQueue } from '../dashboard/queue.js'
@@ -33,24 +33,41 @@ async function withProject<T>(projectId: string, read: (cwd: string) => Promise<
 }
 
 /**
+ * The checkout a read should target: a live run's own worktree when `runId` names one (#738),
+ * else the project root. Since #736 a run edits its worktree, not the user's checkout, so the
+ * branch / dirty flag / file dots shown beside a run have to come from there — asking the
+ * project root would report the user's own working tree instead of the run's.
+ *
+ * An unknown or finished `runId` falls back to the project root rather than failing: the run's
+ * worktree may already be gone, and the project's own status is still the sane thing to show.
+ */
+async function resolveRunPath(projectId: string, runId?: string): Promise<string | undefined> {
+  const cwd = await resolveProjectPath(projectId)
+  if (!cwd || !runId) return cwd
+  const live = await readLiveMetas(cwd).catch(() => [])
+  return live.find(run => run.id === runId)?.cwd ?? cwd
+}
+
+/**
  * The project's runs, most-recent first (or `[]`). The archived (finished) runs
- * from `runs/`, plus the live run prepended when one is present — so the sidebar
- * shows the in-progress run with a `running` status the moment it starts, not
- * only after it closes. The live run is skipped once it has been archived under
- * the same id (it then appears from `listRuns` instead), so there is no double.
- * The status is not filtered on: `readLiveMeta` may have just self-healed a dead
- * run to `stopped` (#716), and that freshly-archived row can lag `listRuns` by a
- * poll — prepending it regardless keeps the row visible (as stopped) with no flicker.
+ * from `runs/`, plus every live run prepended — so the sidebar shows an in-progress
+ * run with a `running` status the moment it starts, not only after it closes.
+ *
+ * Since #736 a project has any number of live runs, each in its own worktree, so this reads
+ * them all (#738) instead of the single one that used to sit at the project path. They come
+ * back as {@link LiveRun}s, carrying the `cwd` of the checkout that run is editing.
+ *
+ * A live run is skipped once it has been archived under the same id (it then appears from
+ * `listRuns` instead), so there is no double. The status is not filtered on: `readLiveMeta`
+ * may have just self-healed a dead run to `stopped` (#716), and that freshly-archived row can
+ * lag `listRuns` by a poll — prepending it regardless keeps the row visible with no flicker.
  */
 export async function onRuns(projectId: string): Promise<RunMeta[]> {
   const cwd = await resolveProjectPath(projectId)
   if (!cwd) return []
   const archived = await listRuns(cwd).catch(() => [])
-  const live = await readLiveMeta(cwd).catch(() => undefined)
-  if (live && !archived.some(r => r.id === live.id)) {
-    return [live, ...archived]
-  }
-  return archived
+  const live = await readLiveMetas(cwd).catch(() => [])
+  return [...live.filter(run => !archived.some(r => r.id === run.id)), ...archived]
 }
 
 /** One archived run's event log for replay (or `[]` when the run or project is gone). */
@@ -104,17 +121,21 @@ export async function onDashboard(): Promise<DashboardData> {
  * The project's files for the `#` context picker (#504) and the panel tree (#492): every
  * file git sees (tracked + untracked, honoring .gitignore), repo-relative and sorted, via
  * `git ls-files`. Localhost-only by nature — the relay has no checkout, so it resolves `[]`.
+ * Pass a live `runId` to list that run's worktree instead of the project root (#738).
  */
-export async function onProjectFiles(projectId: string): Promise<string[]> {
-  return withProject(projectId, crawlRepoFiles, [])
+export async function onProjectFiles(projectId: string, runId?: string): Promise<string[]> {
+  const cwd = await resolveRunPath(projectId, runId)
+  return cwd ? crawlRepoFiles(cwd).catch(() => []) : []
 }
 
 /**
  * Per-file git status for the tree's dots (#492): repo-relative path -> untracked/modified/
  * deleted, from `git status --porcelain`. `{}` when not a repo / on the relay (no checkout).
+ * Pass a live `runId` to see that run's own worktree rather than the project root (#738).
  */
-export async function onProjectFileStatus(projectId: string): Promise<Record<string, FileGitStatus>> {
-  return withProject(projectId, readFileStatuses, {})
+export async function onProjectFileStatus(projectId: string, runId?: string): Promise<Record<string, FileGitStatus>> {
+  const cwd = await resolveRunPath(projectId, runId)
+  return cwd ? readFileStatuses(cwd).catch(() => ({})) : {}
 }
 
 /** The project's GitHub URL from its `origin` remote (#489), or null (no remote / not GitHub / relay). */
@@ -124,9 +145,13 @@ export async function onGithubUrl(projectId: string): Promise<string | null> {
   return (await githubUrlFor(cwd)) ?? null
 }
 
-/** The project's git status (#491): active branch, dirty flag, linked PR. Null when not a repo / relay. */
-export async function onGitStatus(projectId: string): Promise<GitStatus | null> {
-  const cwd = await resolveProjectPath(projectId)
+/**
+ * The project's git status (#491): active branch, dirty flag, linked PR. Null when not a repo /
+ * relay. Pass a live `runId` to read that run's worktree, which is the branch and the dirty
+ * state that actually belong to it (#738).
+ */
+export async function onGitStatus(projectId: string, runId?: string): Promise<GitStatus | null> {
+  const cwd = await resolveRunPath(projectId, runId)
   if (!cwd) return null
   return (await readGitStatus(cwd)) ?? null
 }

--- a/packages/framework/src/dashboard/activity.ts
+++ b/packages/framework/src/dashboard/activity.ts
@@ -1,4 +1,4 @@
-import { listRuns, readLiveMeta, type RunMeta, type RunStatus } from '../store/index.js'
+import { listRuns, readLiveMetas, type LiveRun, type RunMeta, type RunStatus } from '../store/index.js'
 import type { ProjectSummary } from './projects.js'
 
 // The "New activity" feed (#627): the cross-project stream of run lifecycle transitions that
@@ -43,11 +43,10 @@ export interface ActivityDeps {
 async function readAllRuns(cwd: string): Promise<RunMeta[]> {
   const [archived, live] = await Promise.all([
     listRuns(cwd).catch(() => [] as RunMeta[]),
-    readLiveMeta(cwd).catch(() => undefined),
+    readLiveMetas(cwd).catch(() => [] as LiveRun[]),
   ])
-  // Skip the live run when it is already archived under the same id, so it is not counted twice.
-  if (live && !archived.some(r => r.id === live.id)) return [live, ...archived]
-  return archived
+  // Skip a live run already archived under the same id, so it is not counted twice.
+  return [...live.filter(run => !archived.some(r => r.id === run.id)), ...archived]
 }
 
 /** Map one run to its current activity item: `started` while running, else `finished`. */

--- a/packages/framework/src/dashboard/dashboard.test.ts
+++ b/packages/framework/src/dashboard/dashboard.test.ts
@@ -30,7 +30,7 @@ test('buildDashboard rolls up totals, run-status, and per-project counts', async
     { projectId: 'b', projectName: 'b', open: 0, total: 1, items: [] },
   ]
   const data = await buildDashboard(projects, {
-    liveMeta: async cwd => (cwd === '/a' ? run('running', '2026-07-14T11:00:00Z') : undefined),
+    liveRuns: async cwd => (cwd === '/a' ? [{ ...run('running', '2026-07-14T11:00:00Z'), cwd }] : []),
     runs: async cwd => runsByPath[cwd] ?? [],
     queue: async () => queues,
     now: NOW,
@@ -54,7 +54,7 @@ test('buildDashboard buckets run activity across a 14-day window, oldest-first',
     run('done', '2026-06-01T09:00:00Z'), // older than 14 days -> dropped
   ]
   const data = await buildDashboard([project('a', '/a')], {
-    liveMeta: async () => undefined,
+    liveRuns: async () => [],
     runs: async () => runs,
     queue: async () => [],
     now: NOW,

--- a/packages/framework/src/dashboard/interventions.test.ts
+++ b/packages/framework/src/dashboard/interventions.test.ts
@@ -2,12 +2,15 @@ import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { buildInterventions, interventionKey, type OpenPr } from './interventions.js'
 import type { ProjectSummary } from './projects.js'
-import type { RunMeta } from '../store/index.js'
+import type { LiveRun, RunMeta } from '../store/index.js'
 
 const project = (id: string, path: string): ProjectSummary => ({ id, path, name: id, activated: true })
 
 /** No paused run anywhere — keeps the PR-only tests hermetic (no disk read). */
-const noRuns = async (): Promise<RunMeta | undefined> => undefined
+const noRuns = async (): Promise<LiveRun[]> => []
+
+/** A live run in its own worktree (#738), which is what the reader now returns. */
+const live = (meta: RunMeta, cwd = '/a/.the-framework/worktrees/r1'): LiveRun => ({ ...meta, cwd })
 
 const runningMeta = (over: Partial<RunMeta> = {}): RunMeta => ({
   version: 1,
@@ -29,7 +32,7 @@ test('buildInterventions rolls up open non-draft PRs across projects, newest fir
     '/c': [], // no open PRs -> contributes nothing
   }
   const prs = async (cwd: string): Promise<OpenPr[]> => prsByPath[cwd] ?? []
-  const items = await buildInterventions([project('a', '/a'), project('b', '/b'), project('c', '/c')], { prs, liveMeta: noRuns })
+  const items = await buildInterventions([project('a', '/a'), project('b', '/b'), project('c', '/c')], { prs, liveRuns: noRuns })
 
   // Newest PR first; the draft is gone.
   assert.deepEqual(
@@ -47,28 +50,28 @@ test('buildInterventions skips a project whose PR lookup throws', async () => {
     if (cwd === '/boom') throw new Error('gh exploded')
     return [{ number: 1, title: 'ok', url: 'u1', isDraft: false }]
   }
-  const items = await buildInterventions([project('boom', '/boom'), project('ok', '/ok')], { prs, liveMeta: noRuns })
+  const items = await buildInterventions([project('boom', '/boom'), project('ok', '/ok')], { prs, liveRuns: noRuns })
   assert.deepEqual(items.map(i => i.projectId), ['ok'])
 })
 
 test('buildInterventions returns [] when nothing is open anywhere', async () => {
   const prs = async (): Promise<OpenPr[]> => []
-  assert.deepEqual(await buildInterventions([project('a', '/a')], { prs, liveMeta: noRuns }), [])
+  assert.deepEqual(await buildInterventions([project('a', '/a')], { prs, liveRuns: noRuns }), [])
 })
 
 test('buildInterventions dedupes a PR shared by two registered projects (same repo), keeping one', async () => {
   const shared: OpenPr = { number: 285, title: 'release', url: 'https://gh/pr/285', isDraft: false, createdAt: '2026-07-05T00:00:00Z' }
   const prs = async (): Promise<OpenPr[]> => [shared] // both projects resolve to the same repo
-  const items = await buildInterventions([project('root', '/repo'), project('sub', '/repo/packages/x')], { prs, liveMeta: noRuns })
+  const items = await buildInterventions([project('root', '/repo'), project('sub', '/repo/packages/x')], { prs, liveRuns: noRuns })
   assert.deepEqual(items.map(i => i.number), [285])
 })
 
 const noPrs = async (): Promise<OpenPr[]> => []
 
 test('buildInterventions adds an awaiting item for a running run parked on a choice (#636)', async () => {
-  const liveMeta = async (cwd: string): Promise<RunMeta | undefined> =>
-    cwd === '/a' ? runningMeta({ pendingChoice: { id: 'gate-1', title: 'Cache the auth store?' } }) : undefined
-  const items = await buildInterventions([project('a', '/a'), project('b', '/b')], { prs: noPrs, liveMeta })
+  const liveRuns = async (cwd: string): Promise<LiveRun[]> =>
+    cwd === '/a' ? [live(runningMeta({ pendingChoice: { id: 'gate-1', title: 'Cache the auth store?' } }))] : []
+  const items = await buildInterventions([project('a', '/a'), project('b', '/b')], { prs: noPrs, liveRuns })
 
   assert.equal(items.length, 1)
   assert.deepEqual(
@@ -78,25 +81,25 @@ test('buildInterventions adds an awaiting item for a running run parked on a cho
 })
 
 test('buildInterventions ignores a pendingChoice on a run that is no longer running', async () => {
-  const liveMeta = async (): Promise<RunMeta | undefined> =>
-    runningMeta({ status: 'done', pendingChoice: { id: 'gate-1', title: 'stale' } })
-  assert.deepEqual(await buildInterventions([project('a', '/a')], { prs: noPrs, liveMeta }), [])
+  const liveRuns = async (): Promise<LiveRun[]> =>
+    [live(runningMeta({ status: 'done', pendingChoice: { id: 'gate-1', title: 'stale' } }))]
+  assert.deepEqual(await buildInterventions([project('a', '/a')], { prs: noPrs, liveRuns }), [])
 })
 
 test('buildInterventions links an awaiting item to the dashboard URL when given, else empty', async () => {
-  const liveMeta = async (): Promise<RunMeta | undefined> => runningMeta({ pendingChoice: { id: 'g', title: 'q?' } })
-  const withUrl = await buildInterventions([project('a', '/a')], { prs: noPrs, liveMeta, dashboardUrl: 'http://localhost:4200' })
+  const liveRuns = async (): Promise<LiveRun[]> => [live(runningMeta({ pendingChoice: { id: 'g', title: 'q?' } }))]
+  const withUrl = await buildInterventions([project('a', '/a')], { prs: noPrs, liveRuns, dashboardUrl: 'http://localhost:4200' })
   assert.equal(withUrl[0]!.url, 'http://localhost:4200')
-  const withoutUrl = await buildInterventions([project('a', '/a')], { prs: noPrs, liveMeta })
+  const withoutUrl = await buildInterventions([project('a', '/a')], { prs: noPrs, liveRuns })
   assert.equal(withoutUrl[0]!.url, '')
 })
 
 test('buildInterventions surfaces PRs and awaiting runs together, newest first', async () => {
   const prs = async (cwd: string): Promise<OpenPr[]> =>
     cwd === '/a' ? [{ number: 5, title: 'pr', url: 'u5', isDraft: false, createdAt: '2026-07-10T00:00:00Z' }] : []
-  const liveMeta = async (cwd: string): Promise<RunMeta | undefined> =>
-    cwd === '/b' ? runningMeta({ updatedAt: '2026-07-16T00:00:00Z', pendingChoice: { id: 'g', title: 'q?' } }) : undefined
-  const items = await buildInterventions([project('a', '/a'), project('b', '/b')], { prs, liveMeta })
+  const liveRuns = async (cwd: string): Promise<LiveRun[]> =>
+    cwd === '/b' ? [live(runningMeta({ updatedAt: '2026-07-16T00:00:00Z', pendingChoice: { id: 'g', title: 'q?' } }))] : []
+  const items = await buildInterventions([project('a', '/a'), project('b', '/b')], { prs, liveRuns })
   assert.deepEqual(items.map(i => i.kind), ['awaiting', 'pr']) // awaiting is newer
 })
 

--- a/packages/framework/src/dashboard/interventions.ts
+++ b/packages/framework/src/dashboard/interventions.ts
@@ -1,4 +1,4 @@
-import { readLiveMeta, type RunMeta } from '../store/index.js'
+import { readLiveMetas, type LiveRun } from '../store/index.js'
 import type { ProjectSummary } from './projects.js'
 
 // The interventions queue (#632, part of the Queue #624): the cross-project "needs you" list.
@@ -25,6 +25,8 @@ export interface Intervention {
   number?: number
   /** The parked gate's id (`awaiting` only) — its stable identity, so it notifies exactly once. */
   awaitId?: string
+  /** Which run is asking (`awaiting` only, #738): a project can have several parked at once. */
+  runId?: string
   /** When the PR was opened (`pr`) or the run last updated (`awaiting`), ISO, for ordering. */
   createdAt?: string
 }
@@ -63,8 +65,8 @@ export function nodeGhPrLister(): PrLister {
 /** Injectable seam so {@link buildInterventions} is unit-testable off disk. */
 export interface InterventionsDeps {
   prs?: PrLister
-  /** The live-run meta reader (default {@link readLiveMeta}); drives the `awaiting` source (#636). */
-  liveMeta?: (cwd: string) => Promise<RunMeta | undefined>
+  /** The live-run reader (default {@link readLiveMetas}); drives the `awaiting` source (#636). */
+  liveRuns?: (cwd: string) => Promise<LiveRun[]>
   /**
    * The dashboard's own URL, so an `awaiting` item can link back to it. Only the daemon knows
    * it (the card path resolves the project client-side and needs no URL), so it is optional; an
@@ -84,7 +86,7 @@ export async function buildInterventions(
   deps: InterventionsDeps = {},
 ): Promise<Intervention[]> {
   const prs = deps.prs ?? nodeGhPrLister()
-  const liveMeta = deps.liveMeta ?? readLiveMeta
+  const liveRuns = deps.liveRuns ?? readLiveMetas
   const items: Intervention[] = []
   for (const project of projects) {
     const open = await prs(project.path).catch(() => [])
@@ -101,10 +103,11 @@ export async function buildInterventions(
       })
     }
     // A run paused mid-flight to ask the user is a "needs you" too (#636): a live run that is
-    // still `running` and has an unresolved choice gate. One per project (a run parks on one
-    // gate at a time), keyed on the gate id so it notifies once.
-    const meta = await liveMeta(project.path).catch(() => undefined)
-    if (meta?.status === 'running' && meta.pendingChoice) {
+    // still `running` and has an unresolved choice gate. A run parks on one gate at a time, but
+    // a project now has several concurrent runs (#736), so each parked run contributes its own
+    // item — keyed on the gate id, plus the run id so two runs are told apart.
+    for (const meta of await liveRuns(project.path).catch(() => [])) {
+      if (meta.status !== 'running' || !meta.pendingChoice) continue
       items.push({
         projectId: project.id,
         projectName: project.name,
@@ -112,6 +115,7 @@ export async function buildInterventions(
         title: meta.pendingChoice.title,
         url: deps.dashboardUrl ?? '',
         awaitId: meta.pendingChoice.id,
+        runId: meta.id,
         ...(meta.updatedAt ? { createdAt: meta.updatedAt } : {}),
       })
     }

--- a/packages/framework/src/dashboard/overview.test.ts
+++ b/packages/framework/src/dashboard/overview.test.ts
@@ -23,7 +23,7 @@ test('buildOverview surfaces only running runs, most-recently-updated first', as
     '/c': meta('running', 'build the UI', '2026-07-13T12:00:00Z'),
   }
   const overview = await buildOverview([project('a', '/a'), project('b', '/b'), project('c', '/c')], {
-    liveMeta: async cwd => metas[cwd],
+    liveRuns: async cwd => (metas[cwd] ? [{ ...metas[cwd]!, cwd }] : []),
     queue: async () => [],
   })
   assert.deepEqual(
@@ -43,7 +43,7 @@ test('buildOverview sums the open queue and lists recent projects newest-first (
     { projectId: 'p0', projectName: 'p0', open: 3, total: 4, items: [] },
     { projectId: 'p1', projectName: 'p1', open: 2, total: 2, items: [] },
   ]
-  const overview = await buildOverview(projects, { liveMeta: async () => undefined, queue: async () => queues })
+  const overview = await buildOverview(projects, { liveRuns: async () => [], queue: async () => queues })
   assert.equal(overview.active.length, 0)
   assert.equal(overview.queueOpen, 5)
   assert.equal(overview.recent.length, 5)
@@ -55,7 +55,7 @@ test('buildOverview sums the open queue and lists recent projects newest-first (
 
 test('buildOverview omits projects with no activity from recent', async () => {
   const overview = await buildOverview([project('a', '/a'), project('b', '/b', '2026-07-13T00:00:00Z')], {
-    liveMeta: async () => undefined,
+    liveRuns: async () => [],
     queue: async () => [],
   })
   assert.deepEqual(overview.recent.map(r => r.projectId), ['b'])

--- a/packages/framework/src/dashboard/overview.ts
+++ b/packages/framework/src/dashboard/overview.ts
@@ -1,4 +1,4 @@
-import { readLiveMeta, type RunMeta, type RunStatus } from '../store/index.js'
+import { readLiveMetas, type LiveRun, type RunStatus } from '../store/index.js'
 import type { ProjectSummary } from './projects.js'
 import { collectQueue, type ProjectQueue } from './queue.js'
 
@@ -12,6 +12,10 @@ import { collectQueue, type ProjectQueue } from './queue.js'
 export interface ActiveRun {
   projectId: string
   projectName: string
+  /** Which run this is (#738): a project can have several in flight, one per worktree. */
+  runId: string
+  /** The run's own checkout, so its git/file status is read from the worktree it edits (#738). */
+  cwd: string
   status: RunStatus
   /** What the user asked to build (the run's `scope` event). */
   intent?: string
@@ -46,27 +50,30 @@ const RECENT_LIMIT = 5
 
 /** Injectable readers so {@link buildOverview} is unit-testable off disk. */
 export interface OverviewDeps {
-  liveMeta?: (cwd: string) => Promise<RunMeta | undefined>
+  liveRuns?: (cwd: string) => Promise<LiveRun[]>
   queue?: (projects: ProjectSummary[]) => Promise<ProjectQueue[]>
 }
 
 /**
- * Build the cross-project Overview: the running runs (from each project's live meta), the
- * total open TODO count (from {@link collectQueue}), and the most recently active projects
- * (by {@link ProjectSummary.lastActivityAt}). Forgiving — a project whose meta is missing
- * or not running simply contributes nothing to `active`.
+ * Build the cross-project Overview: the running runs (every live run of each project, one per
+ * worktree since #736), the total open TODO count (from {@link collectQueue}), and the most
+ * recently active projects (by {@link ProjectSummary.lastActivityAt}). Forgiving — a project
+ * with no live run, or none running, simply contributes nothing to `active`.
  */
 export async function buildOverview(projects: ProjectSummary[], deps: OverviewDeps = {}): Promise<Overview> {
-  const liveMeta = deps.liveMeta ?? readLiveMeta
+  const liveRuns = deps.liveRuns ?? readLiveMetas
   const queue = deps.queue ?? (p => collectQueue(p))
 
   const active: ActiveRun[] = []
   for (const project of projects) {
-    const meta = await liveMeta(project.path)
-    if (meta?.status === 'running') {
+    // Every live run of the project (#738), not just the one that used to sit at its path.
+    for (const meta of await liveRuns(project.path).catch(() => [])) {
+      if (meta.status !== 'running') continue
       active.push({
         projectId: project.id,
         projectName: project.name,
+        runId: meta.id,
+        cwd: meta.cwd,
         status: meta.status,
         ...(meta.intent ? { intent: meta.intent } : {}),
         ...(meta.scope ? { scope: meta.scope } : {}),

--- a/packages/framework/src/dashboard/projects.ts
+++ b/packages/framework/src/dashboard/projects.ts
@@ -2,7 +2,7 @@ import { basename } from 'node:path'
 import { listProjects, type ProjectRecord } from '../registry.js'
 import { isActivated } from '../project.js'
 import { readLogs, type LogEntry } from '../logs.js'
-import { listRuns, readLiveMeta, type RunMeta } from '../store/index.js'
+import { listRuns, readLiveMetas, type LiveRun, type RunMeta } from '../store/index.js'
 
 /**
  * The multi-project read side (#392): projects the daemon serves come from the
@@ -38,9 +38,10 @@ export interface SummarizeDeps {
 async function readAllRuns(path: string): Promise<RunMeta[]> {
   const [archived, live] = await Promise.all([
     listRuns(path).catch(() => [] as RunMeta[]),
-    readLiveMeta(path).catch(() => undefined),
+    readLiveMetas(path).catch(() => [] as LiveRun[]),
   ])
-  return live ? [live, ...archived] : archived
+  // Dedup by id like every other reader: a live run that has since been archived is one run.
+  return [...live.filter(run => !archived.some(r => r.id === run.id)), ...archived]
 }
 
 /**

--- a/packages/framework/src/store/index.ts
+++ b/packages/framework/src/store/index.ts
@@ -7,15 +7,18 @@ export {
   readLiveMeta,
   reconcileOrphanedRuns,
   loadRunEvents,
+  readLiveMetas,
   runIdFromStartedAt,
   isSafeRunId,
   FRAMEWORK_DIR,
+  WORKTREES_DIR,
   EVENTS_FILE,
   META_FILE,
   RUNS_DIR,
   RUN_META_VERSION,
   type StoreFs,
   type RunMeta,
+  type LiveRun,
   type RunStatus,
   type OpenStoreOptions,
 } from './run-store.js'
@@ -29,9 +32,14 @@ export {
   runBranchName,
   currentBranch,
   renameRunBranch,
-  WORKTREES_DIR,
   type WorktreeInfo,
   type AddWorktreeOptions,
   type AddedWorktree,
 } from './worktree.js'
-export { linkDependencies, findDependencyDirs, nodeLinkFs, type LinkFs } from './worktree-deps.js'
+export {
+  linkDependencies,
+  excludeDependencyLinks,
+  findDependencyDirs,
+  nodeLinkFs,
+  type LinkFs,
+} from './worktree-deps.js'

--- a/packages/framework/src/store/run-store.test.ts
+++ b/packages/framework/src/store/run-store.test.ts
@@ -8,6 +8,7 @@ import {
   metaFromEvents,
   listRuns,
   readLiveMeta,
+  readLiveMetas,
   reconcileOrphanedRuns,
   loadRunEvents,
   runIdFromStartedAt,
@@ -40,13 +41,16 @@ function memFs(seed: Record<string, string> = {}): StoreFs & { files: Map<string
       // no-op: the memory fs has no directories
     },
     async readdir(dir) {
-      // Derive children from the flat path map: basenames whose dirname is `dir`.
+      // Derive children from the flat path map: file basenames whose dirname is `dir`, plus
+      // the first segment of anything deeper (the real fs lists subdirectories too, which is
+      // how `readLiveMetas` finds the per-run worktrees).
       const prefix = dir.endsWith('/') ? dir : dir + '/'
       const names = new Set<string>()
       for (const p of files.keys()) {
         if (!p.startsWith(prefix)) continue
         const rest = p.slice(prefix.length)
-        if (!rest.includes('/')) names.add(rest)
+        const head = rest.split('/')[0]
+        if (head) names.add(head)
       }
       return [...names]
     },
@@ -347,4 +351,52 @@ test('fresh open adopts the id the daemon allocated, ignoring an unsafe one (#73
   // A traversal-shaped id is dropped for the derived one: the id names a directory.
   const unsafe = await RunStore.open(CWD, { fs: memFs(), fresh: true, now: AT, id: '../evil' })
   assert.equal((await unsafe.readMeta())?.id, runIdFromStartedAt(AT))
+})
+
+// #738: since #736 a run lives in its own worktree, so a project's live runs are spread across
+// `.the-framework/worktrees/*` rather than sitting at the project path.
+const worktreeMeta = (runId: string, over: Partial<RunMeta> = {}): string =>
+  JSON.stringify({ version: 1, status: 'running', id: runId, startedAt: AT, updatedAt: AT, passes: 0, ...over })
+
+test('readLiveMetas finds a run living in each worktree, newest first (#738)', async () => {
+  const fs = memFs({
+    [join(CWD, '.the-framework', 'worktrees', 'r1', '.the-framework', 'run.json')]: worktreeMeta('r1'),
+    [join(CWD, '.the-framework', 'worktrees', 'r2', '.the-framework', 'run.json')]: worktreeMeta('r2'),
+  })
+  const runs = await readLiveMetas(CWD, fs)
+  assert.deepEqual(
+    runs.map(r => ({ id: r.id, cwd: r.cwd })),
+    [
+      { id: 'r2', cwd: join(CWD, '.the-framework', 'worktrees', 'r2') },
+      { id: 'r1', cwd: join(CWD, '.the-framework', 'worktrees', 'r1') },
+    ],
+    'both runs, newest id first, each carrying its own checkout',
+  )
+})
+
+test('readLiveMetas also returns a run at the project root (the non-git fallback, and pre-#736 runs)', async () => {
+  const fs = memFs({
+    [META]: worktreeMeta('root-run'),
+    [join(CWD, '.the-framework', 'worktrees', 'r1', '.the-framework', 'run.json')]: worktreeMeta('r1'),
+  })
+  const runs = await readLiveMetas(CWD, fs)
+  assert.deepEqual(runs.map(r => r.id).sort(), ['r1', 'root-run'])
+  assert.equal(runs.find(r => r.id === 'root-run')?.cwd, CWD, 'the root run reports the repo itself')
+})
+
+test('readLiveMetas is empty on a project that never ran, and skips a junk worktree name', async () => {
+  assert.deepEqual(await readLiveMetas(CWD, memFs()), [])
+  // Only our own `<runId>` directories are read; anything else in there is not a run of ours.
+  const fs = memFs({
+    [join(CWD, '.the-framework', 'worktrees', '.tmp-scratch', '.the-framework', 'run.json')]: worktreeMeta('x'),
+  })
+  assert.deepEqual(await readLiveMetas(CWD, fs), [])
+})
+
+test('readLiveMetas self-heals a dead run in a worktree, same as the single reader (#716)', async () => {
+  const path = join(CWD, '.the-framework', 'worktrees', 'r1', '.the-framework', 'run.json')
+  const fs = memFs({ [path]: worktreeMeta('r1', { pid: 999999, host: hostname() }) })
+  const runs = await readLiveMetas(CWD, fs, () => false)
+  assert.equal(runs[0]?.status, 'stopped', 'a running meta whose process is gone reads as stopped')
+  assert.equal((JSON.parse(fs.files.get(path)!) as RunMeta).status, 'stopped', 'and is healed on disk')
 })

--- a/packages/framework/src/store/run-store.ts
+++ b/packages/framework/src/store/run-store.ts
@@ -21,6 +21,15 @@ import { nodeFs } from '../node-fs.js'
  */
 export const FRAMEWORK_DIR = '.the-framework'
 
+/**
+ * Per-run worktrees live under `<repo>/.the-framework/worktrees/` (#736). Kept out of git by
+ * the install-time `.the-framework/.gitignore` (`*` rule, #313), so a worktree's checkout never
+ * shows up as dirty in the parent. Declared here beside {@link FRAMEWORK_DIR} rather than in
+ * `worktree.ts`, which imports from this module: {@link readLiveMetas} needs it to find the
+ * runs living in those worktrees, and the other direction would be an import cycle.
+ */
+export const WORKTREES_DIR = 'worktrees'
+
 /** The append-only event log: one {@link FrameworkEvent} per line (JSONL). */
 export const EVENTS_FILE = 'events.jsonl'
 
@@ -499,6 +508,45 @@ export async function readLiveMeta(
     return stopped
   }
   return meta
+}
+
+/**
+ * A live run plus the checkout it is running in (#738). Since #736 a run lives in its own
+ * worktree, so a project's live run is no longer a single thing and no longer sits at the
+ * project path: `cwd` says which checkout to read that run's git/file status from.
+ */
+export interface LiveRun extends RunMeta {
+  /** The run's own checkout: a worktree under `.the-framework/worktrees/`, or the repo root. */
+  cwd: string
+}
+
+/**
+ * Every live run of a project (#738): the list variant of {@link readLiveMeta}.
+ *
+ * A run started from the dashboard gets its own worktree (#736) and writes its `run.json`
+ * inside it, so the project path alone no longer sees any of them. This looks in both places:
+ * each `.the-framework/worktrees/*` checkout, and the repo root itself, which is where a
+ * project that cannot be given a worktree (not a git repo) still runs and where every run
+ * from before #736 lives.
+ *
+ * Each candidate goes through {@link readLiveMeta}, so a stale run self-heals exactly as it
+ * did. Newest first, by id. Never throws: an unreadable worktree is skipped.
+ */
+export async function readLiveMetas(
+  cwd: string,
+  fs: StoreFs = nodeStoreFs(),
+  isAlive: (pid: number) => boolean = isPidAlive,
+): Promise<LiveRun[]> {
+  const worktreesDir = join(cwd, FRAMEWORK_DIR, WORKTREES_DIR)
+  const names = await fs.readdir(worktreesDir).catch(() => [])
+  // isSafeRunId: the directory name is the run id, and anything else in there is not ours.
+  const candidates = [cwd, ...names.filter(isSafeRunId).map(name => join(worktreesDir, name))]
+  const runs: LiveRun[] = []
+  for (const candidate of candidates) {
+    const meta = await readLiveMeta(candidate, fs, isAlive).catch(() => undefined)
+    if (meta) runs.push({ ...meta, cwd: candidate })
+  }
+  return runs.sort((a, b) => (a.id < b.id ? 1 : a.id > b.id ? -1 : 0))
 }
 
 /**

--- a/packages/framework/src/store/worktree-deps.test.ts
+++ b/packages/framework/src/store/worktree-deps.test.ts
@@ -3,7 +3,9 @@ import { test } from 'node:test'
 import { join } from 'node:path'
 import { mkdtemp, rm, mkdir, writeFile, readFile, lstat, realpath } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { findDependencyDirs, linkDependencies, nodeLinkFs, type LinkFs } from './index.js'
+import { findDependencyDirs, linkDependencies, excludeDependencyLinks, nodeLinkFs, type LinkFs } from './index.js'
+import { nodeFs } from '../node-fs.js'
+import { nodeGitRunner } from '../project.js'
 
 /** A {@link LinkFs} over an in-memory set of directory paths, recording the links made. */
 function fakeFs(dirs: string[]): LinkFs & { links: { target: string; path: string }[] } {
@@ -114,6 +116,45 @@ test('linkDependencies gives a real worktree a working dependency tree', async (
 
     // Idempotent: a second call over the same worktree links nothing new.
     assert.deepEqual(await linkDependencies(repo, wt, nodeLinkFs()), [])
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+// The regression this guards: `.gitignore` says `node_modules/`, which matches a directory and
+// NOT the symlink we create, so without an exclude the run's `git add -A` commits dangling
+// absolute symlinks onto its branch. Exercised against real git, since the whole claim is about
+// what git actually ignores.
+test('excludeDependencyLinks makes git ignore the linked trees in a worktree (#738)', async () => {
+  const git = nodeGitRunner()
+  const root = await realpath(await mkdtemp(join(tmpdir(), 'framework-deps-git-')))
+  const repo = join(root, 'repo')
+  try {
+    await mkdir(join(repo, 'node_modules', 'dep'), { recursive: true })
+    await git(['init'], repo)
+    await git(['config', 'user.email', 't@t'], repo)
+    await git(['config', 'user.name', 't'], repo)
+    await writeFile(join(repo, '.gitignore'), 'node_modules/\n')
+    await writeFile(join(repo, 'README.md'), '# t\n')
+    await git(['add', '-A'], repo)
+    await git(['commit', '-m', 'init'], repo)
+
+    const wt = join(root, 'wt')
+    await git(['worktree', 'add', wt, '-b', 'the-framework/run-1'], repo)
+    await linkDependencies(repo, wt, nodeLinkFs())
+    assert.equal(
+      (await git(['status', '--porcelain'], wt)).includes('node_modules'),
+      true,
+      'the plain .gitignore rule does not cover the symlink',
+    )
+
+    await excludeDependencyLinks(repo, nodeFs(), git)
+    assert.equal((await git(['status', '--porcelain'], wt)).trim(), '', 'the worktree is clean once excluded')
+
+    // Idempotent: a second run over the same repo must not append the rule again.
+    await excludeDependencyLinks(repo, nodeFs(), git)
+    const exclude = await readFile(join(repo, '.git', 'info', 'exclude'), 'utf8')
+    assert.equal(exclude.split('\n').filter(l => l.trim() === 'node_modules').length, 1)
   } finally {
     await rm(root, { recursive: true, force: true })
   }

--- a/packages/framework/src/store/worktree-deps.ts
+++ b/packages/framework/src/store/worktree-deps.ts
@@ -1,4 +1,6 @@
-import { join, relative } from 'node:path'
+import { join, relative, isAbsolute } from 'node:path'
+import { nodeFs, type NodeFs } from '../node-fs.js'
+import { nodeGitRunner, type GitRunner } from '../project.js'
 import { FRAMEWORK_DIR } from './run-store.js'
 
 /**
@@ -109,4 +111,42 @@ export async function linkDependencies(repo: string, worktree: string, fs: LinkF
     }
   }
   return linked
+}
+
+/** The exclude rule that covers a linked tree. Deliberately slash-free: see below. */
+const EXCLUDE_RULE = NODE_MODULES
+
+/**
+ * Make git ignore the dependency links (#738). A repo's `.gitignore` says `node_modules/`, and
+ * a trailing slash matches a *directory* only — the links {@link linkDependencies} makes are
+ * symlinks, so they are not covered, and they show up as untracked in every run's worktree.
+ * That is not cosmetic: the agent runs `git add -A`, so the run would commit dangling absolute
+ * symlinks into its branch and onto the PR.
+ *
+ * The rule goes in the repository's `info/exclude` rather than a worktree-local file because
+ * git resolves excludes from the *common* git dir, so a per-worktree copy is never read (a
+ * detail worth pinning: the per-worktree path looks right and silently does nothing). Writing
+ * a slash-free `node_modules` there covers the symlink form in every worktree. Idempotent, and
+ * the main checkout is unaffected in practice: its `node_modules` is a real directory, already
+ * ignored by the same name.
+ *
+ * Best-effort: a run whose links are merely untracked is still a run.
+ */
+export async function excludeDependencyLinks(
+  repo: string,
+  fs: NodeFs = nodeFs(),
+  run: GitRunner = nodeGitRunner(),
+): Promise<void> {
+  try {
+    const common = (await run(['rev-parse', '--git-common-dir'], repo)).trim()
+    if (!common) return
+    const infoDir = join(isAbsolute(common) ? common : join(repo, common), 'info')
+    const path = join(infoDir, 'exclude')
+    const current = await fs.read(path).catch(() => '')
+    if (current.split('\n').some(line => line.trim() === EXCLUDE_RULE)) return
+    await fs.mkdir(infoDir)
+    await fs.append(path, (current && !current.endsWith('\n') ? '\n' : '') + EXCLUDE_RULE + '\n')
+  } catch {
+    // Not a repo, or an unwritable git dir: the links just stay visible to git status.
+  }
 }

--- a/packages/framework/src/store/worktree.ts
+++ b/packages/framework/src/store/worktree.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path'
 import { nodeGitRunner, type GitRunner } from '../project.js'
-import { FRAMEWORK_DIR, isSafeRunId } from './run-store.js'
+import { FRAMEWORK_DIR, WORKTREES_DIR, isSafeRunId } from './run-store.js'
 
 /**
  * Git-worktree lifecycle for concurrent runs (#453/#735): give each run its own
@@ -9,11 +9,6 @@ import { FRAMEWORK_DIR, isSafeRunId } from './run-store.js'
  * dashboard changes (those are the sibling #453 slices). This module only knows
  * how to add, list, remove, and prune worktrees.
  */
-
-/** Per-run worktrees live under `<repo>/.the-framework/worktrees/`. Already kept
- *  out of git by the install-time `.the-framework/.gitignore` (`*` rule, #313), so
- *  a worktree's checkout never shows up as dirty in the parent. */
-export const WORKTREES_DIR = 'worktrees'
 
 /** The path a run's worktree gets: `<repo>/.the-framework/worktrees/<runId>`. */
 export function worktreePath(repo: string, runId: string): string {


### PR DESCRIPTION
Closes #738.

Since #736 each run lives in its own worktree and writes its `run.json` there, so `readLiveMeta(projectPath)` sees none of them. As of that merge the dashboard is blind to every dashboard-started run: the Runs rail, the "working now" list, the awaiting-you queue, the activity feed and the project summaries all read one live run from the project path, and it is no longer there. This restores them.

## What changed

- **`readLiveMetas(cwd)`** in the store: discovers the live run in each `.the-framework/worktrees/*` checkout, plus the project root (the non-git fallback path from #736, and every pre-#736 run). Each result is a `LiveRun` = `RunMeta` + the `cwd` of the checkout that run is editing. Stale runs self-heal exactly as `readLiveMeta` did, because each candidate goes through it.
- **All five readers aggregate**: `onRuns`, `buildOverview`, `buildInterventions`, `buildActivity`, `summarizeProject`. `ActiveRun` and an `awaiting` `Intervention` now carry a `runId`, so two concurrent runs of one project can be told apart.
- **Per-run git/file status**: `onGitStatus`, `onProjectFileStatus` and `onProjectFiles` take an optional `runId` and read that run's worktree. Without it they behave exactly as before, so no caller has to change.
- **Two UI fixes**: the "working now" list keyed rows by `projectId` alone, which is a duplicate React key once a project has two live runs; and following live highlighted every running row at once rather than the newest.

## A #736 bug fixed on the way

A repo's `.gitignore` says `node_modules/`. A trailing slash matches a **directory**, not the symlink #736 puts in each worktree, so the linked trees were untracked in every run's checkout. That is not cosmetic: the agent runs `git add -A`, so a run would commit dangling absolute symlinks onto its branch and into its PR.

The rule now goes into the repository's `info/exclude`. Worth pinning, because the obvious alternative silently does nothing: git resolves excludes from the **common** git dir, so a per-worktree `info/exclude` is never read. The test asserts the real `git status` in a real worktree, before and after.

## Still broken after this, and not in scope here

The live **event stream and the control channel are still project-scoped**, and they have the same #736 problem this PR fixes for run meta:

- `onEvents(projectId)` tails the *project's* `events.jsonl`, but a worktree run writes to its own. So the run view renders an empty feed, and selecting run A vs run B shows the same thing either way.
- `sendStop` / `sendMessage` / `sendChoice` are `(projectId)`-addressed and append to the project's `control.jsonl`, while the run tails the one in its worktree. So Stop, mid-run messages and choice picks do not reach a worktree run.

That needs run-addressed channels (`onEvents(projectId, runId)`, control entries carrying a run id) plus the UI passing the selected run through. I would rather file that as its own #453 sub-issue than bolt it onto this one. Flagging clearly because until it lands, a dashboard-started run is visible but not watchable or steerable.

## Tests

5 new, 673 total, all green here (framework), plus 105 green in framework-dashboard.
