### PR TITLE
feat(framework): the run owns the browser, and can hand it to a human (#793, #796)

### DIFF
--- a/.changeset/feat-793-shared-browser.md
+++ b/.changeset/feat-793-shared-browser.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+`--browser` now runs against a Chrome the framework launches and stops with the run, instead of letting chrome-devtools-mcp launch its own. The debug port is open, so a second client can attach to the very page the agent is on — the prerequisite for streaming that browser to a human who needs to step in (#609). On a machine with no Chrome, `--browser` falls back to exactly what it did before.

--- a/.changeset/feat-796-browser-gate.md
+++ b/.changeset/feat-796-browser-gate.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+An agent working in a browser can now hand it to a human instead of failing. When it hits a login wall, a captcha, or an SSO step, it ends the turn with an `await-browser` block; the run parks, the user acts on the page, and the agent continues with whether it was handled. It never types a password and never attempts a captcha. An unattended run answers "could not handle it", so an agent is never told a human cleared a wall that is still there.

--- a/packages/framework/prompts/protocols/await.md
+++ b/packages/framework/prompts/protocols/await.md
@@ -15,6 +15,13 @@ For a plan/document approval (showMarkdown of a file you wrote, then AWAIT), tag
 ```
 The framework shows it, waits for the user, and re-prompts you with their answer. Do not continue past it on your own.
 
+## Handing the browser to a human
+When you are working in a browser and hit something you cannot or should not get past yourself — a login wall, a captcha, an SSO or 2FA step — stop and hand it over. Never type a password, never attempt a captcha, and never use a credential you found lying around in the repo or the environment. Tag the block `await-browser`:
+```await-browser
+{ "title": "<what the human needs to do>", "url": "<the page you are stuck on>" }
+```
+The user acts in that browser, then you are re-prompted. Their answer says whether it was handled: if it was not, do not retry the same page — say what you could not reach and work on what you can, or stop. Use this only for the browser; a decision the user needs to make is `await-choices`.
+
 ## Showing a document without waiting
 To display markdown in the side panel without blocking (a plan, a summary, a writeup) and keep working, put a `show-markdown` block anywhere in your turn. The first line is its title:
 ```show-markdown

--- a/packages/framework/src/browser.test.ts
+++ b/packages/framework/src/browser.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { chromeLaunchArgs, freePort, launchSharedBrowser, resolveChromePath, waitForDebugEndpoint } from './browser.js'
+import { browserMcpServers, withBrowser, BROWSER_MCP_SERVERS } from './cli.js'
+
+test('chromeLaunchArgs opens the debug port on a throwaway profile (#793)', () => {
+  const args = chromeLaunchArgs(9333, '/tmp/profile')
+  assert.ok(args.includes('--remote-debugging-port=9333'), 'the port is what a second client attaches to')
+  assert.ok(args.includes('--user-data-dir=/tmp/profile'), 'never the user’s real Chrome profile')
+  assert.ok(args.includes('--headless=new'))
+  assert.equal(args.at(-1), 'about:blank')
+})
+
+test('chromeLaunchArgs can run headful for local debugging', () => {
+  assert.ok(!chromeLaunchArgs(1, '/tmp/p', false).includes('--headless=new'))
+})
+
+test('resolveChromePath prefers an explicit CHROME_PATH over the well-known locations', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'chrome-path-'))
+  const fake = join(dir, 'my-chrome')
+  await writeFile(fake, '')
+  assert.equal(resolveChromePath({ CHROME_PATH: fake }, 'linux'), fake)
+  assert.equal(resolveChromePath({ PUPPETEER_EXECUTABLE_PATH: fake }, 'linux'), fake)
+})
+
+test('resolveChromePath ignores an override that does not exist', () => {
+  assert.equal(resolveChromePath({ CHROME_PATH: '/nope/chrome', PATH: '' }, 'linux'), undefined)
+})
+
+test('resolveChromePath finds a browser on PATH when no standard install exists', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'chrome-onpath-'))
+  await writeFile(join(dir, 'chromium'), '')
+  assert.equal(resolveChromePath({ PATH: dir }, 'linux'), join(dir, 'chromium'))
+})
+
+test('freePort returns a port nothing is listening on', async () => {
+  const port = await freePort()
+  assert.ok(port > 0 && port < 65536)
+})
+
+test('waitForDebugEndpoint resolves once the endpoint answers', async () => {
+  const server = createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ Browser: 'Chrome/150' }))
+  })
+  await new Promise<void>(r => server.listen(0, '127.0.0.1', r))
+  const address = server.address()
+  const port = typeof address === 'object' && address ? address.port : 0
+  try {
+    assert.equal(await waitForDebugEndpoint(`http://127.0.0.1:${port}`, { timeoutMs: 3000 }), true)
+  } finally {
+    server.close()
+  }
+})
+
+test('waitForDebugEndpoint gives up rather than hanging the run when Chrome never listens', async () => {
+  const port = await freePort()
+  assert.equal(await waitForDebugEndpoint(`http://127.0.0.1:${port}`, { timeoutMs: 250, intervalMs: 25 }), false)
+})
+
+test('a machine with no Chrome resolves to nothing, which is what makes --browser fall back', () => {
+  assert.equal(resolveChromePath({ PATH: '' }, 'linux'), undefined)
+})
+
+test('launchSharedBrowser gives up on a binary that never opens the port', async () => {
+  // A path that cannot start: stands in for a Chrome that never listens. The run must get
+  // undefined (and fall back) rather than a handle to a browser nothing is behind.
+  const browser = await launchSharedBrowser({ chromePath: join(tmpdir(), 'definitely-not-chrome'), timeoutMs: 400 })
+  assert.equal(browser, undefined, 'a browser that never listens must not be handed to the agent')
+})
+
+test('browserMcpServers points the MCP server at our Chrome when we launched one (#793)', () => {
+  const args = browserMcpServers('http://127.0.0.1:9333')['chrome-devtools']?.args ?? []
+  assert.ok(args.includes('--browserUrl'))
+  assert.ok(args.includes('http://127.0.0.1:9333'))
+})
+
+test('browserMcpServers is the old launch-its-own spec when there is no shared browser', () => {
+  assert.deepEqual(browserMcpServers(undefined), BROWSER_MCP_SERVERS)
+  assert.ok(!(browserMcpServers(undefined)['chrome-devtools']?.args ?? []).includes('--browserUrl'))
+})
+
+test('withBrowser folds the browser URL through to the driver options', () => {
+  const opts = withBrowser({ permissionMode: 'bypassPermissions' }, true, 'http://127.0.0.1:4242')
+  assert.ok((opts.mcpServers?.['chrome-devtools']?.args ?? []).includes('http://127.0.0.1:4242'))
+})
+
+test('withBrowser stays a no-op without the flag, URL or not', () => {
+  const base = { permissionMode: 'bypassPermissions' } as const
+  assert.deepEqual(withBrowser(base, false, 'http://127.0.0.1:4242'), base)
+})

