### PR TITLE
build: make pnpm build refresh the dashboard bundle (#850)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "GemStack: a collection of high-quality, framework-agnostic tools. Home of @gemstack/ai-sdk.",
   "packageManager": "pnpm@11.5.3",
   "scripts": {
-    "build": "turbo run build",
+    "build": "turbo run build bundle:dashboard",
     "dev": "turbo run dev",
     "typecheck": "turbo run typecheck",
     "clean": "turbo run clean",


### PR DESCRIPTION
Closes #850

Replaces #851, which accidentally picked up a second, unrelated fix. One line here.

`pnpm build` did not rebuild the UI the daemon actually serves, so a dashboard change built green and the browser kept showing the previous UI.

```
bundle built : 2026-07-20 01:07:58
#832 landed  : 2026-07-20 01:28:53
```

That is why the in-session agent/model select looked like it survived #832. The source was right the whole time; the bundle predated it by 21 minutes.

The root scripts disagreed:

```
build   : turbo run build                      <- no bundle
release : turbo run build bundle:dashboard ... <- bundles
```

It cannot fold into `@gemstack/framework`'s own `build`: `framework-dashboard` **depends on** `framework`, so it builds after, and the prerendered client does not exist at that point. That is why it is a separate task, and `turbo.json` already orders it correctly. The root `build` just never asked for it.

Verified: deleted `dist/dashboard-client`, ran `pnpm build`, got 11 tasks instead of 10 and the bundle back, now timestamping newer than the dashboard sources rather than older.

It fails silently and in the worst direction: everything reports success while you debug source that is not running.