### PR TITLE
fix(framework): paint the browser preview's first frame (#818)

### DIFF
--- a/.changeset/browser-preview-first-frame.md
+++ b/.changeset/browser-preview-first-frame.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Paint the browser preview's first frame. Chrome does not finalize a `multipart/x-mixed-replace` part until the next boundary arrives, so a page that was not repainting left the pane blank while the bridge held a good JPEG. The newest frame now repeats while a viewer is attached, which is the case the preview exists for: a run parked on a login wall is not changing on its own.

--- a/packages/framework/src/browser-stream.test.ts
+++ b/packages/framework/src/browser-stream.test.ts
@@ -239,11 +239,23 @@ test('a still page keeps re-sending its frame so the pane paints (#818)', async 
     const res = await fetch(`${stream.url}/stream`)
     const reader = res.body?.getReader()
 
-    // Two parts out of one screencast frame: nothing else changed the page.
-    const first = await reader?.read()
-    const second = await reader?.read()
-    const seen = Buffer.concat([Buffer.from(first?.value ?? []), Buffer.from(second?.value ?? [])]).toString('latin1')
-    assert.equal(seen.split('--frame').length - 1, 2, 'the frame repeats, terminating the part before it')
+    // More than one part out of a single screencast frame: nothing else changed the page, so
+    // every part after the first is the repeat. Counted as "at least two" rather than exactly
+    // two — how many repeats land in a given read is a matter of timing, and pinning the number
+    // made this fail on a busier machine.
+    // Bounded: without the repeat there is simply no second part, and waiting forever for one
+    // would report as a timeout rather than as this assertion.
+    let boundaries = 0
+    const deadline = Date.now() + 5000
+    while (boundaries < 2 && Date.now() < deadline) {
+      const chunk = await Promise.race([
+        reader?.read(),
+        new Promise<undefined>(r => setTimeout(() => r(undefined), 1000)),
+      ])
+      if (!chunk || chunk.done) break
+      boundaries += Buffer.from(chunk.value).toString('latin1').split('--frame').length - 1
+    }
+    assert.ok(boundaries >= 2, `the frame repeats, terminating the part before it (saw ${boundaries})`)
 
     await reader?.cancel()
   } finally {

--- a/packages/framework/src/browser-stream.test.ts
+++ b/packages/framework/src/browser-stream.test.ts
@@ -221,6 +221,61 @@ test('following survives a browser that stops answering', async () => {
   }
 })
 
