### PR TITLE
fix(framework): register the per-project preference telefunctions (#866)

### DIFF
--- a/.changeset/fix-866-register-project-preferences.md
+++ b/.changeset/fix-866-register-project-preferences.md
@@ -1,0 +1,7 @@
+---
+"@gemstack/framework": patch
+---
+
+Per-project settings now actually save (#866). The daemon serves a prebuilt dashboard and so registers each telefunction by hand, and the two per-project preference ones were never added to that list. Every read and write of a project's own settings answered 400, the caller discarded the rejection, and the dashboard went on showing the value you picked, so a setting looked saved until the next reload threw it away. Per-project run options (#800) silently fell back to the global ones.
+
+A test now holds the registry against the telefunc modules' own exports, so a telefunction that is added but never registered fails the suite instead of failing in the daemon.

--- a/packages/framework/src/dashboard-rpc/register.test.ts
+++ b/packages/framework/src/dashboard-rpc/register.test.ts
@@ -1,0 +1,43 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { registerDashboardTelefunctions, registeredTelefunctionNames } from './register.js'
+import * as reads from './reads.telefunc.js'
+import * as control from './control.telefunc.js'
+import * as events from './events.telefunc.js'
+import * as projects from './projects.telefunc.js'
+import * as preferences from './preferences.telefunc.js'
+import * as quota from './quota.telefunc.js'
+
+// Every telefunction the dashboard can call has to be registered here, because the daemon
+// serves a prebuilt bundle and has no Vite transform to discover them by file path. One that
+// is exported but not registered fails at runtime with a 400 and nothing else, which is how
+// per-project preferences shipped broken (#866): the client called `saveProjectPreferences`,
+// the daemon had never heard of it, and the caller swallowed the rejection.
+const MODULES: Array<[string, Record<string, unknown>]> = [
+  ['reads', reads],
+  ['control', control],
+  ['events', events],
+  ['projects', projects],
+  ['preferences', preferences],
+  ['quota', quota],
+]
+
+test('every exported telefunction is registered (#866)', () => {
+  registerDashboardTelefunctions()
+  const registered = registeredTelefunctionNames()
+  const missing: string[] = []
+  for (const [module, exports] of MODULES) {
+    for (const [name, value] of Object.entries(exports)) {
+      if (typeof value !== 'function') continue
+      if (!registered.has(name)) missing.push(`${module}.${name}`)
+    }
+  }
+  assert.deepEqual(missing, [], `not registered, so the daemon answers 400: ${missing.join(', ')}`)
+})
+
+test('the two per-project preference telefunctions are registered (#866)', () => {
+  registerDashboardTelefunctions()
+  const registered = registeredTelefunctionNames()
+  assert.equal(registered.has('onProjectPreferences'), true)
+  assert.equal(registered.has('saveProjectPreferences'), true)
+})

--- a/packages/framework/src/dashboard-rpc/register.ts
+++ b/packages/framework/src/dashboard-rpc/register.ts
@@ -3,7 +3,7 @@ import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventio
 import { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendPushBranch, sendOpenPullRequest } from './control.telefunc.js'
 import { onEvents } from './events.telefunc.js'
 import { onProjects, sendAddProject } from './projects.telefunc.js'
-import { onPreferences, savePreferences, onEditors } from './preferences.telefunc.js'
+import { onPreferences, savePreferences, onProjectPreferences, saveProjectPreferences, onEditors } from './preferences.telefunc.js'
 import { onQuota } from './quota.telefunc.js'
 
 // The client bakes each RPC key from the dashboard's source path (relative to its Vite
@@ -23,6 +23,19 @@ export const DASHBOARD_TELEFUNC_KEYS = {
 let registered = false
 
 /**
+ * What {@link registerDashboardTelefunctions} actually registered, so a test can hold this
+ * list against the telefunc modules' own exports. A telefunction that is exported, re-exported
+ * by the dashboard's shim, and simply never registered here fails at runtime with a 400 and
+ * nothing else: that is how per-project preferences shipped broken (#866).
+ */
+const registeredNames = new Set<string>()
+
+/** The registered telefunction names. Empty until `registerDashboardTelefunctions` runs. */
+export function registeredTelefunctionNames(): ReadonlySet<string> {
+  return registeredNames
+}
+
+/**
  * Register the dashboard telefunctions under the client-baked keys (idempotent). The
  * `appRootDir` is cosmetic here — it is not part of the match key and shields are off
  * on the mount (see dashboard/telefunc-serve.ts).
@@ -30,8 +43,10 @@ let registered = false
 export function registerDashboardTelefunctions(appRootDir: string = process.cwd()): void {
   if (registered) return
   registered = true
-  const reg = (fn: (...args: never[]) => unknown, name: string, key: string): void =>
+  const reg = (fn: (...args: never[]) => unknown, name: string, key: string): void => {
+    registeredNames.add(name)
     __decorateTelefunction(fn as never, name, key, appRootDir)
+  }
   const { reads, control, events, projects, preferences, quota } = DASHBOARD_TELEFUNC_KEYS
   reg(onRuns, 'onRuns', reads)
   reg(onRun, 'onRun', reads)
@@ -69,6 +84,8 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(sendAddProject, 'sendAddProject', projects)
   reg(onPreferences, 'onPreferences', preferences)
   reg(savePreferences, 'savePreferences', preferences)
+  reg(onProjectPreferences, 'onProjectPreferences', preferences)
+  reg(saveProjectPreferences, 'saveProjectPreferences', preferences)
   reg(onEditors, 'onEditors', preferences)
   reg(onQuota, 'onQuota', quota)
 }


### PR DESCRIPTION
Closes #866. Found by live-driving the dashboard against a real daemon while working #863.

## The bug

The daemon serves a prebuilt bundle, so it cannot discover telefunctions by file path the way the dev server does and registers them by hand in `dashboard-rpc/register.ts`. `onProjectPreferences` and `saveProjectPreferences` were never added, so the daemon answered 400 for both.

It was invisible for two reasons that compounded:

- the write is fire-and-forget with a swallowing catch (`lib/preferences.ts:134`), so nothing raised,
- the dashboard updates its local copy regardless, so the setting looked saved right up until a reload discarded it.

Net effect: **per-project run options (#800 / #844) never persisted in the shipped daemon** and every project silently used the global tier. Only the daemon path was affected, which is why dev and the test suite looked fine.

## The fix

Register the two. Then, so this class of bug cannot recur, the registration records what it registered and a test holds that set against the telefunc modules' own exports.

I checked the guard actually fails: with the two `reg(...)` lines removed it reports

```
not registered, so the daemon answers 400: preferences.onProjectPreferences, preferences.saveProjectPreferences
```

## Verified against a real daemon, before and after

Same script, same interaction (toggle a project-scoped setting, reload, read it back):

| | in-page toggle | after reload | 400s |
| --- | --- | --- | --- |
| before | true -> false | **reverted to true** | 3 |
| after | false -> true | **persisted** | 0 |

The daemon log goes from one `Telefunction ... not found` per attempt to none.

Framework typecheck clean, root build 11/11, the 2 new tests pass.