### PR TITLE
fix(framework): point the prompting at the queue file the code promotes (#885)

### DIFF
--- a/.changeset/prompt-todo-file-drift.md
+++ b/.changeset/prompt-todo-file-drift.md
@@ -1,0 +1,17 @@
+---
+'@gemstack/framework': patch
+---
+
+Point the prompting at `TODO_AGENTS.md`, the queue file the code actually promotes (#885)
+
+Both `${{ }}` blocks of the system prompt declared `TODO_FILE` as `TODO_<SESSION_NAME>.agent.md`,
+while the code had already moved to the flat `TODO_AGENTS.md`: that name is `FLAT_TODO_FILE`, the
+session-scoped one is `LEGACY_TODO_FILE`, and `promoteQueue` carries only the flat file off a run's
+branch.
+
+So an agent following the prompt wrote its backlog to a legacy name that nothing promotes, and an
+unattended run's queue never reached the checkout. The reader tolerates both names, which is why
+this stayed invisible.
+
+The two assertions that pinned the old name now derive it from `FLAT_TODO_FILE` instead of
+hardcoding a literal, so the prompt cannot silently desync from the code again.

--- a/packages/framework/prompts/on_before_mergeable_prompt.md
+++ b/packages/framework/prompts/on_before_mergeable_prompt.md
@@ -1,4 +1,4 @@
-TODO_FILE: `TODO_<SESSION_NAME>.agent.md`
+TODO_FILE: `TODO_AGENTS.md`
 
 ## Maintenance
 

--- a/packages/framework/prompts/system_prompt.md
+++ b/packages/framework/prompts/system_prompt.md
@@ -4,7 +4,7 @@ SHOW_MD: Show it via `showMarkdown()`
 SHOW_CHOICES: Show it via `showChoices()`
 AWAIT: Stop, await user answer before resuming
 SESSION_NAME: the name of the session
-TODO_FILE: `TODO_<SESSION_NAME>.agent.md`
+TODO_FILE: `TODO_AGENTS.md`
 ADD_ANALYSIS_ENTRY: Add entry to the ANLYSIS_RESULT.md list
 
 ## Analyze the user prompt

--- a/packages/framework/scripts/op-326-on-before-mergeable.snapshot.md
+++ b/packages/framework/scripts/op-326-on-before-mergeable.snapshot.md
@@ -1,4 +1,4 @@
-TODO_FILE: `TODO_<SESSION_NAME>.agent.md`
+TODO_FILE: `TODO_AGENTS.md`
 
 ## Maintenance
 

--- a/packages/framework/src/on-before-mergeable-prompt.test.ts
+++ b/packages/framework/src/on-before-mergeable-prompt.test.ts
@@ -3,9 +3,12 @@ import { test } from 'node:test'
 import { renderOnBeforeMergeablePrompt, ON_BEFORE_MERGEABLE_PROMPT_TEMPLATE } from './on-before-mergeable-prompt.js'
 import { TemplateFragmentError } from './prompt-template.js'
 import { BUSINESS_KNOWLEDGE_DOCS } from './system-prompt.js'
+import { FLAT_TODO_FILE } from './tickets.js'
 
 test('ON_BEFORE_MERGEABLE_PROMPT_TEMPLATE carries the #326 on-before-mergeable block', () => {
-  assert.ok(ON_BEFORE_MERGEABLE_PROMPT_TEMPLATE.includes('TODO_FILE: `TODO_<SESSION_NAME>.agent.md`'))
+  // Derived from the constant, not a literal (#885) — see the same assertion in
+  // system-prompt.test.ts. Both blocks declare TODO_FILE, so both can drift from the code.
+  assert.ok(ON_BEFORE_MERGEABLE_PROMPT_TEMPLATE.includes(`TODO_FILE: \`${FLAT_TODO_FILE}\``))
   assert.ok(ON_BEFORE_MERGEABLE_PROMPT_TEMPLATE.includes('## Maintenance'))
   for (const preset of ['maintainability', 'readability', 'security_audit']) {
     assert.ok(ON_BEFORE_MERGEABLE_PROMPT_TEMPLATE.includes(`tf.presets.${preset}.filePath`), `missing ${preset}`)

--- a/packages/framework/src/system-prompt.test.ts
+++ b/packages/framework/src/system-prompt.test.ts
@@ -82,7 +82,10 @@ test('SYSTEM_PROMPT_TEMPLATE carries the #326 sections verbatim', () => {
   ]) {
     assert.ok(SYSTEM_PROMPT_TEMPLATE.includes(section), `missing ${section}`)
   }
-  assert.ok(SYSTEM_PROMPT_TEMPLATE.includes('TODO_FILE: `TODO_<SESSION_NAME>.agent.md`'))
+  // Derived from the constant, not a literal (#885): the prompt tells the agent where to write
+  // its backlog, and `promoteQueue` only carries FLAT_TODO_FILE off a run's branch. When the two
+  // disagree, an unattended run's queue is written to a name nothing ever promotes.
+  assert.ok(SYSTEM_PROMPT_TEMPLATE.includes(`TODO_FILE: \`${FLAT_TODO_FILE}\``))
   assert.ok(SYSTEM_PROMPT_TEMPLATE.includes('ADD_ANALYSIS_ENTRY: Add entry to the ANLYSIS_RESULT.md list'))
   assert.ok(SYSTEM_PROMPT_TEMPLATE.includes('${{tf.prompt}}'))
   // The whole block is the branch-free doc now: #326 moved the one `tf.params.autopilot`


### PR DESCRIPTION
Closes #885

This started as "make the `drift` job green" and turned out to be a real bug.

## What was wrong

Both ```md blocks of #326 declare `TODO_FILE`, and both said `TODO_<SESSION_NAME>.agent.md`. The code had already moved on:

| | |
|---|---|
| `FLAT_TODO_FILE` | `TODO_AGENTS.md` |
| `LEGACY_TODO_FILE` | `TODO_<SESSION_NAME>.agent.md` |
| what `promoteQueue` carries off a run's branch | `FLAT_TODO_FILE`, and only that |

So an agent following the system prompt wrote its backlog to a name nothing promotes, and an unattended run's queue never reached the checkout. `findTodoBacklog` tolerates both names, which is exactly why this stayed invisible: the file was always readable in the worktree that wrote it, and only ever went missing at promotion time.

## What changed

Three one-line content changes, plus the tests:

- `prompts/system_prompt.md` is now block 1 copied from the issue verbatim, which is what the drift check demands of it.
- `prompts/on_before_mergeable_prompt.md` keeps its flattening (block 2 nests `${{ }}` fragments and cannot ship verbatim); only the `TODO_FILE` line moved.
- The block 2 snapshot is refreshed via `check:prompt-drift --update`.

The two assertions that pinned the old filename now derive it from `FLAT_TODO_FILE` instead of hardcoding a literal. That is the part worth keeping: the drift check skips itself when GitHub is unreachable, so it cannot be the only thing holding the prompt and the code together.

## Verification

- 859 framework tests, 0 fail. Drift check green locally: `prompts/ is in sync with gemstack-land/gemstack#326`.
- **2 mutation checks**: reverting either prompt's `TODO_FILE` to the legacy name fails exactly one test each, and the baseline is green after restoring both. The assertions are coupled to the constant, not tautological.
- Diff against the issue was exactly one line per block before this change, so nothing else in #326 has drifted.

## Note on scope

I deliberately did not touch the reader's tolerance for the legacy names. Repos with a `TODO_<SESSION_NAME>.agent.md` already on disk keep working, and retiring those constants is a separate decision.

This is the red check that has been failing every PR that touches `prompts/`, including #894.