### PR TITLE
test(framework): follow an append with an append, not a rewrite (#811)

### DIFF
--- a/packages/framework/src/dashboard-rpc/events-tail.test.ts
+++ b/packages/framework/src/dashboard-rpc/events-tail.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { appendFile, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { FrameworkEvent } from '../events.js'
@@ -22,7 +22,11 @@ test('tailEvents seeds with what is already logged, then follows appends', async
   try {
     await sleep(150)
     assert.deepEqual(seen, ['first'])
-    await writeFile(path, line('first') + line('second'))
+    // Append, the way a run writes its log. This used to rewrite the whole file, which truncates
+    // it first — and a poll landing in that instant makes the tailer do exactly what it is built
+    // to do (#567): treat the log as rewritten, reset, and replay `first`. The rewrite path is
+    // covered on purpose by the next test; this one is about following appends (#811).
+    await appendFile(path, line('second'))
     await sleep(1400) // fs.watch is unreliable on CI; wait out the poll backstop behind it
     assert.deepEqual(seen, ['first', 'second'])
   } finally {


### PR DESCRIPTION
Closes #811

`tailEvents seeds with what is already logged, then follows appends` fails intermittently on CI, on PRs that touch nothing near it (seen on the #809 build: expected `['first', 'second']`, got `['first', 'first', 'second']`; a rerun of the same commit passed).

The test simulated an append with `writeFile`, which truncates the file and then writes it. The tailer's fresh-run detection (#567) exists to notice a log that got rewritten, so a poll landing inside that truncated instant did exactly what it is built to do: reset and replay from the start, delivering `first` twice.

So the flake belonged to the test, not the tailer. It now appends with `appendFile`, which is both what its name claims and what a run actually does to `events.jsonl`. The rewrite path stays covered by the next test, which rewrites deliberately and asserts the reset.

No changeset: test-only, nothing published changes.

## Verified

The tail test passes 6/6 runs in isolation, and the full framework suite is 749 pass / 0 fail.