### PR TITLE
fix(framework): continue a session whose agent conversation is gone (#778)

### DIFF
--- a/.changeset/olive-schools-jump.md
+++ b/.changeset/olive-schools-jump.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Continue a finished session even when its agent conversation is gone (#778). Resuming passes the captured session id to the agent CLI, which refuses it once the conversation has left its history. The driver now retries that turn once without the resume flag, so the session continues as a fresh conversation and says so in the event log, instead of failing with the reason buried there.

--- a/packages/framework/src/driver/claude-code.test.ts
+++ b/packages/framework/src/driver/claude-code.test.ts
@@ -236,6 +236,43 @@ test('ClaudeCodeSession seeds a given session id so the opening prompt resumes i
   assert.ok(!captured.includes('--append-system-prompt')) // the resumed transcript already carries its framing
 })
 
+test('ClaudeCodeSession retries without --resume when the conversation is gone (#778)', async () => {
+  const calls: string[][] = []
+  const spawn: SpawnLike = (_cmd, args, options) => {
+    calls.push([...args])
+    // First attempt: the CLI refuses the id it was asked to resume. Second: a normal turn.
+    return calls.length === 1
+      ? fakeSpawn([], 1, 'No conversation found with session ID: sess-42')(_cmd, args, options)
+      : fakeSpawn([JSON.stringify({ type: 'result', result: 'ok', session_id: 'sess-99' })])(_cmd, args, options)
+  }
+  const events: DriverEvent[] = []
+  const session = await new ClaudeCodeDriver({ spawn }).start({ cwd: '/ws', system: 'framing', resumeSessionId: 'sess-42', onEvent: e => events.push(e) })
+
+  const turn = await session.prompt('keep going', { resume: true })
+  assert.equal(turn.text, 'ok') // the message lands rather than failing the session
+  assert.equal(calls.length, 2)
+  assert.equal(calls[0]?.[calls[0].indexOf('--resume') + 1], 'sess-42')
+  // The retry is a fresh conversation, so it carries the system framing the resume skipped.
+  assert.ok(!calls[1]?.includes('--resume'))
+  assert.ok(calls[1]?.includes('--append-system-prompt'))
+  assert.ok(events.some(e => e.type === 'notice' && /no longer available/.test(e.message)))
+
+  // The dead id is dropped, so the next chat turn chains off the new conversation.
+  await session.prompt('and again', { resume: true })
+  assert.equal(calls[2]?.[calls[2].indexOf('--resume') + 1], 'sess-99')
+})
+
+test('ClaudeCodeSession does not retry a turn that failed for any other reason (#778)', async () => {
+  const calls: string[][] = []
+  const spawn: SpawnLike = (_cmd, args, options) => {
+    calls.push([...args])
+    return fakeSpawn([], 1, 'boom')(_cmd, args, options)
+  }
+  const session = await new ClaudeCodeDriver({ spawn }).start({ cwd: '/ws', system: 'framing', resumeSessionId: 'sess-42' })
+  await assert.rejects(session.prompt('keep going', { resume: true }), /boom/)
+  assert.equal(calls.length, 1)
+})
+
 test('ClaudeCodeSession runs a fresh turn when resume is asked with no prior session (#714)', async () => {
   let captured: string[] = []
   const spawn: SpawnLike = (_cmd, args) => {

--- a/packages/framework/src/driver/claude-code.ts
+++ b/packages/framework/src/driver/claude-code.ts
@@ -103,16 +103,33 @@ export class ClaudeCodeSession implements DriverSession {
   async prompt(text: string, opts: DriverPromptOptions = {}): Promise<DriverTurn> {
     const system = combineFraming(this.startOpts.system, opts.system)
     const resumeId = opts.resume ? this.lastSessionId : undefined
-    const turn = await runClaude({
-      bin: this.config.bin ?? 'claude',
-      args: this.buildArgs(system, resumeId),
-      cwd: this.cwd,
-      env: this.config.env ?? process.env,
-      prompt: text,
-      spawn: this.config.spawn ?? (nodeSpawn as unknown as SpawnLike),
-      emit: makeEmit(this.startOpts.onEvent, 'claude-code'),
-      signals: combineSignals(this.startOpts.signal, opts.signal),
-    })
+    const emit = makeEmit(this.startOpts.onEvent, 'claude-code')
+    const signals = combineSignals(this.startOpts.signal, opts.signal)
+    const run = (id: string | undefined): Promise<DriverTurn> =>
+      runClaude({
+        bin: this.config.bin ?? 'claude',
+        args: this.buildArgs(system, id),
+        cwd: this.cwd,
+        env: this.config.env ?? process.env,
+        prompt: text,
+        spawn: this.config.spawn ?? (nodeSpawn as unknown as SpawnLike),
+        emit,
+        signals,
+      })
+
+    let turn: DriverTurn
+    try {
+      turn = await run(resumeId)
+    } catch (err) {
+      // The id we captured outlives what the CLI will resume (#778) — its retention, a
+      // cleared history, another machine. There is no way to ask first, so let it fail
+      // once and continue as a fresh conversation (which gets the system framing back)
+      // rather than losing the message the user already typed.
+      if (resumeId === undefined || !isConversationGone(err) || signals.some(s => s.aborted)) throw err
+      this.lastSessionId = undefined
+      emit({ type: 'notice', message: 'That conversation is no longer available; continuing without its history.' })
+      turn = await run(undefined)
+    }
     // Track the agent's session so a later resume continues this exact conversation.
     if (turn.sessionId) this.lastSessionId = turn.sessionId
     return turn
@@ -168,6 +185,14 @@ export class ClaudeCodeSession implements DriverSession {
     }
     return this.mcpConfigPath
   }
+}
+
+/** How the CLI reports that the session id we asked it to resume is gone from its history (#778). */
+const CONVERSATION_GONE = /No conversation found with session ID/i
+
+/** Whether a failed turn failed because the conversation we tried to resume no longer exists. */
+function isConversationGone(err: unknown): boolean {
+  return CONVERSATION_GONE.test(err instanceof Error ? err.message : String(err))
 }
 
 /** @deprecated Use {@link RunAgentCliOptions}. */

--- a/packages/framework/src/driver/types.ts
+++ b/packages/framework/src/driver/types.ts
@@ -258,3 +258,5 @@ export type DriverEvent =
   | { type: 'rate-limit'; limit: DriverRateLimit }
   /** The agent (or its transport) errored. */
   | { type: 'error'; message: string }
+  /** Something the driver worked around, worth telling the user about (#778). */
+  | { type: 'notice'; message: string }

--- a/packages/framework/src/terminal.ts
+++ b/packages/framework/src/terminal.ts
@@ -73,6 +73,8 @@ function formatDriverEvent(event: DriverEvent): string {
       return `    ${formatRateLimit(event.limit)}`
     case 'error':
       return `  ! agent error: ${event.message}`
+    case 'notice':
+      return `  ~ ${event.message}`
   }
 }
 


### PR DESCRIPTION
Closes #778

Messaging a finished session passes its captured agent session id as `--resume`. That id outlives what the agent CLI will resume (its own retention, a cleared history, another machine), so the spawn dies with `No conversation found with session ID: ...` and the session shows FAILED with the reason only in the event log.

There is no reliable way to ask the CLI whether a conversation still exists, so this takes the recovery route from the issue: let it fail once, then retry the same prompt without the resume flag.

- `ClaudeCodeSession.prompt` catches that specific failure, drops the dead id, and reruns the turn as a fresh conversation. A fresh conversation gets `--append-system-prompt` back, which the resume path deliberately skips.
- Any other failure, and an aborted turn, still throw on the first attempt: no retry.
- A new `notice` driver event carries the explanation into the event log ("That conversation is no longer available; continuing without its history."), so the lost context is visible rather than silent. The terminal formatter renders it; the dashboard already uses that formatter, so there is no UI change.

Codex has no resume path, so this is claude-code only.

## Test

Two cases in `claude-code.test.ts`: the retry (second spawn drops `--resume`, regains `--append-system-prompt`, emits the notice, and the new session id chains for the next chat turn), and a turn failing for any other reason spawning exactly once.

`XDG_CONFIG_HOME=$(mktemp -d) pnpm --filter @gemstack/framework test` : 692 pass, 0 fail.