### PR TITLE
fix(framework): report what the post-merge cleanup did (#835)

### DIFF
--- a/.changeset/post-merge-cleanup-visibility.md
+++ b/.changeset/post-merge-cleanup-visibility.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Report what the post-merge cleanup step did (#835). It used to decline for five reasons, four of them silently, and say so on stdout in the one case that spoke up. A dashboard-started run is spawned with `stdio: 'ignore'`, so turning on Post-merge cleanup and getting nothing was indistinguishable from it having run. The outcome is now a real `on-before-mergeable` event (queued, incomplete, or skipped with the reason), and it fires before the run's event log is archived so it survives into the run's history.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -1,11 +1,11 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { mkdtemp, mkdir, readFile, writeFile, rm } from 'node:fs/promises'
+import { mkdtemp, mkdir, readdir, readFile, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, dirname } from 'node:path'
 import { appendControl } from './control.js'
 import { daemonStatePath } from './daemon.js'
-import { EVENTS_FILE, FRAMEWORK_DIR, type StoreFs } from './store/index.js'
+import { EVENTS_FILE, FRAMEWORK_DIR, RUNS_DIR, type StoreFs } from './store/index.js'
 import {
   activeModes,
   antiLazyPillOff,
@@ -742,5 +742,54 @@ test('a live daemon steers a dashboard-less run through its gates via control.js
     else process.env.XDG_CONFIG_HOME = prevXdg
     await rm(cwd, { recursive: true, force: true })
     await rm(cfg, { recursive: true, force: true })
+  }
+})
+
+test('runOnBeforeMergeable reports how it went, so the caller can emit it (#835)', async () => {
+  const { io } = capture()
+  const fire = (ok: boolean) =>
+    runOnBeforeMergeable('/work/app', '/bin/framework', io, { session_name: 'add-oauth' }, undefined, undefined, () =>
+      Promise.resolve(ok), memFs(),
+    )
+  assert.equal(await fire(true), 'queued')
+  assert.equal(await fire(false), 'incomplete')
+})
+
+test('a declined post-merge cleanup lands in the archived event log, not on stdout (#835)', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'framework-obm-'))
+  try {
+    const { io } = capture()
+    // A fake run never signals ready-for-merge, so the step declines. The point is that the
+    // decline is *reported*: it has to survive into runs/, which close() copies the log into.
+    const code = await runCli(['prompt', 'review the auth flow', '--fake', '--no-dashboard', '--on-before-mergeable', '--cwd', dir], io)
+    assert.equal(code, 0)
+    const runs = join(dir, FRAMEWORK_DIR, RUNS_DIR)
+    const archived = (await readdir(runs)).filter(f => f.endsWith('.jsonl'))
+    assert.equal(archived.length, 1, 'the run was archived')
+    const events = (await readFile(join(runs, archived[0]!), 'utf8'))
+      .split('\n')
+      .filter(Boolean)
+      .map(l => JSON.parse(l) as FrameworkEvent)
+    const outcome = events.find(e => e.kind === 'on-before-mergeable')
+    assert.ok(outcome, 'the outcome is in the archived log')
+    assert.equal(outcome.kind === 'on-before-mergeable' && outcome.outcome, 'skipped')
+    assert.equal(outcome.kind === 'on-before-mergeable' && outcome.outcome === 'skipped' && outcome.reason, 'not-ready-for-merge')
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('a run that never asked for the post-merge cleanup stays quiet about it (#835)', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'framework-obm-off-'))
+  try {
+    const { io } = capture()
+    assert.equal(await runCli(['prompt', 'review the auth flow', '--fake', '--no-dashboard', '--cwd', dir], io), 0)
+    const events = (await readFile(join(dir, FRAMEWORK_DIR, EVENTS_FILE), 'utf8'))
+      .split('\n')
+      .filter(Boolean)
+      .map(l => JSON.parse(l) as FrameworkEvent)
+    assert.equal(events.some(e => e.kind === 'on-before-mergeable'), false)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
   }
 })

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -22,7 +22,7 @@ import { startRelay, relayPublisher, type RelayPublisher } from './relay.js'
 import { randomUUID } from 'node:crypto'
 import { formatFrameworkEvent } from './terminal.js'
 import { CLAUDE_CODE_SESSION_LINK } from './session-link.js'
