### PR TITLE
fix(framework-dashboard): choose the agent at session start, not inside a session (#831)

### DIFF
--- a/.changeset/fix-831-in-session-agent-select.md
+++ b/.changeset/fix-831-in-session-agent-select.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/framework-dashboard': patch
+---
+
+Drop the agent/model select from the in-session composer (#831). A session is bound to the agent it started with: the driver is created once at spawn, and a follow-up message carries only text, so switching the select from Claude to Codex mid-session changed nothing but the *next* session's default. Model and agent are now chosen at the launcher, the one place they take effect.
+
+Also fixes the quieter half of the same bug on a finished session: the resume composer read the global agent pref and sent it alongside the captured session id, so a Claude session id could be handed to `codex --resume`. A continuation now resumes on the agent the run actually ran under.

--- a/packages/framework-dashboard/components/Composer.test.tsx
+++ b/packages/framework-dashboard/components/Composer.test.tsx
@@ -80,6 +80,17 @@ describe('Composer (#721)', () => {
     expect(onSubmit).toHaveBeenCalledWith('quick run', 'build')
   })
 
+  test('showAgentModel={false} (#831) drops the agent/model select, keeping the rest of the row', () => {
+    const { onSubmit } = renderComposer({ showAgentModel: false })
+    // An in-session composer: the session is bound to the agent it started with, so offering the
+    // select there would only ever rewrite the next session's default.
+    expect(screen.queryByTitle(/Agent:/)).toBeNull()
+    expect(screen.getByRole('button', { name: 'Session options' })).toBeTruthy()
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'follow-up' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(onSubmit).toHaveBeenCalledWith('follow-up', 'build')
+  })
+
   test('the submit button is disabled until the editor has text, then fires onSubmit', () => {
     const { onSubmit } = renderComposer()
     const submit = screen.getByRole('button', { name: 'Send' })

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -92,8 +92,11 @@ export const Composer = forwardRef<ComposerHandle, {
    *  or preset panel. The `/` `<` `@` `#` triggers still work; agent/model + options come from the
    *  shared prefs the launcher sets. */
   compact?: boolean | undefined
+  /** Off inside a session (#831): a session is bound to the agent it started with, so the select
+   *  would only ever rewrite the *next* session's default. Chosen at the launcher instead. */
+  showAgentModel?: boolean | undefined
 }>(function Composer(
-  { files, addContext, onSubmit, onPromptChange, onPreset, busy, submitLabel, submitBusyLabel, placeholder, showShortcutHint = false, compact = false },
+  { files, addContext, onSubmit, onPromptChange, onPreset, busy, submitLabel, submitBusyLabel, placeholder, showShortcutHint = false, compact = false, showAgentModel = true },
   ref,
 ) {
   const [prompt, setPrompt] = useState('')
@@ -200,13 +203,15 @@ export const Composer = forwardRef<ComposerHandle, {
   // controls in either place read and write the same state.
   const controls = (
     <>
-      <AgentModelMenu
-        agents={AGENTS}
-        agent={agent}
-        model={model}
-        onChange={(a, m) => updatePreferences({ agent: a, model: m })}
-        busy={busy}
-      />
+      {showAgentModel && (
+        <AgentModelMenu
+          agents={AGENTS}
+          agent={agent}
+          model={model}
+          onChange={(a, m) => updatePreferences({ agent: a, model: m })}
+          busy={busy}
+        />
+      )}
       <OptionsMenu
         options={mainOptions}
         ecoOptions={ecoOptions}

--- a/packages/framework-dashboard/components/RunChat.tsx
+++ b/packages/framework-dashboard/components/RunChat.tsx
@@ -3,10 +3,10 @@ import { Composer, type ComposerHandle } from './Composer.js'
 import { sendMessage } from '../server/control.telefunc.js'
 
 // The live-chat composer (#714/#721): send more messages to a running run. Reuses the same shared
-// Composer the launcher uses, so `/` presets, `<` tags, and `@`/`#` mentions work here too, plus the
-// agent/model + options controls. On submit it writes a `message` control entry that the run drains
-// between turns (continuing the same session via --resume); the agent/model + options edit the
-// Global preferences (the defaults for the next run) — a mid-run message itself carries no options.
+// Composer the launcher uses, so `/` presets, `<` tags, and `@`/`#` mentions work here too. On
+// submit it writes a `message` control entry that the run drains between turns, continuing the same
+// session via --resume. No agent/model select (#831): the run's driver is created once at spawn and
+// a message carries only text, so the select could not change this session, only the next one.
 // Only rendered inside RunLive, i.e. while the run is running — a finished run replays without it.
 export function RunChat({
   projectId,
@@ -49,6 +49,7 @@ export function RunChat({
         busy={sending}
         submitLabel="Send"
         submitBusyLabel="Sending…"
+        showAgentModel={false}
         placeholder="Message the session…  ( / commands · < tags · @ projects · # files )"
       />
     </div>

--- a/packages/framework-dashboard/components/RunReplay.tsx
+++ b/packages/framework-dashboard/components/RunReplay.tsx
@@ -39,7 +39,8 @@ export function RunReplay({
   if (events === null) return <div className="grid flex-1 place-items-center text-sm text-muted-foreground">Loading session…</div>
   // The agent session this run ran under (from its `session-update` events): present once the
   // agent reported it, so a run that never got that far simply can't be resumed.
-  const sessionId = sessionInfo(events)?.sessionId
+  const session = sessionInfo(events)
+  const sessionId = session?.sessionId
   return (
     <>
       <RunActionBar
@@ -59,7 +60,7 @@ export function RunReplay({
         <EventList events={events} stick={false} />
       )}
       {sessionId && (
-        <RunResumeChat projectId={projectId} runId={runId} sessionId={sessionId} files={files} addContext={addContext} onRunStarted={onRunStarted} />
+        <RunResumeChat projectId={projectId} runId={runId} sessionId={sessionId} driver={session?.driver} files={files} addContext={addContext} onRunStarted={onRunStarted} />
       )}
     </>
   )

--- a/packages/framework-dashboard/components/RunResumeChat.test.tsx
+++ b/packages/framework-dashboard/components/RunResumeChat.test.tsx
@@ -71,6 +71,36 @@ describe('RunResumeChat (#720)', () => {
     await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('and now dark mode', undefined))
   })
 
+  test('resumes on the run\'s own agent, not the global pref (#831)', async () => {
+    sendStart.mockResolvedValue({ ok: true })
+    // The pref says Codex, but this run ran under Claude. Handing its session id to `codex --resume`
+    // would be meaningless, so the run's driver wins.
+    prefs = { agent: 'codex', model: 'gpt-5' }
+    renderChat({ driver: 'claude-code' })
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'carry on' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    await waitFor(() => expect(sendStart).toHaveBeenCalledTimes(1))
+    const options = sendStart.mock.calls[0]![3]
+    expect(options.agent).toBeUndefined() // claude is the default, so no --agent flag
+    expect(options.model).toBeUndefined() // the resumed transcript keeps the model it had
+  })
+
+  test('a codex run resumes on codex (#831)', async () => {
+    sendStart.mockResolvedValue({ ok: true })
+    prefs = { agent: 'claude' }
+    renderChat({ driver: 'codex' })
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'carry on' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    await waitFor(() => expect(sendStart).toHaveBeenCalledTimes(1))
+    expect(sendStart.mock.calls[0]![3].agent).toBe('codex')
+  })
+
+  test('offers no agent/model select, since a session cannot change agent (#831)', () => {
+    prefs = { agent: 'claude' }
+    renderChat({ driver: 'claude-code' })
+    expect(screen.queryByTitle(/Agent:/)).toBeNull()
+  })
+
   test('surfaces the busy guard instead of jumping', async () => {
     sendStart.mockResolvedValue({ ok: false, busy: true })
     const { onRunStarted } = renderChat()

--- a/packages/framework-dashboard/components/RunResumeChat.tsx
+++ b/packages/framework-dashboard/components/RunResumeChat.tsx
@@ -1,18 +1,22 @@
 import { useRef, useState } from 'react'
 import { Composer, type ComposerHandle } from './Composer.js'
 import { sendStart } from '../server/control.telefunc.js'
-import { usePreferences } from '../lib/preferences.js'
+
+// The run's driver reports itself by driver name; `--agent` takes the agent name (#831).
+const AGENT_OF_DRIVER: Record<string, string> = { 'claude-code': 'claude', codex: 'codex' }
 
 // The finished-run composer (#720): keep talking to a run that has ended. A live run drains
 // messages in-process (RunChat + sendMessage), but a finished run has no process — so sending here
 // spins a FRESH run whose opening prompt `--resume`s the captured session id, continuing the same
 // conversation with full prior context. Reuses the shared Composer, then jumps to the new run's live
-// output (onRunStarted). Options come from the shared prefs, same as the launcher; the agent should
-// match the one the run used (resume is per-agent). Only rendered when the run has a session id.
+// output (onRunStarted). The agent is the one the run actually ran under, never the global pref
+// (#831): resume is per-agent, so a session id means nothing to a different agent's CLI. Only
+// rendered when the run has a session id.
 export function RunResumeChat({
   projectId,
   runId,
   sessionId,
+  driver,
   files,
   addContext,
   onRunStarted,
@@ -22,6 +26,8 @@ export function RunResumeChat({
   runId: string
   /** The finished run's agent session id, to resume. */
   sessionId: string
+  /** The driver that ran it, so the continuation resumes on the same agent (#831). */
+  driver?: string | undefined
   files: string[]
   addContext: (path: string) => void
   onRunStarted: (intent: string, runId?: string) => void
@@ -29,24 +35,21 @@ export function RunResumeChat({
   const composerRef = useRef<ComposerHandle>(null)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const preferences = usePreferences()
 
   const send = async (text: string): Promise<void> => {
     if (busy) return
     setBusy(true)
     setError(null)
     try {
-      // A continuation is a `prompt` run seeded with the finished run's session id (#720). Carry the
-      // model/agent from the shared prefs (resume is per-agent, so keep the same one the run used);
-      // the system-prompt options are moot here — the resumed transcript keeps its own framing.
-      const model = preferences.model ?? ''
-      const agent = preferences.agent ?? 'claude'
+      // A continuation is a `prompt` run seeded with the finished run's session id (#720). It
+      // resumes on the run's own agent; the model and the system-prompt options are moot here, since
+      // the resumed transcript keeps the framing and model it already had.
+      const agent = driver ? AGENT_OF_DRIVER[driver] : undefined
       const result = await sendStart(projectId, text, 'prompt', {
         resumeSession: sessionId,
         // Continue this run rather than opening a new row (#762): the follow-up writes into the
         // same run, on the same branch, so one thing you asked for stays one entry.
         continueRunId: runId,
-        ...(model ? { model } : {}),
         ...(agent && agent !== 'claude' ? { agent } : {}),
       })
       if (result.ok) {
@@ -73,6 +76,7 @@ export function RunResumeChat({
         busy={busy}
         submitLabel="Send"
         submitBusyLabel="Resuming…"
+        showAgentModel={false}
         placeholder="Message the session to continue it…  ( / commands · < tags · @ projects · # files )"
       />
       {error && <p className="mt-1 text-xs text-red-500">{error}</p>}


### PR DESCRIPTION
Closes #831

## What

The session page offered an agent/model select that could not do anything. Switch it from Claude to Codex, ask the session what model it is, and it answers as Claude, because a session is bound to the agent it started with.

- `cli.ts:1234` creates the driver once at spawn; follow-ups do `session.prompt(text, { resume: true })` (`run.ts:740`) on that same open session.
- `control.ts:19-25` - the message wire type is exactly `{ kind: 'message'; text: string }`. There is nowhere to put an agent.
- `Composer.tsx:207` - the select wrote `updatePreferences({ agent, model })`, i.e. the default for the *next* session.

So the control was purely a lie on that page. Rather than plumb an agent through a channel that cannot honor it (cross-agent continuation is not a wiring fix: `--resume` is per-agent, so it would mean stop, re-spawn with `continueRunId`, and replay the transcript as context), the select goes. Agent and model are chosen at the launcher, the one place they take effect.

## Shape

- `Composer` gains `showAgentModel` (default `true`, so the launcher and the navbar are untouched). `RunChat` and `RunResumeChat` pass `false`.
- The rule the change encodes: **an in-session composer sends no agent/model at all; the session keeps the one it started with.**

That second half matters, because `RunResumeChat` had the quieter instance of the same bug. It read `preferences.agent`/`model` and sent them to `sendStart` *alongside* `resumeSession: <sessionId>` - so if the pref was last set to Codex on the project page, a Claude session id was handed to `codex --resume`. It now resumes on the agent the run actually ran under (`sessionInfo(events).driver`), and sends no model, since the resumed transcript keeps the framing and model it already had.

This is also why the bug felt inconsistent while dogfooding: the switch appeared to work on a finished session and did nothing on a live one.

## Verified

`framework-dashboard` typecheck clean, **173 tests pass** (169 before; 4 new), root `pnpm build` clean.

New tests cover the select's absence with `showAgentModel={false}` while the rest of the control row still works, a Claude run resuming without an `--agent` flag even when the pref says Codex, a Codex run resuming on Codex, and no select rendered in the finished-session composer.

Not eyeballed against a live daemon - the tests render the real `Composer` through the real in-session components, so the missing control is covered, but note the daemon serves a bundled dashboard: `pnpm bundle:dashboard` and a restart are needed to see this in a running instance.

## Follow-up

The options gear in the same in-session composer has the same problem: its run options (Transparent, Browser, Autopilot) are inert mid-session and only affect the next run. Left alone here, noted in #831 as a separate filing.