### PR TITLE
fix(framework): auto PM starts runs with the project's own settings (#858)

### DIFF
--- a/.changeset/auto-pm-run-options.md
+++ b/.changeset/auto-pm-run-options.md
@@ -1,0 +1,14 @@
+---
+'@gemstack/framework': patch
+---
+
+Auto PM now starts runs with the project's own settings (#858)
+
+An unattended run was started with no options at all, so it ignored the agent, the
+model, and every other per-project setting a launcher-started run would have honoured.
+A project configured for Codex had auto PM running Claude.
+
+The preferences to run-options mapping moved out of the dashboard client into the
+framework's browser-safe entry, so the daemon and the launcher now share one copy of it
+rather than two that can drift. `--unattended` is still forced on regardless of what the
+preferences say: that is a property of nobody watching, not something to configure.

--- a/packages/framework-dashboard/lib/preferences.ts
+++ b/packages/framework-dashboard/lib/preferences.ts
@@ -151,10 +151,10 @@ export function usePreferences(): Preferences {
   return preferences
 }
 
-/** Autopilot defaults on (the demo default), matching the old localStorage semantics. */
-export function autopilotEnabled(preferences: Preferences): boolean {
-  return preferences.autopilot ?? true
-}
+// Autopilot's default-on moved into @gemstack/framework with the rest of the preferences ->
+// run options mapping (#858), so the daemon resolves it the same way. Re-exported here because
+// every component reaches for it through this module.
+export { autopilotEnabled } from '@gemstack/framework/client'
 
 export type ThemePreference = NonNullable<Preferences['theme']>
 

--- a/packages/framework-dashboard/lib/run-options.ts
+++ b/packages/framework-dashboard/lib/run-options.ts
@@ -1,38 +1,14 @@
 import type { Preferences } from '@gemstack/framework'
-import { autopilotEnabled } from './preferences.js'
+import { runOptionsFromPreferences } from '@gemstack/framework/client'
 
 // The Global run options for `sendStart`, derived from the shared preferences (#410) plus the run
 // Context set. Shared by the launcher (StartRunForm) and the navbar quick-launch (#723) so a run
 // starts the same way from either surface. Mirrors the toggles the OptionsMenu + AgentModelMenu
-// write. Returned as an inferred literal, not annotated: `StartRunOptions` isn't re-exported to the
-// client bundle, and `sendStart` type-checks the shape at the call site (as the inline version did).
+// write.
+//
+// The mapping itself moved into @gemstack/framework (#858) so the daemon can use it too: auto PM
+// starts runs with nobody watching and passed no options at all, which silently ignored the
+// project's agent and model. This stays as the client's name for it.
 export function collectRunOptions(preferences: Preferences, context: string[] = []) {
-  const autopilot = autopilotEnabled(preferences)
-  const vanilla = preferences.vanilla ?? false
-  const transparent = preferences.transparent ?? false
-  const eco = preferences.eco ?? false
-  const technical = preferences.technical ?? false
-  const onBeforeMergeableQuality = preferences.onBeforeMergeableQuality ?? false
-  const browser = preferences.browser ?? false
-  const model = preferences.model ?? ''
-  const agent = preferences.agent ?? 'claude'
-  const ecoDrops = {
-    ...(preferences.ecoPlanning ? { autoPlanning: true } : {}),
-    ...(preferences.ecoResearch ? { autoResearch: true } : {}),
-    ...(preferences.ecoMaintenance ? { autoMaintenance: true } : {}),
-  }
-  return {
-    ...(autopilot ? { autopilot: true } : {}),
-    ...(technical ? { technical: true } : {}),
-    ...(vanilla ? { vanilla: true } : {}),
-    ...(transparent ? { transparent: true } : {}),
-    ...(eco && !vanilla && !transparent && Object.keys(ecoDrops).length ? { eco: ecoDrops } : {}),
-    ...(onBeforeMergeableQuality ? { onBeforeMergeable: true } : {}),
-    // Claude-only (#801): another agent's driver takes no MCP servers, so sending it would only earn
-    // the CLI's "no effect" notice. Matches the box being disabled off Claude Code.
-    ...(browser && agent === 'claude' ? { browser: true } : {}),
-    ...(model ? { model } : {}),
-    ...(agent !== 'claude' ? { agent } : {}),
-    ...(context.length ? { context } : {}),
-  }
+  return runOptionsFromPreferences(preferences, context)
 }

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -41,3 +41,6 @@ export { renderSuggestNewTicketsPrompt } from './suggest-new-tickets-preset.js'
 export { renderSuggestTicketsToWorkOnPrompt } from './suggest-tickets-to-work-on-preset.js'
 export { renderSpikeAndPlanPrompt } from './spike-and-plan-preset.js'
 export { renderQuickWinsPrompt } from './quick-wins-preset.js'
