### PR TITLE
fix(framework): escape the project log's free-text fields (#897)

### DIFF
--- a/.changeset/fix-897-logs-title-encoding.md
+++ b/.changeset/fix-897-logs-title-encoding.md
@@ -1,0 +1,14 @@
+---
+'@gemstack/framework': patch
+---
+
+The project log survives a multi-line prompt (#897)
+
+`.the-framework/LOGS.md` is committed history, but a run's entry wrote the prompt straight
+into the entry's heading. A prompt spanning several lines spilled the rest of itself into the
+file as loose text, where reading the log dropped it; a prompt containing a line that looked
+like a heading forged a second entry, and one that looked like a status line rewrote the real
+one.
+
+A title and a prompt bullet are now escaped to a single line on write and unescaped on read,
+so a prompt round-trips whole whatever it contains. Logs written before this still read fine.

--- a/packages/framework/src/logs.test.ts
+++ b/packages/framework/src/logs.test.ts
@@ -138,6 +138,37 @@ test('a title containing the separator round-trips intact', () => {
   assert.deepEqual(parseLogs(renderLogEntry(entry)), [entry])
 })
 
+test('a multi-line title stays on one line and round-trips (#897)', () => {
+  const entry: LogEntry = { ...MINIMAL, title: 'Add a blog\n\n- with comments\n- and tags' }
+  const md = renderLogEntry(entry)
+  assert.equal(md.split('\n')[0], '## 2026-07-10T12:00:00.000Z · build · Add a blog\\n\\n- with comments\\n- and tags')
+  assert.deepEqual(parseLogs(md), [entry])
+})
+
+test('a title cannot forge an entry or rewrite the status (#897)', () => {
+  const title = 'Ship it\n## 2026-01-01T00:00:00.000Z · build · Forged\n\n- status: done'
+  const parsed = parseLogs(renderLogEntry({ ...MINIMAL, title }))
+  assert.deepEqual(parsed, [{ ...MINIMAL, title }])
+  assert.equal(parsed[0]!.status, 'failed')
+})
+
+test('a backslash in a title survives the escaping (#897)', () => {
+  const entry: LogEntry = { ...MINIMAL, title: 'Escape \\n and \\\\ literally' }
+  assert.deepEqual(parseLogs(renderLogEntry(entry)), [entry])
+})
+
+test('a multi-line prompt bullet stays on one line and round-trips (#897)', () => {
+  const entry: LogEntry = { ...LOOP, prompts: ['Fix the header\n- and the footer'] }
+  const lines = renderLogEntry(entry).split('\n')
+  assert.equal(lines.at(-1), '  - Fix the header\\n- and the footer')
+  assert.deepEqual(parseLogs(renderLogEntry(entry)), [entry])
+})
+
+test('an entry written before #897 still parses', () => {
+  const md = ['## 2026-07-10T12:00:00.000Z · build · A blog', '', '- status: failed'].join('\n')
+  assert.deepEqual(parseLogs(md), [MINIMAL])
+})
+
 test('parseLogs on empty input is []', () => {
   assert.deepEqual(parseLogs(''), [])
 })

--- a/packages/framework/src/logs.ts
+++ b/packages/framework/src/logs.ts
@@ -30,7 +30,7 @@ export interface LogEntry {
   /** ISO timestamp. */
   at: string
   kind: 'loop' | 'prompt' | 'build'
-  /** Single-line intent/prompt summary. */
+  /** The run's intent/prompt. Escaped to one line on write (#897), so it may hold a whole prompt. */
   title: string
   status: 'done' | 'stopped' | 'failed' | 'running'
   /** Claude Code session id. */
@@ -46,6 +46,22 @@ const STATUSES: readonly string[] = ['done', 'stopped', 'failed', 'running']
 
 /** Heading field separator: a middle dot (U+00B7) with a space on each side. */
 const SEP = ' · '
+
+/**
+ * Escape a free-text field so it stays on its own line (#897). A title is the run's prompt and a
+ * prompt bullet is agent text, but the file is committed history parsed line by line: an unescaped
+ * newline spills the rest of the prompt into the file, where a `## ` line forges an entry and a
+ * `- status: ` line rewrites one. Reversed by {@link decodeField}.
+ */
+export function encodeField(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/\r\n|\r|\n/g, '\\n')
+}
+
+/** Reverse {@link encodeField}. Entries written before #897 are unescaped, so a literal `\n` in
+ * one of them decodes to a newline; harmless next to reading the rest of the prompt as entries. */
+export function decodeField(value: string): string {
+  return value.replace(/\\(\\|n)/g, (_, char) => (char === 'n' ? '\n' : '\\'))
+}
 
 /** The one-time first line of the file, written on the first append. */
 export const LOGS_HEADER = '# The Framework logs\n'
@@ -63,7 +79,7 @@ export function gitignorePath(cwd: string): string {
 /** Markdown for one entry, starting at `## ` (no file header, no blank lines around it). */
 export function renderLogEntry(entry: LogEntry): string {
   const lines = [
-    `## ${entry.at}${SEP}${entry.kind}${SEP}${entry.title}`,
+    `## ${entry.at}${SEP}${entry.kind}${SEP}${encodeField(entry.title)}`,
     '',
     `- status: ${entry.status}`,
   ]
@@ -76,7 +92,7 @@ export function renderLogEntry(entry: LogEntry): string {
   }
   if (entry.prompts && entry.prompts.length > 0) {
     lines.push('- prompts:')
-    for (const prompt of entry.prompts) lines.push(`  - ${prompt}`)
+    for (const prompt of entry.prompts) lines.push(`  - ${encodeField(prompt)}`)
   }
   return lines.join('\n')
 }
@@ -113,7 +129,7 @@ function parseEntry(lines: string[]): LogEntry | undefined {
   const at = parts[0]
   const kind = parts[1]
   // Re-join the rest so a title containing the separator survives.
-  const title = parts.slice(2).join(SEP)
+  const title = decodeField(parts.slice(2).join(SEP))
   if (!at || !kind || !title || !KINDS.includes(kind)) return undefined
 
   let status: string | undefined
@@ -123,7 +139,7 @@ function parseEntry(lines: string[]): LogEntry | undefined {
   let inPrompts = false
   for (const line of lines.slice(1)) {
     if (inPrompts && line.startsWith('  - ')) {
-      prompts!.push(line.slice('  - '.length))
+      prompts!.push(decodeField(line.slice('  - '.length)))
       continue
     }
     inPrompts = false


### PR DESCRIPTION
Closes #897.

`.the-framework/LOGS.md` is the committed project DB, but an entry's title is the run's prompt written straight into the `## ` heading. So a multi-line prompt spilled its remaining lines into the file (visible in this repo's own LOGS.md), a line starting with `## ` forged an entry, and one starting with `- status: ` rewrote the real status.

The title and each prompt bullet are now escaped to one line on write and unescaped on read. Logs written before this parse unchanged.

Groundwork for #857: the same file is where the session list and the #680 conversations are headed, so the format has to hold arbitrary text first.
