### PR TITLE
feat(framework): continue a stopped run in place, as one run (#762)

### DIFF
--- a/.changeset/feat-762-continue-the-same-run.md
+++ b/.changeset/feat-762-continue-the-same-run.md
@@ -1,0 +1,9 @@
+---
+"@gemstack/framework": minor
+---
+
+Messaging a stopped run continues that run instead of opening a new one (#762). Sending a message to a run that had ended spawned a fresh run carrying the old session id: the agent conversation continued, but the history showed an unrelated-looking second row, so one thing you asked for looked like two.
+
+The follow-up is still its own process; what changed is where it writes. `sendStart` takes the run to continue, and the daemon reuses that run's id, its worktree and its branch rather than allocating new ones, restoring the run's archived history into the checkout when teardown (#737) had already removed it. The run then reopens its own log instead of truncating it, keeping its original intent and pass count and flipping back to `running` under the new process. One run, one row, one branch.
+
+Falls back to starting a new run whenever continuing is not possible: no worktree to attach, no branch left, or nothing archived to restore.

--- a/.changeset/fix-761-select-started-run.md
+++ b/.changeset/fix-761-select-started-run.md
@@ -1,0 +1,7 @@
+---
+"@gemstack/framework": patch
+---
+
+Fix starting a second run navigating to the previous one (#761). The dashboard adopted the run it had just started by looking for "the run that is running", which was safe while a project could only have one. Since concurrent runs (#736) it is not: the previous run is still running, and the new one has not written its `run.json` yet, so the old run was the only match and the view parked on it.
+
+`sendStart` now returns the run id the daemon allocated, which it already knows because it names the run's worktree with it, and the dashboard selects that run instead of inferring one. A run with no worktree (the non-git fallback) reports no id and keeps the previous behaviour, which is still correct there because one run at a time still holds.

--- a/packages/framework-dashboard/components/NavbarQuickLaunch.test.tsx
+++ b/packages/framework-dashboard/components/NavbarQuickLaunch.test.tsx
@@ -70,7 +70,7 @@ describe('NavbarQuickLaunch (#723)', () => {
     expect(text).toBe('add a test')
     expect(kind).toBe('build')
     expect(typeof options).toBe('object')
-    await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('add a test'))
+    await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('add a test', undefined))
   })
 
   test('surfaces the busy guard when a run is already active', async () => {
@@ -80,5 +80,24 @@ describe('NavbarQuickLaunch (#723)', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Start' }))
     await waitFor(() => expect(screen.getByText(/run is already active/i)).toBeTruthy())
     expect(onRunStarted).not.toHaveBeenCalled()
+  })
+
+  // #761: the shell has to select the run it just started. Before this, it took "whichever run is
+  // running", which with concurrent runs (#736) is the PREVIOUS one — the new run has not written
+  // its run.json yet — so starting a second run navigated to the first.
+  test('hands the started run id up, so the shell selects that run and not another', async () => {
+    sendStart.mockResolvedValue({ ok: true, runId: '2026-07-19T12-00-00-000Z' })
+    const { onRunStarted } = renderQL()
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'second run' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }))
+    await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('second run', '2026-07-19T12-00-00-000Z'))
+  })
+
+  test('a run with no worktree reports no id, and the shell falls back as before', async () => {
+    sendStart.mockResolvedValue({ ok: true })
+    const { onRunStarted } = renderQL()
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'no worktree' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }))
+    await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('no worktree', undefined))
   })
 })

