### PR TITLE
feat(framework): show the run's browser in the run view (#813)

### DIFF
--- a/.changeset/browser-preview-pane.md
+++ b/.changeset/browser-preview-pane.md
@@ -1,0 +1,6 @@
+---
+'@gemstack/framework-dashboard': minor
+'@gemstack/framework': minor
+---
+
+Show the run's browser in the run view. The stream shipped in #802 but nothing rendered it, and its URL only ever went to stdout, which a dashboard-started run discards. The run now publishes the port on its event log, the daemon proxies the stream and the input POST so the pane is same-origin, and the right rail gains a Browser tab that renders the frames and relays clicks and keys back to the page.

--- a/packages/framework-dashboard/components/BrowserPanel.tsx
+++ b/packages/framework-dashboard/components/BrowserPanel.tsx
@@ -1,0 +1,77 @@
+import { useRef, useState } from 'react'
+
+/**
+ * The run's browser, live in the right rail (#813).
+ *
+ * The run serves its headless Chrome as MJPEG (#802) and takes clicks and keys back over POST;
+ * the daemon proxies both so this stays same-origin. An `<img>` renders
+ * `multipart/x-mixed-replace` natively, so there is no player here — the browser is the player.
+ *
+ * This is the half that makes the `await-browser` gate (#796) actionable: the run parks asking a
+ * human to get past a login wall, and until now that human had no way to reach the page.
+ */
+export function BrowserPanel({ projectId, runId }: { projectId: string; runId: string }) {
+  const img = useRef<HTMLImageElement>(null)
+  const [failed, setFailed] = useState(false)
+  const base = `/browser/${encodeURIComponent(projectId)}/${encodeURIComponent(runId)}`
+
+  /**
+   * Where the click landed on the real page. The frame is capped at 1280x720 by the screencast
+   * and then scaled again to fit the rail, so a rail pixel is not a page pixel: sending the
+   * former clicks the wrong thing on any pane that is not exactly life-size.
+   */
+  const toPageCoords = (event: React.MouseEvent<HTMLImageElement>) => {
+    const el = event.currentTarget
+    const box = el.getBoundingClientRect()
+    return {
+      x: Math.round(((event.clientX - box.left) / box.width) * (el.naturalWidth || box.width)),
+      y: Math.round(((event.clientY - box.top) / box.height) * (el.naturalHeight || box.height)),
+    }
+  }
+
+  const send = (body: unknown) => {
+    void fetch(`${base}/input`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }).catch(() => {})
+  }
+
+  if (failed) {
+    return (
+      <p className="p-3 text-xs text-muted-foreground">
+        The preview is not reachable. It ends with the run, and a run only has one when it was started with Browser
+        on.
+      </p>
+    )
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="min-h-0 flex-1 overflow-auto p-2">
+        {/* tabIndex makes the frame focusable so keystrokes have somewhere to land. */}
+        <img
+          ref={img}
+          src={`${base}/stream`}
+          alt="The run's browser"
+          tabIndex={0}
+          className="w-full cursor-crosshair rounded border border-border bg-muted"
+          onError={() => setFailed(true)}
+          onClick={event => send({ type: 'click', ...toPageCoords(event) })}
+          onWheel={event => send({ type: 'scroll', ...toPageCoords(event), deltaY: event.deltaY })}
+          onKeyDown={event => {
+            // Only real text goes through: `insertText` types a character, so a bare modifier or
+            // an arrow key would otherwise insert the literal string "Shift" or "ArrowLeft".
+            if (event.key.length !== 1 || event.metaKey || event.ctrlKey) return
+            event.preventDefault()
+            send({ type: 'key', text: event.key })
+          }}
+        />
+      </div>
+      <p className="border-t border-border p-2 text-xs text-muted-foreground">
+        Click the frame, then type. Chrome only sends a frame when the page changes, so this stays blank until the
+        agent opens something.
+      </p>
+    </div>
+  )
+}

--- a/packages/framework-dashboard/components/RightRail.tsx
+++ b/packages/framework-dashboard/components/RightRail.tsx
@@ -5,12 +5,13 @@ import { ProjectLogPanel } from './ProjectLogPanel.js'
 import { ChoicesRail } from './ChoicesRail.js'
 import { ViewsRail } from './ViewsRail.js'
 import { FileTree } from './FileTree.js'