-import { type ChoicePick, type ChoiceRequest, type FrameworkEvent } from './events.js'
+import { type ChoicePick, type ChoiceRequest, type FrameworkEvent, type OnBeforeMergeableSkip } from './events.js'
 import {
   runFramework,
   type AppPreview,
@@ -786,8 +786,10 @@ async function settleRun(
     ctx.clearInterrupt()
     io.out(successLine)
     if (preview) io.out(`\n▶ Your app is running at ${preview.url} — open it in a browser.`)
-    await ctx.store?.close() // flush the event log; best-effort
+    // Before the close, not after (#835): close() archives the log into `runs/`, so an
+    // outcome appended afterwards would miss the copy the dashboard's history reads.
     await ctx.maybeFireOnBeforeMergeable()
+    await ctx.store?.close() // flush the event log; best-effort
     // Stay up while the dashboard and/or the app are live, then tear both down.
     if (dashboard || preview) {
       if (dashboard) io.out(`\nDashboard still live at ${dashboard.url}. Press Ctrl+C to exit.`)
@@ -1206,21 +1208,27 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   }
 
   // Fire the #326 on-before-mergeable prompt once a --on-before-mergeable run has settled and the agent
-  // signalled setReadyForMerge(). Skipped for a fake/offline run and when the run was stopped.
+  // signalled setReadyForMerge(). Skipped for a fake/offline run and when the run was stopped —
+  // and every outcome, including each skip, is emitted as an event so the dashboard can show it (#835).
   const maybeFireOnBeforeMergeable = async (): Promise<void> => {
-    if (!opts.onBeforeMergeable || !sawReadyForMerge || stoppedCleanly || fake) return
+    // The step was never asked for, so there is no outcome to report and nothing to explain.
+    if (!opts.onBeforeMergeable) return
+    // Every other exit says so as an event (#835). stdout cannot carry this: a dashboard-started
+    // run is spawned with `stdio: 'ignore'`, so silence there read as "it ran and found nothing".
+    const skip = (reason: OnBeforeMergeableSkip) =>
+      onEvent({ kind: 'on-before-mergeable', outcome: 'skipped', reason })
+    if (!sawReadyForMerge) return skip('not-ready-for-merge')
+    if (stoppedCleanly) return skip('run-stopped')
+    if (fake) return skip('fake-run')
     // --eco-auto-maintenance (#314) no longer skips the whole run: since #537 this prompt
     // also carries `## Business knowledge`, which the flag does not name. It drops just
     // `## Maintenance` inside renderOnBeforeMergeablePrompt() instead.
     // Every line of the prompt names the session, so there is nothing to queue without one.
     // An agent that made changes has one; this is the agent that ignored the instruction.
-    if (!sessionName) {
-      io.out('  ! on-before-mergeable skipped: the session never called setSessionName().')
-      return
-    }
+    if (!sessionName) return skip('no-session-name')
     const binPath = process.argv[1]
-    if (!binPath) return
-    await runOnBeforeMergeable(
+    if (!binPath) return skip('no-bin-path')
+    const outcome = await runOnBeforeMergeable(
       cwd,
       binPath,
       io,
@@ -1228,6 +1236,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
       opts.maxCost,
       opts.eco,
     )
+    onEvent({ kind: 'on-before-mergeable', outcome })
   }
 
   // A mode/kind given with no preset in effect has nothing to act on: note it.
@@ -1633,6 +1642,9 @@ export type PromptRunner = (prompt: string, cwd: string, binPath: string, maxCos
  * child runs back to back (#556). Queueing is both what the doc says and the cheaper thing:
  * one short turn that writes a few TODO lines, rather than three full preset passes serialized
  * on the same git index. Best-effort, like the suite was: a failure is logged, never thrown.
+ *
+ * Returns how it went so the caller can emit it as an event (#835); the `io` lines stay for
+ * a terminal run, which is the one surface that can still read them.
  */
 export async function runOnBeforeMergeable(
   cwd: string,
@@ -1644,7 +1656,7 @@ export async function runOnBeforeMergeable(
   // Vanilla by default: the follow-up must not run the session-name step and branch (#560).
   run: PromptRunner = (prompt, cwd, binPath, maxCost) => spawnPromptRun(prompt, cwd, binPath, maxCost, true),
   fs: StoreFs = nodeStoreFs(),
-): Promise<void> {
+): Promise<'queued' | 'incomplete'> {
   // Ensure the presets exist so the queued entries' filePaths resolve, even in a repo
   // activated before they shipped or a fresh clone (they are gitignored) (#598). Best-effort,
   // like the rest of this run: a materialize failure must not block the queueing.
@@ -1656,6 +1668,7 @@ export async function runOnBeforeMergeable(
   io.out(`\n◆ on-before-mergeable: queueing quality follow-ups for ${tf.session_name}`)
   const ok = await run(renderOnBeforeMergeablePrompt(tf, eco), cwd, binPath, maxCost)
   if (!ok) io.out(`  ! on-before-mergeable queueing did not complete cleanly.`)
+  return ok ? 'queued' : 'incomplete'
 }
 
 /**

--- a/packages/framework/src/events.test.ts
+++ b/packages/framework/src/events.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { OPEN_LOOP_MODES, pickedIds } from './events.js'
+import { OPEN_LOOP_MODES, pickedIds, type OnBeforeMergeableSkip } from './events.js'
 import { formatFrameworkEvent } from './terminal.js'
 import { SESSION_ID_PLACEHOLDER, hasSessionIdPlaceholder, resolveSessionLink } from './session-link.js'
 
@@ -144,4 +144,16 @@ test('formats the rate-limit line by how much the quota actually matters (#517)'
   // An unseen status still renders rather than blowing up or vanishing.
   assert.match(line('some_new_status'), /quota some_new_status/)
   assert.ok(line('allowed').includes(new Date(at).toISOString()))
+})
+
+test('formatFrameworkEvent renders every post-merge cleanup outcome, naming the skip reason (#835)', () => {
+  assert.match(formatFrameworkEvent({ kind: 'on-before-mergeable', outcome: 'queued' })!, /^✓ post-merge cleanup: quality follow-ups queued$/)
+  assert.match(formatFrameworkEvent({ kind: 'on-before-mergeable', outcome: 'incomplete' })!, /! post-merge cleanup: queueing did not complete cleanly/)
+  const skipped = (reason: OnBeforeMergeableSkip) =>
+    formatFrameworkEvent({ kind: 'on-before-mergeable', outcome: 'skipped', reason })!
+  assert.match(skipped('not-ready-for-merge'), /skipped: the session never signalled ready-for-merge/)
+  assert.match(skipped('run-stopped'), /skipped: the run was stopped/)
+  assert.match(skipped('fake-run'), /skipped: this was a fake run/)
+  assert.match(skipped('no-session-name'), /skipped: the session never called setSessionName\(\)/)
+  assert.match(skipped('no-bin-path'), /skipped: the framework binary path is unknown/)
 })

--- a/packages/framework/src/events.ts
+++ b/packages/framework/src/events.ts
@@ -49,6 +49,22 @@ export interface ChoiceRequest {
   file?: string
 }
 
+/**
+ * Why the #326 post-merge cleanup step declined to run (#835). Every decline carries one,
+ * so "I turned it on and nothing happened" has an answer in the log.
+ */
+export type OnBeforeMergeableSkip =
+  /** The agent never signalled `setReadyForMerge()`, so there is nothing to clean up after. */
+  | 'not-ready-for-merge'
+  /** The run was stopped (Stop button, Ctrl+C, budget cap) rather than finished. */
+  | 'run-stopped'
+  /** A fake/offline run: no agent to hand the follow-up prompt to. */
+  | 'fake-run'
+  /** The agent never called `setSessionName()`, which every line of the prompt names. */
+  | 'no-session-name'
+  /** `process.argv[1]` was empty, so there is no binary to spawn the follow-up with. */
+  | 'no-bin-path'
+
 /** Who resolved a {@link ChoiceRequest}: a human, the autopilot countdown, or a headless auto-accept. */
 export type ChoiceBy = 'user' | 'autopilot' | 'auto'
 
@@ -130,6 +146,16 @@ export type FrameworkEvent =
    * building (orange) to ready (green); the on-before-mergeable quality prompts hang off it.
    */
   | { kind: 'ready-for-merge' }
+  /**
+   * The #326 post-merge cleanup step settled (#835): it queued the quality follow-ups,
+   * queued them but did not finish cleanly, or declined with a {@link OnBeforeMergeableSkip}.
+   *
+   * An event rather than stdout because the surfaces that need it cannot read stdout: a
+   * dashboard-started run is spawned with `stdio: 'ignore'`. Emitted only when the option
+   * was on, so a run that never asked for the step stays quiet.
+   */
+  | { kind: 'on-before-mergeable'; outcome: 'queued' | 'incomplete' }
+  | { kind: 'on-before-mergeable'; outcome: 'skipped'; reason: OnBeforeMergeableSkip }
   /**
    * The work has settled and the run is parked on the user (#785): it stays open as a
    * conversation (#714), so its process is still alive and it still takes messages, but

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -94,6 +94,7 @@ export {
   type ChoiceRequest,
   type ChoicePick,
   type ChoiceBy,
+  type OnBeforeMergeableSkip,
   pickedIds,
   OPEN_LOOP_MODES,
 } from './events.js'

--- a/packages/framework/src/terminal.ts
+++ b/packages/framework/src/terminal.ts
@@ -1,6 +1,6 @@
 import type { BootstrapEvent } from '@gemstack/ai-autopilot'
 import type { DriverEvent, DriverRateLimit } from './driver/index.js'
-import { pickedIds, type ChoiceOption, type FrameworkEvent } from './events.js'
+import { pickedIds, type ChoiceOption, type FrameworkEvent, type OnBeforeMergeableSkip } from './events.js'
 
 // The terminal surface for the run's event stream: render one {@link FrameworkEvent} as one
 // human-readable line. This is the CLI's counterpart to the dashboard's read-model
@@ -32,6 +32,15 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
       return `✓ ready for merge`
     case 'settled':
       return `◆ done for now — waiting for your next message`
+    case 'on-before-mergeable':
+      switch (event.outcome) {
+        case 'queued':
+          return `✓ post-merge cleanup: quality follow-ups queued`
+        case 'incomplete':
+          return `  ! post-merge cleanup: queueing did not complete cleanly`
+        case 'skipped':
+          return `  ~ post-merge cleanup skipped: ${skipReason(event.reason)}`
+      }
     case 'usage': {
       const turns = `over ${event.turns} turn${event.turns === 1 ? '' : 's'}`
       // No price to show: report the tokens the agent *did* report, rather than a
@@ -60,6 +69,22 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
       return formatBootstrapEvent(event.event)
     case 'end':
       return event.ok ? '✓ finished' : event.stopped ? '■ stopped' : `✗ failed: ${event.detail ?? 'unknown error'}`
+  }
+}
+
+/** Say why the post-merge cleanup declined in the reader's terms, not the guard's (#835). */
+function skipReason(reason: OnBeforeMergeableSkip): string {
+  switch (reason) {
+    case 'not-ready-for-merge':
+      return 'the session never signalled ready-for-merge'
+    case 'run-stopped':
+      return 'the run was stopped'
+    case 'fake-run':
+      return 'this was a fake run'
+    case 'no-session-name':
+      return 'the session never called setSessionName()'
+    case 'no-bin-path':
+      return 'the framework binary path is unknown'
   }
 }
 


### PR DESCRIPTION
Closes #835

`maybeFireOnBeforeMergeable()` could decline for five reasons and four were silent. The fifth said so on stdout, which the surface that needs it cannot read: a dashboard-started run is spawned with `stdio: 'ignore'` (`daemon.ts:97`). So enabling Post-merge cleanup and getting nothing was indistinguishable from it having run and found nothing. Success and failure were equally invisible, for the same reason.

## What changed

- New `on-before-mergeable` `FrameworkEvent`: `outcome: 'queued' | 'incomplete'`, or `'skipped'` with a typed `reason` (`not-ready-for-merge`, `run-stopped`, `fake-run`, `no-session-name`, `no-bin-path`). It goes through `onEvent`, so it reaches the store, the publisher and the terminal like every other run fact, and the dashboard's EventList renders it from `formatFrameworkEvent` with no dashboard change.
- `runOnBeforeMergeable()` returns how it went instead of only printing. The `io` lines stay for a terminal run, which is the one surface that can still read them.
- `settleRun` now fires the step **before** `store.close()`.

The one case that stays quiet is the option being off. There is no outcome to report when the step was never asked for, and a skip event on every run would be noise. The ambiguity the issue describes only exists once you turn it on.

## Design note: the ordering

`RunStore.close()` is not just a flush. It calls `archiveRun()`, which copies `events.jsonl` into `runs/<id>.jsonl`, and that copy is what the dashboard's run history reads. An event appended after the close lands in the live log but never in the archive, and `archivePriorRun()` will not rescue it either, since it skips a run whose archive already exists. So converting the messages to events without reordering would have moved the problem rather than fixed it: the outcome would be visible for as long as the live log lasts and gone from the history.

Firing before the close is therefore the option that actually persists the outcome. What it risks: the follow-up is a full child `framework prompt` run, so the window between "run finished" and "run archived" now spans that child instead of being immediate. During it the run's row is not in `runs/` yet, and a kill in that window leaves the run unarchived. Both were already possible (a crash anywhere before `close()` does the same), and the existing mitigation covers it: the next fresh run calls `archivePriorRun()`, which archives a live log that never got closed. Writes are per-event `appendFile`, not buffered, so nothing is lost from the live log by holding the store open longer.

The alternative considered was keeping the close where it was and emitting only the decision (ran / skipped) ahead of it, closing, then running the child. That keeps the archive timing untouched but leaves the child's own result (`queued` vs `incomplete`) unreportable, which is half the issue.

## Tests

Four new, each mutation-checked (break it, confirm the test fails, restore):

| Test | Mutation | Result |
|---|---|---|
| formatter renders every outcome + skip reason | changed the `run-stopped` wording | fails |
| `runOnBeforeMergeable` reports how it went | always return `'queued'` | fails |
| a declined cleanup lands in the **archived** log | restored `close()` before the fire | fails |
| a run that never asked for it stays quiet | dropped the option-off early exit | fails |

4/4 mutations caught. Full suite green: `@gemstack/framework` 869 pass / 0 fail, 21/21 turbo tasks, build and typecheck clean.
