### PR TITLE
[on hold] feat(framework): measure a weekly limit against the account's own figure (#876)

### DIFF
--- a/.changeset/feat-876-weekly-limit.md
+++ b/.changeset/feat-876-weekly-limit.md
@@ -1,0 +1,11 @@
+---
+"@gemstack/framework": minor
+---
+
+Add a weekly usage limit, measured against your account's own figure (#876). The other three limits are rolling windows the meter has to derive by diffing readings, which is why a daemon that just restarted has nothing to compare against and reads as untouched however much the week has cost. The agent reports the week absolutely, so this one needs no diffing and survives a restart.
+
+Both gates pick it up, since both already stop at whichever limit is reached: a run pauses on it, and auto PM will not start unattended work past it.
+
+It defaults to 100%, a ceiling rather than a pacing knob, so nothing changes until you lower it. Lowering it is what reserves the rest of the week for yourself.
+
+`ConsumptionLimits` now has a fourth key. A `the-framework.json` written before this keeps working (each limit falls back to its default independently), but TypeScript callers constructing the object literally need to add `week`.

--- a/packages/framework-dashboard/components/UsagePanel.tsx
+++ b/packages/framework-dashboard/components/UsagePanel.tsx
@@ -11,6 +11,7 @@ import { cn } from '../lib/utils.js'
 
 /** The three limits, in the order they bite: widest first. */
 const LIMITS: { key: keyof ConsumptionLimits; label: string; hint: string }[] = [
+  { key: 'week', label: 'This week', hint: "How much of your account's week the framework may consume" },
   { key: 'daily', label: 'Daily', hint: 'How much of your week a single day may consume' },
   { key: 'fiveHour', label: 'Last 5h', hint: "How much of the day's budget a rolling 5 hours may consume" },
   { key: 'session', label: 'This session', hint: "How much of the day's budget one session may consume" },
@@ -155,7 +156,7 @@ export function UsagePanel() {
             </label>
             <p className="text-xs text-muted-foreground">
               When nothing is running and the queue is empty, spike &amp; plan tickets rather than let the
-              budget expire. Only while every limit above still has half its budget free.
+              budget expire. Only while the limits above are not reached.
             </p>
           </div>
         ) : null}

--- a/packages/framework-dashboard/lib/quota.test.ts
+++ b/packages/framework-dashboard/lib/quota.test.ts
@@ -14,7 +14,7 @@ const limit = { enabled: false, budget: 0, consumed: undefined, usedPercent: und
 /** A reading the hook should pass straight through; `percentUsed` just tells them apart. */
 const view = (percentUsed: number): QuotaView => ({
   windows: [{ label: 'Current session', kind: 'session', percentUsed }],
-  limits: { session: limit, fiveHour: limit, daily: limit, reached: null },
+  limits: { session: limit, fiveHour: limit, daily: limit, week: limit, reached: null },
 })
 
 /** Let queued RPCs settle and React apply the state they resolved with. */

--- a/packages/framework/src/auto-pm.test.ts
+++ b/packages/framework/src/auto-pm.test.ts
@@ -95,7 +95,7 @@ test('quotaHeadroom starts with every rolling limit switched off (#870)', () => 
   meter.record({ at: T0 - 1000, weeklyPercent: 0 })
   meter.record({ at: T0, weeklyPercent: 95 })
   const quota: AutoPmQuota = {
-    status: consumptionStatus({ meter, limits: { daily: off, fiveHour: off, session: off }, now: T0 }),
+    status: consumptionStatus({ meter, limits: { week: off, daily: off, fiveHour: off, session: off }, now: T0 }),
   }
   assert.deepEqual(quotaHeadroom(quota), { start: true })
 })

--- a/packages/framework/src/consumption-guard.ts
+++ b/packages/framework/src/consumption-guard.ts
@@ -53,12 +53,17 @@ export function startConsumptionGuard(opts: StartConsumptionGuardOptions): Consu
   return {
     poller,
     stop: () => poller.stop(),
-    gate: () =>
-      consumptionStatus({
+    gate: () => {
+      // The same absolute weekly figure the panel draws (#876), so the run stops on the account's
+      // own week rather than only on the rolling windows the meter derives.
+      const accountWeek = poller.current().lastGood?.windows.find(w => w.kind === 'week')?.percentUsed
+      return consumptionStatus({
         meter: poller.meter,
         limits: opts.limits,
         sessionStartedAt,
+        ...(accountWeek !== undefined ? { accountWeekPercent: accountWeek } : {}),
         now: now(),
-      }).reached,
+      }).reached
+    },
   }
 }

