### PR TITLE
fix(framework): stop auto PM runs hanging on a gate nobody can answer (#846)

### DIFF
--- a/.changeset/unattended-gates.md
+++ b/.changeset/unattended-gates.md
@@ -1,0 +1,11 @@
+---
+'@gemstack/framework': patch
+---
+
+Auto PM runs no longer hang on their first choice gate (#846)
+
+A daemon-spawned run parks each choice gate waiting for a human, and autopilot's
+auto-accept countdown runs in the browser — so a run started while nobody was
+watching waited forever. Runs the daemon starts on its own are now marked
+unattended and take the recommended option, the same fallback a headless run
+already uses. Stop is unaffected.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -65,6 +65,9 @@ test('parseArgs reads the backlog-loop flags (#323)', () => {
   assert.equal(dflt.todoLoop, true)
   assert.equal(dflt.todoMaxItems, undefined)
   assert.equal(parseArgs(['--no-todo-loop', 'x']).todoLoop, false)
+  // Unattended (#846): off unless asked, so an ordinary run still parks its gates for the human.
+  assert.equal(parseArgs(['x']).unattended, undefined)
+  assert.equal(parseArgs(['--unattended', 'x']).unattended, true)
   assert.equal(parseArgs(['--max-todo-items', '5', 'x']).todoMaxItems, 5)
   assert.match(parseArgs(['--max-todo-items', '0', 'x']).error!, /max-todo-items/)
 })

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -173,6 +173,8 @@ Options:
   --browser              Give the agent a real browser during the run via
                          chrome-devtools-mcp: navigate pages, read console + network,
                          inspect the DOM, and screenshot. Off by default (#452).
+  --unattended           Nobody is watching: choice gates take the recommended option
+                         instead of waiting for an answer. Stop still works (#846).
   --kind <name>          Build event kind the preset's review loop fires for, e.g.
                          bug-fix or major-change (default: the-framework.yml's event,
                          else the preset's own, else major-change). Selects which
@@ -247,6 +249,8 @@ export interface CliOptions {
   model?: string | undefined
   /** `--resume-session <id>` (#720): continue a finished run's agent session — the prompt resumes that conversation (full prior context). Set by the dashboard when you message a run that has ended. */
   resumeSession?: string | undefined
+  /** `--unattended`: no human is watching, so choice gates take the recommended option (#846). */
+  unattended?: boolean
   scope: 'prototype' | 'full'
   preset?: string | undefined
   autopilot: boolean
@@ -453,6 +457,9 @@ export function parseArgs(argv: string[]): CliOptions {
         break
       case '--resume-session':
         opts.resumeSession = argv[++i]
+        break
+      case '--unattended':
+        opts.unattended = true
         break
       case '--deploy':
         opts.deploy = argv[++i]
@@ -1126,8 +1133,11 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // workspace daemon's via the control channel (#344). With neither, the gates auto-accept
   // the recommended option (#304). The run's requestChoice parks a resolver in pendingChoices
   // keyed by the choice id; a dashboard/daemon pick (or an abort) resolves it.
+  // An unattended run (#846) is steerable but unwatched: keep the control channel for Stop and
+  // live messages, and leave requestChoice unset so each gate takes its recommended option. Auto
+  // PM (#685) fires when nobody is there, and a parked gate would hang it until someone looked.
   const requestChoice =
-    dashboard || control
+    (dashboard || control) && !opts.unattended
       ? (req: ChoiceRequest): Promise<ChoicePick> => new Promise(resolve => pendingChoices.set(req.id, resolve))
       : undefined
   // The session link shown on the dashboard: --session-link, else Claude Code's own entry for

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -73,6 +73,9 @@ test('startOptionFlags maps only enabled Global options to CLI flags (#314)', ()
   assert.deepEqual(startOptionFlags({ agent: 'codex' }), ['--agent', 'codex'])
   assert.deepEqual(startOptionFlags({ agent: 'claude' }), [])
   assert.deepEqual(startOptionFlags({ agent: '   ' }), [])
+  // Unattended (#846): auto PM's own runs, whose gates must not park for an absent human.
+  assert.deepEqual(startOptionFlags({ unattended: true }), ['--unattended'])
+  assert.deepEqual(startOptionFlags({ unattended: false }), [])
   // Resume a finished run's session (#720): maps to --resume-session, trimmed; blank -> no flag.
   assert.deepEqual(startOptionFlags({ resumeSession: 'sess-42' }), ['--resume-session', 'sess-42'])
   assert.deepEqual(startOptionFlags({ resumeSession: '  sess-7  ' }), ['--resume-session', 'sess-7'])

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -146,6 +146,9 @@ export function startOptionFlags(options: StartRunOptions): string[] {
   if (typeof options.agent === 'string' && options.agent.trim() && options.agent !== 'claude') {
     flags.push('--agent', options.agent.trim())
   }
+  // Unattended (#846): nobody is at the keyboard, so gates take the recommended option
+  // rather than park for an answer that is not coming.
+  if (options.unattended) flags.push('--unattended')
   // Resume a finished run's session (#720): the spawned run continues that conversation.
   if (typeof options.resumeSession === 'string' && options.resumeSession.trim()) {
     flags.push('--resume-session', options.resumeSession.trim())
@@ -451,7 +454,7 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     backlogEmpty: async project => (await findTodoBacklog(project.path)) === undefined,
     activeRuns: project => runtime.activeRunCount(project.id),
     quota: async () => (await quota.read()).limits,
-    start: async (project, job) => (await runtime.onStart(job.prompt, 'prompt', {}, project.id)).ok,
+    start: async (project, job) => (await runtime.onStart(job.prompt, 'prompt', { unattended: true }, project.id)).ok,
     log: message => console.log(message),
   })
 

--- a/packages/framework/src/dashboard/types.ts
+++ b/packages/framework/src/dashboard/types.ts
@@ -40,6 +40,13 @@ export interface StartRunOptions {
   model?: string
   /** Which coding agent drives the run (#650): `claude` or `codex`; maps to `--agent`. Absent = the default (`claude`). */
   agent?: string
+  /**
+   * Nobody is watching this run (#846): its choice gates take the recommended option instead of
+   * parking for an answer, which is the fallback a fully headless run already uses and the one
+   * autopilot would have clicked. Set by the work the daemon starts on its own (auto PM, #685).
+   * Stop still works — that aborts the run controller, not a gate.
+   */
+  unattended?: boolean
   /** Resume a finished run's conversation (#720): its captured agent session id; maps to `--resume-session`. The run's prompt continues that session (full prior context) instead of starting fresh. Sent with `kind: 'prompt'` when you message a run that has ended. */
   resumeSession?: string
   /**


### PR DESCRIPTION
Closes #846

A bug in what I merged an hour ago (#685/#773), found by reading rather than by it biting us.

## The chain

1. A daemon-spawned run has a control channel, so `requestChoice` is defined (`cli.ts:1127`) and every gate **parks a resolver** waiting for a human. Only a fully headless run falls back to the recommended option.
2. Autopilot's auto-accept countdown lives in `ChoicePanel.tsx` — a React component in the **browser**, cancelled by any mouse movement (#433). No tab open on that run, nothing counts down.
3. Auto PM starts runs exactly when nobody is watching, and they run under the #326 system prompt, which gates on an ambiguous prompt, a large scope, and alternatives. They were also started with empty options, so they did not even get autopilot.

Net: the first gate would hang an auto-PM run until someone happened to open the dashboard.

## The fix

Reuse semantics that already exist rather than invent new ones. A run the daemon starts on its own is marked `--unattended`: the control channel stays, so **Stop and live messages keep working** (Stop aborts the run controller and never goes through `requestChoice`, `cli.ts:1042`), but gates take the recommended option — the same fallback a headless run already used, and the one autopilot would have clicked.

Four small pieces: `StartRunOptions.unattended` -> `--unattended` -> `requestChoice` condition -> auto PM passes it.

## Deliberately not done here

Auto PM still starts runs with no model/agent preference. That is a separate question now that #844 made those per-project, and it belongs in its own change.

## Verified

`pnpm build` green (10/10). Framework: 827 pass / 0 fail, with new tests pinning the flag mapping and that `--unattended` is off unless asked, so an ordinary run still parks its gates for the human.

Still worth a live daemon run to confirm end to end — that is my next step regardless.