+// The preferences -> run options mapping (#858), shared with the daemon so an unattended run
+// starts with the same settings a launcher-started one would. Pure field logic, no Node imports.
+export { runOptionsFromPreferences, autopilotEnabled } from './run-options.js'

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -33,7 +33,8 @@ import { findTodoBacklog } from './todo-loop.js'
 import { startPreview, detectServeTargets, type PreviewHandle, type ServeTarget } from './preview.js'
 import { resolveDashboardBundle } from './dashboard/bundle.js'
 import { isActivated } from './project.js'
-import { addProject, listProjects, projectId, readPreferences } from './registry.js'
+import { addProject, listProjects, projectId, readPreferences, readProjectPreferences, resolvePreferences } from './registry.js'
+import { runOptionsFromPreferences } from './run-options.js'
 import { installProject, enumerateGitRepos } from './install.js'
 import { JsonlTailer } from './jsonl-tail.js'
 
@@ -415,6 +416,17 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     }))
   const readPrefs = () =>
     readPreferences(undefined, env).catch(() => ({}) as Awaited<ReturnType<typeof readPreferences>>)
+  /**
+   * The run options a project's settings imply (#858), global tier overlaid with its own (#840).
+   * The same mapping the launcher uses, so a run started by the daemon and a run started by hand
+   * differ only in who asked for it. An unreadable tier falls back to empty rather than failing
+   * the start: the defaults are what the run would have used anyway.
+   */
+  const resolvedRunOptions = async (id: string) => {
+    const global = await readPrefs()
+    const project = await readProjectPreferences(id, undefined, env).catch(() => undefined)
+    return runOptionsFromPreferences(resolvePreferences(global, project))
+  }
   let watcher: InterventionWatcher | undefined
   let activityWatcher: ActivityWatcher | undefined
   if (webhook) {
@@ -462,7 +474,12 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
       return { status: view.limits, weekPercentUsed: typeof week === 'number' ? week : undefined }
     },
     start: async (project, job) => {
-      const result = await runtime.onStart(job.prompt, 'prompt', { unattended: true }, project.id)
+      // The settings a launcher-started run would have used (#858). `onStart` does not resolve
+      // these itself, so passing nothing meant an unattended run silently ignored the project's
+      // agent and model. `unattended` is forced on top: it is a property of nobody watching, not
+      // a preference, and without it every gate parks forever (#846).
+      const options = await resolvedRunOptions(project.id)
+      const result = await runtime.onStart(job.prompt, 'prompt', { ...options, unattended: true }, project.id)
       return result.ok ? result.runId : undefined
     },
     // The daemon promotes the queue, never the agent (#852): the run stays sandboxed in its

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -342,6 +342,7 @@ export {
   QUICK_WINS_PROMPT_TEMPLATE,
   QUICK_WINS_PARAMS,
 } from './quick-wins-preset.js'
