### PR TITLE
fix(framework-dashboard): address the feed at the started run from the first frame (#774)

### DIFF
--- a/.changeset/fix-770-no-stale-flash.md
+++ b/.changeset/fix-770-no-stale-flash.md
@@ -1,0 +1,7 @@
+---
+"@gemstack/framework": patch
+---
+
+Fix a newly started run briefly showing the previous run's log (#774). On Start the shell followed live until the poll surfaced the new run's row, and during that window the feed subscribed with no run id, which resolves to the project root and its older output. The right log replaced it a moment later, so the run flashed the wrong content first.
+
+The shell already gets the run id back from Start, so the feed now subscribes to that run immediately and there is no window addressed at the project root. The same id drives the run's controls, so an immediate Stop or message also reaches the right run rather than the project.

--- a/packages/framework-dashboard/lib/use-live-events.test.tsx
+++ b/packages/framework-dashboard/lib/use-live-events.test.tsx
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, render, waitFor } from '@testing-library/react'
+
+// Record what the feed subscribes to. The channel never sends; we only care about addressing.
+const onEvents = vi.hoisted(() => vi.fn())
+vi.mock('../server/events.telefunc.js', () => ({ onEvents }))
+
+const { useLiveEvents } = await import('./use-live-events.js')
+
+afterEach(() => {
+  cleanup()
+  onEvents.mockReset()
+})
+
+function Probe({ projectId, runId }: { projectId: string | null; runId?: string | null }) {
+  useLiveEvents(projectId, runId)
+  return null
+}
+
+// #770: right after Start, the run's row does not exist yet. The feed used to subscribe with no run
+// id in that window, which resolves server-side to the project root — so a newly started run showed
+// the PREVIOUS run's log for a beat before correcting itself. The shell passes the id it got back
+// from Start, so there is no window where the feed is pointed at the wrong log.
+describe('useLiveEvents addressing (#770)', () => {
+  test('subscribes to the run it was given', async () => {
+    onEvents.mockResolvedValue({ listen: () => {}, close: () => {} })
+    render(<Probe projectId="p1" runId="2026-07-19T13-00-00-000Z" />)
+    await waitFor(() => expect(onEvents).toHaveBeenCalledWith('p1', '2026-07-19T13-00-00-000Z'))
+  })
+
+  test('resubscribes when the selected run changes, so two runs never share a feed', async () => {
+    onEvents.mockResolvedValue({ listen: () => {}, close: () => {} })
+    const { rerender } = render(<Probe projectId="p1" runId="run-a" />)
+    await waitFor(() => expect(onEvents).toHaveBeenCalledWith('p1', 'run-a'))
+    rerender(<Probe projectId="p1" runId="run-b" />)
+    await waitFor(() => expect(onEvents).toHaveBeenCalledWith('p1', 'run-b'))
+  })
+
+  test('no run id still subscribes per project (the non-git fallback path)', async () => {
+    onEvents.mockResolvedValue({ listen: () => {}, close: () => {} })
+    render(<Probe projectId="p1" />)
+    await waitFor(() => expect(onEvents).toHaveBeenCalledWith('p1', undefined))
+  })
+})

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -145,6 +145,7 @@ export default function Page() {
   const selectProject = (id: string) => {
     setProjectId(id) // persisted, so a refresh returns here
     setRunId(null) // switching projects always returns to the home launcher
+    setStartedRunId(null) // and never keeps another project's run in play (#770)
     setFollowLive(false)
     resetContext() // the picked context is the old project's — start fresh
   }
@@ -154,12 +155,18 @@ export default function Page() {
   const showDashboard = () => {
     setProjectId(null)
     setRunId(null)
+    setStartedRunId(null)
     setFollowLive(false)
   }
 
   // The live run feed is owned here so both the main view and the right rail's choice gates
   // (#440) read one shared Telefunc Channel. Hooks run before the relay early return below.
-  const events = useLiveEvents(projectId, runId, runStart.tick)
+  // The run whose feed and controls are in play. `runId` once the poll has surfaced the run;
+  // `startedRunId` covers the gap right after Start, before its row exists (#770). Without that
+  // fallback the feed subscribes with no run id, which resolves to the project root — so a new run
+  // showed the PREVIOUS run's log for a beat before correcting itself.
+  const activeRunId = runId ?? startedRunId
+  const events = useLiveEvents(projectId, activeRunId, runStart.tick)
   const choices = projectId ? pendingChoices(events) : []
   const views = projectId ? agentViews(events) : []
 
@@ -178,7 +185,8 @@ export default function Page() {
     if (!projectId) return <DashboardPage onSelectProject={selectProject} interventions={interventions} />
     if (runId === null) {
       // Just pressed Start: follow the run's live output until the poll adopts its real id above.
-      if (followLive) return <RunLive projectId={projectId} events={events} files={files} addContext={addContext} />
+      if (followLive)
+        return <RunLive projectId={projectId} runId={activeRunId} events={events} files={files} addContext={addContext} />
       return (
         <ProjectHome
           projectId={projectId}
@@ -192,7 +200,7 @@ export default function Page() {
       )
     }
     if (selectedRun?.status === 'running')
-      return <RunLive projectId={projectId} runId={runId} events={events} files={files} addContext={addContext} />
+      return <RunLive projectId={projectId} runId={activeRunId} events={events} files={files} addContext={addContext} />
     return <RunReplay projectId={projectId} runId={runId} files={files} addContext={addContext} onRunStarted={onRunStarted} />
   }
 
@@ -237,7 +245,7 @@ export default function Page() {
         <main className="flex min-w-0 flex-1 flex-col">{renderMain()}</main>
         <RightRail
           projectId={projectId}
-          runId={runId}
+          runId={activeRunId}
           choices={choices}
           views={views}
           files={files}


### PR DESCRIPTION
Closes #774.

Start a run while another is running: the pane shows the previous run's log for a beat, then switches to the new one's.

## Cause

The client half of #766. On Start the shell clears the selection and follows live until the poll surfaces the new row. In that window `runId` is `null`, so the feed subscribes as `onEvents(projectId, undefined)` — which resolves to the project root, whose log holds older output. When the row appears the channel resubscribes and the correct log replaces it. Hence the flash.

#766 made the server resolve a run with no state yet to its worktree. This is the other half: the client was not naming the run at all.

## Fix

Since #761 the shell already has the id back from `sendStart`, so it subscribes with `runId ?? startedRunId` — addressed at the new run from the moment Start returns, with no window pointed at the project root. The same id drives that run's controls, so an immediate Stop or message lands on the run rather than the project, which was the same window where an early Stop used to go nowhere.

Also clears the started run on a project switch, so another project's run is never left in play.

## Tests

3 new on the subscription itself, since this class of bug has now appeared three times (#749, #766, this): it subscribes to the run given, resubscribes when the selection changes so two runs never share a feed, and still subscribes per project when there is no run id (the non-git fallback). 112 green.