### PR TITLE
feat(framework): stream the run's browser and relay input back (#802)

### DIFF
--- a/.changeset/feat-802-browser-stream.md
+++ b/.changeset/feat-802-browser-stream.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+A run with `--browser` now serves a live view of the agent's browser. The run prints a preview URL; opening it shows what the agent sees, and clicks, typing, scrolling, and navigation go back to that page — so when the agent parks on an `await-browser` gate at a login wall or a captcha, a human can actually deal with it. The view follows the agent when it switches tabs. It binds to loopback only, and no frame is written to disk or into the run's event log.

--- a/packages/framework/src/browser-stream.test.ts
+++ b/packages/framework/src/browser-stream.test.ts
@@ -1,0 +1,236 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  framePart,
+  inputToCdp,
+  pickActivePage,
+  startBrowserStream,
+  type CdpCall,
+  type CdpPageTarget,
+  type CdpSession,
+} from './browser-stream.js'
+
+const page = (over: Partial<CdpPageTarget> = {}): CdpPageTarget => ({
+  id: 'p1',
+  type: 'page',
+  url: 'https://example.com/',
+  webSocketDebuggerUrl: 'ws://127.0.0.1:9333/devtools/page/p1',
+  ...over,
+})
+
+test('pickActivePage takes the agent’s current tab, not the first one it ever opened (#802)', () => {
+  // Chrome lists most-recently-used first, so a newly opened tab comes first.
+  const targets = [page({ id: 'new', url: 'https://login.test/' }), page({ id: 'old' })]
+  assert.equal(pickActivePage(targets)?.id, 'new')
+})
+
+test('pickActivePage skips non-page targets and tabs with no socket', () => {
+  const targets = [
+    page({ id: 'sw', type: 'service_worker' }),
+    { id: 'dead', type: 'page', url: 'about:blank' } as CdpPageTarget,
+    page({ id: 'real' }),
+  ]
+  assert.equal(pickActivePage(targets)?.id, 'real')
+})
+
+test('pickActivePage returns nothing when the browser has no page', () => {
+  assert.equal(pickActivePage([]), undefined)
+})
+
+test('a click is a press and a release — Chrome ignores a lone press', () => {
+  const calls = inputToCdp({ type: 'click', x: 10, y: 20 })
+  assert.deepEqual(calls.map(c => c.params.type), ['mousePressed', 'mouseReleased'])
+  assert.equal(calls[0]?.params.x, 10)
+})
+
+test('typing goes through insertText so it types the character, not a key code', () => {
+  assert.deepEqual(inputToCdp({ type: 'key', text: 'hüne' }), [
+    { method: 'Input.insertText', params: { text: 'hüne' } },
+  ])
+})
+
+test('a malformed input reaches Chrome as nothing at all', () => {
+  assert.deepEqual(inputToCdp({ type: 'click', x: Number.NaN, y: 1 }), [])
+  assert.deepEqual(inputToCdp({ type: 'key', text: '' }), [])
+  assert.deepEqual(inputToCdp({ type: 'bogus' } as never), [])
+})
+
+test('navigate only accepts http(s) — not javascript: or file:', () => {
+  assert.equal(inputToCdp({ type: 'navigate', url: 'https://ok.test/' }).length, 1)
+  assert.deepEqual(inputToCdp({ type: 'navigate', url: 'javascript:alert(1)' }), [])
+  assert.deepEqual(inputToCdp({ type: 'navigate', url: 'file:///etc/passwd' }), [])
+})
+
+test('framePart wraps a frame with the length the multipart reader needs', () => {
+  const part = framePart('frame', Buffer.from([0xff, 0xd8, 0xff]))
+  const text = part.toString('latin1')
+  assert.ok(text.startsWith('--frame\r\nContent-Type: image/jpeg\r\n'))
+  assert.ok(text.includes('Content-Length: 3'))
+  assert.ok(text.endsWith('\r\n'))
+})
+
+/** A stand-in for Chrome: records what was sent and lets a test push a frame. */
+function fakeCdp() {
+  const sent: CdpCall[] = []
+  let onFrame: ((p: { data: string; sessionId: number }) => void) | undefined
+  const session: CdpSession = {
+    send: async (method, params = {}) => {
+      sent.push({ method, params })
+      return {}
+    },
+    on: (_event, handler) => {
+      onFrame = handler
+    },
+    close: () => {},
+  }
+  return { session, sent, frame: (data: string) => onFrame?.({ data, sessionId: 1 }) }
+}
+
+test('the stream starts a screencast and serves it as MJPEG', async () => {
+  const cdp = fakeCdp()
+  const stream = await startBrowserStream({
+    browserUrl: 'http://127.0.0.1:9333',
+    connect: async () => cdp.session,
+    listTargets: async () => [page()],
+  })
+  assert.ok(stream, 'a browser with a page yields a stream')
+  try {
+    assert.ok(cdp.sent.some(c => c.method === 'Page.startScreencast'))
+
+    cdp.frame(Buffer.from([1, 2, 3]).toString('base64'))
+    const res = await fetch(`${stream.url}/stream`)
+    assert.equal(res.headers.get('content-type'), 'multipart/x-mixed-replace; boundary=frame')
+
+    // The frame that arrived before anyone looked is still delivered — a pane opened on a
+    // still page must not sit blank.
+    const reader = res.body?.getReader()
+    const first = await reader?.read()
+    assert.ok((first?.value?.length ?? 0) > 0, 'the last known frame is sent on connect')
+    await reader?.cancel()
+  } finally {
+    await stream?.close()
+  }
+})
+
+test('a posted click reaches Chrome; junk is rejected without reaching it', async () => {
+  const cdp = fakeCdp()
+  const stream = await startBrowserStream({
+    browserUrl: 'http://127.0.0.1:9333',
+    connect: async () => cdp.session,
+    listTargets: async () => [page()],
+  })
+  assert.ok(stream)
+  try {
+    const ok = await fetch(`${stream.url}/input`, { method: 'POST', body: JSON.stringify({ type: 'click', x: 5, y: 6 }) })
+    assert.equal(ok.status, 204)
+    assert.ok(cdp.sent.some(c => c.method === 'Input.dispatchMouseEvent'))
+
+    const before = cdp.sent.length
+    const bad = await fetch(`${stream.url}/input`, { method: 'POST', body: 'not json' })
+    assert.equal(bad.status, 400)
+    assert.equal(cdp.sent.length, before, 'a malformed body dispatches nothing')
+  } finally {
+    await stream?.close()
+  }
+})
+
+test('the stream binds to loopback only — these frames can show a password being typed', async () => {
+  const cdp = fakeCdp()
+  const stream = await startBrowserStream({
+    browserUrl: 'http://127.0.0.1:9333',
+    connect: async () => cdp.session,
+    listTargets: async () => [page()],
+  })
+  try {
+    assert.ok(stream?.url.startsWith('http://127.0.0.1:'), stream?.url)
+  } finally {
+    await stream?.close()
+  }
+})
+
+test('no page to stream means no pane, not a failed run', async () => {
+  const stream = await startBrowserStream({
+    browserUrl: 'http://127.0.0.1:9333',
+    connect: async () => fakeCdp().session,
+    listTargets: async () => [],
+  })
+  assert.equal(stream, undefined)
+})
+
+test('a browser that cannot be listed is survivable', async () => {
+  const stream = await startBrowserStream({
+    browserUrl: 'http://127.0.0.1:1',
+    connect: async () => fakeCdp().session,
+    listTargets: async () => {
+      throw new Error('connection refused')
+    },
+  })
+  assert.equal(stream, undefined)
+})
+
+test('the stream follows the agent when it opens another tab (#802)', async () => {
+  const sessions: ReturnType<typeof fakeCdp>[] = []
+  let targets = [page({ id: 'first', url: 'https://first.test/' })]
+  const stream = await startBrowserStream({
+    browserUrl: 'http://127.0.0.1:9333',
+    connect: async () => {
+      const cdp = fakeCdp()
+      sessions.push(cdp)
+      return cdp.session
+    },
+    listTargets: async () => targets,
+    followIntervalMs: 20,
+  })
+  assert.ok(stream)
+  try {
+    assert.equal(sessions.length, 1, 'attached to the page the agent was on')
+
+    // The agent opens a tab; Chrome now lists it first.
+    targets = [page({ id: 'second', url: 'https://login.test/' }), ...targets]
+    await new Promise(r => setTimeout(r, 120))
+
+    assert.equal(sessions.length, 2, 'the pane re-attached instead of going blind')
+    assert.ok(sessions[1]?.sent.some(c => c.method === 'Page.startScreencast'))
+    assert.ok(sessions[0]?.sent.some(c => c.method === 'Page.stopScreencast'), 'the old tab stops streaming')
+  } finally {
+    await stream?.close()
+  }
+})
+
+test('following survives a browser that stops answering', async () => {
+  const cdp = fakeCdp()
+  let fail = false
+  const stream = await startBrowserStream({
+    browserUrl: 'http://127.0.0.1:9333',
+    connect: async () => cdp.session,
+    listTargets: async () => {
+      if (fail) throw new Error('browser went away')
+      return [page()]
+    },
+    followIntervalMs: 20,
+  })
+  assert.ok(stream)
+  try {
+    fail = true
+    await new Promise(r => setTimeout(r, 80))
+    const res = await fetch(`${stream.url}/stream`)
+    assert.equal(res.status, 200, 'the pane keeps serving the page it already had')
+    await res.body?.cancel()
+  } finally {
+    await stream?.close()
+  }
+})
+
+test('close stops the screencast and frees the port', async () => {
+  const cdp = fakeCdp()
+  const stream = await startBrowserStream({
+    browserUrl: 'http://127.0.0.1:9333',
+    connect: async () => cdp.session,
+    listTargets: async () => [page()],
+  })
+  assert.ok(stream)
+  await stream.close()
+  await stream.close() // idempotent
+  assert.ok(cdp.sent.some(c => c.method === 'Page.stopScreencast'))
+  await assert.rejects(fetch(`${stream.url}/stream`), 'the port is closed')
+})