--- a/packages/framework-dashboard/components/NavbarQuickLaunch.tsx
+++ b/packages/framework-dashboard/components/NavbarQuickLaunch.tsx
@@ -24,7 +24,7 @@ export function NavbarQuickLaunch({
   files: string[]
   context: Set<string>
   addContext: (path: string) => void
-  onRunStarted: (intent: string) => void
+  onRunStarted: (intent: string, runId?: string) => void
   className?: string
 }) {
   const composerRef = useRef<ComposerHandle>(null)
@@ -51,7 +51,7 @@ export function NavbarQuickLaunch({
       const result = await sendStart(projectId, text, kind, collectRunOptions(preferences, [...context]))
       if (result.ok) {
         composerRef.current?.clear()
-        onRunStarted(text) // jump to the new run's live output
+        onRunStarted(text, result.runId) // select the run we just started (#761)
       } else {
         setError(result.busy ? 'A run is already active for this project.' : result.error)
       }

--- a/packages/framework-dashboard/components/RunReplay.tsx
+++ b/packages/framework-dashboard/components/RunReplay.tsx
@@ -53,7 +53,7 @@ export function RunReplay({
         <EventList events={events} stick={false} />
       )}
       {sessionId && (
-        <RunResumeChat projectId={projectId} sessionId={sessionId} files={files} addContext={addContext} onRunStarted={onRunStarted} />
+        <RunResumeChat projectId={projectId} runId={runId} sessionId={sessionId} files={files} addContext={addContext} onRunStarted={onRunStarted} />
       )}
     </>
   )

--- a/packages/framework-dashboard/components/RunResumeChat.test.tsx
+++ b/packages/framework-dashboard/components/RunResumeChat.test.tsx
@@ -67,7 +67,7 @@ describe('RunResumeChat (#720)', () => {
     expect(text).toBe('and now dark mode')
     expect(kind).toBe('prompt') // a continuation is a prompt run
     expect(options.resumeSession).toBe('sess-42') // seeded with the finished run's session
-    await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('and now dark mode'))
+    await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('and now dark mode', undefined))
   })
 
   test('surfaces the busy guard instead of jumping', async () => {

--- a/packages/framework-dashboard/components/RunResumeChat.test.tsx
+++ b/packages/framework-dashboard/components/RunResumeChat.test.tsx
@@ -34,6 +34,7 @@ function renderChat(over: Partial<Parameters<typeof RunResumeChat>[0]> = {}) {
   render(
     <RunResumeChat
       projectId="p1"
+      runId="2026-07-19T10-00-00-000Z"
       sessionId="sess-42"
       files={[]}
       addContext={vi.fn()}

--- a/packages/framework-dashboard/components/RunResumeChat.tsx
+++ b/packages/framework-dashboard/components/RunResumeChat.tsx
@@ -11,12 +11,15 @@ import { usePreferences } from '../lib/preferences.js'
 // match the one the run used (resume is per-agent). Only rendered when the run has a session id.
 export function RunResumeChat({
   projectId,
+  runId,
   sessionId,
   files,
   addContext,
   onRunStarted,
 }: {
   projectId: string
+  /** The run being continued (#762), so the follow-up reopens it instead of starting a new one. */
+  runId: string
   /** The finished run's agent session id, to resume. */
   sessionId: string
   files: string[]
@@ -40,6 +43,9 @@ export function RunResumeChat({
       const agent = preferences.agent ?? 'claude'
       const result = await sendStart(projectId, text, 'prompt', {
         resumeSession: sessionId,
+        // Continue this run rather than opening a new row (#762): the follow-up writes into the
+        // same run, on the same branch, so one thing you asked for stays one entry.
+        continueRunId: runId,
         ...(model ? { model } : {}),
         ...(agent && agent !== 'claude' ? { agent } : {}),
       })

--- a/packages/framework-dashboard/components/RunResumeChat.tsx
+++ b/packages/framework-dashboard/components/RunResumeChat.tsx
@@ -21,7 +21,7 @@ export function RunResumeChat({
   sessionId: string
   files: string[]
   addContext: (path: string) => void
-  onRunStarted: (intent: string) => void
+  onRunStarted: (intent: string, runId?: string) => void
 }) {
   const composerRef = useRef<ComposerHandle>(null)
   const [busy, setBusy] = useState(false)
@@ -45,7 +45,7 @@ export function RunResumeChat({
       })
       if (result.ok) {
         composerRef.current?.clear()
-        onRunStarted(text) // jump to the new (resumed) run's live output
+        onRunStarted(text, result.runId) // select the run we just started (#761)
       } else {
         setError(result.busy ? 'A run is already active for this project.' : result.error)
       }

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -24,7 +24,7 @@ export function StartRunForm({
   toggleContext,
 }: {
   projectId: string
-  onRunStarted?: ((intent: string) => void) | undefined
+  onRunStarted?: ((intent: string, runId?: string) => void) | undefined
   /** The project's files for the `#` picker (#504), owned by the shell. */
   files: string[]
   /** The run Context set, shared with the right-rail file tree (#492) — owned by the shell. */
@@ -88,7 +88,7 @@ export function StartRunForm({
       if (result.ok) {
         // Show the run in the Runs rail immediately (#405): the spawned process writes its run.json
         // a beat later, so seed an optimistic row with the typed prompt until the real meta takes over.
-        onRunStarted?.(text)
+        onRunStarted?.(text, result.runId) // select the run we just started (#761)
         composerRef.current?.clear()
         setPrompt('')
         setNote(null)

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -59,6 +59,8 @@ export default function Page() {
   // run is a detached process that writes its run.json a beat later), so follow the shared live
   // feed until the poll surfaces the real run row, which the effect below adopts as the selection.
   const [followLive, setFollowLive] = useState(false)
+  // The id the daemon gave the run we just started (#761), so the poll selects that exact run.
+  const [startedRunId, setStartedRunId] = useState<string | null>(null)
 
   const { runs, reload } = useRuns(projectId)
 
@@ -98,13 +100,14 @@ export default function Page() {
   const { value: activity } = usePolled<Activity[]>(browserActivity ? onActivity : null, EMPTY_ACTIVITY, 15000, [browserActivity])
   useActivityNotifications(activity, browserActivity)
 
-  const onRunStarted = (intent: string) => {
+  const onRunStarted = (intent: string, startedId?: string) => {
     // Jump to the new run's live output. Reset to the home/Live row first (a no-op from the launcher,
     // where it already is) so a navbar quick-launch (#723) or resuming a finished run (#720) jumps to
-    // live even from a finished run's replay; `followLive` streams the shared feed until the poll
-    // adopts the new run's real id below. The new run just appends to the rail; reload so its real
+    // live even from a finished run's replay; `followLive` streams that run's feed until the poll
+    // surfaces its row below. The new run just appends to the rail; reload so its real
     // row shows up quickly.
     setRunId(null)
+    setStartedRunId(startedId ?? null)
     setRunStart(prev => ({ tick: prev.tick + 1, intent }))
     setFollowLive(true)
     reload()
@@ -112,20 +115,30 @@ export default function Page() {
 
   // Adopt the started run's real id as the selection the moment the poll surfaces it as running,
   // so the view follows its normal running -> done -> replay lifecycle and the rail highlights the
-  // run's own row. Until then `followLive` shows the shared live output.
+  // run's own row. Until then `followLive` shows the started run's output.
+  //
+  // Only ever the run we started (#761). This used to take "the running one", which was safe while
+  // a project could only have one; with concurrent runs (#736) the previous run is still running
+  // and the new one has not written its `run.json` yet, so that guess selected the OLD run and
+  // navigated away from the one just started. `startedRunId` is the id the daemon allocated, so
+  // there is nothing to infer. A run with no worktree (the non-git fallback) reports no id, and
+  // keeps the old behavior — there, one run at a time still holds, so the guess is still safe.
   useEffect(() => {
     if (!followLive) return
-    const running = runs.find(run => run.status === 'running')
-    if (running) {
-      setRunId(running.id)
+    const started = startedRunId
+      ? runs.find(run => run.id === startedRunId)
+      : runs.find(run => run.status === 'running')
+    if (started) {
+      setRunId(started.id)
       setFollowLive(false)
     }
-  }, [followLive, runs])
+  }, [followLive, runs, startedRunId])
 
   // Selecting a run (or the Live/Home row) from the rail is always an explicit choice, so it
   // ends the just-started follow.
   const selectRun = (id: string | null) => {
     setFollowLive(false)
+    setStartedRunId(null)
     setRunId(id)
   }
 

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -234,6 +234,12 @@ export interface CliOptions {
    * the session. Absent for a plain `framework "..."`, which runs in the user's own checkout.
    */
   runId?: string | undefined
+  /**
+   * `--continue-run` (#762): this run continues the run `--run-id` names rather than starting a new
+   * one. The store reopens that run's log instead of truncating it, so messaging a stopped run
+   * stays one row in the history.
+   */
+  continueRun?: boolean | undefined
   model?: string | undefined
   /** `--resume-session <id>` (#720): continue a finished run's agent session — the prompt resumes that conversation (full prior context). Set by the dashboard when you message a run that has ended. */
   resumeSession?: string | undefined
@@ -434,6 +440,9 @@ export function parseArgs(argv: string[]): CliOptions {
         break
       case '--run-id':
         opts.runId = argv[++i]
+        break
+      case '--continue-run':
+        opts.continueRun = true
         break
       case '--model':
         opts.model = argv[++i]
@@ -1030,6 +1039,8 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
         intent: intent || (opts.research ? 'this PR' : ''),
         // Adopt the daemon's id (#736) so the run and the worktree it lives in share one.
         ...(opts.runId ? { id: opts.runId } : {}),
+        // Continuing (#762): keep the existing log rather than starting this run's history over.
+        ...(opts.continueRun ? { continueRun: true } : {}),
       })
     } catch (err) {
       io.err(`could not persist run state (${err instanceof Error ? err.message : String(err)}); continuing without it`)

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -11,6 +11,10 @@ import {
   linkDependencies,
   excludeDependencyLinks,
   archiveWorktreeRun,
+  restoreArchivedRun,
+  attachWorktree,
+  worktreePath,
+  listRuns,
   removeWorktree,
   pruneWorktrees,
 } from './store/index.js'
@@ -489,6 +493,32 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
    * main checkout, which is exactly the pre-#736 behavior — and keeps its pre-#736 limit of
    * one run at a time, since those runs *would* collide. Signalled by the absent `runId`.
    */
+  /**
+   * Put a continued run (#762) back in its own checkout: the same worktree if it was retained, else
+   * its own branch checked out fresh. Its archived history is restored into the checkout so the run
+   * reopens its log rather than starting empty, which is what keeps it one row.
+   *
+   * The branch is the session's if the agent named one, else the run-id branch it started on.
+   * Returns undefined when none of that is possible, so the caller can fall back to a new run.
+   */
+  const continueWorkspace = async (projectCwd: string, runId: string): Promise<{ cwd: string; runId: string } | undefined> => {
+    try {
+      const path = worktreePath(projectCwd, runId)
+      const existing = await stat(path).then(s => s.isDirectory()).catch(() => false)
+      if (!existing) {
+        const archived = (await listRuns(projectCwd).catch(() => [])).find(run => run.id === runId)
+        const branch = archived?.sessionName ? `the-framework/${archived.sessionName}` : runBranchName(runId)
+        await attachWorktree(projectCwd, { runId, branch })
+        await linkDependencies(projectCwd, path).catch(() => [])
+      }
+      await restoreArchivedRun(projectCwd, path, runId).catch(() => false)
+      return { cwd: path, runId }
+    } catch (err) {
+      console.log(`[framework] could not continue run ${runId} (${err instanceof Error ? err.message : String(err)}); starting a new one`)
+      return undefined
+    }
+  }
+
   const allocateWorkspace = async (projectCwd: string, runId: string): Promise<{ cwd: string; runId?: string }> => {
     try {
       const worktree = await addWorktree(projectCwd, { runId, branch: runBranchName(runId) })
@@ -553,7 +583,9 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
       return { ok: false, error: err instanceof Error ? err.message : String(err) }
     }
 
-    const workspace = await allocateWorkspace(projectCwd, runIdFromStartedAt(new Date().toISOString()))
+    // Continuing an existing run (#762) reuses its id, checkout and log; anything else is new.
+    const continued = options.continueRunId ? await continueWorkspace(projectCwd, options.continueRunId) : undefined
+    const workspace = continued ?? (await allocateWorkspace(projectCwd, runIdFromStartedAt(new Date().toISOString())))
     // A run in its own worktree is keyed by that worktree, so it never collides with a
     // sibling; a fallback run is keyed by the project, restoring the one-at-a-time guard.
     const key = workspace.runId ? `${projectKey}::${workspace.runId}` : projectKey
@@ -582,6 +614,8 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
         '--cwd',
         workspace.cwd,
         ...(workspace.runId ? ['--run-id', workspace.runId] : []),
+        // Reopen the run's log instead of truncating it: the follow-up IS that run.
+        ...(continued ? ['--continue-run'] : []),
       ])
       // The run narrates itself through its own `.the-framework/events.jsonl`, which the
       // dashboard streams over a Telefunc Channel; the daemon just tracks liveness.

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -592,7 +592,8 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
       child.once('error', settle)
       child.once('exit', settle)
       if (child.pid !== undefined) activeRuns.set(key, child.pid)
-      return { ok: true }
+      // Hand back the run's id (#761) so the dashboard can select this run rather than guess.
+      return { ok: true, ...(workspace.runId ? { runId: workspace.runId } : {}) }
     } finally {
       starting.delete(key)
     }

--- a/packages/framework/src/dashboard/types.ts
+++ b/packages/framework/src/dashboard/types.ts
@@ -54,7 +54,13 @@ export type StartRunKind = 'build' | 'research' | 'prompt'
 
 /** The outcome of a Start attempt (#345). */
 export type StartRunResult =
-  | { ok: true }
+  /**
+   * `runId` is the id the daemon allocated for the run (#761), present whenever it got its own
+   * worktree. The dashboard needs it to select the run it just started: with concurrent runs
+   * (#736) it can no longer find that run by looking for "the running one", because the previous
+   * run is still running and the new one has not written its `run.json` yet.
+   */
+  | { ok: true; runId?: string }
   | { ok: false; busy?: boolean; error: string }
 
 /** The outcome of a Preview attempt (#475): the live URL, or why not. */

--- a/packages/framework/src/dashboard/types.ts
+++ b/packages/framework/src/dashboard/types.ts
@@ -41,6 +41,12 @@ export interface StartRunOptions {
   agent?: string
   /** Resume a finished run's conversation (#720): its captured agent session id; maps to `--resume-session`. The run's prompt continues that session (full prior context) instead of starting fresh. Sent with `kind: 'prompt'` when you message a run that has ended. */
   resumeSession?: string
+  /**
+   * Continue this run rather than starting a new one (#762): the follow-up writes into that run's
+   * own log, on its own branch, so a stopped run you message again stays one row in the history
+   * instead of spawning an unrelated-looking second one.
+   */
+  continueRunId?: string
 }
 
 /**

--- a/packages/framework/src/store/index.ts
+++ b/packages/framework/src/store/index.ts
@@ -9,6 +9,7 @@ export {
   loadRunEvents,
   readLiveMetas,
   archiveWorktreeRun,
+  restoreArchivedRun,
   listWorktreeDirs,
   runIdFromStartedAt,
   isSafeRunId,
@@ -26,6 +27,7 @@ export {
 } from './run-store.js'
 export {
   addWorktree,
+  attachWorktree,
   listWorktrees,
   parseWorktreeList,
   removeWorktree,

--- a/packages/framework/src/store/run-store.test.ts
+++ b/packages/framework/src/store/run-store.test.ts
@@ -10,6 +10,7 @@ import {
   readLiveMeta,
   readLiveMetas,
   archiveWorktreeRun,
+  restoreArchivedRun,
   listWorktreeDirs,
   reconcileOrphanedRuns,
   loadRunEvents,
@@ -455,4 +456,50 @@ test('listWorktreeDirs names the run of each worktree, ignoring anything else in
   })
   assert.deepEqual((await listWorktreeDirs(CWD, fs)).sort(), ['r1', 'r2'])
   assert.deepEqual(await listWorktreeDirs(join(CWD, 'never-ran'), fs), [])
+})
+
+// #762: messaging a stopped run continues THAT run, so the history shows one row rather than an
+// unrelated-looking second one. The follow-up is still a separate process; what makes it one run is
+// that it reopens the same log instead of truncating it.
+test('continueRun reopens the existing run: same id, same log, running again (#762)', async () => {
+  const fs = memFs({
+    [META]: JSON.stringify({ version: 1, status: 'stopped', id: 'r1', startedAt: AT, updatedAt: AT, passes: 3, intent: 'build a blog' }),
+    [EVENTS]: '{"kind":"log","message":"first leg"}\n',
+  })
+  const store = await RunStore.open(CWD, { fs, continueRun: true, now: '2026-07-04T01:00:00.000Z' })
+  const meta = await store.readMeta()
+  assert.equal(meta?.id, 'r1', 'the same run, so the rail shows one row')
+  assert.equal(meta?.status, 'running', 'live again')
+  assert.equal(meta?.intent, 'build a blog', 'and keeps what it was originally asked to do')
+  assert.equal(meta?.passes, 3, 'and what it already did')
+  assert.equal(fs.files.get(EVENTS), '{"kind":"log","message":"first leg"}\n', 'the earlier output survives')
+
+  // The continuing process owns it now, so a liveness probe reads it as alive, not orphaned (#716).
+  assert.equal(meta?.pid, process.pid)
+
+  await store.append({ kind: 'log', message: 'second leg' })
+  assert.match(fs.files.get(EVENTS)!, /first leg[\s\S]*second leg/, 'the second leg appends to the same log')
+})
+
+test('continueRun with nothing to reopen falls back to a fresh run (#762)', async () => {
+  const store = await RunStore.open(CWD, { fs: memFs(), continueRun: true, fresh: true, now: AT, id: 'r9' })
+  assert.equal((await store.readMeta())?.id, 'r9')
+  assert.equal((await store.readMeta())?.status, 'running')
+})
+
+test('restoreArchivedRun puts a torn-down run history back in its worktree (#762)', async () => {
+  // #737 moved the history to the repo and removed the checkout; continuing needs it back.
+  const fs = memFs({
+    [join(CWD, '.the-framework', 'runs', 'r1.json')]: JSON.stringify({ version: 1, status: 'done', id: 'r1', startedAt: AT, updatedAt: AT, passes: 1 }),
+    [join(CWD, '.the-framework', 'runs', 'r1.jsonl')]: '{"kind":"log","message":"archived"}\n',
+  })
+  const wt = join(CWD, '.the-framework', 'worktrees', 'r1')
+  assert.equal(await restoreArchivedRun(CWD, wt, 'r1', fs), true)
+  assert.equal(fs.files.get(join(wt, '.the-framework', 'events.jsonl')), '{"kind":"log","message":"archived"}\n')
+  assert.equal((JSON.parse(fs.files.get(join(wt, '.the-framework', 'run.json'))!) as RunMeta).id, 'r1')
+
+  // Idempotent: a checkout that already holds a live run keeps it (its log is the newer one).
+  assert.equal(await restoreArchivedRun(CWD, wt, 'r1', fs), false)
+  // Nothing archived, nothing to do.
+  assert.equal(await restoreArchivedRun(CWD, join(CWD, 'nope'), 'r404', memFs()), false)
 })

--- a/packages/framework/src/store/run-store.ts
+++ b/packages/framework/src/store/run-store.ts
@@ -153,6 +153,15 @@ export interface OpenStoreOptions {
    * timestamps taken a moment apart. Ignored unless path-safe.
    */
   id?: string
+  /**
+   * Reopen the run already at this path instead of starting a new one (#762): keep its event log
+   * and its original intent, and flip it back to `running` under this process. What makes a
+   * continued run one row in the history rather than two: the follow-up is a second process, but
+   * it writes into the same run.
+   *
+   * Falls back to a fresh run when there is nothing to reopen.
+   */
+  continueRun?: boolean
 }
 
 /**
@@ -302,6 +311,16 @@ export class RunStore {
     await fs.mkdir(dir)
     const owner = opts.owner ?? { pid: process.pid, host: hostname() }
     const store = new RunStore(fs, dir, now, freshMeta(now, opts.intent, owner, opts.id))
+    if (opts.continueRun) {
+      // Reopen: the log stays, the row keeps its original intent, and this process takes ownership
+      // so a liveness probe (#716) reads the run as alive rather than as an orphan.
+      const prior = await readMetaFile(fs, store.metaPath)
+      if (prior) {
+        store.meta = { ...prior, status: 'running', pid: owner.pid, host: owner.host, updatedAt: now }
+        await store.writeMeta()
+        return store
+      }
+    }
     if (opts.fresh) {
       // A new run truncates the live log. First rescue the prior run if it never
       // got archived (e.g. a crash exited before close), so no history is lost.
@@ -397,6 +416,35 @@ async function archivePriorRun(fs: StoreFs, dir: string): Promise<void> {
   if (!meta?.id || !isSafeRunId(meta.id)) return
   if (await fs.exists(archivePaths(dir, meta.id).meta)) return
   await archiveRun(fs, dir, meta, join(dir, EVENTS_FILE))
+}
+
+/**
+ * Put an archived run's history back where a run reads it (#762), so a continued run picks up its
+ * own log rather than starting empty. The inverse of {@link archiveWorktreeRun}: teardown moved the
+ * history to the repo, and continuing needs it in the checkout again.
+ *
+ * A no-op when the worktree already holds a live run (nothing to restore, and its log is newer),
+ * or when there is no archive. Never throws.
+ */
+export async function restoreArchivedRun(
+  repo: string,
+  worktree: string,
+  runId: string,
+  fs: StoreFs = nodeStoreFs(),
+): Promise<boolean> {
+  try {
+    if (!isSafeRunId(runId)) return false
+    const dir = join(worktree, FRAMEWORK_DIR)
+    if (await fs.exists(join(dir, META_FILE))) return false
+    const archive = archivePaths(join(repo, FRAMEWORK_DIR), runId)
+    if (!(await fs.exists(archive.meta))) return false
+    await fs.mkdir(dir)
+    await fs.write(join(dir, EVENTS_FILE), (await fs.exists(archive.events)) ? await fs.read(archive.events) : '')
+    await fs.write(join(dir, META_FILE), await fs.read(archive.meta))
+    return true
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/packages/framework/src/store/worktree.ts
+++ b/packages/framework/src/store/worktree.ts
@@ -68,6 +68,24 @@ export async function addWorktree(
 }
 
 /**
+ * Check an *existing* branch out into a run's worktree (#762): `git worktree add <path> <branch>`,
+ * no `-b`. Continuing a run puts it back on the branch its work is already on, rather than
+ * branching again from HEAD and stranding what it did last time.
+ *
+ * Rejects on git failure, like {@link addWorktree}: a continued run needs its checkout.
+ */
+export async function attachWorktree(
+  repo: string,
+  opts: { runId: string; branch: string },
+  run: GitRunner = nodeGitRunner(),
+): Promise<AddedWorktree> {
+  if (!isSafeRunId(opts.runId)) throw new Error(`unsafe run id: ${opts.runId}`)
+  const path = worktreePath(repo, opts.runId)
+  await run(['worktree', 'add', path, opts.branch], repo)
+  return { path, branch: opts.branch }
+}
+
+/**
  * Every worktree registered for the repo (the main checkout included). Forgiving:
  * a non-repo / git failure yields `[]` so a reconcile scan never throws.
  */


### PR DESCRIPTION
Closes #762. Stacked on #763 (same files); merge that first and this retargets to main.

You stopped a run, messaged it again, and got a second unrelated-looking row. The agent conversation did continue (`--resume-session`, #720) but nothing said so. You picked **one row**: one thing asked for, one entry.

## What changed

The follow-up is still its own process. What changed is where it writes.

- `sendStart` takes `continueRunId`. The daemon reuses that run's **id, worktree and branch** instead of allocating new ones — so the continued work lands on the branch its earlier work is already on, rather than branching again from HEAD and stranding it.
- If #737 already tore the worktree down, it is re-attached to the run's own branch (`the-framework/<sessionName>`, else the run-id branch) and the archived history is restored into it, so the run picks up its own log rather than starting empty.
- A new internal `--continue-run` flag makes the store **reopen** the run: the log stays, the original intent and pass count stay, and it flips back to `running` owned by the new process (so the #716 liveness probe reads it as alive, not orphaned).

Result: one run, one row, one branch, one log that reads start to finish.

## Falling back

Continuing is best-effort. No worktree to attach, no branch left, nothing archived to restore -> it logs why and starts a new run, which is the old behaviour.

## Still open in #762

The other half of that issue is the resume failing outright:

```
No conversation found with session ID: cdffc594-…
```

The captured session id outlives what the agent CLI will resume, and the run just shows FAILED. This PR does not fix that; it should either verify the session before spawning or fall back to a fresh conversation with a note. Left separate because it is a different failure with its own design question.

## Tests

3 new (reopen keeps id/log/intent; falls back when there is nothing to reopen; restore puts a torn-down history back). 688 green in framework, 109 in framework-dashboard.

## Note for whoever runs the suite

Two ways to get false failures locally, neither code-related: a **live machine daemon** makes `runCli` wire its control watcher and hang the CLI tests (isolate with `XDG_CONFIG_HOME`), and a worktree with **no dashboard bundle** makes the daemon answer `/_telefunc` with a 503 text body, so the tests' `JSON.parse` throws. Both cost me a bisect; filing the first as a hermeticity issue.