--- a/packages/framework/src/browser.test.ts
+++ b/packages/framework/src/browser.test.ts
@@ -1,6 +1,5 @@
 import assert from 'node:assert/strict'
 import { createServer } from 'node:http'
-import { mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
@@ -19,23 +18,34 @@ test('chromeLaunchArgs can run headful for local debugging', () => {
   assert.ok(!chromeLaunchArgs(1, '/tmp/p', false).includes('--headless=new'))
 })
 
-test('resolveChromePath prefers an explicit CHROME_PATH over the well-known locations', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'chrome-path-'))
-  const fake = join(dir, 'my-chrome')
-  await writeFile(fake, '')
-  assert.equal(resolveChromePath({ CHROME_PATH: fake }, 'linux'), fake)
-  assert.equal(resolveChromePath({ PUPPETEER_EXECUTABLE_PATH: fake }, 'linux'), fake)
+/**
+ * A filesystem where only `present` exists. Injected so these assertions mean the same thing
+ * on a laptop and on CI — the runners have Chrome at a well-known path, so a test that assumes
+ * "nothing is installed" is really testing the host.
+ */
+const fsWith = (...present: string[]) => (path: string) => present.includes(path)
+
+test('resolveChromePath prefers an explicit CHROME_PATH over the well-known locations', () => {
+  const exists = fsWith('/custom/my-chrome', '/usr/bin/google-chrome')
+  assert.equal(resolveChromePath({ CHROME_PATH: '/custom/my-chrome' }, 'linux', exists), '/custom/my-chrome')
+  assert.equal(resolveChromePath({ PUPPETEER_EXECUTABLE_PATH: '/custom/my-chrome' }, 'linux', exists), '/custom/my-chrome')
 })
 
