### PR TITLE
feat(framework): surface a finished session's branch and diff, offer push and PR (#799)

### DIFF
--- a/.changeset/feat-799-end-of-session-handoff.md
+++ b/.changeset/feat-799-end-of-session-handoff.md
@@ -1,0 +1,11 @@
+---
+'@gemstack/framework': minor
+---
+
+End of session: surface the branch and diff, offer push and PR (#799)
+
+A finished session now reports what it produced and what to do with it. The dashboard shows the branch the work landed on, its commits, its changed files and the line counts, and offers Push branch and Open PR as buttons rather than describing them. A session that changed nothing says so instead of showing an empty branch.
+
+The read is branch-addressed rather than worktree-addressed, so it survives teardown: a clean run's worktree is removed when it finishes, and a checkout-based read then falls back to the project root and reports the project's own branch as though it were the session's. The branch each run left its work on is now recorded in its run meta while the worktree still exists, since the #326 prompt lets the agent name its own branch and neither derivation is reliable after the fact.
+
+New: `onRunHandoff`, `sendPushBranch` and `sendOpenPullRequest` RPCs, and `readRunHandoff` / `pushRunBranch` / `openRunPullRequest` with injectable git and gh seams. Degrades rather than fails when there is no remote, no `gh`, or no git repo.

--- a/packages/framework-dashboard/components/RunHandoffPanel.test.tsx
+++ b/packages/framework-dashboard/components/RunHandoffPanel.test.tsx
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+const onRunHandoff = vi.fn(async () => null as unknown)
+const sendPushBranch = vi.fn(async () => ({ ok: true }) as unknown)
+const sendOpenPullRequest = vi.fn(async () => ({ ok: true }) as unknown)
+vi.mock('../server/reads.telefunc.js', () => ({ onRunHandoff }))
+vi.mock('../server/control.telefunc.js', () => ({ sendPushBranch, sendOpenPullRequest }))
+
+const { RunHandoffPanel } = await import('./RunHandoffPanel.js')
+
+/** A handoff for a session that did real work, on a repo with a remote and no PR yet. */
+const worked = {
+  branch: 'the-framework/dark-mode',
+  exists: true,
+  base: 'origin/main',
+  commits: [{ sha: 'aaaaaaa1', short: 'aaaaaaa', subject: 'add dark mode' }],
+  files: [{ path: 'src/theme.ts', insertions: 12, deletions: 3, binary: false }],
+  insertions: 12,
+  deletions: 3,
+  empty: false,
+  hasRemote: true,
+  pushed: false,
+  merged: false,
+}
+
+beforeEach(() => {
+  onRunHandoff.mockClear()
+  sendPushBranch.mockClear()
+  sendOpenPullRequest.mockClear()
+})
+afterEach(cleanup)
+
+describe('RunHandoffPanel (#799)', () => {
+  test('shows the branch, the commits and the diff a finished session produced', async () => {
+    onRunHandoff.mockResolvedValue(worked)
+    render(<RunHandoffPanel projectId="p1" runId="run-1" />)
+    await waitFor(() => expect(screen.getByText('the-framework/dark-mode')).toBeTruthy())
+    expect(screen.getByText('add dark mode')).toBeTruthy()
+    expect(screen.getByText('src/theme.ts')).toBeTruthy()
+    expect(screen.getByText('1 commit')).toBeTruthy()
+  })
+
+  test('a session that changed nothing says so instead of showing an empty branch', async () => {
+    onRunHandoff.mockResolvedValue({ ...worked, commits: [], files: [], insertions: 0, deletions: 0, empty: true })
+    render(<RunHandoffPanel projectId="p1" runId="run-1" />)
+    await waitFor(() => expect(screen.getByText(/changed nothing/)).toBeTruthy())
+    // Nothing to hand off means nothing to offer.
+    expect(screen.queryByText('Open PR')).toBeNull()
+    expect(screen.queryByText('Push branch')).toBeNull()
+  })
+
+  test('a branch that is gone is reported, not shown as work', async () => {
+    onRunHandoff.mockResolvedValue({ ...worked, exists: false, commits: [], files: [], empty: true })
+    render(<RunHandoffPanel projectId="p1" runId="run-1" />)
+    await waitFor(() => expect(screen.getByText(/Branch is gone/)).toBeTruthy())
+    expect(screen.queryByText('Open PR')).toBeNull()
+  })
+
+  test('push is offered only while the branch is unpushed', async () => {
+    onRunHandoff.mockResolvedValue({ ...worked, pushed: true })
+    render(<RunHandoffPanel projectId="p1" runId="run-1" />)
+    await waitFor(() => expect(screen.getByText('Open PR')).toBeTruthy())
+    expect(screen.queryByText('Push branch')).toBeNull()
+  })
+
+  test('pushing is a click, addressed at this session', async () => {
+    onRunHandoff.mockResolvedValue(worked)
+    render(<RunHandoffPanel projectId="p1" runId="run-1" />)
+    await waitFor(() => expect(screen.getByText('Push branch')).toBeTruthy())
+    fireEvent.click(screen.getByText('Push branch'))
+    await waitFor(() => expect(sendPushBranch).toHaveBeenCalledWith('p1', 'run-1'))
+    // Nothing is published without the click.
+    expect(sendOpenPullRequest).not.toHaveBeenCalled()
+  })
+
+  test('a failed action surfaces its reason rather than doing nothing', async () => {
+    onRunHandoff.mockResolvedValue(worked)
+    sendOpenPullRequest.mockResolvedValue({ ok: false, error: 'gh: not logged in' })
+    render(<RunHandoffPanel projectId="p1" runId="run-1" />)
+    await waitFor(() => expect(screen.getByText('Open PR')).toBeTruthy())
+    fireEvent.click(screen.getByText('Open PR'))
+    await waitFor(() => expect(screen.getByText('gh: not logged in')).toBeTruthy())
+  })
+
+  test('an existing PR replaces the offer, closing the loop back into the dashboard (#632)', async () => {
+    onRunHandoff.mockResolvedValue({
+      ...worked,
+      pushed: true,
+      pr: { number: 42, url: 'https://example.test/42', state: 'OPEN', title: 'Add dark mode' },
+    })
+    render(<RunHandoffPanel projectId="p1" runId="run-1" />)
+    await waitFor(() => expect(screen.getByText('PR #42')).toBeTruthy())
+    expect(screen.queryByText('Open PR')).toBeNull()
+  })
+
+  test('a repo with no remote says why instead of offering a dead button', async () => {
+    onRunHandoff.mockResolvedValue({ ...worked, hasRemote: false })
+    render(<RunHandoffPanel projectId="p1" runId="run-1" />)
+    await waitFor(() => expect(screen.getByText(/No remote to push to/)).toBeTruthy())
+    expect(screen.queryByText('Push branch')).toBeNull()
+  })
+
+  test('nothing is rendered before the first read, so no wrong empty state flashes', () => {
+    onRunHandoff.mockReturnValue(new Promise(() => {}) as never)
+    const { container } = render(<RunHandoffPanel projectId="p1" runId="run-1" />)
+    expect(container.textContent).toBe('')
+  })
+})

--- a/packages/framework-dashboard/components/RunHandoffPanel.tsx
+++ b/packages/framework-dashboard/components/RunHandoffPanel.tsx
@@ -1,0 +1,205 @@
+import type { RunHandoff } from '@gemstack/framework'
+import { GitBranch, GitPullRequest, Upload } from 'lucide-react'
+import { onRunHandoff } from '../server/reads.telefunc.js'
+import { sendOpenPullRequest, sendPushBranch } from '../server/control.telefunc.js'
+import { usePolled } from '../lib/use-async.js'
+import { useAction } from '../lib/use-action.js'
+import { Button } from './ui/button.js'
+
+// The end-of-session handoff (#799): what this session produced, and the next step offered rather
+// than described. Before this, a finished session showed no branch, no commits and no diff, so
+// finding out what it actually did meant leaving the dashboard for the command line.
+//
+// Shown only for a finished session, and only when there is something true to say. The read is
+// branch-addressed, so it survives the checkout: a clean run's worktree is removed when it ends.
+
+const MAX_COMMITS = 6
+const MAX_FILES = 10
+
+export function RunHandoffPanel({ projectId, runId }: { projectId: string; runId: string }) {
+  // Polled rather than read once: a push or a PR opened from here (or from a terminal) changes
+  // what the panel should offer, and `reload` makes the panel's own actions land immediately.
+  const { value: handoff, reload, loaded } = usePolled<RunHandoff | null>(
+    () => onRunHandoff(projectId, runId),
+    null,
+    15_000,
+    [projectId, runId],
+  )
+  const { busy, error, run } = useAction()
+
+  // Nothing read yet, or nothing to report (no git repo, unknown session): say nothing rather
+  // than flash a wrong empty state.
+  if (!loaded || !handoff) return null
+
+  const act = (fn: () => Promise<unknown>, fallback: string): void => {
+    void run(fn, fallback).then(result => result !== undefined && reload())
+  }
+
+  return (
+    <section className="border-b border-border px-4 py-3 text-xs" aria-label="Session handoff">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <span className="flex min-w-0 items-center gap-1.5 text-muted-foreground">
+          <GitBranch className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate font-medium text-foreground" title={handoff.branch}>
+            {handoff.branch}
+          </span>
+        </span>
+        <Summary handoff={handoff} />
+        <div className="min-w-0 flex-1" />
+        {error && <span className="text-red-500">{error}</span>}
+        <Actions handoff={handoff} busy={busy} act={act} projectId={projectId} runId={runId} />
+      </div>
+      {!handoff.empty && handoff.exists && (
+        <div className="mt-3 grid gap-3 sm:grid-cols-2">
+          <Commits handoff={handoff} />
+          <Files handoff={handoff} />
+        </div>
+      )}
+    </section>
+  )
+}
+
+/** The one-line verdict: what the session left behind, or that it left nothing. */
+function Summary({ handoff }: { handoff: RunHandoff }) {
+  // A branch that is gone and a branch that was never pushed are different facts, and the panel
+  // is only useful if it tells them apart.
+  if (!handoff.exists) {
+    return <span className="text-muted-foreground">Branch is gone, so there is nothing left to hand off.</span>
+  }
+  if (handoff.empty) {
+    return <span className="text-muted-foreground">This session changed nothing, so there is nothing to hand off.</span>
+  }
+  const commits = `${handoff.commits.length} commit${handoff.commits.length === 1 ? '' : 's'}`
+  const files = `${handoff.files.length} file${handoff.files.length === 1 ? '' : 's'}`
+  return (
+    <span className="flex flex-wrap items-center gap-x-2 text-muted-foreground">
+      <span>{commits}</span>
+      <span>·</span>
+      <span>{files}</span>
+      <span className="tabular-nums">
+        <span className="text-emerald-500">+{handoff.insertions}</span>{' '}
+        <span className="text-red-500">-{handoff.deletions}</span>
+      </span>
+      {handoff.merged && <span className="text-muted-foreground">· merged</span>}
+    </span>
+  )
+}
+
+/**
+ * The next step, as a button.
+ *
+ * Push and Open PR are clicks, never automatic: both publish the agent's work to a shared remote
+ * under the user's name. Once a PR exists it is shown instead, because the interventions queue
+ * (#632) has picked it up by then and the loop is closed.
+ */
+function Actions({
+  handoff,
+  busy,
+  act,
+  projectId,
+  runId,
+}: {
+  handoff: RunHandoff
+  busy: boolean
+  act: (fn: () => Promise<unknown>, fallback: string) => void
+  projectId: string
+  runId: string
+}) {
+  if (!handoff.exists || handoff.empty) return null
+  if (handoff.pr) {
+    return (
+      <a
+        href={handoff.pr.url}
+        target="_blank"
+        rel="noreferrer"
+        className="flex items-center gap-1.5 text-primary hover:underline"
+        title={handoff.pr.title}
+      >
+        <GitPullRequest className="h-3.5 w-3.5" />
+        <span>PR #{handoff.pr.number}</span>
+        <span className="rounded-full border border-border px-1.5 text-[10px] uppercase text-muted-foreground">
+          {handoff.pr.state.toLowerCase()}
+        </span>
+      </a>
+    )
+  }
+  // No remote means neither action can work, and a disabled button with no reason is worse than
+  // a sentence saying why.
+  if (!handoff.hasRemote) return <span className="text-muted-foreground">No remote to push to.</span>
+  return (
+    <div className="flex items-center gap-2">
+      {!handoff.pushed && (
+        <Button
+          variant="outline"
+          size="xs"
+          disabled={busy}
+          onClick={() => act(() => sendPushBranch(projectId, runId), 'Could not push the branch.')}
+        >
+          <Upload className="h-3.5 w-3.5" />
+          Push branch
+        </Button>
+      )}
+      <Button
+        size="xs"
+        disabled={busy}
+        onClick={() => act(() => sendOpenPullRequest(projectId, runId), 'Could not open the pull request.')}
+      >
+        <GitPullRequest className="h-3.5 w-3.5" />
+        Open PR
+      </Button>
+    </div>
+  )
+}
+
+/** What the session committed. Capped, with the remainder counted rather than dropped silently. */
+function Commits({ handoff }: { handoff: RunHandoff }) {
+  const shown = handoff.commits.slice(0, MAX_COMMITS)
+  const rest = handoff.commits.length - shown.length
+  return (
+    <div>
+      <h3 className="mb-1.5 text-muted-foreground">Commits</h3>
+      <ul className="space-y-1">
+        {shown.map(commit => (
+          <li key={commit.sha} className="flex gap-2">
+            <code className="shrink-0 text-muted-foreground">{commit.short}</code>
+            <span className="truncate" title={commit.subject}>
+              {commit.subject}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {rest > 0 && <p className="mt-1 text-muted-foreground">and {rest} more</p>}
+    </div>
+  )
+}
+
+/** What the session changed. Same capping rule as the commits. */
+function Files({ handoff }: { handoff: RunHandoff }) {
+  const shown = handoff.files.slice(0, MAX_FILES)
+  const rest = handoff.files.length - shown.length
+  return (
+    <div>
+      <h3 className="mb-1.5 text-muted-foreground">Changed files</h3>
+      <ul className="space-y-1">
+        {shown.map(file => (
+          <li key={file.path} className="flex items-center gap-2">
+            <span className="truncate" title={file.path}>
+              {file.path}
+            </span>
+            <span className="ml-auto shrink-0 tabular-nums text-muted-foreground">
+              {file.binary ? (
+                'binary'
+              ) : (
+                <>
+                  <span className="text-emerald-500">+{file.insertions}</span>{' '}
+                  <span className="text-red-500">-{file.deletions}</span>
+                </>
+              )}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {rest > 0 && <p className="mt-1 text-muted-foreground">and {rest} more</p>}
+    </div>
+  )
+}

--- a/packages/framework-dashboard/components/RunReplay.tsx
+++ b/packages/framework-dashboard/components/RunReplay.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'react'
 import { onRun, onRetainedWorktrees } from '../server/reads.telefunc.js'
 import { EventList } from './EventList.js'
 import { RunActionBar } from './RunActionBar.js'
+import { RunHandoffPanel } from './RunHandoffPanel.js'
 import { RunResumeChat } from './RunResumeChat.js'
 import { useLoaded } from '../lib/use-async.js'
 
@@ -47,6 +48,10 @@ export function RunReplay({
         retainedWorktree={!removed && retained.includes(runId)}
         onWorktreeRemoved={onWorktreeRemoved}
       />
+      {/* What this session produced and what to do with it (#799). Directly under the action bar,
+          because it is the first thing you want from a finished session and the last thing the
+          dashboard could answer. */}
+      <RunHandoffPanel projectId={projectId} runId={runId} />
       {events.length === 0 ? (
         <div className="grid flex-1 place-items-center text-sm text-muted-foreground">This session has no events.</div>
       ) : (

--- a/packages/framework-dashboard/server/control.telefunc.ts
+++ b/packages/framework-dashboard/server/control.telefunc.ts
@@ -1,4 +1,4 @@
 // Re-export shim (#405): the steering telefunctions live in @gemstack/framework so the
 // daemon serves them in-process. The file path keeps the baked RPC key
 // `/server/control.telefunc.ts`. See framework's dashboard-rpc/register.ts.
-export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree } from '@gemstack/framework/dashboard-rpc'
+export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendPushBranch, sendOpenPullRequest } from '@gemstack/framework/dashboard-rpc'

--- a/packages/framework-dashboard/server/reads.telefunc.ts
+++ b/packages/framework-dashboard/server/reads.telefunc.ts
@@ -3,4 +3,4 @@
 // the client bakes the RPC key `/server/reads.telefunc.ts` — the exact key the daemon
 // registers the impls under (see framework's dashboard-rpc/register.ts). The telefunc
 // Vite transform turns these named re-exports into client RPC stubs.
-export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onRetainedWorktrees, onRunWorktree } from '@gemstack/framework/dashboard-rpc'
+export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onRetainedWorktrees, onRunWorktree, onRunHandoff } from '@gemstack/framework/dashboard-rpc'

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -534,6 +534,12 @@ fs.appendFileSync(${JSON.stringify(join(cwd, 'started.log'))}, runId + '\\n')
       if (!gone) await new Promise(r => setTimeout(r, 20))
     }
     assert.equal(gone, true, 'and its worktree is removed')
+    // The branch is the only handle left on the work once the checkout goes, so it is recorded
+    // while the worktree still exists (#799) — otherwise the handoff has nothing to read.
+    const doneMeta = JSON.parse(
+      await readFile(join(cwd, FRAMEWORK_DIR, 'runs', `${doneId}.json`), 'utf8'),
+    ) as { branch?: string }
+    assert.equal(doneMeta.branch, `the-framework/run-${doneId}`, "the finished run's branch is recorded")
 
     // A failure: history archived too, but the checkout is kept so it can be inspected.
     const failedId = await runWith('failed', 2)

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -16,6 +16,7 @@ import {
   worktreePath,
   listRuns,
   commitPendingWork,
+  currentBranch,
   removeWorktree,
   pruneWorktrees,
   readLiveMetas,
@@ -569,7 +570,10 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
       // it is about to lose. Stop it first, whether or not the worktree ends up removed: the run
       // is over, so the preview is serving a tree nothing is working on.
       await onStopPreview(projectKeyFor(projectCwd), runId)
-      const meta = await archiveWorktreeRun(worktree, projectCwd)
+      // Where the work ended up, recorded before the checkout can go (#799). The branch outlives
+      // the worktree and is the only handle the dashboard has left on a finished session.
+      const branch = await currentBranch(worktree)
+      const meta = await archiveWorktreeRun(worktree, projectCwd, undefined, branch)
       if (meta?.status !== 'done') return // failed / stopped / unreadable: keep it for inspection
       // A finished run can still be holding an uncommitted edit (#786), and removing the
       // checkout would destroy it. Commit it to the run's branch, which outlives the

--- a/packages/framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/control.telefunc.ts
@@ -2,7 +2,14 @@ import { getContext } from 'telefunc'
 import { appendControl, type ControlEntry } from '../control.js'
 import { openInApp, type OpenTarget, type OpenResult } from '../dashboard/open-in-app.js'
 import { resolveProjectPath, resolveRunPath, contextPreferences, contextPreview } from './context.js'
-import { isSafeRunId, readLiveMetas, removeWorktree, pruneWorktrees, worktreePath } from '../store/index.js'
+import { isSafeRunId, listRuns, readLiveMetas, removeWorktree, pruneWorktrees, worktreePath, type RunMeta } from '../store/index.js'
+import {
+  openRunPullRequest,
+  pushRunBranch,
+  readRunHandoff,
+  runBranchFor,
+  type HandoffResult,
+} from '../dashboard/run-handoff.js'
 import type { ChoiceBy } from '../events.js'
 import type {
   PreviewResult,
@@ -174,4 +181,60 @@ export async function sendOpenInApp(projectId: string, target: OpenTarget, runId
   const editor =
     target === 'editor' ? (await contextPreferences()?.read().catch((): Preferences => ({})))?.editor : undefined
   return openInApp(cwd, target, undefined, editor)
+}
+
+/**
+ * The session's own branch, or undefined when the run/project is unknown. Shared by the two
+ * handoff actions so they address exactly what {@link onRunHandoff} reports on.
+ */
+async function handoffTargetFor(projectId: string, runId: string): Promise<{ cwd: string; run: RunMeta } | undefined> {
+  const cwd = await resolveProjectPath(projectId)
+  if (!cwd || !isSafeRunId(runId)) return undefined
+  const live = (await readLiveMetas(cwd).catch(() => [])).find(run => run.id === runId)
+  const run = live ?? (await listRuns(cwd).catch(() => [])).find(run => run.id === runId)
+  return run ? { cwd, run } : undefined
+}
+
+/**
+ * Push a finished session's branch to `origin` (#799).
+ *
+ * A click rather than something the run does on its way out: pushing publishes the agent's work
+ * to a shared remote under the user's name, which is the user's call.
+ */
+export async function sendPushBranch(projectId: string, runId: string): Promise<HandoffResult> {
+  const target = await handoffTargetFor(projectId, runId)
+  if (!target) return { ok: false, error: 'unknown session' }
+  return pushRunBranch(target.cwd, runBranchFor(target.run))
+}
+
+/**
+ * Open a PR for a finished session's branch (#799), pushing it first if the remote lacks it.
+ *
+ * The title and body come from what the run already recorded: the session name the agent chose
+ * and the intent the user asked for. Nothing new is invented and nothing extra is asked of the
+ * user, which is the point of "offer the next step rather than describe it".
+ */
+export async function sendOpenPullRequest(projectId: string, runId: string): Promise<HandoffResult> {
+  const target = await handoffTargetFor(projectId, runId)
+  if (!target) return { ok: false, error: 'unknown session' }
+  const { cwd, run } = target
+  const branch = runBranchFor(run)
+  const handoff = await readRunHandoff(cwd, branch).catch(() => undefined)
+  if (handoff && !handoff.exists) return { ok: false, error: `branch ${branch} no longer exists` }
+  // Refuse rather than open an empty PR: a session that changed nothing has nothing to hand off.
+  if (handoff?.empty) return { ok: false, error: 'this session produced no commits to open a PR for' }
+  if (handoff?.pr) return { ok: true, url: handoff.pr.url }
+  return openRunPullRequest(cwd, branch, {
+    title: run.sessionName ?? run.intent?.split('\n')[0]?.slice(0, 72) ?? `Session ${run.id}`,
+    body: prBodyFor(run),
+    ...(handoff?.base ? { base: handoff.base } : {}),
+  })
+}
+
+/** The PR body: what was asked for, and which session did it. */
+function prBodyFor(run: RunMeta): string {
+  const lines: string[] = []
+  if (run.intent) lines.push(run.intent.trim(), '')
+  lines.push(`Opened from The Framework session \`${run.sessionName ?? run.id}\`.`)
+  return lines.join('\n')
 }

--- a/packages/framework/src/dashboard-rpc/index.ts
+++ b/packages/framework/src/dashboard-rpc/index.ts
@@ -2,8 +2,8 @@
 // implementations live here in @gemstack/framework so `sendStart` (added with the serve
 // wiring) can reach the daemon's `startRun`; the framework-dashboard client imports
 // these through thin re-export shims so the baked RPC keys stay `/server/*.telefunc.ts`.
-export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onRetainedWorktrees, onRunWorktree } from './reads.telefunc.js'
-export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree } from './control.telefunc.js'
+export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onRetainedWorktrees, onRunWorktree, onRunHandoff } from './reads.telefunc.js'
+export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendPushBranch, sendOpenPullRequest } from './control.telefunc.js'
 export { onEvents } from './events.telefunc.js'
 export { onProjects, sendAddProject } from './projects.telefunc.js'
 export { onPreferences, savePreferences, onEditors, type SavePreferencesResult } from './preferences.telefunc.js'

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -8,6 +8,7 @@ import { buildActivity, type Activity } from '../dashboard/activity.js'
 import { buildDashboard, type DashboardData } from '../dashboard/dashboard.js'
 import { githubUrlFor } from '../dashboard/github.js'
 import { readGitStatus, type GitStatus } from '../dashboard/git-status.js'
+import { readRunHandoff, runBranchFor, type RunHandoff } from '../dashboard/run-handoff.js'
 import type { RunWorktree } from '../dashboard/types.js'
 import { crawlRepoFiles } from '../project.js'
 import { readFileStatuses, type FileGitStatus } from '../dashboard/file-status.js'
@@ -198,4 +199,29 @@ export async function onGitStatus(projectId: string, runId?: string): Promise<Gi
   const cwd = await resolveRunPath(projectId, runId)
   if (!cwd) return null
   return (await readGitStatus(cwd)) ?? null
+}
+
+/**
+ * The end-of-session handoff (#799): the branch a finished session left its work on, what it
+ * committed, what it changed, and whether that has been pushed or opened as a PR.
+ *
+ * Read from the *project* checkout against the session's branch, not from the session's worktree.
+ * A clean run's worktree is removed when it finishes, and `resolveRunPath` then falls back to the
+ * project root — so a worktree-addressed read reports the project's own branch and the user's own
+ * uncommitted changes as though they were the session's. The branch is what outlives the run, so
+ * the branch is what this asks about.
+ */
+export async function onRunHandoff(projectId: string, runId: string): Promise<RunHandoff | null> {
+  const cwd = await resolveProjectPath(projectId)
+  if (!cwd || !isSafeRunId(runId)) return null
+  const run = await runMetaFor(cwd, runId)
+  if (!run) return null
+  return (await readRunHandoff(cwd, runBranchFor(run)).catch(() => undefined)) ?? null
+}
+
+/** One run's meta, live or archived (live wins, as in {@link onRuns}). */
+async function runMetaFor(cwd: string, runId: string): Promise<RunMeta | undefined> {
+  const live = (await readLiveMetas(cwd).catch(() => [])).find(run => run.id === runId)
+  if (live) return live
+  return (await listRuns(cwd).catch(() => [])).find(run => run.id === runId)
 }

--- a/packages/framework/src/dashboard-rpc/register.ts
+++ b/packages/framework/src/dashboard-rpc/register.ts
@@ -1,6 +1,6 @@
 import { __decorateTelefunction } from 'telefunc'
-import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onRetainedWorktrees, onRunWorktree } from './reads.telefunc.js'
-import { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree } from './control.telefunc.js'
+import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onRetainedWorktrees, onRunWorktree, onRunHandoff } from './reads.telefunc.js'
+import { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendPushBranch, sendOpenPullRequest } from './control.telefunc.js'
 import { onEvents } from './events.telefunc.js'
 import { onProjects, sendAddProject } from './projects.telefunc.js'
 import { onPreferences, savePreferences, onEditors } from './preferences.telefunc.js'
@@ -46,6 +46,7 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(onGitStatus, 'onGitStatus', reads)
   reg(onRetainedWorktrees, 'onRetainedWorktrees', reads)
   reg(onRunWorktree, 'onRunWorktree', reads)
+  reg(onRunHandoff, 'onRunHandoff', reads)
   reg(onProjectFiles, 'onProjectFiles', reads)
   reg(onProjectFileStatus, 'onProjectFileStatus', reads)
   reg(sendStop, 'sendStop', control)
@@ -58,6 +59,8 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(onPreviewStatus, 'onPreviewStatus', control)
   reg(sendOpenInApp, 'sendOpenInApp', control)
   reg(sendRemoveWorktree, 'sendRemoveWorktree', control)
+  reg(sendPushBranch, 'sendPushBranch', control)
+  reg(sendOpenPullRequest, 'sendOpenPullRequest', control)
   reg(onEvents, 'onEvents', events)
   reg(onProjects, 'onProjects', projects)
   reg(sendAddProject, 'sendAddProject', projects)

--- a/packages/framework/src/dashboard/index.ts
+++ b/packages/framework/src/dashboard/index.ts
@@ -18,6 +18,22 @@ export { buildOverview, type Overview, type ActiveRun, type RecentProject, type 
 export { buildDashboard, type DashboardData, type ProjectStat, type ActivityDay, type DashboardDeps } from './dashboard.js'
 export { readGitStatus, type GitStatus, type LinkedPr } from './git-status.js'
 export {
+  readRunHandoff,
+  runBranchFor,
+  pushRunBranch,
+  openRunPullRequest,
+  nodeGhRunner,
+  nodeGhBranchPrLookup,
+  type RunHandoff,
+  type HandoffCommit,
+  type HandoffFile,
+  type HandoffResult,
+  type PullRequestDraft,
+  type GhRunner,
+  type BranchPrLookup,
+  type RunHandoffDeps,
+} from './run-handoff.js'
+export {
   buildInterventions,
   nodeGhPrLister,
   type Intervention,

--- a/packages/framework/src/dashboard/run-handoff.test.ts
+++ b/packages/framework/src/dashboard/run-handoff.test.ts
@@ -1,0 +1,240 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { readRunHandoff, runBranchFor, pushRunBranch, openRunPullRequest, gitReason } from './run-handoff.js'
+import { nodeGitRunner, type GitRunner } from '../project.js'
+
+const exec = promisify(execFile)
+const SEP = String.fromCharCode(31)
+
+/** A GitRunner answering from a table, recording what it was asked. */
+function fakeGit(answers: Record<string, string>): { git: GitRunner; calls: string[][] } {
+  const calls: string[][] = []
+  const git: GitRunner = async args => {
+    calls.push(args)
+    const key = args.join(' ')
+    const hit = Object.entries(answers).find(([prefix]) => key.startsWith(prefix))
+    if (!hit) throw new Error(`no stub for: ${key}`)
+    return hit[1]
+  }
+  return { git, calls }
+}
+
+const REPO = { 'rev-parse --git-dir': '.git' }
+
+test('the recorded branch wins over both derivations (#799)', () => {
+  assert.equal(runBranchFor({ id: 'r1', branch: 'feat/mine', sessionName: 'named' }), 'feat/mine')
+  assert.equal(runBranchFor({ id: 'r1', sessionName: 'named' }), 'the-framework/named')
+  assert.equal(runBranchFor({ id: 'r1' }), 'the-framework/run-r1')
+})
+
+test('a non-repo yields no handoff at all', async () => {
+  const { git } = fakeGit({})
+  assert.equal(await readRunHandoff('/nowhere', 'b', { git }), undefined)
+})
+
+test('a branch that no longer exists reports exists:false rather than failing', async () => {
+  const { git } = fakeGit({ ...REPO, 'rev-parse --verify --quiet refs/heads/gone': '', remote: 'origin\n' })
+  const handoff = await readRunHandoff('/repo', 'gone', { git, pr: async () => undefined })
+  assert.equal(handoff?.exists, false)
+  assert.equal(handoff?.empty, true)
+  assert.equal(handoff?.hasRemote, true)
+})
+
+test('a session that changed nothing is reported empty, not as an empty branch', async () => {
+  const { git } = fakeGit({
+    ...REPO,
+    'rev-parse --verify --quiet refs/heads/the-framework/quiet': 'abc123\n',
+    remote: 'origin\n',
+    'symbolic-ref': 'origin/main\n',
+    log: '',
+    diff: '',
+    'rev-parse --verify --quiet refs/remotes': '',
+    branch: '',
+  })
+  const handoff = await readRunHandoff('/repo', 'the-framework/quiet', { git, pr: async () => undefined })
+  assert.equal(handoff?.empty, true)
+  assert.deepEqual(handoff?.commits, [])
+  assert.equal(handoff?.insertions, 0)
+})
+
+test('commits, files and line counts come back for a branch with work', async () => {
+  const { git } = fakeGit({
+    ...REPO,
+    'rev-parse --verify --quiet refs/heads/the-framework/work': 'tip\n',
+    remote: 'origin\n',
+    'symbolic-ref': 'origin/main\n',
+    log: `deadbeefcafe${SEP}add the thing\nfeedface1234${SEP}fix: a subject with spaces\n`,
+    diff: '3\t1\tsrc/a.ts\n-\t-\tlogo.png\n',
+    'rev-parse --verify --quiet refs/remotes/origin/the-framework/work': 'tip\n',
+    branch: '',
+  })
+  const handoff = await readRunHandoff('/repo', 'the-framework/work', { git, pr: async () => undefined })
+  assert.equal(handoff?.empty, false)
+  assert.equal(handoff?.base, 'origin/main')
+  assert.deepEqual(
+    handoff?.commits.map(c => [c.short, c.subject]),
+    [
+      ['deadbee', 'add the thing'],
+      ['feedfac', 'fix: a subject with spaces'],
+    ],
+  )
+  assert.equal(handoff?.insertions, 3)
+  assert.equal(handoff?.deletions, 1)
+  // A binary file is listed but contributes no line counts.
+  assert.equal(handoff?.files.find(f => f.path === 'logo.png')?.binary, true)
+  // The remote is at the same commit, so there is nothing to push.
+  assert.equal(handoff?.pushed, true)
+})
+
+test('an unpushed branch and a repo with no remote are distinguished', async () => {
+  const base = {
+    ...REPO,
+    'rev-parse --verify --quiet refs/heads/b': 'tip\n',
+    'symbolic-ref': 'origin/main\n',
+    log: `sha${SEP}s\n`,
+    diff: '1\t0\ta.ts\n',
+    branch: '',
+  }
+  const unpushed = await readRunHandoff('/repo', 'b', {
+    git: fakeGit({ ...base, remote: 'origin\n', 'rev-parse --verify --quiet refs/remotes': '' }).git,
+    pr: async () => undefined,
+  })
+  assert.equal(unpushed?.hasRemote, true)
+  assert.equal(unpushed?.pushed, false)
+
+  const noRemote = await readRunHandoff('/repo', 'b', {
+    git: fakeGit({ ...base, remote: '' }).git,
+    pr: async () => undefined,
+  })
+  assert.equal(noRemote?.hasRemote, false)
+  assert.equal(noRemote?.pushed, false)
+})
+
+test('the PR is looked up for the session branch, not the checkout HEAD (#799)', async () => {
+  const { git } = fakeGit({
+    ...REPO,
+    'rev-parse --verify --quiet refs/heads/the-framework/x': 'tip\n',
+    remote: 'origin\n',
+    'symbolic-ref': 'origin/main\n',
+    log: `sha${SEP}s\n`,
+    diff: '',
+    'rev-parse --verify --quiet refs/remotes': '',
+    branch: '',
+  })
+  const asked: string[] = []
+  const handoff = await readRunHandoff('/repo', 'the-framework/x', {
+    git,
+    pr: async (_cwd, branch) => {
+      asked.push(branch)
+      return { number: 7, url: 'https://example.test/7', state: 'OPEN', title: 'the pr' }
+    },
+  })
+  assert.deepEqual(asked, ['the-framework/x'])
+  assert.equal(handoff?.pr?.number, 7)
+})
+
+test('a failed push comes back as an error rather than throwing', async () => {
+  const git: GitRunner = async () => {
+    throw new Error('no upstream configured')
+  }
+  const result = await pushRunBranch('/repo', 'b', git)
+  assert.deepEqual(result, { ok: false, error: 'no upstream configured' })
+})
+
+test("a push failure shows git's reason, not the command echoed back", () => {
+  // execFile buries the useful line under its own 'Command failed:' preamble.
+  const err = new Error("Command failed: git push --set-upstream origin b\nfatal: 'origin' does not appear to be a git repository\n")
+  assert.equal(gitReason(err), "fatal: 'origin' does not appear to be a git repository")
+  assert.equal(gitReason(new Error('something odd')), 'something odd')
+})
+
+test('opening a PR pushes first and returns the URL gh printed', async () => {
+  const pushes: string[][] = []
+  const ghCalls: string[][] = []
+  const result = await openRunPullRequest(
+    '/repo',
+    'the-framework/x',
+    { title: 'A title', body: 'A body', base: 'main' },
+    {
+      git: async args => {
+        pushes.push(args)
+        return ''
+      },
+      gh: async args => {
+        ghCalls.push(args)
+        return 'https://github.com/o/r/pull/12\n'
+      },
+    },
+  )
+  assert.deepEqual(result, { ok: true, url: 'https://github.com/o/r/pull/12' })
+  assert.deepEqual(pushes, [['push', '--set-upstream', 'origin', 'the-framework/x']])
+  const args = ghCalls[0] ?? []
+  assert.deepEqual(args.slice(0, 4), ['pr', 'create', '--head', 'the-framework/x'])
+  assert.ok(args.includes('--base') && args.includes('main'))
+  // Not a draft: the interventions queue (#632) lists open non-draft PRs as "needs you".
+  assert.ok(!args.includes('--draft'))
+})
+
+test('a PR is not opened when the push fails', async () => {
+  let ghRan = false
+  const result = await openRunPullRequest(
+    '/repo',
+    'b',
+    { title: 't', body: 'b' },
+    {
+      git: async () => {
+        throw new Error('remote rejected')
+      },
+      gh: async () => {
+        ghRan = true
+        return ''
+      },
+    },
+  )
+  assert.deepEqual(result, { ok: false, error: 'remote rejected' })
+  assert.equal(ghRan, false)
+})
+
+test('a real repo: the branch outlives its worktree and still reports its work (#799)', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'handoff-'))
+  const git = nodeGitRunner()
+  try {
+    await exec('git', ['init', '-b', 'main', dir])
+    await exec('git', ['config', 'user.email', 'test@example.com'], { cwd: dir })
+    await exec('git', ['config', 'user.name', 'Test'], { cwd: dir })
+    await writeFile(join(dir, 'README.md'), 'base\n')
+    await exec('git', ['add', '-A'], { cwd: dir })
+    await exec('git', ['commit', '-m', 'base'], { cwd: dir })
+
+    // A session's work, on its own branch, exactly as teardown leaves it.
+    await exec('git', ['checkout', '-b', 'the-framework/demo'], { cwd: dir })
+    await mkdir(join(dir, 'src'), { recursive: true })
+    await writeFile(join(dir, 'src', 'app.ts'), 'export const a = 1\n')
+    await exec('git', ['add', '-A'], { cwd: dir })
+    await exec('git', ['commit', '-m', 'add the app'], { cwd: dir })
+    await exec('git', ['checkout', 'main'], { cwd: dir })
+
+    // Read from the project checkout, which is on main, about the session's branch.
+    const handoff = await readRunHandoff(dir, 'the-framework/demo', { git, pr: async () => undefined })
+    assert.equal(handoff?.exists, true)
+    assert.equal(handoff?.empty, false)
+    assert.equal(handoff?.base, 'main')
+    assert.deepEqual(handoff?.commits.map(c => c.subject), ['add the app'])
+    assert.deepEqual(handoff?.files.map(f => f.path), ['src/app.ts'])
+    assert.equal(handoff?.insertions, 1)
+    assert.equal(handoff?.hasRemote, false)
+    assert.equal(handoff?.merged, false)
+
+    // And a branch already merged into the base says so.
+    await exec('git', ['merge', '--no-ff', '-m', 'merge', 'the-framework/demo'], { cwd: dir })
+    const merged = await readRunHandoff(dir, 'the-framework/demo', { git, pr: async () => undefined })
+    assert.equal(merged?.merged, true)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})

--- a/packages/framework/src/dashboard/run-handoff.ts
+++ b/packages/framework/src/dashboard/run-handoff.ts
@@ -1,0 +1,304 @@
+import { nodeGitRunner, type GitRunner } from '../project.js'
+import type { LinkedPr } from './git-status.js'
+
+// What a finished session produced, and what is left to do with it (#799).
+//
+// Everything up to "the agent is done" was covered; the handoff back to the human was not. A
+// clean run archives its history, commits what it was holding, removes its worktree and leaves
+// the work on a branch. Nothing pushed, nothing opened, and the dashboard showed none of it.
+//
+// The read is deliberately *branch*-addressed, not worktree-addressed: the common end state has
+// no worktree left, so a checkout-based read (`onRunWorktree`) falls back to the project root and
+// reports the project's own branch as if it were the session's. Here the branch is the subject and
+// the project repo is only where it is read from, so a finished session reads the same whether or
+// not its checkout still exists.
+//
+// Forgiving throughout: a project that is not a git repo, has no remote, or has no `gh` yields a
+// handoff with less in it, never an error.
+
+/** One commit a session put on its branch. */
+export interface HandoffCommit {
+  sha: string
+  /** Short sha, for display. */
+  short: string
+  subject: string
+}
+
+/** One file the session changed, against the branch point. */
+export interface HandoffFile {
+  path: string
+  insertions: number
+  deletions: number
+  /** True for a binary file, where line counts are meaningless. */
+  binary: boolean
+}
+
+/** What a finished session produced and what can still be done with it. */
+export interface RunHandoff {
+  /** The branch the work is on. */
+  branch: string
+  /** The branch still exists in the repo (a deleted or never-created one does not). */
+  exists: boolean
+  /** What the branch is measured against (the repo's default branch), when one was found. */
+  base?: string
+  commits: HandoffCommit[]
+  files: HandoffFile[]
+  insertions: number
+  deletions: number
+  /**
+   * The session produced nothing to hand off: the branch exists but carries no commit the base
+   * does not already have. Said out loud, rather than shown as an empty branch.
+   */
+  empty: boolean
+  /** The repo has a remote to push to at all. */
+  hasRemote: boolean
+  /** The branch is on the remote and the remote is at the same commit. */
+  pushed: boolean
+  /** The branch is already merged into the base. */
+  merged: boolean
+  /** The PR opened for this branch, when there is one. */
+  pr?: LinkedPr
+}
+
+/**
+ * A PR lookup addressed at a *branch* rather than at the checkout's current HEAD.
+ *
+ * The existing `PrLookup` asks `gh` about whatever branch `cwd` happens to be on, which for a
+ * finished session is the project's own branch, not the session's. Here the branch is named.
+ */
+export type BranchPrLookup = (cwd: string, branch: string) => Promise<LinkedPr | undefined>
+
+/** A {@link BranchPrLookup} via `gh`; resolves undefined when gh is missing/unauthed or there is no PR. */
+export function nodeGhBranchPrLookup(): BranchPrLookup {
+  return (cwd, branch) =>
+    new Promise(resolve => {
+      void import('node:child_process').then(({ execFile }) => {
+        const args = ['pr', 'view', branch, '--json', 'number,url,state,title']
+        execFile('gh', args, { cwd, timeout: 8_000 }, (err, stdout) => {
+          if (err) return resolve(undefined)
+          try {
+            const pr = JSON.parse(String(stdout)) as LinkedPr
+            resolve({ number: pr.number, url: pr.url, state: pr.state, title: pr.title })
+          } catch {
+            resolve(undefined)
+          }
+        })
+      })
+    })
+}
+
+/** Runs `gh`, resolving stdout and rejecting with the CLI's own stderr on failure. */
+export type GhRunner = (args: string[], cwd: string) => Promise<string>
+
+/** A {@link GhRunner} backed by `execFile('gh', ...)`. */
+export function nodeGhRunner(): GhRunner {
+  return async (args, cwd) => {
+    const { execFile } = await import('node:child_process')
+    return new Promise((resolvePromise, rejectPromise) => {
+      execFile('gh', args, { cwd, timeout: 60_000 }, (err, stdout, stderr) => {
+        // gh puts the useful part on stderr ("not logged in", "no default remote"), and that is
+        // exactly what the dashboard should show instead of a generic failure.
+        if (err) rejectPromise(new Error(String(stderr).trim() || err.message))
+        else resolvePromise(String(stdout))
+      })
+    })
+  }
+}
+
+/** Injectable seams so the reader is unit-testable off disk. */
+export interface RunHandoffDeps {
+  git?: GitRunner
+  pr?: BranchPrLookup
+}
+
+/**
+ * The branch a run's work is on.
+ *
+ * Prefers what was recorded while the worktree existed (#799), because the #326 prompt lets the
+ * agent name its own branch, which makes both derivations below a guess. They stay as a fallback
+ * for runs archived before the branch was recorded.
+ */
+export function runBranchFor(run: { id: string; branch?: string; sessionName?: string }): string {
+  if (run.branch) return run.branch
+  return run.sessionName ? `the-framework/${run.sessionName}` : `the-framework/run-${run.id}`
+}
+
+/** `git` that resolves to '' instead of rejecting, for reads where "no answer" is a fine answer. */
+function soft(git: GitRunner, cwd: string): (args: string[]) => Promise<string> {
+  return args => git(args, cwd).catch(() => '')
+}
+
+/** The repo's default branch: what the remote points HEAD at, else the first local conventional one. */
+async function detectBase(run: (args: string[]) => Promise<string>): Promise<string | undefined> {
+  const head = (await run(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'])).trim()
+  if (head) return head
+  for (const name of ['main', 'master']) {
+    if ((await run(['rev-parse', '--verify', '--quiet', `refs/heads/${name}`])).trim()) return name
+  }
+  return undefined
+}
+
+/** A subject can hold anything, so the fields are unit-separated rather than space-split. */
+const SEP = String.fromCharCode(31)
+
+/** Parse `git log --format=%H%x1f%s`. */
+function parseCommits(out: string): HandoffCommit[] {
+  return out
+    .split('\n')
+    .filter(line => line.includes(SEP))
+    .map(line => {
+      const [sha = '', subject = ''] = line.split(SEP)
+      return { sha, short: sha.slice(0, 7), subject }
+    })
+}
+
+/** Parse `git diff --numstat`, where a binary file reports `-` for both counts. */
+function parseNumstat(out: string): HandoffFile[] {
+  const files: HandoffFile[] = []
+  for (const line of out.split('\n')) {
+    const parts = line.split('\t')
+    if (parts.length < 3) continue
+    const [added = '', removed = '', path = ''] = parts
+    if (!path) continue
+    const binary = added === '-' || removed === '-'
+    files.push({
+      path,
+      insertions: binary ? 0 : Number(added) || 0,
+      deletions: binary ? 0 : Number(removed) || 0,
+      binary,
+    })
+  }
+  return files
+}
+
+/**
+ * Read what a finished session left behind, from the project repo, for `branch`.
+ *
+ * Returns undefined only when `cwd` is not a git repo at all. A branch that no longer exists
+ * still returns a handoff (with `exists: false`), because "that branch is gone" is itself the
+ * answer the dashboard needs to show.
+ */
+export async function readRunHandoff(
+  cwd: string,
+  branch: string,
+  deps: RunHandoffDeps = {},
+): Promise<RunHandoff | undefined> {
+  const git = deps.git ?? nodeGitRunner()
+  const run = soft(git, cwd)
+
+  // Not a repo (or git is unusable): nothing here is answerable.
+  if (!(await git(['rev-parse', '--git-dir'], cwd).then(() => true).catch(() => false))) return undefined
+
+  const tip = (await run(['rev-parse', '--verify', '--quiet', `refs/heads/${branch}`])).trim()
+  const hasRemote = (await run(['remote'])).trim().length > 0
+  if (!tip) {
+    return { branch, exists: false, commits: [], files: [], insertions: 0, deletions: 0, empty: true, hasRemote, pushed: false, merged: false }
+  }
+
+  const base = await detectBase(run)
+  // Compare against the branch point, not the base tip, so commits that merely landed on the base
+  // after this session started are not read as the session's work.
+  const range = base ? `${base}...${branch}` : undefined
+
+  const [commitsOut, numstatOut, remoteTip, mergedOut] = await Promise.all([
+    range ? run(['log', '--format=%H%x1f%s', range]) : Promise.resolve(''),
+    range ? run(['diff', '--numstat', range]) : Promise.resolve(''),
+    hasRemote ? run(['rev-parse', '--verify', '--quiet', `refs/remotes/origin/${branch}`]) : Promise.resolve(''),
+    base ? run(['branch', '--list', '--merged', base, branch]) : Promise.resolve(''),
+  ])
+
+  const commits = parseCommits(commitsOut)
+  const files = parseNumstat(numstatOut)
+  const pr = await (deps.pr ?? nodeGhBranchPrLookup())(cwd, branch).catch(() => undefined)
+
+  return {
+    branch,
+    exists: true,
+    ...(base ? { base } : {}),
+    commits,
+    files,
+    insertions: files.reduce((sum, f) => sum + f.insertions, 0),
+    deletions: files.reduce((sum, f) => sum + f.deletions, 0),
+    // A session that changed nothing is a real outcome, not an error: it gets said, not shown as
+    // an empty branch with buttons that would push nothing.
+    empty: commits.length === 0,
+    hasRemote,
+    pushed: remoteTip.trim() === tip,
+    merged: mergedOut.trim().length > 0,
+    ...(pr ? { pr } : {}),
+  }
+}
+
+/** The outcome of a handoff action, in the `{ ok }` shape the dashboard's `useAction` understands. */
+export type HandoffResult = { ok: true; url?: string } | { ok: false; error: string }
+
+/**
+ * Push a finished session's branch to `origin`.
+ *
+ * Deliberately a click, not something teardown does on its own: pushing publishes the agent's
+ * work under the user's name to a shared remote, and that is the user's call to make, not a
+ * side effect of a run ending. The dashboard offers it; the human takes it.
+ */
+export async function pushRunBranch(
+  cwd: string,
+  branch: string,
+  git: GitRunner = nodeGitRunner(),
+): Promise<HandoffResult> {
+  try {
+    await git(['push', '--set-upstream', 'origin', branch], cwd)
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: gitReason(err) }
+  }
+}
+
+/**
+ * The line of a failed git invocation worth showing.
+ *
+ * `execFile` rejects with "Command failed: git push ..." and buries git's own `fatal:` line
+ * further down, which in a one-line panel means the user reads the command back instead of the
+ * reason it failed.
+ */
+export function gitReason(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err)
+  const lines = message.split('\n').map(line => line.trim()).filter(Boolean)
+  return lines.find(line => /^(fatal|error|remote):/i.test(line)) ?? lines[0] ?? 'git failed'
+}
+
+/** What to put on the PR. */
+export interface PullRequestDraft {
+  title: string
+  body: string
+  base?: string
+}
+
+/**
+ * Open a PR for a finished session's branch, pushing it first when the remote does not have it.
+ *
+ * Opened ready rather than draft on purpose: the interventions queue (#632) lists open *non-draft*
+ * PRs as "needs you", so a draft would open the loop back into the dashboard and then not appear
+ * in it. The point of the handoff is that the work lands somewhere the human will see it again.
+ */
+export async function openRunPullRequest(
+  cwd: string,
+  branch: string,
+  draft: PullRequestDraft,
+  deps: { git?: GitRunner; gh?: GhRunner } = {},
+): Promise<HandoffResult> {
+  const git = deps.git ?? nodeGitRunner()
+  const gh = deps.gh ?? nodeGhRunner()
+  // gh refuses to open a PR for a branch the remote has never seen, so the push is part of the
+  // action rather than a thing the user has to remember to do first.
+  const pushed = await pushRunBranch(cwd, branch, git)
+  if (!pushed.ok) return pushed
+  try {
+    const args = ['pr', 'create', '--head', branch, '--title', draft.title, '--body', draft.body]
+    if (draft.base) args.push('--base', draft.base)
+    const out = (await gh(args, cwd)).trim()
+    // gh prints the new PR's URL as its last line.
+    const url = out.split('\n').filter(Boolean).at(-1)
+    return url ? { ok: true, url } : { ok: true }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -130,7 +130,7 @@ export {
   type SweepDeps,
   type MaintenanceFs,
 } from './maintenance.js'
-export { startDashboard, summarizeProject, defaultProjectsProvider, readDocs, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunResult, type AddProjectResult, type PreviewResult, type PreviewStatus, type RunWorktree, type ProjectSummary, type ProjectsProvider, type SummarizeDeps, type WorkspaceDoc, type ProjectQueue, type QueueItem, type Overview, type ActiveRun, type RecentProject, type DashboardData, type ProjectStat, type ActivityDay, type GitStatus, type LinkedPr, buildInterventions, nodeGhPrLister, type Intervention, type OpenPr, type PrLister, type InterventionsDeps, buildActivity, activityKey, pickNewActivity, type Activity, type ActivityDeps } from './dashboard/index.js'
+export { startDashboard, summarizeProject, defaultProjectsProvider, readDocs, type Dashboard, type DashboardOptions, type StartRunKind, type StartRunResult, type AddProjectResult, type PreviewResult, type PreviewStatus, type RunWorktree, type ProjectSummary, type ProjectsProvider, type SummarizeDeps, type WorkspaceDoc, type ProjectQueue, type QueueItem, type Overview, type ActiveRun, type RecentProject, type DashboardData, type ProjectStat, type ActivityDay, type GitStatus, type LinkedPr, type RunHandoff, type HandoffCommit, type HandoffFile, type HandoffResult, buildInterventions, nodeGhPrLister, type Intervention, type OpenPr, type PrLister, type InterventionsDeps, buildActivity, activityKey, pickNewActivity, type Activity, type ActivityDeps } from './dashboard/index.js'
 export { startPreview, detectDevScript, detectServeTargets, parsePreviewUrl, PREVIEW_SCRIPTS, type PreviewHandle, type StartPreviewOptions, type ServeTarget } from './preview.js'
 export {
   RunStore,

--- a/packages/framework/src/store/run-store.ts
+++ b/packages/framework/src/store/run-store.ts
@@ -98,6 +98,14 @@ export interface RunMeta {
   sessionLink?: string
   /** The session name the agent chose (#326), also its `the-framework/<name>` branch. */
   sessionName?: string
+  /**
+   * The branch the run's work landed on, recorded while its worktree still exists (#799).
+   *
+   * Not reliably derivable afterwards: a clean run loses its checkout, and the #326 prompt lets
+   * the agent create its own branch, so neither `the-framework/<sessionName>` nor the run-id
+   * branch is guaranteed to be the one holding the commits.
+   */
+  branch?: string
   /** Whether the agent signalled `setReadyForMerge()` (#326): building (false/absent) vs ready (true). */
   readyForMerge?: boolean
   /**
@@ -490,12 +498,16 @@ export async function archiveWorktreeRun(
   worktree: string,
   repo: string,
   fs: StoreFs = nodeStoreFs(),
+  branch?: string,
 ): Promise<RunMeta | undefined> {
   try {
     const worktreeDir = join(worktree, FRAMEWORK_DIR)
     const live = await readMetaFile(fs, join(worktreeDir, META_FILE))
     if (!live?.id || !isSafeRunId(live.id)) return undefined
-    const meta: RunMeta = live.status === 'running' ? { ...live, status: 'stopped' } : live
+    const stopped: RunMeta = live.status === 'running' ? { ...live, status: 'stopped' } : live
+    // The branch is read from the checkout by the caller and stamped here, because this is the
+    // last moment it can be observed: the worktree is about to go (#799).
+    const meta: RunMeta = branch ? { ...stopped, branch } : stopped
     await archiveRun(fs, join(repo, FRAMEWORK_DIR), meta, join(worktreeDir, EVENTS_FILE))
     return meta
   } catch {


### PR DESCRIPTION
Closes #799.

A finished session now reports what it produced and offers the next step. Before this, finding out what a session actually did meant leaving the dashboard and using git by hand.

## What was actually missing

Two of the issue's claims are now stale, and one gap it does not mention is worse than the ones it does. Verified against the code:

- "the dashboard shows no branch" is no longer true. `GitStatusBar` has shown a session's branch, clean/dirty and linked PR since #798/#809.
- What it shows for the common case is **wrong**. A clean run's worktree is removed at teardown, `resolveRunPath` then falls back to the project root, and `onRunWorktree` reports the *project's* branch and the *user's* uncommitted changes as if they were the session's. See the screenshot: the action bar says `main / dirty` for a session whose work is on `the-framework/add-hello`.
- The branch was never persisted. Only `sessionName` was, and the #326 prompt lets the agent create its own branch, so both `the-framework/<sessionName>` and the run-id branch are guesses.

## Decisions, and why

**Branch-addressed, not worktree-addressed.** The worktree is gone in the common case; the branch is what outlives the run. `onRunHandoff` reads the project checkout *about* the session's branch, so a finished session reads the same whether or not its checkout still exists.

**Record the branch at archive time.** `archiveWorktreeRun` runs before the worktree is removed, so it stamps `RunMeta.branch` with what `currentBranch` actually reports. Derivation stays as a fallback for runs archived before this.

**A click, not automatic.** Push and Open PR publish the agent's work to a shared remote under the user's name. That is the user's call, not a side effect of a run ending. The issue asks to "offer the next step rather than describing it", not to take it.

**Opened ready, not draft.** The interventions queue (#632) lists open *non-draft* PRs as "needs you". A draft would open the loop back into the dashboard and then not appear in it.

**Title and body come from what the run already recorded** (`sessionName`, `intent`). Nothing invented, nothing extra asked of the user.

**A session that changed nothing says so**, and no buttons are offered. Same for a branch that is gone, a branch already merged, and a repo with no remote (which says why rather than showing a dead button).

## Shape

- `dashboard/run-handoff.ts`: `readRunHandoff` / `pushRunBranch` / `openRunPullRequest`, with injectable `GitRunner`, `GhRunner` and a branch-addressed `BranchPrLookup`. The existing `PrLookup` asks about the checkout's current HEAD, which for a finished session is the wrong branch.
- RPCs `onRunHandoff`, `sendPushBranch`, `sendOpenPullRequest`.
- `RunHandoffPanel`, mounted in `RunReplay` under the action bar.
- Degrades rather than fails with no remote, no `gh`, or no git repo. A failed push surfaces git's own `fatal:` line instead of `Command failed: git push ...`.

## Verification

- `@gemstack/framework`: 762 tests, 761 pass, 0 fail (1 pre-existing skip). 12 new, including a real-git round trip proving a branch reports its work after its worktree is gone, and an extension to the #737 teardown test asserting the branch is recorded end to end through a real daemon.
- `@gemstack/framework-dashboard`: 147 pass, including 9 new panel tests (empty session, gone branch, no remote, failed action, existing PR).
- Both typechecks clean. `check:prompt-drift` in sync; no prompt file touched.
- Live: a real daemon on a temp `XDG_CONFIG_HOME` with a real git repo, all three RPCs over the real `/_telefunc` mount, 15/15 checks.
- Browser: headless Chromium against the daemon-served dashboard, panel rendered from a real client-side Telefunc call (the action bar above the panel still reads `main / dirty`, which is exactly the misreporting described above).

Panel text as rendered: `the-framework/add-hello  1 commit - 1 file +1 -0  No remote to push to.  Commits b8191db Add a static hello page  Changed files hello.html +1 -0`

