### PR TITLE
fix(framework-dashboard): select the run that was just started (#761)

### DIFF
--- a/.changeset/fix-761-select-started-run.md
+++ b/.changeset/fix-761-select-started-run.md
@@ -1,0 +1,7 @@
+---
+"@gemstack/framework": patch
+---
+
+Fix starting a second run navigating to the previous one (#761). The dashboard adopted the run it had just started by looking for "the run that is running", which was safe while a project could only have one. Since concurrent runs (#736) it is not: the previous run is still running, and the new one has not written its `run.json` yet, so the old run was the only match and the view parked on it.
+
+`sendStart` now returns the run id the daemon allocated, which it already knows because it names the run's worktree with it, and the dashboard selects that run instead of inferring one. A run with no worktree (the non-git fallback) reports no id and keeps the previous behaviour, which is still correct there because one run at a time still holds.

--- a/packages/framework-dashboard/components/NavbarQuickLaunch.test.tsx
+++ b/packages/framework-dashboard/components/NavbarQuickLaunch.test.tsx
@@ -70,7 +70,7 @@ describe('NavbarQuickLaunch (#723)', () => {
     expect(text).toBe('add a test')
     expect(kind).toBe('build')
     expect(typeof options).toBe('object')
-    await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('add a test'))
+    await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('add a test', undefined))
   })
 
   test('surfaces the busy guard when a run is already active', async () => {
@@ -80,5 +80,24 @@ describe('NavbarQuickLaunch (#723)', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Start' }))
     await waitFor(() => expect(screen.getByText(/run is already active/i)).toBeTruthy())
     expect(onRunStarted).not.toHaveBeenCalled()
+  })
+
+  // #761: the shell has to select the run it just started. Before this, it took "whichever run is
+  // running", which with concurrent runs (#736) is the PREVIOUS one — the new run has not written
+  // its run.json yet — so starting a second run navigated to the first.
+  test('hands the started run id up, so the shell selects that run and not another', async () => {
+    sendStart.mockResolvedValue({ ok: true, runId: '2026-07-19T12-00-00-000Z' })
+    const { onRunStarted } = renderQL()
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'second run' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }))
+    await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('second run', '2026-07-19T12-00-00-000Z'))
+  })
+
+  test('a run with no worktree reports no id, and the shell falls back as before', async () => {
+    sendStart.mockResolvedValue({ ok: true })
+    const { onRunStarted } = renderQL()
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'no worktree' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }))
+    await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('no worktree', undefined))
   })
 })

