### PR TITLE
fix(framework): prefer a run's live state over its archived copy (#768)

### DIFF
--- a/.changeset/fix-768-live-beats-archived.md
+++ b/.changeset/fix-768-live-beats-archived.md
@@ -1,0 +1,9 @@
+---
+"@gemstack/framework": patch
+---
+
+Fix a continued run showing as finished (#768). Continuing a stopped run worked — the run went live again and the agent replied — but the dashboard kept rendering its finished replay, so it looked like nothing had happened.
+
+Every reader deduped a run present in both the live and archived lists by keeping the archived copy. That was right while a run was only ever archived on its way out, so the archive was the final word. A continued run (#762) has an archive from its first leg while being live again, and that archive shadowed the live copy, showing a running run as done.
+
+The live copy now wins, in the runs list, the activity feed and the project summaries.

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -41,17 +41,22 @@ async function withProject<T>(projectId: string, read: (cwd: string) => Promise<
  * them all (#738) instead of the single one that used to sit at the project path. They come
  * back as {@link LiveRun}s, carrying the `cwd` of the checkout that run is editing.
  *
- * A live run is skipped once it has been archived under the same id (it then appears from
- * `listRuns` instead), so there is no double. The status is not filtered on: `readLiveMeta`
+ * One row per id, and where both a live and an archived copy exist the live one wins (#768): a
+ * continued run (#762) has an archive from its first leg while being live again, and the archive
+ * would otherwise show a running run as finished. The status is not filtered on: `readLiveMeta`
  * may have just self-healed a dead run to `stopped` (#716), and that freshly-archived row can
- * lag `listRuns` by a poll — prepending it regardless keeps the row visible with no flicker.
+ * lag `listRuns` by a poll — keeping it regardless leaves the row visible with no flicker.
  */
 export async function onRuns(projectId: string): Promise<RunMeta[]> {
   const cwd = await resolveProjectPath(projectId)
   if (!cwd) return []
   const archived = await listRuns(cwd).catch(() => [])
   const live = await readLiveMetas(cwd).catch(() => [])
-  return [...live.filter(run => !archived.some(r => r.id === run.id)), ...archived]
+  // Live wins over archived (#768). The dedup used to drop the live copy, which was right while
+  // "archived" meant "finished for good": a run was only ever copied into `runs/` on its way out.
+  // Continuing a run (#762) breaks that — the run has an archived copy from its first leg AND is
+  // live again — and keeping the archive showed a running run as finished.
+  return [...live, ...archived.filter(run => !live.some(l => l.id === run.id))]
 }
 
 /**

--- a/packages/framework/src/dashboard-rpc/run-addressing.test.ts
+++ b/packages/framework/src/dashboard-rpc/run-addressing.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 import { mkdtemp, rm, mkdir, writeFile, readFile, realpath } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { sendStop, sendMessage, sendChoice, sendRemoveWorktree } from './control.telefunc.js'
-import { onRetainedWorktrees } from './reads.telefunc.js'
+import { onRetainedWorktrees, onRuns } from './reads.telefunc.js'
 import { addProject, projectId as idFor } from '../registry.js'
 import { FRAMEWORK_DIR, WORKTREES_DIR } from '../store/index.js'
 import { CONTROL_FILE } from '../control.js'
@@ -175,6 +175,28 @@ test('a run id with no worktree at all still falls back to the project root (#76
     // The non-git fallback path, and any run whose worktree has since been removed.
     await sendStop(ctx.projectId, '2026-07-19T11-45-00-000Z')
     assert.deepEqual(await entries(ctx.rootControl), [{ kind: 'stop' }])
+  } finally {
+    ctx.restore()
+    await rm(ctx.dir, { recursive: true, force: true })
+  }
+})
+
+// #768: a continued run (#762) has an archived copy from its first leg AND is live again. The
+// dedup used to keep the archive and drop the live copy, so the dashboard showed a running run as
+// finished — the run really was going, the UI just rendered its stale replay and looked dead.
+test('a continued run reads as running, not as its archived first leg (#768)', async () => {
+  const ctx = await projectWithWorktreeRun() // its worktree meta says `running`
+  try {
+    // Its first leg was archived when it finished, exactly as teardown (#737) leaves things.
+    await mkdir(join(ctx.dir, FRAMEWORK_DIR, 'runs'), { recursive: true })
+    await writeFile(
+      join(ctx.dir, FRAMEWORK_DIR, 'runs', `${ctx.runId}.json`),
+      JSON.stringify({ version: 1, status: 'done', id: ctx.runId, startedAt: ctx.runId, updatedAt: ctx.runId, passes: 1 }),
+    )
+    const runs = (await onRuns(ctx.projectId)) as { id: string; status: string }[]
+    const mine = runs.filter(run => run.id === ctx.runId)
+    assert.equal(mine.length, 1, 'still one row, not two')
+    assert.equal(mine[0]?.status, 'running', 'and it reads as live, not as the archived first leg')
   } finally {
     ctx.restore()
     await rm(ctx.dir, { recursive: true, force: true })

--- a/packages/framework/src/dashboard/activity.ts
+++ b/packages/framework/src/dashboard/activity.ts
@@ -46,7 +46,11 @@ async function readAllRuns(cwd: string): Promise<RunMeta[]> {
     readLiveMetas(cwd).catch(() => [] as LiveRun[]),
   ])
   // Skip a live run already archived under the same id, so it is not counted twice.
-  return [...live.filter(run => !archived.some(r => r.id === run.id)), ...archived]
+  // Live wins over archived (#768). The dedup used to drop the live copy, which was right while
+  // "archived" meant "finished for good": a run was only ever copied into `runs/` on its way out.
+  // Continuing a run (#762) breaks that — the run has an archived copy from its first leg AND is
+  // live again — and keeping the archive showed a running run as finished.
+  return [...live, ...archived.filter(run => !live.some(l => l.id === run.id))]
 }
 
 /** Map one run to its current activity item: `started` while running, else `finished`. */

--- a/packages/framework/src/dashboard/projects.ts
+++ b/packages/framework/src/dashboard/projects.ts
@@ -41,7 +41,11 @@ async function readAllRuns(path: string): Promise<RunMeta[]> {
     readLiveMetas(path).catch(() => [] as LiveRun[]),
   ])
   // Dedup by id like every other reader: a live run that has since been archived is one run.
-  return [...live.filter(run => !archived.some(r => r.id === run.id)), ...archived]
+  // Live wins over archived (#768). The dedup used to drop the live copy, which was right while
+  // "archived" meant "finished for good": a run was only ever copied into `runs/` on its way out.
+  // Continuing a run (#762) breaks that — the run has an archived copy from its first leg AND is
+  // live again — and keeping the archive showed a running run as finished.
+  return [...live, ...archived.filter(run => !live.some(l => l.id === run.id))]
 }
 
 /**


### PR DESCRIPTION
Closes #768.

Stop a run, message it to continue: it looked like nothing happened.

## It was working. The UI was reading the wrong copy.

For the run this was reported on, straight after continuing:

- live `run.json`: `status: running`, fresh pid, and the agent had already replied "Hey! Welcome back. What's up?"
- archived `runs/<id>.json`: `status: done`

Every reader deduped like this:

```js
[...live.filter(run => !archived.some(r => r.id === run.id)), ...archived]
```

which keeps the **archived** copy and drops the live one. That was correct while "archived" meant "finished for good" — a run was only ever copied into `runs/` on its way out. #762 broke the assumption: a continued run has an archive from its first leg *and* is live again. So the shell saw `done`, rendered `RunReplay` (a static read of the archived log), and the live output never appeared.

## Fix

Live wins. Applied to all three readers that dedupe: `onRuns`, `dashboard/activity.ts`, `dashboard/projects.ts`.

## Tests

One new, pinning the exact shape: a run whose worktree says running and whose archive says done reads as **one** row, **running**. 691 green in framework, 109 in framework-dashboard.

## Worth knowing

While digging I found the other half of why continuing can misbehave, not fixed here: `git worktree add` refuses a branch that is already checked out. The test-project main checkout is sitting on `the-framework/say-hello-static-html` from an old pre-worktree run, so continuing any run whose session branch is that one cannot attach a worktree and falls back to a new run. Worth deciding whether the framework should ever leave the user's checkout on a run branch, and whether continue should detach instead.