### PR TITLE
test(dashboard): give async queries room on a loaded machine (#886)

### DIFF
--- a/packages/framework-dashboard/vitest.config.ts
+++ b/packages/framework-dashboard/vitest.config.ts
@@ -15,5 +15,10 @@ export default defineConfig({
     globals: true,
     include: ['**/*.test.ts', '**/*.test.tsx'],
     exclude: ['node_modules/**', 'dist/**'],
+    setupFiles: ['./vitest.setup.ts'],
+    // Comfortably above the setup file's 5s query ceiling (#886), so a test that does hit the
+    // ceiling reports the element it was actually waiting for instead of dying on vitest's own
+    // 5s limit first and naming nothing.
+    testTimeout: 20_000,
   },
 })

--- a/packages/framework-dashboard/vitest.setup.ts
+++ b/packages/framework-dashboard/vitest.setup.ts
@@ -1,0 +1,12 @@
+import { configure } from '@testing-library/react'
+
+// Testing Library's async queries (`findBy*`, `waitFor`) give up after 1s by default, which is
+// not enough on a loaded machine (#886). Several components here assert through a Base UI menu,
+// which portals and then positions itself, so the element under assertion arrives a frame or two
+// after the click. That takes ~40ms idle, and CI ran 39 suites at once and blew past the second:
+// `PreviewBar.test.tsx:43` failed with "Unable to find an element with the text: api" at 1079ms,
+// turning main red for a component that works.
+//
+// The timeout is a ceiling, not a delay: a passing query still returns as soon as it matches, so
+// this costs nothing when things are healthy and only buys patience when the machine is starved.
+configure({ asyncUtilTimeout: 5000 })


### PR DESCRIPTION
Closes #886.

## What actually happened

I had guessed this was `fireEvent` sending a bare click where Base UI wants a pointer sequence. That was wrong. The CI log from the run that turned main red (run 29756075137) says:

```
TestingLibraryElementError: Unable to find an element with the text: api
  ❯ components/PreviewBar.test.tsx:43:34
  × a multi-target repo offers a picker; choosing an app serves that target  1079ms
```

1079ms is Testing Library's 1s default plus overhead. The menu never rendered in time. Nothing was wrong with the click.

I measured both click styles against the real component: the menu opens in ~47ms via `fireEvent.click` and ~39ms via a full pointer sequence. Both work, and both are far inside a second. So the event type was never the problem, and swapping to `userEvent` would have changed nothing except adding a dependency the package does not have.

The component portals its menu and then positions it, so the asserted element lands a frame or two after the click. That is ~40ms on an idle machine. CI runs 39 suites at once, and under that starvation it crossed the second.

## The fix

Raise the async query ceiling to 5s in a setup file, and lift vitest's own `testTimeout` above it so a test that genuinely hangs reports the element it was waiting for rather than dying on vitest's 5s limit first and naming nothing.

The ceiling is not a delay. A passing query returns the moment it matches, so a healthy run is exactly as fast as before: the dashboard suite is 217 tests in 4.66s, unchanged.

`ProjectPicker` and `TicketsPanel` assert through the same menu, so they had the same latent race. This covers them too.

## Verification

The probe that matters: an element that arrives at 1.5s, which is past the old default and inside the new ceiling.

- With the setup file registered, it passes.
- With only the `setupFiles` line removed, it fails at 1015ms with the identical error string CI produced, `Unable to find an element with the text: api`.

So the reported failure mode is reproduced deterministically, and the fix is shown to be the thing that addresses it rather than something merely adjacent.

Full suites green: 39 dashboard files / 217 tests, and 21/21 packages at the root.

No changeset: this is test configuration, nothing shipped changes.