### PR TITLE
fix(framework): gate auto PM on the account's own week, not just the meter (#848)

### DIFF
--- a/.changeset/absolute-week-gate.md
+++ b/.changeset/absolute-week-gate.md
@@ -1,0 +1,13 @@
+---
+'@gemstack/framework': patch
+---
+
+Auto PM no longer spends the last of the quota after a daemon restart (#848)
+
+The consumption meter measures how much usage has gone up since it started watching,
+so a restarted daemon had nothing to compare its first reading against and reported
+zero consumed no matter what the account had actually spent. Auto PM read that as a
+full budget.
+
+It now also checks the account's own weekly figure, which is absolute and survives a
+restart, and refuses when that cannot be read.

--- a/packages/framework/src/auto-pm.test.ts
+++ b/packages/framework/src/auto-pm.test.ts
@@ -9,20 +9,27 @@ import {
   type AutoPmDeps,
   type AutoPmJob,
   type AutoPmProject,
+  type AutoPmQuota,
 } from './auto-pm.js'
-import { ConsumptionMeter, consumptionStatus, DEFAULT_CONSUMPTION_LIMITS, type ConsumptionStatus } from './consumption.js'
+import { ConsumptionMeter, consumptionStatus, DEFAULT_CONSUMPTION_LIMITS } from './consumption.js'
 
 const T0 = 1_800_000_000_000
 
-/** A status whose windows read `weekPercent` of the account's week as spent. */
-function status(weekPercent: number | undefined): ConsumptionStatus {
+/**
+ * A reading where the rolling meter has seen `weekPercent` points burned, and the account's
+ * own week is `accountWeek` spent (default: the same, the honest case).
+ */
+function status(weekPercent: number | undefined, accountWeek: number | undefined = weekPercent ?? 0): AutoPmQuota {
   const meter = new ConsumptionMeter()
   if (weekPercent !== undefined) {
     // Two samples, because the meter measures the delta between readings, not an absolute.
     meter.record({ at: T0 - 1000, weeklyPercent: 0 })
     meter.record({ at: T0, weeklyPercent: weekPercent })
   }
-  return consumptionStatus({ meter, limits: DEFAULT_CONSUMPTION_LIMITS, now: T0 })
+  return {
+    status: consumptionStatus({ meter, limits: DEFAULT_CONSUMPTION_LIMITS, now: T0 }),
+    weekPercentUsed: accountWeek,
+  }
 }
 
 /** The happy inputs, so each test names only the condition it is about. */
@@ -79,17 +86,54 @@ test('quotaHeadroom refuses once a window is past the threshold (#685)', () => {
   assert.match(decision.start === false ? decision.reason : '', /% used/)
 })
 
-test('quotaHeadroom refuses when no limit is enabled, having no budget to call spare (#685)', () => {
+test('quotaHeadroom still starts with the rolling limits off, guarded by the account week (#848)', () => {
+  // The rolling limits are the user's own pacing knobs; switching them off used to leave the
+  // gate with no denominator at all. The account's absolute week is the denominator now.
+  const off = { enabled: false, percent: 20 }
   const meter = new ConsumptionMeter()
   meter.record({ at: T0 - 1000, weeklyPercent: 0 })
   meter.record({ at: T0, weeklyPercent: 1 })
-  const off = { enabled: false, percent: 20 }
-  const decision = quotaHeadroom(
-    consumptionStatus({ meter, limits: { daily: off, fiveHour: off, session: off }, now: T0 }),
-    DEFAULT_MIN_FREE_PERCENT,
-  )
+  const quota: AutoPmQuota = {
+    status: consumptionStatus({ meter, limits: { daily: off, fiveHour: off, session: off }, now: T0 }),
+    weekPercentUsed: 5,
+  }
+  assert.deepEqual(quotaHeadroom(quota, DEFAULT_MIN_FREE_PERCENT), { start: true })
+  assert.equal(quotaHeadroom({ ...quota, weekPercentUsed: 95 }, DEFAULT_MIN_FREE_PERCENT).start, false)
+})
+
+test('quotaHeadroom refuses when the account week is nearly spent (#848)', () => {
+  const decision = quotaHeadroom(status(1, 95), DEFAULT_MIN_FREE_PERCENT)
   assert.equal(decision.start, false)
-  assert.match(decision.start === false ? decision.reason : '', /no consumption limit is enabled/)
+  assert.match(decision.start === false ? decision.reason : '', /account's week is 95% used/)
+})
+
+test('quotaHeadroom refuses when the account week cannot be read (#848)', () => {
+  // Built inline, not via status(1, undefined): an explicit undefined argument still triggers
+  // the default parameter, which would quietly hand the check a real number.
+  const decision = quotaHeadroom({ ...status(1), weekPercentUsed: undefined }, DEFAULT_MIN_FREE_PERCENT)
+  assert.equal(decision.start, false)
+  assert.match(decision.start === false ? decision.reason : '', /weekly usage could not be read/)
+})
+
+test('a restarted daemon does not spend the last of the quota (#848)', () => {
+  // The regression, reproduced live on 0f16b3e before the fix. The meter is delta-based, so a
+  // daemon that just restarted has one sample, nothing to diff it against, and honestly reports
+  // 0 consumed -- while the account sits at 95% of its week. Zero and unknown look identical to
+  // a usedPercent check, which is why the absolute reading has to be the one in charge.
+  const fresh = new ConsumptionMeter()
+  fresh.record({ at: T0, weeklyPercent: 95 })
+  const rolling = consumptionStatus({ meter: fresh, limits: DEFAULT_CONSUMPTION_LIMITS, now: T0 })
+  assert.equal(rolling.daily.usedPercent, 0) // the trap: not undefined
+  assert.equal(rolling.daily.complete, false) // the honest signal underneath it
+
+  const decision = autoPmDecision({
+    enabled: true,
+    backlogEmpty: true,
+    activeRuns: 0,
+    quota: { status: rolling, weekPercentUsed: 95 },
+  })
+  assert.equal(decision.start, false)
+  assert.match(decision.start === false ? decision.reason : '', /account's week is 95% used/)
 })
 
 const JOBS: readonly AutoPmJob[] = [

--- a/packages/framework/src/auto-pm.ts
+++ b/packages/framework/src/auto-pm.ts
@@ -35,8 +35,8 @@ export interface AutoPmInputs {
   backlogEmpty: boolean
   /** Live runs on this project. Any run at all means the user's quota is already being spent. */
   activeRuns: number
-  /** Where the consumption limits stand, or `undefined` when the quota could not be read. */
-  quota: ConsumptionStatus | undefined
+  /** The budget readings, or `undefined` when the quota could not be read. */
+  quota: AutoPmQuota | undefined
   /** Milliseconds since this project was last auto-started, or `undefined` if it never was. */
   sinceLastStartMs?: number
   /** Override {@link DEFAULT_MIN_FREE_PERCENT}. */
@@ -49,28 +49,64 @@ export interface AutoPmInputs {
 export type AutoPmDecision = { start: true } | { start: false; reason: string }
 
 /**
- * Whether there is enough headroom to spend unasked, across the windows that recover
- * slowly enough to matter (the day and the rolling 5h). The session window is ignored:
- * this only ever runs when nothing is running, so there is no session to measure.
+ * What one tick knows about the budget: the rolling windows, and the account's own weekly
+ * figure (#848).
+ *
+ * Both, because they fail in opposite directions. The rolling windows come from
+ * {@link ConsumptionMeter}, which measures how much usage has gone *up* since it started
+ * watching — so a restarted daemon has nothing to compare against and honestly reports zero
+ * consumed, whatever the account has actually spent. `weekPercentUsed` is the account's own
+ * absolute number, which survives a restart but says nothing about the last five hours.
+ */
+export interface AutoPmQuota {
+  /** Where the user's configured limits stand, from the rolling meter. */
+  status: ConsumptionStatus
+  /**
+   * The account's weekly allowance consumed so far, 0-100, straight from the agent's own
+   * readout (`kind: 'week'`). `undefined` when there is no reading to take it from.
+   */
+  weekPercentUsed: number | undefined
+}
+
+/**
+ * Whether there is enough headroom to spend unasked.
  *
  * **This gate fails closed, and that is the opposite of the per-run guard.** #519 settled
  * that an unreadable quota must never *stop* the user's own work, so `startConsumptionGuard`
  * fails open. Work nobody asked for is the other way round: if we cannot see the meter we
  * cannot promise we are spending a surplus, and quietly burning a subscription is a far worse
- * failure than skipping a tick. So no reading means no run, and a disabled limit means we
- * have no denominator to call anything "spare".
+ * failure than skipping a tick.
+ *
+ * Two independent checks, because either alone has a blind spot (#848):
+ *
+ * 1. The account's own weekly figure, which is absolute and survives a daemon restart. This
+ *    is the one that matters most, and its absence is itself a refusal.
+ * 2. The rolling day and 5h windows, which catch a burst the weekly figure is too coarse to
+ *    see. The session window is ignored: this only runs when nothing is running.
+ *
+ * The rolling windows cannot carry the decision on their own. They come from a delta meter,
+ * so an empty one reports **0 consumed** rather than "unknown" — indistinguishable from a
+ * genuinely untouched budget, and true every time the daemon restarts, which is usually right
+ * after a long session. `usedPercent === undefined` is kept as a guard but effectively never
+ * fires; `complete` is what says the figure does not yet cover its window, and an incomplete
+ * window is trusted only because check 1 is standing behind it.
  */
-export function quotaHeadroom(quota: ConsumptionStatus | undefined, minFreePercent: number): AutoPmDecision {
+export function quotaHeadroom(quota: AutoPmQuota | undefined, minFreePercent: number): AutoPmDecision {
   if (!quota) return { start: false, reason: 'the quota could not be read, so there is no way to tell what is spare' }
-  const windows: [string, LimitStatus][] = [
-    ['the daily budget', quota.daily],
-    ['the 5h budget', quota.fiveHour],
-  ]
-  const enabled = windows.filter(([, limit]) => limit.enabled)
-  if (!enabled.length) {
-    return { start: false, reason: 'no consumption limit is enabled, so there is no budget to spend a share of' }
+
+  // The absolute check first: it is the only one a restarted daemon can trust.
+  if (quota.weekPercentUsed === undefined) {
+    return { start: false, reason: "the account's weekly usage could not be read, so there is no way to tell what is spare" }
   }
-  for (const [label, limit] of enabled) {
+  if (quota.weekPercentUsed > 100 - minFreePercent) {
+    return { start: false, reason: `the account's week is ${Math.round(quota.weekPercentUsed)}% used` }
+  }
+
+  const windows: [string, LimitStatus][] = [
+    ['the daily budget', quota.status.daily],
+    ['the 5h budget', quota.status.fiveHour],
+  ]
+  for (const [label, limit] of windows.filter(([, limit]) => limit.enabled)) {
     if (limit.usedPercent === undefined) {
       return { start: false, reason: `${label} has no reading yet` }
     }
@@ -146,8 +182,8 @@ export interface AutoPmDeps {
   backlogEmpty(project: AutoPmProject): Promise<boolean>
   /** How many runs are live on a project. */
   activeRuns(project: AutoPmProject): number
-  /** The current consumption reading, or `undefined` when there is none. */
-  quota(): Promise<ConsumptionStatus | undefined>
+  /** The current budget readings, or `undefined` when there are none. */
+  quota(): Promise<AutoPmQuota | undefined>
   /** The jobs to rotate through, in cycle order. */
   jobs: readonly AutoPmJob[]
   /** Start the PM run. Resolves false when the daemon refused, so the cooldown is not armed. */

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -453,7 +453,13 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     enabled: async () => (await readPrefs()).autoPm === true,
     backlogEmpty: async project => (await findTodoBacklog(project.path)) === undefined,
     activeRuns: project => runtime.activeRunCount(project.id),
-    quota: async () => (await quota.read()).limits,
+    quota: async () => {
+      const view = await quota.read()
+      // The account's own week (#848): absolute, so it still means something after a restart
+      // emptied the rolling meter. `percentUsed` of the `week` window, or nothing.
+      const week = view.windows.find(w => w.kind === 'week')?.percentUsed
+      return { status: view.limits, weekPercentUsed: typeof week === 'number' ? week : undefined }
+    },
     start: async (project, job) => (await runtime.onStart(job.prompt, 'prompt', { unattended: true }, project.id)).ok,
     log: message => console.log(message),
   })


### PR DESCRIPTION
Closes #848

Second bug in auto PM, and the one that actually spends money. Found by running the real driver against the decision path rather than by a test.

## Reproduced on main (`0f16b3e`)

```
account week actually used : 95%
daily  -> usedPercent 0 | complete false | consumed 0
5h     -> usedPercent 0 | complete false
AUTO PM DECISION: {"start":true}
```

The account has 5% of its week left and auto PM says go.

## Why

`ConsumptionMeter` is delta-based: it measures how much usage has gone **up** since it started watching. A restarted daemon has one sample and nothing to diff it against, so it honestly reports `0 consumed` regardless of what the account has spent.

My guard failed closed on `usedPercent === undefined` — right instinct, wrong value. An empty meter reports `0`, not `undefined`, so *unknown* and *untouched* were indistinguishable, and the guard never fired. `LimitStatus.complete` was carrying the honest signal the whole time and I was not reading it.

The timing is the nasty part: a restart is what empties the meter, and restarts tend to follow long heavy sessions, which is exactly when the account has least left.

## Fix

Gate on the account's own weekly figure first (`kind: 'week'`, already in the `QuotaView` the daemon reads every tick). It is absolute, it survives a restart, and its absence is itself a refusal. The rolling windows stay on top, since they catch a burst the weekly number is too coarse to see.

Verified against the fixed build:

```
restarted daemon, account at 95% : {"start":false,"reason":"the account's week is 95% used"}
restarted daemon, account at 60% : {"start":false,"reason":"the account's week is 60% used"}
restarted daemon, account at 14% : {"start":true}
no absolute reading              : {"start":false,"reason":"...could not be read..."}
LIVE account week = 14% -> {"start":true}
```

## Two things worth your eye

**The threshold.** Reusing the existing 50% means auto PM goes quiet once the week is half spent, so on a heavy week it does nothing from about Thursday on. Safe, possibly too conservative. Easy to loosen and I would rather you pick the number.

**Disabling every rolling limit no longer blocks auto PM.** It used to refuse with "no denominator"; the account week is the denominator now, so the limits behave like the pacing knobs they are. Called out because it is a behavior change beyond the bug.

## Verified

`pnpm build` green (10/10). Framework: 830 pass / 0 fail, with the 95% scenario pinned as a regression test that asserts the trap directly (`usedPercent` is `0`, not `undefined`).