### PR TITLE
fix(framework-dashboard): group a session's actions at the end of the bar (#807)

### DIFF
--- a/.changeset/fix-807-actions-at-the-end.md
+++ b/.changeset/fix-807-actions-at-the-end.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Group a session's actions at the end of its action bar (#807). Serve, Stop, Remove and Open session sat at the start of the row, interleaved with the worktree chip, and since each one is conditional the row shifted under the cursor as a session moved through its life. What the session is now reads at the start of the bar; what you can do to it sits at the end, in one place.

--- a/packages/framework-dashboard/components/RunActionBar.tsx
+++ b/packages/framework-dashboard/components/RunActionBar.tsx
@@ -44,11 +44,16 @@ export function RunActionBar({
   return (
     <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-2">
       <TooltipProvider delay={300} closeDelay={0}>
-        {/* Serve what THIS session built (#797): its own worktree, not the project's checkout. */}
-        <PreviewBar projectId={projectId} runId={runId} inline />
         {/* Where this session is working (#798): its branch, whether it is holding uncommitted
             work, and a way into the checkout. Only a run has one, so the project home has none. */}
         {runId && <WorktreeChip projectId={projectId} runId={runId} />}
+        {error && <span className="text-xs text-red-500">{error}</span>}
+        {/* What the session IS sits at the start of the bar; what you can DO to it sits at the end,
+            so the buttons keep one home as the row's contents come and go (Stop only while it runs,
+            Remove only on a retained worktree, Open session only once one is reported). */}
+        <div className="min-w-0 flex-1" />
+        {/* Serve what THIS session built (#797): its own worktree, not the project's checkout. */}
+        <PreviewBar projectId={projectId} runId={runId} inline />
         {active && (
           <Tooltip>
             <TooltipTrigger
@@ -88,7 +93,6 @@ export function RunActionBar({
           </Tooltip>
         )}
       </TooltipProvider>
-      {error && <span className="text-xs text-red-500">{error}</span>}
     </div>
   )
 }


### PR DESCRIPTION
Closes #807

Serve, Stop, Remove and Open session sat at the start of the session's action bar, interleaved with the worktree chip. Every one of them is conditional (Stop only while the session runs, Remove only on a retained worktree, Open session only once one is reported), so the row's contents shifted under the cursor as a session moved through its life.

What the session **is** now reads at the start of the bar (the worktree chip, and any error). What you can **do** to it groups at the end, so the buttons keep one home whichever of them are present.

Rendered against a real daemon on a real session:

```
[ ⑂ the-framework/welcome-page · 8 KB ]                              [ ▷ ]  [ 🗑 ]
```

135 dashboard tests pass, typecheck clean.