### PR TITLE
fix(framework-dashboard): scope the file tree to the active worktree (#815)

### DIFF
--- a/.changeset/fix-815-tree-worktree.md
+++ b/.changeset/fix-815-tree-worktree.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework-dashboard': patch
+---
+
+Scope the file tree to the active worktree (#815). The tree listed the project root and dotted it with the project root's git status, while the action bar directly above it resolved the session's worktree for the branch, Serve and open folder. Both reads already took a `runId` (#738); the tree now passes the selected one, and polls the file list so a file the session creates shows up.

--- a/packages/framework-dashboard/components/FileTree.test.tsx
+++ b/packages/framework-dashboard/components/FileTree.test.tsx
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+
+const onProjectFileStatus = vi.fn(async () => ({}) as unknown)
+vi.mock('../server/reads.telefunc.js', () => ({ onProjectFileStatus }))
+
+const { FileTree } = await import('./FileTree.js')
+
+const noop = () => {}
+const files = ['src/app.ts', 'README.md']
+
+beforeEach(() => {
+  onProjectFileStatus.mockClear()
+  onProjectFileStatus.mockResolvedValue({})
+})
+afterEach(cleanup)
+
+describe('FileTree (#815)', () => {
+  test('the project home reads the project checkout', async () => {
+    render(<FileTree projectId="p1" files={files} selected={new Set()} onToggle={noop} />)
+    await waitFor(() => expect(onProjectFileStatus).toHaveBeenCalled())
+    expect(onProjectFileStatus).toHaveBeenCalledWith('p1', undefined)
+  })
+
+  test("a session's dots come from that session's worktree", async () => {
+    // The action bar right above the tree has resolved the worktree since #738. Reading the
+    // project root here put a clean branch next to another checkout's M/U/D dots.
+    render(<FileTree projectId="p1" runId="run-1" files={files} selected={new Set()} onToggle={noop} />)
+    await waitFor(() => expect(onProjectFileStatus).toHaveBeenCalled())
+    expect(onProjectFileStatus).toHaveBeenCalledWith('p1', 'run-1')
+  })
+
+  test('switching session re-reads, rather than keeping the previous one’s dots', async () => {
+    const { rerender } = render(
+      <FileTree projectId="p1" runId="run-1" files={files} selected={new Set()} onToggle={noop} />,
+    )
+    await waitFor(() => expect(onProjectFileStatus).toHaveBeenCalledWith('p1', 'run-1'))
+    rerender(<FileTree projectId="p1" runId="run-2" files={files} selected={new Set()} onToggle={noop} />)
+    await waitFor(() => expect(onProjectFileStatus).toHaveBeenCalledWith('p1', 'run-2'))
+  })
+
+  test('a file the run changed is dotted with its status', async () => {
+    onProjectFileStatus.mockResolvedValue({ 'README.md': 'modified' })
+    render(<FileTree projectId="p1" runId="run-1" files={files} selected={new Set()} onToggle={noop} />)
+    await waitFor(() => expect(screen.getByText('M')).toBeTruthy())
+  })
+})

--- a/packages/framework-dashboard/components/FileTree.tsx
+++ b/packages/framework-dashboard/components/FileTree.tsx
@@ -70,23 +70,28 @@ const byName = (a: { name: string }, b: { name: string }) => a.name.localeCompar
 
 export function FileTree({
   projectId,
+  runId,
   files,
   selected,
   onToggle,
 }: {
   projectId: string
+  /** The selected run, so the dots describe its worktree and not the project root (#815). */
+  runId?: string | null | undefined
   files: string[]
   selected: Set<string>
   onToggle: (path: string) => void
 }) {
   const [query, setQuery] = useState('')
 
-  // Per-file git status for the dots (#492): polled so it tracks a run editing files.
+  // Per-file git status for the dots (#492): polled so it tracks a run editing files. Scoped to
+  // the selected run's worktree (#815) so the dots agree with the branch and Serve in the action
+  // bar right above, which have resolved the worktree since #738.
   const { value: status } = usePolled<Record<string, FileGitStatus>>(
-    () => onProjectFileStatus(projectId),
+    () => onProjectFileStatus(projectId, runId ?? undefined),
     EMPTY_STATUS,
     8_000,
-    [projectId],
+    [projectId, runId],
   )
 
   const folderStatus = useMemo(() => foldersFromStatus(status), [status])

--- a/packages/framework-dashboard/components/RightRail.tsx
+++ b/packages/framework-dashboard/components/RightRail.tsx
@@ -29,7 +29,7 @@ export function RightRail({
   hasBrowser = false,
 }: {
   projectId: string | null
-  /** The selected run, so a choice pick resolves that run's gate (#749). */
+  /** The selected run: resolves a choice pick's gate (#749) and scopes the tree to its worktree (#815). */
   runId?: string | null | undefined
   choices: ChoiceRequest[]
   views: AgentView[]
@@ -117,7 +117,7 @@ export function RightRail({
       </div>
       <div className="flex min-h-0 flex-1 flex-col">
         {tab === 'files' && hasFiles ? (
-          <FileTree projectId={projectId} files={files} selected={context} onToggle={toggleContext} />
+          <FileTree projectId={projectId} runId={runId} files={files} selected={context} onToggle={toggleContext} />
         ) : tab === 'choices' && hasChoices ? (
           <ChoicesRail projectId={projectId} runId={runId} choices={choices} />
         ) : tab === 'views' && hasViews ? (

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -81,9 +81,16 @@ export default function Page() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId])
 
-  // The selected project's files (git ls-files), fetched once here and handed to both the
-  // `#` picker and the tree. Empty when no project / on the relay (no checkout).
-  const files = useLoaded<string[]>(projectId ? () => onProjectFiles(projectId) : null, EMPTY_FILES, [projectId])
+  // The selected project's files (git ls-files), handed to both the `#` picker and the tree.
+  // Empty when no project / on the relay (no checkout). Scoped to the selected session's
+  // worktree (#815), the same checkout the action bar's branch, Serve and open-folder act on;
+  // polled so a file the run creates shows up rather than waiting for a reload.
+  const { value: files } = usePolled<string[]>(
+    projectId ? () => onProjectFiles(projectId, runId ?? undefined) : null,
+    EMPTY_FILES,
+    10_000,
+    [projectId, runId],
+  )
 
   // The cross-project "needs you" queue (#632): open PRs to review. Polled here in the shell so
   // the sidebar badge and the Overview card share one poll. Slow cadence — PRs change rarely and


### PR DESCRIPTION
Closes #815.

The tree listed the project root and dotted it with the project root's git status, while the action bar directly above it resolved the session's worktree for the branch, Serve and open folder. One panel, two checkouts.

Both reads already took a `runId` (#738), the tree just never passed it. Thread the selected one down, and poll the file list so a file the session creates appears instead of waiting for a reload.

## Verified

Against a daemon on a scratch repo, with one real session running in its own worktree:

| | tree shows |
|---|---|
| session page | `greet.ts` U, `keep.ts` D, `app.ts` M (its worktree) |
| project page | `keep.ts`, no `greet.ts`, no dots (the clean checkout) |

Plus 4 new unit tests, and the 154-test dashboard suite.
