### PR TITLE
fix(framework): reject --resume-session on a run that cannot resume (#782)

### DIFF
--- a/.changeset/fix-782-resume-session-guard.md
+++ b/.changeset/fix-782-resume-session-guard.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Reject `--resume-session` on a run kind that cannot honor it (#782). Only the direct-prompt path resumes an agent conversation; a build run took the flag and dropped it, so the run started fresh and looked like it had continued while having silently lost the context. It now fails with a usage error instead.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -479,6 +479,21 @@ test('runCli rejects an unknown --preset with a usage error (exit 2)', async () 
   assert.ok(err.some(l => /unknown --preset: nope/.test(l)))
 })
 
+test('runCli rejects --resume-session on a build run rather than dropping it (#782)', async () => {
+  const { io, err } = capture()
+  const code = await runCli(['--fake', '--no-dashboard', '--resume-session', 'sess-42'], io)
+  assert.equal(code, 2)
+  assert.ok(err.some(l => /--resume-session only applies to a prompt run/.test(l)))
+})
+
+test('runCli honors --resume-session on the prompt path it belongs to (#782)', async () => {
+  const { io, err } = capture()
+  // The dashboard's continuation always runs here, so the guard must never fire on it.
+  const code = await runCli(['prompt', 'keep going', '--fake', '--no-dashboard', '--resume-session', 'sess-42'], io)
+  assert.notEqual(code, 2)
+  assert.ok(!err.some(l => /--resume-session only applies/.test(l)))
+})
+
 test('runCli notes mode flags given without a preset', async () => {
   const { io, err } = capture()
   // --fake so the note fires before any real run; unknown-preset path is not hit.

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -926,6 +926,17 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // one of those sites reads the same answer.
   const transparent = opts.transparent || fileConfig.transparent === true
 
+  // Only the direct-prompt path resumes a conversation (#782): a build run rebuilds the
+  // scope/build framing a resumed transcript already carries, so it takes no session id and
+  // used to drop the flag on the floor. Silently losing the context you asked to continue
+  // from is the worst outcome, so say so and stop rather than run a fresh session that looks
+  // like a resumed one.
+  if (opts.resumeSession && !(opts.research || opts.directPrompt || transparent)) {
+    io.err('--resume-session only applies to a prompt run, e.g. `framework prompt "keep going" --resume-session <id>`.')
+    io.err('Run `framework --help` for usage.')
+    return 2
+  }
+
   // Resolve which Open Loop domain preset (+ modes + build event) to run under:
   // --preset / the-framework.yml, or none at all (#545). Nothing infers one.
   const merged = mergeRunConfig(opts, fileConfig)


### PR DESCRIPTION
Closes #782

`--resume-session <id>` is parsed into `CliOptions.resumeSession` but read in exactly one place, inside the `research || directPrompt || transparent` branch. `runFramework` takes no session id at all, so a build run given the flag started a fresh conversation, said nothing, and looked like it had continued the one you named. Silently losing the context you asked to resume from is the worst of the available outcomes.

This takes the fail-loud route from the issue rather than teaching build runs to resume: a build run rebuilds the scope/build framing that a resumed transcript already carries, so honoring the flag there is the wrong shape.

The check sits right after `transparent` resolves, which is the first point where the run kind is fully known, and before the run does any work. Exit code 2, matching the other usage errors.

Nothing changes for the dashboard: a continuation posts `kind: 'prompt'` (`RunResumeChat.tsx:45`), the daemon turns that into the `prompt` subcommand (`daemon.ts:605`), and `directPrompt` is set, so the guard cannot fire on that path. A test pins exactly that.

## Test

Two cases in `cli.test.ts`: the flag on a build run exits 2 with the usage line, and the flag on the prompt path is untouched.

`pnpm --filter @gemstack/framework test` : 694 pass, 0 fail.