### PR TITLE
feat(framework): show the resolved run options in the launcher (#842)

### DIFF
--- a/.changeset/launcher-resolved-options.md
+++ b/.changeset/launcher-resolved-options.md
@@ -1,0 +1,19 @@
+---
+'@gemstack/framework': minor
+---
+
+The launcher shows what a session will actually run with (#842)
+
+`the-framework.yml` was read exactly once, inside the freshly spawned CLI child. The daemon never
+read it and the dashboard never saw it, so the gear could only ever show your own preferences
+while the repo's committed options quietly took effect later.
+
+The project payload now carries the repo file, read fresh on each request. The dashboard resolves
+the same layers the CLI does, nearest first: your project options, the repo's `the-framework.yml`,
+then your global preferences. The launcher lists what is in play inline, without opening the gear,
+and marks the values that come from the repo rather than from you.
+
+Because the launcher now resolves the repo file itself, a start sends the four toggles it owns
+(autopilot, technical, vanilla, transparent) explicitly, including `false`, which the CLI takes as
+the nearest layer. Turning one off in the gear no longer gets undone by the repo file. Runs the
+daemon starts on its own resolve through the same layers.

--- a/packages/framework-dashboard/components/Composer.test.tsx
+++ b/packages/framework-dashboard/components/Composer.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import type { Preferences } from '@gemstack/framework'
 
 // Preferences are the shared daemon store; stub them so the composer reads a fixed value.
@@ -10,6 +10,9 @@ vi.mock('../lib/preferences.js', () => ({
   updatePreferences,
   autopilotEnabled: (p: Preferences) => p.autopilot ?? true,
   themePreference: (p: Preferences) => p.theme ?? 'system',
+  // #842: the launcher strip reads the resolved layers; nothing here sets a repo tier.
+  usePreferenceSources: () => ({}),
+  useProjectFileConfig: () => ({}),
 }))
 // The editor picker (#727) detects installed editors over Telefunc; stub it to none in the test.
 vi.mock('../lib/editors.js', () => ({ useDetectedEditors: () => [] }))
@@ -96,8 +99,10 @@ describe('Composer (#721)', () => {
     renderComposer()
     fireEvent.click(screen.getByRole('button', { name: 'Session options' }))
     // Autopilot no longer claims to relax the maintenance stance: #556 took that section out of the
-    // prompt, leaving the countdown as the whole feature.
-    const autopilot = screen.getByText('Autopilot').closest('[title]')
+    // prompt, leaving the countdown as the whole feature. Scoped to the menu: the same label is on
+    // the resolved-options strip (#842), which carries its own "where it came from" title.
+    const menu = screen.getByRole('menu')
+    const autopilot = within(menu).getByText('Autopilot').closest('[title]')
     expect(autopilot?.getAttribute('title')).not.toMatch(/maintenance/i)
     expect(autopilot?.getAttribute('title')).toMatch(/countdown/i)
   })

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -16,7 +16,14 @@ import {
   renderTriageQuickPrompt,
   renderTriageConsensualPrompt,
 } from '@gemstack/framework/client'
-import { usePreferences, updatePreferences, autopilotEnabled, themePreference } from '../lib/preferences.js'
+import {
+  usePreferences,
+  updatePreferences,
+  autopilotEnabled,
+  themePreference,
+  usePreferenceSources,
+  useProjectFileConfig,
+} from '../lib/preferences.js'
 import { useDetectedEditors } from '../lib/editors.js'
 import { useLoaded } from '../lib/use-async.js'
 import { onProjects } from '../server/projects.telefunc.js'
@@ -24,6 +31,7 @@ import { PromptEditor, type PromptEditorHandle } from './PromptEditor.js'
 import { PresetCreatePanel } from './PresetCreatePanel.js'
 import { AgentModelMenu, type AgentOption } from './AgentModelMenu.js'
 import { OptionsMenu, type OptionRow } from './OptionsMenu.js'
+import { ResolvedOptions } from './ResolvedOptions.js'
 import { ClaudeLogo, CodexLogo } from './agent-logos.js'
 import { Button } from './ui/button.js'
 
@@ -146,6 +154,8 @@ export const Composer = forwardRef<ComposerHandle, {
   const projects = useLoaded<ProjectSummary[]>(onProjects, [], [])
 
   const preferences = usePreferences()
+  const sources = usePreferenceSources() // #842: which layer won each option
+  const fileConfig = useProjectFileConfig() // #842: the repo's committed the-framework.yml
   const autopilot = autopilotEnabled(preferences)
   const technical = preferences.technical ?? false
   const vanilla = preferences.vanilla ?? false
@@ -337,6 +347,10 @@ export const Composer = forwardRef<ComposerHandle, {
           )}
         </Button>
       </div>
+
+      {/* What the session resolves to, without opening the gear (#842). Off in the compact row
+          above, which is one line on purpose. */}
+      <ResolvedOptions options={mainOptions} sources={sources} fileConfig={fileConfig} />
 
       {addingPreset && (
         <PresetCreatePanel

--- a/packages/framework-dashboard/components/ResolvedOptions.test.tsx
+++ b/packages/framework-dashboard/components/ResolvedOptions.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ResolvedOptions } from './ResolvedOptions.js'
+import type { OptionRow } from './OptionsMenu.js'
+
+const rows = (over: Partial<Record<string, boolean>> = {}): OptionRow[] => [
+  { key: 'autopilot', label: 'Autopilot', title: 'a', description: 'a', checked: over.autopilot ?? false },
+  { key: 'technical', label: 'Technical control', title: 't', description: 't', checked: over.technical ?? false },
+  {
+    key: 'browser',
+    label: 'Browser',
+    title: 'b',
+    description: 'b',
+    checked: over.browser ?? false,
+    disabled: over.browserDisabled ?? false,
+  },
+]
+
+describe('ResolvedOptions (#842)', () => {
+  test('renders nothing when no option is on and the repo sets nothing', () => {
+    const { container } = render(<ResolvedOptions options={rows()} sources={{}} fileConfig={{}} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  test('lists the options in play without opening the gear', () => {
+    render(<ResolvedOptions options={rows({ autopilot: true, technical: true })} sources={{}} fileConfig={{}} />)
+    expect(screen.getByText('Autopilot')).toBeTruthy()
+    expect(screen.getByText('Technical control')).toBeTruthy()
+    expect(screen.queryByText('Browser')).toBeNull()
+  })
+
+  test('a disabled option is not in play, however it is stored', () => {
+    render(
+      <ResolvedOptions options={rows({ browser: true, browserDisabled: true })} sources={{}} fileConfig={{}} />,
+    )
+    expect(screen.queryByText('Browser')).toBeNull()
+  })
+
+  test('a value inherited from the repo yml is marked as not yours', () => {
+    render(
+      <ResolvedOptions
+        options={rows({ autopilot: true, technical: true })}
+        sources={{ technical: 'repo', autopilot: 'global' }}
+        fileConfig={{}}
+      />,
+    )
+    const repo = screen.getByText('Technical control').closest('span')
+    const yours = screen.getByText('Autopilot').closest('span')
+    expect(repo?.textContent).toContain('repo')
+    expect(repo?.getAttribute('title')).toContain('the-framework.yml')
+    expect(yours?.textContent).not.toContain('repo')
+    expect(yours?.getAttribute('title')).toContain('Your setting')
+  })
+
+  test('shows the yml keys the gear cannot set, always as the repo tier', () => {
+    render(
+      <ResolvedOptions options={rows()} sources={{}} fileConfig={{ preset: 'software-development', event: 'bug-fix' }} />,
+    )
+    expect(screen.getByText(/preset: software-development/).textContent).toContain('repo')
+    expect(screen.getByText(/kind: bug-fix/).textContent).toContain('repo')
+  })
+})

--- a/packages/framework-dashboard/components/ResolvedOptions.tsx
+++ b/packages/framework-dashboard/components/ResolvedOptions.tsx
@@ -1,0 +1,54 @@
+import type { FrameworkFileConfig, Preferences } from '@gemstack/framework'
+import type { PreferenceSources } from '../lib/preferences.js'
+import type { OptionRow } from './OptionsMenu.js'
+
+/**
+ * What this session will actually run with, inline under the launcher (#842).
+ *
+ * The options used to be invisible until you opened the gear, and the gear only ever showed your
+ * own preferences. A repo's committed `the-framework.yml` is a layer too, so a value can be in
+ * play that you never chose and the gear cannot change. Those are marked as the repo's, since
+ * "not yours" is the part worth seeing.
+ */
+export function ResolvedOptions({
+  options,
+  sources,
+  fileConfig,
+}: {
+  /** The same rows the gear renders, so the strip and the menu can never disagree. */
+  options: OptionRow[]
+  sources: PreferenceSources
+  /** The repo file, for the keys with no preference counterpart: `preset` and `event`. */
+  fileConfig: FrameworkFileConfig
+}) {
+  const on = options.filter(o => o.checked && !o.disabled)
+  const chips = [
+    ...(fileConfig.preset ? [{ key: 'preset', label: `preset: ${fileConfig.preset}`, repo: true }] : []),
+    ...(fileConfig.event ? [{ key: 'event', label: `kind: ${fileConfig.event}`, repo: true }] : []),
+    ...on.map(o => ({ key: o.key, label: o.label, repo: sources[o.key as keyof Preferences] === 'repo' })),
+  ]
+  if (!chips.length) return null
+  return (
+    <div className="mt-1.5 flex flex-wrap items-center gap-1 text-[11px] text-muted-foreground">
+      <span className="mr-0.5">In play:</span>
+      {chips.map(chip => (
+        <span
+          key={chip.key}
+          title={
+            chip.repo
+              ? 'From this repo’s the-framework.yml, committed for everyone who clones it'
+              : 'Your setting, from the options gear'
+          }
+          className={
+            chip.repo
+              ? 'rounded border border-dashed border-border px-1.5 py-0.5'
+              : 'rounded border border-transparent bg-muted px-1.5 py-0.5'
+          }
+        >
+          {chip.label}
+          {chip.repo && <span className="ml-1 opacity-70">repo</span>}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/packages/framework-dashboard/components/RunResumeChat.test.tsx
+++ b/packages/framework-dashboard/components/RunResumeChat.test.tsx
@@ -9,6 +9,9 @@ vi.mock('../lib/preferences.js', () => ({
   updatePreferences: vi.fn(),
   autopilotEnabled: (p: Preferences) => p.autopilot ?? true,
   themePreference: (p: Preferences) => p.theme ?? 'system',
+  // #842: the launcher strip reads the resolved layers; nothing here sets a repo tier.
+  usePreferenceSources: () => ({}),
+  useProjectFileConfig: () => ({}),
 }))
 const sendStart = vi.hoisted(() => vi.fn())
 vi.mock('../server/control.telefunc.js', () => ({ sendStart }))

--- a/packages/framework-dashboard/lib/preferences.test.ts
+++ b/packages/framework-dashboard/lib/preferences.test.ts
@@ -11,6 +11,9 @@ vi.mock('../server/preferences.telefunc.js', () => ({
   onProjectPreferences,
   saveProjectPreferences,
 }))
+// The repo tier (#842) rides on the project payload, so the store reads the projects RPC too.
+const onProjects = vi.hoisted(() => vi.fn())
+vi.mock('../server/projects.telefunc.js', () => ({ onProjects }))
 
 const flush = () => act(async () => {
   await Promise.resolve()
@@ -29,6 +32,7 @@ describe('preferences', () => {
     savePreferences.mockReset().mockResolvedValue({ ok: true })
     onProjectPreferences.mockReset().mockResolvedValue({})
     saveProjectPreferences.mockReset().mockResolvedValue({ ok: true })
+    onProjects.mockReset().mockResolvedValue([])
     openProject(null)
   })
 
@@ -145,6 +149,115 @@ describe('preferences', () => {
     await flush()
     // Project B never chose a model, so it gets the global one rather than A's.
     expect(result.current.model).toBe('sonnet')
+  })
+
+  test("the repo's the-framework.yml resolves over the global tier (#842)", async () => {
+    onPreferences.mockResolvedValue({ autopilot: true, technical: false })
+    onProjects.mockResolvedValue([{ id: 'app-a-1', path: '/repos/a', name: 'a', activated: true, fileConfig: { technical: true, antiLazyPill: false } }])
+    openProject('app-a-1')
+    const { usePreferences } = await import('./preferences.js')
+
+    const { result } = renderHook(() => usePreferences())
+    await flush()
+    expect(result.current.technical).toBe(true) // the repo turned it on over the global off
+    expect(result.current.vanilla).toBe(true) // antiLazyPill: false is the file's Vanilla
+    expect(result.current.autopilot).toBe(true) // the repo said nothing, so global stands
+  })
+
+  test("a project's own option beats the repo file (#842)", async () => {
+    onPreferences.mockResolvedValue({})
+    onProjects.mockResolvedValue([{ id: 'app-a-1', path: '/repos/a', name: 'a', activated: true, fileConfig: { technical: true } }])
+    onProjectPreferences.mockResolvedValue({ technical: false })
+    openProject('app-a-1')
+    const { usePreferences } = await import('./preferences.js')
+
+    const { result } = renderHook(() => usePreferences())
+    await flush()
+    expect(result.current.technical).toBe(false)
+  })
+
+  test('a repo that sets nothing changes nothing (#842)', async () => {
+    onPreferences.mockResolvedValue({ technical: true })
+    onProjects.mockResolvedValue([{ id: 'app-a-1', path: '/repos/a', name: 'a', activated: true }])
+    openProject('app-a-1')
+    const { usePreferences } = await import('./preferences.js')
+
+    const { result } = renderHook(() => usePreferences())
+    await flush()
+    expect(result.current).toEqual({ technical: true })
+  })
+
+  test('usePreferenceSources names the layer that won each key (#842)', async () => {
+    onPreferences.mockResolvedValue({ autopilot: true, model: 'sonnet' })
+    onProjects.mockResolvedValue([{ id: 'app-a-1', path: '/repos/a', name: 'a', activated: true, fileConfig: { technical: true, autopilot: false } }])
+    onProjectPreferences.mockResolvedValue({ model: 'opus' })
+    openProject('app-a-1')
+    const { usePreferenceSources } = await import('./preferences.js')
+
+    const { result } = renderHook(() => usePreferenceSources())
+    await flush()
+    expect(result.current.technical).toBe('repo')
+    expect(result.current.autopilot).toBe('repo') // the repo's false beats the global true
+    expect(result.current.model).toBe('project')
+    expect(result.current.vanilla).toBe(undefined) // nobody set it
+  })
+
+  test('useProjectFileConfig exposes the keys the gear cannot set (#842)', async () => {
+    onPreferences.mockResolvedValue({})
+    onProjects.mockResolvedValue([{ id: 'app-a-1', path: '/repos/a', name: 'a', activated: true, fileConfig: { preset: 'software-development', event: 'bug-fix' } }])
+    openProject('app-a-1')
+    const { useProjectFileConfig } = await import('./preferences.js')
+
+    const { result } = renderHook(() => useProjectFileConfig())
+    await flush()
+    expect(result.current).toEqual({ preset: 'software-development', event: 'bug-fix' })
+  })
+
+  test('refreshFileConfigs re-reads the repo tier after an edit on disk (#842)', async () => {
+    onPreferences.mockResolvedValue({})
+    onProjects.mockResolvedValue([{ id: 'app-a-1', path: '/repos/a', name: 'a', activated: true, fileConfig: { technical: true } }])
+    openProject('app-a-1')
+    const { usePreferences, refreshFileConfigs } = await import('./preferences.js')
+
+    const { result } = renderHook(() => usePreferences())
+    await flush()
+    expect(result.current.technical).toBe(true)
+
+    // Someone edits the yml; the launcher must not keep showing the old answer.
+    onProjects.mockResolvedValue([{ id: 'app-a-1', path: '/repos/a', name: 'a', activated: true, fileConfig: { technical: false } }])
+    refreshFileConfigs()
+    await flush()
+    expect(result.current.technical).toBe(false)
+
+    // And a yml deleted outright stops contributing at all, rather than lingering in the cache.
+    onProjects.mockResolvedValue([{ id: 'app-a-1', path: '/repos/a', name: 'a', activated: true }])
+    refreshFileConfigs()
+    await flush()
+    expect('technical' in result.current).toBe(false)
+  })
+
+  test('a failed project read leaves the other tiers intact (#842)', async () => {
+    const unhandled = vi.fn()
+    process.on('unhandledRejection', unhandled)
+    onPreferences.mockResolvedValue({ autopilot: false })
+    onProjects.mockRejectedValue(new Error('offline'))
+    openProject('app-a-1')
+    const { usePreferences, refreshFileConfigs } = await import('./preferences.js')
+
+    const { result } = renderHook(() => usePreferences())
+    await flush()
+    expect(result.current.autopilot).toBe(false)
+
+    // The read is best-effort like every other tier: it must be swallowed, not left to surface as
+    // an unhandled rejection, and the next refresh must still be able to run.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(unhandled).not.toHaveBeenCalled()
+    process.off('unhandledRejection', unhandled)
+
+    onProjects.mockResolvedValue([{ id: 'app-a-1', path: '/repos/a', name: 'a', activated: true, fileConfig: { technical: true } }])
+    refreshFileConfigs()
+    await flush()
+    expect(result.current.technical).toBe(true)
   })
 
   test('themePreference falls back to system and resolvedDark honours the choice (#725)', async () => {

--- a/packages/framework-dashboard/lib/preferences.ts
+++ b/packages/framework-dashboard/lib/preferences.ts
@@ -1,11 +1,13 @@
 import { useEffect, useSyncExternalStore } from 'react'
-import type { Preferences, ProjectPreferences } from '@gemstack/framework'
+import type { FrameworkFileConfig, Preferences, ProjectPreferences, ProjectSummary } from '@gemstack/framework'
+import { preferencesFromFileConfig } from '@gemstack/framework/client'
 import {
   onPreferences,
   savePreferences,
   onProjectPreferences,
   saveProjectPreferences,
 } from '../server/preferences.telefunc.js'
+import { onProjects } from '../server/projects.telefunc.js'
 import { parseRoute } from './route.js'
 
 // The dashboard's Global options (#410), owned by the daemon and persisted in the same
@@ -38,17 +40,24 @@ const PROJECT_KEYS = new Set<string>([
 ])
 
 const EMPTY: Preferences = {}
+const EMPTY_FILE: FrameworkFileConfig = {}
 let cache: Preferences | null = null
 let loading: Promise<void> | null = null
 const projects = new Map<string, ProjectPreferences>()
 const projectLoads = new Set<string>()
+/** Each project's committed `the-framework.yml`, as served on the project payload (#842). */
+const files = new Map<string, FrameworkFileConfig>()
+let filesLoading: Promise<void> | null = null
+let filesLoaded = false
 /** Resolved snapshots, one per project, cleared on every notify. `useSyncExternalStore` compares
  * snapshots by identity, so resolving fresh on each read would re-render forever. */
 let resolved = new Map<string, Preferences>()
+let sources = new Map<string, PreferenceSources>()
 const listeners = new Set<() => void>()
 
 function notify(): void {
   resolved = new Map()
+  sources = new Map()
   for (const listener of listeners) listener()
 }
 
@@ -57,13 +66,48 @@ function subscribe(listener: () => void): () => void {
   return () => listeners.delete(listener)
 }
 
+/** Which layer a resolved preference came from (#842). Absent = nobody set it. */
+export type PreferenceSource = 'project' | 'repo' | 'global'
+
+/** The winning layer per key, for showing what is inherited rather than yours. */
+export type PreferenceSources = Partial<Record<keyof Preferences, PreferenceSource>>
+
+/** The repo tier as preference keys: `the-framework.yml`, committed, shared by everyone who clones. */
+function fileTier(projectId: string | null): Preferences {
+  const file = projectId ? files.get(projectId) : undefined
+  return file ? preferencesFromFileConfig(file) : EMPTY
+}
+
 function snapshot(projectId: string | null): Preferences {
   const key = projectId ?? ''
   const hit = resolved.get(key)
   if (hit) return hit
   const project = projectId ? projects.get(projectId) : undefined
-  const value = project ? { ...(cache ?? EMPTY), ...project } : (cache ?? EMPTY)
+  const repo = fileTier(projectId)
+  // Nearest wins (#800/#841): your project options, then the repo's committed file, then global.
+  const value =
+    project || repo !== EMPTY ? { ...(cache ?? EMPTY), ...repo, ...project } : (cache ?? EMPTY)
   resolved.set(key, value)
+  return value
+}
+
+function sourceSnapshot(projectId: string | null): PreferenceSources {
+  const key = projectId ?? ''
+  const hit = sources.get(key)
+  if (hit) return hit
+  const value: PreferenceSources = {}
+  const tiers: [PreferenceSource, Preferences][] = [
+    ['global', cache ?? EMPTY],
+    ['repo', fileTier(projectId)],
+    ['project', (projectId ? projects.get(projectId) : undefined) ?? EMPTY],
+  ]
+  // Later tiers are nearer, so each one that set a key overwrites the recorded source.
+  for (const [name, values] of tiers) {
+    for (const [k, v] of Object.entries(values)) {
+      if (v !== undefined) value[k as keyof Preferences] = name
+    }
+  }
+  sources.set(key, value)
   return value
 }
 
@@ -83,6 +127,7 @@ function ensureLoaded(projectId: string | null): void {
         notify()
       })
   }
+  if (!filesLoaded) loadFileConfigs()
   if (!projectId || projects.has(projectId) || projectLoads.has(projectId)) return
   projectLoads.add(projectId)
   void onProjectPreferences(projectId)
@@ -98,6 +143,36 @@ function ensureLoaded(projectId: string | null): void {
       notify()
     })
 }
+
+/**
+ * Load every project's `the-framework.yml` off the project payload (#842). One call covers all
+ * projects, since that is what the RPC returns; the daemon re-reads the file on each request, so
+ * refetching is how the launcher stops showing a stale answer after someone edits the yml.
+ */
+function loadFileConfigs(): void {
+  if (filesLoading) return
+  filesLoading = onProjects()
+    .then((list: ProjectSummary[]) => {
+      files.clear()
+      for (const project of list) if (project.fileConfig) files.set(project.id, project.fileConfig)
+    })
+    .catch(() => {})
+    .finally(() => {
+      filesLoading = null
+      filesLoaded = true
+      notify()
+    })
+}
+
+/**
+ * Re-read the repo tier. Wired to the window regaining focus, which is when an edit made in an
+ * editor becomes visible to someone looking at the launcher again.
+ */
+export function refreshFileConfigs(): void {
+  loadFileConfigs()
+}
+
+if (typeof window !== 'undefined') window.addEventListener('focus', refreshFileConfigs)
 
 /**
  * The project a write belongs to, read straight off the URL (#784 makes it the selection).
@@ -137,8 +212,9 @@ export function updatePreferences(patch: Partial<Preferences>): void {
 }
 
 /**
- * The user preferences in force: the global object, with the open project's own run options
- * on top (#840). Loaded once from the daemon per tier and kept in sync across components.
+ * The user preferences in force: the global object, the open project's committed
+ * `the-framework.yml` (#842), then its own run options on top (#840). Loaded once from the daemon
+ * per tier and kept in sync across components.
  */
 export function usePreferences(): Preferences {
   const projectId = typeof window === 'undefined' ? null : parseRoute(window.location.pathname).projectId
@@ -150,6 +226,38 @@ export function usePreferences(): Preferences {
   useEffect(() => ensureLoaded(projectId), [projectId])
   return preferences
 }
+
+/**
+ * Where each resolved preference came from (#842), so the launcher can show a repo-inherited
+ * value as not-yours rather than implying you chose it.
+ */
+export function usePreferenceSources(): PreferenceSources {
+  const projectId = typeof window === 'undefined' ? null : parseRoute(window.location.pathname).projectId
+  const value = useSyncExternalStore(
+    subscribe,
+    () => sourceSnapshot(projectId),
+    () => EMPTY_SOURCES,
+  )
+  useEffect(() => ensureLoaded(projectId), [projectId])
+  return value
+}
+
+/**
+ * The open project's raw `the-framework.yml` (#842). The launcher shows `preset` and `event` from
+ * it directly: they steer the run but have no preference counterpart, so the gear cannot set them.
+ */
+export function useProjectFileConfig(): FrameworkFileConfig {
+  const projectId = typeof window === 'undefined' ? null : parseRoute(window.location.pathname).projectId
+  const value = useSyncExternalStore(
+    subscribe,
+    () => (projectId ? (files.get(projectId) ?? EMPTY_FILE) : EMPTY_FILE),
+    () => EMPTY_FILE,
+  )
+  useEffect(() => ensureLoaded(projectId), [projectId])
+  return value
+}
+
+const EMPTY_SOURCES: PreferenceSources = {}
 
 // Autopilot's default-on moved into @gemstack/framework with the rest of the preferences ->
 // run options mapping (#858), so the daemon resolves it the same way. Re-exported here because

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -238,6 +238,13 @@ When any layer contributes something, the run narrates what won and where it cam
 from (`◆ config: preset=software-development (the-framework.yml), autopilot=off (flag)`).
 A malformed file is a warning, never a failed run.
 
+The dashboard reads the file too (#842): it rides on the project payload, so the
+launcher lists what a session will actually run with and marks the values that come
+from the repo rather than from your own options gear. The layers there are the same
+order, nearest first: this run's options, your project options, the repo's
+`the-framework.yml`, then your global preferences. The daemon re-reads the file on
+every request, so an edit shows up when the dashboard next asks.
+
 ### System prompt: the built-in working agreement + `SYSTEM.md`
 
 Every prompt is framed with the built-in system prompt (#326, the successor of the

--- a/packages/framework/src/client.ts
+++ b/packages/framework/src/client.ts
@@ -47,5 +47,5 @@ export { renderMaintenancePrompt } from './maintenance-preset.js'
 export { renderTriageQuickPrompt, renderTriageConsensualPrompt } from './triage-presets.js'
 // The preferences -> run options mapping (#858), shared with the daemon so an unattended run
 // starts with the same settings a launcher-started one would. Pure field logic, no Node imports.
-export { runOptionsFromPreferences, autopilotEnabled } from './run-options.js'
+export { runOptionsFromPreferences, autopilotEnabled, preferencesFromFileConfig } from './run-options.js'
 export { renderMarketResearchPrompt } from './market-research-preset.js'

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -65,6 +65,16 @@ test('startOptionFlags maps only enabled Global options to CLI flags (#314)', ()
   assert.deepEqual(startOptionFlags({ browser: true }), ['--browser'])
   // Transparent (#625): the master off-switch maps to --transparent.
   assert.deepEqual(startOptionFlags({ transparent: true }), ['--transparent'])
+})
+
+test('startOptionFlags spells an explicit off as the --no-* form (#842)', () => {
+  // The launcher resolves the repo yml itself now, so a toggle it shows as off has to travel as
+  // one: without --no-autopilot the file would turn it back on inside the run (#841).
+  assert.deepEqual(startOptionFlags({ autopilot: false, technical: false }), ['--no-autopilot', '--no-technical'])
+  assert.deepEqual(startOptionFlags({ vanilla: false, transparent: false }), ['--no-vanilla', '--no-transparent'])
+  // Absent still says nothing, so the repo file keeps deciding.
+  assert.deepEqual(startOptionFlags({}), [])
+  assert.deepEqual(startOptionFlags({ autopilot: true, technical: false }), ['--autopilot', '--no-technical'])
   // Model (#628): maps to --model, trimmed; blank/whitespace is no choice -> no flag.
   assert.deepEqual(startOptionFlags({ model: 'opus' }), ['--model', 'opus'])
   assert.deepEqual(startOptionFlags({ model: '  sonnet  ' }), ['--model', 'sonnet'])

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -35,7 +35,8 @@ import { startPreview, detectServeTargets, type PreviewHandle, type ServeTarget 
 import { resolveDashboardBundle } from './dashboard/bundle.js'
 import { isActivated } from './project.js'
 import { addProject, listProjects, projectId, readPreferences, readProjectPreferences, resolvePreferences } from './registry.js'
-import { runOptionsFromPreferences } from './run-options.js'
+import { runOptionsFromPreferences, preferencesFromFileConfig } from './run-options.js'
+import { loadFrameworkConfig } from './config.js'
 import { installProject, enumerateGitRepos } from './install.js'
 import { JsonlTailer } from './jsonl-tail.js'
 
@@ -134,10 +135,19 @@ export async function registerHomeProject(cwd: string, env: NodeJS.ProcessEnv = 
  */
 export function startOptionFlags(options: StartRunOptions): string[] {
   const flags: string[] = []
-  if (options.autopilot) flags.push('--autopilot')
-  if (options.technical) flags.push('--technical')
-  if (options.vanilla) flags.push('--vanilla')
-  if (options.transparent) flags.push('--transparent')
+  // The four toggles the repo's the-framework.yml also owns are tri-state (#842): an explicit
+  // `false` emits the `--no-*` form (#841) so a start from the launcher can turn off what the
+  // repo file turned on. Absent still emits nothing, leaving the file to decide.
+  for (const [key, flag] of [
+    ['autopilot', '--autopilot'],
+    ['technical', '--technical'],
+    ['vanilla', '--vanilla'],
+    ['transparent', '--transparent'],
+  ] as const) {
+    const value = options[key]
+    if (value === true) flags.push(flag)
+    else if (value === false) flags.push(`--no-${flag.slice(2)}`)
+  }
   if (options.eco?.autoPlanning) flags.push('--eco-auto-planning')
   if (options.eco?.autoResearch) flags.push('--eco-auto-research')
   if (options.eco?.autoMaintenance) flags.push('--eco-auto-maintenance')
@@ -418,15 +428,20 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
   const readPrefs = () =>
     readPreferences(undefined, env).catch(() => ({}) as Awaited<ReturnType<typeof readPreferences>>)
   /**
-   * The run options a project's settings imply (#858), global tier overlaid with its own (#840).
-   * The same mapping the launcher uses, so a run started by the daemon and a run started by hand
-   * differ only in who asked for it. An unreadable tier falls back to empty rather than failing
-   * the start: the defaults are what the run would have used anyway.
+   * The run options a project's settings imply (#858): the global tier, then the repo's committed
+   * `the-framework.yml` (#842), then the project's own overrides (#840) on top. The same mapping
+   * and the same layer order the launcher uses, so a run started by the daemon and a run started
+   * by hand differ only in who asked for it. An unreadable tier falls back to empty rather than
+   * failing the start: the defaults are what the run would have used anyway.
    */
   const resolvedRunOptions = async (id: string) => {
     const global = await readPrefs()
     const project = await readProjectPreferences(id, undefined, env).catch(() => undefined)
-    return runOptionsFromPreferences(resolvePreferences(global, project))
+    const path = (await listProjects(undefined, env).catch(() => [])).find(p => p.id === id)?.path
+    const file = path ? await loadFrameworkConfig(path).catch(() => ({})) : {}
+    return runOptionsFromPreferences(
+      resolvePreferences({ ...global, ...preferencesFromFileConfig(file) }, project),
+    )
   }
   let watcher: InterventionWatcher | undefined
   let activityWatcher: ActivityWatcher | undefined

--- a/packages/framework/src/dashboard/projects.test.ts
+++ b/packages/framework/src/dashboard/projects.test.ts
@@ -8,7 +8,13 @@ import { RUN_META_VERSION, type RunMeta } from '../store/index.js'
 const RECORD: ProjectRecord = { id: 'app-a-1', path: '/repos/app-a', addedAt: '2026-07-11T00:00:00.000Z' }
 
 function deps(over: SummarizeDeps): SummarizeDeps {
-  return { isActivated: async () => true, readLogs: async () => [], readRuns: async () => [], ...over }
+  return {
+    isActivated: async () => true,
+    readLogs: async () => [],
+    readRuns: async () => [],
+    readFileConfig: async () => ({}),
+    ...over,
+  }
 }
 
 const run = (id: string, updatedAt: string): RunMeta => ({
@@ -104,4 +110,32 @@ test('singleProjectProvider honors a custom id', async () => {
   assert.equal((await provider.list())[0]?.id, 'run-1')
   assert.equal(await provider.resolvePath('run-1'), '/repos/scratch')
   assert.equal(await provider.resolvePath('home'), undefined)
+})
+
+test('the summary carries the repo the-framework.yml so the launcher can resolve (#842)', async () => {
+  const summary = await summarizeProject(
+    RECORD,
+    deps({ readFileConfig: async () => ({ preset: 'software-development', autopilot: true }) }),
+  )
+  assert.deepEqual(summary.fileConfig, { preset: 'software-development', autopilot: true })
+})
+
+test('a repo that sets nothing carries no fileConfig key at all (#842)', async () => {
+  const summary = await summarizeProject(RECORD, deps({ readFileConfig: async () => ({}) }))
+  assert.equal('fileConfig' in summary, false)
+})
+
+test('an unreadable yml leaves the summary intact (#842)', async () => {
+  // loadFrameworkConfig already downgrades a malformed file to {}; this covers the read itself
+  // failing, which must not take the whole project summary down with it.
+  const summary = await summarizeProject(
+    RECORD,
+    deps({
+      readFileConfig: async () => {
+        throw new Error('EACCES')
+      },
+    }),
+  )
+  assert.equal(summary.name, 'app-a')
+  assert.equal(summary.fileConfig, undefined)
 })

--- a/packages/framework/src/dashboard/projects.ts
+++ b/packages/framework/src/dashboard/projects.ts
@@ -1,6 +1,7 @@
 import { basename } from 'node:path'
 import { listProjects, type ProjectRecord } from '../registry.js'
 import { isActivated } from '../project.js'
+import { loadFrameworkConfig, type FrameworkFileConfig } from '../config.js'
 import { readLogs, type LogEntry } from '../logs.js'
 import { listRuns, readLiveMetas, type LiveRun, type RunMeta } from '../store/index.js'
 
@@ -24,6 +25,13 @@ export interface ProjectSummary {
   activated: boolean
   /** ISO timestamp of the project's newest activity: the latest `LOGS.md` entry or run, whichever is newer. */
   lastActivityAt?: string
+  /**
+   * The repo's committed run defaults from `the-framework.yml` (#842), so the launcher can show
+   * what a run there will actually resolve to. Read fresh on every summarize, which is what keeps
+   * it current after an edit; absent when the repo sets nothing (or the file is malformed, which
+   * {@link loadFrameworkConfig} reports as empty rather than failing).
+   */
+  fileConfig?: FrameworkFileConfig
 }
 
 /** Injectable readers so {@link summarizeProject} is unit-testable off disk. */
@@ -32,6 +40,8 @@ export interface SummarizeDeps {
   readLogs?: (path: string) => Promise<LogEntry[]>
   /** The project's runs (live + archived), newest-first. Defaults to {@link readAllRuns}. */
   readRuns?: (path: string) => Promise<RunMeta[]>
+  /** The repo's `the-framework.yml` (#842). Defaults to {@link loadFrameworkConfig}. */
+  readFileConfig?: (path: string) => Promise<FrameworkFileConfig>
 }
 
 /** A project's runs, live prepended to the archived history. Forgiving: a failed read is `[]`. */
@@ -58,10 +68,12 @@ export async function summarizeProject(record: ProjectRecord, deps: SummarizeDep
   const checkActivated = deps.isActivated ?? isActivated
   const loadLogs = deps.readLogs ?? readLogs
   const loadRuns = deps.readRuns ?? readAllRuns
+  const loadFileConfig = deps.readFileConfig ?? (path => loadFrameworkConfig(path))
   const activated = await checkActivated(record.path).catch(() => false)
-  const [logs, runs] = await Promise.all([
+  const [logs, runs, fileConfig] = await Promise.all([
     loadLogs(record.path).catch(() => [] as LogEntry[]),
     loadRuns(record.path).catch(() => [] as RunMeta[]),
+    loadFileConfig(record.path).catch(() => ({}) as FrameworkFileConfig),
   ])
   // Newest of the latest LOGS.md entry and the latest run: a run is activity even
   // when it stopped before writing to LOGS.md. ISO timestamps sort chronologically.
@@ -74,6 +86,8 @@ export async function summarizeProject(record: ProjectRecord, deps: SummarizeDep
     activated,
   }
   if (lastActivityAt) summary.lastActivityAt = lastActivityAt
+  // Omitted when the repo sets nothing, so a project with no yml carries no key at all.
+  if (Object.keys(fileConfig).length) summary.fileConfig = fileConfig
   return summary
 }
 

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -371,7 +371,7 @@ export {
   MARKET_RESEARCH_PROMPT_TEMPLATE,
   MARKET_RESEARCH_PARAMS,
 } from './market-research-preset.js'
-export { runOptionsFromPreferences, autopilotEnabled } from './run-options.js'
+export { runOptionsFromPreferences, autopilotEnabled, preferencesFromFileConfig } from './run-options.js'
 export {
   startAutoPm,
   AUTO_PM_JOBS,

--- a/packages/framework/src/run-options.test.ts
+++ b/packages/framework/src/run-options.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { runOptionsFromPreferences, autopilotEnabled } from './run-options.js'
+import { runOptionsFromPreferences, autopilotEnabled, preferencesFromFileConfig } from './run-options.js'
 import { resolvePreferences } from './registry.js'
 
 test('autopilot defaults on when nothing is set (#858)', () => {
@@ -9,7 +9,48 @@ test('autopilot defaults on when nothing is set (#858)', () => {
 })
 
 test('an empty preference set still starts a run in autopilot (#858)', () => {
-  assert.deepEqual(runOptionsFromPreferences({}), { autopilot: true })
+  // The four yml-owned toggles travel explicitly since #842, so the run states the settled answer
+  // rather than letting the repo file fill the silence.
+  assert.deepEqual(runOptionsFromPreferences({}), {
+    autopilot: true,
+    technical: false,
+    vanilla: false,
+    transparent: false,
+  })
+})
+
+test('the yml-owned toggles travel as explicit booleans (#842)', () => {
+  const off = runOptionsFromPreferences({ autopilot: false })
+  assert.equal(off.autopilot, false)
+  const on = runOptionsFromPreferences({ technical: true, vanilla: true, transparent: true })
+  assert.deepEqual(
+    { technical: on.technical, vanilla: on.vanilla, transparent: on.transparent },
+    { technical: true, vanilla: true, transparent: true },
+  )
+})
+
+test('preferencesFromFileConfig maps the repo yml onto the preference keys (#842)', () => {
+  assert.deepEqual(preferencesFromFileConfig({}), {})
+  assert.deepEqual(preferencesFromFileConfig({ autopilot: true, technical: false }), {
+    autopilot: true,
+    technical: false,
+  })
+  // antiLazyPill is the file's name for the inverse of Vanilla.
+  assert.deepEqual(preferencesFromFileConfig({ antiLazyPill: false }), { vanilla: true })
+  assert.deepEqual(preferencesFromFileConfig({ antiLazyPill: true }), { vanilla: false })
+  assert.deepEqual(preferencesFromFileConfig({ transparent: true }), { transparent: true })
+  // preset and event have no preference counterpart, so they are not mapped.
+  assert.deepEqual(preferencesFromFileConfig({ preset: 'software-development', event: 'bug-fix' }), {})
+})
+
+test('a repo yml sits under the project overrides and over the global tier (#842)', () => {
+  const global = { autopilot: true, technical: true }
+  const repo = preferencesFromFileConfig({ technical: false, antiLazyPill: false })
+  // The layer order the daemon and the launcher both use: global, repo, then the project's own.
+  const resolved = resolvePreferences({ ...global, ...repo }, { vanilla: false })
+  assert.equal(resolved.autopilot, true) // nobody nearer set it
+  assert.equal(resolved.technical, false) // the repo turned it off
+  assert.equal(resolved.vanilla, false) // the project overrode the repo's antiLazyPill:false
 })
 
 test('the agent is sent only when it is not the default (#858)', () => {

--- a/packages/framework/src/run-options.ts
+++ b/packages/framework/src/run-options.ts
@@ -1,5 +1,6 @@
 import type { Preferences } from './registry.js'
 import type { StartRunOptions } from './dashboard/types.js'
+import type { FrameworkFileConfig } from './config.js'
 
 /**
  * Turning the user's preferences into the options a run starts with (#858).
@@ -15,6 +16,24 @@ import type { StartRunOptions } from './dashboard/types.js'
  * preferences collapse into one object. Re-exported from the browser-safe `./client` entry (#431)
  * so the dashboard can go on importing it at runtime.
  */
+
+/**
+ * A repo's committed `the-framework.yml` as the preference keys it speaks for (#842), so the
+ * launcher and the daemon can layer it under the user's own options the same way. Only the keys
+ * the file set come back, since an unset key must leave the tier below it alone.
+ *
+ * `antiLazyPill` is the file's name for the inverse of Vanilla: removing the built-in prompt.
+ * `preset` and `event` have no preference counterpart (there is no preset picker) and stay on the
+ * raw file config for display.
+ */
+export function preferencesFromFileConfig(file: FrameworkFileConfig): Preferences {
+  return {
+    ...(file.autopilot !== undefined ? { autopilot: file.autopilot } : {}),
+    ...(file.technical !== undefined ? { technical: file.technical } : {}),
+    ...(file.transparent !== undefined ? { transparent: file.transparent } : {}),
+    ...(file.antiLazyPill !== undefined ? { vanilla: !file.antiLazyPill } : {}),
+  }
+}
 
 /** Autopilot defaults on (the demo default), matching the old localStorage semantics. */
 export function autopilotEnabled(preferences: Preferences): boolean {
@@ -43,10 +62,14 @@ export function runOptionsFromPreferences(preferences: Preferences, context: str
     ...(preferences.ecoMaintenance ? { autoMaintenance: true } : {}),
   }
   return {
-    ...(autopilot ? { autopilot: true } : {}),
-    ...(technical ? { technical: true } : {}),
-    ...(vanilla ? { vanilla: true } : {}),
-    ...(transparent ? { transparent: true } : {}),
+    // The four toggles `the-framework.yml` also owns go out explicitly, `false` included (#842):
+    // the caller has already resolved every layer it can see, so the run states the settled answer
+    // and the CLI's own resolve (#841) takes it as the nearest layer. Sending nothing would let the
+    // repo file turn back on what the launcher just showed as off.
+    autopilot,
+    technical,
+    vanilla,
+    transparent,
     ...(eco && !vanilla && !transparent && Object.keys(ecoDrops).length ? { eco: ecoDrops } : {}),
     ...(onBeforeMergeableQuality ? { onBeforeMergeable: true } : {}),
     // Claude-only (#801): another agent's driver takes no MCP servers, so sending it would only earn


### PR DESCRIPTION
Closes #842. Last child of #800.

## The blocker

`the-framework.yml` was read exactly once, inside the freshly spawned CLI child, using the run's own cwd. The daemon never read it and the dashboard never saw it, so the launcher could not show a resolved answer: it did not have one of the layers. The gear showed your own preferences while the repo's committed options took effect later, unseen.

## The change

**Server.** `summarizeProject` reads the repo file and puts it on the project payload beside the existing `ProjectSummary` fields. It is read fresh on every request, which is what keeps it current after an edit; a missing or malformed file stays the forgiving `{}` it already was, and a failed read leaves the rest of the summary intact.

**Resolution.** A new `preferencesFromFileConfig` maps the yml onto the preference keys it speaks for (`antiLazyPill` is the file's name for the inverse of Vanilla; `preset` and `event` have no preference counterpart and stay on the raw config). Both the dashboard store and the daemon's own `resolvedRunOptions` layer it the same way, nearest first: project options > repo yml > global.

**Launcher.** A strip under the composer lists what the session will actually run with, without opening the gear, and marks repo-inherited values as not-yours (dashed chip + `repo`), including the `preset` / `kind` the gear cannot set. The store gained `usePreferenceSources()` and `useProjectFileConfig()`; `usePreferences()` keeps its signature, so no component changed shape. It re-reads the repo tier when the window regains focus.

**Sending the answer.** Because the launcher now resolves the file itself, a start sends the four toggles the yml also owns explicitly, `false` included, and the daemon spells those as the `--no-*` flags #841 added. Without that, unchecking Autopilot in the gear would be silently undone by a repo that set it: the file would win the silence.

## Verification

- `pnpm -r test` green: framework 890 pass / 0 fail, framework-dashboard 229 pass. `pnpm -r typecheck` and a root `pnpm build` (plus `bundle:dashboard`) clean.
- Mutation-checked every new assertion: **17 mutations, 17 caught**. Dropped the `--no-*` emission; mapped `antiLazyPill` without inverting; dropped `fileConfig` from the summary; set it even when empty; removed the read's catch; reverted the toggles to truthy-only; made the yml tier ignore an explicit false; dropped the repo tier from the resolve; put it over the project tier; reversed the source order; made refresh a no-op; unmarked repo chips; showed disabled options; dropped the yml-only chips; rendered an empty strip; kept stale file entries; removed the loader's catch. Two escaped on the first pass (stale-entry clearing, the swallowed rejection) and the tests were strengthened until both failed, then restored.