### PR TITLE
fix(framework-dashboard): show a dash, not "Invalid Date", for a missing timestamp (#759)

### DIFF
--- a/.changeset/fix-759-invalid-date.md
+++ b/.changeset/fix-759-invalid-date.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Never render a timestamp as "Invalid Date" (#759). A project timestamp reaches the UI as a plain string (a LOGS.md heading carries its `at` verbatim), so a missing or unparseable one used to print literally. Every date the dashboard shows now formats through one helper that falls back to a dash, or to "no activity yet" in the Projects sidebar.

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -9,6 +9,7 @@ import { UsagePanel } from './UsagePanel.js'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card.js'
 import { usePolled } from '../lib/use-async.js'
 import { cn } from '../lib/utils.js'
+import { formatDate } from '../lib/format-date.js'
 
 // The Overview dashboard page (#471). What used to be a cramped, collapsible section in the
 // first sidebar is now a proper at-a-glance landing: KPI tiles, a two-week activity chart,
@@ -308,7 +309,7 @@ function ProjectsTable({ projects, onSelectProject }: { projects: ProjectStat[];
               <td className="py-2 pr-4 text-right tabular-nums">{p.runs}</td>
               <td className="py-2 pr-4 text-right tabular-nums">{p.openTodos || '—'}</td>
               <td className="py-2 text-right text-xs text-muted-foreground">
-                {p.lastActivityAt ? new Date(p.lastActivityAt).toLocaleDateString() : '—'}
+                {formatDate(p.lastActivityAt)}
               </td>
             </tr>
           ))}

--- a/packages/framework-dashboard/components/ProjectLogPanel.tsx
+++ b/packages/framework-dashboard/components/ProjectLogPanel.tsx
@@ -3,6 +3,7 @@ import { onProjectLog } from '../server/reads.telefunc.js'
 import { Badge } from './ui/badge.js'
 import { usePolled } from '../lib/use-async.js'
 import { cn } from '../lib/utils.js'
+import { formatDateTime } from '../lib/format-date.js'
 
 const STATUS_TONE: Record<string, string> = {
   running: 'text-primary',
@@ -28,7 +29,7 @@ export function ProjectLogPanel({ projectId }: { projectId: string | null }) {
           <div className="flex items-center gap-2">
             <Badge className="text-[10px] uppercase text-muted-foreground">{log.kind}</Badge>
             <Badge className={cn('border-transparent px-0 text-[10px] uppercase', STATUS_TONE[log.status])}>{log.status}</Badge>
-            <span className="ml-auto text-xs text-muted-foreground">{new Date(log.at).toLocaleString()}</span>
+            <span className="ml-auto text-xs text-muted-foreground">{formatDateTime(log.at)}</span>
           </div>
           <p className="mt-1 text-sm">{log.title}</p>
         </li>

--- a/packages/framework-dashboard/components/ProjectsSidebar.tsx
+++ b/packages/framework-dashboard/components/ProjectsSidebar.tsx
@@ -5,6 +5,7 @@ import { onProjects, sendAddProject } from '../server/projects.telefunc.js'
 import { useAction } from '../lib/use-action.js'
 import { Button } from './ui/button.js'
 import { cn } from '../lib/utils.js'
+import { formatDateTime } from '../lib/format-date.js'
 
 // The Projects sidebar (#406/#314). Loads the registry over a Telefunc RPC and lets the
 // user pick which project's live stream to watch, or add a new one (#396/#433) via the
@@ -93,7 +94,7 @@ export function ProjectsSidebar({
               <span className="truncate font-medium">{p.name}</span>
             </span>
             <span className="truncate pl-4 text-xs font-normal text-muted-foreground">
-              {p.lastActivityAt ? new Date(p.lastActivityAt).toLocaleString() : 'no activity yet'}
+              {formatDateTime(p.lastActivityAt, 'no activity yet')}
             </span>
           </Button>
           ))}

--- a/packages/framework-dashboard/components/RunHistory.tsx
+++ b/packages/framework-dashboard/components/RunHistory.tsx
@@ -3,6 +3,7 @@ import type { RunMeta, RunStatus } from '@gemstack/framework'
 import { Button } from './ui/button.js'
 import { Badge } from './ui/badge.js'
 import { cn } from '../lib/utils.js'
+import { formatDateTime } from '../lib/format-date.js'
 
 const STATUS_TONE: Record<string, string> = {
   running: 'text-primary',
@@ -83,7 +84,7 @@ export function RunHistory({
             key={run.id}
             status={run.status}
             intent={run.intent}
-            subtitle={new Date(run.startedAt).toLocaleString()}
+            subtitle={formatDateTime(run.startedAt)}
             // Following live highlights the newest running run, not every one of them (#738):
             // `runs` is newest-first, so that is the first with a running status.
             active={run.id === selectedRunId || (followLive && run.id === newestRunningId)}

--- a/packages/framework-dashboard/lib/format-date.test.ts
+++ b/packages/framework-dashboard/lib/format-date.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+import { formatDate, formatDateTime } from './format-date.js'
+
+describe('format-date (#759)', () => {
+  test('formats a real timestamp', () => {
+    const at = '2026-07-19T14:55:16.905Z'
+    expect(formatDateTime(at)).toBe(new Date(at).toLocaleString())
+    expect(formatDate(at)).toBe(new Date(at).toLocaleDateString())
+  })
+
+  test('an absent timestamp reads as the fallback, never "Invalid Date"', () => {
+    expect(formatDateTime(undefined)).toBe('—')
+    expect(formatDate(undefined)).toBe('—')
+    expect(formatDateTime('')).toBe('—')
+  })
+
+  test('an unparseable timestamp reads as the fallback too', () => {
+    // A LOGS.md heading carries its `at` verbatim, so a hand-edited one lands here as-is.
+    expect(formatDateTime('not a date')).toBe('—')
+    expect(formatDate('not a date')).toBe('—')
+  })
+
+  test('the caller can word the fallback', () => {
+    expect(formatDateTime(undefined, 'no activity yet')).toBe('no activity yet')
+    expect(formatDateTime('nonsense', 'no activity yet')).toBe('no activity yet')
+  })
+})

--- a/packages/framework-dashboard/lib/format-date.ts
+++ b/packages/framework-dashboard/lib/format-date.ts
@@ -1,0 +1,24 @@
+// Timestamps reach the UI as plain strings: a run's `startedAt` from the store, a log
+// entry's `at` read verbatim out of a LOGS.md heading. Nothing validates them on the way
+// in, and `new Date(...).toLocaleString()` renders anything it cannot parse as the literal
+// "Invalid Date" (#759). So every display site formats through here, and an absent or
+// unparseable timestamp reads as the fallback instead.
+
+/** The parsed date, or undefined when there is nothing usable to show. */
+function parse(value: string | undefined): Date | undefined {
+  if (!value) return undefined
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? undefined : date
+}
+
+/** A timestamp as local date + time, e.g. a project's last activity. */
+export function formatDateTime(value: string | undefined, fallback = '—'): string {
+  const date = parse(value)
+  return date ? date.toLocaleString() : fallback
+}
+
+/** A timestamp as a local date alone, for the denser table columns. */
+export function formatDate(value: string | undefined, fallback = '—'): string {
+  const date = parse(value)
+  return date ? date.toLocaleDateString() : fallback
+}


### PR DESCRIPTION
Closes #759

A project with no activity rendered literal **Invalid Date** in the Projects sidebar and the Overview table.

Both of those sites already guarded `lastActivityAt` for undefined, so the guard was not the whole story: a timestamp reaches the UI as a plain string and nothing validates it on the way in. A LOGS.md heading carries its `at` verbatim (`parseEntry` checks that the field is present, never that it is a date), and a run's `startedAt` is whatever the store recorded. Any truthy-but-unparseable value walked straight past `value ? ... : fallback` into `new Date(...).toLocaleString()`.

So the fix is one formatter, used everywhere, that treats absent and unparseable the same:

- New `lib/format-date.ts` with `formatDateTime` / `formatDate`, both falling back to a dash (the caller can word it).
- All four date-rendering sites now go through it, which is the whole set: `ProjectsSidebar` (keeps "no activity yet"), `DashboardPage`'s Projects table, `RunHistory` (`startedAt`, previously unguarded), `ProjectLogPanel` (`log.at`, previously unguarded).

No layout or markup change, so nothing here touches the direction under discussion in #772.

## Test

`lib/format-date.test.ts` covers a real timestamp, absent, empty, unparseable, and a custom fallback.

`pnpm --filter @gemstack/framework-dashboard test` : 116 pass, 0 fail.