### PR TITLE
docs(framework): say the browser protocol guidance in plain words (#837)

### DIFF
--- a/.changeset/browser-prompt-single-page-wording.md
+++ b/.changeset/browser-prompt-single-page-wording.md
@@ -2,4 +2,4 @@
 '@gemstack/framework': patch
 ---
 
-Say the browser protocol's single-page rule in plain words. The line asking the agent to stay on one page was written for the agent and read as jargon to everyone else, and users do read the system prompt. Same rule, said so a human gets it on the first pass.
+Say the browser protocol's two guidance lines in plain words. Both were written for the agent and read as jargon to everyone else, and users do read the system prompt: one told the agent to reach for the browser "when fetching the HTML would not answer the question", the other to prefer "one page and navigate it, rather than opening a new page per URL". Same two rules, said so a human gets them on the first pass.

--- a/.changeset/browser-prompt-single-page-wording.md
+++ b/.changeset/browser-prompt-single-page-wording.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Say the browser protocol's single-page rule in plain words. The line asking the agent to stay on one page was written for the agent and read as jargon to everyone else, and users do read the system prompt. Same rule, said so a human gets it on the first pass.

--- a/packages/framework/prompts/protocols/browser.md
+++ b/packages/framework/prompts/protocols/browser.md
@@ -4,4 +4,4 @@ This run has a real Chrome attached, through the `chrome-devtools` tools (`new_p
 
 `WebFetch` is still the right tool for reading an article or a doc page as text. Reach for the browser when fetching the HTML would not answer the question.
 
-Prefer one page and navigate it, rather than opening a new page per URL: the human watching sees the tab you are on.
+Prefer navigating within a single page rather than opening new pages, so the user can more easily watch you navigate.

--- a/packages/framework/prompts/protocols/browser.md
+++ b/packages/framework/prompts/protocols/browser.md
@@ -2,6 +2,6 @@
 
 This run has a real Chrome attached, through the `chrome-devtools` tools (`new_page`, `navigate_page`, `click`, `fill`, `take_snapshot`, `evaluate_script`). It is the same browser a human can watch and take over, so use it for anything you need to *see* or *act on*: pages that render their content with JavaScript, a flow you have to click through, a form to fill, an app you are checking actually works.
 
-`WebFetch` is still the right tool for reading an article or a doc page as text. Reach for the browser when fetching the HTML would not answer the question.
+When you only need to read a page, `WebFetch` is still the better tool: it is faster and hands you the text directly. Use the browser when `WebFetch` would come back with nothing useful, such as a page that is blank until its JavaScript runs.
 
 Prefer navigating within a single page rather than opening new pages, so the user can more easily watch you navigate.


### PR DESCRIPTION
Reworks the two guidance lines in the browser protocol so they read on the first pass. Prompted by the review left on #827 after it merged (https://github.com/gemstack-land/gemstack/pull/827#discussion_r3611478166), and by the same complaint about the line above it.

Before:

> `WebFetch` is still the right tool for reading an article or a doc page as text. Reach for the browser when fetching the HTML would not answer the question.
>
> Prefer one page and navigate it, rather than opening a new page per URL: the human watching sees the tab you are on.

After:

> When you only need to read a page, `WebFetch` is still the better tool: it is faster and hands you the text directly. Use the browser when `WebFetch` would come back with nothing useful, such as a page that is blank until its JavaScript runs.
>
> Prefer navigating within a single page rather than opening new pages, so the user can more easily watch you navigate.

The first line stated the rule in terms of the mechanism ("when fetching the HTML would not answer the question") rather than naming the case it covers. The second is the wording suggested in review, verbatim.

Same two rules, no behaviour change. The opening paragraph was reviewed on #827 and left alone.

Verified: `gen-prompts.mjs` regenerates cleanly and `check-prompt-drift.mjs` still reports prompts/ in sync. No test asserts either sentence (they compare against the `BROWSER_PROTOCOL` constant).

Closes #837
