### PR TITLE
fix(framework): sub-plans in the ticket format, and drop a stale panel line (#684)

### DIFF
--- a/.changeset/fix-684-subplans-and-stale-copy.md
+++ b/.changeset/fix-684-subplans-and-stale-copy.md
@@ -1,0 +1,9 @@
+---
+"@gemstack/framework": patch
+---
+
+Two small corrections.
+
+The ticket format now tells a plan to break itself into sub-plans when there is variability (#684), matching the spec.
+
+The usage panel no longer says the roadmap toggle needs half of every budget free. That rule was removed in #870, so the sentence had been describing behaviour that no longer existed.

--- a/packages/framework-dashboard/components/UsagePanel.tsx
+++ b/packages/framework-dashboard/components/UsagePanel.tsx
@@ -155,7 +155,7 @@ export function UsagePanel() {
             </label>
             <p className="text-xs text-muted-foreground">
               When nothing is running and the queue is empty, spike &amp; plan tickets rather than let the
-              budget expire. Only while every limit above still has half its budget free.
+              budget expire. Only while the limits above are not reached.
             </p>
           </div>
         ) : null}

--- a/packages/framework/prompts/ticketing_format.md
+++ b/packages/framework/prompts/ticketing_format.md
@@ -86,6 +86,7 @@ Typical plan content:
   - Thorough analysis
   - Overview of code changes
   - ...
+- Plan broken down in multiple (sub)plans in case of variability
 - Hard problems
   - Exhaustive list of all aspects with low confidence regarding how to solve them (the hard problems), with explanation why
 - Variability


### PR DESCRIPTION
Two unrelated one-liners, both corrections to text that is already shipped.

**1. Ticket format (#684).** You added to the OP:

> - Plan broken down in multiple (sub)plans in case of variability

`prompts/ticketing_format.md` did not have it. Added verbatim, under "Typical plan content", and it flows through to the generated prompt.

**2. A stale line in the usage panel.** It still said the roadmap toggle runs "only while every limit above still has half its budget free". #870 removed that rule this morning, so the panel has been describing behaviour that no longer exists. Now: "Only while the limits above are not reached."

Split out of #877 deliberately, since that one is parked pending your new quota design and this sentence is wrong on `main` today either way.

Framework tickets suite green, dashboard 39 files / 217 tests, root build 11/11.