### PR TITLE
fix(framework): gate auto PM on the configured usage limits (#870)

### DIFF
--- a/.changeset/fix-870-auto-pm-configured-limits.md
+++ b/.changeset/fix-870-auto-pm-configured-limits.md
@@ -1,0 +1,9 @@
+---
+"@gemstack/framework": patch
+---
+
+Auto PM now paces itself by your own usage limits (#870). It used to keep a second budget rule of its own, refusing unless half of every window was still free, so there were two sets of limits to reason about and the stricter one was invisible. It now runs while your configured limits are not met and stands down once one is, which is the same line autopilot already stops at.
+
+It still refuses to start anything when the quota cannot be read at all: an unreadable budget must never stop your own work, but it does stop work nobody asked for.
+
+The `DEFAULT_MIN_FREE_PERCENT` export and the `minFreePercent` override are gone with the rule.

--- a/packages/framework/src/auto-pm.test.ts
+++ b/packages/framework/src/auto-pm.test.ts
@@ -4,7 +4,6 @@ import {
   autoPmDecision,
   quotaHeadroom,
   startAutoPm,
-  DEFAULT_MIN_FREE_PERCENT,
   AUTO_PM_JOBS,
   AUTO_PM_DRAIN_JOB,
   type AutoPmDeps,
@@ -17,20 +16,16 @@ import { ConsumptionMeter, consumptionStatus, DEFAULT_CONSUMPTION_LIMITS } from 
 const T0 = 1_800_000_000_000
 
 /**
- * A reading where the rolling meter has seen `weekPercent` points burned, and the account's
- * own week is `accountWeek` spent (default: the same, the honest case).
+ * A reading where the rolling meter has seen `weekPercent` points burned.
  */
-function status(weekPercent: number | undefined, accountWeek: number | undefined = weekPercent ?? 0): AutoPmQuota {
+function status(weekPercent: number | undefined): AutoPmQuota {
   const meter = new ConsumptionMeter()
   if (weekPercent !== undefined) {
     // Two samples, because the meter measures the delta between readings, not an absolute.
     meter.record({ at: T0 - 1000, weeklyPercent: 0 })
     meter.record({ at: T0, weeklyPercent: weekPercent })
   }
-  return {
-    status: consumptionStatus({ meter, limits: DEFAULT_CONSUMPTION_LIMITS, now: T0 }),
-    weekPercentUsed: accountWeek,
-  }
+  return { status: consumptionStatus({ meter, limits: DEFAULT_CONSUMPTION_LIMITS, now: T0 }) }
 }
 
 /** The happy inputs, so each test names only the condition it is about. */
@@ -76,72 +71,52 @@ test('autoPmDecision holds off during the cooldown after a start (#685)', () => 
 test('quotaHeadroom refuses to start when the quota cannot be read (#685)', () => {
   // The inverse of the per-run guard's fail-open (#519): that one must never STOP the user's
   // own work, this one must never START work nobody asked for on an unknown budget.
-  const decision = quotaHeadroom(undefined, DEFAULT_MIN_FREE_PERCENT)
+  const decision = quotaHeadroom(undefined)
   assert.equal(decision.start, false)
   assert.match(decision.start === false ? decision.reason : '', /could not be read/)
 })
 
-test('quotaHeadroom refuses while a window has no reading yet (#685)', () => {
-  const decision = quotaHeadroom(status(undefined), DEFAULT_MIN_FREE_PERCENT)
-  assert.equal(decision.start, false)
-  assert.match(decision.start === false ? decision.reason : '', /no reading yet/)
+test('quotaHeadroom starts while no configured limit is met (#870)', () => {
+  assert.deepEqual(quotaHeadroom(status(1)), { start: true })
 })
 
-test('quotaHeadroom refuses once a window is past the threshold (#685)', () => {
-  // The 5h budget is 12 points, so 10 points spent is ~83% of it: well past half.
-  const decision = quotaHeadroom(status(10), DEFAULT_MIN_FREE_PERCENT)
+test('quotaHeadroom stands down once a configured limit is reached, and names it (#870)', () => {
+  // The user's own limits are the gate now: auto PM has no threshold of its own to trip first.
+  const decision = quotaHeadroom(status(99))
   assert.equal(decision.start, false)
-  assert.match(decision.start === false ? decision.reason : '', /% used/)
+  assert.match(decision.start === false ? decision.reason : '', /limit is reached/)
 })
 
-test('quotaHeadroom still starts with the rolling limits off, guarded by the account week (#848)', () => {
-  // The rolling limits are the user's own pacing knobs; switching them off used to leave the
-  // gate with no denominator at all. The account's absolute week is the denominator now.
+test('quotaHeadroom starts with every rolling limit switched off (#870)', () => {
+  // Switching the limits off is the user saying "do not pace me". Auto PM used to keep its own
+  // 50%-free rule here and refuse anyway, which is the second budget notion #870 removed.
   const off = { enabled: false, percent: 20 }
   const meter = new ConsumptionMeter()
   meter.record({ at: T0 - 1000, weeklyPercent: 0 })
-  meter.record({ at: T0, weeklyPercent: 1 })
+  meter.record({ at: T0, weeklyPercent: 95 })
   const quota: AutoPmQuota = {
     status: consumptionStatus({ meter, limits: { daily: off, fiveHour: off, session: off }, now: T0 }),
-    weekPercentUsed: 5,
   }
-  assert.deepEqual(quotaHeadroom(quota, DEFAULT_MIN_FREE_PERCENT), { start: true })
-  assert.equal(quotaHeadroom({ ...quota, weekPercentUsed: 95 }, DEFAULT_MIN_FREE_PERCENT).start, false)
+  assert.deepEqual(quotaHeadroom(quota), { start: true })
 })
 
-test('quotaHeadroom refuses when the account week is nearly spent (#848)', () => {
-  const decision = quotaHeadroom(status(1, 95), DEFAULT_MIN_FREE_PERCENT)
-  assert.equal(decision.start, false)
-  assert.match(decision.start === false ? decision.reason : '', /account's week is 95% used/)
-})
-
-test('quotaHeadroom refuses when the account week cannot be read (#848)', () => {
-  // Built inline, not via status(1, undefined): an explicit undefined argument still triggers
-  // the default parameter, which would quietly hand the check a real number.
-  const decision = quotaHeadroom({ ...status(1), weekPercentUsed: undefined }, DEFAULT_MIN_FREE_PERCENT)
-  assert.equal(decision.start, false)
-  assert.match(decision.start === false ? decision.reason : '', /weekly usage could not be read/)
-})
-
-test('a restarted daemon does not spend the last of the quota (#848)', () => {
-  // The regression, reproduced live on 0f16b3e before the fix. The meter is delta-based, so a
-  // daemon that just restarted has one sample, nothing to diff it against, and honestly reports
-  // 0 consumed -- while the account sits at 95% of its week. Zero and unknown look identical to
-  // a usedPercent check, which is why the absolute reading has to be the one in charge.
+test('a restarted daemon reads as untouched, which the configured limits are what guard (#870)', () => {
+  // Pinning a known blind spot rather than leaving it to be rediscovered. The meter is delta
+  // based, so a daemon that just restarted has one sample, nothing to diff it against, and
+  // honestly reports 0 consumed -- while the account may sit at 95% of its week.
+  //
+  // #848 covered this with the account's own absolute weekly figure, measured against auto PM's
+  // 50%-free rule. #870 removed that rule as a second set of limits, and the absolute check went
+  // with it, so what stands here now is whatever the user configured. With the defaults that is
+  // enough; with the limits off, nothing stops a fresh daemon. Raised on #870.
   const fresh = new ConsumptionMeter()
   fresh.record({ at: T0, weeklyPercent: 95 })
   const rolling = consumptionStatus({ meter: fresh, limits: DEFAULT_CONSUMPTION_LIMITS, now: T0 })
   assert.equal(rolling.daily.usedPercent, 0) // the trap: not undefined
   assert.equal(rolling.daily.complete, false) // the honest signal underneath it
 
-  const decision = autoPmDecision({
-    enabled: true,
-    backlogEmpty: true,
-    activeRuns: 0,
-    quota: { status: rolling, weekPercentUsed: 95 },
-  })
-  assert.equal(decision.start, false)
-  assert.match(decision.start === false ? decision.reason : '', /account's week is 95% used/)
+  const decision = autoPmDecision({ enabled: true, backlogEmpty: true, activeRuns: 0, quota: { status: rolling } })
+  assert.equal(decision.start, true)
 })
 
 const JOBS: readonly AutoPmJob[] = [

--- a/packages/framework/src/auto-pm.ts
+++ b/packages/framework/src/auto-pm.ts
@@ -1,12 +1,12 @@
-import type { ConsumptionStatus, LimitStatus } from './consumption.js'
+import type { ConsumptionStatus } from './consumption.js'
 import { renderSpikeAndPlanPrompt, SPIKE_AND_PLAN_PRESET_NAME } from './spike-and-plan-preset.js'
 import { renderQuickWinsPrompt, QUICK_WINS_PRESET_NAME } from './quick-wins-preset.js'
 import { renderDrainQueuePrompt, DRAIN_QUEUE_PRESET_NAME } from './drain-queue-preset.js'
 
 /**
  * Auto PM (#685): spend leftover subscription quota on product management instead of
- * letting it expire. While there is plenty of budget left and nobody is at the keyboard,
- * the daemon runs the cycle by itself: it works the agent queue down entry by entry (#855),
+ * letting it expire. While the configured usage limits are not met and nobody is at the
+ * keyboard, the daemon runs the cycle by itself: it works the agent queue down entry by entry (#855),
  * and once that is empty it refills it — harvesting quick-wins, then spiking and planning
  * the tickets that have neither yet.
  *
@@ -15,9 +15,6 @@ import { renderDrainQueuePrompt, DRAIN_QUEUE_PRESET_NAME } from './drain-queue-p
  * supplies the readings. #298 is the parent idea (background jobs / "max out the usage"),
  * and #519 already built the meter this reads.
  */
-
-/** How much of every enabled budget must still be free before a run starts unasked. */
-export const DEFAULT_MIN_FREE_PERCENT = 50
 
 /** How often the daemon re-asks {@link autoPmDecision}. */
 export const DEFAULT_AUTO_PM_INTERVAL_MS = 10 * 60 * 1000
@@ -45,8 +42,6 @@ export interface AutoPmInputs {
   quota: AutoPmQuota | undefined
   /** Milliseconds since this project was last auto-started, or `undefined` if it never was. */
   sinceLastStartMs?: number
-  /** Override {@link DEFAULT_MIN_FREE_PERCENT}. */
-  minFreePercent?: number
   /** Override {@link DEFAULT_AUTO_PM_COOLDOWN_MS}. */
   cooldownMs?: number
 }
@@ -67,71 +62,43 @@ export type QuotaDecision = { start: true } | AutoPmRefusal
 export type AutoPmDecision = { start: true; mode: AutoPmMode } | AutoPmRefusal
 
 /**
- * What one tick knows about the budget: the rolling windows, and the account's own weekly
- * figure (#848).
+ * What one tick knows about the budget: where the user's configured limits stand.
  *
- * Both, because they fail in opposite directions. The rolling windows come from
- * {@link ConsumptionMeter}, which measures how much usage has gone *up* since it started
- * watching — so a restarted daemon has nothing to compare against and honestly reports zero
- * consumed, whatever the account has actually spent. `weekPercentUsed` is the account's own
- * absolute number, which survives a restart but says nothing about the last five hours.
+ * It used to carry the account's own absolute weekly figure as well (#848), to cover the
+ * rolling meter reading zero after a restart. That was only meaningful next to a percentage
+ * threshold, and #870 removed the threshold, so it went with it rather than sitting here unread.
  */
 export interface AutoPmQuota {
   /** Where the user's configured limits stand, from the rolling meter. */
   status: ConsumptionStatus
-  /**
-   * The account's weekly allowance consumed so far, 0-100, straight from the agent's own
-   * readout (`kind: 'week'`). `undefined` when there is no reading to take it from.
-   */
-  weekPercentUsed: number | undefined
 }
 
 /**
- * Whether there is enough headroom to spend unasked.
+ * Whether the budget allows spending unasked.
  *
- * **This gate fails closed, and that is the opposite of the per-run guard.** #519 settled
- * that an unreadable quota must never *stop* the user's own work, so `startConsumptionGuard`
- * fails open. Work nobody asked for is the other way round: if we cannot see the meter we
- * cannot promise we are spending a surplus, and quietly burning a subscription is a far worse
- * failure than skipping a tick.
+ * The gate is the user's own configured limits (#870): auto PM starts while they are not met
+ * and stands down once one is. It used to require half of every budget still free, which was a
+ * second budget notion nobody had asked for — and two sets of limits to reason about is worse
+ * than one, even when the extra one is stricter.
  *
- * Two independent checks, because either alone has a blind spot (#848):
+ * `status.reached` is that question already answered: "the limit to pause for, or null",
+ * widest-first, so the window it names is the one that takes longest to recover.
  *
- * 1. The account's own weekly figure, which is absolute and survives a daemon restart. This
- *    is the one that matters most, and its absence is itself a refusal.
- * 2. The rolling day and 5h windows, which catch a burst the weekly figure is too coarse to
- *    see. The session window is ignored: this only runs when nothing is running.
+ * **It still fails closed on a quota it cannot read at all, and that is the opposite of the
+ * per-run guard.** #519 settled that an unreadable quota must never *stop* the user's own work,
+ * so `startConsumptionGuard` fails open. Work nobody asked for is the other way round: quietly
+ * burning a subscription is a far worse failure than skipping a tick. That is a separate
+ * property from the threshold, so dropping the threshold left it alone.
  *
- * The rolling windows cannot carry the decision on their own. They come from a delta meter,
- * so an empty one reports **0 consumed** rather than "unknown" — indistinguishable from a
- * genuinely untouched budget, and true every time the daemon restarts, which is usually right
- * after a long session. `usedPercent === undefined` is kept as a guard but effectively never
- * fires; `complete` is what says the figure does not yet cover its window, and an incomplete
- * window is trusted only because check 1 is standing behind it.
+ * Note what this no longer covers. `reached` reads the rolling meter, which is delta-based: a
+ * restarted daemon has nothing to diff and honestly reports zero consumed however much the
+ * account has spent (#848). With no configured limit to trip, nothing then stands between a
+ * fresh daemon and work nobody asked for. Raised on #870 as a decision rather than fixed here,
+ * since the answer is a limit that stops unattended work specifically.
  */
-export function quotaHeadroom(quota: AutoPmQuota | undefined, minFreePercent: number): QuotaDecision {
+export function quotaHeadroom(quota: AutoPmQuota | undefined): QuotaDecision {
   if (!quota) return { start: false, reason: 'the quota could not be read, so there is no way to tell what is spare' }
-
-  // The absolute check first: it is the only one a restarted daemon can trust.
-  if (quota.weekPercentUsed === undefined) {
-    return { start: false, reason: "the account's weekly usage could not be read, so there is no way to tell what is spare" }
-  }
-  if (quota.weekPercentUsed > 100 - minFreePercent) {
-    return { start: false, reason: `the account's week is ${Math.round(quota.weekPercentUsed)}% used` }
-  }
-
-  const windows: [string, LimitStatus][] = [
-    ['the daily budget', quota.status.daily],
-    ['the 5h budget', quota.status.fiveHour],
-  ]
-  for (const [label, limit] of windows.filter(([, limit]) => limit.enabled)) {
-    if (limit.usedPercent === undefined) {
-      return { start: false, reason: `${label} has no reading yet` }
-    }
-    if (limit.usedPercent > 100 - minFreePercent) {
-      return { start: false, reason: `${label} is ${Math.round(limit.usedPercent)}% used` }
-    }
-  }
+  if (quota.status.reached) return { start: false, reason: `the ${quota.status.reached} limit is reached` }
   return { start: true }
 }
 
@@ -152,7 +119,7 @@ export function autoPmDecision(input: AutoPmInputs): AutoPmDecision {
   if (input.backlogEmpty === undefined) {
     return { start: false, reason: 'the agent queue could not be read, so there is no way to tell what to do' }
   }
-  const headroom = quotaHeadroom(input.quota, input.minFreePercent ?? DEFAULT_MIN_FREE_PERCENT)
+  const headroom = quotaHeadroom(input.quota)
   if (!headroom.start) return headroom
   // The queue picks the job, and a non-empty one wins (#855). It used to be a refusal, on the
   // reasoning that the backlog loop would drain it — but that loop only exists inside a run a
@@ -248,8 +215,6 @@ export interface AutoPmDeps {
   intervalMs?: number
   /** Override the per-project cooldown. */
   cooldownMs?: number
-  /** Override the headroom threshold. */
-  minFreePercent?: number
   /** Clock, injectable for tests. */
   now?: () => number
 }
@@ -321,7 +286,6 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
           activeRuns: deps.activeRuns(project),
           quota,
           ...(since !== undefined ? { sinceLastStartMs: now() - since } : {}),
-          ...(deps.minFreePercent !== undefined ? { minFreePercent: deps.minFreePercent } : {}),
           ...(deps.cooldownMs !== undefined ? { cooldownMs: deps.cooldownMs } : {}),
         })
         if (!decision.start) {

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -466,13 +466,8 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     enabled: async () => (await readPrefs()).autoPm === true,
     backlogEmpty: async project => (await findTodoBacklog(project.path)) === undefined,
     activeRuns: project => runtime.activeRunCount(project.id),
-    quota: async () => {
-      const view = await quota.read()
-      // The account's own week (#848): absolute, so it still means something after a restart
-      // emptied the rolling meter. `percentUsed` of the `week` window, or nothing.
-      const week = view.windows.find(w => w.kind === 'week')?.percentUsed
-      return { status: view.limits, weekPercentUsed: typeof week === 'number' ? week : undefined }
-    },
+    // The user's own configured limits are the gate (#870): auto PM has no budget notion of its own.
+    quota: async () => ({ status: (await quota.read()).limits }),
     start: async (project, job) => {
       // The settings a launcher-started run would have used (#858). `onStart` does not resolve
       // these itself, so passing nothing meant an unattended run silently ignored the project's

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -354,7 +354,6 @@ export {
   AUTO_PM_JOBS,
   autoPmDecision,
   quotaHeadroom,
-  DEFAULT_MIN_FREE_PERCENT,
   DEFAULT_AUTO_PM_INTERVAL_MS,
   DEFAULT_AUTO_PM_COOLDOWN_MS,
   type AutoPmInputs,


### PR DESCRIPTION
Closes #870. Implements @brillout's call on #839:

> So I'd suggest we replace the "when there's plenty of token left to spent" part with "when the usage quota limits aren't met".

Agreed, and there was no use case for two limits. It maps onto something that already existed: `ConsumptionStatus.reached` is documented as "the limit to pause for, or `null`", widest-first, which is exactly "the usage quota limits are met".

## What changed

- `DEFAULT_MIN_FREE_PERCENT` (50) and the `minFreePercent` override are gone. Auto PM has no budget notion of its own any more.
- `quotaHeadroom(quota)` starts while nothing is `reached`, and stands down naming the window when something is.
- It still fails closed on a quota it cannot read at all. That is a separate property from the threshold (#519: an unreadable quota must never stop *your* work, but it does stop work nobody asked for), so it stayed.

Switching every rolling limit off now lets auto PM run, which is the point: that is you saying "do not pace me". It used to refuse anyway, on its own invisible rule.

## The part worth your decision

Removing the threshold also removes what #848 added. That fix checked the account's absolute weekly figure, but only ever as a percentage against the 50%-free rule, so it could not survive the rule.

The blind spot it covered is real: the meter is delta-based, so a restarted daemon has nothing to diff and honestly reports **0 consumed** however much the account has spent. With the default limits configured that is fine. With the limits off, nothing stands between a fresh daemon and work nobody asked for.

I did not quietly keep a threshold of my own to paper over it, since that is the thing you asked me to remove. There is a test pinning the new behaviour so it is recorded rather than rediscovered.

This lands close to your own next paragraph:

> Soft => stop autopilot (the current limit settings)
> Hard => stop all work

A soft limit that stops unattended work while leaving your own runs alone is exactly what auto PM wants. Say the word and I will do that as its own ticket.

## Verified

Framework auto-pm suite 25 pass (rewritten around the new gate: starts while nothing is reached, stands down naming the window, starts with the limits off, still refuses an unreadable quota, and the restart blind spot). consumption, consumption-guard and client suites green. Root build 11/11.