### PR TITLE
fix: option labels that promise more than the code does (#801)

### DIFF
--- a/.changeset/fix-801-honest-option-labels.md
+++ b/.changeset/fix-801-honest-option-labels.md
@@ -1,0 +1,12 @@
+---
+'@gemstack/framework-dashboard': patch
+'@gemstack/framework': patch
+---
+
+Make the run-options menu say only what the code delivers (#801).
+
+- **Autopilot** no longer claims it "also relaxes the maintenance stance". #556 moved that section out of the system prompt, so the choice-gate countdown is its whole effect. Stale comments in `cli.ts` and `run.ts` asserting it steers the prompt are corrected too.
+- **Eco > Auto maintenance** is gated on Post-merge cleanup. It trims the on-before-mergeable prompt, not the built-in one, so on its own it dropped nothing. The `--eco-auto-maintenance` CLI help said the same wrong thing and now points at the right prompt.
+- **Browser** is disabled with a reason off Claude Code. The browser is wired through Claude Code's MCP config and other drivers take no MCP servers, so the box was checkable and inert. The CLI already warned via `unguardedNotices`; the dashboard was silent. `collectRunOptions` now also stops sending `browser` for a non-Claude agent, so the disable is real rather than cosmetic.
+
+Also fixes an Eco sub-row bug found on the way: the sub-drops rendered a `disabledReason` but ignored `disabled`, so a gated one would have looked disabled and still written through on click.

--- a/packages/framework-dashboard/components/Composer.test.tsx
+++ b/packages/framework-dashboard/components/Composer.test.tsx
@@ -91,6 +91,33 @@ describe('Composer (#721)', () => {
     expect(onSubmit).toHaveBeenCalledWith('follow-up', 'build')
   })
 
+  test('option labels promise only what the code delivers (#801)', () => {
+    prefs = { onBeforeMergeableQuality: true }
+    renderComposer()
+    fireEvent.click(screen.getByRole('button', { name: 'Session options' }))
+    // Autopilot no longer claims to relax the maintenance stance: #556 took that section out of the
+    // prompt, leaving the countdown as the whole feature.
+    const autopilot = screen.getByText('Autopilot').closest('[title]')
+    expect(autopilot?.getAttribute('title')).not.toMatch(/maintenance/i)
+    expect(autopilot?.getAttribute('title')).toMatch(/countdown/i)
+  })
+
+  test('Browser is disabled with a reason off Claude Code (#801)', () => {
+    prefs = { agent: 'codex', browser: true }
+    renderComposer()
+    fireEvent.click(screen.getByRole('button', { name: 'Session options' }))
+    // The browser rides Claude Code's MCP config, so under Codex the box was checkable and inert.
+    expect(screen.getByText(/only on Claude Code/)).toBeTruthy()
+  })
+
+  test('Auto maintenance is gated on Post-merge cleanup (#801)', () => {
+    // It trims the post-merge prompt, so with that pass off it drops nothing.
+    prefs = { eco: true, ecoMaintenance: true, onBeforeMergeableQuality: false }
+    renderComposer()
+    fireEvent.click(screen.getByRole('button', { name: 'Session options' }))
+    expect(screen.getByText(/only applies while Post-merge cleanup is on/)).toBeTruthy()
+  })
+
   test('the submit button is disabled until the editor has text, then fires onSubmit', () => {
     const { onSubmit } = renderComposer()
     const submit = screen.getByRole('button', { name: 'Send' })

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -163,17 +163,24 @@ export const Composer = forwardRef<ComposerHandle, {
   // is disabled + dimmed under Vanilla; the Eco sub-drops show only while Eco is on.
   const mainOptions: OptionRow[] = [
     { key: 'transparent', label: 'Transparent', description: 'Raw Claude Code — turns the whole framework off.', title: 'Fully transparent (#625): run the agent exactly like plain Claude Code, with no framework system prompt, controls, dashboard, guard, or TODO loop. Overrides the options below.', checked: transparent },
-    { key: 'autopilot', label: 'Autopilot', description: 'Auto-accepts the recommended choice after a countdown.', title: 'Auto-accept the recommended choice after a countdown; also relaxes the maintenance stance', checked: autopilot && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
+    // Says only what it does (#801): the maintenance stance it used to relax left the system prompt
+    // with that section (#556), so the countdown is the whole feature.
+    { key: 'autopilot', label: 'Autopilot', description: 'Auto-accepts the recommended choice after a countdown.', title: 'Auto-accept the recommended choice after a countdown, instead of waiting for you to pick', checked: autopilot && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
     { key: 'technical', label: 'Technical control', description: 'Surfaces technical detail like tech-stack choices.', title: 'Expose technical detail (e.g. tech-stack choices)', checked: technical && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
     { key: 'vanilla', label: 'Disable system prompt', description: 'Drops the added system prompt; keeps the session controls.', title: "Remove the built-in system prompt but keep the framework's session controls. For a fully raw session, use Transparent. Expand 'Actual prompt' to read what it removes.", checked: vanilla && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
     { key: 'eco', label: 'Eco', description: 'Trims the system prompt to save tokens.', title: 'Trim the built-in system prompt to save tokens', checked: eco && !ecoDisabled, disabled: ecoDisabled, disabledReason: 'nothing to trim while the system prompt is off' },
     { key: 'onBeforeMergeableQuality', label: 'Post-merge cleanup', description: 'Runs quality passes once it is ready to merge.', title: "When the session signals it's ready for merge, run maintainability, readability, and security-audit passes", checked: onBeforeMergeableQuality && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
-    { key: 'browser', label: 'Browser', description: 'Gives the agent a real browser to inspect pages.', title: 'Give the agent a real browser via chrome-devtools-mcp: navigate pages, read console + network, inspect the DOM, and screenshot', checked: browser && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
+    // Claude-only (#801): the browser is wired through Claude Code's MCP config, so another agent's
+    // driver takes no MCP servers and the box would be checkable but inert. The CLI has always
+    // warned about this (`unguardedNotices`); now the dashboard says it too.
+    { key: 'browser', label: 'Browser', description: 'Gives the agent a real browser to inspect pages.', title: 'Give the agent a real browser via chrome-devtools-mcp: navigate pages, read console + network, inspect the DOM, and screenshot', checked: browser && !transparent && agent === 'claude', disabled: transparent || agent !== 'claude', disabledReason: transparent ? 'off while Transparent is on' : 'only on Claude Code — the browser is wired through its MCP config' },
   ]
   const ecoOptions: OptionRow[] = [
     { key: 'ecoPlanning', label: 'Auto planning', description: 'Drops the planning section; the agent plans itself.', title: 'Drop the planning section, letting the agent plan on its own', checked: ecoPlanning },
     { key: 'ecoResearch', label: 'Auto research', description: 'Drops the alternatives/variability section.', title: 'Drop the alternatives/variability section', checked: ecoResearch },
-    { key: 'ecoMaintenance', label: 'Auto maintenance', description: 'Drops the maintenance section.', title: 'Drop the maintenance section', checked: ecoMaintenance },
+    // Gated on Post-merge cleanup (#801): #556 moved the Maintenance section out of the system
+    // prompt and into the on-before-mergeable prompt, so this trims nothing unless that pass runs.
+    { key: 'ecoMaintenance', label: 'Auto maintenance', description: 'Drops the maintenance section from the post-merge prompt.', title: 'Drop the Maintenance section from the post-merge cleanup prompt', checked: ecoMaintenance && onBeforeMergeableQuality, disabled: !onBeforeMergeableQuality, disabledReason: 'only applies while Post-merge cleanup is on' },
   ]
 
   const editorEl = (

--- a/packages/framework-dashboard/components/OptionsMenu.test.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.test.tsx
@@ -51,6 +51,30 @@ describe('OptionsMenu (#654)', () => {
     expect(screen.getByText('Auto planning')).toBeTruthy()
   })
 
+  test('a disabled row is greyed out and says why, and cannot be toggled', () => {
+    const options: OptionRow[] = [
+      { key: 'browser', label: 'Browser', title: 't', description: 'Gives the agent a real browser.', checked: false, disabled: true, disabledReason: 'only on Claude Code' },
+    ]
+    render(<OptionsMenu options={options} ecoOptions={ecoOptions()} showEco={false} busy={false} {...editorProps} />)
+    open()
+    expect(screen.getByText(/only on Claude Code/)).toBeTruthy()
+    fireEvent.click(screen.getByText('Browser'))
+    expect(updatePreferences).not.toHaveBeenCalled()
+  })
+
+  test('a disabled Eco sub-drop cannot be toggled either (#801)', () => {
+    // The sub-rows rendered the reason but stayed clickable, so a gated one (Auto maintenance under
+    // Post-merge cleanup) would have looked disabled and still written through.
+    const eco: OptionRow[] = [
+      { key: 'ecoMaintenance', label: 'Auto maintenance', title: 't', checked: false, disabled: true, disabledReason: 'only applies while Post-merge cleanup is on' },
+    ]
+    render(<OptionsMenu options={mainOptions()} ecoOptions={eco} showEco={true} busy={false} {...editorProps} />)
+    open()
+    expect(screen.getByText(/only applies while Post-merge cleanup is on/)).toBeTruthy()
+    fireEvent.click(screen.getByText('Auto maintenance'))
+    expect(updatePreferences).not.toHaveBeenCalled()
+  })
+
 })
 
 describe('OptionsMenu editor picker (#727)', () => {

--- a/packages/framework-dashboard/components/OptionsMenu.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.tsx
@@ -119,7 +119,7 @@ export function OptionsMenu({
               <DropdownMenuCheckboxItem
                 key={o.key}
                 checked={o.checked}
-                disabled={busy}
+                disabled={busy || !!o.disabled}
                 onCheckedChange={checked => setOption(o.key, checked)}
                 title={o.title}
                 className="items-start pl-8"

--- a/packages/framework-dashboard/lib/run-options.test.ts
+++ b/packages/framework-dashboard/lib/run-options.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test, vi } from 'vitest'
+import type { Preferences } from '@gemstack/framework'
+
+// collectRunOptions reads the autopilot default through the preferences module; stub just that.
+vi.mock('./preferences.js', () => ({ autopilotEnabled: (p: Preferences) => p.autopilot ?? true }))
+
+const { collectRunOptions } = await import('./run-options.js')
+
+describe('collectRunOptions (#410)', () => {
+  test('sends browser on Claude Code', () => {
+    expect(collectRunOptions({ browser: true }).browser).toBe(true)
+  })
+
+  test('does not send browser off Claude Code (#801)', () => {
+    // The browser is wired through Claude Code's MCP config; another agent's driver takes no MCP
+    // servers, so sending it would only earn the CLI's "no effect" notice.
+    const options = collectRunOptions({ browser: true, agent: 'codex' })
+    expect(options.browser).toBeUndefined()
+    expect(options.agent).toBe('codex')
+  })
+})

--- a/packages/framework-dashboard/lib/run-options.ts
+++ b/packages/framework-dashboard/lib/run-options.ts
@@ -28,7 +28,9 @@ export function collectRunOptions(preferences: Preferences, context: string[] = 
     ...(transparent ? { transparent: true } : {}),
     ...(eco && !vanilla && !transparent && Object.keys(ecoDrops).length ? { eco: ecoDrops } : {}),
     ...(onBeforeMergeableQuality ? { onBeforeMergeable: true } : {}),
-    ...(browser ? { browser: true } : {}),
+    // Claude-only (#801): another agent's driver takes no MCP servers, so sending it would only earn
+    // the CLI's "no effect" notice. Matches the box being disabled off Claude Code.
+    ...(browser && agent === 'claude' ? { browser: true } : {}),
     ...(model ? { model } : {}),
     ...(agent !== 'claude' ? { agent } : {}),
     ...(context.length ? { context } : {}),

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -502,7 +502,7 @@ test('runCli notes mode flags given without a preset', async () => {
   assert.ok(err.some(l => /technical mode\(s\) have no effect without a preset/.test(l)))
 })
 
-test('runCli does not note --autopilot without a preset (it steers the #326 prompt)', async () => {
+test('runCli does not note --autopilot without a preset (it auto-answers choice gates)', async () => {
   const { io, err } = capture()
   const code = await runCli(['--fake', '--no-dashboard', '--autopilot'], io)
   assert.equal(code, 0)

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -159,7 +159,9 @@ Options:
                          the-framework.yml (transparent: true) or per user.
   --eco-auto-planning    Drop the built-in prompt's "Large scope" (planning) section.
   --eco-auto-research    Drop the built-in prompt's "Alternatives" (research) section.
-  --eco-auto-maintenance Drop the built-in prompt's "Maintenance" section.
+  --eco-auto-maintenance Drop the "Maintenance" section from the post-merge
+                         cleanup prompt. Needs --on-before-mergeable; #556 moved
+                         that section out of the built-in prompt.
                          (The --eco-* flags trim the #326 prompt to save tokens.)
   --context <dir>        Focus the agent on this directory (repeatable). Adds one
                          "Context: <dirs>" line to the system prompt; the agent can
@@ -1218,8 +1220,9 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   }
 
   // A mode/kind given with no preset in effect has nothing to act on: note it.
-  // Autopilot is the exception — it also steers the #326 system prompt's
-  // maintenance stance, so it works preset or not.
+  // Autopilot is the exception — it auto-answers the run's choice gates, which
+  // needs no preset. (It no longer steers the prompt's maintenance stance: #556
+  // moved that section out, see #801.)
   const presetOnlyModes = modeList.filter(m => m !== 'autopilot')
   if (presetOnlyModes.length && !domainPreset) {
     io.err(`note: ${presetOnlyModes.join(' + ')} mode(s) have no effect without a preset.`)

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -120,8 +120,9 @@ export interface RunFrameworkOptions {
   preset?: DomainPreset
   /**
    * The active modes for the run (e.g. `['autopilot']`). Narrated with the
-   * {@link preset} (which is expected to be loaded with them already applied),
-   * and `autopilot` also steers the #326 system prompt's maintenance stance.
+   * {@link preset}, which is expected to be loaded with them already applied.
+   * (`autopilot` no longer steers the system prompt: #556 moved the maintenance
+   * section out, leaving the choice-gate countdown as its whole effect. See #801.)
    */
   modes?: readonly string[]
   /**


### PR DESCRIPTION
Closes #801

Each of the three was verified against the code before touching the copy, since "this label lies" is a claim worth checking rather than trusting. All three held, and two of them were worse than the issue said.

## 1. Autopilot

The tooltip promised "also relaxes the maintenance stance". Traced the whole `autopilot` path: preference to `--autopilot` (`daemon.ts:131`), into `activeModes()`, then read in exactly four places. The prompt is not one of them - `grep -rni autopilot packages/framework/prompts/` is **zero hits**, and the codebase's own test (`system-prompt.test.ts:75-78`) pins that `tf.prompt` is the only remaining `${{ }}` fragment, precisely because #556 took the maintenance ternary out with that section.

Two further findings not in the issue:
- The preset `conditions` variants it can select **do not exist in any shipped preset** (`find packages/ai-autopilot/presets -name "*.*.md"` returns 5 files, all `major-change.technical.md`).
- The countdown is client-side (`ChoicePanel.tsx:83-104`) and reads `usePreferences()` directly, not the run's flag - so `--autopilot` is redundant even for the one thing that does work.

The tooltip now says only what happens: the countdown. Stale comments in `cli.ts` and `run.ts` asserting it steers the prompt are corrected.

**Kept the behavior at `cli.ts:1220`.** Autopilot is exempt from the "no effect without a preset" note, and that exemption is still correct - auto-answering gates genuinely needs no preset. Only its stated reason was wrong, so I fixed the comment and the test name rather than flipping the behavior.

## 2. Eco > Auto maintenance

`ECO_SECTION_HEADINGS` (`system-prompt.ts:64-67`) maps only `autoPlanning` and `autoResearch`; `autoMaintenance` has no entry, and the source comment already says why. Its one real effect is in `on-before-mergeable-prompt.ts:57-63`, reachable only when `--on-before-mergeable` is set. So alone it dropped nothing.

Now gated on Post-merge cleanup in the menu, with the description pointing at the prompt it actually trims. The `--eco-auto-maintenance` CLI help said the same wrong thing and is corrected.

## 3. Browser off Claude Code

`createDriver()` (`agent.ts:68-75`) passes options only in `case 'claude'`; `case 'codex'` takes none, and `grep -n mcp driver/codex.ts` is zero hits. The framework already knows - `cli.ts:1252` computes `browserAttached = opts.browser && !fake && opts.agent === 'claude'` - and the CLI warns via `unguardedNotices()` (`cli.ts:628`). That warning is stderr-only and dashboard runs spawn with `stdio: 'ignore'` (`daemon.ts:97`), so it could never reach the UI.

Now disabled with the reason, reusing the existing `disabled`/`disabledReason` mechanism. **Also gated the send side**: `collectRunOptions` stopped sending `browser` for a non-Claude agent, otherwise the disable is cosmetic while the stored preference still ships `browser: true`.

## Bug found on the way

`OptionsMenu`'s Eco sub-rows passed `disabled={busy}` but rendered `o.disabledReason`, so a gated sub-row would have looked disabled and still written through on click. Fixed, otherwise the Auto-maintenance gate above would have been text-only.

## Verified

`framework-dashboard` typecheck clean, **180 tests** (173 before, 7 new). `framework` typecheck clean, **797 pass / 0 fail / 1 skipped**. Root `pnpm build` clean.

New tests cover each label claim, Browser disabled off Claude, the Auto-maintenance gate, `collectRunOptions` dropping browser under Codex, and both disabled-row paths in `OptionsMenu` (main and Eco sub-row) which had **no** prior coverage.

I mutation-tested the Autopilot label assertion - reinstating the old "also relaxes the maintenance stance" string makes it fail - so it is a live assertion, not a green no-op.

## Left out

The issue's "also worth deciding": Post-merge cleanup skipping silently. That one is not a copy fix. It has five silent early returns (`cli.ts:1198-1210`), and its messages are `io.out` rather than events, so the dashboard cannot show them for two independent structural reasons - runs spawn with `stdio: 'ignore'`, and `settleRun` closes the event store *before* calling it (`cli.ts:778-780`). Making it visible means new events plus a lifecycle reorder, which is its own change. Filed separately as #835.