--- a/packages/framework/src/consumption.test.ts
+++ b/packages/framework/src/consumption.test.ts
@@ -21,16 +21,17 @@ function meterOf(...samples: [hoursAgo: number, weeklyPercent: number][]): Consu
 
 test("budgetsFrom resolves Rom's chain into weekly-meter points (#523)", () => {
   // A day is 20% of the week; a 5h stretch 60% of that day; a session 40% of it.
-  assert.deepEqual(budgetsFrom(DEFAULT_CONSUMPTION_LIMITS), { daily: 20, fiveHour: 12, session: 8 })
+  assert.deepEqual(budgetsFrom(DEFAULT_CONSUMPTION_LIMITS), { week: 100, daily: 20, fiveHour: 12, session: 8 })
 })
 
 test('budgetsFrom rescales the shorter limits when the day changes (#523)', () => {
   const limits: ConsumptionLimits = {
+    week: { enabled: true, percent: 100 },
     daily: { enabled: true, percent: 50 },
     fiveHour: { enabled: true, percent: 60 },
     session: { enabled: true, percent: 40 },
   }
-  assert.deepEqual(budgetsFrom(limits), { daily: 50, fiveHour: 30, session: 20 })
+  assert.deepEqual(budgetsFrom(limits), { week: 100, daily: 50, fiveHour: 30, session: 20 })
 })
 
 test('ConsumptionMeter measures what was spent across a window (#523)', () => {
@@ -165,4 +166,60 @@ test('consumptionStatus keeps a full bar at 100 rather than overflowing it (#523
   const status = consumptionStatus({ meter, limits: DEFAULT_CONSUMPTION_LIMITS, sessionStartedAt: T0 - HOUR, now: T0 })
   assert.equal(status.daily.usedPercent, 100)
   assert.equal(status.session.usedPercent, 100)
+})
+
+// #876: the account's own week is absolute, so it is the one limit that still means something
+// to a daemon with nothing to diff. Rom's question on #871: "don't we retrieve the real quota
+// usage from CC?" -- we do, and this is it being used.
+test('the weekly limit is measured against the account, not the meter (#876)', () => {
+  const limits: ConsumptionLimits = {
+    week: { enabled: true, percent: 80 },
+    daily: { enabled: true, percent: 20 },
+    fiveHour: { enabled: true, percent: 60 },
+    session: { enabled: true, percent: 40 },
+  }
+  // A meter that has seen nothing at all: every rolling window is unmeasurable.
+  const status = consumptionStatus({ meter: new ConsumptionMeter(), limits, accountWeekPercent: 95 })
+  assert.equal(status.week.consumed, 95)
+  assert.equal(status.week.complete, true)
+  assert.equal(status.week.reached, true)
+  assert.equal(status.reached, 'week')
+})
+
+test('a restarted daemon still knows the account week is spent (#876)', () => {
+  // The #848 scenario, which #870 left uncovered: one sample, nothing to diff, so the rolling
+  // windows honestly read 0 consumed while the account sits at 95% of its week.
+  const meter = new ConsumptionMeter()
+  meter.record({ at: 1_800_000_000_000, weeklyPercent: 95 })
+  const limits: ConsumptionLimits = {
+    week: { enabled: true, percent: 90 },
+    daily: { enabled: true, percent: 20 },
+    fiveHour: { enabled: true, percent: 60 },
+    session: { enabled: true, percent: 40 },
+  }
+  const status = consumptionStatus({ meter, limits, accountWeekPercent: 95, now: 1_800_000_000_000 })
+  assert.equal(status.daily.usedPercent, 0) // the trap that fooled the old gate
+  assert.equal(status.reached, 'week') // and the limit that catches it anyway
+})
+
+test('the weekly limit is unmeasurable without a reading, never "untouched" (#876)', () => {
+  // Fail-open, as everywhere else: no reading must not stop the user's own work.
+  const status = consumptionStatus({ meter: new ConsumptionMeter(), limits: DEFAULT_CONSUMPTION_LIMITS })
+  assert.equal(status.week.consumed, undefined)
+  assert.equal(status.week.reached, false)
+  assert.equal(status.reached, null)
+})
+
+test('the default weekly limit only stops an account that is actually spent (#876)', () => {
+  const at99 = consumptionStatus({ meter: new ConsumptionMeter(), limits: DEFAULT_CONSUMPTION_LIMITS, accountWeekPercent: 99 })
+  assert.equal(at99.reached, null)
+  const at100 = consumptionStatus({ meter: new ConsumptionMeter(), limits: DEFAULT_CONSUMPTION_LIMITS, accountWeekPercent: 100 })
+  assert.equal(at100.reached, 'week')
+})
+
+test('a disabled weekly limit is not reached whatever the account says (#876)', () => {
+  const limits: ConsumptionLimits = { ...DEFAULT_CONSUMPTION_LIMITS, week: { enabled: false, percent: 50 } }
+  const status = consumptionStatus({ meter: new ConsumptionMeter(), limits, accountWeekPercent: 99 })
+  assert.equal(status.week.reached, false)
+  assert.equal(status.reached, null)
 })

--- a/packages/framework/src/consumption.ts
+++ b/packages/framework/src/consumption.ts
@@ -19,6 +19,9 @@ export const FIVE_HOURS_MS = 5 * 60 * 60 * 1000
 /** A rolling day, in ms. */
 export const ONE_DAY_MS = 24 * 60 * 60 * 1000
 
+/** The account's own week, the window {@link ConsumptionLimits.week} is measured over. */
+export const ONE_WEEK_MS = 7 * ONE_DAY_MS
+
 /** One reading of the weekly meter. */
 export interface QuotaSample {
   /** When it was read, epoch ms. */
@@ -135,14 +138,15 @@ export class ConsumptionMeter {
   }
 }
 
-/** One of Rom's three limits. */
-export type ConsumptionWindow = 'session' | 'five-hour' | 'daily'
+/** One of the limits (#519, plus the account week from #876). */
+export type ConsumptionWindow = 'session' | 'five-hour' | 'daily' | 'week'
 
 /** How each limit reads in a log line and a stop reason. */
 export const CONSUMPTION_LIMIT_LABEL: Record<ConsumptionWindow, string> = {
   session: 'Session',
   'five-hour': '5h',
   daily: 'Daily',
+  week: 'Weekly',
 }
 
 /** A single limit: a share, and whether it's on. */
@@ -158,6 +162,15 @@ export interface ConsumptionLimit {
  * raises all three together.
  */
 export interface ConsumptionLimits {
+  /**
+   * Share of the account's weekly allowance the framework may consume (#876).
+   *
+   * The odd one out, and deliberately so: the other three are rolling windows the meter has
+   * to derive by diffing readings, while this one is measured straight against the agent's own
+   * absolute weekly figure. That is why it is the only limit that still means something to a
+   * daemon that just restarted and has nothing to diff.
+   */
+  week: ConsumptionLimit
   /** Share of the weekly allowance one day may consume. */
   daily: ConsumptionLimit
   /** Share of the day's budget a rolling 5h may consume. */
@@ -168,12 +181,16 @@ export interface ConsumptionLimits {
 
 /** Rom's defaults (#519). */
 export const DEFAULT_CONSUMPTION_LIMITS: ConsumptionLimits = {
+  // A ceiling rather than a pacing knob: at 100 it only stops work the account could not have
+  // run anyway, so it changes nothing until it is lowered. Lowering it is what reserves the
+  // rest of the week for a human.
+  week: { enabled: true, percent: 100 },
   daily: { enabled: true, percent: 20 },
   fiveHour: { enabled: true, percent: 60 },
   session: { enabled: true, percent: 40 },
 }
 
-const CONSUMPTION_LIMIT_KEYS = ['daily', 'fiveHour', 'session'] as const
+const CONSUMPTION_LIMIT_KEYS = ['week', 'daily', 'fiveHour', 'session'] as const
 
 /**
  * Read one limit out of a hand-edited or browser-supplied object.
@@ -208,6 +225,7 @@ export function sanitizeConsumptionLimits(value: unknown): ConsumptionLimits | u
 
 /** What each limit works out to, in points of the weekly meter. */
 export interface ConsumptionBudgets {
+  week: number
   daily: number
   fiveHour: number
   session: number
@@ -217,6 +235,8 @@ export interface ConsumptionBudgets {
 export function budgetsFrom(limits: ConsumptionLimits): ConsumptionBudgets {
   const daily = limits.daily.percent
   return {
+    // Already a share of the weekly allowance, which is the unit points are counted in.
+    week: limits.week.percent,
     daily,
     fiveHour: (limits.fiveHour.percent / 100) * daily,
     session: (limits.session.percent / 100) * daily,
@@ -243,6 +263,8 @@ export interface ConsumptionStatus {
   session: LimitStatus
   fiveHour: LimitStatus
   daily: LimitStatus
+  /** The account's own week (#876), measured absolutely rather than through the meter. */
+  week: LimitStatus
   /**
    * The limit to pause for, or `null`. Widest-first (`daily`, then `five-hour`,
    * then `session`), so what surfaces is the one that takes longest to recover.
@@ -283,10 +305,26 @@ export function consumptionStatus(input: {
   limits: ConsumptionLimits
   /** When the current session started, epoch ms. Omit when nothing is running. */
   sessionStartedAt?: number
+  /**
+   * How much of the account's week is gone, 0-100, straight from the agent's own reading
+   * (#876). Omit when there is none, which leaves the weekly limit unmeasurable rather than
+   * reading it as untouched.
+   */
+  accountWeekPercent?: number
   now?: number
 }): ConsumptionStatus {
   const now = input.now ?? Date.now()
   const budgets = budgetsFrom(input.limits)
+  // The account's week needs no meter: the agent reports it absolutely, so it is `complete` by
+  // construction and survives a daemon restart, which is exactly what the rolling windows cannot
+  // do (#876). Absent reading -> unmeasurable -> never reached, the same fail-open as the rest.
+  const week = statusFor(
+    input.limits.week,
+    budgets.week,
+    input.accountWeekPercent === undefined
+      ? undefined
+      : { points: input.accountWeekPercent, coveredMs: ONE_WEEK_MS, complete: true },
+  )
   const daily = statusFor(input.limits.daily, budgets.daily, input.meter.rolling(ONE_DAY_MS, now))
   const fiveHour = statusFor(input.limits.fiveHour, budgets.fiveHour, input.meter.rolling(FIVE_HOURS_MS, now))
   const session = statusFor(
@@ -294,12 +332,16 @@ export function consumptionStatus(input: {
     budgets.session,
     input.sessionStartedAt === undefined ? undefined : input.meter.since(input.sessionStartedAt, now),
   )
-  const reached: ConsumptionWindow | null = daily.reached
-    ? 'daily'
-    : fiveHour.reached
-      ? 'five-hour'
-      : session.reached
-        ? 'session'
-        : null
-  return { session, fiveHour, daily, reached }
+  // Widest first, so what surfaces is the limit that takes longest to recover. The account's
+  // week is wider than any of ours.
+  const reached: ConsumptionWindow | null = week.reached
+    ? 'week'
+    : daily.reached
+      ? 'daily'
+      : fiveHour.reached
+        ? 'five-hour'
+        : session.reached
+          ? 'session'
+          : null
+  return { session, fiveHour, daily, week, reached }
 }

--- a/packages/framework/src/dashboard/quota.ts
+++ b/packages/framework/src/dashboard/quota.ts
@@ -44,9 +44,17 @@ export function pollerQuotaSource(poller: QuotaPoller, limits: () => Promise<Con
     stop: () => poller.stop(),
     read: async () => {
       const envelope = poller.current()
+      const windows = envelope.lastGood?.windows ?? []
+      // The account's own week, handed to the limits so the weekly one is measured against it
+      // rather than against the delta meter (#876).
+      const accountWeek = windows.find(w => w.kind === 'week')?.percentUsed
       const view: QuotaView = {
-        windows: envelope.lastGood?.windows ?? [],
-        limits: consumptionStatus({ meter: poller.meter, limits: await limits().catch(() => DEFAULT_CONSUMPTION_LIMITS) }),
+        windows,
+        limits: consumptionStatus({
+          meter: poller.meter,
+          limits: await limits().catch(() => DEFAULT_CONSUMPTION_LIMITS),
+          ...(accountWeek !== undefined ? { accountWeekPercent: accountWeek } : {}),
+        }),
         ...(envelope.lastGoodAt !== undefined ? { readAt: envelope.lastGoodAt } : {}),
         ...(envelope.latest && !envelope.latest.available ? { unavailable: envelope.latest.reason } : {}),
       }

--- a/packages/framework/src/registry.test.ts
+++ b/packages/framework/src/registry.test.ts
@@ -369,6 +369,7 @@ test('registryPreferencesStore round-trips through the same file', async () => {
 })
 
 const LIMITS = {
+  week: { enabled: true, percent: 90 },
   daily: { enabled: true, percent: 25 },
   fiveHour: { enabled: false, percent: 50 },
   session: { enabled: true, percent: 30 },
@@ -394,6 +395,8 @@ test('a hand-edited limit falls back to the default rather than unguarding the a
   })
   const prefs = await readPreferences(memFs({ [FILE]: raw }), ENV)
   assert.deepEqual(prefs.consumptionLimits, {
+    // A config written before the weekly limit existed gets its default too (#876).
+    week: DEFAULT_CONSUMPTION_LIMITS.week,
     daily: { enabled: true, percent: 25 }, // the good one survives
     fiveHour: DEFAULT_CONSUMPTION_LIMITS.fiveHour,
     session: DEFAULT_CONSUMPTION_LIMITS.session,


### PR DESCRIPTION
> [!WARNING]
> **On hold, do not merge.** Rom is reworking the quota limits from scratch ("the whole quota limits design is broken... I've a completely new design. Zero config").
>
> This PR adds a *fourth configurable limit*, which is more config inside the design being replaced, plus a breaking `ConsumptionLimits` key. Merging it would hand the new design a migration it never needed.
>
> The finding it is built on still stands and is the useful part, whatever shape the redesign takes:
> - Claude reports `session` (5h), `week` and `week-model` -- and **no day**.
> - The weekly figure is **absolute and complete**, so it survives a daemon restart.
> - The rolling windows are derived by diffing readings, so **the diff is what a restart loses, not the reading**.
>
> The one genuinely-wrong-today line it contained (the usage panel still describing auto PM's removed half-free rule) is split out into #878 so it lands regardless.

Closes #876. Answers @brillout on #871:

> Don't we retrieve the real quota usage from CC?

We do, and you were right that it makes the blind spot smaller than I described.

## What was actually wrong

`ClaudeCodeDriver.readQuota()` returns absolute `percentUsed` per window, and it was already in the same object the gates read (`QuotaView.windows`) — it draws the usage panel.

What Claude does *not* report is a **day**. The windows are `session` (its 5 hours), `week`, and `week-model`; `driver/types.ts` says so outright ("#519 was specced against a daily limit that does not exist"). Our limits are shares of the weekly allowance spent per day / per 5h / per session, so the meter derives them by diffing successive weekly readings.

**So the diff is what a restart loses, not the reading.** My #870 description overstated it.

## The change

The budgets are already denominated in points of the weekly allowance, which is the same unit as the absolute weekly figure. So the weekly limit needs no meter:

- `ConsumptionLimits` gains `week`, measured straight against the account's reading. `complete` by construction, survives a restart.
- `reached` reports it widest-first, ahead of `daily`.
- Both gates get it without changes, since both already read `reached`: the per-run guard (which holds the poller) and auto PM. **Still one set of limits**, per your call on #839 — no separate rule for unattended work.
- No reading still means unmeasurable, never "untouched": the same fail-open as the rest, so an unreadable quota cannot stop your own work.

**Default `{ enabled: true, percent: 100 }`** — a ceiling, not a pacing knob. It only stops work the account could not have run anyway, so nothing changes until you lower it; lowering it is what reserves the rest of the week for a human. Set it to 50 and you get #848's old behaviour back, now as a visible setting instead of a rule buried in auto PM.

## Verified against a real account

Ran the daemon and read the panel with live quota:

```
Current week (all models)   16% used · resets Jul 25
...
This week   100%   16% of its budget
Daily        20%    0% of its budget   (Counting from when the dashboard started, so this covers less than the full window.)
```

The new row carries the account's real 16% and, unlike the rolling ones, no "covers less than the full window" caveat — which is the whole point.

Also drops a line in the panel still telling users auto PM needs half of every budget free. #870 removed that rule, so the copy has been wrong since it merged.

## Breaking, mildly

`ConsumptionLimits` has a fourth key. A `the-framework.json` written before this keeps working (each limit falls back independently, and there is a test), but TS callers building the literal need `week`. Hence `minor` rather than `patch` on 0.x.

Framework 99 tests green (6 new, including the restart case that fooled the old gate), dashboard 39 files / 217, typecheck clean, root build 11/11.
