### PR TITLE
feat(framework): address the event stream and control channel by run (#749)

### DIFF
--- a/.changeset/feat-749-run-addressed-events-control.md
+++ b/.changeset/feat-749-run-addressed-events-control.md
@@ -1,0 +1,9 @@
+---
+"@gemstack/framework": minor
+---
+
+Watch and steer a run in its own worktree (#749). #738 made concurrent runs visible; they were still not watchable or steerable, because the live event stream and the control channel were addressed by project while a run reads and writes inside its worktree (#736). The feed for a worktree run was therefore empty, and Stop, mid-run messages and choice picks were written to a log nothing was tailing.
+
+`onEvents` now takes an optional run id and tails that run's own `events.jsonl`, so selecting one run or another shows that run's output rather than the same empty feed. `sendStop`, `sendMessage` and `sendChoice` take the run id too and append to that run's `control.jsonl`, which is the file the run tails. Both resolve through the shared `resolveRunPath`, so an unknown or finished run id falls back to the project root, and omitting the id keeps the pre-#736 behavior for a run that has no worktree.
+
+The dashboard threads the selected run through the feed subscription and every steering control, and resubscribes when you switch runs.

--- a/packages/framework-dashboard/components/ChoicePanel.tsx
+++ b/packages/framework-dashboard/components/ChoicePanel.tsx
@@ -15,10 +15,13 @@ import { cn } from '../lib/utils.js'
 // `active` (the first gate in the right rail, #440) binds Ctrl+Enter to Accept.
 export function ChoicePanel({
   projectId,
+  runId,
   choice,
   active = false,
 }: {
   projectId: string
+  /** Which run the pick resolves (#749); absent falls back to the project's control log. */
+  runId?: string | null | undefined
   choice: ChoiceRequest
   active?: boolean
 }) {
@@ -34,7 +37,7 @@ export function ChoicePanel({
   const post = (pick: string | string[], by: 'user' | 'autopilot' = 'user') => {
     setBusy(true)
     setError(null)
-    void sendChoice(projectId, choice.id, pick, by).catch(() => {
+    void sendChoice(projectId, choice.id, pick, by, runId ?? undefined).catch(() => {
       setBusy(false)
       setError('Could not send your choice — try again.')
     })

--- a/packages/framework-dashboard/components/ChoicesRail.tsx
+++ b/packages/framework-dashboard/components/ChoicesRail.tsx
@@ -7,7 +7,16 @@ import { ChoicePanel } from './ChoicePanel.js'
 // top-nav jumps between the sets; the first (topmost) gate is `active`, so Ctrl+Enter
 // accepts it unambiguously. Gates clear themselves as their `choice-resolved` events stream
 // in (pendingChoices drops them); an empty list means there is nothing to decide right now.
-export function ChoicesRail({ projectId, choices }: { projectId: string; choices: ChoiceRequest[] }) {
+export function ChoicesRail({
+  projectId,
+  runId,
+  choices,
+}: {
+  projectId: string
+  /** Which run the picks resolve (#749), forwarded to each panel. */
+  runId?: string | null | undefined
+  choices: ChoiceRequest[]
+}) {
   const scroller = useRef<HTMLDivElement>(null)
   const panels = useRef(new Map<string, HTMLDivElement>())
 
@@ -43,7 +52,7 @@ export function ChoicesRail({ projectId, choices }: { projectId: string; choices
               else panels.current.delete(c.id)
             }}
           >
-            <ChoicePanel projectId={projectId} choice={c} active={i === 0} />
+            <ChoicePanel projectId={projectId} runId={runId} choice={c} active={i === 0} />
           </div>
         ))}
       </div>

--- a/packages/framework-dashboard/components/RightRail.tsx
+++ b/packages/framework-dashboard/components/RightRail.tsx
@@ -19,6 +19,7 @@ type Tab = 'files' | 'choices' | 'views' | 'docs' | 'log'
 // jumps to whatever the run most wants seen: a choice gate first, else a fresh view.
 export function RightRail({
   projectId,
+  runId,
   choices,
   views,
   files,
@@ -26,6 +27,8 @@ export function RightRail({
   toggleContext,
 }: {
   projectId: string | null
+  /** The selected run, so a choice pick resolves that run's gate (#749). */
+  runId?: string | null | undefined
   choices: ChoiceRequest[]
   views: AgentView[]
   /** The project's files for the Files tab tree (#492); empty on the relay. */
@@ -100,7 +103,7 @@ export function RightRail({
         {tab === 'files' && hasFiles ? (
           <FileTree projectId={projectId} files={files} selected={context} onToggle={toggleContext} />
         ) : tab === 'choices' && hasChoices ? (
-          <ChoicesRail projectId={projectId} choices={choices} />
+          <ChoicesRail projectId={projectId} runId={runId} choices={choices} />
         ) : tab === 'views' && hasViews ? (
           <ViewsRail views={views} />
         ) : tab === 'log' ? (

--- a/packages/framework-dashboard/components/RunActionBar.tsx
+++ b/packages/framework-dashboard/components/RunActionBar.tsx
@@ -14,7 +14,16 @@ import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './ui/t
 // finished replay (RunReplay), so the controls stay put when a run reaches Done. Serve is a
 // project-level action (always available); Stop shows only while the run is active; Open session
 // appears once the run has reported one (honestly labeled — see describeSessionLink).
-export function RunActionBar({ projectId, events }: { projectId: string; events: FrameworkEvent[] }) {
+export function RunActionBar({
+  projectId,
+  runId,
+  events,
+}: {
+  projectId: string
+  /** Which run Stop addresses (#749); absent falls back to the project's own control log. */
+  runId?: string | null | undefined
+  events: FrameworkEvent[]
+}) {
   // Stop routes through useAction like every other mutation: a click disables + shows "Stopping…"
   // and a failed stop surfaces instead of silently doing nothing.
   const { busy, error, run } = useAction()
@@ -36,7 +45,7 @@ export function RunActionBar({ projectId, events }: { projectId: string; events:
                   variant="outline"
                   size="icon-sm"
                   disabled={busy}
-                  onClick={() => void run(() => sendStop(projectId), 'Could not stop the run.')}
+                  onClick={() => void run(() => sendStop(projectId, runId ?? undefined), 'Could not stop the run.')}
                 />
               }
             >

--- a/packages/framework-dashboard/components/RunChat.tsx
+++ b/packages/framework-dashboard/components/RunChat.tsx
@@ -10,10 +10,13 @@ import { sendMessage } from '../server/control.telefunc.js'
 // Only rendered inside RunLive, i.e. while the run is running — a finished run replays without it.
 export function RunChat({
   projectId,
+  runId,
   files,
   addContext,
 }: {
   projectId: string
+  /** Which run the message goes to (#749); absent falls back to the project's control log. */
+  runId?: string | null | undefined
   /** The project's files for the `#` picker (#504), owned by the shell. */
   files: string[]
   /** Add a path to the run Context (from an `@`/`#` mention). */
@@ -26,7 +29,7 @@ export function RunChat({
     if (sending) return
     setSending(true)
     try {
-      await sendMessage(projectId, text)
+      await sendMessage(projectId, text, runId ?? undefined)
       composerRef.current?.clear()
     } catch {
       // Leave the text in place so the user can retry; the run may have just ended.

--- a/packages/framework-dashboard/components/RunLive.tsx
+++ b/packages/framework-dashboard/components/RunLive.tsx
@@ -6,26 +6,29 @@ import { RunFeed } from './RunFeed.js'
 // One running run's own view (its output): the action bar (Serve · Stop · Open session), the run
 // overview + live event feed from the shared Telefunc Channel, and the chat composer to send it
 // more messages (#714). Distinct from the home launcher (ProjectHome) and a finished run's replay
-// (RunReplay, which has no composer). Single-run today streams the project's one live feed; per-run
-// streams arrive with worktrees (#453). The session link lives in the action bar now, so the feed's
+// (RunReplay, which has no composer). The feed and every steering call are addressed by run id
+// (#749), so this is one run's view even when the project has others live. The session link lives in the action bar now, so the feed's
 // overview drops it (`showSessionLink={false}`). `files`/`addContext` flow through to RunChat's
 // shared Composer for the `#`/`@` pickers (#721).
 export function RunLive({
   projectId,
+  runId,
   events,
   files,
   addContext,
 }: {
   projectId: string
+  /** Which run to steer (#749); absent right after Start, before the poll adopts its id. */
+  runId?: string | null | undefined
   events: FrameworkEvent[]
   files: string[]
   addContext: (path: string) => void
 }) {
   return (
     <>
-      <RunActionBar projectId={projectId} events={events} />
+      <RunActionBar projectId={projectId} runId={runId} events={events} />
       <RunFeed events={events} showSessionLink={false} />
-      <RunChat projectId={projectId} files={files} addContext={addContext} />
+      <RunChat projectId={projectId} runId={runId} files={files} addContext={addContext} />
     </>
   )
 }

--- a/packages/framework-dashboard/lib/use-live-events.ts
+++ b/packages/framework-dashboard/lib/use-live-events.ts
@@ -8,8 +8,13 @@ import { currentRunEvents } from './live-state.js'
 // `.the-framework/events.jsonl`, streamed over a Telefunc Channel that pushes one
 // `FrameworkEvent` per new line. Both the main event view and the right rail's choice gates
 // (#440) read this same stream, so the subscription lives here and each consumer owns one
-// channel for its project rather than opening a second.
-export function useLiveEvents(projectId: string | null, resetKey?: unknown): FrameworkEvent[] {
+// channel rather than opening a second.
+//
+// The feed is per RUN, not per project (#749): each run tails its own worktree's log since #736,
+// so the selected run id picks the log to follow. Changing it resubscribes, which is what makes
+// selecting run A vs run B show different output. Omitted (the relay, or a Start whose id has not
+// been adopted yet) falls back to the project root.
+export function useLiveEvents(projectId: string | null, runId?: string | null, resetKey?: unknown): FrameworkEvent[] {
   const [events, setEvents] = useState<FrameworkEvent[]>([])
 
   // Drop the accumulated feed at a run boundary the caller knows about (a fresh Start bumps
@@ -27,7 +32,7 @@ export function useLiveEvents(projectId: string | null, resetKey?: unknown): Fra
     if (!projectId) return
     let channel: ClientChannel<never, FrameworkEvent> | undefined
     let cancelled = false
-    void onEvents(projectId).then(ch => {
+    void onEvents(projectId, runId ?? undefined).then(ch => {
       if (cancelled) {
         void ch.close()
         return
@@ -39,7 +44,8 @@ export function useLiveEvents(projectId: string | null, resetKey?: unknown): Fra
       cancelled = true
       void channel?.close()
     }
-  }, [projectId])
+    // runId is a dependency: selecting another run must resubscribe to that run's log (#749).
+  }, [projectId, runId])
 
   // Scope the accumulated feed to the run in progress. The subscription lives across run
   // boundaries (it only resets on a project switch), so without this a second run would show

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -145,7 +145,7 @@ export default function Page() {
 
   // The live run feed is owned here so both the main view and the right rail's choice gates
   // (#440) read one shared Telefunc Channel. Hooks run before the relay early return below.
-  const events = useLiveEvents(projectId, runStart.tick)
+  const events = useLiveEvents(projectId, runId, runStart.tick)
   const choices = projectId ? pendingChoices(events) : []
   const views = projectId ? agentViews(events) : []
 
@@ -157,8 +157,8 @@ export default function Page() {
   if (relayRun) return <RelayView runId={relayRun} />
 
   // Route the main pane: the Overview dashboard when no project is selected (#471); else the
-  // project home/launcher, a running run's live output, or a finished run's replay. (One
-  // project streams one live feed today; per-run streams land with worktrees, #453.)
+  // project home/launcher, a running run's live output, or a finished run's replay. Each live
+  // run streams its own feed and is steered by its own id (#749).
   const selectedRun = runId ? runs.find(run => run.id === runId) : undefined
   const renderMain = () => {
     if (!projectId) return <DashboardPage onSelectProject={selectProject} interventions={interventions} />
@@ -177,7 +177,8 @@ export default function Page() {
         />
       )
     }
-    if (selectedRun?.status === 'running') return <RunLive projectId={projectId} events={events} files={files} addContext={addContext} />
+    if (selectedRun?.status === 'running')
+      return <RunLive projectId={projectId} runId={runId} events={events} files={files} addContext={addContext} />
     return <RunReplay projectId={projectId} runId={runId} files={files} addContext={addContext} onRunStarted={onRunStarted} />
   }
 
@@ -221,6 +222,7 @@ export default function Page() {
         <main className="flex min-w-0 flex-1 flex-col">{renderMain()}</main>
         <RightRail
           projectId={projectId}
+          runId={runId}
           choices={choices}
           views={views}
           files={files}

--- a/packages/framework/src/dashboard-rpc/context.ts
+++ b/packages/framework/src/dashboard-rpc/context.ts
@@ -1,4 +1,5 @@
 import { getContext } from 'telefunc'
+import { readLiveMetas } from '../store/index.js'
 import { defaultProjectsProvider, type ProjectsProvider } from '../dashboard/projects.js'
 import type { DashboardContext, EventsSource } from '../dashboard/telefunc-serve.js'
 import type { PreferencesStore } from '../registry.js'
@@ -32,6 +33,22 @@ export function contextProjects(): ProjectsProvider {
 /** The workspace path for a project id (registry, or single-project #427), else undefined. */
 export function resolveProjectPath(projectId: string): Promise<string | undefined> {
   return contextProjects().resolvePath(projectId)
+}
+
+/**
+ * The checkout a call should act on: a live run's own worktree when `runId` names one (#738/#749),
+ * else the project root. Since #736 a run reads and writes inside its worktree — its event log,
+ * its control log, its working tree — so anything addressed at a *run* has to resolve here, not
+ * at the project path, or it reads an empty log and steers a run that is not listening.
+ *
+ * An unknown or finished `runId` falls back to the project root rather than failing: the run's
+ * worktree may already be gone, and the project's own state is still the sane thing to act on.
+ */
+export async function resolveRunPath(projectId: string, runId?: string): Promise<string | undefined> {
+  const cwd = await resolveProjectPath(projectId)
+  if (!cwd || !runId) return cwd
+  const live = await readLiveMetas(cwd).catch(() => [])
+  return live.find(run => run.id === runId)?.cwd ?? cwd
 }
 
 /**

--- a/packages/framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/control.telefunc.ts
@@ -1,7 +1,7 @@
 import { getContext } from 'telefunc'
 import { appendControl, type ControlEntry } from '../control.js'
 import { openInApp, type OpenTarget, type OpenResult } from '../dashboard/open-in-app.js'
-import { resolveProjectPath, contextPreferences } from './context.js'
+import { resolveProjectPath, resolveRunPath, contextPreferences } from './context.js'
 import type { ChoiceBy } from '../events.js'
 import type { PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from '../dashboard/types.js'
 import type { ServeTarget } from '../preview.js'
@@ -10,25 +10,29 @@ import type { Preferences } from '../registry.js'
 
 // The write side behind the new dashboard (#405): steering a live run. The reverse of
 // the event stream — events flow run -> events.jsonl -> Channel -> browser; steering
-// flows browser -> here -> the project's `.the-framework/control.jsonl` -> run, which
-// tails that file and aborts or resolves its gate. Same file-is-the-seam design as the
-// daemon's legacy onStop/onChoice (#344/#393), so any live run in the project is
-// steerable. (Starting a run needs a spawn + the daemon's busy guard, so `sendStart`
+// flows browser -> here -> the run's `.the-framework/control.jsonl` -> run, which tails that
+// file and aborts or resolves its gate. Same file-is-the-seam design as the daemon's legacy
+// onStop/onChoice (#344/#393). Each steering call takes the run id (#749): a run tails the
+// log inside its own worktree since #736, so the entry has to be written there. (Starting a run needs a spawn + the daemon's busy guard, so `sendStart`
 // lands with the daemon-serves-the-bundle wiring, not here.)
 
 /**
- * Resolve the project's local path and append one steering entry to its `control.jsonl`.
- * A no-op when the project has no local path (the read-only relay), so the run channel is
- * only ever written by a host that owns the workspace.
+ * Resolve the checkout to steer and append one entry to its `control.jsonl`. A no-op when
+ * there is no local path (the read-only relay), so the run channel is only ever written by a
+ * host that owns the workspace.
+ *
+ * The `runId` is what makes steering land (#749): a run tails the control log inside its own
+ * worktree, so an entry written to the project root reaches nothing. Absent, it addresses the
+ * project root, which is still right for a run that has no worktree (the non-git fallback).
  */
-async function appendControlFor(projectId: string, entry: ControlEntry): Promise<void> {
-  const cwd = await resolveProjectPath(projectId)
+async function appendControlFor(projectId: string, entry: ControlEntry, runId?: string): Promise<void> {
+  const cwd = await resolveRunPath(projectId, runId)
   if (cwd) await appendControl(cwd, entry)
 }
 
-/** Stop the project's live run (the Stop button): append a stop entry to its control log. */
-export async function sendStop(projectId: string): Promise<void> {
-  await appendControlFor(projectId, { kind: 'stop' })
+/** Stop a live run (the Stop button): append a stop entry to the run's control log. */
+export async function sendStop(projectId: string, runId?: string): Promise<void> {
+  await appendControlFor(projectId, { kind: 'stop' }, runId)
 }
 
 /**
@@ -41,8 +45,9 @@ export async function sendChoice(
   id: string,
   pick: string | string[],
   by: ChoiceBy = 'user',
+  runId?: string,
 ): Promise<void> {
-  await appendControlFor(projectId, { kind: 'choice', id, pick, by })
+  await appendControlFor(projectId, { kind: 'choice', id, pick, by }, runId)
 }
 
 /**
@@ -50,10 +55,10 @@ export async function sendChoice(
  * that the run drains between turns, continuing the same session via `--resume`. Empty
  * messages are dropped.
  */
-export async function sendMessage(projectId: string, text: string): Promise<void> {
+export async function sendMessage(projectId: string, text: string, runId?: string): Promise<void> {
   const message = text.trim()
   if (!message) return
-  await appendControlFor(projectId, { kind: 'message', text: message })
+  await appendControlFor(projectId, { kind: 'message', text: message }, runId)
 }
 
 /**

--- a/packages/framework/src/dashboard-rpc/events.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/events.telefunc.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import type { ClientChannel } from 'telefunc'
 import { FRAMEWORK_DIR, EVENTS_FILE } from '../store/index.js'
-import { contextEventsSource, resolveProjectPath } from './context.js'
+import { contextEventsSource, resolveRunPath } from './context.js'
 import type { FrameworkEvent } from '../events.js'
 import { tailEvents } from './events-tail.js'
 import { forwardStream, streamChannel } from './stream-channel.js'
@@ -12,23 +12,31 @@ import { forwardStream, streamChannel } from './stream-channel.js'
 // Telefunc Channel — serialization, type validation, and reconnect come for free. Runs,
 // docs, and the project log come over the read-model RPCs (reads.telefunc.ts).
 
-/** The events file for a project id, or undefined when the project is unknown. */
-async function resolveEventsPath(projectId: string): Promise<string | undefined> {
-  const path = await resolveProjectPath(projectId)
+/**
+ * The events file to tail, or undefined when the project is unknown. With a `runId` this is
+ * that run's own log inside its worktree (#749): since #736 a run appends there, not to the
+ * project root, so streaming the project path would follow a file nothing writes to.
+ */
+async function resolveEventsPath(projectId: string, runId?: string): Promise<string | undefined> {
+  const path = await resolveRunPath(projectId, runId)
   return path ? join(path, FRAMEWORK_DIR, EVENTS_FILE) : undefined
 }
 
 /**
- * `onEvents(projectId)` returns a Channel that streams the project's live run: the
- * client `.listen()`s for `FrameworkEvent`s and `.close()`s to unsubscribe, which
- * stops the tail. An unknown project yields a channel that closes immediately
- * (mirrors the read model's empty results rather than throwing at the client).
+ * `onEvents(projectId, runId?)` returns a Channel that streams one live run: the client
+ * `.listen()`s for `FrameworkEvent`s and `.close()`s to unsubscribe, which stops the tail.
+ * An unknown project yields a channel that closes immediately (mirrors the read model's
+ * empty results rather than throwing at the client).
+ *
+ * Pass the `runId` to follow that run's own log (#749). A project has several concurrent
+ * runs since #736, each writing inside its worktree, so the run id is what makes the feed
+ * that run's rather than a mix — and without it the feed for a worktree run is empty.
+ * Omitting it keeps the pre-#736 behavior of tailing the project root.
  *
  * Two sources, chosen by the mount: the relay (#426) streams from an in-memory run on
- * the context; everywhere else there is no such source, so it tails the project's
- * `.the-framework/events.jsonl` on disk.
+ * the context; everywhere else there is no such source, so it tails the log on disk.
  */
-export async function onEvents(projectId: string): Promise<ClientChannel<never, FrameworkEvent>> {
+export async function onEvents(projectId: string, runId?: string): Promise<ClientChannel<never, FrameworkEvent>> {
   const source = contextEventsSource()
   if (source) {
     // The relay: replay + follow its in-memory run, mirroring how serveSSE consumes it.
@@ -37,7 +45,7 @@ export async function onEvents(projectId: string): Promise<ClientChannel<never, 
       return stream ? forwardStream(stream, send) : undefined
     })
   }
-  // Everywhere else: tail the project's on-disk events.jsonl (undefined path -> closed channel).
-  const path = await resolveEventsPath(projectId)
+  // Everywhere else: tail the run's on-disk events.jsonl (undefined path -> closed channel).
+  const path = await resolveEventsPath(projectId, runId)
   return streamChannel<FrameworkEvent>(send => (path ? tailEvents(path, send) : undefined))
 }

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -10,7 +10,7 @@ import { githubUrlFor } from '../dashboard/github.js'
 import { readGitStatus, type GitStatus } from '../dashboard/git-status.js'
 import { crawlRepoFiles } from '../project.js'
 import { readFileStatuses, type FileGitStatus } from '../dashboard/file-status.js'
-import { contextProjects, resolveProjectPath } from './context.js'
+import { contextProjects, resolveProjectPath, resolveRunPath } from './context.js'
 import type { FrameworkEvent } from '../events.js'
 
 // The read model behind the new dashboard (#405): the run history, a run's replay, the
@@ -30,22 +30,6 @@ import type { FrameworkEvent } from '../events.js'
 async function withProject<T>(projectId: string, read: (cwd: string) => Promise<T>, empty: T): Promise<T> {
   const cwd = await resolveProjectPath(projectId)
   return cwd ? read(cwd).catch(() => empty) : empty
-}
-
-/**
- * The checkout a read should target: a live run's own worktree when `runId` names one (#738),
- * else the project root. Since #736 a run edits its worktree, not the user's checkout, so the
- * branch / dirty flag / file dots shown beside a run have to come from there — asking the
- * project root would report the user's own working tree instead of the run's.
- *
- * An unknown or finished `runId` falls back to the project root rather than failing: the run's
- * worktree may already be gone, and the project's own status is still the sane thing to show.
- */
-async function resolveRunPath(projectId: string, runId?: string): Promise<string | undefined> {
-  const cwd = await resolveProjectPath(projectId)
-  if (!cwd || !runId) return cwd
-  const live = await readLiveMetas(cwd).catch(() => [])
-  return live.find(run => run.id === runId)?.cwd ?? cwd
 }
 
 /**

--- a/packages/framework/src/dashboard-rpc/run-addressing.test.ts
+++ b/packages/framework/src/dashboard-rpc/run-addressing.test.ts
@@ -1,0 +1,102 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { join } from 'node:path'
+import { mkdtemp, rm, mkdir, writeFile, readFile, realpath } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { sendStop, sendMessage, sendChoice } from './control.telefunc.js'
+import { addProject, projectId as idFor } from '../registry.js'
+import { FRAMEWORK_DIR, WORKTREES_DIR } from '../store/index.js'
+import { CONTROL_FILE } from '../control.js'
+
+// #749: a run tails the control log inside its own worktree (#736), so a steering call has to
+// resolve the RUN, not the project. Addressed at the project root, Stop / messages / choice picks
+// reach a file the run is not watching, which is why they silently did nothing.
+//
+// These run against the real registry, pointed at a temp $XDG_CONFIG_HOME so the user's own
+// registry is never touched.
+
+/** A project with one live run in a worktree. Returns its ids and the two candidate log paths. */
+async function projectWithWorktreeRun(): Promise<{
+  dir: string
+  projectId: string
+  runId: string
+  runControl: string
+  rootControl: string
+  restore: () => void
+}> {
+  const dir = await realpath(await mkdtemp(join(tmpdir(), 'framework-addressing-')))
+  const runId = '2026-07-19T10-00-00-000Z'
+  const worktree = join(dir, FRAMEWORK_DIR, WORKTREES_DIR, runId)
+  await mkdir(join(worktree, FRAMEWORK_DIR), { recursive: true })
+  // The live meta is what readLiveMetas discovers, and its id is what the caller addresses.
+  await writeFile(
+    join(worktree, FRAMEWORK_DIR, 'run.json'),
+    JSON.stringify({ version: 1, status: 'running', id: runId, startedAt: runId, updatedAt: runId, passes: 0 }),
+  )
+
+  const previous = process.env.XDG_CONFIG_HOME
+  process.env.XDG_CONFIG_HOME = join(dir, 'cfg')
+  await mkdir(process.env.XDG_CONFIG_HOME, { recursive: true })
+  await addProject(dir, new Date().toISOString())
+
+  return {
+    dir,
+    projectId: idFor(dir),
+    runId,
+    runControl: join(worktree, FRAMEWORK_DIR, CONTROL_FILE),
+    rootControl: join(dir, FRAMEWORK_DIR, CONTROL_FILE),
+    restore: () => {
+      if (previous === undefined) delete process.env.XDG_CONFIG_HOME
+      else process.env.XDG_CONFIG_HOME = previous
+    },
+  }
+}
+
+const entries = async (path: string): Promise<unknown[]> =>
+  (await readFile(path, 'utf8').catch(() => ''))
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line) as unknown)
+
+test('sendStop with a run id writes to that run worktree control log, not the project root (#749)', async () => {
+  const ctx = await projectWithWorktreeRun()
+  try {
+    await sendStop(ctx.projectId, ctx.runId)
+    assert.deepEqual(await entries(ctx.runControl), [{ kind: 'stop' }], 'the run gets the stop it is tailing for')
+    assert.deepEqual(await entries(ctx.rootControl), [], 'and nothing is written where nothing is listening')
+  } finally {
+    ctx.restore()
+    await rm(ctx.dir, { recursive: true, force: true })
+  }
+})
+
+test('sendMessage and sendChoice address the run too (#749)', async () => {
+  const ctx = await projectWithWorktreeRun()
+  try {
+    await sendMessage(ctx.projectId, 'also add tests', ctx.runId)
+    await sendChoice(ctx.projectId, 'gate-1', 'option-b', 'user', ctx.runId)
+    assert.deepEqual(await entries(ctx.runControl), [
+      { kind: 'message', text: 'also add tests' },
+      { kind: 'choice', id: 'gate-1', pick: 'option-b', by: 'user' },
+    ])
+    assert.deepEqual(await entries(ctx.rootControl), [])
+  } finally {
+    ctx.restore()
+    await rm(ctx.dir, { recursive: true, force: true })
+  }
+})
+
+test('an unknown or absent run id falls back to the project root, as before #736 (#749)', async () => {
+  const ctx = await projectWithWorktreeRun()
+  try {
+    // No run id at all: the pre-#736 addressing, still right for a run with no worktree.
+    await sendStop(ctx.projectId)
+    // A run that has since finished and had its worktree removed must not throw or vanish.
+    await sendStop(ctx.projectId, 'a-run-that-is-gone')
+    assert.deepEqual(await entries(ctx.rootControl), [{ kind: 'stop' }, { kind: 'stop' }])
+    assert.deepEqual(await entries(ctx.runControl), [], 'the live run is left alone')
+  } finally {
+    ctx.restore()
+    await rm(ctx.dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Closes #749.

#738 made concurrent runs visible. They were still not watchable or steerable: the live event stream and the control channel are addressed by project, while since #736 a run reads and writes inside its own worktree. So the feed for a worktree run was empty (and selecting run A vs run B showed the same nothing), and Stop, mid-run messages and choice picks were appended to a log no run was tailing.

## What changed

- **`onEvents(projectId, runId?)`** tails that run's own `events.jsonl`. The client resubscribes when the selected run changes, which is what makes A and B show different output.
- **`sendStop` / `sendMessage` / `sendChoice` take the run id** and append to that run's `control.jsonl`, which is the file the run actually tails. No protocol change was needed: control was already per-cwd, so this is purely an addressing fix.
- **`resolveRunPath` moved to `context.ts`** so the read side (#738) and the write side share one resolver. An unknown or finished run id falls back to the project root, and omitting the id keeps the pre-#736 behavior, which is still correct for a run with no worktree (the non-git fallback).
- **The UI threads the selected run** through the feed subscription, the action bar, the chat composer and the choice rail.

One thing that needed no change: `live-state.ts` slices the feed from the last `session` event and ends it on `end`. With a per-run feed those assumptions are now true rather than approximately true, so that logic is correct as written.

## Tests

3 new integration tests against the real registry (pointed at a temp `$XDG_CONFIG_HOME`), asserting that a steering call with a run id lands in the run's worktree log and that the project root stays empty, plus the fallback for an absent and a stale run id. 676 green in framework, 105 green in framework-dashboard.

Events go through the same `resolveRunPath` as control, so the control tests cover the shared resolution; what is not covered end-to-end is the Channel tail itself.

## The epic after this

#453 has one sub-issue left: #737, teardown and archiving, which still needs Rom's retention-on-failure call. Until it lands, worktrees accumulate and a finished run's history stays inside its worktree instead of the project.