-test('resolveChromePath ignores an override that does not exist', () => {
-  assert.equal(resolveChromePath({ CHROME_PATH: '/nope/chrome', PATH: '' }, 'linux'), undefined)
+test('resolveChromePath falls through an override that does not exist', () => {
+  assert.equal(resolveChromePath({ CHROME_PATH: '/nope/chrome', PATH: '' }, 'linux', fsWith()), undefined)
+  assert.equal(
+    resolveChromePath({ CHROME_PATH: '/nope/chrome', PATH: '' }, 'linux', fsWith('/usr/bin/chromium')),
+    '/usr/bin/chromium',
+    'a bad override must not hide a browser that is actually installed',
+  )
 })
 
-test('resolveChromePath finds a browser on PATH when no standard install exists', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'chrome-onpath-'))
-  await writeFile(join(dir, 'chromium'), '')
-  assert.equal(resolveChromePath({ PATH: dir }, 'linux'), join(dir, 'chromium'))
+test('resolveChromePath finds a browser on PATH when no standard install exists', () => {
+  assert.equal(resolveChromePath({ PATH: '/opt/bin' }, 'linux', fsWith('/opt/bin/chromium')), '/opt/bin/chromium')
 })
+
+// No Windows PATH-lookup test on purpose: `join` and `delimiter` follow the host, so asserting
+// a `C:\...` result only passes when the test itself runs on Windows.
 
 test('freePort returns a port nothing is listening on', async () => {
   const port = await freePort()
@@ -63,7 +73,7 @@ test('waitForDebugEndpoint gives up rather than hanging the run when Chrome neve
 })
 
 test('a machine with no Chrome resolves to nothing, which is what makes --browser fall back', () => {
-  assert.equal(resolveChromePath({ PATH: '' }, 'linux'), undefined)
+  assert.equal(resolveChromePath({ PATH: '/usr/bin' }, 'linux', fsWith()), undefined)
 })
 
 test('launchSharedBrowser gives up on a binary that never opens the port', async () => {

--- a/packages/framework/src/browser.ts
+++ b/packages/framework/src/browser.ts
@@ -38,13 +38,16 @@ const CHROME_PATHS: Record<string, string[]> = {
 /** The binaries to look for on `PATH` when no well-known path exists. */
 const CHROME_BINARIES = ['google-chrome', 'google-chrome-stable', 'chromium', 'chromium-browser']
 
+/** Whether a path exists. Injectable so a test does not depend on what the host has installed. */
+export type ExistsFn = (path: string) => boolean
+
 /** First existing match for `name` on `PATH`, or undefined. */
-function onPath(name: string, env: NodeJS.ProcessEnv, platform: string): string | undefined {
+function onPath(name: string, env: NodeJS.ProcessEnv, platform: string, exists: ExistsFn): string | undefined {
   const exts = platform === 'win32' ? ['.exe', '.cmd', ''] : ['']
   for (const dir of (env.PATH ?? '').split(delimiter).filter(Boolean)) {
     for (const ext of exts) {
       const full = join(dir, name + ext)
-      if (existsSync(full)) return full
+      if (exists(full)) return full
     }
   }
   return undefined
@@ -54,16 +57,24 @@ function onPath(name: string, env: NodeJS.ProcessEnv, platform: string): string 
  * The Chrome binary to launch, or undefined when the machine has none. `CHROME_PATH` (and
  * Puppeteer's variable, since a repo that has one usually means it) wins so a user on a
  * non-standard install is not stuck.
+ *
+ * `exists` is a parameter rather than a direct `existsSync` call so the lookup can be tested
+ * against a known filesystem: CI runners have Chrome installed, so a test that assumes the
+ * well-known paths are absent passes on a laptop and fails there.
  */
-export function resolveChromePath(env: NodeJS.ProcessEnv = process.env, platform: string = process.platform): string | undefined {
+export function resolveChromePath(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: string = process.platform,
+  exists: ExistsFn = existsSync,
+): string | undefined {
   for (const override of [env.CHROME_PATH, env.PUPPETEER_EXECUTABLE_PATH]) {
-    if (override && existsSync(override)) return override
+    if (override && exists(override)) return override
   }
   for (const candidate of CHROME_PATHS[platform] ?? []) {
-    if (existsSync(candidate)) return candidate
+    if (exists(candidate)) return candidate
   }
   for (const name of CHROME_BINARIES) {
-    const found = onPath(name, env, platform)
+    const found = onPath(name, env, platform, exists)
     if (found) return found
   }
   return undefined

--- a/packages/framework/src/browser.ts
+++ b/packages/framework/src/browser.ts
@@ -1,0 +1,167 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { createServer } from 'node:net'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+
+/**
+ * The run's browser (#793, first slice of #609).
+ *
+ * `--browser` (#452) used to let chrome-devtools-mcp launch its own Chrome. That is fine
+ * while the agent is the only client, but #609 wants a human watching the same page over a
+ * screencast, and a second client cannot attach to a browser whose port we never opened. So
+ * the run launches Chrome itself with `--remote-debugging-port` and hands the MCP server a
+ * `--browserUrl`. Chrome takes both CDP clients at once, which is what makes the preview and
+ * the step-in relay possible at all.
+ */
+export interface SharedBrowser {
+  /** The CDP endpoint both the agent and any preview attach to. */
+  browserUrl: string
+  /** Kill Chrome and remove its throwaway profile. Safe to call twice. */
+  close(): Promise<void>
+}
+
+/** Where Chrome usually lives, per platform. First hit wins. */
+const CHROME_PATHS: Record<string, string[]> = {
+  darwin: [
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+  ],
+  linux: ['/opt/google/chrome/chrome', '/usr/bin/google-chrome', '/usr/bin/chromium', '/usr/bin/chromium-browser'],
+  win32: [
+    'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+    'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+  ],
+}
+
+/** The binaries to look for on `PATH` when no well-known path exists. */
+const CHROME_BINARIES = ['google-chrome', 'google-chrome-stable', 'chromium', 'chromium-browser']
+
+/** First existing match for `name` on `PATH`, or undefined. */
+function onPath(name: string, env: NodeJS.ProcessEnv, platform: string): string | undefined {
+  const exts = platform === 'win32' ? ['.exe', '.cmd', ''] : ['']
+  for (const dir of (env.PATH ?? '').split(delimiter).filter(Boolean)) {
+    for (const ext of exts) {
+      const full = join(dir, name + ext)
+      if (existsSync(full)) return full
+    }
+  }
+  return undefined
+}
+
+/**
+ * The Chrome binary to launch, or undefined when the machine has none. `CHROME_PATH` (and
+ * Puppeteer's variable, since a repo that has one usually means it) wins so a user on a
+ * non-standard install is not stuck.
+ */
+export function resolveChromePath(env: NodeJS.ProcessEnv = process.env, platform: string = process.platform): string | undefined {
+  for (const override of [env.CHROME_PATH, env.PUPPETEER_EXECUTABLE_PATH]) {
+    if (override && existsSync(override)) return override
+  }
+  for (const candidate of CHROME_PATHS[platform] ?? []) {
+    if (existsSync(candidate)) return candidate
+  }
+  for (const name of CHROME_BINARIES) {
+    const found = onPath(name, env, platform)
+    if (found) return found
+  }
+  return undefined
+}
+
+/**
+ * The launch flags. Headless by default — the agent has no screen, and a screencast reads a
+ * headless page fine. The profile is throwaway so a run never inherits (or dirties) the
+ * user's real Chrome session.
+ */
+export function chromeLaunchArgs(port: number, userDataDir: string, headless = true): string[] {
+  return [
+    ...(headless ? ['--headless=new'] : []),
+    `--remote-debugging-port=${port}`,
+    `--user-data-dir=${userDataDir}`,
+    '--no-first-run',
+    '--no-default-browser-check',
+    '--window-size=1280,720',
+    'about:blank',
+  ]
+}
+
+/** A free localhost port, asked of the OS rather than guessed. */
+export async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer()
+    server.on('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      const port = typeof address === 'object' && address ? address.port : 0
+      server.close(() => (port ? resolve(port) : reject(new Error('no port'))))
+    })
+  })
+}
+
+/**
+ * Poll `/json/version` until Chrome answers. Chrome opens the port a beat after the process
+ * starts, so handing the MCP server a URL that is not listening yet is the obvious race.
+ */
+export async function waitForDebugEndpoint(
+  browserUrl: string,
+  opts: { timeoutMs?: number; intervalMs?: number; fetchImpl?: typeof fetch } = {},
+): Promise<boolean> {
+  const { timeoutMs = 15_000, intervalMs = 100, fetchImpl = fetch } = opts
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetchImpl(`${browserUrl}/json/version`)
+      if (res.ok) return true
+    } catch {
+      // Not listening yet.
+    }
+    await new Promise(r => setTimeout(r, intervalMs))
+  }
+  return false
+}
+
+/**
+ * Launch the run's Chrome, or return undefined when this machine has none — in which case the
+ * caller leaves `--browser` exactly as it was (chrome-devtools-mcp launches its own). A
+ * missing browser should cost the run its preview, never its browser tools.
+ */
+export async function launchSharedBrowser(
+  opts: { chromePath?: string | undefined; headless?: boolean; timeoutMs?: number } = {},
+): Promise<SharedBrowser | undefined> {
+  const chromePath = opts.chromePath ?? resolveChromePath()
+  if (!chromePath) return undefined
+
+  const port = await freePort()
+  const userDataDir = await mkdtemp(join(tmpdir(), 'framework-chrome-'))
+  const browserUrl = `http://127.0.0.1:${port}`
+
+  let child: ChildProcess
+  try {
+    child = spawn(chromePath, chromeLaunchArgs(port, userDataDir, opts.headless ?? true), { stdio: 'ignore' })
+  } catch {
+    await rm(userDataDir, { recursive: true, force: true })
+    return undefined
+  }
+
+  let closed = false
+  const close = async () => {
+    if (closed) return
+    closed = true
+    child.kill()
+    await rm(userDataDir, { recursive: true, force: true }).catch(() => {})
+  }
+
+  // A Chrome that dies on its own must not leave the run pointing at a dead port. `error`
+  // needs its own handler or a failed spawn (bad path, no exec bit) throws unhandled and
+  // takes the run with it — a missing browser must only cost the preview.
+  child.on('exit', () => void close())
+  child.on('error', () => void close())
+
+  const timeoutOpt = opts.timeoutMs === undefined ? {} : { timeoutMs: opts.timeoutMs }
+  if (!(await waitForDebugEndpoint(browserUrl, timeoutOpt))) {
+    await close()
+    return undefined
+  }
+  return { browserUrl, close }
+}

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -14,6 +14,7 @@ import {
 } from '@gemstack/ai-autopilot'
 import { type ClaudeCodeDriverOptions, type Driver, type DriverSession, type McpServerSpec, type PermissionMode } from './driver/index.js'
 import { AGENTS, AGENT_SPECS, createDriver, isAgentName, type AgentName } from './agent.js'
+import { launchSharedBrowser, type SharedBrowser } from './browser.js'
 import { hostExecutor } from './host-exec.js'
 import { startDashboard, singleProjectProvider, resolveDashboardBundle, type Dashboard } from './dashboard/index.js'
 import { startRelay, relayPublisher, type RelayPublisher } from './relay.js'
@@ -584,10 +585,24 @@ export const BROWSER_MCP_SERVERS: Record<string, McpServerSpec> = {
   'chrome-devtools': { command: 'npx', args: ['-y', 'chrome-devtools-mcp@latest'] },
 }
 
+/**
+ * The same server, pointed at a Chrome the run already launched (#793). `--browserUrl` makes
+ * it attach instead of launching, which is what lets a second client (the #609 screencast)
+ * watch the very page the agent is on. Without a URL this is the old spec unchanged.
+ */
+export function browserMcpServers(browserUrl?: string | undefined): Record<string, McpServerSpec> {
+  if (!browserUrl) return BROWSER_MCP_SERVERS
+  return { 'chrome-devtools': { command: 'npx', args: ['-y', 'chrome-devtools-mcp@latest', '--browserUrl', browserUrl] } }
+}
+
 /** Fold the `--browser` MCP server into driver options when the flag is set. */
-export function withBrowser(base: ClaudeCodeDriverOptions, browser: boolean): ClaudeCodeDriverOptions {
+export function withBrowser(
+  base: ClaudeCodeDriverOptions,
+  browser: boolean,
+  browserUrl?: string | undefined,
+): ClaudeCodeDriverOptions {
   if (!browser) return base
-  return { ...base, mcpServers: { ...base.mcpServers, ...BROWSER_MCP_SERVERS } }
+  return { ...base, mcpServers: { ...base.mcpServers, ...browserMcpServers(browserUrl) } }
 }
 
 /**
@@ -729,6 +744,8 @@ interface RunEpilogue {
   control: ControlWatcher | undefined
   guard: { stop: () => void } | undefined
   publisher: RelayPublisher | undefined
+  /** The run's Chrome (#793), stopped with the run so no headless browser outlives it. */
+  sharedBrowser: SharedBrowser | undefined
   clearInterrupt: () => void
   maybeFireOnBeforeMergeable: () => Promise<void>
   /** True once the run stopped cleanly (interrupt / budget cap) rather than failed. */
@@ -784,6 +801,7 @@ async function settleRun(
     ctx.clearInterrupt()
     ctx.control?.close()
     ctx.guard?.stop()
+    await ctx.sharedBrowser?.close()
     // Make sure every event (including the final `end`) reached the relay before exit.
     if (ctx.publisher) await ctx.publisher.flush()
   }
@@ -1199,7 +1217,17 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     io.err(`note: --sandbox docker has no effect without --serve.`)
   }
 
-  const driver: Driver = fake ? fakeDriver() : createDriver({ agent: opts.agent, claudeOpts: withBrowser(claudeOpts, opts.browser) })
+  // The run owns the browser (#793): launching it here, rather than letting chrome-devtools-mcp
+  // launch its own, is what lets the #609 preview attach to the same page. Undefined when the
+  // machine has no Chrome, which leaves `--browser` on its old path rather than failing the run.
+  const sharedBrowser = opts.browser && !fake ? await launchSharedBrowser() : undefined
+  if (opts.browser && !fake && !sharedBrowser) {
+    io.err('note: no Chrome found, so --browser falls back to its own browser (no preview).')
+  }
+
+  const driver: Driver = fake
+    ? fakeDriver()
+    : createDriver({ agent: opts.agent, claudeOpts: withBrowser(claudeOpts, opts.browser, sharedBrowser?.browserUrl) })
 
   // The consumption limits (#519/#531). Read from the user's own file rather than
   // taken as a flag: unlike autopilot or eco, a limit is not a per-run choice, so
@@ -1228,6 +1256,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     control,
     guard,
     publisher,
+    sharedBrowser,
     clearInterrupt,
     maybeFireOnBeforeMergeable,
     isStopped: () => controller.signal.aborted || stoppedCleanly,

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -26,7 +26,7 @@ import { type ConsumptionWindow } from './consumption.js'
 import type { Driver, DriverSession, DriverTurn } from './driver/index.js'
 import { composeRunSystem, type EcoOptions, type TfContext } from './system-prompt.js'
 import { createRunControls, emitSessionStart, endStopDetail } from './run-telemetry.js'
-import { AWAIT_PROTOCOL, CONFIRM_APPROVED, CONFIRM_DECLINED, MAX_AWAIT_ROUNDS, PLAN_DECLINED_MESSAGE, continuationPrompt, createTurnSignalEmitter, isDeclinedConfirmation, parseAwaitGate, type ParsedAwaitGate } from './turn-gate.js'
+import { AWAIT_PROTOCOL, BROWSER_HANDLED, BROWSER_NOT_HANDLED, CONFIRM_APPROVED, CONFIRM_DECLINED, MAX_AWAIT_ROUNDS, PLAN_DECLINED_MESSAGE, continuationPrompt, createTurnSignalEmitter, isDeclinedConfirmation, parseAwaitGate, type ParsedAwaitGate } from './turn-gate.js'
 // Value import from todo-loop.js is a benign cycle: todo-loop.js only calls
 // run.js's hoisted function declarations (requestChoices / resolveAwaitGate).
 import { leaveResumeNote, runTodoLoop, type TodoLoopResult } from './todo-loop.js'
@@ -584,8 +584,37 @@ export async function resolveAwaitGate(
 ): Promise<string> {
   const signalOpt = deps.signal ? { signal: deps.signal } : {}
   const choiceOpt = deps.requestChoice ? { requestChoice: deps.requestChoice } : {}
-  const baseId = gate.kind === 'multi' ? 'await-multiselect' : gate.kind === 'confirm' ? 'await-confirmation' : 'await-choices'
+  const baseId =
+    gate.kind === 'multi'
+      ? 'await-multiselect'
+      : gate.kind === 'confirm'
+        ? 'await-confirmation'
+        : gate.kind === 'browser'
+          ? 'await-browser'
+          : 'await-choices'
   const id = round === 0 ? baseId : `${baseId}-${round}`
+  if (gate.kind === 'browser') {
+    // The agent is stuck on a page and needs a human to act on it (#796). Rides the same
+    // choice plumbing as every other gate, so the CLI and the dashboard render it today.
+    //
+    // Recommended is "could not handle it" — the opposite of the confirmation gate's default.
+    // A headless run has nobody at the browser, and telling the agent a human cleared the
+    // login wall when none did sends it back to a page that is still blocked.
+    const picked = await requestChoices({
+      id,
+      title: gate.url ? `${gate.title} (${gate.url})` : gate.title,
+      options: [
+        { id: 'handled', label: BROWSER_HANDLED },
+        { id: 'not-handled', label: BROWSER_NOT_HANDLED },
+      ],
+      recommended: 'not-handled',
+      confirm: true,
+      emit: deps.emit,
+      ...choiceOpt,
+      ...signalOpt,
+    })
+    return picked === 'handled' ? BROWSER_HANDLED : BROWSER_NOT_HANDLED
+  }
   if (gate.kind === 'confirm') {
     // The plan-approval confirmation (#358): a fixed Approve / Decline pair, recommended
     // Approve so a headless (or aborted) run proceeds — the same semantics as the other gates.

--- a/packages/framework/src/turn-gate-browser.test.ts
+++ b/packages/framework/src/turn-gate-browser.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { resolveAwaitGate } from './run.js'
+import { BROWSER_HANDLED, BROWSER_NOT_HANDLED, parseAwaitGate, parseBrowserGate } from './turn-gate.js'
+
+const block = (body: string) => `Stuck on the login page.\n\n\`\`\`await-browser\n${body}\n\`\`\``
+
+test('parseBrowserGate reads the title and the page the agent is stuck on (#796)', () => {
+  const gate = parseBrowserGate(block('{ "title": "Log in to the dashboard", "url": "https://app.example.com/login" }'))
+  assert.deepEqual(gate, { title: 'Log in to the dashboard', url: 'https://app.example.com/login' })
+})
+
+test('parseBrowserGate falls back rather than showing a blank prompt', () => {
+  assert.deepEqual(parseBrowserGate(block('{}')), { title: 'Take over in the browser' })
+})
+
+test('parseBrowserGate drops a non-string url instead of rendering "undefined"', () => {
+  assert.deepEqual(parseBrowserGate(block('{ "title": "Solve the captcha", "url": 42 }')), { title: 'Solve the captcha' })
+})
+
+test('parseBrowserGate ignores a malformed block rather than crashing the run', () => {
+  assert.equal(parseBrowserGate(block('{ not json')), undefined)
+  assert.equal(parseBrowserGate(block('"a string"')), undefined)
+})
+
+test('a turn with no browser block is not a gate', () => {
+  assert.equal(parseBrowserGate('All done, the tests pass.'), undefined)
+})
+
+test('parseAwaitGate recognises the browser gate alongside the other kinds', () => {
+  const gate = parseAwaitGate(block('{ "title": "Sign in", "url": "https://x.test/" }'))
+  assert.equal(gate?.kind, 'browser')
+  assert.equal(gate?.kind === 'browser' ? gate.title : '', 'Sign in')
+})
+
+test('the latest block wins when a turn carries a choice and a browser gate', () => {
+  const text = '```await-choices\n{ "title": "Which?", "options": [{ "label": "A" }] }\n```\n' + block('{ "title": "Log in" }')
+  assert.equal(parseAwaitGate(text)?.kind, 'browser')
+})
+
+test('resolveAwaitGate offers handled / could-not-handle and reports what the user picked', async () => {
+  const events: unknown[] = []
+  const answer = await resolveAwaitGate({ kind: 'browser', title: 'Log in', url: 'https://x.test/' }, 0, {
+    emit: e => events.push(e),
+    requestChoice: async req => {
+      assert.equal(req.id, 'await-browser')
+      assert.ok(req.title.includes('https://x.test/'), 'the user is told which page to look at')
+      assert.deepEqual(req.options.map(o => o.label), [BROWSER_HANDLED, BROWSER_NOT_HANDLED])
+      return { picked: 'handled' }
+    },
+  })
+  assert.equal(answer, BROWSER_HANDLED)
+})
+
+test('an unattended run answers "could not handle it" — nobody was at the browser (#796)', async () => {
+  // No requestChoice: the headless path falls back to the recommended option. Recommending
+  // "handled" would send the agent back to a page that is still blocked.
+  const answer = await resolveAwaitGate({ kind: 'browser', title: 'Solve the captcha' }, 0, { emit: () => {} })
+  assert.equal(answer, BROWSER_NOT_HANDLED)
+})
+
+test('a re-ask in a later round gets its own gate id', async () => {
+  let seen = ''
+  await resolveAwaitGate({ kind: 'browser', title: 'Log in' }, 2, {
+    emit: () => {},
+    requestChoice: async req => {
+      seen = req.id
+      return { picked: 'handled' }
+    },
+  })
+  assert.equal(seen, 'await-browser-2')
+})

--- a/packages/framework/src/turn-gate.ts
+++ b/packages/framework/src/turn-gate.ts
@@ -5,7 +5,7 @@ import type { MultiSelectOption } from './run.js'
 
 /**
  * The framework-owned "await" protocol (#337 / #339): the *code side* of the
- * `showChoices()` / `showMultiSelect()` + `AWAIT` macros that Rom delegated. The
+ * `showChoices()` / `showMultiSelect()` + `AWAIT` macros the system prompt delegates. The
  * driver runs each agent turn as a black box to completion (#165), so the only way
  * the framework can learn the agent stopped to ask (rather than deciding for itself)
  * is a signal in the turn's final message. This appends one to the system prompt: it
@@ -17,7 +17,7 @@ export const AWAIT_PROTOCOL = PROTOCOLS_AWAIT
 
 /**
  * The session-lifecycle protocol (#326): the code side of the `setSessionName()` and
- * `setReadyForMerge()` actions Rom's system prompt calls out. Like {@link AWAIT_PROTOCOL},
+ * `setReadyForMerge()` actions the system prompt calls out. Like {@link AWAIT_PROTOCOL},
  * it does not restate *when* to act — the system prompt owns that — it only pins *how* to
  * emit the signal so the turn-boundary can detect it. Both are non-blocking: the agent
  * emits the block and keeps going (the framework records it and reflects it in the
@@ -52,15 +52,35 @@ export interface ParsedConfirmationGate {
   file?: string
 }
 
+/**
+ * A browser the agent is stuck in, parsed from an `await-browser` block (#796).
+ *
+ * The other gates ask the user to decide something; this one asks them to *do* something.
+ * A login wall, a captcha, an SSO redirect: work the agent must not do on its own, either
+ * because it cannot or because it means handling a credential we deliberately never touch.
+ * The run parks, the human acts on the page, and the agent picks up from there.
+ */
+export interface ParsedBrowserGate {
+  /** What the human needs to do, shown above the buttons. */
+  title: string
+  /** The page the agent is stuck on, so the user knows where to look. */
+  url?: string
+}
+
 /** A parsed await gate: any kind, discriminated by `kind`. */
 export type ParsedAwaitGate =
   | ({ kind: 'choices' } & ParsedChoicesGate)
   | ({ kind: 'multi' } & ParsedMultiSelectGate)
   | ({ kind: 'confirm' } & ParsedConfirmationGate)
+  | ({ kind: 'browser' } & ParsedBrowserGate)
 
 /** The answer a resolved confirmation gate (#358) yields: the picked button's label. */
 export const CONFIRM_APPROVED = 'Approve'
 export const CONFIRM_DECLINED = 'Decline'
+
+/** The answers a resolved browser gate (#796) yields. */
+export const BROWSER_HANDLED = 'Handled it'
+export const BROWSER_NOT_HANDLED = 'Could not handle it'
 
 /**
  * How many times the agent may stop to ask, and be resumed, before a run stops honoring
@@ -269,7 +289,27 @@ export function parseConfirmationGate(text: string): ParsedConfirmationGate | un
 }
 
 /**
- * Parse whichever await gate a build turn ended on (#337 / #339 / #358). When more
+ * Parse a trailing `await-browser` block (#796): the agent is stuck on a page and needs a
+ * human to act on it. Same tolerance as the other parsers — blank-title fallback, malformed
+ * block ignored. A `url` that is not a string is dropped rather than shown as "undefined".
+ */
+export function parseBrowserGate(text: string): ParsedBrowserGate | undefined {
+  const block = lastBlock(text, 'await-browser')
+  if (!block) return undefined
+  let raw: unknown
+  try {
+    raw = JSON.parse(block.body)
+  } catch {
+    return undefined
+  }
+  if (typeof raw !== 'object' || raw === null) return undefined
+  const record = raw as Record<string, unknown>
+  const url = str(record.url)
+  return { title: str(record.title) || 'Take over in the browser', ...(url ? { url } : {}) }
+}
+
+/**
+ * Parse whichever await gate a build turn ended on (#337 / #339 / #358 / #796). When more
  * than one block kind is present (an agent shouldn't emit several), the one that
  * appears latest in the text wins; a malformed later block falls back to an earlier
  * one. Returns `undefined` when the agent just finished — the common case, so a
@@ -296,6 +336,13 @@ export function parseAwaitGate(text: string): ParsedAwaitGate | undefined {
       parse: () => {
         const g = parseConfirmationGate(text)
         return g ? { kind: 'confirm', ...g } : undefined
+      },
+    },
+    {
+      at: lastBlock(text, 'await-browser')?.index ?? -1,
+      parse: () => {
+        const g = parseBrowserGate(text)
+        return g ? { kind: 'browser', ...g } : undefined
       },
     },
   ]


### PR DESCRIPTION
Closes #793. Closes #796. The first two slices of #609.

Both are here in one PR rather than stacked: the second commit landed on this branch before I split it, and I would rather say so than force-push over a pushed branch. Two commits, two changesets, reviewable separately.

## 1. The run owns the browser (#793)

`--browser` handed Claude Code chrome-devtools-mcp, which launched its own Chrome. Nothing else could attach to it, so the streamed preview in #609 was impossible before this.

Now the run launches one Chrome with `--remote-debugging-port` on a free port and a throwaway profile, passes `--browserUrl` so the MCP server attaches instead of launching, and stops it in the run epilogue alongside the control channel and the consumption guard. If no Chrome resolves, `--browser` behaves exactly as it does today (with a note on stderr) — a missing browser costs the preview, never the browser tools.

Verified by spike first, on Chrome 150 with `--headless=new`: `--browserUrl` attaches to a running Chrome; Chrome takes that client and a Puppeteer screencast at once, one browser and one page set; the screencast shows the page the agent navigated to; and clicking and typing on the streamer side is read back by the agent via `evaluate_script`, which is the step-in loop end to end.

## 2. A gate for a blocked page (#796)

The agent hits a login wall, a captcha, or an SSO step and today the run just fails or wanders. It can now end a turn with:

```await-browser
{ "title": "Log in to the dashboard", "url": "https://app.example.com/login" }
```

The run parks like any other gate, the human acts on the page, and the agent continues knowing whether it was handled.

Two deliberate calls:

- The protocol tells the agent never to type a password, never to attempt a captcha, and never to use a credential it found in the repo or environment. A captcha means something worth a human, and a password is not ours to handle.
- The headless fallback is **not handled**, the opposite of the plan-approval gate's default. An unattended run has nobody at the browser; telling the agent a human cleared the wall would send it back to a page that is still blocked.

It rides the existing choice plumbing, so the CLI and the dashboard render it today with no UI change.

## Checks

24 new tests. Typecheck clean. `check:prompt-drift` in sync — `protocols/await.md` is not one of the pinned #326 blocks, so this needed no issue edit. The suite's 9 daemon failures are pre-existing in a fresh worktree, identical with these changes stashed.

Writing the tests caught a real bug: a Chrome that fails to spawn emits `error` asynchronously, and with no handler it throws unhandled and takes the run down. Fixed, with a test.

## Next

The streamed pane in the dashboard, which uses this gate to know when to open. Known gotcha for it: a streamer pinned to the first page goes stale the moment the agent opens a tab, so it has to follow the active target.