### PR TITLE
feat(framework): add the [Maintenance] preset (#881)

### DIFF
--- a/.changeset/maintenance-preset.md
+++ b/.changeset/maintenance-preset.md
@@ -1,0 +1,17 @@
+---
+'@gemstack/framework': minor
+---
+
+Add the [Maintenance] preset (#881)
+
+A codebase-wide sweep that queues work instead of doing it: for each subset that needs attention
+it appends a [Maintainability] and a [Security audit] entry to `TODO_AGENTS.md`, so the backlog
+loop does the actual refactoring later, one bounded piece at a time. [Readability] joins them
+only under `technical_control`.
+
+It complements the post-merge maintenance block, which only ever sees the changes one session
+introduced. A repo that adopted The Framework late has a whole history no session has touched,
+and this is what reaches it.
+
+Available as a preset button in the dashboard, and materialized to
+`.the-framework/presets/maintenance.md` like the other presets.

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -12,6 +12,7 @@ import {
   renderSpikeAndPlanPrompt,
   renderQuickWinsPrompt,
   renderMarketResearchPrompt,
+  renderMaintenancePrompt,
 } from '@gemstack/framework/client'
 import { usePreferences, updatePreferences, autopilotEnabled, themePreference } from '../lib/preferences.js'
 import { useDetectedEditors } from '../lib/editors.js'
@@ -42,6 +43,12 @@ const PRESETS: { id: string; label: string; render: (what?: string, ctx?: Preset
   { id: 'spike-and-plan', label: 'Spike & plan', render: renderSpikeAndPlanPrompt },
   { id: 'quick-wins', label: 'Quick wins', render: renderQuickWinsPrompt },
   { id: 'market-research', label: 'Market research', render: renderMarketResearchPrompt },
+  {
+    id: 'maintenance',
+    label: 'Maintenance',
+    render: renderMaintenancePrompt,
+    tooltip: 'Queue maintainability + security work per codebase subset (TODO_AGENTS.md)',
+  },
 ]
 
 // The agent + model tree (#650/#656/#658): each agent lists ONLY its own models, since `--model`

--- a/packages/framework/prompts/presets/maintenance.md
+++ b/packages/framework/prompts/presets/maintenance.md
@@ -1,0 +1,6 @@
+Analyze ${{ tf.params.what }} and look for opportunities to refactor code.
+
+For each codebase subset that needs it, add following entries to TODO_AGENTS.md (usually as low priority) and replace <CODEBASE_SUBSET> with a clear designation.
+- "Apply ${{ tf.presets.maintainability.filePath }} with tf.params.what set to <CODEBASE_SUBSET>"
+- "Apply ${{ tf.presets.security_audit.filePath }} with tf.params.what set to <CODEBASE_SUBSET>"
+${{ tf.settings.technical_control ? '- "Apply ' + tf.presets.readability.filePath + ' with tf.params.what set to <CODEBASE_SUBSET>"\n' : '' }}

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -43,6 +43,7 @@ export { renderSuggestNewTicketsPrompt } from './suggest-new-tickets-preset.js'
 export { renderSuggestTicketsToWorkOnPrompt } from './suggest-tickets-to-work-on-preset.js'
 export { renderSpikeAndPlanPrompt } from './spike-and-plan-preset.js'
 export { renderQuickWinsPrompt } from './quick-wins-preset.js'
+export { renderMaintenancePrompt } from './maintenance-preset.js'
 // The preferences -> run options mapping (#858), shared with the daemon so an unattended run
 // starts with the same settings a launcher-started one would. Pure field logic, no Node imports.
 export { runOptionsFromPreferences, autopilotEnabled } from './run-options.js'

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -335,6 +335,12 @@ export {
   QUICK_WINS_PARAMS,
 } from './quick-wins-preset.js'
 export {
+  renderMaintenancePrompt,
+  MAINTENANCE_PRESET_NAME,
+  MAINTENANCE_PROMPT_TEMPLATE,
+  MAINTENANCE_PARAMS,
+} from './maintenance-preset.js'
+export {
   renderMarketResearchPrompt,
   MARKET_RESEARCH_PRESET_NAME,
   MARKET_RESEARCH_PROMPT_TEMPLATE,

--- a/packages/framework/src/maintenance-preset.test.ts
+++ b/packages/framework/src/maintenance-preset.test.ts
@@ -1,0 +1,42 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import {
+  renderMaintenancePrompt,
+  MAINTENANCE_PARAMS,
+  MAINTENANCE_PRESET_NAME,
+  MAINTENANCE_PROMPT_TEMPLATE,
+} from './maintenance-preset.js'
+import { presetFilePath } from './preset-registry.js'
+
+test('the Maintenance template queues work rather than doing it (#881)', () => {
+  assert.equal(MAINTENANCE_PRESET_NAME, 'maintenance')
+  assert.match(MAINTENANCE_PROMPT_TEMPLATE, /look for opportunities to refactor code/)
+  assert.match(MAINTENANCE_PROMPT_TEMPLATE, /TODO_AGENTS\.md \(usually as low priority\)/)
+  assert.match(MAINTENANCE_PROMPT_TEMPLATE, /<CODEBASE_SUBSET>/)
+  assert.deepEqual(MAINTENANCE_PARAMS.map(p => p.name), ['what'])
+})
+
+test('it points at the other presets by their real file paths (#881)', () => {
+  const out = renderMaintenancePrompt()
+  assert.ok(out.includes(presetFilePath('maintainability')), 'expected the maintainability path')
+  assert.ok(out.includes(presetFilePath('security_audit')), 'expected the security_audit path')
+  // No raw placeholder survives a render — the whole point of flattening the nested fragment.
+  assert.equal(out.includes('${{'), false)
+})
+
+test('readability is queued only under technical_control (#881)', () => {
+  const off = renderMaintenancePrompt(undefined, { settings: { technical_control: false } })
+  assert.equal(off.includes(presetFilePath('readability')), false)
+  // Absent settings behave like off, and must not throw.
+  assert.equal(renderMaintenancePrompt().includes(presetFilePath('readability')), false)
+
+  const on = renderMaintenancePrompt(undefined, { settings: { technical_control: true } })
+  assert.ok(on.includes(presetFilePath('readability')), 'expected the readability path')
+  assert.equal(on.includes('${{'), false)
+})
+
+test('the sweep target defaults to the session, else the whole codebase (#874/#881)', () => {
+  assert.match(renderMaintenancePrompt(), /^Analyze entire codebase and/)
+  assert.match(renderMaintenancePrompt(undefined, { session_name: 'fix-login' }), /^Analyze fix-login and/)
+  assert.match(renderMaintenancePrompt('the auth package'), /^Analyze the auth package and/)
+})

--- a/packages/framework/src/maintenance-preset.ts
+++ b/packages/framework/src/maintenance-preset.ts
@@ -1,0 +1,26 @@
+import { definePreset } from './preset-prompt.js'
+import { PRESETS_MAINTENANCE } from './prompts.generated.js'
+
+/**
+ * The [Maintenance] preset (#881): a codebase-wide sweep that does not refactor anything itself.
+ * It looks for subsets that need work and queues one [Maintainability] and one [Security audit]
+ * entry per subset in `TODO_AGENTS.md`, so the backlog loop does the actual work later, one
+ * bounded piece at a time. [Readability] joins them only under `technical_control`.
+ *
+ * Why it exists alongside the on-before-mergeable maintenance block (#326): that block only ever
+ * sees the changes one session introduced. A repo that adopted The Framework late has a whole
+ * history no session ever touched, and this is what reaches it (#882 fires it on a schedule).
+ *
+ * The template is flattened rather than copied verbatim from the issue: `${{ }}` fragments cannot
+ * nest (the scanner stops at the first `}}`), so the conditional line concatenates instead.
+ */
+const maintenance = definePreset('maintenance', PRESETS_MAINTENANCE, 'What to analyze for refactor opportunities')
+
+/** The preset's run-kind name, as the dashboard button uses it. */
+export const MAINTENANCE_PRESET_NAME = maintenance.name
+/** The one user param: what to sweep. Defaults to the launching session, else the whole codebase. */
+export const MAINTENANCE_PARAMS = maintenance.params
+/** The prompt template, from `prompts/presets/maintenance.md`. */
+export const MAINTENANCE_PROMPT_TEMPLATE = maintenance.template
+/** Render the Maintenance prompt, filling its `${{ tf.params.what }}` blank. */
+export const renderMaintenancePrompt = maintenance.render

--- a/packages/framework/src/preset-registry.ts
+++ b/packages/framework/src/preset-registry.ts
@@ -4,6 +4,7 @@ import {
   PRESETS_SECURITY_AUDIT,
   PRESETS_RESEARCH,
   PRESETS_UX,
+  PRESETS_MAINTENANCE,
 } from './prompts.generated.js'
 import { THE_FRAMEWORK_DIR } from './framework-dir.js'
 
@@ -25,6 +26,7 @@ export const PRESETS: Readonly<Record<string, string>> = {
   security_audit: PRESETS_SECURITY_AUDIT,
   research: PRESETS_RESEARCH,
   ux: PRESETS_UX,
+  maintenance: PRESETS_MAINTENANCE,
 }
 
 /** Where the materialized presets live under a repo's `.the-framework/` (#326). */

--- a/packages/framework/src/presets.test.ts
+++ b/packages/framework/src/presets.test.ts
@@ -4,11 +4,13 @@ import { join } from 'node:path'
 import { PRESETS, PRESET_DIR, presetFilePath, presetContext, materializePresets } from './presets.js'
 import type { StoreFs } from './store/index.js'
 
-test('PRESETS carries the five quality presets, keyed by file stem (#326)', () => {
+test('PRESETS carries the quality presets, keyed by file stem (#326/#881)', () => {
   assert.deepEqual(
     Object.keys(PRESETS).sort(),
-    ['maintainability', 'readability', 'research', 'security_audit', 'ux'],
+    ['maintainability', 'maintenance', 'readability', 'research', 'security_audit', 'ux'],
   )
+  // `maintenance` (#881) is in the registry, not just exported: it materializes like the rest, so
+  // a scheduled entry (#882) can point at `.the-framework/presets/maintenance.md` by path.
   // Underscore stem, not the hyphenated SECURITY_AUDIT_PRESET_NAME: matches the tf.presets key
   // Rom's #326 OP reads (`tf.presets.security_audit.filePath`).
   assert.ok('security_audit' in PRESETS)


### PR DESCRIPTION
Closes #881

Stacked on #887 (#874), which it needs: the template reads `tf.presets.*.filePath` and `tf.settings.technical_control`, and neither was in the preset render context before. **Review/merge #887 first** — the diff here will shrink to just this preset once it lands.

## The one deviation from the issue

The conditional line could not be copied verbatim. `${{ }}` fragments cannot nest: the scanner is non-greedy and stops at the first `}}`, so the inner `${{ tf.presets.readability.filePath }}` would have terminated the outer fragment. Flattened with concatenation, which is the same shape `on_before_mergeable_prompt.md` already uses:

```
${{ tf.settings.technical_control ? '- "Apply ' + tf.presets.readability.filePath + ' with tf.params.what set to <CODEBASE_SUBSET>"\n' : '' }}
```

Also fixed the "opportunites" typo. Everything else is the issue's text.

## Choices worth a look

- **It is in the preset registry**, not just exported, so it materializes to `.the-framework/presets/maintenance.md` like the others. That is what would let #882 queue it by file path, the way the post-merge prompt queues the others.
- **It has a dashboard button too.** #882 fires it on a schedule, but there is no reason it cannot also be run by hand.
- The sweep target defaults to the session, or the whole codebase when there is none — the #874 default. For the cron case that means the whole codebase, which is the point of the ticket.

## Testing

847 framework tests and all 21 packages green. Covers: the real preset paths appearing in the output, readability appearing only under `technical_control` (and absent settings not throwing), no `${{` surviving a render, and the target defaulting correctly.

The existing "five quality presets" registry test now expects six — deliberate, and commented.