--- a/packages/framework-dashboard/components/NavbarQuickLaunch.tsx
+++ b/packages/framework-dashboard/components/NavbarQuickLaunch.tsx
@@ -24,7 +24,7 @@ export function NavbarQuickLaunch({
   files: string[]
   context: Set<string>
   addContext: (path: string) => void
-  onRunStarted: (intent: string) => void
+  onRunStarted: (intent: string, runId?: string) => void
   className?: string
 }) {
   const composerRef = useRef<ComposerHandle>(null)
@@ -51,7 +51,7 @@ export function NavbarQuickLaunch({
       const result = await sendStart(projectId, text, kind, collectRunOptions(preferences, [...context]))
       if (result.ok) {
         composerRef.current?.clear()
-        onRunStarted(text) // jump to the new run's live output
+        onRunStarted(text, result.runId) // select the run we just started (#761)
       } else {
         setError(result.busy ? 'A run is already active for this project.' : result.error)
       }

--- a/packages/framework-dashboard/components/RunResumeChat.test.tsx
+++ b/packages/framework-dashboard/components/RunResumeChat.test.tsx
@@ -67,7 +67,7 @@ describe('RunResumeChat (#720)', () => {
     expect(text).toBe('and now dark mode')
     expect(kind).toBe('prompt') // a continuation is a prompt run
     expect(options.resumeSession).toBe('sess-42') // seeded with the finished run's session
-    await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('and now dark mode'))
+    await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('and now dark mode', undefined))
   })
 
   test('surfaces the busy guard instead of jumping', async () => {

--- a/packages/framework-dashboard/components/RunResumeChat.tsx
+++ b/packages/framework-dashboard/components/RunResumeChat.tsx
@@ -21,7 +21,7 @@ export function RunResumeChat({
   sessionId: string
   files: string[]
   addContext: (path: string) => void
-  onRunStarted: (intent: string) => void
+  onRunStarted: (intent: string, runId?: string) => void
 }) {
   const composerRef = useRef<ComposerHandle>(null)
   const [busy, setBusy] = useState(false)
@@ -45,7 +45,7 @@ export function RunResumeChat({
       })
       if (result.ok) {
         composerRef.current?.clear()
-        onRunStarted(text) // jump to the new (resumed) run's live output
+        onRunStarted(text, result.runId) // select the run we just started (#761)
       } else {
         setError(result.busy ? 'A run is already active for this project.' : result.error)
       }

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -24,7 +24,7 @@ export function StartRunForm({
   toggleContext,
 }: {
   projectId: string
-  onRunStarted?: ((intent: string) => void) | undefined
+  onRunStarted?: ((intent: string, runId?: string) => void) | undefined
   /** The project's files for the `#` picker (#504), owned by the shell. */
   files: string[]
   /** The run Context set, shared with the right-rail file tree (#492) — owned by the shell. */
@@ -88,7 +88,7 @@ export function StartRunForm({
       if (result.ok) {
         // Show the run in the Runs rail immediately (#405): the spawned process writes its run.json
         // a beat later, so seed an optimistic row with the typed prompt until the real meta takes over.
-        onRunStarted?.(text)
+        onRunStarted?.(text, result.runId) // select the run we just started (#761)
         composerRef.current?.clear()
         setPrompt('')
         setNote(null)

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -59,6 +59,8 @@ export default function Page() {
   // run is a detached process that writes its run.json a beat later), so follow the shared live
   // feed until the poll surfaces the real run row, which the effect below adopts as the selection.
   const [followLive, setFollowLive] = useState(false)
+  // The id the daemon gave the run we just started (#761), so the poll selects that exact run.
+  const [startedRunId, setStartedRunId] = useState<string | null>(null)
 
   const { runs, reload } = useRuns(projectId)
 
@@ -98,13 +100,14 @@ export default function Page() {
   const { value: activity } = usePolled<Activity[]>(browserActivity ? onActivity : null, EMPTY_ACTIVITY, 15000, [browserActivity])
   useActivityNotifications(activity, browserActivity)
 
-  const onRunStarted = (intent: string) => {
+  const onRunStarted = (intent: string, startedId?: string) => {
     // Jump to the new run's live output. Reset to the home/Live row first (a no-op from the launcher,
     // where it already is) so a navbar quick-launch (#723) or resuming a finished run (#720) jumps to
-    // live even from a finished run's replay; `followLive` streams the shared feed until the poll
-    // adopts the new run's real id below. The new run just appends to the rail; reload so its real
+    // live even from a finished run's replay; `followLive` streams that run's feed until the poll
+    // surfaces its row below. The new run just appends to the rail; reload so its real
     // row shows up quickly.
     setRunId(null)
+    setStartedRunId(startedId ?? null)
     setRunStart(prev => ({ tick: prev.tick + 1, intent }))
     setFollowLive(true)
     reload()
@@ -112,20 +115,30 @@ export default function Page() {
 
   // Adopt the started run's real id as the selection the moment the poll surfaces it as running,
   // so the view follows its normal running -> done -> replay lifecycle and the rail highlights the
-  // run's own row. Until then `followLive` shows the shared live output.
+  // run's own row. Until then `followLive` shows the started run's output.
+  //
+  // Only ever the run we started (#761). This used to take "the running one", which was safe while
+  // a project could only have one; with concurrent runs (#736) the previous run is still running
+  // and the new one has not written its `run.json` yet, so that guess selected the OLD run and
+  // navigated away from the one just started. `startedRunId` is the id the daemon allocated, so
+  // there is nothing to infer. A run with no worktree (the non-git fallback) reports no id, and
+  // keeps the old behavior — there, one run at a time still holds, so the guess is still safe.
   useEffect(() => {
     if (!followLive) return
-    const running = runs.find(run => run.status === 'running')
-    if (running) {
-      setRunId(running.id)
+    const started = startedRunId
+      ? runs.find(run => run.id === startedRunId)
+      : runs.find(run => run.status === 'running')
+    if (started) {
+      setRunId(started.id)
       setFollowLive(false)
     }
-  }, [followLive, runs])
+  }, [followLive, runs, startedRunId])
 
   // Selecting a run (or the Live/Home row) from the rail is always an explicit choice, so it
   // ends the just-started follow.
   const selectRun = (id: string | null) => {
     setFollowLive(false)
+    setStartedRunId(null)
     setRunId(id)
   }
 

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -592,7 +592,8 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
       child.once('error', settle)
       child.once('exit', settle)
       if (child.pid !== undefined) activeRuns.set(key, child.pid)
-      return { ok: true }
+      // Hand back the run's id (#761) so the dashboard can select this run rather than guess.
+      return { ok: true, ...(workspace.runId ? { runId: workspace.runId } : {}) }
     } finally {
       starting.delete(key)
     }

--- a/packages/framework/src/dashboard/types.ts
+++ b/packages/framework/src/dashboard/types.ts
@@ -54,7 +54,13 @@ export type StartRunKind = 'build' | 'research' | 'prompt'
 
 /** The outcome of a Start attempt (#345). */
 export type StartRunResult =
-  | { ok: true }
+  /**
+   * `runId` is the id the daemon allocated for the run (#761), present whenever it got its own
+   * worktree. The dashboard needs it to select the run it just started: with concurrent runs
+   * (#736) it can no longer find that run by looking for "the running one", because the previous
+   * run is still running and the new one has not written its `run.json` yet.
+   */
+  | { ok: true; runId?: string }
   | { ok: false; busy?: boolean; error: string }
 
 /** The outcome of a Preview attempt (#475): the live URL, or why not. */


### PR DESCRIPTION
Closes #761.

Start a run, then start a second one: the view navigated to the **first** run. A regression from #736.

## Cause

The shell adopted the started run by guessing:

```js
const running = runs.find(run => run.status === 'running')
```

Safe while a project could only have one live run. Since #736 it cannot be: the previous run is still `running` and the new one has not written its `run.json` yet, so the only running row is the old one. It got selected, `followLive` cleared, and you were parked on the previous run.

## Fix

`sendStart` returns the run id the daemon allocated — it already knows it, since it names the worktree with it — and the shell selects that exact run. Nothing is inferred.

A run with no worktree (the non-git fallback) reports no id and keeps the old behaviour, which is still correct there: one run at a time still holds. Picking a run by hand also clears the pending adoption, so a manual choice is never overridden a beat later.

## Tests

Two new, pinning both paths (id returned -> that run selected; no id -> previous fallback). 109 green, typecheck clean.

## Not in this PR

The second thing reported alongside this is #762: resuming a stopped run spawns a new run rather than continuing it, and the resume itself often fails with `No conversation found with session ID`. That one has a design question in it, so it is filed rather than guessed at.