### PR TITLE
feat(framework): add the triage presets (#891, #892)

### DIFF
--- a/.changeset/triage-presets.md
+++ b/.changeset/triage-presets.md
@@ -1,0 +1,21 @@
+---
+'@gemstack/framework': minor
+---
+
+Add the [Do quick-win work] and [Do consensual work] triage presets (#891, #892)
+
+Both read `tickets/*.md`, pick the tickets matching one filter, and append them to
+`TODO_AGENTS.md`. They are how the agent queue refills itself from the ticket backlog, where
+[Quick wins] refills it from the `.plan.md` companions that already exist.
+
+The pair splits on cost: both are consensual (zero open questions, zero variability), so neither
+needs a human, and they differ only in whether the work is cheap. Keeping them apart lets the
+queue be refilled with the cheap batch and the significant batch on separate turns rather than in
+one indiscriminate sweep.
+
+Both join the auto-PM rotation, which now runs quick-wins, quick triage, consensual triage, then
+spike-and-plan: cheapest and readiest first, planning last. Each prompt pins its own session name
+and aborts when `the-framework/<SESSION_NAME>` already exists, so a firing that lands while the
+previous triage is still in flight does nothing instead of triaging the same tickets twice.
+
+Available as preset buttons in the dashboard.

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -13,6 +13,8 @@ import {
   renderQuickWinsPrompt,
   renderMarketResearchPrompt,
   renderMaintenancePrompt,
+  renderTriageQuickPrompt,
+  renderTriageConsensualPrompt,
 } from '@gemstack/framework/client'
 import { usePreferences, updatePreferences, autopilotEnabled, themePreference } from '../lib/preferences.js'
 import { useDetectedEditors } from '../lib/editors.js'
@@ -48,6 +50,18 @@ const PRESETS: { id: string; label: string; render: (what?: string, ctx?: Preset
     label: 'Maintenance',
     render: renderMaintenancePrompt,
     tooltip: 'Queue maintainability + security work per codebase subset (TODO_AGENTS.md)',
+  },
+  {
+    id: 'triage-quick',
+    label: 'Do quick-win work',
+    render: renderTriageQuickPrompt,
+    tooltip: 'Add `tickets/*.md` to queue (TODO_AGENTS.md), only quick-win and consensual tickets',
+  },
+  {
+    id: 'triage-consensual',
+    label: 'Do consensual work',
+    render: renderTriageConsensualPrompt,
+    tooltip: 'Add `tickets/*.md` to queue (TODO_AGENTS.md), only significant (no quick-wins) and consensual tickets',
   },
 ]
 

--- a/packages/framework/prompts/presets/triage_consensual.md
+++ b/packages/framework/prompts/presets/triage_consensual.md
@@ -1,0 +1,6 @@
+1. Look at all tickets and choose tickets to work on next
+   - Only pick tickets that are significant (no quick-wins) and consensual (zero open questions, zero variability, e.g. a single fairly obvious plan)
+2. Add tickets to TODO_AGENTS.md
+
+Always set <SESSION_NAME> to triage-consensual
+- If branch the-framework/<SESSION_NAME> already exists, abort and do nothing

--- a/packages/framework/prompts/presets/triage_quick.md
+++ b/packages/framework/prompts/presets/triage_quick.md
@@ -1,0 +1,6 @@
+1. Look at all tickets and choose tickets to work on next
+   - Only pick tickets that are quick-wins and consensual (zero open questions, zero variability, e.g. a single fairly obvious plan)
+2. Add tickets to TODO_AGENTS.md
+
+Always set <SESSION_NAME> to triage-quick
+- If branch the-framework/<SESSION_NAME> already exists, abort and do nothing

--- a/packages/framework/src/auto-pm.test.ts
+++ b/packages/framework/src/auto-pm.test.ts
@@ -176,9 +176,30 @@ test('startAutoPm survives a project whose backlog cannot be read (#685)', async
   assert.deepEqual(started, [])
 })
 
-test('AUTO_PM_JOBS harvests before it plans (#773)', () => {
-  // Quick wins lead: a machine that already has plans should start doing, not planning more.
-  assert.deepEqual(AUTO_PM_JOBS.map(j => j.name), ['quick-wins', 'spike-and-plan'])
+test('AUTO_PM_JOBS harvests, then triages, then plans (#773/#891/#892)', () => {
+  // Cheapest-and-readiest first: harvest existing plans, triage the cheap tickets, then the
+  // significant ones, and leave planning last — it is the priciest turn and the one whose
+  // output every earlier job consumes.
+  assert.deepEqual(AUTO_PM_JOBS.map(j => j.name), [
+    'quick-wins',
+    'triage-quick',
+    'triage-consensual',
+    'spike-and-plan',
+  ])
+})
+
+test('the rotation is the schedule the triage presets asked for (#891/#892)', () => {
+  // #891/#892 both say "with a cron job regularly firing this preset". The rotation already
+  // fires on every idle tick where the queue is dry, so no separate scheduler exists — unlike
+  // the maintenance sweep (#882), which needs a calendar key because it would never come due.
+  const names = AUTO_PM_JOBS.map(j => j.name)
+  assert.ok(names.includes('triage-quick'), 'quick triage must be in the rotation')
+  assert.ok(names.includes('triage-consensual'), 'consensual triage must be in the rotation')
+  // The gated sibling (#698) must never be: it ends in <AWAIT> and would park a run forever.
+  assert.equal(names.includes('suggest-tickets-to-work-on'), false)
+  for (const job of AUTO_PM_JOBS) {
+    assert.equal(job.prompt.includes('<AWAIT>'), false, `${job.name} must not wait on a human`)
+  }
 })
 
 test('startAutoPm walks the job cycle across idle moments (#773)', async () => {

--- a/packages/framework/src/auto-pm.ts
+++ b/packages/framework/src/auto-pm.ts
@@ -3,6 +3,12 @@ import { renderSpikeAndPlanPrompt, SPIKE_AND_PLAN_PRESET_NAME } from './spike-an
 import { renderQuickWinsPrompt, QUICK_WINS_PRESET_NAME } from './quick-wins-preset.js'
 import { renderDrainQueuePrompt, DRAIN_QUEUE_PRESET_NAME } from './drain-queue-preset.js'
 import { renderMaintenancePrompt, MAINTENANCE_PRESET_NAME } from './maintenance-preset.js'
+import {
+  renderTriageQuickPrompt,
+  TRIAGE_QUICK_PRESET_NAME,
+  renderTriageConsensualPrompt,
+  TRIAGE_CONSENSUAL_PRESET_NAME,
+} from './triage-presets.js'
 
 /**
  * Auto PM (#685): spend leftover subscription quota on product management instead of
@@ -135,11 +141,34 @@ export interface AutoPmJob {
 }
 
 /**
- * The default cycle: harvest the plans we have (#773), then make more plans (#685). Quick wins
- * lead because a machine sitting on unharvested plans should start doing rather than planning.
+ * The default cycle, ordered cheapest-and-readiest first: harvest the plans we have (#773), triage
+ * the quick tickets (#891), then the significant-but-agreed ones (#892), and only then make more
+ * plans (#685). A machine sitting on work it has already thought through should start *doing*
+ * rather than planning, and planning is both the most expensive turn and the one whose output the
+ * earlier jobs consume.
+ *
+ * This rotation is what #891/#892 mean by "with a cron job regularly firing this preset". No
+ * separate scheduler is involved and none is needed: the rotation already fires on every idle tick
+ * where the queue is dry, which is exactly when the queue wants refilling. That is the opposite of
+ * the maintenance sweep (#882), which is paced by a calendar because it looks at static history and
+ * would otherwise never come due — hence its own {@link AUTO_PM_MAINTENANCE_JOB} outside the cycle.
+ *
+ * The gated triage sibling (#698) is deliberately not here: it ends in `<AWAIT>`, so firing it with
+ * nobody at the keyboard would park a run against a human who will never answer.
+ *
+ * Each triage prompt pins its own session name and aborts if that branch already exists, so a
+ * rotation that comes round again while the previous triage is still in flight is a no-op rather
+ * than a duplicate. The rotation still advances past it, which is the wanted behaviour: the next
+ * idle tick tries the next job instead of retrying a job that is already running.
  */
 export const AUTO_PM_JOBS: readonly AutoPmJob[] = [
   { name: QUICK_WINS_PRESET_NAME, prompt: renderQuickWinsPrompt(), describe: 'harvesting quick-wins from the plans' },
+  { name: TRIAGE_QUICK_PRESET_NAME, prompt: renderTriageQuickPrompt(), describe: 'triaging quick-win tickets' },
+  {
+    name: TRIAGE_CONSENSUAL_PRESET_NAME,
+    prompt: renderTriageConsensualPrompt(),
+    describe: 'triaging consensual tickets',
+  },
   { name: SPIKE_AND_PLAN_PRESET_NAME, prompt: renderSpikeAndPlanPrompt(), describe: 'spiking & planning tickets' },
 ]
 

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -44,6 +44,7 @@ export { renderSuggestTicketsToWorkOnPrompt } from './suggest-tickets-to-work-on
 export { renderSpikeAndPlanPrompt } from './spike-and-plan-preset.js'
 export { renderQuickWinsPrompt } from './quick-wins-preset.js'
 export { renderMaintenancePrompt } from './maintenance-preset.js'
+export { renderTriageQuickPrompt, renderTriageConsensualPrompt } from './triage-presets.js'
 // The preferences -> run options mapping (#858), shared with the daemon so an unattended run
 // starts with the same settings a launcher-started one would. Pure field logic, no Node imports.
 export { runOptionsFromPreferences, autopilotEnabled } from './run-options.js'

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -344,6 +344,16 @@ export {
   MAINTENANCE_PARAMS,
 } from './maintenance-preset.js'
 export {
+  renderTriageQuickPrompt,
+  TRIAGE_QUICK_PRESET_NAME,
+  TRIAGE_QUICK_PROMPT_TEMPLATE,
+  TRIAGE_QUICK_PARAMS,
+  renderTriageConsensualPrompt,
+  TRIAGE_CONSENSUAL_PRESET_NAME,
+  TRIAGE_CONSENSUAL_PROMPT_TEMPLATE,
+  TRIAGE_CONSENSUAL_PARAMS,
+} from './triage-presets.js'
+export {
   renderMarketResearchPrompt,
   MARKET_RESEARCH_PRESET_NAME,
   MARKET_RESEARCH_PROMPT_TEMPLATE,

--- a/packages/framework/src/triage-presets.test.ts
+++ b/packages/framework/src/triage-presets.test.ts
@@ -1,0 +1,64 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import {
+  renderTriageQuickPrompt,
+  TRIAGE_QUICK_PARAMS,
+  TRIAGE_QUICK_PRESET_NAME,
+  TRIAGE_QUICK_PROMPT_TEMPLATE,
+  renderTriageConsensualPrompt,
+  TRIAGE_CONSENSUAL_PARAMS,
+  TRIAGE_CONSENSUAL_PRESET_NAME,
+  TRIAGE_CONSENSUAL_PROMPT_TEMPLATE,
+} from './triage-presets.js'
+import { SUGGEST_TICKETS_TO_WORK_ON_PROMPT_TEMPLATE } from './suggest-tickets-to-work-on-preset.js'
+
+test('the quick triage template picks quick-win AND consensual tickets (#891)', () => {
+  assert.equal(TRIAGE_QUICK_PRESET_NAME, 'triage-quick')
+  assert.match(TRIAGE_QUICK_PROMPT_TEMPLATE, /Only pick tickets that are quick-wins and consensual/)
+  assert.match(TRIAGE_QUICK_PROMPT_TEMPLATE, /Add tickets to TODO_AGENTS\.md/)
+  assert.deepEqual(TRIAGE_QUICK_PARAMS, [])
+})
+
+test('the consensual triage template excludes quick-wins (#892)', () => {
+  assert.equal(TRIAGE_CONSENSUAL_PRESET_NAME, 'triage-consensual')
+  // "significant (no quick-wins)" is what keeps the pair disjoint: without the exclusion both
+  // presets would queue the same cheap tickets and the split would buy nothing.
+  assert.match(TRIAGE_CONSENSUAL_PROMPT_TEMPLATE, /Only pick tickets that are significant \(no quick-wins\) and consensual/)
+  assert.match(TRIAGE_CONSENSUAL_PROMPT_TEMPLATE, /Add tickets to TODO_AGENTS\.md/)
+  assert.deepEqual(TRIAGE_CONSENSUAL_PARAMS, [])
+})
+
+test('each triage preset pins its own session name and aborts on a taken branch (#891/#892)', () => {
+  // The collision guard is what makes these safe to fire on a schedule: a triage already in
+  // flight owns the branch, so the next firing must do nothing rather than triage twice.
+  for (const [render, session] of [
+    [renderTriageQuickPrompt, 'triage-quick'],
+    [renderTriageConsensualPrompt, 'triage-consensual'],
+  ] as const) {
+    const out = render()
+    assert.match(out, new RegExp(`Always set <SESSION_NAME> to ${session}`))
+    assert.match(out, /If branch the-framework\/<SESSION_NAME> already exists, abort and do nothing/)
+  }
+  // Distinct session names, or the two presets would collide with each other rather than with
+  // their own in-flight run.
+  assert.notEqual(TRIAGE_QUICK_PRESET_NAME, TRIAGE_CONSENSUAL_PRESET_NAME)
+})
+
+test('neither ungated triage preset waits on a human (#891/#892 vs #698)', () => {
+  // They run unattended from the rotation, so an <AWAIT> would park the run against nobody.
+  // The gated sibling is the one that legitimately has it.
+  for (const out of [renderTriageQuickPrompt(), renderTriageConsensualPrompt()]) {
+    assert.equal(out.includes('<AWAIT>'), false)
+    assert.equal(out.includes('<SHOW_CHOICES>'), false)
+    assert.equal(out.includes('showMultiSelect'), false)
+  }
+  assert.ok(SUGGEST_TICKETS_TO_WORK_ON_PROMPT_TEMPLATE.includes('<AWAIT>'), 'the gated preset still awaits')
+})
+
+test('paramless renders are the template verbatim (#891/#892)', () => {
+  assert.equal(renderTriageQuickPrompt(), TRIAGE_QUICK_PROMPT_TEMPLATE)
+  assert.equal(renderTriageConsensualPrompt(), TRIAGE_CONSENSUAL_PROMPT_TEMPLATE)
+  // Nothing to fill, so nothing may survive unrendered either.
+  assert.equal(renderTriageQuickPrompt().includes('${{'), false)
+  assert.equal(renderTriageConsensualPrompt().includes('${{'), false)
+})

--- a/packages/framework/src/triage-presets.ts
+++ b/packages/framework/src/triage-presets.ts
@@ -1,0 +1,66 @@
+import { PRESETS_TRIAGE_QUICK, PRESETS_TRIAGE_CONSENSUAL } from './prompts.generated.js'
+
+/**
+ * The triage presets (#891, #892): read `tickets/*.md`, pick the ones that match one filter, and
+ * append them to `TODO_AGENTS.md`. They are how the queue refills itself from the ticket backlog,
+ * where [Quick wins] (#773) refills it from the `.plan.md` companions that already exist.
+ *
+ * The pair splits on cost, and the split is the whole point: both are consensual (zero open
+ * questions, zero variability), so neither needs a human, and they differ only in whether the
+ * work is cheap. Keeping them apart lets the rotation queue the cheap batch and the significant
+ * batch on separate turns rather than in one indiscriminate sweep.
+ *
+ * The gated third sibling (#698, complex work) is deliberately absent here: it ends in `<AWAIT>`,
+ * so firing it unattended would wedge a run against a human who is not there. It ships separately
+ * as [Suggest tickets to work on] and stays out of {@link AUTO_PM_JOBS}.
+ *
+ * Each prompt pins its own `<SESSION_NAME>` and aborts when `the-framework/<SESSION_NAME>` already
+ * exists. That is the collision guard, and it is what makes them safe to fire on a schedule: a
+ * triage still in flight owns the branch, so the next firing does nothing instead of triaging the
+ * same tickets twice.
+ */
+
+/** A triage preset's public shape. Paramless: the prompt scopes itself to the repo's tickets. */
+interface TriagePreset {
+  /** The run-kind name, as the dashboard button uses it. */
+  name: string
+  /** The prompt template, from `prompts/presets/<stem>.md`. */
+  template: string
+  /** No user params, so nothing to fill. */
+  params: readonly []
+  /** Render the prompt. Paramless, so it is the template verbatim. */
+  render: () => string
+}
+
+/**
+ * Define one triage preset. The two differ by a single clause in the prompt and by their session
+ * name, so the shape lives here once — the same reason {@link definePreset} exists for the quality
+ * presets, minus the `what` param these have no use for.
+ */
+function defineTriagePreset(name: string, template: string): TriagePreset {
+  return { name, template, params: [] as const, render: () => template }
+}
+
+/** [Do quick-win work] (#891): tickets that are quick-wins *and* consensual. */
+const triageQuick = defineTriagePreset('triage-quick', PRESETS_TRIAGE_QUICK)
+
+/** [Do consensual work] (#892): tickets that are consensual but *not* quick-wins. */
+const triageConsensual = defineTriagePreset('triage-consensual', PRESETS_TRIAGE_CONSENSUAL)
+
+/** The [Do quick-win work] run-kind name (#891). */
+export const TRIAGE_QUICK_PRESET_NAME = triageQuick.name
+/** The [Do quick-win work] prompt template. */
+export const TRIAGE_QUICK_PROMPT_TEMPLATE = triageQuick.template
+/** No user params. */
+export const TRIAGE_QUICK_PARAMS = triageQuick.params
+/** Render the [Do quick-win work] prompt. */
+export const renderTriageQuickPrompt = triageQuick.render
+
+/** The [Do consensual work] run-kind name (#892). */
+export const TRIAGE_CONSENSUAL_PRESET_NAME = triageConsensual.name
+/** The [Do consensual work] prompt template. */
+export const TRIAGE_CONSENSUAL_PROMPT_TEMPLATE = triageConsensual.template
+/** No user params. */
+export const TRIAGE_CONSENSUAL_PARAMS = triageConsensual.params
+/** Render the [Do consensual work] prompt. */
+export const renderTriageConsensualPrompt = triageConsensual.render


### PR DESCRIPTION
Closes #891
Closes #892

Both presets read `tickets/*.md`, pick the tickets matching one filter, and append them to `TODO_AGENTS.md`. Button text and tooltips are verbatim from the two OPs, as are the prompts.

| Preset | Filter | `<SESSION_NAME>` |
|---|---|---|
| Do quick-win work | quick-win AND consensual | `triage-quick` |
| Do consensual work | significant (no quick-wins) AND consensual | `triage-consensual` |

## Three calls I made, each worth a look

**1. "With a cron job regularly firing this preset" is the auto-PM rotation, no new scheduler.**

`AUTO_PM_JOBS` already fires on every idle tick where the queue is dry, which is exactly when the queue wants refilling. So both presets join the rotation, which is now:

`quick-wins` -> `triage-quick` -> `triage-consensual` -> `spike-and-plan`

Cheapest and readiest first, planning last: planning is the priciest turn and the one whose output every earlier job consumes.

This is deliberately unlike #882's maintenance sweep, which needed its own `sweptAt` calendar key because it looks at static history and would otherwise never come due. Triage is queue-paced, not calendar-paced, so it needs no key. **I specifically did not copy `sweptAt` per preset** or build a scheduled-jobs table; if you did mean a wall-clock cadence separate from "queue is dry", say so and I will add one.

**2. #698 stays out of the rotation, and I did not touch it.**

It ends in `<SHOW_CHOICES>` + `<AWAIT>`, so firing it unattended would park a run against a human who is not there. A test pins that no rotation job contains `<AWAIT>`.

Worth flagging separately: **#698's preset already shipped** in #845 as `[Suggest tickets to work on]`, which is why it is closed. Your 17:13 OP rewrite changes it (new filter, new button text, `<SESSION_NAME>`, the abort guard), so it needs a revision PR rather than a fresh build. It is closed, so I left it alone. Reopen it and I will do that revision, which would also let all three siblings share one shape.

**3. Overlap with [Quick wins] (#773), flagging rather than merging.**

`quick_wins.md` reads `tickets/**.plan.md`, so its input is work that is already planned and costed. #891 reads *all tickets* and adds the consensual filter. Different input, same destination, so I kept them as separate jobs. If you would rather #891 replace [Quick wins] outright, that is a one-line rotation change.

## The collision guard

Each prompt pins its own session name and aborts when `the-framework/<SESSION_NAME>` already exists. That is what makes these safe to fire repeatedly: a triage still in flight owns the branch, so the next firing does nothing instead of triaging the same tickets twice. The rotation still advances past an aborted job, which is what you want, since the next idle tick then tries the next job rather than retrying one that is already running.

## Verification

- 865 framework tests (was 859), 217 dashboard tests, all green. 21/21 packages build.
- **3 mutation checks**, each failing exactly the intended tests and no others: dropping `triage-quick` from the rotation (2 fail), dropping `(no quick-wins)` from the consensual prompt (1 fail), adding an `<AWAIT>` to the quick prompt (2 fail). Baseline green after restoring each.
- Not live-verified in a running daemon: watching auto PM actually fire a triage costs quota.

## The red check is not from this PR

This touches `prompts/`, so the drift job runs and fails on the pre-existing #885 drift (`TODO_FILE` is `TODO_AGENTS.md` on #326, still `TODO_<SESSION_NAME>.agent.md` in the repo). Reproduced on a clean `origin/main` tree. #885 is still waiting on your call.