### PR TITLE
feat(framework): render preset defaults, so a preset targets its session (#874)

### DIFF
--- a/.changeset/preset-render-context.md
+++ b/.changeset/preset-render-context.md
@@ -1,0 +1,17 @@
+---
+'@gemstack/framework': minor
+---
+
+Presets target the session they were launched from (#874)
+
+A preset's `what` param defaulted to the literal `this PR`. It now defaults to the session the
+preset was launched from, falling back to `entire codebase` when there is no session yet.
+
+`${{ }}` has always been JS-evaluated, but the default value was the one string that never went
+through the evaluator, so a `${{ }}` inside it reached the prompt as literal text. Defaults are
+now rendered against the same context as the preset body, and that context carries
+`session_name`, `presets` and `settings` — so a preset can also point at another preset's file
+path, which #881 needs.
+
+In the dashboard, a preset picked from a run page renders against that run's session; the
+launcher has no session and gets the codebase-wide default.

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -1,5 +1,6 @@
-import { forwardRef, useImperativeHandle, useRef, useState, type FormEvent } from 'react'
+import { forwardRef, useImperativeHandle, useMemo, useRef, useState, type FormEvent } from 'react'
 import type { ProjectSummary } from '@gemstack/framework'
+import type { PresetRenderContext } from '@gemstack/framework/client'
 import {
   renderResearchPrompt,
   renderReadabilityPrompt,
@@ -25,7 +26,7 @@ import { Button } from './ui/button.js'
 
 // The presets (#353/#433): each PREFILLS the editor with a rendered prompt and runs it verbatim
 // (`kind: 'prompt'`). Emptying the box falls back to a normal `build` run.
-const PRESETS: { id: string; label: string; render: () => string; tooltip?: string }[] = [
+const PRESETS: { id: string; label: string; render: (what?: string, ctx?: PresetRenderContext) => string; tooltip?: string }[] = [
   { id: 'research', label: 'Research', render: renderResearchPrompt },
   { id: 'readability', label: 'Readability', render: renderReadabilityPrompt },
   { id: 'maintainability', label: 'Maintainability', render: renderMaintainabilityPrompt },
@@ -108,8 +109,12 @@ export const Composer = forwardRef<ComposerHandle, {
   /** Off inside a session (#831): a session is bound to the agent it started with, so the select
    *  would only ever rewrite the *next* session's default. Chosen at the launcher instead. */
   showAgentModel?: boolean | undefined
+  /** The session this composer sits in, if any (#874): a preset launched from a run page targets
+   *  that session by default, instead of the whole codebase. Absent at the launcher, where no
+   *  session exists yet. */
+  sessionName?: string | undefined
 }>(function Composer(
-  { files, addContext, onSubmit, onPromptChange, onPreset, busy, submitLabel, submitBusyLabel, placeholder, showShortcutHint = false, compact = false, showAgentModel = true },
+  { files, addContext, onSubmit, onPromptChange, onPreset, busy, submitLabel, submitBusyLabel, placeholder, showShortcutHint = false, compact = false, showAgentModel = true, sessionName },
   ref,
 ) {
   const [prompt, setPrompt] = useState('')
@@ -123,6 +128,18 @@ export const Composer = forwardRef<ComposerHandle, {
   const autopilot = autopilotEnabled(preferences)
   const technical = preferences.technical ?? false
   const vanilla = preferences.vanilla ?? false
+
+  // Presets render against the session they are launched from (#874). The run pages pass their
+  // session name so a preset targets that session by default; the launcher passes none, and the
+  // default falls through to the whole codebase.
+  const presets = useMemo(
+    () =>
+      PRESETS.map(p => ({
+        ...p,
+        render: () => p.render(undefined, { session_name: sessionName, settings: { technical_control: technical } }),
+      })),
+    [sessionName, technical],
+  )
   const transparent = preferences.transparent ?? false // #625: the master off-switch (raw Claude Code)
   const eco = preferences.eco ?? false
   const ecoPlanning = preferences.ecoPlanning ?? false
@@ -207,7 +224,7 @@ export const Composer = forwardRef<ComposerHandle, {
       onMentionFile={addContext}
       projects={projects}
       files={files}
-      presets={PRESETS}
+      presets={presets}
       customPresets={customPresets}
       // The `/` menu offers "New preset…" only in the full composer, where the create panel renders;
       // the compact navbar launch has no panel, so it gets no callback (and no item).

--- a/packages/framework-dashboard/components/RunChat.tsx
+++ b/packages/framework-dashboard/components/RunChat.tsx
@@ -13,6 +13,7 @@ export function RunChat({
   runId,
   files,
   addContext,
+  sessionName,
 }: {
   projectId: string
   /** Which run the message goes to (#749); absent falls back to the project's control log. */
@@ -21,6 +22,8 @@ export function RunChat({
   files: string[]
   /** Add a path to the run Context (from an `@`/`#` mention). */
   addContext: (path: string) => void
+  /** This session's name (#874), so a preset launched here targets it by default. */
+  sessionName?: string | undefined
 }) {
   const composerRef = useRef<ComposerHandle>(null)
   const [sending, setSending] = useState(false)
@@ -50,6 +53,7 @@ export function RunChat({
         submitLabel="Send"
         submitBusyLabel="Sending…"
         showAgentModel={false}
+        sessionName={sessionName}
         placeholder="Message the session…  ( / commands · < tags · @ projects · # files )"
       />
     </div>

--- a/packages/framework-dashboard/components/RunLive.tsx
+++ b/packages/framework-dashboard/components/RunLive.tsx
@@ -1,4 +1,5 @@
 import type { FrameworkEvent } from '@gemstack/framework'
+import { runProgress } from '@gemstack/framework/client'
 import { RunActionBar } from './RunActionBar.js'
 import { RunChat } from './RunChat.js'
 import { RunFeed } from './RunFeed.js'
@@ -25,6 +26,9 @@ export function RunLive({
   files: string[]
   addContext: (path: string) => void
 }) {
+  // The session's own name, once the agent has set it (#874): presets in the chat below default
+  // to targeting this session rather than the whole codebase.
+  const sessionName = runProgress(events).sessionName
   return (
     <>
       <RunActionBar projectId={projectId} runId={runId} events={events} />
@@ -32,7 +36,7 @@ export function RunLive({
           falls back to the project root and would report the user's own dirty files as the run's. */}
       {runId && <RunChanges projectId={projectId} runId={runId} />}
       <RunFeed events={events} showSessionLink={false} />
-      <RunChat projectId={projectId} runId={runId} files={files} addContext={addContext} />
+      <RunChat projectId={projectId} runId={runId} files={files} addContext={addContext} sessionName={sessionName} />
     </>
   )
 }

--- a/packages/framework-dashboard/components/RunReplay.tsx
+++ b/packages/framework-dashboard/components/RunReplay.tsx
@@ -1,5 +1,5 @@
 import type { FrameworkEvent } from '@gemstack/framework'
-import { sessionInfo } from '@gemstack/framework/client'
+import { runProgress, sessionInfo } from '@gemstack/framework/client'
 import { useCallback, useState } from 'react'
 import { onRun, onRetainedWorktrees } from '../server/reads.telefunc.js'
 import { EventList } from './EventList.js'
@@ -41,6 +41,8 @@ export function RunReplay({
   // agent reported it, so a run that never got that far simply can't be resumed.
   const session = sessionInfo(events)
   const sessionId = session?.sessionId
+  // Presets in the resume composer default to this session (#874).
+  const sessionName = runProgress(events).sessionName
   return (
     <>
       <RunActionBar
@@ -60,7 +62,7 @@ export function RunReplay({
         <EventList events={events} stick={false} />
       )}
       {sessionId && (
-        <RunResumeChat projectId={projectId} runId={runId} sessionId={sessionId} driver={session?.driver} files={files} addContext={addContext} onRunStarted={onRunStarted} />
+        <RunResumeChat projectId={projectId} runId={runId} sessionId={sessionId} driver={session?.driver} files={files} addContext={addContext} onRunStarted={onRunStarted} sessionName={sessionName} />
       )}
     </>
   )

--- a/packages/framework-dashboard/components/RunResumeChat.tsx
+++ b/packages/framework-dashboard/components/RunResumeChat.tsx
@@ -20,6 +20,7 @@ export function RunResumeChat({
   files,
   addContext,
   onRunStarted,
+  sessionName,
 }: {
   projectId: string
   /** The run being continued (#762), so the follow-up reopens it instead of starting a new one. */
@@ -31,6 +32,8 @@ export function RunResumeChat({
   files: string[]
   addContext: (path: string) => void
   onRunStarted: (intent: string, runId?: string) => void
+  /** This session's name (#874), so a preset launched here targets it by default. */
+  sessionName?: string | undefined
 }) {
   const composerRef = useRef<ComposerHandle>(null)
   const [busy, setBusy] = useState(false)
@@ -77,6 +80,7 @@ export function RunResumeChat({
         submitLabel="Send"
         submitBusyLabel="Resuming…"
         showAgentModel={false}
+        sessionName={sessionName}
         placeholder="Message the session to continue it…  ( / commands · < tags · @ projects · # files )"
       />
       {error && <p className="mt-1 text-xs text-red-500">{error}</p>}

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -54,6 +54,7 @@ import {
   short,
   type RepoReview,
 } from './maintenance.js'
+import { defaultWhat } from './preset-prompt.js'
 import { renderMaintainabilityPrompt } from './maintainability-preset.js'
 import { renderOnBeforeMergeablePrompt, type OnBeforeMergeableContext } from './on-before-mergeable-prompt.js'
 import { runPrompt } from './prompt-run.js'
@@ -938,7 +939,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     io.err('Run `framework --help` for usage.')
     return 2
   }
-  // A bare `framework research` is a real run — its "what" defaults to `this PR`.
+  // A bare `framework research` is a real run — its "what" falls back to the preset default.
   if (!intent && !fake && !opts.research) return runForegroundDaemonCmd(opts, io)
 
   const cwd = opts.cwd ?? (fake ? join(tmpdir(), 'framework-fake-workspace') : process.cwd())
@@ -1075,10 +1076,10 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     try {
       // Seed the run's intent (its prompt) so the dashboard's Runs list labels it instead of
       // showing "(no prompt)". A build run refines this via its scope event; a prompt/research
-      // run keeps it. Research with no "what" defaults to the same "this PR" the log title uses.
+      // run keeps it. Research with no "what" uses the same preset default the log title uses.
       store = await RunStore.open(cwd, {
         fresh: true,
-        intent: intent || (opts.research ? 'this PR' : ''),
+        intent: intent || (opts.research ? defaultWhat() : ''),
         // Adopt the daemon's id (#736) so the run and the worktree it lives in share one.
         ...(opts.runId ? { id: opts.runId } : {}),
         // Continuing (#762): keep the existing log rather than starting this run's history over.
@@ -1160,7 +1161,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // `end` event (fired once by both run paths) closes the entry. Best-effort: the
   // project DB is committed history, so it must never break a run.
   const logKind = runLogKind(opts, transparent)
-  const logTitle = intent || (opts.research ? 'this PR' : '')
+  const logTitle = intent || (opts.research ? defaultWhat() : '')
   let logSessionId: string | undefined
   let logSessionLink: string | undefined
   // The browser preview's port, announced on the first `session` event rather than when the

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -33,7 +33,7 @@ export {
 } from './system-prompt.js'
 // What a preset can read beyond its params (#874), so the dashboard can render a preset against
 // the session it was launched from. Pure string work, like the renderers below.
-export type { PresetRenderContext } from './preset-prompt.js'
+export { defaultWhat, DEFAULT_WHAT, type PresetRenderContext } from './preset-prompt.js'
 export { renderResearchPrompt } from './research-preset.js'
 export { renderReadabilityPrompt } from './readability-preset.js'
 export { renderMaintainabilityPrompt } from './maintainability-preset.js'

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -31,6 +31,9 @@ export {
   type EcoOptions,
   type RenderedSystemPrompt,
 } from './system-prompt.js'
+// What a preset can read beyond its params (#874), so the dashboard can render a preset against
+// the session it was launched from. Pure string work, like the renderers below.
+export type { PresetRenderContext } from './preset-prompt.js'
 export { renderResearchPrompt } from './research-preset.js'
 export { renderReadabilityPrompt } from './readability-preset.js'
 export { renderMaintainabilityPrompt } from './maintainability-preset.js'

--- a/packages/framework/src/framework-dir.ts
+++ b/packages/framework/src/framework-dir.ts
@@ -1,0 +1,8 @@
+/**
+ * The directory, under a project root, that holds The Framework's own files.
+ *
+ * Its own module because it is the one piece of `logs.ts` the browser needs: the preset registry
+ * builds `tf.presets.<name>.filePath` from it (#874), and the dashboard renders presets in the
+ * browser (#520), where `logs.ts` cannot go — it imports `node:path`.
+ */
+export const THE_FRAMEWORK_DIR = '.the-framework'

--- a/packages/framework/src/logs.ts
+++ b/packages/framework/src/logs.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path'
+import { THE_FRAMEWORK_DIR } from './framework-dir.js'
 import { nodeStoreFs, type StoreFs } from './store/index.js'
 
 /**
@@ -8,8 +9,10 @@ import { nodeStoreFs, type StoreFs } from './store/index.js'
  * land in later issues (#379/#380).
  */
 
-/** The directory, under the project root, that holds the log. */
-export const THE_FRAMEWORK_DIR = '.the-framework'
+/** The directory, under the project root, that holds the log. Defined in its own node-free
+ * module (#874) so the browser-reachable preset registry can share it; re-exported here
+ * because this is where every existing import site expects to find it. */
+export { THE_FRAMEWORK_DIR }
 
 /** The markdown log file name. */
 export const LOGS_FILE = 'LOGS.md'

--- a/packages/framework/src/maintainability-preset.test.ts
+++ b/packages/framework/src/maintainability-preset.test.ts
@@ -14,11 +14,11 @@ test('the Maintainability template carries the #361 prompt: deliberately minimal
   assert.deepEqual(MAINTAINABILITY_PARAMS.map(p => p.name), ['what'])
 })
 
-test('renderMaintainabilityPrompt defaults the blank to "this PR" and takes an override', () => {
+test('renderMaintainabilityPrompt defaults the blank to the session, else the whole codebase (#874)', () => {
   const byDefault = renderMaintainabilityPrompt()
-  assert.match(byDefault, /^Refactor this PR to make it/)
+  assert.match(byDefault, /^Refactor entire codebase to make it/)
   const blank = renderMaintainabilityPrompt('   ')
-  assert.match(blank, /^Refactor this PR to make it/) // blank falls back, not erased
+  assert.match(blank, /^Refactor entire codebase to make it/) // blank falls back, not erased
   const custom = renderMaintainabilityPrompt('the queue package')
   assert.match(custom, /^Refactor the queue package to make it/)
   // No raw placeholder survives a render.

--- a/packages/framework/src/maintainability-preset.ts
+++ b/packages/framework/src/maintainability-preset.ts
@@ -11,9 +11,9 @@ const maintainability = definePreset('maintainability', PRESETS_MAINTAINABILITY,
 
 /** The preset's name, as the dashboard button uses it. */
 export const MAINTAINABILITY_PRESET_NAME = maintainability.name
-/** The one user param: what to refactor. Defaults to `this PR`, like the others. */
+/** The one user param: what to refactor. Defaults to the launching session, else the whole codebase (#874). */
 export const MAINTAINABILITY_PARAMS = maintainability.params
 /** The prompt template, verbatim from #361, in `prompts/presets/maintainability.md` (#551). */
 export const MAINTAINABILITY_PROMPT_TEMPLATE = maintainability.template
-/** Render the Maintainability prompt, filling its `${{ tf.params.what }}` blank (defaults to `this PR`). */
+/** Render the Maintainability prompt, filling its `${{ tf.params.what }}` blank (defaults to the launching session, else the whole codebase). */
 export const renderMaintainabilityPrompt = maintainability.render

--- a/packages/framework/src/preset-prompt.test.ts
+++ b/packages/framework/src/preset-prompt.test.ts
@@ -1,0 +1,35 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { DEFAULT_WHAT, definePreset } from './preset-prompt.js'
+import { presetFilePath } from './preset-registry.js'
+
+const preset = definePreset('demo', 'Work on ${{ tf.params.what }}.', 'What to work on')
+
+test('the default is a template, not a literal, so it can read the session (#874)', () => {
+  // The regression this guards: a `${{ }}` inside the default used to reach the prompt verbatim,
+  // because the default was the one string never passed through the evaluator.
+  assert.match(DEFAULT_WHAT, /^\$\{\{/)
+  assert.equal(preset.params[0].default, DEFAULT_WHAT)
+  assert.equal(preset.render().includes('${{'), false)
+})
+
+test('the default resolves to the session name when there is one, else the whole codebase (#874)', () => {
+  assert.equal(preset.render(), 'Work on entire codebase.')
+  assert.equal(preset.render(undefined, {}), 'Work on entire codebase.')
+  assert.equal(preset.render(undefined, { session_name: 'fix-login' }), 'Work on fix-login.')
+  // An explicit target still wins, and is trimmed; a blank one still falls back.
+  assert.equal(preset.render('  the API  ', { session_name: 'fix-login' }), 'Work on the API.')
+  assert.equal(preset.render('   ', { session_name: 'fix-login' }), 'Work on fix-login.')
+})
+
+test('a preset template can read tf.presets and tf.settings (#874, needed by #881)', () => {
+  const p = definePreset('demo2', 'Apply ${{ tf.presets.maintainability.filePath }}.', 'What')
+  // Defaults to the registry, so a caller that passes nothing still gets real paths.
+  assert.equal(p.render(), `Apply ${presetFilePath('maintainability')}.`)
+  assert.equal(p.render(undefined, { presets: { maintainability: { filePath: 'x.md' } } }), 'Apply x.md.')
+
+  const s = definePreset('demo3', "${{ tf.settings.technical_control ? 'on' : 'off' }}", 'What')
+  // Absent settings must not throw: they default to `{}`.
+  assert.equal(s.render(), 'off')
+  assert.equal(s.render(undefined, { settings: { technical_control: true } }), 'on')
+})

--- a/packages/framework/src/preset-prompt.ts
+++ b/packages/framework/src/preset-prompt.ts
@@ -31,6 +31,23 @@ export interface PresetRenderContext {
   presets?: Record<string, { filePath: string }> | undefined
 }
 
+/** The `tf` a preset renders against. `settings`/`presets` default so a template never throws. */
+function tfFrom(ctx: PresetRenderContext): Record<string, unknown> {
+  return {
+    session_name: ctx.session_name,
+    settings: ctx.settings ?? {},
+    presets: ctx.presets ?? presetContext(),
+  }
+}
+
+/**
+ * {@link DEFAULT_WHAT}, rendered. Exported so a caller that *labels* a run (the CLI's log title)
+ * says the same thing the prompt targets, instead of keeping its own copy of the default.
+ */
+export function defaultWhat(ctx: PresetRenderContext = {}): string {
+  return renderTemplate(DEFAULT_WHAT, { tf: { ...tfFrom(ctx), params: {} } })
+}
+
 /** A quality preset's public shape: its run-kind name, the `what` param, its template, and a renderer. */
 export interface PresetDef {
   name: string
@@ -60,14 +77,9 @@ export function definePreset(name: string, template: string, whatDescription: st
     params,
     template,
     render: (what, ctx = {}) => {
-      const tf = {
-        session_name: ctx.session_name,
-        settings: ctx.settings ?? {},
-        presets: ctx.presets ?? presetContext(),
-      }
       // The default renders with an empty `params`: it can read the session, but not itself.
-      const target = what?.trim() || renderTemplate(params[0].default, { tf: { ...tf, params: {} } })
-      return renderTemplate(template, { tf: { ...tf, params: { what: target } } })
+      const target = what?.trim() || defaultWhat(ctx)
+      return renderTemplate(template, { tf: { ...tfFrom(ctx), params: { what: target } } })
     },
   }
 }

--- a/packages/framework/src/preset-prompt.ts
+++ b/packages/framework/src/preset-prompt.ts
@@ -1,10 +1,34 @@
 import { renderTemplate } from './prompt-template.js'
+import { presetContext } from './preset-registry.js'
+import type { TfContext } from './system-prompt.js'
+
+/**
+ * The default target a preset runs against (#874): the session it was launched from, falling back
+ * to the whole codebase when there is no session yet. A template, not a plain string — see
+ * {@link definePreset} for why that distinction matters.
+ */
+export const DEFAULT_WHAT = '${{ tf.session_name || "entire codebase" }}'
 
 /** A quality preset's single user param: the target to run against. */
 export interface PresetParam {
   name: 'what'
+  /** A `${{ }}` template, rendered against the same context as the preset body. */
   default: string
   description: string
+}
+
+/**
+ * What a preset can read beyond its own params. Everything is optional: a preset rendered before
+ * any session exists (the launcher's prompt preview) simply has no `session_name`, which is what
+ * makes {@link DEFAULT_WHAT}'s `||` fall through to the codebase-wide default.
+ */
+export interface PresetRenderContext {
+  /** The launching session's name, once one has been set. */
+  session_name?: string | undefined
+  /** Framework settings, e.g. `technical_control`. Defaults to `{}` so a template never throws. */
+  settings?: TfContext['settings']
+  /** stem -> `{ filePath }`, so a preset can point at another preset. Defaults to the registry. */
+  presets?: Record<string, { filePath: string }> | undefined
 }
 
 /** A quality preset's public shape: its run-kind name, the `what` param, its template, and a renderer. */
@@ -13,23 +37,37 @@ export interface PresetDef {
   params: readonly [PresetParam]
   template: string
   /** Render the template, filling `${{ tf.params.what }}`; a blank/omitted `what` falls back to the default. */
-  render: (what?: string) => string
+  render: (what?: string, ctx?: PresetRenderContext) => string
 }
 
 /**
  * Define a quality preset (#326/#330) from the three things that actually differ between them:
  * the run-kind name, the prompt template, and what the one `what` param means. Every preset
- * has the identical shape — a single `what` param defaulting to `this PR`, rendered by filling
- * the `${{ tf.params.what }}` blank — so that shape lives here once instead of in each preset
- * file. A blank/omitted `what` falls back to the default, so a dashboard button runs with zero
- * input; a passed value is trimmed first.
+ * has the identical shape — a single `what` param rendered into the `${{ tf.params.what }}`
+ * blank — so that shape lives here once instead of in each preset file. A blank/omitted `what`
+ * falls back to the default, so a dashboard button runs with zero input; a passed value is
+ * trimmed first.
+ *
+ * The default is itself rendered (#874). `${{ }}` has always been JS-evaluated, but the default
+ * was the one string that never went through the evaluator, so a `${{ }}` inside it reached the
+ * prompt as literal text. Rendering it against the same context is what lets the default depend
+ * on the session the preset was launched from.
  */
 export function definePreset(name: string, template: string, whatDescription: string): PresetDef {
-  const params = [{ name: 'what', default: 'this PR', description: whatDescription }] as const
+  const params = [{ name: 'what', default: DEFAULT_WHAT, description: whatDescription }] as const
   return {
     name,
     params,
     template,
-    render: what => renderTemplate(template, { tf: { params: { what: what?.trim() || params[0].default } } }),
+    render: (what, ctx = {}) => {
+      const tf = {
+        session_name: ctx.session_name,
+        settings: ctx.settings ?? {},
+        presets: ctx.presets ?? presetContext(),
+      }
+      // The default renders with an empty `params`: it can read the session, but not itself.
+      const target = what?.trim() || renderTemplate(params[0].default, { tf: { ...tf, params: {} } })
+      return renderTemplate(template, { tf: { ...tf, params: { what: target } } })
+    },
   }
 }

--- a/packages/framework/src/preset-registry.ts
+++ b/packages/framework/src/preset-registry.ts
@@ -1,0 +1,46 @@
+import {
+  PRESETS_MAINTAINABILITY,
+  PRESETS_READABILITY,
+  PRESETS_SECURITY_AUDIT,
+  PRESETS_RESEARCH,
+  PRESETS_UX,
+} from './prompts.generated.js'
+import { THE_FRAMEWORK_DIR } from './framework-dir.js'
+
+/**
+ * The preset registry: which presets exist and where they land on disk. Split out of `presets.ts`
+ * (#874) so it stays free of `node:*` — a preset's own template can now reference
+ * `tf.presets.<name>.filePath`, and presets render in the browser (#520). `materializePresets`,
+ * which actually writes the files, stays behind in `presets.ts`.
+ */
+
+/**
+ * The quality preset prompts (#326), keyed by file stem. The stem is both the on-disk name
+ * and the `tf.presets.<stem>` key the prompts read: `tf.presets.security_audit.filePath` uses
+ * the underscore file stem, not the hyphenated run-kind name (`security-audit`).
+ */
+export const PRESETS: Readonly<Record<string, string>> = {
+  maintainability: PRESETS_MAINTAINABILITY,
+  readability: PRESETS_READABILITY,
+  security_audit: PRESETS_SECURITY_AUDIT,
+  research: PRESETS_RESEARCH,
+  ux: PRESETS_UX,
+}
+
+/** Where the materialized presets live under a repo's `.the-framework/` (#326). */
+export const PRESET_DIR = `${THE_FRAMEWORK_DIR}/presets`
+
+/**
+ * The workspace-relative path a materialized preset lives at, e.g.
+ * `.the-framework/presets/maintainability.md`. A TODO entry carries this as
+ * `tf.presets.<name>.filePath`, and the agent opens it. Workspace-relative, because that
+ * is the agent's cwd.
+ */
+export function presetFilePath(name: string): string {
+  return `${PRESET_DIR}/${name}.md`
+}
+
+/** The `tf.presets` map the prompts read: stem -> `{ filePath }`. */
+export function presetContext(): Record<string, { filePath: string }> {
+  return Object.fromEntries(Object.keys(PRESETS).map(name => [name, { filePath: presetFilePath(name) }]))
+}

--- a/packages/framework/src/presets.ts
+++ b/packages/framework/src/presets.ts
@@ -1,45 +1,11 @@
 import { join } from 'node:path'
-import {
-  PRESETS_MAINTAINABILITY,
-  PRESETS_READABILITY,
-  PRESETS_SECURITY_AUDIT,
-  PRESETS_RESEARCH,
-  PRESETS_UX,
-} from './prompts.generated.js'
-import { THE_FRAMEWORK_DIR } from './logs.js'
+import { PRESETS, PRESET_DIR } from './preset-registry.js'
 import { nodeStoreFs, type StoreFs } from './store/index.js'
 
-/**
- * The quality preset prompts (#326), keyed by file stem. The stem is both the on-disk name
- * and the `tf.presets.<stem>` key the on-before-mergeable prompt reads: Rom's OP writes
- * `tf.presets.security_audit.filePath`, so the key is the underscore file stem, not the
- * hyphenated run-kind name (`SECURITY_AUDIT_PRESET_NAME` is `security-audit`).
- */
-export const PRESETS: Readonly<Record<string, string>> = {
-  maintainability: PRESETS_MAINTAINABILITY,
-  readability: PRESETS_READABILITY,
-  security_audit: PRESETS_SECURITY_AUDIT,
-  research: PRESETS_RESEARCH,
-  ux: PRESETS_UX,
-}
-
-/** Where the materialized presets live under a repo's `.the-framework/` (#326). */
-export const PRESET_DIR = `${THE_FRAMEWORK_DIR}/presets`
-
-/**
- * The workspace-relative path a materialized preset lives at, e.g.
- * `.the-framework/presets/maintainability.md`. A on-before-mergeable TODO entry carries this as
- * `tf.presets.<name>.filePath`, and the agent opens it. Workspace-relative, because that
- * is the agent's cwd.
- */
-export function presetFilePath(name: string): string {
-  return `${PRESET_DIR}/${name}.md`
-}
-
-/** The `tf.presets` map the on-before-mergeable prompt reads: stem -> `{ filePath }`. */
-export function presetContext(): Record<string, { filePath: string }> {
-  return Object.fromEntries(Object.keys(PRESETS).map(name => [name, { filePath: presetFilePath(name) }]))
-}
+// The registry moved to `preset-registry.ts` (#874) to keep it free of `node:*`, since a preset
+// template can now read `tf.presets.<name>.filePath` and presets render in the browser (#520).
+// Re-exported here so every existing import site keeps working.
+export { PRESETS, PRESET_DIR, presetFilePath, presetContext } from './preset-registry.js'
 
 /**
  * Materialize every preset into `<cwd>/.the-framework/presets/<name>.md` so an on-before-mergeable

--- a/packages/framework/src/readability-preset.test.ts
+++ b/packages/framework/src/readability-preset.test.ts
@@ -15,11 +15,11 @@ test('the Readability template carries the #360 flow: seams, altitude pass, rati
   assert.deepEqual(READABILITY_PARAMS.map(p => p.name), ['what'])
 })
 
-test('renderReadabilityPrompt defaults the blank to "this PR" and takes an override', () => {
+test('renderReadabilityPrompt defaults the blank to the session, else the whole codebase (#874)', () => {
   const byDefault = renderReadabilityPrompt()
-  assert.match(byDefault, /^Refactor this PR to make it/)
+  assert.match(byDefault, /^Refactor entire codebase to make it/)
   const blank = renderReadabilityPrompt('   ')
-  assert.match(blank, /^Refactor this PR to make it/) // blank falls back, not erased
+  assert.match(blank, /^Refactor entire codebase to make it/) // blank falls back, not erased
   const custom = renderReadabilityPrompt('the dashboard package')
   assert.match(custom, /^Refactor the dashboard package to make it/)
   // No raw placeholder survives a render; <FUNCTION> is not a param and stays.

--- a/packages/framework/src/readability-preset.ts
+++ b/packages/framework/src/readability-preset.ts
@@ -12,9 +12,9 @@ const readability = definePreset('readability', PRESETS_READABILITY, 'What to re
 
 /** The preset's name, as the dashboard button uses it. */
 export const READABILITY_PRESET_NAME = readability.name
-/** The one user param: what to refactor. Defaults to `this PR`, like Research. */
+/** The one user param: what to refactor. Defaults to the launching session, else the whole codebase (#874). */
 export const READABILITY_PARAMS = readability.params
 /** The prompt template, verbatim from #360 (with `${{ tf.params.what }}` as the blank). */
 export const READABILITY_PROMPT_TEMPLATE = readability.template
-/** Render the Readability prompt, filling its `${{ tf.params.what }}` blank (defaults to `this PR`). */
+/** Render the Readability prompt, filling its `${{ tf.params.what }}` blank (defaults to the launching session, else the whole codebase). */
 export const renderReadabilityPrompt = readability.render

--- a/packages/framework/src/research-preset.test.ts
+++ b/packages/framework/src/research-preset.test.ts
@@ -13,11 +13,11 @@ test('the Research template carries the #331 flow: rating, multi-select gate, TO
   assert.deepEqual(RESEARCH_PARAMS.map(p => p.name), ['what'])
 })
 
-test('renderResearchPrompt defaults the blank to "this PR" and takes an override', () => {
+test('renderResearchPrompt defaults the blank to the session, else the whole codebase (#874)', () => {
   const byDefault = renderResearchPrompt()
-  assert.match(byDefault, /problem variability" of this PR/)
+  assert.match(byDefault, /problem variability" of entire codebase/)
   const blank = renderResearchPrompt('   ')
-  assert.match(blank, /problem variability" of this PR/) // blank falls back, not erased
+  assert.match(blank, /problem variability" of entire codebase/) // blank falls back, not erased
   const custom = renderResearchPrompt('the auth flow')
   assert.match(custom, /problem variability" of the auth flow/)
   // No raw placeholder survives a render.

--- a/packages/framework/src/research-preset.ts
+++ b/packages/framework/src/research-preset.ts
@@ -14,9 +14,9 @@ const research = definePreset('research', PRESETS_RESEARCH, 'What to measure pro
 
 /** The preset's name, as the CLI subcommand and the dashboard button use it. */
 export const RESEARCH_PRESET_NAME = research.name
-/** The one user param: what to measure. Defaults to `this PR`, per the issue. */
+/** The one user param: what to measure. Defaults to the launching session, else the whole codebase (#874). */
 export const RESEARCH_PARAMS = research.params
 /** The prompt template, verbatim from #331 (with `${{ tf.params.what }}` as the blank). */
 export const RESEARCH_PROMPT_TEMPLATE = research.template
-/** Render the Research prompt, filling its `${{ tf.params.what }}` blank (defaults to `this PR`). */
+/** Render the Research prompt, filling its `${{ tf.params.what }}` blank (defaults to the launching session, else the whole codebase). */
 export const renderResearchPrompt = research.render

--- a/packages/framework/src/security-audit-preset.test.ts
+++ b/packages/framework/src/security-audit-preset.test.ts
@@ -16,11 +16,11 @@ test('the Security audit template carries the #461 prompt: exhaustive, per-aspec
   assert.deepEqual(SECURITY_AUDIT_PARAMS.map(p => p.name), ['what'])
 })
 
-test('renderSecurityAuditPrompt defaults the blank to "this PR" and takes an override', () => {
+test('renderSecurityAuditPrompt defaults the blank to the session, else the whole codebase (#874)', () => {
   const byDefault = renderSecurityAuditPrompt()
-  assert.match(byDefault, /^Security audit this PR/)
+  assert.match(byDefault, /^Security audit entire codebase/)
   const blank = renderSecurityAuditPrompt('   ')
-  assert.match(blank, /^Security audit this PR/) // blank falls back, not erased
+  assert.match(blank, /^Security audit entire codebase/) // blank falls back, not erased
   const custom = renderSecurityAuditPrompt('the auth package')
   assert.match(custom, /^Security audit the auth package/)
   // No raw placeholder survives a render.

--- a/packages/framework/src/security-audit-preset.ts
+++ b/packages/framework/src/security-audit-preset.ts
@@ -4,7 +4,7 @@ import { PRESETS_SECURITY_AUDIT } from './prompts.generated.js'
 /**
  * The [Security audit] preset (#461): Rom's exhaustive security pass, shipped as
  * a direct prompt like [Readability] (#360) and [Maintainability] (#361) — it
- * scrutinizes existing code, so it skips the scope -> build scaffolding. `${{ tf.params.what }}` is the user-facing blank (defaults to `this PR`).
+ * scrutinizes existing code, so it skips the scope -> build scaffolding. `${{ tf.params.what }}` is the user-facing blank (defaults to the launching session, else the whole codebase).
  * It is also one of the on-before-mergeable quality prompts #326 fires on
  * `setReadyForMerge()`. Keep it in sync with the issue rather than growing it here.
  */
@@ -12,9 +12,9 @@ const securityAudit = definePreset('security-audit', PRESETS_SECURITY_AUDIT, 'Wh
 
 /** The preset's name, as the dashboard button uses it. */
 export const SECURITY_AUDIT_PRESET_NAME = securityAudit.name
-/** The one user param: what to audit. Defaults to `this PR`, like the others. */
+/** The one user param: what to audit. Defaults to the launching session, else the whole codebase (#874). */
 export const SECURITY_AUDIT_PARAMS = securityAudit.params
 /** The prompt template, verbatim from #461 (with `${{ tf.params.what }}` as the blank). */
 export const SECURITY_AUDIT_PROMPT_TEMPLATE = securityAudit.template
-/** Render the Security audit prompt, filling its `${{ tf.params.what }}` blank (defaults to `this PR`). */
+/** Render the Security audit prompt, filling its `${{ tf.params.what }}` blank (defaults to the launching session, else the whole codebase). */
 export const renderSecurityAuditPrompt = securityAudit.render

--- a/packages/framework/src/ux-preset.test.ts
+++ b/packages/framework/src/ux-preset.test.ts
@@ -13,11 +13,11 @@ test('the UX template carries the #472 flow: usability review, showChoices gate,
   assert.deepEqual(UX_PARAMS.map(p => p.name), ['what'])
 })
 
-test('renderUxPrompt defaults the blank to "this PR" and takes an override', () => {
+test('renderUxPrompt defaults the blank to the session, else the whole codebase (#874)', () => {
   const byDefault = renderUxPrompt()
-  assert.match(byDefault, /^Thoroughly review UX of this PR/)
+  assert.match(byDefault, /^Thoroughly review UX of entire codebase/)
   const blank = renderUxPrompt('   ')
-  assert.match(blank, /^Thoroughly review UX of this PR/) // blank falls back, not erased
+  assert.match(blank, /^Thoroughly review UX of entire codebase/) // blank falls back, not erased
   const custom = renderUxPrompt('the settings page')
   assert.match(custom, /^Thoroughly review UX of the settings page/)
   // No raw placeholder survives a render.

--- a/packages/framework/src/ux-preset.ts
+++ b/packages/framework/src/ux-preset.ts
@@ -6,7 +6,7 @@ import { PRESETS_UX } from './prompts.generated.js'
  * as a direct interactive prompt rather than a build run — it reviews existing UI
  * from a user's perspective, so it skips the scope -> build scaffolding. It enumerates every finding as a `showChoices()` list, stops at
  * `<AWAIT>` for the user to accept proposals, then works on the accepted ones.
- * `${{ tf.params.what }}` is the user-facing blank (defaults to `this PR`); `<AWAIT>` is the
+ * `${{ tf.params.what }}` is the user-facing blank (defaults to the launching session, else the whole codebase); `<AWAIT>` is the
  * agent-facing turn-gate macro (#339/#340) the dashboard resolves. Keep it in sync
  * with the issue rather than growing it here.
  */
@@ -14,9 +14,9 @@ const ux = definePreset('ux', PRESETS_UX, 'What to review the UX of')
 
 /** The preset's name, as the dashboard button uses it. */
 export const UX_PRESET_NAME = ux.name
-/** The one user param: what to review. Defaults to `this PR`, like the others. */
+/** The one user param: what to review. Defaults to the launching session, else the whole codebase (#874). */
 export const UX_PARAMS = ux.params
 /** The prompt template, from #472 (with `${{ tf.params.what }}` as the blank, `<AWAIT>` as the gate). */
 export const UX_PROMPT_TEMPLATE = ux.template
-/** Render the UX prompt, filling its `${{ tf.params.what }}` blank (defaults to `this PR`). */
+/** Render the UX prompt, filling its `${{ tf.params.what }}` blank (defaults to the launching session, else the whole codebase). */
 export const renderUxPrompt = ux.render


### PR DESCRIPTION
Closes #874

Per the thread on the issue: `${{ }}` is already JS-eval'd (`new Function`, `prompt-template.ts`). The gap was narrower than I first described — the *default value* was the one string that never went through the evaluator, so a `${{ }}` inside it would have reached the prompt as literal text.

## What changed

- Defaults are rendered, against the same context as the preset body. The default is now `${{ tf.session_name || "entire codebase" }}`, exactly as specced.
- That context gained `session_name`, `presets` and `settings`. `presets` and `settings` are what #881 needs (`tf.presets.maintainability.filePath`, `tf.settings.technical_control`), so it can be written as-is.
- The registry moved to a node-free `preset-registry.ts`. It had to: a preset template can now read `tf.presets.<name>.filePath`, presets render in the browser (#520), and `presets.ts` imports `node:path`. `presets.ts` re-exports it, so no import site changed.

## Dashboard

A preset picked inside a run page now renders against that run's session, which is the case you described. `RunLive` and `RunReplay` already hold the events, so the name comes from `runProgress(events).sessionName`. The launcher has no session and falls through to `entire codebase` on its own, via your `||`.

The composer also passes `technical_control` from preferences, so `tf.settings` is real in the browser too.

## Testing

843 framework tests, all 21 packages green. New `preset-prompt.test.ts` covers the default resolving to the session, falling back without one, an explicit target still winning, and `tf.presets` / `tf.settings` being readable from a template. The five preset tests that asserted the old `this PR` default were updated.

Not live-verified in a running dashboard yet — the logic is unit-covered, but the run-page wiring is the part worth clicking once before this is trusted.
