### PR TITLE
feat(framework): archive a run's history and retire its worktree (#737)

### DIFF
--- a/.changeset/feat-737-worktree-teardown-archive.md
+++ b/.changeset/feat-737-worktree-teardown-archive.md
@@ -1,0 +1,11 @@
+---
+"@gemstack/framework": minor
+---
+
+Retire a run's worktree when it finishes, keeping the ones worth looking at (#737). A run's history lives inside its worktree since #736, so it is now copied into the project's own `runs/` when the run ends, and only then is the checkout considered for removal.
+
+The retention rule: a run that finished cleanly has nothing left to inspect, so its worktree goes. A run that failed or was stopped keeps its checkout, because that is exactly when the half-finished working tree and the diff it died holding are worth seeing. Nothing is removed on a timer; a retained worktree goes when you remove it, via a Remove action on the finished run in the dashboard.
+
+A daemon that dies mid-run never runs that teardown, so the boot-time reconcile now sweeps the worktrees too: each orphaned run is flipped out of `running` and its history rescued into the project, with the checkout left on disk (a run that ended that way did not end cleanly).
+
+New surface: `archiveWorktreeRun` and `listWorktreeDirs` in the store, `onRetainedWorktrees` and `sendRemoveWorktree` as RPCs. Removal refuses while the run is still live, since Stop is how a run ends.

--- a/packages/framework-dashboard/components/RemoveWorktreeButton.tsx
+++ b/packages/framework-dashboard/components/RemoveWorktreeButton.tsx
@@ -1,0 +1,50 @@
+import { Trash2 } from 'lucide-react'
+import { sendRemoveWorktree } from '../server/control.telefunc.js'
+import { useAction } from '../lib/use-action.js'
+import { Button } from './ui/button.js'
+import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip.js'
+
+// Remove a retained worktree (#737). A run that failed or was stopped keeps its checkout so you
+// can go look at what it was holding when it died; nothing removes those on a timer, so this is
+// the way they go. Rendered only for a finished run that still has one, so its absence is the
+// signal that there is nothing on disk to clean up.
+//
+// It sits in the action bar rather than on the Runs rail row: a rail row IS a button (selecting
+// the run), and a button inside a button is invalid DOM. Same place you already reach for Serve
+// and Open session on a finished run, one click from the run you are inspecting.
+export function RemoveWorktreeButton({
+  projectId,
+  runId,
+  onRemoved,
+}: {
+  projectId: string
+  runId: string
+  /** Told after a successful removal, so the caller can drop the button. */
+  onRemoved: () => void
+}) {
+  const { busy, error, run } = useAction()
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="outline"
+            size="icon-sm"
+            disabled={busy}
+            onClick={() =>
+              void run(() => sendRemoveWorktree(projectId, runId), 'Could not remove the worktree.').then(
+                result => result !== undefined && onRemoved(),
+              )
+            }
+          />
+        }
+      >
+        <Trash2 className="h-3.5 w-3.5" />
+      </TooltipTrigger>
+      <TooltipContent>
+        {error ?? (busy ? 'Removing…' : "Remove this run's worktree (its history is already saved)")}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/packages/framework-dashboard/components/RunActionBar.tsx
+++ b/packages/framework-dashboard/components/RunActionBar.tsx
@@ -6,6 +6,7 @@ import { useAction } from '../lib/use-action.js'
 import { isRunActive } from '../lib/live-state.js'
 import { describeSessionLink } from '../lib/session-link.js'
 import { PreviewBar } from './PreviewBar.js'
+import { RemoveWorktreeButton } from './RemoveWorktreeButton.js'
 import { Button, buttonVariants } from './ui/button.js'
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './ui/tooltip.js'
 
@@ -13,16 +14,23 @@ import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './ui/t
 // tooltips, instead of three stacked labeled rows. Shared by the live view (RunLive) and the
 // finished replay (RunReplay), so the controls stay put when a run reaches Done. Serve is a
 // project-level action (always available); Stop shows only while the run is active; Open session