--- a/packages/framework/src/browser-stream.ts
+++ b/packages/framework/src/browser-stream.ts
@@ -1,0 +1,298 @@
+import { createServer, type Server } from 'node:http'
+import { AddressInfo } from 'node:net'
+
+/**
+ * The run's browser, streamed to a human (#802, part of #609).
+ *
+ * The `await-browser` gate (#796) parks a run and asks someone to deal with a login wall or a
+ * captcha. The browser it is parked on is headless and owned by the run (#793), so there is
+ * nothing for that person to click. This serves it: the latest screencast frame as MJPEG, and
+ * clicks/keys back in over POST.
+ *
+ * Why the run hosts this rather than the dashboard driving Chrome directly: Chrome refuses
+ * DevTools socket connections carrying an `Origin` header unless launched with
+ * `--remote-allow-origins`, and opening that up would let any page the user happens to visit
+ * drive the agent's browser. The debug port stays unreachable from the web; this bridge is the
+ * only way in.
+ *
+ * Why MJPEG rather than a WebSocket: an `<img>` renders `multipart/x-mixed-replace` natively
+ * and input is a plain POST, so the dashboard needs no client library and the framework needs
+ * no new dependency — Node's global WebSocket is enough to talk to Chrome.
+ */
+export interface BrowserStream {
+  /** Where the dashboard points an `<img>` (`/stream`) and posts input (`/input`). */
+  url: string
+  /** Stop streaming and close the server. Safe to call twice. */
+  close(): Promise<void>
+}
+
+/** One page Chrome is showing, from `/json/list`. */
+export interface CdpPageTarget {
+  id: string
+  type: string
+  url: string
+  webSocketDebuggerUrl?: string
+}
+
+/**
+ * The page a human should be looking at: the agent's current one.
+ *
+ * Chrome lists targets most-recently-used first, so the first `page` is the one the agent is
+ * working in. Picking by position is what keeps the pane from going blind when the agent opens
+ * a tab — the failure the spike hit. Ignores targets with no socket (a crashed or detached
+ * tab) rather than returning something unusable.
+ */
+export function pickActivePage(targets: readonly CdpPageTarget[]): CdpPageTarget | undefined {
+  return targets.find(t => t.type === 'page' && !!t.webSocketDebuggerUrl)
+}
+
+/** The input a human can send back through the pane. Coordinates are in page pixels. */
+export type BrowserInput =
+  | { type: 'click'; x: number; y: number }
+  | { type: 'key'; text: string }
+  | { type: 'scroll'; x: number; y: number; deltaY: number }
+  | { type: 'navigate'; url: string }
+
+/** A CDP call the bridge makes on the human's behalf. */
+export interface CdpCall {
+  method: string
+  params: Record<string, unknown>
+}
+
+/**
+ * The CDP calls one input maps to, or `[]` for anything unrecognized — a malformed POST must
+ * never reach Chrome. A click is press + release (Chrome ignores a lone `mousePressed`), and
+ * text goes through `insertText` so it types the character rather than a key code, which is
+ * what makes non-ASCII and password managers behave.
+ */
+export function inputToCdp(input: BrowserInput): CdpCall[] {
+  switch (input?.type) {
+    case 'click': {
+      if (!Number.isFinite(input.x) || !Number.isFinite(input.y)) return []
+      const base = { x: input.x, y: input.y, button: 'left', clickCount: 1 }
+      return [
+        { method: 'Input.dispatchMouseEvent', params: { ...base, type: 'mousePressed' } },
+        { method: 'Input.dispatchMouseEvent', params: { ...base, type: 'mouseReleased' } },
+      ]
+    }
+    case 'key': {
+      if (typeof input.text !== 'string' || input.text === '') return []
+      return [{ method: 'Input.insertText', params: { text: input.text } }]
+    }
+    case 'scroll': {
+      if (!Number.isFinite(input.deltaY)) return []
+      return [
+        {
+          method: 'Input.dispatchMouseEvent',
+          params: { type: 'mouseWheel', x: input.x ?? 0, y: input.y ?? 0, deltaX: 0, deltaY: input.deltaY },
+        },
+      ]
+    }
+    case 'navigate': {
+      if (typeof input.url !== 'string' || !/^https?:\/\//i.test(input.url)) return []
+      return [{ method: 'Page.navigate', params: { url: input.url } }]
+    }
+    default:
+      return []
+  }
+}
+
+/** The MJPEG part header for one frame. */
+export function framePart(boundary: string, jpeg: Buffer): Buffer {
+  return Buffer.concat([
+    Buffer.from(`--${boundary}\r\nContent-Type: image/jpeg\r\nContent-Length: ${jpeg.length}\r\n\r\n`),
+    jpeg,
+    Buffer.from('\r\n'),
+  ])
+}
+
+const BOUNDARY = 'frame'
+
+/** What the bridge needs from a CDP connection, so a test can stand in for Chrome. */
+export interface CdpSession {
+  send(method: string, params?: Record<string, unknown>): Promise<unknown>
+  on(event: 'Page.screencastFrame', handler: (params: { data: string; sessionId: number }) => void): void
+  close(): void
+}
+
+/** How the bridge reaches a page. Injectable: the real one speaks WebSocket to Chrome. */
+export type CdpConnect = (webSocketDebuggerUrl: string) => Promise<CdpSession>
+
+/**
+ * Start the bridge. Returns undefined when Chrome has no page to stream — the caller carries
+ * on without a pane rather than failing the run.
+ *
+ * The stream is bound to loopback explicitly: the frames can contain whatever the human is
+ * typing, including a password, so this must not be reachable from the network. For the same
+ * reason no frame is ever written to disk or into the run's event log.
+ */
+export async function startBrowserStream(opts: {
+  browserUrl: string
+  connect: CdpConnect
+  listTargets?: (browserUrl: string) => Promise<CdpPageTarget[]>
+  /** How often to check whether the agent moved to another tab. 0 disables following. */
+  followIntervalMs?: number
+}): Promise<BrowserStream | undefined> {
+  const listTargets = opts.listTargets ?? defaultListTargets
+  const targets = await listTargets(opts.browserUrl).catch(() => [])
+  const page = pickActivePage(targets)
+  if (!page?.webSocketDebuggerUrl) return undefined
+
+  let latest: Buffer | undefined
+  const viewers = new Set<import('node:http').ServerResponse>()
+
+  /** Attach the screencast to one page. Frames land in `latest` and go straight to viewers. */
+  const attach = async (target: CdpPageTarget): Promise<CdpSession> => {
+    const session = await opts.connect(target.webSocketDebuggerUrl!)
+    session.on('Page.screencastFrame', ({ data, sessionId }) => {
+      latest = Buffer.from(data, 'base64')
+      for (const res of viewers) res.write(framePart(BOUNDARY, latest))
+      void session.send('Page.screencastFrameAck', { sessionId }).catch(() => {})
+    })
+    await session.send('Page.startScreencast', { format: 'jpeg', quality: 60, maxWidth: 1280, maxHeight: 720 })
+    return session
+  }
+
+  let current = page
+  let session = await attach(page)
+
+  /**
+   * Follow the agent when it opens or switches tabs. Without this the pane shows whichever
+   * page happened to be first while the agent works somewhere else — the exact failure the
+   * #609 spike reproduced. Cheap: one `/json/list` on an interval, re-attach only on change.
+   */
+  const followMs = opts.followIntervalMs ?? 2000
+  const follow = followMs
+    ? setInterval(() => {
+        void (async () => {
+          const next = pickActivePage(await listTargets(opts.browserUrl).catch(() => []))
+          if (!next?.webSocketDebuggerUrl || next.id === current.id) return
+          const previous = session
+          try {
+            session = await attach(next)
+            current = next
+            await previous.send('Page.stopScreencast').catch(() => {})
+            previous.close()
+          } catch {
+            // Keep streaming the page we already have rather than dropping the pane.
+          }
+        })()
+      }, followMs)
+    : undefined
+  follow?.unref?.()
+
+  const server: Server = createServer((req, res) => {
+    if (req.method === 'GET' && req.url?.startsWith('/stream')) {
+      res.writeHead(200, {
+        'content-type': `multipart/x-mixed-replace; boundary=${BOUNDARY}`,
+        'cache-control': 'no-store',
+        connection: 'close',
+      })
+      // Node holds the headers back until the first write, so a pane opened before any frame
+      // exists would hang waiting for a response rather than showing an empty stream.
+      res.flushHeaders()
+      // Chrome only emits a frame when the page changes, so a pane opened on a still page
+      // would sit blank. Send the last one we have immediately.
+      if (latest) res.write(framePart(BOUNDARY, latest))
+      viewers.add(res)
+      req.on('close', () => viewers.delete(res))
+      return
+    }
+    if (req.method === 'POST' && req.url?.startsWith('/input')) {
+      let body = ''
+      req.on('data', chunk => {
+        body += chunk
+        if (body.length > 8192) req.destroy() // an input payload is tiny; anything else is not input
+      })
+      req.on('end', () => {
+        let calls: CdpCall[] = []
+        try {
+          calls = inputToCdp(JSON.parse(body) as BrowserInput)
+        } catch {
+          calls = []
+        }
+        for (const call of calls) void session.send(call.method, call.params).catch(() => {})
+        res.writeHead(calls.length ? 204 : 400).end()
+      })
+      return
+    }
+    res.writeHead(404).end()
+  })
+
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  const port = (server.address() as AddressInfo).port
+
+  let closed = false
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: async () => {
+      if (closed) return
+      closed = true
+      if (follow) clearInterval(follow)
+      for (const res of viewers) res.end()
+      viewers.clear()
+      await session.send('Page.stopScreencast').catch(() => {})
+      session.close()
+      await new Promise<void>(resolve => server.close(() => resolve()))
+    },
+  }
+}
+
+/**
+ * Talk CDP to Chrome over its debugger socket. Node's global WebSocket is enough, which is
+ * what keeps this dependency-free.
+ */
+export const connectCdp: CdpConnect = async (webSocketDebuggerUrl: string) => {
+  const ws = new WebSocket(webSocketDebuggerUrl)
+  await new Promise<void>((resolve, reject) => {
+    ws.addEventListener('open', () => resolve(), { once: true })
+    ws.addEventListener('error', () => reject(new Error(`could not open ${webSocketDebuggerUrl}`)), { once: true })
+  })
+
+  let nextId = 1
+  const pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>()
+  const frameHandlers: ((p: { data: string; sessionId: number }) => void)[] = []
+
+  ws.addEventListener('message', ev => {
+    let msg: { id?: number; method?: string; params?: unknown; result?: unknown; error?: { message?: string } }
+    try {
+      msg = JSON.parse(String(ev.data))
+    } catch {
+      return
+    }
+    if (typeof msg.id === 'number') {
+      const p = pending.get(msg.id)
+      if (!p) return
+      pending.delete(msg.id)
+      msg.error ? p.reject(new Error(msg.error.message ?? 'CDP error')) : p.resolve(msg.result)
+      return
+    }
+    if (msg.method === 'Page.screencastFrame') {
+      for (const handler of frameHandlers) handler(msg.params as { data: string; sessionId: number })
+    }
+  })
+
+  return {
+    send: (method, params = {}) =>
+      new Promise((resolve, reject) => {
+        const id = nextId++
+        pending.set(id, { resolve, reject })
+        try {
+          ws.send(JSON.stringify({ id, method, params }))
+        } catch (err) {
+          pending.delete(id)
+          reject(err instanceof Error ? err : new Error(String(err)))
+        }
+      }),
+    on: (_event, handler) => void frameHandlers.push(handler),
+    close: () => ws.close(),
+  }
+}
+
+/** The real target list: Chrome's own `/json/list`. */
+async function defaultListTargets(browserUrl: string): Promise<CdpPageTarget[]> {
+  const res = await fetch(`${browserUrl}/json/list`)
+  if (!res.ok) return []
+  const body = (await res.json()) as CdpPageTarget[]
+  return Array.isArray(body) ? body : []
+}

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -15,6 +15,7 @@ import {
 import { type ClaudeCodeDriverOptions, type Driver, type DriverSession, type McpServerSpec, type PermissionMode } from './driver/index.js'
 import { AGENTS, AGENT_SPECS, createDriver, isAgentName, type AgentName } from './agent.js'
 import { launchSharedBrowser, type SharedBrowser } from './browser.js'
+import { connectCdp, startBrowserStream, type BrowserStream } from './browser-stream.js'
 import { hostExecutor } from './host-exec.js'
 import { startDashboard, singleProjectProvider, resolveDashboardBundle, type Dashboard } from './dashboard/index.js'
 import { startRelay, relayPublisher, type RelayPublisher } from './relay.js'
@@ -746,6 +747,8 @@ interface RunEpilogue {
   publisher: RelayPublisher | undefined
   /** The run's Chrome (#793), stopped with the run so no headless browser outlives it. */
   sharedBrowser: SharedBrowser | undefined
+  /** The preview of that browser (#802), stopped with the run. */
+  browserStream: BrowserStream | undefined
   clearInterrupt: () => void
   maybeFireOnBeforeMergeable: () => Promise<void>
   /** True once the run stopped cleanly (interrupt / budget cap) rather than failed. */
@@ -801,6 +804,7 @@ async function settleRun(
     ctx.clearInterrupt()
     ctx.control?.close()
     ctx.guard?.stop()
+    await ctx.browserStream?.close()
     await ctx.sharedBrowser?.close()
     // Make sure every event (including the final `end`) reached the relay before exit.
     if (ctx.publisher) await ctx.publisher.flush()
@@ -1229,6 +1233,14 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     ? fakeDriver()
     : createDriver({ agent: opts.agent, claudeOpts: withBrowser(claudeOpts, opts.browser, sharedBrowser?.browserUrl) })
 
+  // The preview of that browser (#802): the agent's Chrome is headless, so when it parks on an
+  // `await-browser` gate (#796) there is nothing for a human to click. This serves it. Opening
+  // the stream costs nothing while the page is still — Chrome only emits a frame on a change.
+  const browserStream = sharedBrowser
+    ? await startBrowserStream({ browserUrl: sharedBrowser.browserUrl, connect: connectCdp }).catch(() => undefined)
+    : undefined
+  if (browserStream) io.out(`◆ browser preview: ${browserStream.url}/stream`)
+
   // The consumption limits (#519/#531). Read from the user's own file rather than
   // taken as a flag: unlike autopilot or eco, a limit is not a per-run choice, so
   // a run started from a terminal is guarded exactly like one started from the
@@ -1257,6 +1269,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     guard,
     publisher,
     sharedBrowser,
+    browserStream,
     clearInterrupt,
     maybeFireOnBeforeMergeable,
     isStopped: () => controller.signal.aborted || stoppedCleanly,


### PR DESCRIPTION
Closes #802. Third slice of #609, on top of #793 and #796.

The `await-browser` gate parks a run and asks a human to deal with a login wall or a captcha. The browser it is parked on is headless and owned by the run, so until now there was nothing for that person to click. This serves it: the latest frame as MJPEG, and clicks, typing, scrolling and navigation back in over POST.

A run with `--browser` now prints `◆ browser preview: http://127.0.0.1:<port>/stream`.

## Two decisions

**The run bridges, rather than the dashboard driving Chrome directly.** Chrome refuses DevTools socket connections carrying an `Origin` header unless launched with `--remote-allow-origins`, and opening that up would let any page the user happens to visit drive the agent's browser. The debug port stays unreachable from the web.

**MJPEG, not a WebSocket.** An `<img>` renders `multipart/x-mixed-replace` natively and input is a plain POST, so the dashboard will need no client library and the framework takes no new dependency — Node's global WebSocket is enough to talk to Chrome. (`stream-headless` uses a WebSocket because it ships its own client; here the client is the dashboard we already serve.)

## Safety

Loopback only, asserted in a test. No frame is written to disk or into the event log — someone will type a password into this. `navigate` accepts `http(s)` only, so a posted `javascript:` or `file:` URL never reaches Chrome, and a malformed body dispatches nothing.

## Following the agent

A view pinned to the first tab goes blind the moment the agent opens another — the gotcha the spike found. The bridge re-checks the active page on an interval and re-attaches, keeping the old view if the browser stops answering rather than dropping the pane.

## Checks

16 new tests against a fake CDP, so CI needs no Chrome. Plus a live run against real Chrome 150: real screencast, a real JPEG arriving over the multipart stream, a click accepted and junk rejected.

Two real bugs the tests caught, both fixed:
- Node holds response headers until the first write, so a pane opened before any frame existed hung instead of connecting. That test went from 300s to 274ms.
- A `--browser` run with no page to stream must carry on without a preview rather than failing.

The suite's 9 daemon failures are pre-existing in a fresh worktree, identical with this change stashed.

## Next

The dashboard pane that embeds this and opens itself when the gate fires.