### PR TITLE
feat(framework): resolve config layers by precedence, not OR (#841)

### DIFF
--- a/.changeset/config-layers-precedence.md
+++ b/.changeset/config-layers-precedence.md
@@ -1,0 +1,16 @@
+---
+'@gemstack/framework': minor
+---
+
+Config layers now resolve by precedence, so a layer can turn a mode off (#841)
+
+The layers used to combine with OR: a flag could only ever turn a mode on, and
+`the-framework.yml` could only ever turn one on. Neither could say `false`, so a repo
+that committed `autopilot: true` gave every run in it autopilot with no way back.
+
+The layers now feed one resolve helper where the nearest layer that *set* a key wins and
+a layer that said nothing does not participate. Absent stays absent, so an existing setup
+resolves exactly as before; the change is that an explicit `false` in a nearer layer now
+wins. `--no-autopilot`, `--no-technical`, `--no-vanilla` and `--no-transparent` give a run
+that nearer `false`, and the startup line now narrates which layer won each key
+(`◆ config: preset=software-development (the-framework.yml), autopilot=off (flag)`).

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -224,13 +224,18 @@ event: bug-fix        # the build event kind its review loop fires for
 antiLazyPill: false   # remove the built-in system prompt (default: on)
 ```
 
-Every field is optional. CLI flags override the file, so the precedence is:
+Every field is optional. Config resolves layer by layer, and the nearest layer that
+*set* a key wins (#841). A layer that says nothing about a key does not participate:
 
 - **preset**: `--preset` > `the-framework.yml` `preset`
-- **modes**: a flag and the file OR together (a flag can only *enable* a mode)
+- **modes**: `--autopilot` / `--no-autopilot` (and the `--technical`, `--vanilla`,
+  `--transparent` pairs) > the file's boolean > off. Without either flag the file
+  decides, so a repo that turns a mode on can be turned back off for one run with
+  `--no-<mode>`.
 - **event**: `--kind` > `the-framework.yml` `event` > the preset's own default > `major-change`
 
-When the file contributes anything, the run narrates it (`◆ the-framework.yml: ...`).
+When any layer contributes something, the run narrates what won and where it came
+from (`◆ config: preset=software-development (the-framework.yml), autopilot=off (flag)`).
 A malformed file is a warning, never a failed run.
 
 ### System prompt: the built-in working agreement + `SYSTEM.md`

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -8,7 +8,6 @@ import { daemonStatePath } from './daemon.js'
 import { EVENTS_FILE, FRAMEWORK_DIR, type StoreFs } from './store/index.js'
 import {
   activeModes,
-  antiLazyPillOff,
   buildDeployTarget,
   chooseSessionLink,
   claudeDriverOptions,
@@ -194,16 +193,18 @@ test('parseArgs reads the maintain subcommand + its bounds (#298)', () => {
 
 test('parseArgs reads the Global options flags: vanilla + eco (#314)', () => {
   const dflt = parseArgs(['x'])
-  assert.equal(dflt.vanilla, false)
+  assert.equal(dflt.vanilla, undefined) // tri-state since #841: unset, so the repo file decides
   assert.deepEqual(dflt.eco, { autoPlanning: false, autoResearch: false, autoMaintenance: false })
   const on = parseArgs(['--vanilla', '--eco-auto-planning', '--eco-auto-maintenance', 'x'])
   assert.equal(on.vanilla, true)
   assert.deepEqual(on.eco, { autoPlanning: true, autoResearch: false, autoMaintenance: true })
 })
 
-test('parseArgs reads --transparent, off by default (#625)', () => {
-  assert.equal(parseArgs(['x']).transparent, false)
+test('parseArgs reads --transparent, unset by default (#625)', () => {
+  assert.equal(parseArgs(['x']).transparent, undefined) // tri-state since #841
   assert.equal(parseArgs(['--transparent', 'x']).transparent, true)
+  // Unset resolves to off, so a run with no flag and no file is still a normal run.
+  assert.equal(mergeRunConfig(parseArgs(['x']), {}).transparent, false)
 })
 
 test('ecoOptions returns undefined when nothing is set, else only the enabled drops (#314)', () => {
@@ -215,10 +216,12 @@ test('ecoOptions returns undefined when nothing is set, else only the enabled dr
   })
 })
 
-test('antiLazyPillOff is true for --vanilla or the-framework.yml antiLazyPill:false (#314)', () => {
-  assert.equal(antiLazyPillOff(parseArgs(['x']), {}), false)
-  assert.equal(antiLazyPillOff(parseArgs(['--vanilla', 'x']), {}), true)
-  assert.equal(antiLazyPillOff(parseArgs(['x']), { antiLazyPill: false }), true)
+test('the built-in prompt is off for --vanilla or the-framework.yml antiLazyPill:false (#314)', () => {
+  assert.equal(mergeRunConfig(parseArgs(['x']), {}).antiLazyPill, true)
+  assert.equal(mergeRunConfig(parseArgs(['--vanilla', 'x']), {}).antiLazyPill, false)
+  assert.equal(mergeRunConfig(parseArgs(['x']), { antiLazyPill: false }).antiLazyPill, false)
+  // #841: --no-vanilla puts the prompt back over a file that removed it.
+  assert.equal(mergeRunConfig(parseArgs(['--no-vanilla', 'x']), { antiLazyPill: false }).antiLazyPill, true)
 })
 
 test('runLogKind maps the run path to a project-log kind (#379)', () => {
@@ -402,8 +405,8 @@ test('parseArgs reads --preset and the mode flags (#256)', () => {
   assert.equal(opts.technical, true)
   const dflt = parseArgs(['x'])
   assert.equal(dflt.preset, undefined)
-  assert.equal(dflt.autopilot, false)
-  assert.equal(dflt.technical, false)
+  assert.equal(dflt.autopilot, undefined) // tri-state since #841
+  assert.equal(dflt.technical, undefined)
 })
 
 test('parseArgs reads --kind as the build event (#265)', () => {
@@ -438,26 +441,55 @@ test('activeModes maps the mode flags to Open Loop mode names', () => {
 })
 
 test('mergeRunConfig: the-framework.yml supplies defaults, flags override (#258)', () => {
-  const flags = { preset: undefined, autopilot: false, technical: false }
+  const flags = {}
+  const modes = (config: { autopilot: boolean; technical: boolean }) => [config.autopilot, config.technical]
   // file-only: the repo config drives the run
-  assert.deepEqual(mergeRunConfig(flags, { preset: 'software-development', autopilot: true }), {
-    presetName: 'software-development',
-    autopilot: true,
-    technical: false,
-  })
+  const fromFile = mergeRunConfig(flags, { preset: 'software-development', autopilot: true })
+  assert.equal(fromFile.presetName, 'software-development')
+  assert.deepEqual(modes(fromFile), [true, false])
   // a --preset flag wins over the file's preset
-  assert.equal(mergeRunConfig({ ...flags, preset: 'web-dev' }, { preset: 'software-development' }).presetName, 'web-dev')
-  // modes OR together: a flag can only enable a mode
-  assert.deepEqual(mergeRunConfig({ ...flags, technical: true }, { autopilot: true }), {
-    autopilot: true,
-    technical: true,
-  })
+  assert.equal(mergeRunConfig({ preset: 'web-dev' }, { preset: 'software-development' }).presetName, 'web-dev')
+  // a mode set by either layer is on; the flag layer says nothing about the mode it did not set
+  assert.deepEqual(modes(mergeRunConfig({ technical: true }, { autopilot: true })), [true, true])
   // nothing set anywhere: no preset, no modes
-  assert.deepEqual(mergeRunConfig(flags, {}), { autopilot: false, technical: false })
+  assert.deepEqual(modes(mergeRunConfig(flags, {})), [false, false])
+  assert.equal(mergeRunConfig(flags, {}).presetName, undefined)
   // build event: the file's `event` supplies a default, --kind overrides it (#265)
   assert.equal(mergeRunConfig(flags, { event: 'bug-fix' }).buildEvent, 'bug-fix')
-  assert.equal(mergeRunConfig({ ...flags, buildEvent: 'major-change' }, { event: 'bug-fix' }).buildEvent, 'major-change')
+  assert.equal(mergeRunConfig({ buildEvent: 'major-change' }, { event: 'bug-fix' }).buildEvent, 'major-change')
   assert.equal(mergeRunConfig(flags, {}).buildEvent, undefined)
+})
+
+test('mergeRunConfig: a nearer layer can turn a mode off, not just on (#841)', () => {
+  // The bug: with OR, a flag could only ever enable. Now --no-* beats a file that enabled it.
+  assert.equal(mergeRunConfig(parseArgs(['--no-autopilot', 'x']), { autopilot: true }).autopilot, false)
+  assert.equal(mergeRunConfig(parseArgs(['--no-technical', 'x']), { technical: true }).technical, false)
+  assert.equal(mergeRunConfig(parseArgs(['--no-transparent', 'x']), { transparent: true }).transparent, false)
+  // And the file still supplies the value when this run says nothing.
+  assert.equal(mergeRunConfig(parseArgs(['x']), { autopilot: true }).autopilot, true)
+  assert.equal(mergeRunConfig(parseArgs(['x']), { transparent: true }).transparent, true)
+  // The flag layer still wins when it says "on" over a file that says "off".
+  assert.equal(mergeRunConfig(parseArgs(['--autopilot', 'x']), { autopilot: false }).autopilot, true)
+  // A layer that set nothing does not participate: absent stays absent, defaults hold.
+  const bare = mergeRunConfig(parseArgs(['x']), {})
+  assert.deepEqual(
+    { autopilot: bare.autopilot, technical: bare.technical, transparent: bare.transparent, antiLazyPill: bare.antiLazyPill },
+    { autopilot: false, technical: false, transparent: false, antiLazyPill: true },
+  )
+  assert.deepEqual(bare.sources, {})
+})
+
+test('parseArgs leaves the mode toggles unset until a flag names them (#841)', () => {
+  const bare = parseArgs(['x'])
+  assert.equal(bare.autopilot, undefined)
+  assert.equal(bare.technical, undefined)
+  assert.equal(bare.vanilla, undefined)
+  assert.equal(bare.transparent, undefined)
+  assert.equal(parseArgs(['--autopilot', 'x']).autopilot, true)
+  assert.equal(parseArgs(['--no-autopilot', 'x']).autopilot, false)
+  assert.equal(parseArgs(['--no-technical', 'x']).technical, false)
+  assert.equal(parseArgs(['--no-vanilla', 'x']).vanilla, false)
+  assert.equal(parseArgs(['--no-transparent', 'x']).transparent, false)
 })
 
 test('resolveDomainPreset resolves a shipped preset by name (#254/#256)', async () => {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -34,6 +34,14 @@ import {
 import { FAKE_DEPLOY, FAKE_INTENT, FAKE_SIGNALS, fakeDriver } from './fake-script.js'
 import { readProjectSignals } from './project.js'
 import { loadFrameworkConfig, type FrameworkFileConfig } from './config.js'
+import {
+  describeResolvedConfig,
+  fileConfigLayer,
+  resolveRunConfig,
+  resolvedModes,
+  type ConfigLayer,
+  type ResolvedRunConfig,
+} from './config-layers.js'
 import { type EcoOptions } from './system-prompt.js'
 import { loadUserSystemPrompt, SYSTEM_PROMPT_FILE } from './system-prompt-file.js'
 import { checkForUpdate, formatUpdateStatus, nodeVersionFetcher } from './update-check.js'
@@ -149,6 +157,10 @@ Options:
   --technical            Activate the preset's Technical mode variants.
                          (--preset / --autopilot / --technical / --kind can also be
                           set per repo in the-framework.yml; these flags override it.)
+  --no-autopilot, --no-technical, --no-vanilla, --no-transparent
+                         The off switch for each toggle: this run overrides a repo
+                         the-framework.yml that turned it on (--no-vanilla puts the
+                         built-in prompt back). With neither form, the file decides.
   --vanilla              Remove the built-in system prompt entirely. The agent still
                          gets the AWAIT/SIGNAL emit contract, so it can drive the
                          dashboard's gates; for a fully raw session use --transparent.
@@ -254,13 +266,17 @@ export interface CliOptions {
   unattended?: boolean
   scope: 'prototype' | 'full'
   preset?: string | undefined
-  autopilot: boolean
-  technical: boolean
+  /**
+   * The mode toggles are tri-state (#841): `undefined` is "this run said nothing", so the repo's
+   * the-framework.yml decides, while an explicit `--no-*` turns the mode off over the file.
+   */
+  autopilot?: boolean | undefined
+  technical?: boolean | undefined
   /** `--vanilla`: remove the built-in #326 system prompt entirely (antiLazyPill off, #314). */
-  vanilla: boolean
+  vanilla?: boolean | undefined
   /** `--transparent` (#625): run the wrapped agent fully raw — no framework system prompt, emit
    * protocols, consumption guard, dashboard, or TODO loop, so a run is identical to `claude -p`. */
-  transparent: boolean
+  transparent?: boolean | undefined
   /** `--eco-*`: fine-grained #326 section drops to save tokens (#314). */
   eco: Required<EcoOptions>
   /** `--context <dir>` (repeatable): in-context directories added as one `Context:` line (#439). */
@@ -323,10 +339,6 @@ export function parseArgs(argv: string[]): CliOptions {
     intent: '',
     agent: 'claude',
     scope: 'full',
-    autopilot: false,
-    technical: false,
-    vanilla: false,
-    transparent: false,
     eco: { autoPlanning: false, autoResearch: false, autoMaintenance: false },
     context: [],
     onBeforeMergeable: false,
@@ -378,14 +390,26 @@ export function parseArgs(argv: string[]): CliOptions {
       case '--autopilot':
         opts.autopilot = true
         break
+      case '--no-autopilot':
+        opts.autopilot = false
+        break
       case '--technical':
         opts.technical = true
+        break
+      case '--no-technical':
+        opts.technical = false
         break
       case '--vanilla':
         opts.vanilla = true
         break
+      case '--no-vanilla':
+        opts.vanilla = false
+        break
       case '--transparent':
         opts.transparent = true
+        break
+      case '--no-transparent':
+        opts.transparent = false
         break
       case '--on-before-mergeable':
         opts.onBeforeMergeable = true
@@ -644,21 +668,8 @@ export function unguardedNotices(
   return notices
 }
 
-/** The active Open Loop modes from the mode flags, in a stable order. */
-export function activeModes(opts: Pick<CliOptions, 'autopilot' | 'technical'>): string[] {
-  const modes: string[] = []
-  if (opts.autopilot) modes.push('autopilot')
-  if (opts.technical) modes.push('technical')
-  return modes
-}
-
-/**
- * Whether the built-in #326 system prompt is removed for this run (#314): the
- * Vanilla toggle (`--vanilla`) or `the-framework.yml`'s `antiLazyPill: false`.
- */
-export function antiLazyPillOff(opts: Pick<CliOptions, 'vanilla'>, file: FrameworkFileConfig): boolean {
-  return opts.vanilla || file.antiLazyPill === false
-}
+/** The active Open Loop modes of a resolved run config, in a stable order. */
+export const activeModes = resolvedModes
 
 /** The Eco section drops in effect (#314), or `undefined` when none are set. */
 export function ecoOptions(opts: Pick<CliOptions, 'eco'>): EcoOptions | undefined {
@@ -698,33 +709,30 @@ export function runLogEntry(input: {
   }
 }
 
-/**
- * Merge CLI flags over a project's `the-framework.yml` defaults (#258). A `--preset`
- * flag wins over the file's `preset`; the mode flags OR with the file's booleans
- * (a flag can only *enable* a mode, so there is nothing to override the other way).
- */
-export function mergeRunConfig(
-  opts: Pick<CliOptions, 'preset' | 'autopilot' | 'technical' | 'buildEvent'>,
-  file: FrameworkFileConfig,
-): { presetName?: string; autopilot: boolean; technical: boolean; buildEvent?: string } {
-  const presetName = opts.preset ?? file.preset
-  const buildEvent = opts.buildEvent ?? file.event
+/** This run's own flags as the nearest config layer (#841). A flag left off says nothing. */
+export function flagConfigLayer(opts: RunConfigFlags): ConfigLayer {
   return {
-    ...(presetName ? { presetName } : {}),
-    ...(buildEvent ? { buildEvent } : {}),
-    autopilot: opts.autopilot || file.autopilot === true,
-    technical: opts.technical || file.technical === true,
+    name: 'flag',
+    values: {
+      ...(opts.preset !== undefined ? { preset: opts.preset } : {}),
+      ...(opts.buildEvent !== undefined ? { event: opts.buildEvent } : {}),
+      ...(opts.autopilot !== undefined ? { autopilot: opts.autopilot } : {}),
+      ...(opts.technical !== undefined ? { technical: opts.technical } : {}),
+      // --vanilla is the negative face of the same key: it removes the built-in prompt.
+      ...(opts.vanilla !== undefined ? { antiLazyPill: !opts.vanilla } : {}),
+      ...(opts.transparent !== undefined ? { transparent: opts.transparent } : {}),
+    },
   }
 }
 
-/** A short summary of what the-framework.yml contributed and is in effect, or `''` for nothing to report. */
-function describeConfigSource(opts: Pick<CliOptions, 'preset' | 'buildEvent'>, file: FrameworkFileConfig): string {
-  const parts: string[] = []
-  if (file.preset && !opts.preset) parts.push(`preset=${file.preset}`) // a --preset flag would override it
-  if (file.autopilot) parts.push('autopilot')
-  if (file.technical) parts.push('technical')
-  if (file.event && !opts.buildEvent) parts.push(`event=${file.event}`) // a --kind flag would override it
-  return parts.join(', ')
+type RunConfigFlags = Pick<CliOptions, 'preset' | 'autopilot' | 'technical' | 'buildEvent' | 'vanilla' | 'transparent'>
+
+/**
+ * Resolve a run's config over its layers, nearest wins (#841): the run's flags, then the repo's
+ * `the-framework.yml`. #800 slots the project-user and global tiers in between and at the end.
+ */
+export function mergeRunConfig(opts: RunConfigFlags, file: FrameworkFileConfig): ResolvedRunConfig {
+  return resolveRunConfig([flagConfigLayer(opts), fileConfigLayer(file)])
 }
 
 /**
@@ -858,18 +866,20 @@ async function startRunDashboard(
  */
 async function resolvePromptConfig(
   opts: CliOptions,
-  fileConfig: FrameworkFileConfig,
+  config: ResolvedRunConfig,
   cwd: string,
   io: CliIO,
   transparent: boolean,
 ): Promise<{ userSystemPrompt?: string; noBuiltinPrompt: boolean; eco?: EcoOptions }> {
   const userSystemPrompt = await loadUserSystemPrompt(cwd)
   // Transparent empties the whole channel, which subsumes "no built-in prompt".
-  const noBuiltinPrompt = transparent || antiLazyPillOff(opts, fileConfig)
+  const noBuiltinPrompt = transparent || !config.antiLazyPill
   const eco = ecoOptions(opts)
   if (userSystemPrompt) io.out(`◆ system prompt: ${SYSTEM_PROMPT_FILE}`)
   // Transparent already announced itself (guard line); don't double-report the prompt being off.
-  if (noBuiltinPrompt && !transparent) io.out(`◆ built-in system prompt: off (${opts.vanilla ? 'vanilla' : 'the-framework.yml'})`)
+  // Name the layer that turned it off; at the flag tier that flag is --vanilla.
+  const offBy = config.sources.antiLazyPill === 'flag' ? '--vanilla' : (config.sources.antiLazyPill ?? 'transparent')
+  if (noBuiltinPrompt && !transparent) io.out(`◆ built-in system prompt: off (${offBy})`)
   else if (eco) io.out(`◆ eco: dropping ${Object.keys(eco).filter(k => eco[k as keyof EcoOptions]).join(', ')}`)
   if (opts.context.length) io.out(`◆ context: ${opts.context.join(', ')}`)
   return { ...(userSystemPrompt ? { userSystemPrompt } : {}), noBuiltinPrompt, ...(eco ? { eco } : {}) }
@@ -949,14 +959,17 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // file is a warning, never a failed run. Read from the run's own workspace, so a
   // --fake demo (empty tmp cwd) stays deterministic unless pointed at a config dir.
   const fileConfig = await loadFrameworkConfig(cwd, msg => io.err(msg))
-  const fromFile = describeConfigSource(opts, fileConfig)
-  if (fromFile) io.out(`◆ the-framework.yml: ${fromFile}`)
+  // One resolve over the layers (#841): the nearest layer that set a key wins, so this run's
+  // flags beat the repo file and an explicit `--no-autopilot` can turn off what the file set.
+  const config = mergeRunConfig(opts, fileConfig)
+  const fromConfig = describeResolvedConfig(config)
+  if (fromConfig) io.out(`◆ config: ${fromConfig}`)
 
   // Transparent mode (#625): the coarse master off-switch — `--transparent` or the-framework.yml.
   // When on, this run is byte-identical to raw `claude -p`: no framework system channel (composed
   // empty below), no consumption guard, no dashboard, no TODO loop. Resolved once here so every
   // one of those sites reads the same answer.
-  const transparent = opts.transparent || fileConfig.transparent === true
+  const transparent = config.transparent
 
   // Only the direct-prompt path resumes a conversation (#782): a build run rebuilds the
   // scope/build framing a resumed transcript already carries, so it takes no session id and
@@ -971,10 +984,9 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
 
   // Resolve which Open Loop domain preset (+ modes + build event) to run under:
   // --preset / the-framework.yml, or none at all (#545). Nothing infers one.
-  const merged = mergeRunConfig(opts, fileConfig)
-  let presetName = merged.presetName
-  let modeList = activeModes(merged)
-  let buildEvent = merged.buildEvent
+  let presetName = config.presetName
+  let modeList = activeModes(config)
+  let buildEvent = config.buildEvent
   let domainPreset: DomainPreset | undefined
 
   // An explicit --preset / the-framework.yml preset is validated up front — a bad
@@ -1224,7 +1236,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
       cwd,
       binPath,
       io,
-      { session_name: sessionName, settings: { technical_control: opts.technical } },
+      { session_name: sessionName, settings: { technical_control: config.technical } },
       opts.maxCost,
       opts.eco,
     )
@@ -1295,7 +1307,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
 
   // A user SYSTEM.md + the anti-lazy-pill toggle shape the system prompt (#301), and the eco
   // flags trim the built-in one (#314). Resolve and echo once, shared by both run paths.
-  const promptConfig = await resolvePromptConfig(opts, fileConfig, cwd, io, transparent)
+  const promptConfig = await resolvePromptConfig(opts, config, cwd, io, transparent)
 
   // The run-scoped state both run paths hand to settleRun to close out. stoppedCleanly is a
   // getter because the onEvent sink sets it as the `end` event arrives.

--- a/packages/framework/src/config-layers.test.ts
+++ b/packages/framework/src/config-layers.test.ts
@@ -1,0 +1,96 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import {
+  describeResolvedConfig,
+  fileConfigLayer,
+  resolveConfigKey,
+  resolveRunConfig,
+  resolvedModes,
+  RUN_CONFIG_DEFAULTS,
+  type ConfigLayer,
+} from './config-layers.js'
+
+// The #800 chain, nearest first.
+const chain = (run = {}, project = {}, repo = {}, global = {}): ConfigLayer[] => [
+  { name: 'run', values: run },
+  { name: 'project', values: project },
+  { name: 'the-framework.yml', values: repo },
+  { name: 'global', values: global },
+]
+
+test('resolveConfigKey takes the nearest layer that set the key (#841)', () => {
+  assert.deepEqual(resolveConfigKey(chain({ autopilot: false }, { autopilot: true }), 'autopilot'), {
+    value: false,
+    from: 'run',
+  })
+  assert.deepEqual(resolveConfigKey(chain({}, { autopilot: true }), 'autopilot'), { value: true, from: 'project' })
+  assert.deepEqual(resolveConfigKey(chain({}, {}, {}, { autopilot: false }), 'autopilot'), {
+    value: false,
+    from: 'global',
+  })
+})
+
+test('resolveConfigKey ignores layers that left the key unset (#841)', () => {
+  assert.equal(resolveConfigKey(chain(), 'autopilot'), undefined)
+  // An unset key in a nearer layer does not shadow a farther one that set it.
+  assert.deepEqual(resolveConfigKey(chain({ technical: true }, {}, { autopilot: true }), 'autopilot'), {
+    value: true,
+    from: 'the-framework.yml',
+  })
+})
+
+test('resolveRunConfig: each layer can win, and each can be absent (#841)', () => {
+  for (const layer of ['run', 'project', 'the-framework.yml', 'global']) {
+    const layers = chain().map(l => (l.name === layer ? { ...l, values: { autopilot: true, preset: layer } } : l))
+    const resolved = resolveRunConfig(layers)
+    assert.equal(resolved.autopilot, true, `${layer} should win autopilot`)
+    assert.equal(resolved.presetName, layer)
+    assert.equal(resolved.sources.autopilot, layer)
+  }
+  // Every layer absent: the defaults hold and nothing claims a source.
+  const bare = resolveRunConfig(chain())
+  assert.equal(bare.autopilot, RUN_CONFIG_DEFAULTS.autopilot)
+  assert.equal(bare.technical, RUN_CONFIG_DEFAULTS.technical)
+  assert.equal(bare.antiLazyPill, RUN_CONFIG_DEFAULTS.antiLazyPill)
+  assert.equal(bare.transparent, RUN_CONFIG_DEFAULTS.transparent)
+  assert.equal(bare.presetName, undefined)
+  assert.equal(bare.buildEvent, undefined)
+  assert.deepEqual(bare.sources, {})
+  // No layers at all resolves the same way as layers that set nothing.
+  assert.deepEqual(resolveRunConfig([]), bare)
+})
+
+test('resolveRunConfig: a nearer false beats a farther true (#841)', () => {
+  const resolved = resolveRunConfig(chain({}, { transparent: false }, { transparent: true }))
+  assert.equal(resolved.transparent, false)
+  assert.equal(resolved.sources.transparent, 'project')
+})
+
+test('fileConfigLayer carries only the keys the-framework.yml set', () => {
+  assert.deepEqual(fileConfigLayer({}), { name: 'the-framework.yml', values: {} })
+  assert.deepEqual(fileConfigLayer({ autopilot: false, preset: 'software-development' }).values, {
+    autopilot: false,
+    preset: 'software-development',
+  })
+  // `event` is the file's name for the build event key.
+  assert.deepEqual(fileConfigLayer({ event: 'bug-fix' }).values, { event: 'bug-fix' })
+  assert.equal(fileConfigLayer({}, 'other.yml').name, 'other.yml')
+})
+
+test('resolvedModes lists the active Open Loop modes in a stable order', () => {
+  assert.deepEqual(resolvedModes({ autopilot: false, technical: false }), [])
+  assert.deepEqual(resolvedModes({ autopilot: true, technical: false }), ['autopilot'])
+  assert.deepEqual(resolvedModes({ autopilot: true, technical: true }), ['autopilot', 'technical'])
+})
+
+test('describeResolvedConfig narrates which layer won each key (#841)', () => {
+  assert.equal(describeResolvedConfig(resolveRunConfig(chain())), '')
+  assert.equal(
+    describeResolvedConfig(resolveRunConfig(chain({ autopilot: false }, {}, { autopilot: true, preset: 'software-development' }))),
+    'preset=software-development (the-framework.yml), autopilot=off (run)',
+  )
+  assert.equal(
+    describeResolvedConfig(resolveRunConfig(chain({}, {}, { event: 'bug-fix', transparent: true }))),
+    'transparent=on (the-framework.yml), event=bug-fix (the-framework.yml)',
+  )
+})

--- a/packages/framework/src/config-layers.ts
+++ b/packages/framework/src/config-layers.ts
@@ -1,0 +1,138 @@
+import type { FrameworkFileConfig } from './config.js'
+
+/**
+ * Resolving a run's settings across config layers (#841).
+ *
+ * The layers used to combine with `||`, which meant a flag could only ever turn a mode *on* and
+ * the-framework.yml could only ever turn one *on*: no layer could say `false`. #800 needs "a
+ * project overrides only what it sets", which cannot be built on OR.
+ *
+ * So: nearest layer that set a key wins, and a layer that left a key unset does not participate.
+ * Absent stays absent, so an existing setup resolves the same way; the one behaviour change is
+ * that an explicit `false` in a nearer layer now wins.
+ */
+
+/** The run settings a config layer can carry. Keys left `undefined` mean "this layer said nothing". */
+export interface RunConfigValues {
+  /** Open Loop domain preset name. */
+  preset?: string | undefined
+  /** Build event kind the preset's review loop fires for (#265). */
+  event?: string | undefined
+  autopilot?: boolean | undefined
+  technical?: boolean | undefined
+  /** Inject the built-in #326 system prompt (#314). */
+  antiLazyPill?: boolean | undefined
+  /** Run the wrapped agent fully raw (#625). */
+  transparent?: boolean | undefined
+}
+
+/** One tier of config, with the label the run narrates when this tier wins a key. */
+export interface ConfigLayer {
+  /** Where these values came from, e.g. `flag` or `the-framework.yml`. */
+  name: string
+  values: RunConfigValues
+}
+
+/** What a key resolves to when no layer set it. */
+export const RUN_CONFIG_DEFAULTS = {
+  autopilot: false,
+  technical: false,
+  antiLazyPill: true,
+  transparent: false,
+} as const
+
+/**
+ * The nearest layer that set `key`, or `undefined` when none did. Layers are ordered
+ * nearest-first: run flags > project user > repo yml > global.
+ */
+export function resolveConfigKey<K extends keyof RunConfigValues>(
+  layers: readonly ConfigLayer[],
+  key: K,
+): { value: NonNullable<RunConfigValues[K]>; from: string } | undefined {
+  for (const layer of layers) {
+    const value = layer.values[key]
+    if (value !== undefined) return { value: value as NonNullable<RunConfigValues[K]>, from: layer.name }
+  }
+  return undefined
+}
+
+/** A run's settled config, plus which layer supplied each key a layer actually set. */
+export interface ResolvedRunConfig {
+  presetName?: string | undefined
+  buildEvent?: string | undefined
+  autopilot: boolean
+  technical: boolean
+  antiLazyPill: boolean
+  transparent: boolean
+  /** Winning layer name per key; a key left to its default is absent here. */
+  sources: Partial<Record<keyof RunConfigValues, string>>
+}
+
+/** Resolve every run setting over `layers` (nearest first), falling back to {@link RUN_CONFIG_DEFAULTS}. */
+export function resolveRunConfig(layers: readonly ConfigLayer[]): ResolvedRunConfig {
+  const sources: Partial<Record<keyof RunConfigValues, string>> = {}
+  const pick = <K extends keyof RunConfigValues>(key: K): NonNullable<RunConfigValues[K]> | undefined => {
+    const hit = resolveConfigKey(layers, key)
+    if (!hit) return undefined
+    sources[key] = hit.from
+    return hit.value
+  }
+  const preset = pick('preset')
+  const event = pick('event')
+  return {
+    ...(preset ? { presetName: preset } : {}),
+    ...(event ? { buildEvent: event } : {}),
+    autopilot: pick('autopilot') ?? RUN_CONFIG_DEFAULTS.autopilot,
+    technical: pick('technical') ?? RUN_CONFIG_DEFAULTS.technical,
+    antiLazyPill: pick('antiLazyPill') ?? RUN_CONFIG_DEFAULTS.antiLazyPill,
+    transparent: pick('transparent') ?? RUN_CONFIG_DEFAULTS.transparent,
+    sources,
+  }
+}
+
+/** The repo tier: `the-framework.yml` as a layer. */
+export function fileConfigLayer(file: FrameworkFileConfig, name = 'the-framework.yml'): ConfigLayer {
+  return {
+    name,
+    values: {
+      ...(file.preset !== undefined ? { preset: file.preset } : {}),
+      ...(file.event !== undefined ? { event: file.event } : {}),
+      ...(file.autopilot !== undefined ? { autopilot: file.autopilot } : {}),
+      ...(file.technical !== undefined ? { technical: file.technical } : {}),
+      ...(file.antiLazyPill !== undefined ? { antiLazyPill: file.antiLazyPill } : {}),
+      ...(file.transparent !== undefined ? { transparent: file.transparent } : {}),
+    },
+  }
+}
+
+/** The active Open Loop modes of a resolved config, in a stable order. */
+export function resolvedModes(config: Pick<ResolvedRunConfig, 'autopilot' | 'technical'>): string[] {
+  const modes: string[] = []
+  if (config.autopilot) modes.push('autopilot')
+  if (config.technical) modes.push('technical')
+  return modes
+}
+
+/**
+ * A one-line summary of what a layer set and which one won, e.g.
+ * `preset=software-development (the-framework.yml), autopilot=off (flag)`. Keys nobody set are
+ * left out, so a run with no config anywhere narrates nothing.
+ */
+export function describeResolvedConfig(config: ResolvedRunConfig): string {
+  const shown: [keyof RunConfigValues, string][] = [
+    ['preset', config.presetName ?? ''],
+    ['autopilot', onOff(config.autopilot)],
+    ['technical', onOff(config.technical)],
+    ['antiLazyPill', onOff(config.antiLazyPill)],
+    ['transparent', onOff(config.transparent)],
+    ['event', config.buildEvent ?? ''],
+  ]
+  return shown
+    .filter(([key]) => config.sources[key])
+    .map(([key, value]) => `${key}=${value} (${config.sources[key]})`)
+    .join(', ')
+}
+
+function onOff(value: boolean): string {
+  return value ? 'on' : 'off'
+}

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -219,6 +219,17 @@ export {
   type FrameworkFileConfig,
 } from './config.js'
 export {
+  resolveConfigKey,
+  resolveRunConfig,
+  resolvedModes,
+  fileConfigLayer,
+  describeResolvedConfig,
+  RUN_CONFIG_DEFAULTS,
+  type ConfigLayer,
+  type RunConfigValues,
+  type ResolvedRunConfig,
+} from './config-layers.js'
+export {
   systemPromptBlock,
   composeRunSystem,
   renderSystemPrompt,


### PR DESCRIPTION
Closes #841.

## The bug

Config layers combined with `||`, not precedence:

```ts
autopilot: opts.autopilot || file.autopilot === true,
```

Same for `transparent` and `antiLazyPill`. A flag could only ever turn a mode *on*, and the yml could only ever turn one *on*, so no layer could say `false`. A repo that committed `autopilot: true` gave every run in it autopilot with no way back, and #800 ("a project overrides only what it sets") cannot be built on OR.

## The change

One resolve helper (`src/config-layers.ts`) the layers feed into: the nearest layer that *set* a key wins, and a layer that left it unset does not participate. Today the chain is run flags > `the-framework.yml`; #800 slots the project-user and global tiers in between and at the end without touching this.

- The mode toggles in `CliOptions` are tri-state, so "unset" and "explicitly off" are distinguishable.
- `--no-autopilot`, `--no-technical`, `--no-vanilla`, `--no-transparent` give a run that nearer `false`.
- The startup line narrates which layer won each key: `◆ config: preset=software-development (the-framework.yml), autopilot=off (flag)`, replacing the old yml-only `◆ the-framework.yml: ...`.
- `mergeRunConfig` now returns the resolved config; `antiLazyPillOff` and `describeConfigSource` are gone, replaced by keys on it.

Absent stays absent, so an existing setup resolves identically. The one behaviour change is the point of the ticket: an explicit `false` in a nearer layer now wins.

## Verification

- `pnpm -r test` green; framework package 874 pass / 0 fail.
- `pnpm -r typecheck` and a root `pnpm build` clean.
- Mutation-checked every new assertion: 10 mutations (reverse layer order, unset layers participate, defaults flipped, flag layer dropping an explicit false, `--no-technical` set to true, `--vanilla` mapped without negation, the file layer dropping `event`, mode order flipped, sources never recorded, narration dropping the layer name). All 10 were caught by the new tests; sources restored after each.

Scoped to the config resolution region plus the new helper module, staying clear of the run lifecycle work in #835.