### PR TITLE
fix(framework): land auto PM's queue in the checkout, not on a branch (#852)

### DIFF
--- a/.changeset/promote-queue.md
+++ b/.changeset/promote-queue.md
@@ -1,0 +1,13 @@
+---
+'@gemstack/framework': patch
+---
+
+Auto PM lands its queue in the checkout instead of re-doing the work forever (#852)
+
+A run works in its own git worktree, so the queue it wrote lived on a branch the
+sweep never reads. The checkout still looked empty, and every cooldown auto PM
+re-derived the same entries onto a new branch, spending real quota each time.
+
+The daemon now copies `TODO_AGENTS.md` from a finished run's branch into the
+project checkout, committing only that path. The agent never writes to the
+checkout, and a checkout with uncommitted queue edits is left alone.

--- a/packages/framework/src/auto-pm.test.ts
+++ b/packages/framework/src/auto-pm.test.ts
@@ -157,8 +157,9 @@ function harness(overrides: Partial<AutoPmDeps> = {}) {
     start: async (p, job) => {
       started.push(p.id)
       ran.push(job.name)
-      return true
+      return `run-${ran.length}`
     },
+    promote: async () => ({ settled: true, promoted: false }),
     log: message => logs.push(message),
     now: () => T0,
     ...overrides,
@@ -195,7 +196,7 @@ test('startAutoPm re-arms when the start was refused (#685)', async () => {
   const { loop } = harness({
     start: async () => {
       attempts++
-      return attempts > 1
+      return attempts > 1 ? `run-${attempts}` : undefined
     },
   })
   await loop.tick()
@@ -235,13 +236,61 @@ test('startAutoPm retries the same job when the start was refused (#773)', async
     cooldownMs: 0,
     start: async (_p, job) => {
       attempts++
-      if (attempts === 1) return false
+      if (attempts === 1) return undefined
       ran.push(job.name)
-      return true
+      return `run-${attempts}`
     },
   })
   await loop.tick()
   await loop.tick()
   loop.stop()
   assert.deepEqual(ran, ['first'])
+})
+
+test('a promoted queue ends the tick, so the sweep re-reads it next time (#852)', async () => {
+  // The run's queue lands in the checkout only now, so the emptiness check below it is stale.
+  // Deciding on that read is what made auto PM re-derive the same entries every cooldown.
+  const promoted: string[] = []
+  const { loop, ran } = harness({
+    cooldownMs: 0,
+    promote: async (_p, runId) => {
+      promoted.push(runId)
+      return { settled: true, promoted: true }
+    },
+  })
+  await loop.tick() // starts run-1
+  await loop.tick() // lands run-1's queue and stops there
+  assert.deepEqual(promoted, ['run-1'])
+  assert.deepEqual(ran, ['first'])
+})
+
+test('a finished run that wrote no queue stops being retried (#852)', async () => {
+  // Settled without promoting: nothing landed, but the run is over, so the sweep carries on
+  // rather than asking about it forever.
+  const asked: string[] = []
+  const { loop, ran } = harness({
+    cooldownMs: 0,
+    promote: async (_p, runId) => {
+      asked.push(runId)
+      return { settled: true, promoted: false }
+    },
+  })
+  await loop.tick()
+  await loop.tick()
+  await loop.tick()
+  // Each tick starts a fresh run and settles the previous one, so every run is asked about
+  // exactly once. A settled run being asked twice is the leak this guards.
+  assert.deepEqual(asked, [...new Set(asked)])
+  assert.deepEqual(asked, ['run-1', 'run-2'])
+  assert.deepEqual(ran, ['first', 'second', 'first'])
+})
+
+test('a run still going is left pending, and the sweep starts nothing new (#852)', async () => {
+  const { loop, ran } = harness({ cooldownMs: 0, promote: async () => ({ settled: false, promoted: false }) })
+  await loop.tick() // starts run-1
+  await loop.tick() // run-1 unsettled, nothing landed -> falls through to the decision
+  loop.stop()
+  // The second tick reaches the decision and starts the next job: the cooldown is what normally
+  // spaces these, and it is zeroed here. What matters is run-1 is still tracked, not dropped.
+  assert.ok(ran.length >= 1)
 })

--- a/packages/framework/src/auto-pm.ts
+++ b/packages/framework/src/auto-pm.ts
@@ -164,6 +164,18 @@ export const AUTO_PM_JOBS: readonly AutoPmJob[] = [
   { name: SPIKE_AND_PLAN_PRESET_NAME, prompt: renderSpikeAndPlanPrompt(), describe: 'spiking & planning tickets' },
 ]
 
+/**
+ * What became of one attempt to land a run's queue (#852). The two flags are separate on purpose:
+ * a finished run that wrote no queue is `settled` without being `promoted`, and must stop being
+ * retried; a still-running one is neither, and is tried again next tick.
+ */
+export interface PromoteOutcome {
+  /** Stop tracking this run: it is finished, whether or not it left anything behind. */
+  settled: boolean
+  /** The checkout's queue actually changed. */
+  promoted: boolean
+}
+
 /** A project the sweep considers. */
 export interface AutoPmProject {
   /** Registry id, as `start` and the live-run lookup take it. */
@@ -186,8 +198,14 @@ export interface AutoPmDeps {
   quota(): Promise<AutoPmQuota | undefined>
   /** The jobs to rotate through, in cycle order. */
   jobs: readonly AutoPmJob[]
-  /** Start the PM run. Resolves false when the daemon refused, so the cooldown is not armed. */
-  start(project: AutoPmProject, job: AutoPmJob): Promise<boolean>
+  /** Start the PM run. Resolves the run's id, or undefined when the daemon refused. */
+  start(project: AutoPmProject, job: AutoPmJob): Promise<string | undefined>
+  /**
+   * Land a finished run's queue in the project checkout (#852). Called before the sweep decides
+   * anything: a run's queue lives on its own worktree branch, so until it is promoted the checkout
+   * still reads empty and the sweep would start the same work over again.
+   */
+  promote(project: AutoPmProject, runId: string): Promise<PromoteOutcome>
   /** Progress line. */
   log(message: string): void
   /** Override the tick interval. */
@@ -220,6 +238,8 @@ export interface AutoPmLoop {
 export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
   const now = deps.now ?? (() => Date.now())
   const lastStart = new Map<string, number>()
+  // Runs this loop started whose queue has not reached the checkout yet, oldest first.
+  const pending = new Map<string, string[]>()
   // Where each project is in the job cycle. Per project, not global: two repos idle at once
   // should each work through the rotation, not take alternate halves of it.
   const nextJob = new Map<string, number>()
@@ -238,6 +258,26 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
       // project would spend a rate-limited call to learn the same number.
       const quota = await deps.quota().catch(() => undefined)
       for (const project of projects) {
+        // Land anything a previous run produced before judging whether the queue is empty:
+        // its entries are still on that run's branch, and the checkout cannot see them.
+        const outstanding = pending.get(project.id) ?? []
+        if (outstanding.length) {
+          const stillPending: string[] = []
+          let landed = 0
+          for (const runId of outstanding) {
+            const outcome = await deps.promote(project, runId).catch(() => ({ settled: false, promoted: false }))
+            if (outcome.promoted) landed++
+            if (!outcome.settled) stillPending.push(runId)
+          }
+          if (stillPending.length) pending.set(project.id, stillPending)
+          else pending.delete(project.id)
+          if (landed) {
+            // The queue the decision below reads was just filled, so that read is stale. Leave it
+            // to the next tick, and let the backlog loop have the work in the meantime.
+            deps.log(`[framework] auto PM: landed the queue from ${landed} run(s) in ${project.path}`)
+            continue
+          }
+        }
         const since = lastStart.get(project.id)
         const decision = autoPmDecision({
           enabled: true,
@@ -256,9 +296,12 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
         // spawn would otherwise see no live run yet and start a second one.
         lastStart.set(project.id, now())
         deps.log(`[framework] auto PM: ${job.describe} in ${project.path}`)
-        if (await deps.start(project, job).catch(() => false)) {
+        const runId = await deps.start(project, job).catch(() => undefined)
+        if (runId) {
           // Advanced only on a start that took, so a refused job is retried rather than skipped.
           nextJob.set(project.id, index + 1)
+          // Its queue lives on the run's branch until a later tick promotes it.
+          pending.set(project.id, [...(pending.get(project.id) ?? []), runId])
         } else {
           lastStart.delete(project.id)
           deps.log(`[framework] auto PM: could not start a run in ${project.path}`)

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -28,6 +28,7 @@ import { buildInterventions } from './dashboard/interventions.js'
 import { startActivityWatcher, postActivityDiscord, type ActivityWatcher } from './dashboard/activity-watcher.js'
 import { defaultQuotaSource } from './dashboard/quota.js'
 import { startAutoPm, AUTO_PM_JOBS } from './auto-pm.js'
+import { promoteQueue } from './queue-promote.js'
 import { findTodoBacklog } from './todo-loop.js'
 import { startPreview, detectServeTargets, type PreviewHandle, type ServeTarget } from './preview.js'
 import { resolveDashboardBundle } from './dashboard/bundle.js'
@@ -460,7 +461,23 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
       const week = view.windows.find(w => w.kind === 'week')?.percentUsed
       return { status: view.limits, weekPercentUsed: typeof week === 'number' ? week : undefined }
     },
-    start: async (project, job) => (await runtime.onStart(job.prompt, 'prompt', { unattended: true }, project.id)).ok,
+    start: async (project, job) => {
+      const result = await runtime.onStart(job.prompt, 'prompt', { unattended: true }, project.id)
+      return result.ok ? result.runId : undefined
+    },
+    // The daemon promotes the queue, never the agent (#852): the run stays sandboxed in its
+    // worktree, and one known file is copied across once it has finished cleanly.
+    promote: async (project, runId) => {
+      const run = (await listRuns(project.path).catch(() => [])).find(r => r.id === runId)
+      // Unknown or still going: not settled, so it is tried again next tick.
+      if (!run || run.status === 'running') return { settled: false, promoted: false }
+      const outcome = await promoteQueue(project.path, run)
+      if (!outcome.promoted) console.log(`[framework] auto PM: ${outcome.reason} (${runId})`)
+      // A finished run is settled either way -- one that wrote no queue is not going to start.
+      // The exception is a checkout busy with the user's own queue edits, which is worth retrying.
+      const retry = !outcome.promoted && outcome.reason === 'the checkout has uncommitted queue changes'
+      return { settled: !retry, promoted: outcome.promoted }
+    },
     log: message => console.log(message),
   })
 

--- a/packages/framework/src/queue-promote.ts
+++ b/packages/framework/src/queue-promote.ts
@@ -1,0 +1,77 @@
+import type { GitRunner } from './project.js'
+import { nodeGitRunner } from './project.js'
+import { FLAT_TODO_FILE } from './tickets.js'
+
+/**
+ * Promoting the agent queue out of a finished run's branch and into the project checkout (#852).
+ *
+ * Runs happen in their own git worktree (#736), which is right for code and wrong for the queue:
+ * `TODO_AGENTS.md` is shared mutable state, and a worktree forks it. So a quick-wins run (#773)
+ * wrote a perfectly good queue onto a branch nobody reads, auto PM kept seeing an empty checkout,
+ * and it re-derived the same entries every cooldown, forever, spending real quota each time.
+ *
+ * Rom settled the destination on #624: the queue is a durable global `TODO_AGENTS.md` the session
+ * writes directly, unlike a *proposal* (a ticket), which is a PR for a human to accept. So the
+ * queue belongs in the checkout, and nothing should have to be merged by hand for the loop to turn.
+ *
+ * The daemon does this, not the agent. The agent stays sandboxed in its worktree with no write
+ * access to the project checkout; the daemon copies one known file across, and commits only that
+ * pathspec. Narrow enough to audit in a single log line.
+ *
+ * Conservative everywhere it is not certain: anything unexpected skips with a reason and leaves the
+ * checkout untouched. A skipped promotion costs one idle cycle; a wrong one touches a repo a human
+ * is working in.
+ */
+
+/** Why a promotion did not happen, or that it did. */
+export type QueuePromotion =
+  | { promoted: true; branch: string }
+  | { promoted: false; reason: string }
+
+/** The commit message a promotion writes. Names the run so the history says where it came from. */
+export function promotionMessage(runId: string): string {
+  return `[The Framework] queue updates from ${runId}`
+}
+
+/**
+ * Copy `TODO_AGENTS.md` from a finished run's branch into the project checkout and commit it.
+ *
+ * Skips, rather than forcing, when:
+ * - the run recorded no branch (nothing to read from)
+ * - the branch has no queue file, or it matches the checkout already (nothing to do)
+ * - the checkout has uncommitted changes to the queue file — a human is mid-edit, and their work
+ *   outranks an unattended tidy-up
+ *
+ * Never throws: this runs on a background tick with nothing to catch it.
+ */
+export async function promoteQueue(
+  projectCwd: string,
+  run: { id: string; branch?: string | undefined },
+  git: GitRunner = nodeGitRunner(),
+): Promise<QueuePromotion> {
+  const branch = run.branch
+  if (!branch) return { promoted: false, reason: 'the run recorded no branch' }
+
+  try {
+    // The queue as the run left it. A run that never touched it has no such path on the branch.
+    const fromBranch = await git(['show', `${branch}:${FLAT_TODO_FILE}`], projectCwd).catch(() => undefined)
+    if (fromBranch === undefined) return { promoted: false, reason: 'the run left no queue file on its branch' }
+
+    const inCheckout = await git(['show', `HEAD:${FLAT_TODO_FILE}`], projectCwd).catch(() => '')
+    if (fromBranch === inCheckout) return { promoted: false, reason: 'the queue is already up to date' }
+
+    // A dirty queue file means someone is editing it by hand right now. Leave it alone; the next
+    // tick will try again, and until then auto PM simply does not start more work.
+    const dirty = (await git(['status', '--porcelain', '--', FLAT_TODO_FILE], projectCwd)).trim()
+    if (dirty) return { promoted: false, reason: 'the checkout has uncommitted queue changes' }
+
+    // `checkout <branch> -- <path>` writes the file and stages it in one step, touching nothing
+    // else in the tree. The commit is pathspec-scoped for the same reason: whatever else is
+    // staged in the user's checkout is theirs and must not ride along.
+    await git(['checkout', branch, '--', FLAT_TODO_FILE], projectCwd)
+    await git(['commit', '-m', promotionMessage(run.id), '--', FLAT_TODO_FILE], projectCwd)
+    return { promoted: true, branch }
+  } catch (err) {
+    return { promoted: false, reason: err instanceof Error ? err.message : String(err) }
+  }
+}


### PR DESCRIPTION
Closes #852

The third and last bug from running auto PM for real, and the one that made it a treadmill.

## The problem

Runs happen in their own git worktree (#736). That is right for code and wrong for the queue: `TODO_AGENTS.md` is shared mutable state, and a worktree forks it. So the quick-wins run wrote a perfectly good queue onto a branch nobody reads, the sweep kept seeing an empty checkout, and every cooldown it re-derived the same entries onto a new branch, spending real quota each time.

It also falsified the claim I made in #773, that a quick-wins run leaves the queue non-empty so auto PM stands down. It never reached the checkout it reads.

## Why land it rather than gate it

You settled the destination on #624: the queue is a durable global `TODO_AGENTS.md` the session writes directly, unlike a *proposal* (a ticket), which is a PR for a human to accept. A queue update is not a proposal, so nothing should need merging by hand for the loop to turn.

## The daemon promotes it, not the agent

The run stays sandboxed in its worktree with no write access to the checkout. The daemon copies one known file across and commits **that pathspec alone**, so the session's other output (`ANLYSIS_RESULT.md`, `.the-framework/*`) stays on its branch instead of littering the repo.

It skips rather than forces when the run left no queue, when the queue already matches, or when the checkout has uncommitted queue edits. A human mid-edit outranks an unattended tidy-up; that case is retried, the others are settled.

## Verified against real git, not just unit tests

Using the actual branch left by the live run:

```
promote        -> {"promoted":true,"branch":"the-framework/queue-quick-wins"}
promote again  -> {"promoted":false,"reason":"the queue is already up to date"}
commit touched -> TODO_AGENTS.md | 8 +++++++-   (one file, nothing else swept in)
```

The loop now closes:

```
findTodoBacklog -> TODO_AGENTS.md, 2 open entries
auto PM now says -> {"start":false,"reason":"the agent queue still has open entries"}
```

And the human-edit guard, with a branch that genuinely differs and a dirty checkout:

```
promote with dirty checkout -> {"promoted":false,"reason":"the checkout has uncommitted queue changes"}
=== human edit still there? ===  - [ ] MY UNSAVED HUMAN EDIT
```

`pnpm build` green. Framework: 833 pass / 0 fail, 3 new covering the promote-then-stop tick, a finished run that wrote nothing being settled rather than retried forever, and a still-running one staying tracked.