### PR TITLE
fix(framework): tell the agent it has a browser (#824)

### DIFF
--- a/.changeset/tell-agent-about-browser.md
+++ b/.changeset/tell-agent-about-browser.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Tell the agent it has a browser. `--browser` wired the chrome-devtools tools into the run but the system channel never mentioned them, so the agent reached for `WebFetch` and the browser sat on `about:blank` for the whole run, taking the preview with it. Runs with a browser attached now get a short section saying it exists and that anything it needs to see or act on goes through those tools. Only when the tools are really there: the flag wires nothing on another agent or the fake driver.

--- a/packages/framework/prompts/protocols/browser.md
+++ b/packages/framework/prompts/protocols/browser.md
@@ -1,0 +1,7 @@
+## You have a real browser
+
+This run has a real Chrome attached, through the `chrome-devtools` tools (`new_page`, `navigate_page`, `click`, `fill`, `take_snapshot`, `evaluate_script`). It is the same browser a human can watch and take over, so use it for anything you need to *see* or *act on*: pages that render their content with JavaScript, a flow you have to click through, a form to fill, an app you are checking actually works.
+
+`WebFetch` is still the right tool for reading an article or a doc page as text. Reach for the browser when fetching the HTML would not answer the question.
+
+Prefer one page and navigate it, rather than opening a new page per URL: the human watching sees the tab you are on.

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -1233,6 +1233,12 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     ? fakeDriver()
     : createDriver({ agent: opts.agent, claudeOpts: withBrowser(claudeOpts, opts.browser, sharedBrowser?.browserUrl) })
 
+  // Whether the agent actually ends up with browser tools, which is narrower than the flag: they
+  // ride Claude Code's MCP config, so `--browser` on another agent wires nothing (see
+  // `unguardedNotices`), and the fake driver has no tools at all. The system channel must only
+  // claim a browser the run really has (#824).
+  const browserAttached = opts.browser && !fake && opts.agent === 'claude'
+
   // The preview of that browser (#802): the agent's Chrome is headless, so when it parks on an
   // `await-browser` gate (#796) there is nothing for a human to click. This serves it. Opening
   // the stream costs nothing while the page is still — Chrome only emits a frame on a change.
@@ -1309,6 +1315,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
         ...(guard ? { consumptionGate: guard.gate } : {}),
         ...(userSystemPrompt ? { systemPrompt: userSystemPrompt } : {}),
         ...(noBuiltinPrompt ? { antiLazyPill: false } : {}),
+        ...(browserAttached ? { browser: true } : {}),
         ...(transparent ? { transparent: true } : {}),
         ...(eco ? { eco } : {}),
         ...(opts.context.length ? { context: opts.context } : {}),
@@ -1388,6 +1395,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     ...(buildEvent ? { buildEvent } : {}),
     ...(userSystemPrompt ? { systemPrompt: userSystemPrompt } : {}),
     ...(noBuiltinPrompt ? { antiLazyPill: false } : {}),
+    ...(browserAttached ? { browser: true } : {}),
     ...(transparent ? { transparent: true } : {}),
     ...(eco ? { eco } : {}),
     ...(opts.context.length ? { context: opts.context } : {}),

--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -41,6 +41,8 @@ export interface RunPromptOptions {
   systemPrompt?: string
   /** Include the built-in #326 system prompt. Default true (#301; the name is the historical config key). */
   antiLazyPill?: boolean
+  /** This run has a real browser (#824), so the system channel says so. */
+  browser?: boolean
   /** Transparent mode (#625): empty the system channel and pass the prompt verbatim (raw `claude -p`). */
   transparent?: boolean
   /** Whether autopilot mode is on: steers the #326 prompt's maintenance stance (#325). Default false. */
@@ -104,7 +106,7 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
     prompt: opts.prompt,
     params: { autopilot: opts.autopilot === true, ...(opts.eco ? { eco: opts.eco } : {}) },
   }
-  const system = composeRunSystem({ antiLazyPill: opts.antiLazyPill, transparent: opts.transparent, user: opts.systemPrompt, tf, context: opts.context })
+  const system = composeRunSystem({ antiLazyPill: opts.antiLazyPill, browser: opts.browser, transparent: opts.transparent, user: opts.systemPrompt, tf, context: opts.context })
   // The template's `# User prompt` half carries the prompt (today it renders to
   // exactly `opts.prompt`; any framing Rom adds around the slot rides along). With
   // the built-in prompt off (or transparent, #625), the raw prompt is sent as-is.

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -102,6 +102,8 @@ export interface RunFrameworkOptions {
    * is the historical config key: #326 is the anti-lazy-pill's (#297) successor.
    */
   antiLazyPill?: boolean
+  /** This run has a real browser (#824), so the system channel says so. */
+  browser?: boolean
   /** Transparent mode (#625): empty the system channel entirely (raw `claude -p`); overrides antiLazyPill/eco. */
   transparent?: boolean
   /** Eco fine-grained control (#314): drop the enabled #326 sections to save tokens. */
@@ -294,6 +296,7 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
   // direct-prompt path so the two can never drift (the drift behind #500).
   const system = composeRunSystem({
     antiLazyPill: opts.antiLazyPill,
+    browser: opts.browser,
     transparent: opts.transparent,
     user: opts.systemPrompt,
     tf,

--- a/packages/framework/src/system-prompt.test.ts
+++ b/packages/framework/src/system-prompt.test.ts
@@ -32,7 +32,7 @@ test('CONTEXT_DOCS is the #683 fragment: business knowledge plus the roadmap/que
   const tickets = CONTEXT_DOCS.find(d => d.path === 'tickets/**.md')
   assert.ok(tickets?.comment.includes(TICKETING_FORMAT_FILE), `expected the ${TICKETING_FORMAT_FILE} pointer`)
 })
-import { AWAIT_PROTOCOL, SIGNAL_PROTOCOL } from './turn-gate.js'
+import { AWAIT_PROTOCOL, BROWSER_PROTOCOL, SIGNAL_PROTOCOL } from './turn-gate.js'
 
 test('loadUserSystemPrompt reads and trims SYSTEM.md', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'system-prompt-'))
@@ -256,6 +256,27 @@ test('composeRunSystem appends nothing after the protocols, whatever the options
   })
   assert.equal(system, [block, AWAIT_PROTOCOL, SIGNAL_PROTOCOL].join('\n\n'))
   assert.ok(system.endsWith(SIGNAL_PROTOCOL), 'the signal protocol is the last thing in the channel')
+})
+
+test('composeRunSystem says nothing about a browser unless the run has one (#824)', () => {
+  // The default: no browser wired, so no claim of one. An agent told it has tools it does not
+  // have is worse than one that reaches for WebFetch.
+  assert.ok(!composeRunSystem().includes(BROWSER_PROTOCOL))
+})
+
+test('composeRunSystem tells the agent it has a browser when the run does (#824)', () => {
+  // Without this the chrome-devtools tools are wired but never mentioned, so the agent uses
+  // WebFetch and the browser (and its preview) sits on about:blank for the whole run.
+  const system = composeRunSystem({ browser: true })
+  assert.ok(system.includes(BROWSER_PROTOCOL))
+  assert.ok(system.endsWith(SIGNAL_PROTOCOL), 'the signal protocol is still last (#547)')
+})
+
+test('the browser section survives --vanilla but not transparent (#824)', () => {
+  // It describes what the run can do, like the emit protocols, so dropping the built-in prompt
+  // keeps it. Transparent means an empty channel, so nothing at all.
+  assert.ok(composeRunSystem({ antiLazyPill: false, browser: true }).includes(BROWSER_PROTOCOL))
+  assert.equal(composeRunSystem({ transparent: true, browser: true }), '')
 })
 
 test('composeRunSystem keeps the emit protocols even with the built-in prompt off (#500/#501)', () => {

--- a/packages/framework/src/system-prompt.ts
+++ b/packages/framework/src/system-prompt.ts
@@ -1,6 +1,6 @@
 import { renderTemplate } from './prompt-template.js'
 import { SYSTEM_PROMPT } from './prompts.generated.js'
-import { AWAIT_PROTOCOL, SIGNAL_PROTOCOL } from './turn-gate.js'
+import { AWAIT_PROTOCOL, BROWSER_PROTOCOL, SIGNAL_PROTOCOL } from './turn-gate.js'
 
 // No Node imports here, deliberately. This module composes the prompt and the
 // dashboard renders it in the browser (#520), so reading the user's SYSTEM.md off
@@ -213,6 +213,12 @@ export interface SystemPromptOptions {
    * Short-circuits {@link composeRunSystem}, so it overrides every other option here.
    */
   transparent?: boolean | undefined
+  /**
+   * This run has a real browser attached (#824). Adds the section telling the agent so: the
+   * tools are wired through MCP, which the agent discovers, but nothing otherwise says to prefer
+   * them — so it reaches for `WebFetch`, and the browser (and its preview) sits unused.
+   */
+  browser?: boolean | undefined
 }
 
 /**
@@ -269,5 +275,10 @@ export type RunSystemOptions = SystemPromptOptions
 export function composeRunSystem(opts: RunSystemOptions = {}): string {
   if (opts.transparent) return ''
   const promptBlock = systemPromptBlock(opts)
-  return [...(promptBlock ? [promptBlock] : []), AWAIT_PROTOCOL, SIGNAL_PROTOCOL].join('\n\n')
+  // The browser section rides with the protocols, not with the built-in prompt: like them it
+  // describes what this run can do, so `--vanilla` (no framework prompt) still gets it — the
+  // tools are there either way.
+  // Ahead of the protocols, so the signal protocol stays the last thing in the channel (#547).
+  const browser = opts.browser ? [BROWSER_PROTOCOL] : []
+  return [...(promptBlock ? [promptBlock] : []), ...browser, AWAIT_PROTOCOL, SIGNAL_PROTOCOL].join('\n\n')
 }

--- a/packages/framework/src/turn-gate.ts
+++ b/packages/framework/src/turn-gate.ts
@@ -1,5 +1,5 @@
 import type { FrameworkEvent } from './events.js'
-import { PROTOCOLS_AWAIT, PROTOCOLS_SIGNAL } from './prompts.generated.js'
+import { PROTOCOLS_BROWSER, PROTOCOLS_AWAIT, PROTOCOLS_SIGNAL } from './prompts.generated.js'
 import type { ChoicesOption } from './run.js'
 import type { MultiSelectOption } from './run.js'
 
@@ -14,6 +14,13 @@ import type { MultiSelectOption } from './run.js'
  * #326 wording still being written. The text lives in `prompts/protocols/await.md` (#551).
  */
 export const AWAIT_PROTOCOL = PROTOCOLS_AWAIT
+
+/**
+ * Told to the agent only when the run has a browser (#824): that it has one, and that anything
+ * it needs to see or act on goes through the chrome-devtools tools rather than `WebFetch`.
+ * Lives in `prompts/protocols/browser.md`.
+ */
+export const BROWSER_PROTOCOL = PROTOCOLS_BROWSER
 
 /**
  * The session-lifecycle protocol (#326): the code side of the `setSessionName()` and


### PR DESCRIPTION
Closes #824

`--browser` wires the chrome-devtools MCP server into the run. Nothing in the system channel ever said so, so the agent reached for `WebFetch`, which it knows, and the browser sat on `about:blank` for the whole run. The preview then had nothing to show, which reads as a broken preview rather than an unused browser.

**Before and after, same prompt, no hint in it**

| | tools used |
|---|---|
| before | `WebFetch`, `WebFetch` |
| after | `mcp__chrome-devtools__new_page`, `mcp__chrome-devtools__evaluate_script` |

Before, getting the browser used at all took spelling it out in the prompt: "Use the chrome-devtools browser tools, not WebFetch."

**Where it goes**

A new `prompts/protocols/browser.md`, added by `composeRunSystem` when the run has a browser. It sits with the emit protocols rather than inside the built-in prompt, because like them it describes what this run can do — so `--vanilla` keeps it, and transparent mode (an empty channel) does not.

It is placed ahead of AWAIT/SIGNAL so the signal protocol is still the last thing in the channel, which #547 pins.

**Gated on the tools really being there**

`browserAttached` is narrower than the flag: the tools ride Claude Code's MCP config, so `--browser` on another agent wires nothing (`unguardedNotices` already says so) and the fake driver has none. Claiming a browser the run does not have would be worse than saying nothing.

Suite green: 788 pass.