### PR TITLE
build: make pnpm build refresh the dashboard bundle (#850)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "GemStack: a collection of high-quality, framework-agnostic tools. Home of @gemstack/ai-sdk.",
   "packageManager": "pnpm@11.5.3",
   "scripts": {
-    "build": "turbo run build",
+    "build": "turbo run build bundle:dashboard",
     "dev": "turbo run dev",
     "typecheck": "turbo run typecheck",
     "clean": "turbo run clean",


### PR DESCRIPTION
Closes #850

One line. `pnpm build` did not rebuild the UI the daemon actually serves.

## The symptom

The in-session agent/model select was still on screen after #832 removed it. It looked like a regression, or like a merge had clobbered the fix. Neither:

```
bundle built : 2026-07-20 01:07:58
#832 landed  : 2026-07-20 01:28:53
```

The source was correct the whole time. The daemon was serving a bundle built 21 minutes before the fix existed.

## The cause

The root scripts disagreed:

```
build   : turbo run build                      <- no bundle
release : turbo run build bundle:dashboard ... <- bundles
```

`packages/framework/dist/dashboard-client` is what the daemon serves, and only `bundle:dashboard` refreshes it. It cannot fold into `@gemstack/framework`'s own `build`, because `framework-dashboard` **depends on** `framework` and therefore builds after it, so the prerendered client does not exist yet at that point. That is why it is a separate task, and `turbo.json` already orders it:

```json
"bundle:dashboard": { "dependsOn": ["@gemstack/framework-dashboard#build"], "outputs": ["dist/dashboard-client/**"] }
```

The root `build` just never asked for it.

## Verified

Deleted `dist/dashboard-client`, ran `pnpm build`: 11 tasks instead of 10, bundle restored, and it now timestamps newer than the dashboard sources rather than older.

## Why bother, rather than just remembering

It fails silently in the worst direction: everything reports success and you debug source that is not running. It will mislead an agent even faster than a human, because a green build reads as proof.