### PR TITLE
feat(framework): ship a TODO_AGENTS.md format spec (#880)

### DIFF
--- a/.changeset/todo-format-spec.md
+++ b/.changeset/todo-format-spec.md
@@ -1,0 +1,15 @@
+---
+'@gemstack/framework': minor
+---
+
+Ship a TODO_AGENTS.md format spec the agent can read (#880)
+
+The backlog had no written layout, so each agent invented one. The package now ships
+`prompts/todo_format.md`, and the context fragment points at it the same way it already
+points at the ticket format: by its `node_modules` path, so the layout versions with the
+package instead of going stale in a committed file.
+
+The format is a priority-sorted file with `## URGENT`, `## High priority`,
+`## Medium priority` and `## Low priority` sections. It needs no parser change, because
+entries are read in file order and headings are skipped, so a priority-sorted file drains
+in priority order.

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -29,7 +29,8 @@
   },
   "files": [
     "dist",
-    "prompts/ticketing_format.md"
+    "prompts/ticketing_format.md",
+    "prompts/todo_format.md"
   ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/framework/prompts/todo_format.md
+++ b/packages/framework/prompts/todo_format.md
@@ -1,0 +1,24 @@
+# TODO_AGENTS.md
+
+Content:
+```md
+## URGENT
+
+...
+
+## High priority
+
+...
+
+## Medium priority
+
+...
+
+## Low priority
+
+...
+```
+
+The TODO_AGENTS.md file lists *all* tasks AI will work on next, sorted by priority.
+
+URGENT is rarely used (e.g. for critical production bugs) and should be treated as utmost priority.

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -273,6 +273,7 @@ export {
   LEGACY_TODO_FILE,
   TICKETS_DIR,
   TICKETING_FORMAT_FILE,
+  TODO_FORMAT_FILE,
   DEFAULT_MAX_TODO_ITEMS,
   type TodoBacklog,
   type TodoLoopOptions,

--- a/packages/framework/src/system-prompt.test.ts
+++ b/packages/framework/src/system-prompt.test.ts
@@ -11,7 +11,7 @@ import {
   systemPromptBlock,
   SYSTEM_PROMPT_TEMPLATE,
 } from './system-prompt.js'
-import { TICKETING_FORMAT_FILE } from './tickets.js'
+import { FLAT_TODO_FILE, TICKETING_FORMAT_FILE, TODO_FORMAT_FILE } from './tickets.js'
 import { loadUserSystemPrompt, SYSTEM_PROMPT_FILE } from './system-prompt-file.js'
 
 /** The context docs as the commented bullets they render to (#559/#683). */
@@ -41,6 +41,9 @@ test('CONTEXT_DOCS is the #683 fragment: business knowledge plus the roadmap/que
   // canonical constant in tickets.ts (#684) — they must never drift.
   const tickets = CONTEXT_DOCS.find(d => d.path === 'tickets/**.md')
   assert.ok(tickets?.comment.includes(TICKETING_FORMAT_FILE), `expected the ${TICKETING_FORMAT_FILE} pointer`)
+  // Same for the #880 backlog-format pointer.
+  const todo = CONTEXT_DOCS.find(d => d.path === FLAT_TODO_FILE)
+  assert.ok(todo?.comment.includes(TODO_FORMAT_FILE), `expected the ${TODO_FORMAT_FILE} pointer`)
 })
 import { AWAIT_PROTOCOL, BROWSER_PROTOCOL, SIGNAL_PROTOCOL } from './turn-gate.js'
 

--- a/packages/framework/src/system-prompt.ts
+++ b/packages/framework/src/system-prompt.ts
@@ -118,7 +118,8 @@ export const BUSINESS_KNOWLEDGE_DOCS: readonly ContextDoc[] = [DECISIONS_DOC, KN
  * task queue. Repo-root paths, because that is the agent's cwd. README is left out: a repo's
  * own `README.md` already covers the overview. The ticket-format path is inlined rather than
  * imported from `tickets.ts`: this module must stay free of `node:fs` (it renders in the
- * browser, #520), and a test pins the literal to `TICKETING_FORMAT_FILE`.
+ * browser, #520), and a test pins the literal to `TICKETING_FORMAT_FILE`. The `TODO_AGENTS.md`
+ * format pointer (#880) is inlined for the same reason and pinned to `TODO_FORMAT_FILE`.
  */
 export const CONTEXT_DOCS: readonly ContextDoc[] = [
   DECISIONS_DOC,
@@ -129,7 +130,7 @@ export const CONTEXT_DOCS: readonly ContextDoc[] = [
   // back into, so it stays out of BUSINESS_KNOWLEDGE_DOCS.
   { path: 'MARKET_RESEARCH.md', comment: 'the market the project competes in' },
   { path: 'tickets/**.md', comment: 'things to potentially work on; format: node_modules/@gemstack/framework/prompts/ticketing_format.md' },
-  { path: 'TODO_AGENTS.md', comment: 'the AI task queue' },
+  { path: 'TODO_AGENTS.md', comment: 'the AI task queue; format: node_modules/@gemstack/framework/prompts/todo_format.md' },
 ]
 
 /** The two halves of the rendered {@link SYSTEM_PROMPT_TEMPLATE}. */

--- a/packages/framework/src/tickets.test.ts
+++ b/packages/framework/src/tickets.test.ts
@@ -10,9 +10,10 @@ import {
   LEGACY_TODO_FILE,
   TICKETS_DIR,
   TICKETING_FORMAT_FILE,
+  TODO_FORMAT_FILE,
   findFlatTodo,
 } from './tickets.js'
-import { TICKETING_FORMAT } from './prompts.generated.js'
+import { TICKETING_FORMAT, TODO_FORMAT } from './prompts.generated.js'
 
 test('the flat backlog lives at the root TODO_AGENTS.md, with the legacy locations named (#674/#682)', () => {
   assert.equal(TICKETS_DIR, 'tickets')
@@ -31,6 +32,18 @@ test('the ticket-format spec ships in the package (not materialized), with prior
   assert.ok(TICKETING_FORMAT.includes('tickets/<DATE>_<SLUG>.spike.md'))
   assert.ok(TICKETING_FORMAT.includes('priority: low/medium/high/urgent'))
   assert.ok(TICKETING_FORMAT.includes('topics:'))
+})
+
+test('the backlog-format spec ships in the package and teaches the priority sections (#880)', () => {
+  // Ships inside the package like the ticket format, so the layout versions with the package.
+  assert.equal(TODO_FORMAT_FILE, 'node_modules/@gemstack/framework/prompts/todo_format.md')
+  assert.ok(TODO_FORMAT.includes(FLAT_TODO_FILE))
+  for (const section of ['## URGENT', '## High priority', '## Medium priority', '## Low priority']) {
+    assert.ok(TODO_FORMAT.includes(section), `expected the ${section} section`)
+  }
+  // URGENT is the exception, not the default, and the file is priority-sorted.
+  assert.ok(TODO_FORMAT.includes('rarely used'))
+  assert.ok(TODO_FORMAT.includes('sorted by priority'))
 })
 
 test('findFlatTodo prefers TODO_AGENTS.md, then legacy tickets/TODO.md, then root TODO.md, else undefined (#682)', async () => {

--- a/packages/framework/src/tickets.ts
+++ b/packages/framework/src/tickets.ts
@@ -29,6 +29,15 @@ export const TICKETING_FORMAT_FILE = 'node_modules/@gemstack/framework/prompts/t
  */
 export const FLAT_TODO_FILE = 'TODO_AGENTS.md'
 
+/**
+ * The backlog-format spec (#880): the static reference an agent opens to learn how
+ * {@link FLAT_TODO_FILE} is laid out — priority sections, URGENT first. Ships inside the
+ * installed package for the same reason as {@link TICKETING_FORMAT_FILE}, and the #683 context
+ * fragment points here. The priority sections need no parser support: `parseTodoEntries` skips
+ * headings and returns entries in file order, so a priority-sorted file drains in priority order.
+ */
+export const TODO_FORMAT_FILE = 'node_modules/@gemstack/framework/prompts/todo_format.md'
+
 /** The brief hyphen spelling from #682, read as a fallback after #674 settled on the underscore. */
 export const LEGACY_HYPHEN_TODO_FILE = 'TODO-AGENTS.md'
 

--- a/packages/framework/src/todo-loop.test.ts
+++ b/packages/framework/src/todo-loop.test.ts
@@ -34,6 +34,28 @@ test('parseTodoEntries reads open list items and skips checked/blank/prose lines
   ])
 })
 
+test('the #880 priority sections need no parser support: headings are skipped, so a sorted file drains in priority order', () => {
+  const md = [
+    '## URGENT',
+    '- restore checkout',
+    '',
+    '## High priority',
+    '- flaky auth test',
+    '',
+    '## Medium priority',
+    '- tidy the config loader',
+    '',
+    '## Low priority',
+    '- rename the legacy flag',
+  ].join('\n')
+  assert.deepEqual(parseTodoEntries(md), [
+    'restore checkout',
+    'flaky auth test',
+    'tidy the config loader',
+    'rename the legacy flag',
+  ])
+})
+
 test('findTodoBacklog prefers the newest session-scoped file, falls back to flat TODO.md', async () => {
   const cwd = await tmpWorkspace()
   try {

--- a/packages/framework/src/todo-loop.ts
+++ b/packages/framework/src/todo-loop.ts
@@ -6,7 +6,7 @@ import { requestChoices, runAwaitRounds } from './run.js'
 import { FLAT_TODO_FILE, findFlatTodo } from './tickets.js'
 import { createTurnSignalEmitter } from './turn-gate.js'
 
-export { FLAT_TODO_FILE, LEGACY_HYPHEN_TODO_FILE, LEGACY_TICKETS_TODO_FILE, LEGACY_TODO_FILE, TICKETS_DIR, TICKETING_FORMAT_FILE } from './tickets.js'
+export { FLAT_TODO_FILE, LEGACY_HYPHEN_TODO_FILE, LEGACY_TICKETS_TODO_FILE, LEGACY_TODO_FILE, TICKETS_DIR, TICKETING_FORMAT_FILE, TODO_FORMAT_FILE } from './tickets.js'
 
 /**
  * The backlog loop (#323): once the main work settles, consume the agent's own


### PR DESCRIPTION
Closes #880

Ships the backlog-format spec as a static file in the package, mirroring how the ticket format already works.

## What

- `packages/framework/prompts/todo_format.md`, with the layout from the issue verbatim.
- `TODO_FORMAT_FILE` in `tickets.ts`, pointing at `node_modules/@gemstack/framework/prompts/todo_format.md`, and added to the `files` allowlist so it actually ships.
- The `TODO_AGENTS.md` entry in `CONTEXT_DOCS` (the #683 fragment) now carries that pointer, next to the existing `tickets/**.md` one.

## No parser change needed

The priority sections work as-is: `parseTodoEntries` skips headings and returns entries in file order, so a priority-sorted file drains in priority order. There is a test pinning that, so a future parser change cannot break it silently.

## Naming

The file is `todo_format.md`, not `todo-format.md` as written in the issue, to match its siblings (`ticketing_format.md`, `on_before_mergeable_prompt.md`, `presets/*.md`). One-line change if you prefer the hyphen.

## Heads up: the Prompt drift check will be red, and not because of this PR

Adding a file under `prompts/**` triggers that workflow, and it is already failing on `main`. #326 was edited at 14:38 UTC today so that `TODO_FILE` is `TODO_AGENTS.md` instead of `TODO_<SESSION_NAME>.agent.md`; the last drift run was 14:13, before the edit, so nothing has caught it yet. Verified by running the check on a clean `origin/main` tree.

Left out of this PR deliberately: that change swaps the session-scoped backlog for the flat one, which is behavioral, not a copy-paste. Filed separately.

## Testing

840 framework tests pass. Both new assertions were mutation-checked (removing the pointer fails the CONTEXT_DOCS test).