-// appears once the run has reported one (honestly labeled — see describeSessionLink).
+// appears once the run has reported one (honestly labeled — see describeSessionLink). A finished
+// run that kept its worktree (#737) also gets a Remove.
 export function RunActionBar({
   projectId,
   runId,
   events,
+  retainedWorktree = false,
+  onWorktreeRemoved,
 }: {
   projectId: string
   /** Which run Stop addresses (#749); absent falls back to the project's own control log. */
   runId?: string | null | undefined
   events: FrameworkEvent[]
+  /** True when this finished run still has a worktree on disk, so it can be removed (#737). */
+  retainedWorktree?: boolean
+  /** Told after that worktree is removed, so the button goes. */
+  onWorktreeRemoved?: () => void
 }) {
   // Stop routes through useAction like every other mutation: a click disables + shows "Stopping…"
   // and a failed stop surfaces instead of silently doing nothing.
@@ -53,6 +61,10 @@ export function RunActionBar({
             </TooltipTrigger>
             <TooltipContent>{busy ? 'Stopping…' : 'Stop run'}</TooltipContent>
           </Tooltip>
+        )}
+        {/* A retained worktree only exists for a finished run, so this never sits beside Stop. */}
+        {retainedWorktree && !active && runId && (
+          <RemoveWorktreeButton projectId={projectId} runId={runId} onRemoved={() => onWorktreeRemoved?.()} />
         )}
         {session && (
           <Tooltip>

--- a/packages/framework-dashboard/components/RunReplay.tsx
+++ b/packages/framework-dashboard/components/RunReplay.tsx
@@ -1,6 +1,7 @@
 import type { FrameworkEvent } from '@gemstack/framework'
 import { sessionInfo } from '@gemstack/framework/client'
-import { onRun } from '../server/reads.telefunc.js'
+import { useCallback, useState } from 'react'
+import { onRun, onRetainedWorktrees } from '../server/reads.telefunc.js'
 import { EventList } from './EventList.js'
 import { RunActionBar } from './RunActionBar.js'
 import { RunResumeChat } from './RunResumeChat.js'
@@ -26,6 +27,12 @@ export function RunReplay({
 }) {
   // null until the first answer: "Loading run…" and "no events" are different things.
   const events = useLoaded<FrameworkEvent[] | null>(() => onRun(projectId, runId), null, [projectId, runId])
+  // Whether this run kept its worktree (#737): a failed/stopped run does, a clean one had it
+  // removed when it finished. Drives the Remove button, and is cleared locally once removed so
+  // the button goes without waiting for a refetch.
+  const retained = useLoaded<string[]>(() => onRetainedWorktrees(projectId), [], [projectId, runId])
+  const [removed, setRemoved] = useState(false)
+  const onWorktreeRemoved = useCallback(() => setRemoved(true), [])
 
   if (events === null) return <div className="grid flex-1 place-items-center text-sm text-muted-foreground">Loading run…</div>
   // The agent session this run ran under (from its `session-update` events): present once the
@@ -33,7 +40,13 @@ export function RunReplay({
   const sessionId = sessionInfo(events)?.sessionId
   return (
     <>
-      <RunActionBar projectId={projectId} events={events} />
+      <RunActionBar
+        projectId={projectId}
+        runId={runId}
+        events={events}
+        retainedWorktree={!removed && retained.includes(runId)}
+        onWorktreeRemoved={onWorktreeRemoved}
+      />
       {events.length === 0 ? (
         <div className="grid flex-1 place-items-center text-sm text-muted-foreground">This run has no events.</div>
       ) : (

--- a/packages/framework-dashboard/server/control.telefunc.ts
+++ b/packages/framework-dashboard/server/control.telefunc.ts
@@ -1,4 +1,4 @@
 // Re-export shim (#405): the steering telefunctions live in @gemstack/framework so the
 // daemon serves them in-process. The file path keeps the baked RPC key
 // `/server/control.telefunc.ts`. See framework's dashboard-rpc/register.ts.
-export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp } from '@gemstack/framework/dashboard-rpc'
+export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree } from '@gemstack/framework/dashboard-rpc'

--- a/packages/framework-dashboard/server/reads.telefunc.ts
+++ b/packages/framework-dashboard/server/reads.telefunc.ts
@@ -3,4 +3,4 @@
 // the client bakes the RPC key `/server/reads.telefunc.ts` — the exact key the daemon
 // registers the impls under (see framework's dashboard-rpc/register.ts). The telefunc
 // Vite transform turns these named re-exports into client RPC stubs.
-export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from '@gemstack/framework/dashboard-rpc'
+export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onRetainedWorktrees } from '@gemstack/framework/dashboard-rpc'

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -404,6 +404,94 @@ setTimeout(() => {}, 800)
   }
 })
 
+test('a finished run loses its worktree; a failed one keeps it, history saved either way (#737)', async () => {
+  const cwd = await realpath(await mkdtemp(join(tmpdir(), 'framework-daemon-teardown-')))
+  const git = nodeGitRunner()
+  const ac = new AbortController()
+  try {
+    await mkdir(join(cwd, FRAMEWORK_DIR), { recursive: true })
+    await git(['init'], cwd)
+    await git(['config', 'user.email', 't@t'], cwd)
+    await git(['config', 'user.name', 't'], cwd)
+    await writeFile(join(cwd, 'README.md'), '# t\n')
+    await git(['add', '-A'], cwd)
+    await git(['commit', '-m', 'init'], cwd)
+
+    // The stub plays a run: it writes the meta a real run would leave behind, with the status
+    // read from a file the test controls, then exits so the daemon's teardown fires.
+    const stub = join(cwd, 'stub-cli.cjs')
+    await writeFile(
+      stub,
+      `const fs = require('node:fs'), path = require('node:path')
+const args = process.argv.slice(2)
+const runCwd = args[args.indexOf('--cwd') + 1]
+const runId = args[args.indexOf('--run-id') + 1]
+const status = fs.readFileSync(${JSON.stringify(join(cwd, 'status.txt'))}, 'utf8').trim()
+const dir = path.join(runCwd, '.the-framework')
+fs.mkdirSync(dir, { recursive: true })
+fs.writeFileSync(path.join(dir, 'events.jsonl'), JSON.stringify({ kind: 'log', message: 'worked' }) + '\\n')
+fs.writeFileSync(path.join(dir, 'run.json'), JSON.stringify({ version: 1, status, id: runId, startedAt: runId, updatedAt: runId, passes: 1 }))
+fs.appendFileSync(${JSON.stringify(join(cwd, 'started.log'))}, runId + '\\n')
+`,
+    )
+    const env = await configEnv(cwd)
+    const done = runDaemon(cwd, { port: 0, signal: ac.signal, binPath: stub, env })
+    let state = await readDaemonState(env)
+    for (let i = 0; i < 100 && !state; i++) {
+      await new Promise(r => setTimeout(r, 20))
+      state = await readDaemonState(env)
+    }
+    assert.ok(state, 'daemon wrote its state file')
+
+    /** Start a run whose stub reports `status`, and resolve once its worktree has settled. */
+    const runWith = async (status: string, nth: number): Promise<string> => {
+      await writeFile(join(cwd, 'status.txt'), status)
+      assert.equal((await sendStart(state!.url, cwd, `run ${status}`)).ok, true)
+      let ids: string[] = []
+      for (let i = 0; i < 150 && ids.length < nth; i++) {
+        await new Promise(r => setTimeout(r, 20))
+        ids = await readFile(join(cwd, 'started.log'), 'utf8').then(s => s.split('\n').filter(Boolean), () => [])
+      }
+      assert.equal(ids.length, nth, `run ${nth} started`)
+      return ids[nth - 1]!
+    }
+
+    /** Poll for the archived history to appear, which is the teardown having run. */
+    const archived = async (runId: string): Promise<boolean> => {
+      for (let i = 0; i < 150; i++) {
+        if (await stat(join(cwd, FRAMEWORK_DIR, 'runs', `${runId}.json`)).then(() => true, () => false)) return true
+        await new Promise(r => setTimeout(r, 20))
+      }
+      return false
+    }
+
+    // A clean finish: history archived into the repo, worktree gone.
+    const doneId = await runWith('done', 1)
+    assert.equal(await archived(doneId), true, "a finished run's history is copied into the project")
+    let gone = false
+    for (let i = 0; i < 150 && !gone; i++) {
+      gone = await stat(join(cwd, FRAMEWORK_DIR, 'worktrees', doneId)).then(() => false, () => true)
+      if (!gone) await new Promise(r => setTimeout(r, 20))
+    }
+    assert.equal(gone, true, 'and its worktree is removed')
+
+    // A failure: history archived too, but the checkout is kept so it can be inspected.
+    const failedId = await runWith('failed', 2)
+    assert.equal(await archived(failedId), true, "a failed run's history is copied too")
+    assert.equal(
+      (await stat(join(cwd, FRAMEWORK_DIR, 'worktrees', failedId, 'README.md'))).isFile(),
+      true,
+      'and its worktree is retained, content and all, for inspection',
+    )
+
+    ac.abort()
+    await done
+  } finally {
+    ac.abort()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
 test('sendStart spawns the run child (prompt, --no-dashboard, --cwd) one at a time when the project has no worktree (#345)', async () => {
   // A non-git workspace cannot be given a worktree, so runs share the one checkout and the
   // pre-#736 one-at-a-time guard still applies. tmpWorkspace() is deliberately not a repo.

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -10,6 +10,9 @@ import {
   runBranchName,
   linkDependencies,
   excludeDependencyLinks,
+  archiveWorktreeRun,
+  removeWorktree,
+  pruneWorktrees,
 } from './store/index.js'
 import { startDashboard, type Dashboard, type StartRunKind, type StartRunOptions, type StartRunResult, type AddProjectResult, type PreviewResult, type PreviewStatus } from './dashboard/index.js'
 import { startInterventionWatcher, postDiscord, type InterventionWatcher } from './dashboard/intervention-watcher.js'
@@ -500,6 +503,30 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
     }
   }
 
+  /**
+   * Retire a finished run's worktree (#737). Its history lives inside the worktree, so it is
+   * copied into the repo first — otherwise removing the checkout would delete the run from the
+   * dashboard's history.
+   *
+   * Then the retention rule: a run that finished cleanly has nothing left to look at, so its
+   * worktree goes. A run that failed or was stopped keeps its checkout, because that is exactly
+   * when you want to see the half-finished working tree and the diff it died holding. Those are
+   * removed explicitly (the dashboard's Remove), never silently on a timer.
+   *
+   * Best-effort from end to end: this runs off a process-exit event with nothing to return to,
+   * so a failure here must not take the daemon down.
+   */
+  const tearDownWorktree = async (projectCwd: string, worktree: string): Promise<void> => {
+    try {
+      const meta = await archiveWorktreeRun(worktree, projectCwd)
+      if (meta?.status !== 'done') return // failed / stopped / unreadable: keep it for inspection
+      await removeWorktree(projectCwd, worktree)
+      await pruneWorktrees(projectCwd)
+    } catch {
+      // A worktree we could not retire is a worktree left on disk, which is the safe direction.
+    }
+  }
+
   // Start-from-dashboard (#345): spawn `framework "<prompt>" --no-dashboard --cwd <checkout>`
   // as a detached child — the same spawn ensureDaemon uses for the daemon itself. The run
   // streams into the page via its tailed event log, and its gates + Stop steer through the
@@ -557,10 +584,13 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
         ...(workspace.runId ? ['--run-id', workspace.runId] : []),
       ])
       // The run narrates itself through its own `.the-framework/events.jsonl`, which the
-      // dashboard streams over a Telefunc Channel; the daemon just tracks liveness. The
-      // worktree is left in place on exit — archiving its history and tearing it down is #737.
-      child.once('error', () => activeRuns.delete(key))
-      child.once('exit', () => activeRuns.delete(key))
+      // dashboard streams over a Telefunc Channel; the daemon just tracks liveness.
+      const settle = (): void => {
+        activeRuns.delete(key)
+        if (workspace.runId) void tearDownWorktree(projectCwd, workspace.cwd)
+      }
+      child.once('error', settle)
+      child.once('exit', settle)
       if (child.pid !== undefined) activeRuns.set(key, child.pid)
       return { ok: true }
     } finally {

--- a/packages/framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/control.telefunc.ts
@@ -2,8 +2,16 @@ import { getContext } from 'telefunc'
 import { appendControl, type ControlEntry } from '../control.js'
 import { openInApp, type OpenTarget, type OpenResult } from '../dashboard/open-in-app.js'
 import { resolveProjectPath, resolveRunPath, contextPreferences } from './context.js'
+import { isSafeRunId, readLiveMetas, removeWorktree, pruneWorktrees, worktreePath } from '../store/index.js'
 import type { ChoiceBy } from '../events.js'
-import type { PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from '../dashboard/types.js'
+import type {
+  PreviewResult,
+  PreviewStatus,
+  RemoveWorktreeResult,
+  StartRunKind,
+  StartRunOptions,
+  StartRunResult,
+} from '../dashboard/types.js'
 import type { ServeTarget } from '../preview.js'
 import type { DashboardContext } from '../dashboard/telefunc-serve.js'
 import type { Preferences } from '../registry.js'
@@ -59,6 +67,31 @@ export async function sendMessage(projectId: string, text: string, runId?: strin
   const message = text.trim()
   if (!message) return
   await appendControlFor(projectId, { kind: 'message', text: message }, runId)
+}
+
+/**
+ * Remove a retained worktree (#737). A run that failed or was stopped keeps its checkout so you
+ * can inspect it; this is the explicit cleanup for one, since nothing removes them on a timer.
+ *
+ * Refuses while that run is still live: its worktree is the checkout the agent is working in, and
+ * Stop is the way to end a run, not pulling the floor out from under it. The run's history was
+ * archived into the repo when it finished, so removal costs no history.
+ */
+export async function sendRemoveWorktree(projectId: string, runId: string): Promise<RemoveWorktreeResult> {
+  const cwd = await resolveProjectPath(projectId)
+  if (!cwd) return { ok: false, error: 'this project has no local path on this server' }
+  if (!isSafeRunId(runId)) return { ok: false, error: `invalid run id: ${runId}` }
+  const live = await readLiveMetas(cwd).catch(() => [])
+  if (live.some(run => run.id === runId && run.status === 'running')) {
+    return { ok: false, error: 'that run is still going; stop it before removing its worktree' }
+  }
+  try {
+    await removeWorktree(cwd, worktreePath(cwd, runId))
+    await pruneWorktrees(cwd)
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
 }
 
 /**

--- a/packages/framework/src/dashboard-rpc/index.ts
+++ b/packages/framework/src/dashboard-rpc/index.ts
@@ -2,8 +2,8 @@
 // implementations live here in @gemstack/framework so `sendStart` (added with the serve
 // wiring) can reach the daemon's `startRun`; the framework-dashboard client imports
 // these through thin re-export shims so the baked RPC keys stay `/server/*.telefunc.ts`.
-export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from './reads.telefunc.js'
-export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
+export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onRetainedWorktrees } from './reads.telefunc.js'
+export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree } from './control.telefunc.js'
 export { onEvents } from './events.telefunc.js'
 export { onProjects, sendAddProject } from './projects.telefunc.js'
 export { onPreferences, savePreferences, onEditors, type SavePreferencesResult } from './preferences.telefunc.js'

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -1,4 +1,4 @@
-import { listRuns, readLiveMetas, loadRunEvents, type RunMeta } from '../store/index.js'
+import { listRuns, readLiveMetas, loadRunEvents, listWorktreeDirs, type RunMeta } from '../store/index.js'
 import { readLogs, type LogEntry } from '../logs.js'
 import { readDocs, type WorkspaceDoc } from '../dashboard/docs.js'
 import { collectQueue, type ProjectQueue } from '../dashboard/queue.js'
@@ -52,6 +52,22 @@ export async function onRuns(projectId: string): Promise<RunMeta[]> {
   const archived = await listRuns(cwd).catch(() => [])
   const live = await readLiveMetas(cwd).catch(() => [])
   return [...live.filter(run => !archived.some(r => r.id === run.id)), ...archived]
+}
+
+/**
+ * The run ids that still have a worktree on disk (#737). A run that failed or was stopped keeps
+ * its checkout so you can go look at what it was holding; this is how the dashboard knows which
+ * finished run has one to offer removing. Live runs are excluded — their worktree is in use.
+ */
+export async function onRetainedWorktrees(projectId: string): Promise<string[]> {
+  const cwd = await resolveProjectPath(projectId)
+  if (!cwd) return []
+  const [names, live] = await Promise.all([
+    listWorktreeDirs(cwd).catch(() => []),
+    readLiveMetas(cwd).catch(() => []),
+  ])
+  const running = new Set(live.filter(run => run.status === 'running').map(run => run.id))
+  return names.filter(id => !running.has(id)).sort((a, b) => (a < b ? 1 : a > b ? -1 : 0))
 }
 
 /** One archived run's event log for replay (or `[]` when the run or project is gone). */

--- a/packages/framework/src/dashboard-rpc/register.ts
+++ b/packages/framework/src/dashboard-rpc/register.ts
@@ -1,6 +1,6 @@
 import { __decorateTelefunction } from 'telefunc'
-import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus } from './reads.telefunc.js'
-import { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp } from './control.telefunc.js'
+import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onRetainedWorktrees } from './reads.telefunc.js'
+import { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree } from './control.telefunc.js'
 import { onEvents } from './events.telefunc.js'
 import { onProjects, sendAddProject } from './projects.telefunc.js'
 import { onPreferences, savePreferences, onEditors } from './preferences.telefunc.js'
@@ -44,6 +44,7 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(onDashboard, 'onDashboard', reads)
   reg(onGithubUrl, 'onGithubUrl', reads)
   reg(onGitStatus, 'onGitStatus', reads)
+  reg(onRetainedWorktrees, 'onRetainedWorktrees', reads)
   reg(onProjectFiles, 'onProjectFiles', reads)
   reg(onProjectFileStatus, 'onProjectFileStatus', reads)
   reg(sendStop, 'sendStop', control)
@@ -55,6 +56,7 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(sendStopPreview, 'sendStopPreview', control)
   reg(onPreviewStatus, 'onPreviewStatus', control)
   reg(sendOpenInApp, 'sendOpenInApp', control)
+  reg(sendRemoveWorktree, 'sendRemoveWorktree', control)
   reg(onEvents, 'onEvents', events)
   reg(onProjects, 'onProjects', projects)
   reg(sendAddProject, 'sendAddProject', projects)

--- a/packages/framework/src/dashboard-rpc/run-addressing.test.ts
+++ b/packages/framework/src/dashboard-rpc/run-addressing.test.ts
@@ -3,7 +3,8 @@ import { test } from 'node:test'
 import { join } from 'node:path'
 import { mkdtemp, rm, mkdir, writeFile, readFile, realpath } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { sendStop, sendMessage, sendChoice } from './control.telefunc.js'
+import { sendStop, sendMessage, sendChoice, sendRemoveWorktree } from './control.telefunc.js'
+import { onRetainedWorktrees } from './reads.telefunc.js'
 import { addProject, projectId as idFor } from '../registry.js'
 import { FRAMEWORK_DIR, WORKTREES_DIR } from '../store/index.js'
 import { CONTROL_FILE } from '../control.js'
@@ -95,6 +96,50 @@ test('an unknown or absent run id falls back to the project root, as before #736
     await sendStop(ctx.projectId, 'a-run-that-is-gone')
     assert.deepEqual(await entries(ctx.rootControl), [{ kind: 'stop' }, { kind: 'stop' }])
     assert.deepEqual(await entries(ctx.runControl), [], 'the live run is left alone')
+  } finally {
+    ctx.restore()
+    await rm(ctx.dir, { recursive: true, force: true })
+  }
+})
+
+// #737: a failed run keeps its worktree for inspection, so removing one is an explicit action —
+// and must never yank the checkout out from under a run that is still going.
+
+test('sendRemoveWorktree refuses while that run is still live (#737)', async () => {
+  const ctx = await projectWithWorktreeRun() // its run.json says `running`
+  try {
+    const result = await sendRemoveWorktree(ctx.projectId, ctx.runId)
+    assert.equal(result.ok, false)
+    assert.match(result.ok === false ? result.error : '', /still going/)
+    assert.equal(await entries(ctx.runControl).then(() => true), true, 'the worktree is untouched')
+  } finally {
+    ctx.restore()
+    await rm(ctx.dir, { recursive: true, force: true })
+  }
+})
+
+test('sendRemoveWorktree rejects an unsafe run id before touching anything (#737)', async () => {
+  const ctx = await projectWithWorktreeRun()
+  try {
+    const result = await sendRemoveWorktree(ctx.projectId, '../../etc')
+    assert.equal(result.ok, false)
+    assert.match(result.ok === false ? result.error : '', /invalid run id/)
+  } finally {
+    ctx.restore()
+    await rm(ctx.dir, { recursive: true, force: true })
+  }
+})
+
+test('onRetainedWorktrees hides a live run, and lists one that has finished (#737)', async () => {
+  const ctx = await projectWithWorktreeRun()
+  try {
+    assert.deepEqual(await onRetainedWorktrees(ctx.projectId), [], 'a running run has nothing to offer removing')
+    // Once it is no longer running, its retained checkout is listed.
+    await writeFile(
+      join(ctx.dir, FRAMEWORK_DIR, WORKTREES_DIR, ctx.runId, FRAMEWORK_DIR, 'run.json'),
+      JSON.stringify({ version: 1, status: 'failed', id: ctx.runId, startedAt: ctx.runId, updatedAt: ctx.runId, passes: 0 }),
+    )
+    assert.deepEqual(await onRetainedWorktrees(ctx.projectId), [ctx.runId])
   } finally {
     ctx.restore()
     await rm(ctx.dir, { recursive: true, force: true })

--- a/packages/framework/src/dashboard/types.ts
+++ b/packages/framework/src/dashboard/types.ts
@@ -4,6 +4,9 @@ import type { EcoOptions } from '../system-prompt.js'
 // Preview RPCs speak. They live here, on neither the HTTP server nor the Telefunc mount, so
 // both — plus the telefunctions themselves — depend on this leaf rather than on each other.
 
+/** The outcome of removing a retained worktree (#737). */
+export type RemoveWorktreeResult = { ok: true } | { ok: false; error: string }
+
 /** The outcome of an add-project attempt (#396). */
 export type AddProjectResult =
   | { ok: true; added: number; alreadyActivated: number }

--- a/packages/framework/src/store/index.ts
+++ b/packages/framework/src/store/index.ts
@@ -8,6 +8,8 @@ export {
   reconcileOrphanedRuns,
   loadRunEvents,
   readLiveMetas,
+  archiveWorktreeRun,
+  listWorktreeDirs,
   runIdFromStartedAt,
   isSafeRunId,
   FRAMEWORK_DIR,

--- a/packages/framework/src/store/run-store.test.ts
+++ b/packages/framework/src/store/run-store.test.ts
@@ -9,6 +9,8 @@ import {
   listRuns,
   readLiveMeta,
   readLiveMetas,
+  archiveWorktreeRun,
+  listWorktreeDirs,
   reconcileOrphanedRuns,
   loadRunEvents,
   runIdFromStartedAt,
@@ -399,4 +401,58 @@ test('readLiveMetas self-heals a dead run in a worktree, same as the single read
   const runs = await readLiveMetas(CWD, fs, () => false)
   assert.equal(runs[0]?.status, 'stopped', 'a running meta whose process is gone reads as stopped')
   assert.equal((JSON.parse(fs.files.get(path)!) as RunMeta).status, 'stopped', 'and is healed on disk')
+})
+
+// #737: a run's history lives inside its worktree, so removing that worktree would delete the run
+// from the dashboard's history. It is copied into the repo first, which is what makes teardown safe.
+const worktreeAt = (runId: string) => join(CWD, '.the-framework', 'worktrees', runId)
+const worktreeFiles = (runId: string, meta: Record<string, unknown>, events = '') => ({
+  [join(worktreeAt(runId), '.the-framework', 'run.json')]: JSON.stringify(meta),
+  [join(worktreeAt(runId), '.the-framework', 'events.jsonl')]: events,
+})
+
+test('archiveWorktreeRun copies a finished run into the repo history (#737)', async () => {
+  const fs = memFs(worktreeFiles('r1', { version: 1, status: 'done', id: 'r1', startedAt: AT, updatedAt: AT, passes: 2 }, '{"kind":"log","message":"hi"}\n'))
+  const meta = await archiveWorktreeRun(worktreeAt('r1'), CWD, fs)
+  assert.equal(meta?.status, 'done')
+  assert.equal(fs.files.get(join(CWD, '.the-framework', 'runs', 'r1.jsonl')), '{"kind":"log","message":"hi"}\n', 'the log lands in the repo')
+  assert.equal((JSON.parse(fs.files.get(join(CWD, '.the-framework', 'runs', 'r1.json'))!) as RunMeta).passes, 2)
+  // And the archived copy is what listRuns reads, so the run survives losing its worktree.
+  assert.deepEqual((await listRuns(CWD, fs)).map(r => r.id), ['r1'])
+})
+
+test('archiveWorktreeRun records a run that died mid-flight as stopped, not running (#737)', async () => {
+  const fs = memFs(worktreeFiles('r1', { version: 1, status: 'running', id: 'r1', startedAt: AT, updatedAt: AT, passes: 0 }))
+  // The process is gone by the time we archive, so `running` here means it never closed.
+  assert.equal((await archiveWorktreeRun(worktreeAt('r1'), CWD, fs))?.status, 'stopped')
+  assert.equal((JSON.parse(fs.files.get(join(CWD, '.the-framework', 'runs', 'r1.json'))!) as RunMeta).status, 'stopped')
+})
+
+test('archiveWorktreeRun is forgiving of a worktree with no run', async () => {
+  assert.equal(await archiveWorktreeRun(worktreeAt('nope'), CWD, memFs()), undefined)
+})
+
+test('reconcileOrphanedRuns rescues a run a crashed daemon left in a worktree (#737)', async () => {
+  const fs = memFs(worktreeFiles('r1', { version: 1, status: 'running', id: 'r1', startedAt: AT, updatedAt: AT, passes: 0 }))
+  assert.equal(await reconcileOrphanedRuns(CWD, fs), 1)
+  assert.equal(
+    (JSON.parse(fs.files.get(join(worktreeAt('r1'), '.the-framework', 'run.json'))!) as RunMeta).status,
+    'stopped',
+    'the live meta stops claiming to be running',
+  )
+  assert.equal(
+    (JSON.parse(fs.files.get(join(CWD, '.the-framework', 'runs', 'r1.json'))!) as RunMeta).status,
+    'stopped',
+    'and its history is rescued into the repo',
+  )
+})
+
+test('listWorktreeDirs names the run of each worktree, ignoring anything else in there', async () => {
+  const fs = memFs({
+    ...worktreeFiles('r1', { id: 'r1' }),
+    ...worktreeFiles('r2', { id: 'r2' }),
+    [join(CWD, '.the-framework', 'worktrees', '.tmp', 'x')]: '',
+  })
+  assert.deepEqual((await listWorktreeDirs(CWD, fs)).sort(), ['r1', 'r2'])
+  assert.deepEqual(await listWorktreeDirs(join(CWD, 'never-ran'), fs), [])
 })

--- a/packages/framework/src/store/run-store.ts
+++ b/packages/framework/src/store/run-store.ts
@@ -400,6 +400,45 @@ async function archivePriorRun(fs: StoreFs, dir: string): Promise<void> {
 }
 
 /**
+ * The run ids that have a worktree directory under `.the-framework/worktrees/` (#737). Names
+ * only, from the filesystem: a directory here IS a run's checkout, and its name is the run id.
+ * Forgiving — a project that never ran concurrently has no such dir and yields `[]`.
+ */
+export async function listWorktreeDirs(cwd: string, fs: StoreFs = nodeStoreFs()): Promise<string[]> {
+  const names = await fs.readdir(join(cwd, FRAMEWORK_DIR, WORKTREES_DIR)).catch(() => [])
+  return names.filter(isSafeRunId)
+}
+
+/**
+ * Archive a worktree run's history into the *main repo* (#737), returning the meta it archived.
+ *
+ * A run writes its `run.json` / `events.jsonl` inside its own worktree (#736), so deleting that
+ * worktree would delete the run's history with it. This copies it to the repo's `runs/`, which is
+ * the one place the dashboard's history reads from, so teardown becomes safe.
+ *
+ * A meta still marked `running` is flipped to `stopped` first: this runs when the process is
+ * already gone, so `running` means it died without closing (crash, kill -9), exactly the case
+ * {@link reconcileOrphanedRuns} handles for the project path. Idempotent per id, and forgiving:
+ * a worktree with no run, or an unreadable one, yields `undefined` rather than throwing.
+ */
+export async function archiveWorktreeRun(
+  worktree: string,
+  repo: string,
+  fs: StoreFs = nodeStoreFs(),
+): Promise<RunMeta | undefined> {
+  try {
+    const worktreeDir = join(worktree, FRAMEWORK_DIR)
+    const live = await readMetaFile(fs, join(worktreeDir, META_FILE))
+    if (!live?.id || !isSafeRunId(live.id)) return undefined
+    const meta: RunMeta = live.status === 'running' ? { ...live, status: 'stopped' } : live
+    await archiveRun(fs, join(repo, FRAMEWORK_DIR), meta, join(worktreeDir, EVENTS_FILE))
+    return meta
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * List a project's archived runs, most-recent first. Reads every `runs/*.json`
  * meta; the id sorts chronologically so no timestamp parse is needed. Missing or
  * unreadable dir/entries are skipped, never thrown.
@@ -453,6 +492,21 @@ export async function reconcileOrphanedRuns(cwd: string, fs: StoreFs = nodeStore
     const stopped: RunMeta = { ...live, status: 'stopped' }
     await fs.write(join(dir, META_FILE), JSON.stringify(stopped, null, 2) + '\n').catch(() => {})
     await archivePriorRun(fs, dir).catch(() => {})
+    fixed++
+  }
+
+  // Runs living in worktrees (#736/#737). A daemon that died mid-run never ran its teardown, so
+  // each of those runs is orphaned the same way — except its history sits inside the worktree,
+  // where nothing reads it. Flip it in place (so the dashboard stops showing it as live) and copy
+  // it into the repo's history. The worktree itself is left on disk: a run that ended this way did
+  // not end cleanly, and those are kept for inspection. Removing one is an explicit action.
+  for (const name of await fs.readdir(join(dir, WORKTREES_DIR))) {
+    if (!isSafeRunId(name)) continue
+    const worktreeDir = join(dir, WORKTREES_DIR, name, FRAMEWORK_DIR)
+    const meta = await readMetaFile(fs, join(worktreeDir, META_FILE))
+    if (meta?.status !== 'running') continue
+    await fs.write(join(worktreeDir, META_FILE), JSON.stringify({ ...meta, status: 'stopped' }, null, 2) + '\n').catch(() => {})
+    await archiveWorktreeRun(join(dir, WORKTREES_DIR, name), cwd, fs).catch(() => undefined)
     fixed++
   }
   return fixed


### PR DESCRIPTION
Closes #737. Last sub-issue of #453.

A run's history lives inside its worktree since #736, so removing that worktree would delete the run from the dashboard's history. This archives first, then retires the checkout.

## The retention decision

Answered as **retain on failure, with an explicit remove**:

- **Finished cleanly** -> history archived into the project, worktree removed. Nothing left to look at.
- **Failed or stopped** -> history archived too, worktree **kept**. That is exactly when the half-finished working tree and the diff it died holding are worth seeing.
- Nothing is removed on a timer or behind a cap. A retained worktree goes when you remove it.

## What changed

- **`archiveWorktreeRun(worktree, repo)`** copies a run's `run.json` + `events.jsonl` into the repo's `runs/`, which is the one place the history list reads from. A meta still marked `running` is recorded as `stopped`, since this runs when the process is already gone.
- **Daemon teardown on child exit** archives, then removes only on a clean finish. Best-effort throughout: it runs off a process-exit event with nothing to return to, and a worktree it fails to retire is a worktree left on disk, which is the safe direction.
- **Boot-time reconcile sweeps worktrees.** A daemon that dies mid-run never runs that teardown, so each orphaned run is flipped out of `running` and rescued into the project. The checkout stays: a run that ended that way did not end cleanly.
- **Remove in the dashboard**: `onRetainedWorktrees(projectId)` lists finished runs that still have a checkout, `sendRemoveWorktree(projectId, runId)` deletes one. It refuses while the run is still live, because Stop is how a run ends, not pulling the floor out from under it.

## One deviation to flag

The Remove button is in the **run's action bar**, not on the Runs rail row as discussed. A rail row *is* a button (it selects the run), and a button inside a button is invalid DOM. The action bar is where Serve and Open session already live for a finished run, and you are one click away in the run you are inspecting. Happy to restructure the row into a container with two controls if you want it literally on the row.

## Follow-up

A CLI equivalent (`framework worktrees` / `... rm <runId>`) is the agreed next step, not in this PR.

## Tests

9 new, 685 green in framework, 105 in framework-dashboard. The load-bearing one drives the real daemon on a real git repo: a run reporting `done` loses its worktree, a run reporting `failed` keeps it with its content intact, and both have their history in the project either way.