+import { BrowserPanel } from './BrowserPanel.js'
 import type { AgentView } from '../lib/live-state.js'
 import { Badge } from './ui/badge.js'
 import { Button } from './ui/button.js'
 import { cn } from '../lib/utils.js'
 
-type Tab = 'files' | 'choices' | 'views' | 'docs' | 'log'
+type Tab = 'files' | 'choices' | 'views' | 'browser' | 'docs' | 'log'
 
 // The right sidebar (#314 third rail): the interactive choice gates the run parks on
 // (#440), the ad-hoc markdown views the agent pushes (#441), the surfaced docs (PLAN/TODO),
@@ -25,6 +26,7 @@ export function RightRail({
   files,
   context,
   toggleContext,
+  hasBrowser = false,
 }: {
   projectId: string | null
   /** The selected run, so a choice pick resolves that run's gate (#749). */
@@ -37,6 +39,8 @@ export function RightRail({
   context: Set<string>
   /** Toggle a file path in the Context. */
   toggleContext: (path: string) => void
+  /** Whether the selected run is serving a browser preview (#813), i.e. it was started with Browser on. */
+  hasBrowser?: boolean
 }) {
   const [tab, setTab] = useState<Tab>('docs')
   // Once the user picks a tab, stop auto-defaulting (#695/U22) — only a genuinely new choice
@@ -73,11 +77,23 @@ export function RightRail({
     ...(hasFiles ? ['files' as const] : []),
     ...(hasChoices ? ['choices' as const] : []),
     ...(hasViews ? ['views' as const] : []),
+    // Only when the run actually has one (#813) — a dead tab teaches people the preview is broken.
+    ...(hasBrowser && runId ? ['browser' as const] : []),
     'docs',
     'log',
   ]
   const label = (t: Tab) =>
-    t === 'files' ? 'Files' : t === 'choices' ? 'Choices' : t === 'views' ? 'Views' : t === 'docs' ? 'Docs' : 'Log'
+    t === 'files'
+      ? 'Files'
+      : t === 'choices'
+        ? 'Choices'
+        : t === 'views'
+          ? 'Views'
+          : t === 'browser'
+            ? 'Browser'
+            : t === 'docs'
+              ? 'Docs'
+              : 'Log'
   // The Files badge counts only selected files, not whole-repo entries (#661): the shared context
   // set also holds project paths (from the Start form's repo checkboxes), which aren't in `files`.
   const selectedFiles = files.filter(f => context.has(f)).length
@@ -106,6 +122,8 @@ export function RightRail({
           <ChoicesRail projectId={projectId} runId={runId} choices={choices} />
         ) : tab === 'views' && hasViews ? (
           <ViewsRail views={views} />
+        ) : tab === 'browser' && hasBrowser && runId ? (
+          <BrowserPanel projectId={projectId} runId={runId} />
         ) : tab === 'log' ? (
           <ProjectLogPanel projectId={projectId} />
         ) : (

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -259,6 +259,7 @@ export default function Page() {
           files={files}
           context={context}
           toggleContext={toggleContext}
+          hasBrowser={selectedRun?.status === 'running' && selectedRun.browserStreamPort !== undefined}
         />
       </div>
     </div>

--- a/packages/framework/src/browser-stream.ts
+++ b/packages/framework/src/browser-stream.ts
@@ -22,6 +22,8 @@ import { AddressInfo } from 'node:net'
 export interface BrowserStream {
   /** Where the dashboard points an `<img>` (`/stream`) and posts input (`/input`). */
   url: string
+  /** The loopback port {@link url} is on, published on the run's log so the daemon can proxy it (#813). */
+  port: number
   /** Stop streaming and close the server. Safe to call twice. */
   close(): Promise<void>
 }
@@ -225,6 +227,7 @@ export async function startBrowserStream(opts: {
   let closed = false
   return {
     url: `http://127.0.0.1:${port}`,
+    port,
     close: async () => {
       if (closed) return
       closed = true

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -1239,7 +1239,13 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   const browserStream = sharedBrowser
     ? await startBrowserStream({ browserUrl: sharedBrowser.browserUrl, connect: connectCdp }).catch(() => undefined)
     : undefined
-  if (browserStream) io.out(`◆ browser preview: ${browserStream.url}/stream`)
+  // A dashboard-started run is spawned with its stdout discarded, so printing the URL reaches
+  // nobody (#813). The port goes through onEvent — persisted and published live — which is how
+  // the dashboard finds the pane to render.
+  // Through onEvent rather than a print: a dashboard-started run is spawned with its stdout
+  // discarded, so a printed URL reaches nobody (#813). This persists and publishes the port,
+  // which is how the dashboard finds the pane to render — and still prints, on a terminal run.
+  if (browserStream) onEvent({ kind: 'browser-stream', port: browserStream.port })
 
   // The consumption limits (#519/#531). Read from the user's own file rather than
   // taken as a flag: unlike autopilot or eco, a limit is not a per-run choice, so

--- a/packages/framework/src/dashboard/browser-proxy.test.ts
+++ b/packages/framework/src/dashboard/browser-proxy.test.ts
@@ -1,0 +1,131 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { parseBrowserRoute, handleBrowserProxy, type BrowserPortLookup } from './browser-proxy.js'
+
+// #813: the pane is served through the daemon so it stays same-origin, and so the run's own
+// port is never something a client gets to name.
+
+test('parseBrowserRoute reads a project, a run, and a leg', () => {
+  assert.deepEqual(parseBrowserRoute('/browser/proj/2026-07-19T10-00-00-000Z/stream'), {
+    projectId: 'proj',
+    runId: '2026-07-19T10-00-00-000Z',
+    leg: 'stream',
+  })
+  assert.equal(parseBrowserRoute('/browser/proj/run/input')?.leg, 'input')
+})
+
+test('parseBrowserRoute ignores anything that is not a browser route', () => {
+  // Must fall through to the client bundle rather than be guessed at.
+  for (const url of ['/', '/assets/app.js', '/browser', '/browser/proj', '/browser/proj/run', '/browser/a/b/c/d']) {
+    assert.equal(parseBrowserRoute(url), undefined, url)
+  }
+})
+
+test('parseBrowserRoute rejects a leg it does not serve', () => {
+  assert.equal(parseBrowserRoute('/browser/proj/run/evict'), undefined)
+})
+
+test('parseBrowserRoute keeps a query string out of the leg', () => {
+  assert.equal(parseBrowserRoute('/browser/proj/run/stream?t=1')?.leg, 'stream')
+})
+
+/** A stand-in for the run's bridge, recording what reached it. */
+async function fakeBridge(): Promise<{ port: number; hits: { url: string; body: string }[]; close: () => void }> {
+  const hits: { url: string; body: string }[] = []
+  const server: Server = createServer((req, res) => {
+    let body = ''
+    req.on('data', c => (body += c))
+    req.on('end', () => {
+      hits.push({ url: req.url ?? '', body })
+      if (req.url === '/stream') {
+        res.writeHead(200, { 'content-type': 'multipart/x-mixed-replace; boundary=frame' })
+        res.end('--frame')
+      } else {
+        res.writeHead(204).end()
+      }
+    })
+  })
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  return { port: (server.address() as AddressInfo).port, hits, close: () => server.close() }
+}
+
+/** Mount the proxy on a real server so the test exercises piping, not just the handler. */
+async function proxyServer(lookup: BrowserPortLookup): Promise<{ url: string; close: () => void }> {
+  const server = createServer((req, res) => {
+    void handleBrowserProxy(req, res, lookup).then(handled => {
+      if (!handled) res.writeHead(404).end('fell through')
+    })
+  })
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  return { url: `http://127.0.0.1:${(server.address() as AddressInfo).port}`, close: () => server.close() }
+}
+
+test('proxies the stream to the run bridge', async () => {
+  const bridge = await fakeBridge()
+  const proxy = await proxyServer(async () => bridge.port)
+  try {
+    const res = await fetch(`${proxy.url}/browser/proj/run/stream`)
+    assert.equal(res.status, 200)
+    assert.match(res.headers.get('content-type') ?? '', /multipart\/x-mixed-replace/)
+    await res.text()
+    assert.equal(bridge.hits[0]?.url, '/stream')
+  } finally {
+    bridge.close()
+    proxy.close()
+  }
+})
+
+test('forwards an input POST body through to the bridge', async () => {
+  const bridge = await fakeBridge()
+  const proxy = await proxyServer(async () => bridge.port)
+  try {
+    const res = await fetch(`${proxy.url}/browser/proj/run/input`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'click', x: 4, y: 2 }),
+    })
+    assert.equal(res.status, 204)
+    assert.deepEqual(JSON.parse(bridge.hits[0]?.body ?? '{}'), { type: 'click', x: 4, y: 2 })
+  } finally {
+    bridge.close()
+    proxy.close()
+  }
+})
+
+test('404s a run with no preview rather than reaching for a port', async () => {
+  // The ordinary case: a run started without Browser, or one that already ended.
+  const proxy = await proxyServer(async () => undefined)
+  try {
+    const res = await fetch(`${proxy.url}/browser/proj/run/stream`)
+    assert.equal(res.status, 404)
+  } finally {
+    proxy.close()
+  }
+})
+
+test('502s when the bridge is gone', async () => {
+  // A port from a run that just died: the connection is refused, and that must answer rather
+  // than hang the pane.
+  const bridge = await fakeBridge()
+  const dead = bridge.port
+  bridge.close()
+  const proxy = await proxyServer(async () => dead)
+  try {
+    const res = await fetch(`${proxy.url}/browser/proj/run/stream`)
+    assert.equal(res.status, 502)
+  } finally {
+    proxy.close()
+  }
+})
+
+test('a non-browser url is left for the client bundle', async () => {
+  const proxy = await proxyServer(async () => 1)
+  try {
+    const res = await fetch(`${proxy.url}/assets/app.js`)
+    assert.equal(await res.text(), 'fell through')
+  } finally {
+    proxy.close()
+  }
+})

--- a/packages/framework/src/dashboard/browser-proxy.ts
+++ b/packages/framework/src/dashboard/browser-proxy.ts
@@ -1,0 +1,117 @@
+import { request, type IncomingMessage, type ServerResponse } from 'node:http'
+import { readLiveMetas } from '../store/index.js'
+import { defaultProjectsProvider } from './projects.js'
+
+/**
+ * The dashboard's route to a run's browser preview (#813).
+ *
+ * The bridge itself lives in the run (#802) on a port the OS picks per run. The dashboard is a
+ * different origin, on the daemon's port, so it cannot post to that bridge directly: a JSON POST
+ * would need a CORS preflight, and answering it would mean letting browser origins reach the
+ * bridge — giving up exactly the containment #802 paid for by keeping Chrome's debug port
+ * unreachable from the web.
+ *
+ * So the daemon proxies. The pane talks same-origin to the daemon, the daemon talks to loopback,
+ * and the run's port is never named by the client: it comes from the run's own meta. A caller
+ * cannot point this at an arbitrary port, which is what keeps it from being an open relay into
+ * anything else listening on loopback.
+ */
+
+/** Where a proxied request is headed, once the URL has been understood. */
+export interface BrowserRoute {
+  projectId: string
+  runId: string
+  /** `stream` renders in an `<img>`; `input` carries a click or a key back. */
+  leg: 'stream' | 'input'
+}
+
+/** The prefix the dashboard client posts to. */
+export const BROWSER_PROXY_PREFIX = '/browser'
+
+/**
+ * Parse `/browser/<projectId>/<runId>/stream|input`, or undefined for anything else — an
+ * unrecognized shape must fall through to the bundle rather than be guessed at. Ids are taken
+ * verbatim and only ever used to look a run up, never as a path.
+ */
+export function parseBrowserRoute(url: string | undefined): BrowserRoute | undefined {
+  if (!url) return undefined
+  const { pathname } = new URL(url, 'http://localhost')
+  if (!pathname.startsWith(`${BROWSER_PROXY_PREFIX}/`)) return undefined
+  const parts = pathname.slice(BROWSER_PROXY_PREFIX.length + 1).split('/')
+  if (parts.length !== 3) return undefined
+  const [projectId, runId, leg] = parts
+  if (!projectId || !runId) return undefined
+  if (leg !== 'stream' && leg !== 'input') return undefined
+  return { projectId, runId: decodeURIComponent(runId), leg }
+}
+
+/** How the proxy finds the run's bridge. Injectable so a test needs no registry and no run. */
+export type BrowserPortLookup = (projectId: string, runId: string) => Promise<number | undefined>
+
+/**
+ * The real lookup: the port the run recorded on its own meta. A run with no browser, a finished
+ * run, or an unknown id all read as undefined, which the caller turns into a 404.
+ */
+export const defaultBrowserPortLookup: BrowserPortLookup = async (projectId, runId) => {
+  const cwd = await defaultProjectsProvider().resolvePath(projectId)
+  if (!cwd) return undefined
+  const live = await readLiveMetas(cwd).catch(() => [])
+  const run = live.find(meta => meta.id === runId)
+  // Only a live run: the bridge is torn down with the run, so a port off a finished one would
+  // reach whatever the OS handed that number next.
+  return run?.status === 'running' ? run.browserStreamPort : undefined
+}
+
+/**
+ * Proxy one request to the run's bridge. Returns false when the URL is not a browser route, so
+ * the dashboard server can carry on to the client bundle.
+ *
+ * Streams both ways rather than buffering: `/stream` is an endless `multipart/x-mixed-replace`
+ * body, so anything that waits for it to finish never answers.
+ */
+export async function handleBrowserProxy(
+  req: IncomingMessage,
+  res: ServerResponse,
+  lookup: BrowserPortLookup = defaultBrowserPortLookup,
+): Promise<boolean> {
+  const route = parseBrowserRoute(req.url)
+  if (!route) return false
+
+  const port = await lookup(route.projectId, route.runId).catch(() => undefined)
+  if (!port) {
+    // The pane polls this while a run is starting, and a run may never have a browser at all,
+    // so a miss is ordinary rather than an error worth logging.
+    res.writeHead(404, { 'content-type': 'text/plain' }).end('no browser preview for this run')
+    return true
+  }
+
+  const upstream = request(
+    {
+      host: '127.0.0.1',
+      port,
+      path: route.leg === 'stream' ? '/stream' : '/input',
+      method: route.leg === 'stream' ? 'GET' : 'POST',
+      headers: route.leg === 'input' ? { 'content-type': 'application/json' } : {},
+    },
+    proxied => {
+      res.writeHead(proxied.statusCode ?? 502, {
+        ...proxied.headers,
+        // The frames are a live view of whatever the human is typing. Nothing caches this.
+        'cache-control': 'no-store',
+      })
+      proxied.pipe(res)
+    },
+  )
+
+  // The run can die mid-stream, which lands here rather than as a response.
+  upstream.on('error', () => {
+    if (!res.headersSent) res.writeHead(502, { 'content-type': 'text/plain' })
+    res.end()
+  })
+  // Stop pulling frames the moment the pane goes away, or the run keeps serving a dead viewer.
+  res.on('close', () => upstream.destroy())
+
+  if (route.leg === 'input') req.pipe(upstream)
+  else upstream.end()
+  return true
+}

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -4,6 +4,7 @@ import type { ProjectsProvider } from './projects.js'
 import { registryPreferencesStore, type PreferencesStore } from '../registry.js'
 import { defaultQuotaSource, type QuotaSource } from './quota.js'
 import { serveClientBundle } from './static.js'
+import { BROWSER_PROXY_PREFIX, handleBrowserProxy } from './browser-proxy.js'
 import { makeTelefuncMount } from './telefunc-serve.js'
 import type { AddProjectResult, PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from './types.js'
 import type { ServeTarget } from '../preview.js'
@@ -137,6 +138,14 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
     const { pathname } = new URL(req.url ?? '/', 'http://localhost')
     if (pathname === '/_telefunc' || pathname.startsWith('/_telefunc/')) {
       void telefuncMount(req, res)
+      return
+    }
+    // The browser preview (#813) is proxied, not Telefunc'd: it is an endless MJPEG body and a
+    // raw input POST, neither of which is an RPC.
+    if (pathname.startsWith(`${BROWSER_PROXY_PREFIX}/`)) {
+      void handleBrowserProxy(req, res).then(handled => {
+        if (!handled) void serveClientBundle(req, res, clientBundleDir)
+      })
       return
     }
     void serveClientBundle(req, res, clientBundleDir)

--- a/packages/framework/src/events.ts
+++ b/packages/framework/src/events.ts
@@ -101,6 +101,14 @@ export type FrameworkEvent =
    * the dashboard shows a live preview link (torn down on Ctrl+C).
    */
   | { kind: 'preview'; url: string; command: string }
+  /**
+   * The run's browser preview is up and listening on this loopback port (#813).
+   *
+   * Only the port travels. The dashboard reaches the stream through the daemon, which proxies
+   * to this port, so the run's bridge stays same-origin-invisible and unreachable from the web.
+   * Frames themselves never enter the log: someone will type a password into that pane.
+   */
+  | { kind: 'browser-stream'; port: number }
   /** A framework-level log line. */
   | { kind: 'log'; message: string }
   /**

--- a/packages/framework/src/store/run-store.ts
+++ b/packages/framework/src/store/run-store.ts
@@ -115,6 +115,12 @@ export interface RunMeta {
    * you — which `status` cannot carry because it only changes when the run ends.
    */
   settledAt?: string
+  /**
+   * The loopback port the run's browser preview is listening on (#813), or absent when the run
+   * has no browser. What lets the daemon proxy the pane: the port is allocated per run and the
+   * dashboard is a different process, so meta is the only place it can learn it.
+   */
+  browserStreamPort?: number
 }
 
 /**
@@ -213,6 +219,9 @@ export function applyEventToMeta(meta: RunMeta, event: FrameworkEvent, at: strin
       }
       break
     }
+    case 'browser-stream':
+      next.browserStreamPort = event.port
+      break
     case 'settled':
       next.settledAt = at
       break
@@ -224,6 +233,9 @@ export function applyEventToMeta(meta: RunMeta, event: FrameworkEvent, at: strin
       next.status = event.ok ? 'done' : event.stopped ? 'stopped' : 'failed'
       delete next.pendingChoice // a finished run is not awaiting anything
       delete next.settledAt // nor is it waiting on you
+      // The bridge dies with the run, so a kept port would send the pane at whatever else
+      // the OS handed that number next.
+      delete next.browserStreamPort
       break
     default:
       break

--- a/packages/framework/src/terminal.ts
+++ b/packages/framework/src/terminal.ts
@@ -20,6 +20,8 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
       return `  system prompt sent (${event.text.length} chars)`
     case 'preview':
       return `▶ your app is running at ${event.url}`
+    case 'browser-stream':
+      return `◆ browser preview: http://127.0.0.1:${event.port}/stream`
     case 'log':
       return `  ${event.message}`
     case 'view':


### PR DESCRIPTION
Closes #813

The consuming half of #609. #802 shipped the bridge (MJPEG frames out, click / key / scroll / navigate back in) and nothing rendered it, so the preview has been running and unreachable.

**What was actually broken**

The stream URL was written to stdout only. The daemon spawns runs with `stdio: 'ignore'`, so for every run started from the dashboard that line went to `/dev/null`. There was no way for the UI to learn the port.

**The change**

- A `browser-stream` event carries the port. It goes through `onEvent`, so it is both persisted to the run's meta and published live. Only the port travels, never a frame.
- The daemon proxies `/browser/<projectId>/<runId>/stream` and `/input` to the run's loopback port. The port comes from the run's meta, never from the client, so this cannot be pointed at anything else listening on loopback. Same-origin also means the input POST needs no CORS preflight, which would otherwise have meant opening the bridge to browser origins and giving up the containment #802 paid for.
- A `Browser` tab in the right rail, shown only when the selected run actually has a preview. An `<img>` renders `multipart/x-mixed-replace` natively, so there is no player.
- Clicks are scaled from the rendered size to the page, or every click on a pane that is not life-size lands somewhere else. Keys go through only for real characters, since `insertText` would otherwise type the literal string "Shift".
- The port is dropped from meta when the run ends: the bridge dies with the run, so a kept port would reach whatever the OS handed that number next.

**Tests**

10 new (route parsing, both proxied legs, the no-preview 404, the dead-bridge 502, fall-through to the bundle). Full suites green: 758 framework, 138 dashboard.

**Worth knowing when reviewing**

Chrome only emits a frame on a visual change and a run starts on `about:blank`, so the pane is legitimately blank until the agent navigates. The pane says so rather than looking broken.