### PR TITLE
feat(framework-dashboard): give the room to a big view (#862)

### DIFF
--- a/.changeset/feat-862-shrink-sessions-rail.md
+++ b/.changeset/feat-862-shrink-sessions-rail.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Give the room to a big view (#862). The right rail is where the agent's pushed views, its browser and its choice gates are read, and it was a fixed narrow column whatever it held. It now widens for those three, and the sessions rail shrinks to a strip of status dots for as long as they are shown. Hovering the strip, or tabbing into it, brings the sessions back over the main pane rather than pushing it aside, so nothing you are reading moves. A list-shaped tab (files, docs, log) returns both rails to their usual widths.

--- a/packages/framework-dashboard/components/RightRail.test.tsx
+++ b/packages/framework-dashboard/components/RightRail.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { AgentView } from '../lib/live-state.js'
+
+// The rail's panels are Telefunc-backed; this is about the rail's own width, so stub them.
+vi.mock('./DocsPanel.js', () => ({ DocsPanel: () => <div>docs</div> }))
+vi.mock('./ProjectLogPanel.js', () => ({ ProjectLogPanel: () => <div>log</div> }))
+vi.mock('./FileTree.js', () => ({ FileTree: () => <div>files</div> }))
+vi.mock('./BrowserPanel.js', () => ({ BrowserPanel: () => <div>browser</div> }))
+vi.mock('./ChoicesRail.js', () => ({ ChoicesRail: () => <div>choices</div> }))
+
+const { RightRail } = await import('./RightRail.js')
+
+afterEach(cleanup)
+
+const view: AgentView = { id: 'v1', title: 'Plan', markdown: '# hello' } as AgentView
+
+const baseProps = {
+  projectId: 'p1',
+  runId: 'r1',
+  choices: [],
+  views: [],
+  files: [],
+  context: new Set<string>(),
+  toggleContext: () => {},
+}
+
+// #862: the rail asks for the room when it is showing something worth reading wide, and the
+// shell hands it over by collapsing the sessions rail. Reported up, since only the rail knows
+// which tab is open.
+describe('RightRail wide mode (#862)', () => {
+  const rail = (container: HTMLElement) => container.querySelector('aside')!
+
+  test('a list-shaped tab stays narrow and asks for nothing', () => {
+    const onWideChange = vi.fn()
+    const { container } = render(<RightRail {...baseProps} onWideChange={onWideChange} />)
+    expect(rail(container).className).toContain('w-80')
+    expect(onWideChange).toHaveBeenLastCalledWith(false)
+  })
+
+  test('a pushed view takes the wide form and says so', () => {
+    const onWideChange = vi.fn()
+    const { container } = render(<RightRail {...baseProps} views={[view]} onWideChange={onWideChange} />)
+    // The first view pulls the rail to the Views tab on its own.
+    expect(rail(container).className).toContain('w-[32rem]')
+    expect(onWideChange).toHaveBeenLastCalledWith(true)
+  })
+
+  test('leaving the view gives the room back', () => {
+    const onWideChange = vi.fn()
+    const { container } = render(<RightRail {...baseProps} views={[view]} onWideChange={onWideChange} />)
+    fireEvent.click(screen.getByRole('button', { name: /docs/i }))
+    expect(rail(container).className).toContain('w-80')
+    expect(onWideChange).toHaveBeenLastCalledWith(false)
+  })
+
+  test('no project means no rail and no claim on the room', () => {
+    const onWideChange = vi.fn()
+    const { container } = render(<RightRail {...baseProps} projectId={null} onWideChange={onWideChange} />)
+    expect(container.querySelector('aside')).toBeNull()
+    expect(onWideChange).toHaveBeenLastCalledWith(false)
+  })
+})

--- a/packages/framework-dashboard/components/RightRail.tsx
+++ b/packages/framework-dashboard/components/RightRail.tsx
@@ -27,6 +27,7 @@ export function RightRail({
   context,
   toggleContext,
   hasBrowser = false,
+  onWideChange,
 }: {
   projectId: string | null
   /** The selected run: resolves a choice pick's gate (#749) and scopes the tree to its worktree (#815). */
@@ -41,6 +42,8 @@ export function RightRail({
   toggleContext: (path: string) => void
   /** Whether the selected run is serving a browser preview (#813), i.e. it was started with Browser on. */
   hasBrowser?: boolean
+  /** Told when the rail takes its wide form (#862), so the shell can free the room for it. */
+  onWideChange?: (wide: boolean) => void
 }) {
   const [tab, setTab] = useState<Tab>('docs')
   // Once the user picks a tab, stop auto-defaulting (#695/U22) — only a genuinely new choice
@@ -69,6 +72,16 @@ export function RightRail({
     else if (firstView) setTab('views')
     else if (!touched.current && !hasChoices && !hasViews) setTab(hasFiles ? 'files' : 'docs')
   }, [choices, hasChoices, hasViews, hasFiles])
+
+  // The rail's own content decides when it needs the room (#862): a pushed view, the agent's
+  // browser, and a choice gate are the surfaces worth reading wide. Files/docs/log are lists and
+  // read fine narrow. Reported up rather than decided there, since only the rail knows its tab.
+  const wide = projectId !== null && (tab === 'views' || tab === 'browser' || tab === 'choices')
+  useEffect(() => {
+    onWideChange?.(wide)
+    // `onWideChange` is a fresh closure each render; the state it reports is the trigger.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wide])
 
   if (!projectId) return null
 
@@ -100,7 +113,12 @@ export function RightRail({
   const count = (t: Tab) => (t === 'choices' ? choices.length : t === 'views' ? views.length : t === 'files' ? selectedFiles : 0)
 
   return (
-    <aside className="flex w-80 shrink-0 flex-col border-l border-border">
+    <aside
+      className={cn(
+        'flex shrink-0 flex-col border-l border-border transition-[width] duration-150',
+        wide ? 'w-[32rem]' : 'w-80',
+      )}
+    >
       <div className="flex gap-1 border-b border-border p-2">
         {tabs.map(t => (
           <Button

--- a/packages/framework-dashboard/components/RunHistory.test.tsx
+++ b/packages/framework-dashboard/components/RunHistory.test.tsx
@@ -65,3 +65,41 @@ describe('RunHistory (#785)', () => {
     expect(screen.queryByText('waiting')).toBeNull()
   })
 })
+
+// #862: a big view in the right rail takes the room, and the sessions rail gives up its column.
+describe('RunHistory collapsed (#862)', () => {
+  const rail = (container: HTMLElement) => container.querySelector('aside')!
+
+  test('expanded by default, so nothing changes for the ordinary layout', () => {
+    const { container } = render(<RunHistory projectId="p1" runs={[run()]} selectedRunId={null} onSelect={() => {}} />)
+    expect(rail(container).className).toContain('w-60')
+    expect(rail(container).className).not.toContain('w-12')
+  })
+
+  test('collapsed reserves only a strip', () => {
+    const { container } = render(
+      <RunHistory projectId="p1" runs={[run()]} selectedRunId={null} onSelect={() => {}} collapsed />,
+    )
+    expect(rail(container).className).toContain('w-12')
+  })
+
+  // The rows must stay reachable while narrow: it is a squeeze, not a hidden rail.
+  test('collapsed still renders the sessions, and reopens on hover or focus', () => {
+    const { container } = render(
+      <RunHistory projectId="p1" runs={[run()]} selectedRunId={null} onSelect={() => {}} collapsed />,
+    )
+    expect(screen.getByText("replace 'Hello, world!' with 'Welcome!'")).toBeTruthy()
+    const panel = rail(container).firstElementChild as HTMLElement
+    expect(panel.className).toContain('group-hover:w-60')
+    expect(panel.className).toContain('group-focus-within:w-60')
+  })
+
+  // Floating rather than pushing: hovering the rail must not reflow what is being read.
+  test('the collapsed panel floats over the main pane', () => {
+    const { container } = render(
+      <RunHistory projectId="p1" runs={[run()]} selectedRunId={null} onSelect={() => {}} collapsed />,
+    )
+    const panel = rail(container).firstElementChild as HTMLElement
+    expect(panel.className).toContain('absolute')
+  })
+})

--- a/packages/framework-dashboard/components/RunHistory.tsx
+++ b/packages/framework-dashboard/components/RunHistory.tsx
@@ -26,6 +26,7 @@ export function RunHistory({
   startTick = 0,
   startIntent = '',
   followLive = false,
+  collapsed = false,
 }: {
   projectId: string | null
   runs: RunMeta[]
@@ -37,6 +38,8 @@ export function RunHistory({
    *  put the highlight on the running/optimistic row rather than the Live home row until the
    *  shell adopts the run's real id. A run that did report one is selected by URL instead (#784). */
   followLive?: boolean
+  /** Give the room to a big view (#862): narrow to a strip, expanded again on hover or focus. */
+  collapsed?: boolean
 }) {
   const [optimistic, setOptimistic] = useState<string | null>(null)
 
@@ -62,26 +65,54 @@ export function RunHistory({
   // a beat later (#784): the optimistic row is standing in for it, so highlight that.
   const starting = followLive || (selectedRunId !== null && !runs.some(run => run.id === selectedRunId))
 
+  // Collapsed, the strip is too narrow for words, and clipped half-words read as broken rather
+  // than as deliberate. Fade the labels out and leave the status dots, which is all that fits;
+  // opening the rail brings them back. Fading rather than unmounting keeps one DOM, so the
+  // reveal is CSS and the rows stay tab-reachable while narrow.
+  const label = collapsed
+    ? 'opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100'
+    : ''
+
   return (
-    <aside className="flex w-60 shrink-0 flex-col border-r border-border">
-      <div className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Sessions</div>
+    // Collapsed (#862), the rail reserves only a strip and its panel floats over the main pane
+    // when opened, so hovering it does not reflow what you are reading. Focus-within opens it
+    // too: hover is a mouse affordance, and the rows are still tab-reachable while narrow.
+    <aside
+      className={cn(
+        'group relative shrink-0 transition-[width] duration-150',
+        collapsed ? 'w-12' : 'w-60',
+      )}
+    >
+      <div
+        className={cn(
+          'flex h-full flex-col overflow-hidden border-r border-border bg-background transition-[width] duration-150',
+          collapsed
+            ? 'absolute inset-y-0 left-0 z-20 w-12 group-hover:w-60 group-hover:shadow-lg group-focus-within:w-60 group-focus-within:shadow-lg'
+            : 'w-full',
+        )}
+      >
+      <div className={cn('whitespace-nowrap px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground', label)}>
+        Sessions
+      </div>
       <div className="flex-1 overflow-y-auto px-2">
         {/* Permanent home / launcher — always present, never a run. */}
         <Button
           variant="ghost"
-          className={cn('mb-1 w-full justify-start', atHome && 'bg-accent text-accent-foreground')}
+          className={cn('mb-1 w-full justify-start', collapsed && 'justify-center px-0', atHome && 'bg-accent text-accent-foreground')}
           onClick={() => onSelect(null)}
+          title={collapsed ? 'Live' : undefined}
         >
-          <span className="mr-2 inline-block h-2 w-2 rounded-full bg-primary" /> Live
+          <span className={cn('inline-block h-2 w-2 shrink-0 rounded-full bg-primary', !collapsed && 'mr-2')} />
+          <span className={cn('whitespace-nowrap', label)}>Live</span>
         </Button>
 
         {/* A just-started run, before its run.json exists — highlighted while following it. */}
         {optimistic !== null && !hasRunning && (
-          <RunRow status="running" intent={optimistic} subtitle="starting…" active={starting} dim onClick={() => onSelect(null)} />
+          <RunRow status="running" intent={optimistic} subtitle="starting…" active={starting} dim collapsed={collapsed} onClick={() => onSelect(null)} />
         )}
 
         {runs.length === 0 && optimistic === null && (
-          <p className="px-2 py-1 text-sm text-muted-foreground">No sessions yet.</p>
+          <p className={cn('whitespace-nowrap px-2 py-1 text-sm text-muted-foreground', label)}>No sessions yet.</p>
         )}
         {runs.map(run => (
           <RunRow
@@ -93,9 +124,11 @@ export function RunHistory({
             // `runs` is newest-first, so that is the first with a running status.
             active={run.id === selectedRunId || (followLive && run.id === newestRunningId)}
             waiting={run.settledAt !== undefined}
+            collapsed={collapsed}
             onClick={() => onSelect(run.id)}
           />
         ))}
+      </div>
       </div>
     </aside>
   )
@@ -111,6 +144,7 @@ function RunRow({
   onClick,
   dim = false,
   waiting = false,
+  collapsed = false,
 }: {
   status: RunStatus
   intent: string | undefined
@@ -120,14 +154,20 @@ function RunRow({
   dim?: boolean
   /** Live, but parked on the user rather than working (#785). */
   waiting?: boolean
+  /** In the narrow strip (#862): labels fade out, so the row is carried by its dot alone. */
+  collapsed?: boolean
 }) {
   // Only a live run can be waiting on you; a finished one is just finished.
   const parked = waiting && status === 'running'
+  const label = collapsed
+    ? 'opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100'
+    : ''
   return (
     <Button
       variant="ghost"
       className={cn(
         'mb-0.5 h-auto w-full flex-col items-start gap-0.5 px-2 py-2 text-left',
+        collapsed && 'px-0',
         active && 'bg-accent text-accent-foreground',
         dim && 'opacity-70',
       )}
@@ -139,12 +179,18 @@ function RunRow({
         {status === 'running' && (
           <span className={cn('inline-block h-2 w-2 shrink-0 rounded-full', parked ? 'bg-muted-foreground' : 'animate-pulse bg-primary')} />
         )}
-        <Badge className={cn('shrink-0 border-transparent px-0 text-[10px] uppercase', parked ? 'text-muted-foreground' : STATUS_TONE[status])}>
+        {/* Collapsed, a finished run has no dot of its own and its badge has faded, so the row
+            would be an empty line. Give it one in the status' colour: the strip is a list of
+            sessions by state, which is as much as fits. */}
+        {collapsed && status !== 'running' && (
+          <span className={cn('inline-block h-2 w-2 shrink-0 rounded-full bg-current', STATUS_TONE[status])} />
+        )}
+        <Badge className={cn('shrink-0 border-transparent px-0 text-[10px] uppercase', parked ? 'text-muted-foreground' : STATUS_TONE[status], label)}>
           {parked ? 'waiting' : status}
         </Badge>
-        <span className="truncate text-xs font-normal text-muted-foreground">{subtitle}</span>
+        <span className={cn('truncate text-xs font-normal text-muted-foreground', label)}>{subtitle}</span>
       </span>
-      <span className="w-full truncate text-sm font-medium">{intent || '(no prompt)'}</span>
+      <span className={cn('w-full truncate text-sm font-medium', label)}>{intent || '(no prompt)'}</span>
     </Button>
   )
 }

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -68,6 +68,10 @@ export default function Page() {
   // be known.
   const [adopting, setAdopting] = useState(false)
 
+  // The right rail is showing something worth reading wide (#862), so the sessions rail gives up
+  // its column for it. Owned here because it is the two rails' shared layout, not either's state.
+  const [wideRail, setWideRail] = useState(false)
+
   const { runs, reload, loaded: runsLoaded } = useRuns(projectId)
 
   // The run Context set lives in the shell (#492/#504) so the two surfaces that feed it share
@@ -277,6 +281,7 @@ export default function Page() {
           startTick={runStart.tick}
           startIntent={runStart.intent}
           followLive={adopting}
+          collapsed={wideRail}
         />
         <main className="flex min-w-0 flex-1 flex-col">{renderMain()}</main>
         <RightRail
@@ -288,6 +293,7 @@ export default function Page() {
           context={context}
           toggleContext={toggleContext}
           hasBrowser={selectedRun?.status === 'running' && selectedRun.browserStreamPort !== undefined}
+          onWideChange={setWideRail}
         />
       </div>
     </div>


### PR DESCRIPTION
Closes #862.

## One change to your idea, and why

Shrinking the sessions rail on its own would not have made the views bigger: the right rail was a fixed `w-80`, so the freed column went to the main pane instead. Your actual ask was big views, so this does both halves. The right rail takes a wider form (`w-80` -> `w-[32rem]`) when it is showing something worth reading wide, and the sessions rail collapses for exactly as long as that lasts.

Wide applies to **views, the browser, and choice gates**, which are the three you named. Files, Docs and Log are lists and read fine narrow, so they leave the layout alone.

## The collapsed strip

- 48px, keeping one status dot per session, with the labels faded out. A 48px column of clipped half-words reads as broken rather than deliberate, which is what the first cut looked like.
- Hover **or keyboard focus** brings it back, so it is not a mouse-only affordance and the rows stay tab-reachable while narrow.
- The expanded rail **floats over the main pane** rather than pushing it, so hovering does not reflow whatever you are reading.

## Verified in the real browser

Driven against a live daemon, measuring actual boxes:

| state | sessions rail | right rail |
| --- | --- | --- |
| a view is shown | **48px** | **512px** |
| hovering the strip | 240px (floating) | 512px |
| back on Docs | 240px | 320px |

Main pane measured 840px before and after hovering the strip: no reflow. No page errors.

I drove the wide state without spending any quota by writing a synthetic `view` event into a scratch project's `.the-framework/events.jsonl`, which is what the feed tails anyway. Worth knowing for future UI work that depends on run state.

Dashboard suite 38 files / 211 tests (8 new, covering the collapse, the float, the hover/focus reveal, and the rail asking for and giving back the room), typecheck clean, root build 11/11.

## Unrelated thing I noticed

A view containing a Markdown table renders as raw pipes: `Markdown.tsx` is a deliberate dependency-free renderer that falls anything unknown through as a paragraph. That is a fair call on its own, but it does blunt the point of a wide view. Filing it separately rather than folding it in here.