### PR TITLE
chore(framework-dashboard): drop the navbar New session button for now (#772)

### DIFF
--- a/.changeset/chore-772-drop-new-session-button.md
+++ b/.changeset/chore-772-drop-new-session-button.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Drop the navbar `New session` button (#772). The button shipped alongside removing the navbar textarea, but the navbar's shape is still being decided, so it comes out until it lands with the rest of the redesign. The rail's Live row already starts a new session in the selected project, so nothing is lost meanwhile.

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -6,7 +6,6 @@ import { ProjectsSidebar } from '../../components/ProjectsSidebar.js'
 import { Logo } from '../../components/Logo.js'
 import { ThemeToggle } from '../../components/ThemeToggle.js'
 import { NotificationsMenu } from '../../components/NotificationsMenu.js'
-import { Button } from '../../components/ui/button.js'
 import { RunHistory } from '../../components/RunHistory.js'
 import { ProjectHome } from '../../components/ProjectHome.js'
 import { DashboardPage } from '../../components/DashboardPage.js'
@@ -142,13 +141,6 @@ export default function Page() {
     setRunId(id)
   }
 
-  // "New session" (#772): back to the selected project's launcher — the Live home row — with a
-  // fresh Context, so the navbar button starts a run the same way the rail's Live row does.
-  const newSession = () => {
-    selectRun(null)
-    resetContext()
-  }
-
   const selectProject = (id: string) => {
     setProjectId(id) // persisted, so a refresh returns here
     setRunId(null) // switching projects always returns to the home launcher
@@ -218,17 +210,6 @@ export default function Page() {
         <span className="shrink-0 font-semibold">The Framework</span>
         <div className="min-w-0 flex-1" />
         <div className="flex shrink-0 items-center gap-1">
-          {/* New session (#772): the de-facto standard button instead of a navbar textarea —
-              it lands on the selected project's launcher, where the one textarea lives. */}
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={newSession}
-            disabled={!projectId}
-            title={projectId ? undefined : 'Select a project first'}
-          >
-            New session
-          </Button>
           <ThemeToggle />
           <NotificationsMenu />
         </div>


### PR DESCRIPTION
Follow-on to #789. Takes the navbar `New session` button back out for now — it goes back in later with the rest of the navbar redesign in #772.

Net effect: the top nav is Logo + title on the left, theme toggle + notifications on the right. Still no textarea there (that part of #789 stands).

Nothing is lost meanwhile: the Sessions rail's `Live` row already lands on the selected project's launcher, which is where the single textarea lives.

Typecheck + the dashboard suite (27 files, 114 tests) pass.
