### PR TITLE
feat(framework): serve a session's own worktree (#797)

### DIFF
--- a/.changeset/feat-797-serve-session-worktree.md
+++ b/.changeset/feat-797-serve-session-worktree.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Serve a session's own worktree (#797). Preview was keyed by project and always booted the project's checkout, so pressing Serve inside a session showed you an app built from code that session never wrote, and two live sessions shared one preview. A session now serves the worktree it is working in, the project home keeps serving the main checkout, and the two run side by side. Stop and status are addressed the same way, the servable-app picker lists what the session's branch actually has, and a worktree's preview is stopped before its checkout is removed.

--- a/packages/framework-dashboard/components/PreviewBar.test.tsx
+++ b/packages/framework-dashboard/components/PreviewBar.test.tsx
@@ -31,7 +31,7 @@ describe('PreviewBar serve picker (#651)', () => {
     expect(screen.getAllByRole('button')).toHaveLength(1)
     fireEvent.click(screen.getByRole('button'))
     // No target id → the daemon serves the root/remembered default.
-    await waitFor(() => expect(sendPreview).toHaveBeenCalledWith('p1', undefined))
+    await waitFor(() => expect(sendPreview).toHaveBeenCalledWith('p1', undefined, undefined))
   })
 
   test('a multi-target repo offers a picker; choosing an app serves that target', async () => {
@@ -41,7 +41,7 @@ describe('PreviewBar serve picker (#651)', () => {
     await waitFor(() => expect(screen.getAllByRole('button')).toHaveLength(2))
     fireEvent.click(screen.getAllByRole('button')[1]!) // open the caret dropdown
     fireEvent.click(await screen.findByText('api'))
-    await waitFor(() => expect(sendPreview).toHaveBeenCalledWith('p2', 'apps/api'))
+    await waitFor(() => expect(sendPreview).toHaveBeenCalledWith('p2', 'apps/api', undefined))
   })
 
   test('the multi-target primary button serves the last pick (no explicit id)', async () => {
@@ -49,6 +49,25 @@ describe('PreviewBar serve picker (#651)', () => {
     render(<PreviewBar projectId="p3" inline />)
     await waitFor(() => expect(screen.getAllByRole('button')).toHaveLength(2))
     fireEvent.click(screen.getAllByRole('button')[0]!) // the primary Serve
-    await waitFor(() => expect(sendPreview).toHaveBeenCalledWith('p3', undefined))
+    await waitFor(() => expect(sendPreview).toHaveBeenCalledWith('p3', undefined, undefined))
+  })
+})
+
+describe('PreviewBar addressing (#797)', () => {
+  test("a session's Serve addresses that session, so it boots the session's own worktree", async () => {
+    onServeTargets.mockResolvedValueOnce([{ id: '.', label: 'app', dir: '', script: 'dev' }])
+    render(<PreviewBar projectId="p1" runId="run-1" inline />)
+    await waitFor(() => expect(onServeTargets).toHaveBeenCalledWith('p1', 'run-1'))
+    // The rehydrate has to be run-addressed too, or a reload adopts the project preview's URL
+    // as if it were the session's.
+    expect(onPreviewStatus).toHaveBeenCalledWith('p1', 'run-1')
+    fireEvent.click(screen.getByRole('button')) // icon-only inline control
+    await waitFor(() => expect(sendPreview).toHaveBeenCalledWith('p1', undefined, 'run-1'))
+  })
+
+  test('the project home stays unaddressed, serving the project checkout', async () => {
+    onServeTargets.mockResolvedValueOnce([{ id: '.', label: 'app', dir: '', script: 'dev' }])
+    render(<PreviewBar projectId="p1" inline />)
+    await waitFor(() => expect(onServeTargets).toHaveBeenCalledWith('p1', undefined))
   })
 })

--- a/packages/framework-dashboard/components/PreviewBar.tsx
+++ b/packages/framework-dashboard/components/PreviewBar.tsx
@@ -16,7 +16,21 @@ import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuIte
 // Multi-package repos (#651): a monorepo has several servable apps, so onServeTargets lists them
 // and the Serve button becomes a split control — the primary serves the last pick (the daemon
 // remembers), a caret opens the picker. A single-app repo keeps the plain one-click button.
-export function PreviewBar({ projectId, inline = false }: { projectId: string; inline?: boolean }) {
+//
+// `runId` serves that session's own worktree (#797). Sitting in a session's action bar without it,
+// this booted the *project's* checkout: you pressed Serve on a session and looked at an app built
+// from code that session never wrote. Each session gets its own preview, so two can serve at once
+// (dev servers pick their own free port), and the project home keeps serving the main checkout.
+export function PreviewBar({
+  projectId,
+  runId,
+  inline = false,
+}: {
+  projectId: string
+  /** The session whose worktree to serve; absent serves the project's checkout. */
+  runId?: string | null | undefined
+  inline?: boolean
+}) {
   const [url, setUrl] = useState<string | null>(null)
   const [command, setCommand] = useState<string | null>(null)
   const [targets, setTargets] = useState<ServeTarget[]>([])
@@ -30,22 +44,22 @@ export function PreviewBar({ projectId, inline = false }: { projectId: string; i
     setCommand(null)
     setTargets([])
     reset()
-    void onPreviewStatus(projectId).then(status => {
+    void onPreviewStatus(projectId, runId ?? undefined).then(status => {
       if (!live || !status.running) return
       setUrl(status.url ?? null)
       setCommand(status.command ?? null)
     })
-    void onServeTargets(projectId).then(list => {
+    void onServeTargets(projectId, runId ?? undefined).then(list => {
       if (live) setTargets(list)
     })
     return () => {
       live = false
     }
-  }, [projectId, reset])
+  }, [projectId, runId, reset])
 
   // Serve the given app (or the daemon's remembered/default one when no id is passed).
   const open = async (targetId?: string) => {
-    const result = await run(() => sendPreview(projectId, targetId), 'Failed to start the preview.')
+    const result = await run(() => sendPreview(projectId, targetId, runId ?? undefined), 'Failed to start the preview.')
     if (result?.ok) {
       setUrl(result.url)
       setCommand(result.command)
@@ -54,7 +68,7 @@ export function PreviewBar({ projectId, inline = false }: { projectId: string; i
 
   const stop = async () => {
     const stopped = await run(async () => {
-      await sendStopPreview(projectId)
+      await sendStopPreview(projectId, runId ?? undefined)
       return true as const
     }, 'Failed to stop the preview.')
     if (stopped) {

--- a/packages/framework-dashboard/components/RunActionBar.tsx
+++ b/packages/framework-dashboard/components/RunActionBar.tsx
@@ -44,8 +44,8 @@ export function RunActionBar({
   return (
     <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-2">
       <TooltipProvider delay={300} closeDelay={0}>
-        {/* Serve the project's built result (its own icon button + tooltip). */}
-        <PreviewBar projectId={projectId} inline />
+        {/* Serve what THIS session built (#797): its own worktree, not the project's checkout. */}
+        <PreviewBar projectId={projectId} runId={runId} inline />
         {/* Where this session is working (#798): its branch, whether it is holding uncommitted
             work, and a way into the checkout. Only a run has one, so the project home has none. */}
         {runId && <WorktreeChip projectId={projectId} runId={runId} />}

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -17,7 +17,7 @@ import {
   registerHomeProject,
   isNestedWithin,
 } from './daemon.js'
-import { EVENTS_FILE, FRAMEWORK_DIR } from './store/index.js'
+import { EVENTS_FILE, FRAMEWORK_DIR, addWorktree } from './store/index.js'
 import { controlPath } from './control.js'
 import { projectId, listProjects, addProject } from './registry.js'
 import { nodeGitRunner } from './project.js'
@@ -320,6 +320,66 @@ test('onServeTargets lists a monorepo\'s servable apps over telefunc (#651)', as
       ['apps/api:start', 'apps/web:dev'],
       'lists only servable workspace apps, sorted; the non-servable package is excluded',
     )
+    ac.abort()
+    await done
+  } finally {
+    ac.abort()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test("a session's Serve reads its own worktree, not the project's checkout (#797)", async () => {
+  // The point of the change: Serve inside a session used to boot the project's tree, so you
+  // pressed it on a session and got an app built from code that session never wrote. Here the
+  // worktree has an app the project's checkout does not, so the two lists cannot be confused.
+  const cwd = await realpath(await mkdtemp(join(tmpdir(), 'framework-daemon-serve-')))
+  const git = nodeGitRunner()
+  const env = await configEnv(cwd)
+  const ac = new AbortController()
+  try {
+    await git(['init'], cwd)
+    await git(['config', 'user.email', 'test@example.com'], cwd)
+    await git(['config', 'user.name', 'Test'], cwd)
+    await writeFile(join(cwd, 'package.json'), JSON.stringify({ name: 'root', scripts: { dev: 'vite' } }))
+    await git(['add', '-A'], cwd)
+    await git(['commit', '-m', 'init'], cwd)
+
+    // A session's worktree, with a servable app that exists only on its branch.
+    const runId = '2026-07-19T12-00-00-000Z'
+    await addWorktree(cwd, { runId, branch: 'the-framework/session' })
+    const worktree = join(cwd, FRAMEWORK_DIR, 'worktrees', runId)
+    await writeFile(join(worktree, 'pnpm-workspace.yaml'), 'packages:\n  - "apps/*"\n')
+    await mkdir(join(worktree, 'apps', 'new-thing'), { recursive: true })
+    await writeFile(
+      join(worktree, 'apps', 'new-thing', 'package.json'),
+      JSON.stringify({ name: 'new-thing', scripts: { dev: 'vite' } }),
+    )
+
+    const done = runDaemon(cwd, { port: 0, signal: ac.signal, env })
+    let state = await readDaemonState(env)
+    for (let i = 0; i < 100 && !state; i++) {
+      await new Promise(r => setTimeout(r, 20))
+      state = await readDaemonState(env)
+    }
+    assert.ok(state, 'daemon wrote its state file')
+
+    const idsFor = async (runArg?: string): Promise<string[]> => {
+      const targets = (await callTelefunc(state!.url, '/server/control.telefunc.ts', 'onServeTargets', [
+        homeId(cwd),
+        ...(runArg ? [runArg] : []),
+      ])) as Array<{ id: string }>
+      return targets.map(t => t.id).sort()
+    }
+
+    assert.deepEqual(await idsFor(), ['.'], "the project's checkout serves only its own root app")
+    assert.deepEqual(
+      await idsFor(runId),
+      ['.', 'apps/new-thing'],
+      "the session's checkout serves what its branch added",
+    )
+    // An unknown session falls back to the project rather than failing, like every other
+    // run-addressed call.
+    assert.deepEqual(await idsFor('2026-01-01T00-00-00-000Z'), ['.'])
     ac.abort()
     await done
   } finally {

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -18,6 +18,8 @@ import {
   commitPendingWork,
   removeWorktree,
   pruneWorktrees,
+  readLiveMetas,
+  isSafeRunId,
 } from './store/index.js'
 import { startDashboard, type Dashboard, type StartRunKind, type StartRunOptions, type StartRunResult, type AddProjectResult, type PreviewResult, type PreviewStatus } from './dashboard/index.js'
 import { startInterventionWatcher, postDiscord, type InterventionWatcher } from './dashboard/intervention-watcher.js'
@@ -485,6 +487,20 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
   }
 
   /**
+   * The checkout a *session* is working in (#797): its own worktree, else the project's tree.
+   * Same resolution the read and control RPCs use — live metas first, then the directory, which
+   * exists before the run has written its `run.json`.
+   */
+  const resolveRunCheckout = async (projectCwd: string, runId: string | undefined): Promise<string> => {
+    if (!runId || !isSafeRunId(runId)) return projectCwd
+    const live = await readLiveMetas(projectCwd).catch(() => [])
+    const running = live.find(run => run.id === runId)?.cwd
+    if (running) return running
+    const path = worktreePath(projectCwd, runId)
+    return (await stat(path).then(s => s.isDirectory()).catch(() => false)) ? path : projectCwd
+  }
+
+  /**
    * The checkout a run gets (#736). Each run is given its own git worktree under the
    * project's `.the-framework/worktrees/<runId>`, on a `the-framework/run-<runId>` branch,
    * so N runs on one repo never fight over the working tree — and the user's own checkout,
@@ -547,8 +563,12 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
    * Best-effort from end to end: this runs off a process-exit event with nothing to return to,
    * so a failure here must not take the daemon down.
    */
-  const tearDownWorktree = async (projectCwd: string, worktree: string): Promise<void> => {
+  const tearDownWorktree = async (projectCwd: string, worktree: string, runId?: string): Promise<void> => {
     try {
+      // A session can be serving its own checkout (#797), and that dev server holds the directory
+      // it is about to lose. Stop it first, whether or not the worktree ends up removed: the run
+      // is over, so the preview is serving a tree nothing is working on.
+      await onStopPreview(projectKeyFor(projectCwd), runId)
       const meta = await archiveWorktreeRun(worktree, projectCwd)
       if (meta?.status !== 'done') return // failed / stopped / unreadable: keep it for inspection
       // A finished run can still be holding an uncommitted edit (#786), and removing the
@@ -629,7 +649,7 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
       // dashboard streams over a Telefunc Channel; the daemon just tracks liveness.
       const settle = (): void => {
         activeRuns.delete(key)
-        if (workspace.runId) void tearDownWorktree(projectCwd, workspace.cwd)
+        if (workspace.runId) void tearDownWorktree(projectCwd, workspace.cwd, workspace.runId)
       }
       child.once('error', settle)
       child.once('exit', settle)
@@ -671,6 +691,15 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
   // key and evict it the moment it stops serving (stop, or a self-exit: crash / build error /
   // the user killing it), so previewStatus never reports a dead URL and the idempotent open
   // below never hands back a corpse instead of restarting.
+  //
+  // Since #797 the key carries the session too, because a session serves its OWN worktree: one
+  // preview per project as before, plus one per session that asks for it, each pointing at the
+  // tree it belongs to. Keyed by project alone, a session's Serve booted the project's checkout
+  // and showed you code that session never wrote.
+  const previewKeyFor = (projectKey: string, runId?: string): string =>
+    runId ? `${projectKey}::${runId}` : projectKey
+  /** The project half of a preview key from a checkout: the registry id every RPC keys by. */
+  const projectKeyFor = (projectCwd: string): string => projectId(resolve(projectCwd))
   const trackPreview = (key: string, handle: PreviewHandle): void => {
     activePreviews.set(key, handle)
     void handle.exited.then(() => {
@@ -681,44 +710,51 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
   // without re-choosing. In-memory: a live preview already rehydrates via onPreviewStatus, and
   // the pick resets on daemon restart (the picker still lists everything).
   const lastServeTarget = new Map<string, string>()
-  const onServeTargets = async (targetProjectId?: string): Promise<ServeTarget[]> => {
+  const onServeTargets = async (targetProjectId?: string, runId?: string): Promise<ServeTarget[]> => {
     const projectCwd = await resolveProject(targetProjectId)
-    return projectCwd ? detectServeTargets(projectCwd).catch(() => []) : []
+    if (!projectCwd) return []
+    // Detected in the checkout that will actually be served: a session's branch may have added or
+    // removed a servable package, and offering the project's list would offer apps it cannot serve.
+    const serveCwd = await resolveRunCheckout(projectCwd, runId)
+    return detectServeTargets(serveCwd).catch(() => [])
   }
-  const onPreview = async (targetProjectId?: string, targetId?: string): Promise<PreviewResult> => {
-    const key = targetProjectId ?? homeId
+  const onPreview = async (targetProjectId?: string, targetId?: string, runId?: string): Promise<PreviewResult> => {
+    const projectKey = targetProjectId ?? homeId
+    const key = previewKeyFor(projectKey, runId)
     const existing = activePreviews.get(key)
     if (existing) return { ok: true, url: existing.url, command: existing.command }
     const projectCwd = await resolveProject(targetProjectId)
     if (!projectCwd) return { ok: false, error: `unknown project: ${targetProjectId}` }
+    const serveCwd = await resolveRunCheckout(projectCwd, runId)
     try {
       // Resolve the pick: an explicit choice, else the one remembered from last time. Both are
       // matched against the live target list so a stale/unknown id falls back to the root default.
-      const wantId = targetId ?? lastServeTarget.get(key)
-      const target = wantId ? (await detectServeTargets(projectCwd).catch(() => [])).find(t => t.id === wantId) : undefined
-      const handle = await startPreview(target ? { cwd: projectCwd, target } : { cwd: projectCwd })
+      // The memory is per project, not per session: which app you serve is a property of the repo.
+      const wantId = targetId ?? lastServeTarget.get(projectKey)
+      const target = wantId ? (await detectServeTargets(serveCwd).catch(() => [])).find(t => t.id === wantId) : undefined
+      const handle = await startPreview(target ? { cwd: serveCwd, target } : { cwd: serveCwd })
       // A racing second open won the slot while we were booting: keep theirs, drop ours.
       const raced = activePreviews.get(key)
       if (raced) {
         await handle.stop().catch(() => {})
         return { ok: true, url: raced.url, command: raced.command }
       }
-      if (target) lastServeTarget.set(key, target.id)
+      if (target) lastServeTarget.set(projectKey, target.id)
       trackPreview(key, handle)
       return { ok: true, url: handle.url, command: handle.command }
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : String(err) }
     }
   }
-  const onStopPreview = async (targetProjectId?: string): Promise<void> => {
-    const key = targetProjectId ?? homeId
+  const onStopPreview = async (targetProjectId?: string, runId?: string): Promise<void> => {
+    const key = previewKeyFor(targetProjectId ?? homeId, runId)
     const handle = activePreviews.get(key)
     if (!handle) return
     activePreviews.delete(key)
     await handle.stop().catch(() => {})
   }
-  const onPreviewStatus = (targetProjectId?: string): PreviewStatus => {
-    const handle = activePreviews.get(targetProjectId ?? homeId)
+  const onPreviewStatus = (targetProjectId?: string, runId?: string): PreviewStatus => {
+    const handle = activePreviews.get(previewKeyFor(targetProjectId ?? homeId, runId))
     return handle ? { running: true, url: handle.url, command: handle.command } : { running: false }
   }
 

--- a/packages/framework/src/dashboard-rpc/context.ts
+++ b/packages/framework/src/dashboard-rpc/context.ts
@@ -65,6 +65,16 @@ export async function resolveRunPath(projectId: string, runId?: string): Promise
 }
 
 /**
+ * The Preview handler set on the context (#475), or undefined where Preview is not wired (the
+ * relay, or a call made outside a request). Read through the same tolerant accessor as the rest:
+ * `sendRemoveWorktree` stops a session's preview before taking its checkout away (#797), and that
+ * telefunction is also called directly by tests, where there is no context at all.
+ */
+export function contextPreview(): DashboardContext['preview'] {
+  return fromContext(ctx => ctx.preview)
+}
+
+/**
  * The in-memory {@link EventsSource} on the context, or undefined (#426). Only the relay
  * sets one — it has no `.the-framework/events.jsonl` on disk, so `onEvents` streams from
  * the relay's in-memory run instead. Unset on the daemon/foreground, where `onEvents`

--- a/packages/framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/control.telefunc.ts
@@ -1,7 +1,7 @@
 import { getContext } from 'telefunc'
 import { appendControl, type ControlEntry } from '../control.js'
 import { openInApp, type OpenTarget, type OpenResult } from '../dashboard/open-in-app.js'
-import { resolveProjectPath, resolveRunPath, contextPreferences } from './context.js'
+import { resolveProjectPath, resolveRunPath, contextPreferences, contextPreview } from './context.js'
 import { isSafeRunId, readLiveMetas, removeWorktree, pruneWorktrees, worktreePath } from '../store/index.js'
 import type { ChoiceBy } from '../events.js'
 import type {
@@ -78,6 +78,9 @@ export async function sendMessage(projectId: string, text: string, runId?: strin
  * archived into the repo when it finished, so removal costs no history.
  */
 export async function sendRemoveWorktree(projectId: string, runId: string): Promise<RemoveWorktreeResult> {
+  // Read the context before the first await: telefunc only exposes it synchronously, at the top
+  // of the telefunction. Through the tolerant accessor, since this is also called directly.
+  const preview = contextPreview()
   const cwd = await resolveProjectPath(projectId)
   if (!cwd) return { ok: false, error: 'this project has no local path on this server' }
   if (!isSafeRunId(runId)) return { ok: false, error: `invalid session id: ${runId}` }
@@ -86,6 +89,9 @@ export async function sendRemoveWorktree(projectId: string, runId: string): Prom
     return { ok: false, error: 'that session is still going; stop it before removing its worktree' }
   }
   try {
+    // A retained worktree can still be serving (#797), and that dev server holds the tree being
+    // removed. Stop it first rather than pulling the directory out from under it.
+    await preview?.stop(projectId, runId)
     await removeWorktree(cwd, worktreePath(cwd, runId))
     await pruneWorktrees(cwd)
     return { ok: true }
@@ -121,10 +127,12 @@ export async function sendStart(
  * (like `sendStart`). Idempotent — opening while a preview is up returns the running one.
  * Returns an error result when Preview is not enabled on this host (the relay/per-run view).
  */
-export async function sendPreview(projectId: string, targetId?: string): Promise<PreviewResult> {
+export async function sendPreview(projectId: string, targetId?: string, runId?: string): Promise<PreviewResult> {
   const { preview } = getContext<DashboardContext>()
   if (!preview) return { ok: false, error: 'preview is not enabled on this server' }
-  return preview.start(projectId, targetId)
+  // With a session id this serves that session's own worktree (#797). Without one it is the
+  // project's checkout, which is what the project home asks for.
+  return preview.start(projectId, targetId, runId)
 }
 
 /**
@@ -132,23 +140,23 @@ export async function sendPreview(projectId: string, targetId?: string): Promise
  * that has a dev/serve script. A single-package repo returns at most one, so the button stays a
  * plain Serve; a monorepo returns several to choose from. Empty when Preview is not enabled.
  */
-export async function onServeTargets(projectId: string): Promise<ServeTarget[]> {
+export async function onServeTargets(projectId: string, runId?: string): Promise<ServeTarget[]> {
   const { preview } = getContext<DashboardContext>()
   if (!preview) return []
-  return preview.targets(projectId)
+  return preview.targets(projectId, runId)
 }
 
 /** Stop a project's Preview (#475). A no-op when none is running, or Preview is not enabled. */
-export async function sendStopPreview(projectId: string): Promise<void> {
+export async function sendStopPreview(projectId: string, runId?: string): Promise<void> {
   const { preview } = getContext<DashboardContext>()
-  if (preview) await preview.stop(projectId)
+  if (preview) await preview.stop(projectId, runId)
 }
 
 /** Report whether a project's Preview is already running (#475), so a reload rehydrates the button. */
-export async function onPreviewStatus(projectId: string): Promise<PreviewStatus> {
+export async function onPreviewStatus(projectId: string, runId?: string): Promise<PreviewStatus> {
   const { preview } = getContext<DashboardContext>()
   if (!preview) return { running: false }
-  return preview.status(projectId)
+  return preview.status(projectId, runId)
 }
 
 /**

--- a/packages/framework/src/dashboard/telefunc-serve.ts
+++ b/packages/framework/src/dashboard/telefunc-serve.ts
@@ -22,11 +22,12 @@ export type AddProjectHandler = (path: string, directory: boolean) => AddProject
 
 /** Wired by the daemon so the Preview RPCs can serve/stop/report a project's app (#475). */
 export interface PreviewHandlers {
-  start: (projectId?: string, targetId?: string) => PreviewResult | Promise<PreviewResult>
-  /** List the project's servable apps (#651) for the Serve picker in a multi-package repo. */
-  targets: (projectId?: string) => ServeTarget[] | Promise<ServeTarget[]>
-  stop: (projectId?: string) => void | Promise<void>
-  status: (projectId?: string) => PreviewStatus | Promise<PreviewStatus>
+  /** `runId` serves that session's own worktree instead of the project's checkout (#797). */
+  start: (projectId?: string, targetId?: string, runId?: string) => PreviewResult | Promise<PreviewResult>
+  /** List the servable apps (#651) for the Serve picker in a multi-package repo. */
+  targets: (projectId?: string, runId?: string) => ServeTarget[] | Promise<ServeTarget[]>
+  stop: (projectId?: string, runId?: string) => void | Promise<void>
+  status: (projectId?: string, runId?: string) => PreviewStatus | Promise<PreviewStatus>
 }
 
 /** Resolve a project id to its live event stream (#426): the relay feeds `onEvents` from


### PR DESCRIPTION
Closes #797

## What

A session's Serve now boots the worktree that session is working in. The project home keeps serving the main checkout, and both can run at once.

## Why

Preview was keyed by project and always started in `resolveProject(id)`, the main checkout. Since #736 a session works in its own worktree, so the Serve button in a session's action bar showed you an app built from code that session never wrote. With two live sessions it was worse: both Serve buttons opened the same app. The run's own serve gate was already worktree-scoped, so only the dashboard's on-demand Preview (#475) was wrong.

## Shape

- The preview key carries the session (`project::run`), so a session gets its own preview alongside the project's rather than fighting over one slot.
- Its checkout is resolved the way every other run-addressed call resolves one: live metas first, then the worktree directory, which exists before the run has written its `run.json`.
- `sendPreview` / `sendStopPreview` / `onPreviewStatus` / `onServeTargets` all take an optional run id, mirroring #749.
- Serve targets are detected in the checkout that will be served: a session's branch may have added or removed a servable package, and offering the project's list offers apps it cannot serve.
- Worktree teardown and the dashboard's Remove both stop that session's preview first. A dev server holds the directory being removed.
- Which app to serve is still remembered per project. That is a property of the repo, not of the session.

## Known edge, left as is

A finished session whose worktree was already removed falls back to serving the project's checkout, like every other run-addressed call falls back. Once the tree is gone there is nothing else to serve.

## Verified

733 framework + 135 dashboard tests pass, typecheck clean. New daemon test drives the real daemon over Telefunc against a real git worktree: the project lists only its own root app, the session lists what its branch added, and an unknown session falls back to the project.

Then end to end against a real daemon with two real dev servers, one per checkout, each serving a marker file: the project preview returns `PROJECT CHECKOUT`, the session preview returns `SESSION WORKTREE`, they are two different ports, status is reported per session, stopping the session leaves the project serving, and removing the worktree stops its preview first.

Two things the e2e caught that the unit tests did not: `getContext()` must be read before the first `await` (and through the tolerant accessor, since `sendRemoveWorktree` is also called directly by tests), and npm echoes the dev script it runs, so a command containing a literal `http://localhost:` is parsed as the served URL. The latter is pre-existing and only bit my test fixture, but it would bite a real `wait-on http://localhost:3000 && ...` dev script.