### PR TITLE
fix(framework): run the tests against a throwaway config home (#765)

### DIFF
--- a/.changeset/fix-765-test-config-isolation.md
+++ b/.changeset/fix-765-test-config-isolation.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Isolate the test suite from the machine's own daemon (#765). The tests read the global state at `$XDG_CONFIG_HOME`, so running them while a daemon was up wired the control watcher and its file follower kept the event loop alive, timing several cases out. The suite now runs against a throwaway config home, so a developer using the dashboard no longer gets false failures.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ pnpm typecheck
 pnpm test
 ```
 
+Working on `@gemstack/framework`, run `pnpm build` first: the framework tests need the dashboard bundle. Without `packages/framework-dashboard/dist/client`, the daemon answers `/_telefunc` with a 503 text body and `daemon.test.ts` fails on `JSON.parse` (`SyntaxError: Unexpected token 'h'`), which reads like a real regression but is a missing build step.
+
 This is a pnpm + Turborepo + Changesets monorepo. Runnable examples live under [`examples/`](./examples) — e.g. [`mcp-quickstart`](./examples/mcp-quickstart), [`autopilot-quickstart`](./examples/autopilot-quickstart) (Supervisor + runner + surfaces), and [`bootstrap-quickstart`](./examples/bootstrap-quickstart) (the whole bootstrap flow, offline). See [`.changeset/README.md`](./.changeset/README.md) for the release flow.
 
 ## Origin

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -54,7 +54,7 @@
     "build": "node scripts/gen-prompts.mjs && tsc -p tsconfig.build.json",
     "dev": "node scripts/gen-prompts.mjs && tsc -p tsconfig.build.json --watch",
     "typecheck": "node scripts/gen-prompts.mjs && tsc --noEmit",
-    "test": "node scripts/gen-prompts.mjs && tsc -p tsconfig.test.json && cd dist-test && node --test --test-timeout=60000",
+    "test": "node scripts/gen-prompts.mjs && tsc -p tsconfig.test.json && node scripts/run-tests.mjs",
     "bundle:dashboard": "node scripts/bundle-dashboard.mjs",
     "clean": "rm -rf dist dist-test src/prompts.generated.ts",
     "gen:prompts": "node scripts/gen-prompts.mjs",

--- a/packages/framework/scripts/run-tests.mjs
+++ b/packages/framework/scripts/run-tests.mjs
@@ -1,0 +1,31 @@
+// Run the compiled test suite against a throwaway config home (#765).
+//
+// The machine-global state lives at `$XDG_CONFIG_HOME` (the registry, the daemon state
+// file). A test that finds the developer's live daemon there wires the control watcher,
+// whose file follower keeps the event loop alive until the test times out, so a dashboard
+// user gets false failures. Nothing in the suite should ever read the real one, so the
+// isolation belongs here rather than in each test file.
+import { spawn } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const configHome = mkdtempSync(join(tmpdir(), 'framework-test-config-'))
+const packageDir = fileURLToPath(new URL('..', import.meta.url))
+
+const child = spawn(process.execPath, ['--test', '--test-timeout=60000', ...process.argv.slice(2)], {
+  cwd: join(packageDir, 'dist-test'),
+  env: { ...process.env, XDG_CONFIG_HOME: configHome },
+  stdio: 'inherit',
+})
+
+const cleanup = () => rmSync(configHome, { recursive: true, force: true })
+child.on('error', err => {
+  cleanup()
+  throw err
+})
+child.on('close', (code, signal) => {
+  cleanup()
+  process.exit(signal ? 1 : (code ?? 1))
+})


### PR DESCRIPTION
Closes #765

Running `pnpm test` in `packages/framework` while a daemon is up (the normal state if you use the dashboard) timed several `cli.test.ts` cases out at 20s each. `daemonStatus()` reads the machine-global state file at `$XDG_CONFIG_HOME`/`$HOME`; when it finds a live daemon, the run path wires the control watcher, whose `followFile` keeps the event loop alive past the end of the test.

Nothing in the suite should ever read the developer's real registry or daemon, so the isolation belongs in the runner rather than in each test file. `scripts/run-tests.mjs` mkdtemps a config home, runs `node --test` with `XDG_CONFIG_HOME` pointed at it, and removes it on exit. `daemon.test.ts`'s own `configEnv()` helper is untouched and still works.

Also documents the other trap from the issue: a worktree with no dashboard bundle makes the daemon answer `/_telefunc` with a 503 text body, so `daemon.test.ts` dies on `JSON.parse` with `SyntaxError: Unexpected token 'h'`. That reads like a regression but is a missing `pnpm build`.

## Test

Verified against a live daemon (pid on `~/.the-framework-daemon.json`, port 4200), no env override:

- before: the suite was still running after 14 minutes, ten `node --test` workers stuck.
- after: 690 pass, 0 fail, 1 skipped, in 9s.