+export { runOptionsFromPreferences, autopilotEnabled } from './run-options.js'
 export {
   startAutoPm,
   AUTO_PM_JOBS,

--- a/packages/framework/src/run-options.test.ts
+++ b/packages/framework/src/run-options.test.ts
@@ -1,0 +1,46 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { runOptionsFromPreferences, autopilotEnabled } from './run-options.js'
+import { resolvePreferences } from './registry.js'
+
+test('autopilot defaults on when nothing is set (#858)', () => {
+  assert.equal(autopilotEnabled({}), true)
+  assert.equal(autopilotEnabled({ autopilot: false }), false)
+})
+
+test('an empty preference set still starts a run in autopilot (#858)', () => {
+  assert.deepEqual(runOptionsFromPreferences({}), { autopilot: true })
+})
+
+test('the agent is sent only when it is not the default (#858)', () => {
+  // The daemon spells this out as a flag, and `--agent claude` is the default anyway.
+  assert.equal(runOptionsFromPreferences({ agent: 'claude' }).agent, undefined)
+  assert.equal(runOptionsFromPreferences({ agent: 'codex' }).agent, 'codex')
+})
+
+test('the model passes through, and an empty one does not (#858)', () => {
+  assert.equal(runOptionsFromPreferences({ model: 'opus' }).model, 'opus')
+  assert.equal(runOptionsFromPreferences({ model: '' }).model, undefined)
+})
+
+test('browser is dropped for an agent that cannot use it (#801)', () => {
+  assert.equal(runOptionsFromPreferences({ browser: true }).browser, true)
+  assert.equal(runOptionsFromPreferences({ browser: true, agent: 'codex' }).browser, undefined)
+})
+
+test('the eco drops are suppressed under vanilla and transparent (#858)', () => {
+  const eco = { eco: true, ecoPlanning: true }
+  assert.deepEqual(runOptionsFromPreferences(eco).eco, { autoPlanning: true })
+  assert.equal(runOptionsFromPreferences({ ...eco, vanilla: true }).eco, undefined)
+  assert.equal(runOptionsFromPreferences({ ...eco, transparent: true }).eco, undefined)
+  // Eco on with nothing to drop is not an eco run.
+  assert.equal(runOptionsFromPreferences({ eco: true }).eco, undefined)
+})
+
+test("a project's settings beat the global ones (#840/#858)", () => {
+  // The path auto PM takes: resolve the two tiers, then map the answer.
+  const resolved = resolvePreferences({ agent: 'claude', model: 'sonnet' }, { agent: 'codex' })
+  const options = runOptionsFromPreferences(resolved)
+  assert.equal(options.agent, 'codex')
+  assert.equal(options.model, 'sonnet') // untouched by the project tier
+})

--- a/packages/framework/src/run-options.ts
+++ b/packages/framework/src/run-options.ts
@@ -1,0 +1,59 @@
+import type { Preferences } from './registry.js'
+import type { StartRunOptions } from './dashboard/types.js'
+
+/**
+ * Turning the user's preferences into the options a run starts with (#858).
+ *
+ * This lived in the dashboard client, which was fine while the browser was the only thing that
+ * started runs. Auto PM (#685) starts them too, and passed nothing at all — so an unattended run
+ * ignored the agent, the model and every other per-project setting (#840) that a run started from
+ * the launcher would have honoured.
+ *
+ * It lives here, in pure code with no Node imports, so both callers share one mapping rather than
+ * keeping two copies of rules that are not a plain field copy: autopilot defaults on, browser is
+ * Claude-only, the eco drops are suppressed under vanilla/transparent, and the four eco
+ * preferences collapse into one object. Re-exported from the browser-safe `./client` entry (#431)
+ * so the dashboard can go on importing it at runtime.
+ */
+
+/** Autopilot defaults on (the demo default), matching the old localStorage semantics. */
+export function autopilotEnabled(preferences: Preferences): boolean {
+  return preferences.autopilot ?? true
+}
+
+/**
+ * The run options a set of already-resolved preferences implies.
+ *
+ * Takes the merged view, not the two tiers: who wins between the global and the project setting is
+ * `resolvePreferences`' job, and this stays a pure mapping of one settled answer.
+ */
+export function runOptionsFromPreferences(preferences: Preferences, context: string[] = []): StartRunOptions {
+  const autopilot = autopilotEnabled(preferences)
+  const vanilla = preferences.vanilla ?? false
+  const transparent = preferences.transparent ?? false
+  const eco = preferences.eco ?? false
+  const technical = preferences.technical ?? false
+  const onBeforeMergeableQuality = preferences.onBeforeMergeableQuality ?? false
+  const browser = preferences.browser ?? false
+  const model = preferences.model ?? ''
+  const agent = preferences.agent ?? 'claude'
+  const ecoDrops = {
+    ...(preferences.ecoPlanning ? { autoPlanning: true } : {}),
+    ...(preferences.ecoResearch ? { autoResearch: true } : {}),
+    ...(preferences.ecoMaintenance ? { autoMaintenance: true } : {}),
+  }
+  return {
+    ...(autopilot ? { autopilot: true } : {}),
+    ...(technical ? { technical: true } : {}),
+    ...(vanilla ? { vanilla: true } : {}),
+    ...(transparent ? { transparent: true } : {}),
+    ...(eco && !vanilla && !transparent && Object.keys(ecoDrops).length ? { eco: ecoDrops } : {}),
+    ...(onBeforeMergeableQuality ? { onBeforeMergeable: true } : {}),
+    // Claude-only (#801): another agent's driver takes no MCP servers, so sending it would only earn
+    // the CLI's "no effect" notice. Matches the box being disabled off Claude Code.
+    ...(browser && agent === 'claude' ? { browser: true } : {}),
+    ...(model ? { model } : {}),
+    ...(agent !== 'claude' ? { agent } : {}),
+    ...(context.length ? { context } : {}),
+  }
+}


### PR DESCRIPTION
Closes #858

Auto PM passed only `{ unattended: true }` to `onStart`, and `onStart` does not resolve preferences itself (it resolves the project *path* and nothing else from the registry). So an unattended run ignored the agent, the model, and every other per-project setting from #840 that a launcher-started run honours. A project configured for Codex had auto PM running Claude.

Now that auto PM actually does work unattended (#855), that is the difference between "the daemon works on your project" and "the daemon works on your project, its own way".

## Why the mapping moved

The preferences to run-options mapping only existed in the browser (`framework-dashboard/lib/run-options.ts`), and it is not a plain field copy:

- autopilot defaults **on** when unset
- `agent` is sent only when it is not `claude`
- `browser` is dropped for a non-claude agent (#801)
- the eco drops are suppressed under vanilla/transparent
- `onBeforeMergeableQuality` renames to `onBeforeMergeable`, and four eco preferences collapse into one `EcoOptions`

Copying that into the daemon would have left two versions of the same rules to drift apart. It moves into `framework/src/run-options.ts` as pure logic and is re-exported from the browser-safe `./client` entry (#431), which the dashboard already imports runtime values from. `collectRunOptions` stays as the client's name for it and delegates; `autopilotEnabled` re-exports from the same place so every component keeps reaching for it through `lib/preferences.js`.

`--unattended` is forced on top of the resolved options rather than read from them: it describes nobody watching, not something to configure, and without it every gate parks forever (#846).

## Verified

- The compiled `run-options.js` has zero imports, and the built client bundle contains no `node:` builtins, so the shared module did not drag the server barrel into the browser. That was the one real risk in putting it on `./client`.
- Build 11/11, typecheck 21/21, framework 844 pass / 0 fail (6 new), dashboard 186 pass / 36 files.

## Not done here

Not live-verified against a real daemon: proving it needs a project pinned to a non-default agent and a real auto-PM run, which is a quota spend I have not made. The mapping itself is covered by tests either way, and the wiring is one call.
