### PR TITLE
feat(framework): add the [Market research] preset (#694)

### DIFF
--- a/.changeset/market-research-preset.md
+++ b/.changeset/market-research-preset.md
@@ -1,0 +1,12 @@
+---
+'@gemstack/framework': patch
+---
+
+New [Market research] preset (#694)
+
+Researches the market, writes it to `MARKET_RESEARCH.md`, and queues a follow-up that
+turns the findings into tickets. Researching and deciding what to build from the research
+are separate runs, so a human can read the findings before anything is proposed.
+
+`MARKET_RESEARCH.md` joins the context every run starts with, as a document the agent
+reads rather than one it folds knowledge back into at merge.

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -10,6 +10,7 @@ import {
   renderSuggestTicketsToWorkOnPrompt,
   renderSpikeAndPlanPrompt,
   renderQuickWinsPrompt,
+  renderMarketResearchPrompt,
 } from '@gemstack/framework/client'
 import { usePreferences, updatePreferences, autopilotEnabled, themePreference } from '../lib/preferences.js'
 import { useDetectedEditors } from '../lib/editors.js'
@@ -39,6 +40,7 @@ const PRESETS: { id: string; label: string; render: () => string; tooltip?: stri
   },
   { id: 'spike-and-plan', label: 'Spike & plan', render: renderSpikeAndPlanPrompt },
   { id: 'quick-wins', label: 'Quick wins', render: renderQuickWinsPrompt },
+  { id: 'market-research', label: 'Market research', render: renderMarketResearchPrompt },
 ]
 
 // The agent + model tree (#650/#656/#658): each agent lists ONLY its own models, since `--model`

--- a/packages/framework/prompts/presets/market_research.md
+++ b/packages/framework/prompts/presets/market_research.md
@@ -1,0 +1,5 @@
+- Make a thorough market research
+- Write it to `MARKET_RESEARCH.md`
+- Add TODO_AGENTS.md entry: "Read <SESSION_NAME> then suggest new tickets"
+
+SESSION_NAME: the name of the session

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -44,3 +44,4 @@ export { renderQuickWinsPrompt } from './quick-wins-preset.js'
 // The preferences -> run options mapping (#858), shared with the daemon so an unattended run
 // starts with the same settings a launcher-started one would. Pure field logic, no Node imports.
 export { runOptionsFromPreferences, autopilotEnabled } from './run-options.js'
+export { renderMarketResearchPrompt } from './market-research-preset.js'

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -342,6 +342,12 @@ export {
   QUICK_WINS_PROMPT_TEMPLATE,
   QUICK_WINS_PARAMS,
 } from './quick-wins-preset.js'
+export {
+  renderMarketResearchPrompt,
+  MARKET_RESEARCH_PRESET_NAME,
+  MARKET_RESEARCH_PROMPT_TEMPLATE,
+  MARKET_RESEARCH_PARAMS,
+} from './market-research-preset.js'
 export { runOptionsFromPreferences, autopilotEnabled } from './run-options.js'
 export {
   startAutoPm,

--- a/packages/framework/src/market-research-preset.test.ts
+++ b/packages/framework/src/market-research-preset.test.ts
@@ -1,0 +1,25 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { renderMarketResearchPrompt, MARKET_RESEARCH_PRESET_NAME } from './market-research-preset.js'
+
+test('the market research preset carries #694: research, then queue the follow-up', () => {
+  const prompt = renderMarketResearchPrompt()
+  assert.match(prompt, /thorough market research/)
+  assert.match(prompt, /MARKET_RESEARCH\.md/)
+  assert.match(prompt, /TODO_AGENTS\.md entry/)
+  assert.match(prompt, /suggest new tickets/)
+})
+
+test('the session name is deferred to the agent, not interpolated (#694)', () => {
+  const prompt = renderMarketResearchPrompt()
+  // The catch-22: the session name does not exist when the preset renders, so an interpolation
+  // here would always resolve to nothing. The placeholder is left for the agent to fill.
+  assert.ok(!prompt.includes('${{'), 'no template interpolation should survive rendering')
+  assert.match(prompt, /<SESSION_NAME>/)
+  // Defined in the preset itself, so it still resolves with no system prompt (--vanilla).
+  assert.match(prompt, /^SESSION_NAME: /m)
+})
+
+test('the preset name is the id the menu uses (#694)', () => {
+  assert.equal(MARKET_RESEARCH_PRESET_NAME, 'market-research')
+})

--- a/packages/framework/src/market-research-preset.ts
+++ b/packages/framework/src/market-research-preset.ts
@@ -1,0 +1,26 @@
+import { PRESETS_MARKET_RESEARCH } from './prompts.generated.js'
+
+/**
+ * The [Market research] preset (#694): research the market, then queue a follow-up that turns the
+ * findings into tickets. The two halves are deliberately separate runs — researching and deciding
+ * what to build from the research are different jobs, and splitting them lets a human read the
+ * findings before anything is proposed.
+ *
+ * `<SESSION_NAME>` rather than `${{ tf.session_name }}`, per #694: the session name does not exist
+ * yet when a preset renders (the agent picks it early in the run), so interpolating here would
+ * always produce an empty string. Deferring it to the agent is the fix, and the preset defines the
+ * placeholder itself the way `research.md` does, so it still resolves under `--vanilla`, where
+ * there is no system prompt to define it.
+ */
+
+/** The preset's run-kind name, as the dashboard menu uses it. */
+export const MARKET_RESEARCH_PRESET_NAME = 'market-research'
+
+/** The prompt, from `prompts/presets/market_research.md`. */
+export const MARKET_RESEARCH_PROMPT_TEMPLATE = PRESETS_MARKET_RESEARCH
+
+/** No user params: the prompt takes no blank to fill. */
+export const MARKET_RESEARCH_PARAMS: readonly [] = []
+
+/** Render the prompt. Paramless, so it is the template verbatim. */
+export const renderMarketResearchPrompt = (): string => MARKET_RESEARCH_PROMPT_TEMPLATE

--- a/packages/framework/src/system-prompt.test.ts
+++ b/packages/framework/src/system-prompt.test.ts
@@ -21,12 +21,22 @@ const KNOWLEDGE_CONTEXT = `Context:\n${KNOWLEDGE_LINES}`
 
 test('CONTEXT_DOCS is the #683 fragment: business knowledge plus the roadmap/queue pointers', () => {
   const paths = CONTEXT_DOCS.map(d => d.path)
-  assert.deepEqual(paths, ['DECISIONS.md', 'GOAL.md', 'KNOWLEDGE-BASE.md', 'tickets/**.md', 'TODO_AGENTS.md'])
+  assert.deepEqual(paths, [
+    'DECISIONS.md',
+    'GOAL.md',
+    'KNOWLEDGE-BASE.md',
+    'MARKET_RESEARCH.md',
+    'tickets/**.md',
+    'TODO_AGENTS.md',
+  ])
   // The business-knowledge docs are a subset the agent also updates at merge.
   for (const doc of BUSINESS_KNOWLEDGE_DOCS) assert.ok(paths.includes(doc.path), `missing ${doc.path}`)
-  // GOAL / tickets / TODO_AGENTS are read-only context, so they are not in the merge-update set.
+  // GOAL / market research / tickets / TODO_AGENTS are read-only context, so they are not in the
+  // merge-update set.
   const businessPaths = BUSINESS_KNOWLEDGE_DOCS.map(d => d.path)
-  for (const p of ['GOAL.md', 'tickets/**.md', 'TODO_AGENTS.md']) assert.ok(!businessPaths.includes(p))
+  for (const p of ['GOAL.md', 'MARKET_RESEARCH.md', 'tickets/**.md', 'TODO_AGENTS.md']) {
+    assert.ok(!businessPaths.includes(p))
+  }
   // The ticket-format pointer is inlined here (this module stays node-free), so pin it to the
   // canonical constant in tickets.ts (#684) — they must never drift.
   const tickets = CONTEXT_DOCS.find(d => d.path === 'tickets/**.md')

--- a/packages/framework/src/system-prompt.ts
+++ b/packages/framework/src/system-prompt.ts
@@ -124,6 +124,10 @@ export const CONTEXT_DOCS: readonly ContextDoc[] = [
   DECISIONS_DOC,
   { path: 'GOAL.md', comment: 'the goal of the project (long-term direction, scope, non-scope, ...)' },
   KNOWLEDGE_BASE_DOC,
+  // What the market looks like (#694): written by the [Market research] preset and read by the
+  // follow-up that turns it into tickets. A pointer the agent reads, not a doc it folds knowledge
+  // back into, so it stays out of BUSINESS_KNOWLEDGE_DOCS.
+  { path: 'MARKET_RESEARCH.md', comment: 'the market the project competes in' },
   { path: 'tickets/**.md', comment: 'things to potentially work on; format: node_modules/@gemstack/framework/prompts/ticketing_format.md' },
   { path: 'TODO_AGENTS.md', comment: 'the AI task queue' },
 ]


### PR DESCRIPTION
Closes #694

Adds the [Market research] preset and puts `MARKET_RESEARCH.md` in the context every run starts with.

The prompt:

```md
- Make a thorough market research
- Write it to `MARKET_RESEARCH.md`
- Add TODO_AGENTS.md entry: "Read <SESSION_NAME> then suggest new tickets"

SESSION_NAME: the name of the session
```

## The catch-22

Handled as the ticket suggests: `<SESSION_NAME>` rather than `${{ tf.session_name }}`. The session name does not exist when a preset renders (the agent picks it early in the run), so interpolating there would always produce an empty string.

The ticket also suggests throwing when the prompt wrapper does not define `SESSION_NAME:`. I did not add that, because the preset defines the placeholder itself, the way `research.md` already does. That removes the failure rather than detecting it, and it also survives `--vanilla`, where there is no system prompt to define anything. Happy to add the check as well if you would rather have the guarantee.

## One question

The queue entry is your line verbatim: `Read <SESSION_NAME> then suggest new tickets`. Since you also want `MARKET_RESEARCH.md` in the context, I suspect the entry means "read the market research" and should say `MARKET_RESEARCH.md` outright, which would also be a real filename rather than a slug. I left your wording rather than guess. Say which and I will change the one line.

## Verified

Build 11/11, typecheck 21/21, framework 847 pass / 0 fail (3 new), dashboard 186 pass.

Not run against a live agent: it is a prompt, so what it actually produces only shows up in a real session, and that is a quota spend I have not made here.