+test('a still page keeps re-sending its frame so the pane paints (#818)', async () => {
+  // Chrome holds the last MJPEG part back until the next boundary arrives, so one frame on a
+  // page that never changes rendered as nothing. Found against a real run: the bridge served a
+  // good JPEG and the pane stayed blank.
+  const cdp = fakeCdp()
+  const stream = await startBrowserStream({
+    browserUrl: 'http://127.0.0.1:9333',
+    connect: async () => cdp.session,
+    listTargets: async () => [page()],
+    followIntervalMs: 0,
+    repeatIntervalMs: 20,
+  })
+  assert.ok(stream)
+  try {
+    cdp.frame(Buffer.from([1, 2, 3]).toString('base64'))
+    const res = await fetch(`${stream.url}/stream`)
+    const reader = res.body?.getReader()
+
+    // Two parts out of one screencast frame: nothing else changed the page.
+    const first = await reader?.read()
+    const second = await reader?.read()
+    const seen = Buffer.concat([Buffer.from(first?.value ?? []), Buffer.from(second?.value ?? [])]).toString('latin1')
+    assert.equal(seen.split('--frame').length - 1, 2, 'the frame repeats, terminating the part before it')
+
+    await reader?.cancel()
+  } finally {
+    await stream?.close()
+  }
+})
+
+test('the repeat stops when nobody is watching', async () => {
+  // The interval must not keep writing into a closed response.
+  const cdp = fakeCdp()
+  const stream = await startBrowserStream({
+    browserUrl: 'http://127.0.0.1:9333',
+    connect: async () => cdp.session,
+    listTargets: async () => [page()],
+    followIntervalMs: 0,
+    repeatIntervalMs: 10,
+  })
+  assert.ok(stream)
+  try {
+    cdp.frame(Buffer.from([1, 2, 3]).toString('base64'))
+    const res = await fetch(`${stream.url}/stream`)
+    await res.body?.cancel()
+    await new Promise(r => setTimeout(r, 60))
+    // Still serving: a viewer leaving must not take the bridge down with it.
+    const again = await fetch(`${stream.url}/stream`)
+    assert.equal(again.status, 200)
+    await again.body?.cancel()
+  } finally {
+    await stream?.close()
+  }
+})
+
 test('close stops the screencast and frees the port', async () => {
   const cdp = fakeCdp()
   const stream = await startBrowserStream({

--- a/packages/framework/src/browser-stream.ts
+++ b/packages/framework/src/browser-stream.ts
@@ -134,6 +134,8 @@ export async function startBrowserStream(opts: {
   listTargets?: (browserUrl: string) => Promise<CdpPageTarget[]>
   /** How often to check whether the agent moved to another tab. 0 disables following. */
   followIntervalMs?: number
+  /** How often to re-send the newest frame so a still page still paints (#818). */
+  repeatIntervalMs?: number
 }): Promise<BrowserStream | undefined> {
   const listTargets = opts.listTargets ?? defaultListTargets
   const targets = await listTargets(opts.browserUrl).catch(() => [])
@@ -163,6 +165,22 @@ export async function startBrowserStream(opts: {
    * page happened to be first while the agent works somewhere else — the exact failure the
    * #609 spike reproduced. Cheap: one `/json/list` on an interval, re-attach only on change.
    */
+  /**
+   * Re-send the newest frame while anyone is watching (#818).
+   *
+   * Chrome does not finalize a `multipart/x-mixed-replace` part until the next boundary arrives,
+   * so the most recent frame is always held back unpainted. A still page never produces that next
+   * frame, which left the pane blank while holding a perfectly good JPEG — and a still page is
+   * exactly the case this exists for: a run parked on a login wall is not repainting itself.
+   *
+   * Repeating the frame supplies the boundary. Loopback only, and only while a viewer is attached.
+   */
+  const repeat = setInterval(() => {
+    if (!latest || viewers.size === 0) return
+    for (const res of viewers) res.write(framePart(BOUNDARY, latest))
+  }, opts.repeatIntervalMs ?? 1000)
+  repeat.unref?.()
+
   const followMs = opts.followIntervalMs ?? 2000
   const follow = followMs
     ? setInterval(() => {
@@ -232,6 +250,7 @@ export async function startBrowserStream(opts: {
       if (closed) return
       closed = true
       if (follow) clearInterval(follow)
+      clearInterval(repeat)
       for (const res of viewers) res.end()
       viewers.clear()
       await session.send('Page.stopScreencast').catch(() => {})


### PR DESCRIPTION
Closes #818

Found by driving the #813 pane against a real run rather than a stub.

The bridge was serving correctly: `curl` on the run's stream returned a 12.7 KB JPEG. The pane's `<img>` stayed at `naturalWidth: 0, complete: false` and rendered nothing. Navigating the page to force a second frame flipped it to `1280x633` at once.

Chrome does not finalize a `multipart/x-mixed-replace` part until it sees the next boundary, so the last frame in the stream is always held back. On a still page there is no next frame. That is exactly the case the preview exists for: a run parked on an `await-browser` gate (#796) is sitting on a login wall that is not repainting itself.

The newest frame now repeats on an interval while a viewer is attached, which supplies the boundary. Loopback only, and it stops when nobody is watching.

**Verified**

Same visual test, on a real `--browser` run, without forcing a second frame:

| | first frame |
|---|---|
| before | `naturalWidth: 0, complete: false` |
| after | `naturalWidth: 1280, complete: true` |

Two new tests (the repeat itself, and that a viewer leaving does not take the bridge down). Full framework suite green.