### PR TITLE
fix(framework): commit a run's pending work before removing its worktree (#786)

### DIFF
--- a/.changeset/fix-786-commit-before-teardown.md
+++ b/.changeset/fix-786-commit-before-teardown.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Never delete work a run left uncommitted (#786). Retiring a finished run removed its worktree with `git worktree remove --force`, so an edit the agent made but never committed was destroyed with the checkout, unrecoverably. Teardown now commits the run's pending work to its own branch first, which outlives the worktree, and keeps the checkout when that commit cannot be made.

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -15,6 +15,7 @@ import {
   attachWorktree,
   worktreePath,
   listRuns,
+  commitPendingWork,
   removeWorktree,
   pruneWorktrees,
 } from './store/index.js'
@@ -538,10 +539,10 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
    * copied into the repo first — otherwise removing the checkout would delete the run from the
    * dashboard's history.
    *
-   * Then the retention rule: a run that finished cleanly has nothing left to look at, so its
-   * worktree goes. A run that failed or was stopped keeps its checkout, because that is exactly
-   * when you want to see the half-finished working tree and the diff it died holding. Those are
-   * removed explicitly (the dashboard's Remove), never silently on a timer.
+   * Then the retention rule: a run that finished cleanly has nothing left to look at once its
+   * work is committed, so its worktree goes. A run that failed or was stopped keeps its checkout,
+   * because that is exactly when you want to see the half-finished working tree and the diff it
+   * died holding. Those are removed explicitly (the dashboard's Remove), never silently on a timer.
    *
    * Best-effort from end to end: this runs off a process-exit event with nothing to return to,
    * so a failure here must not take the daemon down.
@@ -550,6 +551,13 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
     try {
       const meta = await archiveWorktreeRun(worktree, projectCwd)
       if (meta?.status !== 'done') return // failed / stopped / unreadable: keep it for inspection
+      // A finished run can still be holding an uncommitted edit (#786), and removing the
+      // checkout would destroy it. Commit it to the run's branch, which outlives the
+      // worktree; if that cannot be done, keep the checkout rather than take the diff with it.
+      if (!(await commitPendingWork(worktree))) {
+        console.log(`[framework] keeping worktree ${worktree}: its uncommitted work could not be committed`)
+        return
+      }
       await removeWorktree(projectCwd, worktree)
       await pruneWorktrees(projectCwd)
     } catch {

--- a/packages/framework/src/store/index.ts
+++ b/packages/framework/src/store/index.ts
@@ -30,6 +30,7 @@ export {
   attachWorktree,
   listWorktrees,
   parseWorktreeList,
+  commitPendingWork,
   removeWorktree,
   pruneWorktrees,
   worktreePath,

--- a/packages/framework/src/store/worktree.test.ts
+++ b/packages/framework/src/store/worktree.test.ts
@@ -7,6 +7,7 @@ import type { GitRunner } from '../project.js'
 import { nodeGitRunner } from '../project.js'
 import {
   addWorktree,
+  commitPendingWork,
   listWorktrees,
   parseWorktreeList,
   removeWorktree,
@@ -92,10 +93,8 @@ test('listWorktrees passes --porcelain and is forgiving of a git failure', async
   assert.deepEqual(await listWorktrees(REPO, failingGit), [])
 })
 
-test('removeWorktree forces the removal and tolerates an already-gone path', async () => {
-  const git = recordingGit()
-  await removeWorktree(REPO, '/repo/wt', git)
-  assert.deepEqual(git.calls[0]?.args, ['worktree', 'remove', '--force', '/repo/wt'])
+test('removeWorktree tolerates an already-gone path', async () => {
+  // Both attempts fail for a path git never registered; teardown stays idempotent.
   await assert.doesNotReject(() => removeWorktree(REPO, '/repo/gone', failingGit))
 })
 
@@ -134,6 +133,76 @@ test('add/list/remove round-trips against a real git repo', async () => {
     assert.equal((await listWorktrees(repo, git)).some(w => w.path === path), false, 'removed worktree is no longer listed')
 
     await assert.doesNotReject(() => pruneWorktrees(repo, git))
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})
+
+test('commitPendingWork stages and commits a dirty checkout (#786)', async () => {
+  const git = recordingGit(' M index.html\n')
+  assert.equal(await commitPendingWork('/wt', git), true)
+  assert.deepEqual(
+    git.calls.map(c => c.args),
+    [['status', '--porcelain'], ['add', '-A'], ['commit', '-m', '[The Framework] uncommitted changes']],
+  )
+  assert.equal(git.calls[1]?.cwd, '/wt', 'commits in the worktree, not the repo')
+})
+
+test('commitPendingWork leaves a clean checkout alone (#786)', async () => {
+  const git = recordingGit('')
+  assert.equal(await commitPendingWork('/wt', git), true)
+  assert.deepEqual(git.calls.map(c => c.args), [['status', '--porcelain']]) // nothing to commit
+})
+
+test('commitPendingWork reports failure so the caller keeps the checkout (#786)', async () => {
+  // No git identity, a refusing hook: the work is still only in the working tree, so the
+  // caller must not go on to remove it.
+  assert.equal(await commitPendingWork('/wt', failingGit), false)
+})
+
+test('removeWorktree tries a plain removal before forcing (#786)', async () => {
+  const git = recordingGit()
+  await removeWorktree(REPO, '/wt', git)
+  assert.deepEqual(git.calls.map(c => c.args), [['worktree', 'remove', '/wt']]) // no --force needed
+})
+
+test('removeWorktree falls back to --force when git calls the checkout unclean (#786)', async () => {
+  const calls: string[][] = []
+  const git: GitRunner = async args => {
+    calls.push(args)
+    if (!args.includes('--force')) throw new Error('contains modified or untracked files')
+    return ''
+  }
+  await removeWorktree(REPO, '/wt', git)
+  assert.deepEqual(calls, [
+    ['worktree', 'remove', '/wt'],
+    ['worktree', 'remove', '--force', '/wt'],
+  ])
+})
+
+// The whole point of #786: a finished run's uncommitted edit must survive teardown.
+test('a dirty run worktree keeps its work on the branch after removal (#786)', async () => {
+  const git = nodeGitRunner()
+  const repo = await realpath(await mkdtemp(join(tmpdir(), 'framework-worktree-')))
+  try {
+    await git(['init'], repo)
+    await git(['config', 'user.email', 't@t'], repo)
+    await git(['config', 'user.name', 't'], repo)
+    await writeFile(join(repo, 'index.html'), '<h1>Hello, world!</h1>\n')
+    await git(['add', '-A'], repo)
+    await git(['commit', '-m', 'init'], repo)
+
+    const { path, branch } = await addWorktree(repo, { runId: 'run1', branch: 'the-framework/run-run1' }, git)
+    // The agent edits and stops without committing, exactly as the system prompt leaves it.
+    await writeFile(join(path, 'index.html'), '<h1>Welcome!</h1>\n')
+
+    assert.equal(await commitPendingWork(path, git), true)
+    await removeWorktree(repo, path, git)
+    await assert.rejects(() => stat(path), 'checkout dir is gone')
+
+    // The branch outlived the worktree and carries the edit.
+    const shown = await git(['show', `${branch}:index.html`], repo)
+    assert.match(shown, /Welcome!/, 'the edit survives on the run branch')
   } finally {
     await rm(repo, { recursive: true, force: true })
   }

--- a/packages/framework/src/store/worktree.ts
+++ b/packages/framework/src/store/worktree.ts
@@ -120,14 +120,51 @@ export function parseWorktreeList(porcelain: string): WorktreeInfo[] {
 }
 
 /**
- * Remove a run's worktree: `git worktree remove --force <path>` (force so an
- * in-progress checkout with untracked build output still tears down). Tolerant of
- * an already-gone / never-registered path so teardown stays idempotent (the run
- * child is detached; the daemon only holds its pid).
+ * Commit whatever the run left behind, on the run's own branch (#786).
+ *
+ * An agent that edits and stops without committing is behaving as instructed: the
+ * system prompt has it commit *pre-existing* changes before it starts, never its own
+ * work at the end. Removing that checkout would destroy the diff (the work was never
+ * staged, so it is not recoverable from git afterwards), so teardown commits it first
+ * and the branch outlives the worktree.
+ *
+ * Returns whether the checkout is safe to remove: true when it was already clean or
+ * the work is now committed, false when the commit failed (no git identity, a hook
+ * refusing it). False means keep the checkout, which is the safe direction.
+ */
+export async function commitPendingWork(path: string, run: GitRunner = nodeGitRunner()): Promise<boolean> {
+  try {
+    const status = await run(['status', '--porcelain'], path)
+    if (!status.trim()) return true
+    await run(['add', '-A'], path)
+    // Same wording as the install-time safety commit (install.ts), for one vocabulary.
+    await run(['commit', '-m', '[The Framework] uncommitted changes'], path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Remove a run's worktree. Tolerant of an already-gone / never-registered path so
+ * teardown stays idempotent (the run child is detached; the daemon only holds its pid).
+ *
+ * Plain removal first: it refuses a checkout git considers unclean, which after
+ * {@link commitPendingWork} means a state we did not anticipate. Falling back to
+ * `--force` keeps teardown working (an ignored build artifact must not strand a
+ * worktree forever), but it says so, because forcing past unknown state is exactly
+ * how uncommitted work got deleted in the first place.
  */
 export async function removeWorktree(repo: string, path: string, run: GitRunner = nodeGitRunner()): Promise<void> {
   try {
+    await run(['worktree', 'remove', path], repo)
+    return
+  } catch {
+    // Unclean by git's reckoning, already removed, or never registered: try forcing.
+  }
+  try {
     await run(['worktree', 'remove', '--force', path], repo)
+    console.log(`[framework] forced removal of worktree ${path} (git called it unclean)`)
   } catch {
     // Already removed, or never registered: nothing to do.
   }


### PR DESCRIPTION
Closes #786

A build run edited `index.html` exactly as asked, reported success, and the change is gone. `tearDownWorktree` archived the run and removed its checkout; the agent had never committed, so the edit went with it. The branch survives at the base commit, nothing contains the edit, and `git fsck` finds nothing, because the work was never staged.

## The fix

`commitPendingWork(path)` in the worktree module: if the checkout is dirty, stage and commit it **on the run's own branch**, which outlives the worktree. So the work ends up reachable at `the-framework/<sessionName>` instead of being destroyed. Same wording as the install-time safety commit (`install.ts:50`), so there is one vocabulary for "the framework committed this for you".

It returns whether the checkout is safe to remove. `tearDownWorktree` removes only on `true`; if the commit could not be made (no git identity, a refusing hook) it keeps the checkout and logs why. A worktree left on disk is the safe direction, which is already how that function reasons.

`removeWorktree` no longer forces blindly. It tries the plain removal first and falls back to `--force` with a log line, so a checkout in a state nobody anticipated is visible rather than silently destroyed. The force is still there because an ignored build artifact must not strand a worktree forever.

## Scope

The hygiene half is not here: getting the agent to commit its own work with a real message belongs in the system prompt, which ships verbatim from #326 and is guarded by `check-prompt-drift.mjs`. That needs Rom, and it does not replace this. An agent can ignore an instruction, crash, or be stopped mid-edit, so the framework still needs the safety net.

Worth reading with #785: `done` is not the strong signal this teardown path assumed it was.

## Test

Six cases. The load-bearing one runs against real git: create a worktree, edit a file without committing (exactly what the agent did), tear it down, then assert `git show <branch>:index.html` still contains the edit.

Also unit cases for dirty/clean/failed commits and for the plain-then-force removal order. One existing test asserted the old force-first argv and was updated.

`pnpm --filter @gemstack/framework test` : 700 pass, 0 fail.