### PR TITLE
fix(framework): resolve a run by its worktree, not its not-yet-written state (#766)

### DIFF
--- a/.changeset/fix-766-resolve-run-before-meta.md
+++ b/.changeset/fix-766-resolve-run-before-meta.md
@@ -1,0 +1,9 @@
+---
+"@gemstack/framework": patch
+---
+
+Fix a newly started run showing the previous run's logs (#766). A run is resolved to its checkout by looking through the live run state, but for the first seconds of a run there is none: the daemon creates the worktree, spawns the process, and the run writes its `run.json` a beat later. The lookup missed a run that certainly existed and fell back to the project root, whose event log holds an older run's output.
+
+It stuck because a Telefunc Channel resolves its path once, when the client subscribes, so the feed tailed the wrong file for the life of the subscription rather than correcting a moment later.
+
+A run is now resolved by its worktree directory, which is named with the run id and exists before the process starts. A run id with no worktree still falls back to the project root, which stays correct for the non-git fallback path and for a run whose worktree has been removed.

--- a/packages/framework/src/dashboard-rpc/context.ts
+++ b/packages/framework/src/dashboard-rpc/context.ts
@@ -1,5 +1,6 @@
 import { getContext } from 'telefunc'
-import { readLiveMetas } from '../store/index.js'
+import { readLiveMetas, worktreePath, isSafeRunId } from '../store/index.js'
+import { nodeFs } from '../node-fs.js'
 import { defaultProjectsProvider, type ProjectsProvider } from '../dashboard/projects.js'
 import type { DashboardContext, EventsSource } from '../dashboard/telefunc-serve.js'
 import type { PreferencesStore } from '../registry.js'
@@ -46,9 +47,21 @@ export function resolveProjectPath(projectId: string): Promise<string | undefine
  */
 export async function resolveRunPath(projectId: string, runId?: string): Promise<string | undefined> {
   const cwd = await resolveProjectPath(projectId)
-  if (!cwd || !runId) return cwd
+  if (!cwd || !runId || !isSafeRunId(runId)) return cwd
   const live = await readLiveMetas(cwd).catch(() => [])
-  return live.find(run => run.id === runId)?.cwd ?? cwd
+  const running = live.find(run => run.id === runId)?.cwd
+  if (running) return running
+  // Not in the live list yet. That is the normal state for the first seconds of a run (#766): the
+  // daemon creates the worktree and spawns the process, and only then does the run write its
+  // `run.json`, so a lookup by run state misses a run that certainly exists. The directory is named
+  // with the run id and is there before the process starts, so ask the filesystem instead.
+  //
+  // This matters beyond a slow first read: a Telefunc Channel resolves its path once, when the
+  // client subscribes. Falling back to the project root here does not self-correct a moment later
+  // — it tails the wrong file for the life of the subscription, which is how a newly started run
+  // ended up showing a previous run's output.
+  const path = worktreePath(cwd, runId)
+  return (await nodeFs().isDirectory(path)) ? path : cwd
 }
 
 /**

--- a/packages/framework/src/dashboard-rpc/run-addressing.test.ts
+++ b/packages/framework/src/dashboard-rpc/run-addressing.test.ts
@@ -145,3 +145,38 @@ test('onRetainedWorktrees hides a live run, and lists one that has finished (#73
     await rm(ctx.dir, { recursive: true, force: true })
   }
 })
+
+// #766: for the first seconds of a run there is a worktree but no `run.json` yet. Resolving by run
+// state misses it and falls back to the project root, and because a Telefunc Channel resolves its
+// path once at subscribe time, the feed then tails the root's log — a previous run's output — for
+// the life of the subscription. Resolve by the directory, which the daemon creates before it spawns.
+test('a run that has a worktree but has not written its state yet still resolves to it (#766)', async () => {
+  const ctx = await projectWithWorktreeRun()
+  try {
+    const fresh = '2026-07-19T11-30-00-000Z'
+    const worktree = join(ctx.dir, FRAMEWORK_DIR, WORKTREES_DIR, fresh)
+    await mkdir(worktree, { recursive: true }) // the daemon has made the checkout; the run has not started writing
+    await sendStop(ctx.projectId, fresh)
+    assert.deepEqual(
+      await entries(join(worktree, FRAMEWORK_DIR, CONTROL_FILE)),
+      [{ kind: 'stop' }],
+      'addressed at the run whose worktree exists, not the project root',
+    )
+    assert.deepEqual(await entries(ctx.rootControl), [], 'the project root is left alone')
+  } finally {
+    ctx.restore()
+    await rm(ctx.dir, { recursive: true, force: true })
+  }
+})
+
+test('a run id with no worktree at all still falls back to the project root (#766)', async () => {
+  const ctx = await projectWithWorktreeRun()
+  try {
+    // The non-git fallback path, and any run whose worktree has since been removed.
+    await sendStop(ctx.projectId, '2026-07-19T11-45-00-000Z')
+    assert.deepEqual(await entries(ctx.rootControl), [{ kind: 'stop' }])
+  } finally {
+    ctx.restore()
+    await rm(ctx.dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Closes #766.

Start a run, start a second one: the second is running, but the pane shows the first one's log.

## Cause

`resolveRunPath` finds a run through `readLiveMetas`, which reads each worktree's `run.json`. For the first seconds of a run there is none — the daemon creates the worktree, spawns the process, and the run writes its state a beat later. So the lookup missed a run that certainly existed and fell back to the project root, whose `events.jsonl` holds an older run's output.

What made it stick rather than flicker: a Telefunc Channel resolves its path **once**, at subscribe time. There is no second chance a moment later; the feed tails the project root for the life of the subscription.

## Fix

Resolve by the directory. The worktree is named with the run id and is created before the process starts, so it answers correctly during exactly the window where run state does not exist yet. A run id with no worktree still falls back to the project root, which remains right for the non-git fallback and for a run whose worktree has been removed.

This also fixes the same window for steering: a Stop or a choice pick sent in the first seconds of a run was being written to the project root, where nothing was listening.

## Tests

Two new: a worktree with no `run.json` resolves to that worktree, and a run id with no worktree at all still falls back. 690 green.

## Note

Ran the suite with an isolated `XDG_CONFIG_HOME` per #765, since a live daemon otherwise hangs the CLI tests.