### PR TITLE
feat(framework): say when a session is parked on the user (#785)

### DIFF
--- a/.changeset/feat-785-settled-state.md
+++ b/.changeset/feat-785-settled-state.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Tell a settled session from a working one (#785). A run that finished its work stays open as a conversation, so it kept reporting `running` with a pulsing dot until the user closed it, whether the agent was mid-edit or had been idle for an hour. A run now says when it parks (`settled` event, `RunMeta.settledAt`), and the sessions rail reads "waiting" with a still dot instead of animating at you.

--- a/packages/framework-dashboard/components/RunHistory.test.tsx
+++ b/packages/framework-dashboard/components/RunHistory.test.tsx
@@ -1,0 +1,51 @@
+import type { RunMeta } from '@gemstack/framework'
+import { afterEach, describe, expect, test } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { RunHistory } from './RunHistory.js'
+
+afterEach(cleanup)
+
+function run(over: Partial<RunMeta> = {}): RunMeta {
+  return {
+    version: 1,
+    status: 'running',
+    id: 'run-1',
+    startedAt: '2026-07-19T16:05:44.756Z',
+    updatedAt: '2026-07-19T16:06:21.000Z',
+    passes: 1,
+    intent: "replace 'Hello, world!' with 'Welcome!'",
+    ...over,
+  }
+}
+
+describe('RunHistory (#785)', () => {
+  test('a working run reads as running and animates', () => {
+    const { container } = render(<RunHistory projectId="p1" runs={[run()]} selectedRunId={null} onSelect={() => {}} />)
+    expect(screen.getByText('running')).toBeTruthy()
+    expect(container.querySelector('.animate-pulse')).toBeTruthy()
+  })
+
+  test('a run parked on the user reads as waiting and stops animating', () => {
+    // The build settled and it is waiting for a message: same live process, different meaning.
+    const { container } = render(
+      <RunHistory projectId="p1" runs={[run({ settledAt: '2026-07-19T16:06:21.000Z' })]} selectedRunId={null} onSelect={() => {}} />,
+    )
+    expect(screen.getByText('waiting')).toBeTruthy()
+    expect(screen.queryByText('running')).toBeNull()
+    expect(container.querySelector('.animate-pulse')).toBeNull()
+  })
+
+  test('a finished run is finished, never waiting', () => {
+    // settledAt is cleared on `end`, but a stale one must not relabel a terminal status.
+    render(
+      <RunHistory
+        projectId="p1"
+        runs={[run({ status: 'done', settledAt: '2026-07-19T16:06:21.000Z' })]}
+        selectedRunId={null}
+        onSelect={() => {}}
+      />,
+    )
+    expect(screen.getByText('done')).toBeTruthy()
+    expect(screen.queryByText('waiting')).toBeNull()
+  })
+})

--- a/packages/framework-dashboard/components/RunHistory.tsx
+++ b/packages/framework-dashboard/components/RunHistory.tsx
@@ -88,6 +88,7 @@ export function RunHistory({
             // Following live highlights the newest running run, not every one of them (#738):
             // `runs` is newest-first, so that is the first with a running status.
             active={run.id === selectedRunId || (followLive && run.id === newestRunningId)}
+            waiting={run.settledAt !== undefined}
             onClick={() => onSelect(run.id)}
           />
         ))}
@@ -96,7 +97,8 @@ export function RunHistory({
   )
 }
 
-// One run row: a pulsing dot + RUNNING badge for a live run, else the terminal-status badge.
+// One run row: a pulsing dot + RUNNING badge for a working run, a still dot + WAITING for one
+// parked on the user (#785), else the terminal-status badge.
 function RunRow({
   status,
   intent,
@@ -104,6 +106,7 @@ function RunRow({
   active,
   onClick,
   dim = false,
+  waiting = false,
 }: {
   status: RunStatus
   intent: string | undefined
@@ -111,7 +114,11 @@ function RunRow({
   active: boolean
   onClick: () => void
   dim?: boolean
+  /** Live, but parked on the user rather than working (#785). */
+  waiting?: boolean
 }) {
+  // Only a live run can be waiting on you; a finished one is just finished.
+  const parked = waiting && status === 'running'
   return (
     <Button
       variant="ghost"
@@ -123,8 +130,14 @@ function RunRow({
       onClick={onClick}
     >
       <span className="flex w-full items-center gap-2">
-        {status === 'running' && <span className="inline-block h-2 w-2 shrink-0 animate-pulse rounded-full bg-primary" />}
-        <Badge className={cn('shrink-0 border-transparent px-0 text-[10px] uppercase', STATUS_TONE[status])}>{status}</Badge>
+        {/* The dot means "the agent is working", so a run parked on you gets a still one (#785):
+            it used to pulse identically whether it was mid-edit or had been idle for an hour. */}
+        {status === 'running' && (
+          <span className={cn('inline-block h-2 w-2 shrink-0 rounded-full', parked ? 'bg-muted-foreground' : 'animate-pulse bg-primary')} />
+        )}
+        <Badge className={cn('shrink-0 border-transparent px-0 text-[10px] uppercase', parked ? 'text-muted-foreground' : STATUS_TONE[status])}>
+          {parked ? 'waiting' : status}
+        </Badge>
         <span className="truncate text-xs font-normal text-muted-foreground">{subtitle}</span>
       </span>
       <span className="w-full truncate text-sm font-medium">{intent || '(no prompt)'}</span>

--- a/packages/framework/src/events.ts
+++ b/packages/framework/src/events.ts
@@ -123,6 +123,16 @@ export type FrameworkEvent =
    */
   | { kind: 'ready-for-merge' }
   /**
+   * The work has settled and the run is parked on the user (#785): it stays open as a
+   * conversation (#714), so its process is still alive and it still takes messages, but
+   * the agent is not doing anything until you say something.
+   *
+   * Emitted each time the run parks, and undone by the next `driver` `start` — so "is it
+   * working or waiting for me" is answerable from the event log rather than inferred from
+   * a status that only changes when the run ends.
+   */
+  | { kind: 'settled' }
+  /**
    * Cumulative token + cost usage for the run so far (#322). Emitted after each
    * agent turn that reports usage; the dashboard renders a live spend readout and
    * the run stops itself once `costUsd` reaches the budget cap, if one is set.

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -889,6 +889,34 @@ test('runAwaitRounds gives up after MAX_AWAIT_ROUNDS and reports it exhausted', 
   assert.equal(prompts.length, MAX_AWAIT_ROUNDS + 1) // the opener, then one per round
 })
 
+test('the run says it is parked each time it waits for the user (#785)', async () => {
+  // The build settles, chat opens: that is the moment the agent stops working and the run is
+  // waiting on you. Before #785 nothing said so, and the dashboard kept animating "running".
+  const driver = new FakeDriver({ respond: () => 'built it' })
+  const session = await driver.start({ cwd: '/tmp/ws' })
+  const messages = new RunMessageQueue()
+  const events: FrameworkEvent[] = []
+
+  const done = runAwaitRounds({
+    session,
+    prompt: 'build it',
+    emitTurnSignals: () => {},
+    emit: e => events.push(e),
+    messages,
+  })
+  // One message, then close: parked -> working -> parked again -> end.
+  messages.push('now add dark mode')
+  await new Promise(resolve => setImmediate(resolve))
+  messages.close()
+  await done
+
+  // Once after the build settles, once after the chat turn: every park is announced, so the
+  // dashboard can stop animating the moment the agent stops. (The matching "working again"
+  // edge is the driver's own `start` event, which applyEventToMeta clears the flag on.)
+  assert.equal(events.filter(e => e.kind === 'settled').length, 2)
+  assert.ok(events.some(e => e.kind === 'log' && e.message === 'You: now add dark mode'), 'the chat turn ran between the two parks')
+})
+
 test('runAwaitRounds does not report exhausted when a chat phase follows the opening cap (#742)', async () => {
   // The opening prompt asks forever and hits the cap, but live chat is wired: the run stays open
   // and ends because chat closes (Stop), not "at the await limit". So exhausted must be false —

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -703,6 +703,9 @@ export async function runChatPhase(session: DriverSession, messages: RunMessages
   let turn = seed
   let exhausted = false
   for (;;) {
+    // Parked on the user (#785): the work is settled and nothing is running until a message
+    // arrives. Said out loud each time round, so a reader can tell waiting from working.
+    deps.emit({ kind: 'settled' })
     const message = await messages.next(deps.signal)
     if (message === undefined) return { turn, exhausted } // Stop / budget cap: end the conversation.
     deps.emit({ kind: 'log', message: `You: ${message}` })

--- a/packages/framework/src/store/run-store.test.ts
+++ b/packages/framework/src/store/run-store.test.ts
@@ -167,6 +167,24 @@ test('applyEventToMeta marks a user-stopped run as stopped, not failed (#218)', 
   assert.equal(stopped.status, 'stopped')
 })
 
+test('applyEventToMeta tracks whether the run is working or parked on the user (#785)', () => {
+  const base = metaFromEvents(RUN.slice(0, 4), AT)
+  assert.equal(base.settledAt, undefined, 'a working run is not parked')
+
+  const parked = applyEventToMeta(base, { kind: 'settled' }, AT)
+  assert.equal(parked.settledAt, AT)
+  assert.equal(parked.status, 'running', 'still live: it holds the project and takes messages')
+
+  // The user answers: the next turn starts, so it is working again.
+  const working = applyEventToMeta(parked, { kind: 'driver', event: { type: 'start', prompt: 'and dark mode' } }, AT)
+  assert.equal(working.settledAt, undefined)
+
+  // A run that has ended is not waiting on anyone.
+  const ended = applyEventToMeta(applyEventToMeta(base, { kind: 'settled' }, AT), { kind: 'end', ok: true }, AT)
+  assert.equal(ended.settledAt, undefined)
+  assert.equal(ended.status, 'done')
+})
+
 test('applyEventToMeta records the session name + ready-for-merge lifecycle signals (#326)', () => {
   const base = metaFromEvents(RUN.slice(0, 4), AT)
   assert.equal(base.sessionName, undefined)

--- a/packages/framework/src/store/run-store.ts
+++ b/packages/framework/src/store/run-store.ts
@@ -106,6 +106,15 @@ export interface RunMeta {
    * paused waiting for the user's answer — the second "needs you" source after open PRs (#624).
    */
   pendingChoice?: { id: string; title: string }
+  /**
+   * When the run settled and parked on the user (#785), or absent while the agent is working.
+   *
+   * Deliberately not a {@link RunStatus} value: the run IS still live while it waits (its
+   * process is alive, it still takes messages, it still holds the project), and a dozen readers
+   * key "live" off `status === 'running'`. This is the orthogonal fact — working, or waiting on
+   * you — which `status` cannot carry because it only changes when the run ends.
+   */
+  settledAt?: string
 }
 
 /**
@@ -204,9 +213,17 @@ export function applyEventToMeta(meta: RunMeta, event: FrameworkEvent, at: strin
       }
       break
     }
+    case 'settled':
+      next.settledAt = at
+      break
+    case 'driver':
+      // Any new turn means the agent is working again, so the run is no longer parked (#785).
+      if (event.event.type === 'start') delete next.settledAt
+      break
     case 'end':
       next.status = event.ok ? 'done' : event.stopped ? 'stopped' : 'failed'
       delete next.pendingChoice // a finished run is not awaiting anything
+      delete next.settledAt // nor is it waiting on you
       break
     default:
       break

--- a/packages/framework/src/terminal.ts
+++ b/packages/framework/src/terminal.ts
@@ -28,6 +28,8 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
       return `  session: ${event.name}`
     case 'ready-for-merge':
       return `✓ ready for merge`
+    case 'settled':
+      return `◆ done for now — waiting for your next message`
     case 'usage': {
       const turns = `over ${event.turns} turn${event.turns === 1 ? '' : 's'}`
       // No price to show: report the tokens the agent *did* report, rather than a


### PR DESCRIPTION
Closes #785

A build finished, went idle, and kept showing the pulsing "running" dot four minutes later. There was no way to tell "finished, waiting for you" from "still working".

## Why it happened

Status is written in exactly one place, on the `end` event (`run-store.ts`), and `end` only fires after `runChatPhase` returns, i.e. when the user closes the session. The stay-open lifecycle (#714) is deliberate, but it meant a settled run had no way to say so.

## Not a fifth status

`status === 'running'` is how a dozen readers decide a run is **live** (the stale-pid sweep, the busy guard, interventions, overview, activity, the shell's selection). A settled run is still live: its process is up, it holds the project, it takes messages. Adding a `waiting` status would have quietly broken all of those.

So this adds the orthogonal fact instead:

- a `settled` event, emitted each time the run parks on the user (once, inside `runChatPhase`, which is the single seam both the build path and the direct-prompt path reach),
- `RunMeta.settledAt`, set by that event and cleared by the next `driver` `start` (any new turn means it is working again) and by `end`.

Status keeps meaning exactly what it meant.

## UI

The sessions rail only: a parked run gets a still dot and reads `waiting` instead of `running`. The dot has always meant "the agent is working" and now it tells the truth. No layout change, so nothing here touches the direction under discussion in #772.

## What I did not change

**The done/stopped split.** I claimed in the issue that it is decided by click timing. That is true mechanically, but I checked the outcomes and they already line up: Stop while parked records `done` (the work had settled), Stop mid-turn records `stopped` (you cut a turn short). Both are defensible, so I left the behavior alone rather than churn it. `settledAt` now makes that distinction explicit in the data instead of implicit in which code path throws.

**LOGS.md at settle time.** The issue suggests recording the run when work settles rather than when the user closes it. That needs care: the log is append-only markdown, so writing at settle and again at end risks duplicate entries. Worth its own change.

## Test

- `run-store.test.ts`: the full lifecycle, working -> parked -> working -> ended, including that a parked run is still `running`.
- `run.test.ts`: a chat phase announces every park (twice around one chat turn), so the UI can stop animating the moment the agent stops.
- `RunHistory.test.tsx` (new): a working run animates and reads "running", a parked one is still and reads "waiting", and a terminal status is never relabelled.

`pnpm --filter @gemstack/framework test` : 702 pass, 0 fail. Dashboard: 119 pass, 0 fail.