### PR TITLE
fix(framework): auto PM drains the agent queue, not just fills it (#855)

### DIFF
--- a/.changeset/auto-pm-drains-queue.md
+++ b/.changeset/auto-pm-drains-queue.md
@@ -1,0 +1,15 @@
+---
+'@gemstack/framework': patch
+---
+
+Auto PM now drains the agent queue as well as filling it (#855)
+
+Auto PM only ever put work into `TODO_AGENTS.md`, and nothing unattended took it out
+again: the backlog loop is a phase inside a run a human started, and auto PM's own runs
+go down the prompt path, which never reaches it. So the queue filled once and every
+later tick refused because it was no longer empty, and the daemon went quiet for good.
+
+A tick that finds open entries now starts a run for the first one instead of standing
+down, and goes back to harvesting quick-wins and planning tickets once the queue is dry.
+A queue that cannot be read at all is still a refusal. The refusal reason is logged each
+tick, so a wedged sweep no longer looks the same as a healthy idle one.

--- a/packages/framework/prompts/presets/drain_queue.md
+++ b/packages/framework/prompts/presets/drain_queue.md
@@ -1,0 +1,1 @@
+Open TODO_AGENTS.md and work on the FIRST open entry only, then check it off. Do not start any other entry.

--- a/packages/framework/src/auto-pm.test.ts
+++ b/packages/framework/src/auto-pm.test.ts
@@ -6,6 +6,7 @@ import {
   startAutoPm,
   DEFAULT_MIN_FREE_PERCENT,
   AUTO_PM_JOBS,
+  AUTO_PM_DRAIN_JOB,
   type AutoPmDeps,
   type AutoPmJob,
   type AutoPmProject,
@@ -36,7 +37,7 @@ function status(weekPercent: number | undefined, accountWeek: number | undefined
 const IDLE = { enabled: true, backlogEmpty: true, activeRuns: 0, quota: status(1) } as const
 
 test('autoPmDecision starts when the queue is dry and the budget is barely touched (#685)', () => {
-  assert.deepEqual(autoPmDecision(IDLE), { start: true })
+  assert.deepEqual(autoPmDecision(IDLE), { start: true, mode: 'pm' })
 })
 
 test('autoPmDecision does nothing while the preference is off (#685)', () => {
@@ -51,18 +52,25 @@ test('autoPmDecision leaves a busy project alone (#685)', () => {
   assert.match(decision.start === false ? decision.reason : '', /already going/)
 })
 
-test('autoPmDecision waits while the queue still has entries (#685)', () => {
-  // #685 is only about the dry-queue case: with work queued, the backlog loop has it.
-  const decision = autoPmDecision({ ...IDLE, backlogEmpty: false })
+test('autoPmDecision drains the queue before filling it again (#855)', () => {
+  // It used to refuse here, on the reasoning that the backlog loop would drain it. That loop
+  // only runs inside a run a human started, so unattended nothing ever emptied the queue.
+  assert.deepEqual(autoPmDecision({ ...IDLE, backlogEmpty: false }), { start: true, mode: 'drain' })
+})
+
+test('autoPmDecision refuses when the queue cannot be read at all (#855)', () => {
+  // Empty and non-empty both start something now, so "could not tell" has to be its own answer
+  // rather than falling back to either.
+  const decision = autoPmDecision({ ...IDLE, backlogEmpty: undefined })
   assert.equal(decision.start, false)
-  assert.match(decision.start === false ? decision.reason : '', /still has open entries/)
+  assert.match(decision.start === false ? decision.reason : '', /queue could not be read/)
 })
 
 test('autoPmDecision holds off during the cooldown after a start (#685)', () => {
   const decision = autoPmDecision({ ...IDLE, sinceLastStartMs: 60_000 })
   assert.equal(decision.start, false)
   const later = autoPmDecision({ ...IDLE, sinceLastStartMs: 60 * 60_000 })
-  assert.deepEqual(later, { start: true })
+  assert.deepEqual(later, { start: true, mode: 'pm' })
 })
 
 test('quotaHeadroom refuses to start when the quota cannot be read (#685)', () => {
@@ -293,4 +301,64 @@ test('a run still going is left pending, and the sweep starts nothing new (#852)
   // The second tick reaches the decision and starts the next job: the cooldown is what normally
   // spaces these, and it is zeroed here. What matters is run-1 is still tracked, not dropped.
   assert.ok(ran.length >= 1)
+})
+
+test('startAutoPm drains a standing queue, then goes back to filling it (#855)', async () => {
+  // The deadlock this fixes: a PM job filled the queue, nothing unattended drained it, and every
+  // later tick refused because it was no longer empty. The cycle has to come back round.
+  let open = 1
+  const ran: string[] = []
+  const { loop } = harness({
+    cooldownMs: 0,
+    backlogEmpty: async () => open === 0,
+    // A drain run works one entry off; a PM run puts one there.
+    start: async (_project, job) => {
+      ran.push(job.name)
+      open += job.name === AUTO_PM_DRAIN_JOB.name ? -1 : 1
+      return `run-${ran.length}`
+    },
+  })
+  await loop.tick() // an entry is standing -> work it off
+  await loop.tick() // dry now -> refill
+  await loop.tick() // standing again -> work it off
+  loop.stop()
+  assert.deepEqual(ran, [AUTO_PM_DRAIN_JOB.name, 'first', AUTO_PM_DRAIN_JOB.name])
+})
+
+test('draining does not advance the PM rotation (#855)', async () => {
+  // The rotation is about what to make when there is nothing to do. A queue worked off over
+  // several ticks must not push it forward once per entry and skip a job.
+  let open = 2
+  const ran: string[] = []
+  const { loop } = harness({
+    cooldownMs: 0,
+    backlogEmpty: async () => open === 0,
+    start: async (_project, job) => {
+      ran.push(job.name)
+      open += job.name === AUTO_PM_DRAIN_JOB.name ? -1 : 1
+      return `run-${ran.length}`
+    },
+  })
+  await loop.tick()
+  await loop.tick()
+  await loop.tick() // dry -> the rotation resumes at its first job, not its second
+  loop.stop()
+  assert.deepEqual(ran, [AUTO_PM_DRAIN_JOB.name, AUTO_PM_DRAIN_JOB.name, 'first'])
+})
+
+test('an unreadable queue starts nothing at all (#855)', async () => {
+  const ran: string[] = []
+  const { loop } = harness({
+    cooldownMs: 0,
+    backlogEmpty: async () => {
+      throw new Error('no such file')
+    },
+    start: async (_project, job) => {
+      ran.push(job.name)
+      return 'run-1'
+    },
+  })
+  await loop.tick()
+  loop.stop()
+  assert.deepEqual(ran, [])
 })

--- a/packages/framework/src/auto-pm.ts
+++ b/packages/framework/src/auto-pm.ts
@@ -1,12 +1,14 @@
 import type { ConsumptionStatus, LimitStatus } from './consumption.js'
 import { renderSpikeAndPlanPrompt, SPIKE_AND_PLAN_PRESET_NAME } from './spike-and-plan-preset.js'
 import { renderQuickWinsPrompt, QUICK_WINS_PRESET_NAME } from './quick-wins-preset.js'
+import { renderDrainQueuePrompt, DRAIN_QUEUE_PRESET_NAME } from './drain-queue-preset.js'
 
 /**
  * Auto PM (#685): spend leftover subscription quota on product management instead of
- * letting it expire. When the agent queue is empty and there is plenty of budget left,
- * the daemon starts a PM run by itself — spiking and planning the tickets that have
- * neither yet — so the backlog refills while nobody is at the keyboard.
+ * letting it expire. While there is plenty of budget left and nobody is at the keyboard,
+ * the daemon runs the cycle by itself: it works the agent queue down entry by entry (#855),
+ * and once that is empty it refills it — harvesting quick-wins, then spiking and planning
+ * the tickets that have neither yet.
  *
  * The whole feature is one policy question ("is now a good time to spend tokens on our
  * own roadmap?"), so that question lives here as a pure function and the daemon only
@@ -31,8 +33,12 @@ export const DEFAULT_AUTO_PM_COOLDOWN_MS = 30 * 60 * 1000
 export interface AutoPmInputs {
   /** The `autoPm` preference. Off = the feature does nothing at all. */
   enabled: boolean
-  /** Whether the project's agent queue (`TODO_AGENTS.md`) has no open entry left. */
-  backlogEmpty: boolean
+  /**
+   * Whether the project's agent queue (`TODO_AGENTS.md`) has no open entry left, or `undefined`
+   * when it could not be read. Unreadable is not empty and not full: it fails closed, because
+   * since #855 both answers now *start* something and only "we could not tell" does not.
+   */
+  backlogEmpty: boolean | undefined
   /** Live runs on this project. Any run at all means the user's quota is already being spent. */
   activeRuns: number
   /** The budget readings, or `undefined` when the quota could not be read. */
@@ -45,8 +51,20 @@ export interface AutoPmInputs {
   cooldownMs?: number
 }
 
-/** Start, or the reason not to. The reason is logged, so it reads as a sentence. */
-export type AutoPmDecision = { start: true } | { start: false; reason: string }
+/** Why the sweep is not starting anything. Logged, so it reads as a sentence. */
+export type AutoPmRefusal = { start: false; reason: string }
+
+/**
+ * Which half of the cycle a start belongs to (#855). `drain` works an entry the queue already
+ * holds; `pm` puts new work in it. The queue decides: standing work is spent before more is made.
+ */
+export type AutoPmMode = 'drain' | 'pm'
+
+/** Whether the budget allows spending unasked at all, before asking what to spend it on. */
+export type QuotaDecision = { start: true } | AutoPmRefusal
+
+/** Start (and at what), or the reason not to. */
+export type AutoPmDecision = { start: true; mode: AutoPmMode } | AutoPmRefusal
 
 /**
  * What one tick knows about the budget: the rolling windows, and the account's own weekly
@@ -91,7 +109,7 @@ export interface AutoPmQuota {
  * fires; `complete` is what says the figure does not yet cover its window, and an incomplete
  * window is trusted only because check 1 is standing behind it.
  */
-export function quotaHeadroom(quota: AutoPmQuota | undefined, minFreePercent: number): AutoPmDecision {
+export function quotaHeadroom(quota: AutoPmQuota | undefined, minFreePercent: number): QuotaDecision {
   if (!quota) return { start: false, reason: 'the quota could not be read, so there is no way to tell what is spare' }
 
   // The absolute check first: it is the only one a restarted daemon can trust.
@@ -127,14 +145,19 @@ export function autoPmDecision(input: AutoPmInputs): AutoPmDecision {
   if (input.activeRuns > 0) {
     return { start: false, reason: `${input.activeRuns} run${input.activeRuns === 1 ? ' is' : 's are'} already going` }
   }
-  // A non-empty queue is not idleness: the backlog loop has work to drain, and #685 is
-  // about the case where it has run dry.
-  if (!input.backlogEmpty) return { start: false, reason: 'the agent queue still has open entries' }
   const cooldownMs = input.cooldownMs ?? DEFAULT_AUTO_PM_COOLDOWN_MS
   if (input.sinceLastStartMs !== undefined && input.sinceLastStartMs < cooldownMs) {
     return { start: false, reason: 'a run was started for this project a moment ago' }
   }
-  return quotaHeadroom(input.quota, input.minFreePercent ?? DEFAULT_MIN_FREE_PERCENT)
+  if (input.backlogEmpty === undefined) {
+    return { start: false, reason: 'the agent queue could not be read, so there is no way to tell what to do' }
+  }
+  const headroom = quotaHeadroom(input.quota, input.minFreePercent ?? DEFAULT_MIN_FREE_PERCENT)
+  if (!headroom.start) return headroom
+  // The queue picks the job, and a non-empty one wins (#855). It used to be a refusal, on the
+  // reasoning that the backlog loop would drain it — but that loop only exists inside a run a
+  // human started, so unattended the queue filled once and nothing ever emptied it again.
+  return { start: true, mode: input.backlogEmpty ? 'pm' : 'drain' }
 }
 
 /**
@@ -143,8 +166,8 @@ export function autoPmDecision(input: AutoPmInputs): AutoPmDecision {
  * The jobs form a cycle, and the order matters: [Quick wins] turns existing plans into queued
  * work, [Spike & plan] turns tickets into plans. Harvesting first means a machine that already
  * has plans starts *doing* rather than planning more. Once a job queues something the sweep
- * stands down anyway — the backlog is no longer empty — so the next idle moment picks up the
- * rotation where it left off.
+ * switches to draining it (#855), and the rotation resumes where it left off once the queue is
+ * empty again.
  */
 export interface AutoPmJob {
   /** Stable id, used for the rotation and the log line. */
@@ -163,6 +186,17 @@ export const AUTO_PM_JOBS: readonly AutoPmJob[] = [
   { name: QUICK_WINS_PRESET_NAME, prompt: renderQuickWinsPrompt(), describe: 'harvesting quick-wins from the plans' },
   { name: SPIKE_AND_PLAN_PRESET_NAME, prompt: renderSpikeAndPlanPrompt(), describe: 'spiking & planning tickets' },
 ]
+
+/**
+ * The job for a queue that is not empty (#855): work its first entry off. Outside the rotation
+ * on purpose — the rotation is about what to *make* when there is nothing to do, and this is
+ * the thing to do.
+ */
+export const AUTO_PM_DRAIN_JOB: AutoPmJob = {
+  name: DRAIN_QUEUE_PRESET_NAME,
+  prompt: renderDrainQueuePrompt(),
+  describe: 'draining the first open queue entry',
+}
 
 /**
  * What became of one attempt to land a run's queue (#852). The two flags are separate on purpose:
@@ -196,8 +230,10 @@ export interface AutoPmDeps {
   activeRuns(project: AutoPmProject): number
   /** The current budget readings, or `undefined` when there are none. */
   quota(): Promise<AutoPmQuota | undefined>
-  /** The jobs to rotate through, in cycle order. */
+  /** The jobs to rotate through, in cycle order. Used only while the queue is empty. */
   jobs: readonly AutoPmJob[]
+  /** The job for a queue with open entries (#855); {@link AUTO_PM_DRAIN_JOB} by default. */
+  drainJob?: AutoPmJob
   /** Start the PM run. Resolves the run's id, or undefined when the daemon refused. */
   start(project: AutoPmProject, job: AutoPmJob): Promise<string | undefined>
   /**
@@ -281,16 +317,20 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
         const since = lastStart.get(project.id)
         const decision = autoPmDecision({
           enabled: true,
-          backlogEmpty: await deps.backlogEmpty(project).catch(() => false),
+          backlogEmpty: await deps.backlogEmpty(project).catch(() => undefined),
           activeRuns: deps.activeRuns(project),
           quota,
           ...(since !== undefined ? { sinceLastStartMs: now() - since } : {}),
           ...(deps.minFreePercent !== undefined ? { minFreePercent: deps.minFreePercent } : {}),
           ...(deps.cooldownMs !== undefined ? { cooldownMs: deps.cooldownMs } : {}),
         })
-        if (!decision.start) continue
+        if (!decision.start) {
+          // Logged, so a wedged sweep is distinguishable from a healthy idle one (#855).
+          deps.log(`[framework] auto PM: standing down for ${project.path} — ${decision.reason}`)
+          continue
+        }
         const index = nextJob.get(project.id) ?? 0
-        const job = deps.jobs[index % deps.jobs.length]
+        const job = decision.mode === 'drain' ? (deps.drainJob ?? AUTO_PM_DRAIN_JOB) : deps.jobs[index % deps.jobs.length]
         if (!job) continue
         // Armed before the spawn, not after: starting is slow, and a tick that overlapped the
         // spawn would otherwise see no live run yet and start a second one.
@@ -299,7 +339,9 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
         const runId = await deps.start(project, job).catch(() => undefined)
         if (runId) {
           // Advanced only on a start that took, so a refused job is retried rather than skipped.
-          nextJob.set(project.id, index + 1)
+          // Draining does not advance it: it is not part of the cycle, and a queue worked off
+          // over several ticks must not skip the rotation forward once per entry.
+          if (decision.mode === 'pm') nextJob.set(project.id, index + 1)
           // Its queue lives on the run's branch until a later tick promotes it.
           pending.set(project.id, [...(pending.get(project.id) ?? []), runId])
         } else {

--- a/packages/framework/src/drain-queue-preset.ts
+++ b/packages/framework/src/drain-queue-preset.ts
@@ -1,0 +1,26 @@
+import { PRESETS_DRAIN_QUEUE } from './prompts.generated.js'
+
+/**
+ * The [Drain queue] preset (#855): work the first open entry of `TODO_AGENTS.md` and check it
+ * off. This is the half of the cycle auto PM was missing — [Quick wins] and [Spike & plan] only
+ * ever *fill* the queue, and the in-session backlog loop only exists inside a run a human
+ * started, so an unattended daemon filled the queue once and then refused forever.
+ *
+ * One entry per run, not the whole backlog: the sweep's cooldown and quota gate then apply per
+ * entry, so a long queue is spent deliberately rather than in one unattended burst.
+ *
+ * The wording mirrors the in-session backlog loop's own per-item prompt, so both paths ask the
+ * agent for the same thing and a queue drained either way looks the same afterwards.
+ */
+
+/** The preset's run-kind name, as the dashboard button uses it. */
+export const DRAIN_QUEUE_PRESET_NAME = 'drain-queue'
+
+/** The prompt, from `prompts/presets/drain_queue.md`. */
+export const DRAIN_QUEUE_PROMPT_TEMPLATE = PRESETS_DRAIN_QUEUE
+
+/** No user params: the whole prompt is the one line, so there is nothing to fill. */
+export const DRAIN_QUEUE_PARAMS: readonly [] = []
+
+/** Render the prompt. Paramless, so it is the template verbatim. */
+export const renderDrainQueuePrompt = (): string => DRAIN_QUEUE_PROMPT_TEMPLATE


### PR DESCRIPTION
Closes #855

Auto PM filled the agent queue and nothing unattended ever emptied it, so the autonomy loop ran exactly one turn and then went quiet for good.

## Why it deadlocked

`autoPmDecision` refused whenever the queue had open entries, on the reasoning in the comment: "the backlog loop has work to drain". But that loop (`runTodoLoop`) has one non-test caller, `run.ts:410` - a phase at the end of an already-running build. In the daemon, the only non-test caller of `runtime.onStart` is auto PM itself. So the one thing that starts runs unattended is the one that refuses whenever there is work to do.

And auto PM's runs could not have drained it anyway: they start with kind `'prompt'`, which returns early through `runPrompt` (`cli.ts:1327`) and never reaches `runFramework`. It can only fill.

## What changed

A tick that finds open entries starts a run for the first one ([Drain queue], one entry per run) instead of standing down; once the queue is dry the [Quick wins] / [Spike & plan] rotation resumes where it left off. The existing #854 promotion already carries the check-off back from the run's branch into the checkout, which is what lets the next tick see progress.

Draining deliberately does not advance the PM rotation: that cycle is about what to *make* when there is nothing to do, and a queue worked off over several ticks must not skip a job once per entry.

One entry per run, not the whole backlog, so the cooldown and the quota gate apply per entry rather than letting a long queue go off in one unattended burst.

## Two things worth a second look

**An unreadable queue is now its own refusal.** It used to fall through as "non-empty", which was safe when non-empty meant stop. Now both readable answers start something, so "could not tell" needs its own branch or an unreadable queue would start a drain run. An existing #685 test caught this, which is the only reason it is in the diff.

**Refusals are now logged each tick.** They were silent, so a wedged sweep looked exactly like a healthy idle one - that is why this went unnoticed.

## Verified

Live, isolated registry + scratch repo, daemon on 4399. Before the fix: the tick fired at the 10-minute mark and nothing happened - no run, no branch, both queue entries still open, no log line. That is the bug, on merged main.

Build 11/11, typecheck 21/21, framework tests 838 pass / 0 fail (5 new, including one that runs three ticks and asserts drain -> fill -> drain).

## Note

The drain run's code changes stay on its worktree branch; only `TODO_AGENTS.md` is promoted. That is intended - a human still reviews the work - but it is the same "unattended write to the checkout" question raised on #852 and worth ratifying together.
