### PR TITLE
fix(framework): use the numeric priority scale in the TODO format spec (#880)

### DIFF
--- a/.changeset/todo-format-numeric.md
+++ b/.changeset/todo-format-numeric.md
@@ -1,0 +1,11 @@
+---
+'@gemstack/framework': patch
+---
+
+Use the numeric priority scale in the TODO_AGENTS.md format spec (#880)
+
+The shipped spec described named tiers (URGENT / High / Medium / Low). The format was revised to
+a numeric 0-10 scale — 10 is act-immediately, 0 is only-if-capacity — so the spec now matches.
+
+Still no parser change: entries are read in file order and headings are skipped, so a
+priority-sorted file drains in priority order.

--- a/packages/framework/prompts/todo_format.md
+++ b/packages/framework/prompts/todo_format.md
@@ -2,23 +2,19 @@
 
 Content:
 ```md
-## URGENT
+## Priority 10 (critical — act immediately)
 
 ...
 
-## High priority
+## Priority 9
 
 ...
 
-## Medium priority
-
-...
-
-## Low priority
+## Priority 0 (only if capacity)
 
 ...
 ```
 
 The TODO_AGENTS.md file lists *all* tasks AI will work on next, sorted by priority.
 
-URGENT is rarely used (e.g. for critical production bugs) and should be treated as utmost priority.
+Priority 10 is rarely used (e.g. critical production bugs) and should be treated as utmost priority.

--- a/packages/framework/src/tickets.test.ts
+++ b/packages/framework/src/tickets.test.ts
@@ -38,11 +38,12 @@ test('the backlog-format spec ships in the package and teaches the priority sect
   // Ships inside the package like the ticket format, so the layout versions with the package.
   assert.equal(TODO_FORMAT_FILE, 'node_modules/@gemstack/framework/prompts/todo_format.md')
   assert.ok(TODO_FORMAT.includes(FLAT_TODO_FILE))
-  for (const section of ['## URGENT', '## High priority', '## Medium priority', '## Low priority']) {
+  // A numeric 0-10 scale, not named tiers: 10 is act-immediately, 0 is only-if-capacity.
+  for (const section of ['## Priority 10 (critical', '## Priority 9', '## Priority 0 (only if capacity)']) {
     assert.ok(TODO_FORMAT.includes(section), `expected the ${section} section`)
   }
-  // URGENT is the exception, not the default, and the file is priority-sorted.
-  assert.ok(TODO_FORMAT.includes('rarely used'))
+  // Priority 10 is the exception, not the default, and the file is priority-sorted.
+  assert.ok(TODO_FORMAT.includes('Priority 10 is rarely used'))
   assert.ok(TODO_FORMAT.includes('sorted by priority'))
 })
 

--- a/packages/framework/src/todo-loop.test.ts
+++ b/packages/framework/src/todo-loop.test.ts
@@ -36,16 +36,16 @@ test('parseTodoEntries reads open list items and skips checked/blank/prose lines
 
 test('the #880 priority sections need no parser support: headings are skipped, so a sorted file drains in priority order', () => {
   const md = [
-    '## URGENT',
+    '## Priority 10 (critical — act immediately)',
     '- restore checkout',
     '',
-    '## High priority',
+    '## Priority 9',
     '- flaky auth test',
     '',
-    '## Medium priority',
+    '## Priority 5',
     '- tidy the config loader',
     '',
-    '## Low priority',
+    '## Priority 0 (only if capacity)',
     '- rename the legacy flag',
   ].join('\n')
   assert.deepEqual(parseTodoEntries(md), [


### PR DESCRIPTION
Refs #880

#880's OP was revised to a numeric priority scale after #884 had already merged, so `main` currently ships a spec describing a format that no longer exists.

Named tiers (`## URGENT` / `## High priority` / `## Medium priority` / `## Low priority`) become `## Priority 10 (critical — act immediately)` … `## Priority 0 (only if capacity)`, verbatim from the updated OP.

Still no parser change: entries are read in file order and headings are skipped, so a priority-sorted file drains in priority order. The test covering that now uses the numeric headings.

New PR rather than a push to the merged branch. 840 framework tests green.
