### PR TITLE
feat(framework-dashboard): colour the mark while the AI is working (#875)

### DIFF
--- a/.changeset/logo-easter-egg.md
+++ b/.changeset/logo-easter-egg.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Colour the mark while the AI is working (#875). The hexknot in the top bar, and the tab icon beside it, switch to the brand's animated colour variant for as long as any project has a session running, and back to the black & white mark when nothing does. Hovering the mark says which: "AI is working for you 🚀" or "AI isn't working for you 💤". The shared read-only relay view follows the one run it is watching.

--- a/packages/framework-dashboard/components/Logo.test.tsx
+++ b/packages/framework-dashboard/components/Logo.test.tsx
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { Logo, logoLabel } from './Logo.js'
+
+afterEach(cleanup)
+
+// #875: the mark is the ambient "is the AI working for you" signal. These pin the two states
+// apart — same knot, different fills — and that the label says which one you are looking at.
+describe('Logo', () => {
+  test('idle wears the neutral ramp and animates nothing', () => {
+    const { container } = render(<Logo />)
+    const fills = [...container.querySelectorAll('path')].map(p => p.getAttribute('fill'))
+    expect(fills).toEqual(['var(--logo-1)', 'var(--logo-2)', 'var(--logo-3)', 'var(--logo-4)', 'var(--logo-5)', 'var(--logo-6)'])
+    expect(container.querySelectorAll('animate').length).toBe(0)
+  })
+
+  test('working paints every strand from an animated gradient', () => {
+    const { container } = render(<Logo working />)
+    const fills = [...container.querySelectorAll('path')].map(p => p.getAttribute('fill'))
+    expect(fills).toEqual([0, 1, 2, 3, 4, 5].map(i => `url(#hexknot-${i})`))
+    // Six strands, two stops each, one animation per stop.
+    expect(container.querySelectorAll('linearGradient').length).toBe(6)
+    expect(container.querySelectorAll('animate').length).toBe(12)
+  })
+
+  test('every hue cycle closes on the hue it opened with, so the loop does not jump', () => {
+    const { container } = render(<Logo working />)
+    for (const animate of container.querySelectorAll('animate')) {
+      const hues = (animate.getAttribute('values') ?? '').split(';')
+      expect(hues.length).toBe(7)
+      expect(hues.at(-1)).toBe(hues[0])
+      expect(new Set(hues).size).toBe(6)
+    }
+  })
+
+  test('the label says which state the mark is in', () => {
+    expect(logoLabel(true)).toBe('AI is working for you 🚀')
+    expect(logoLabel(false)).toBe("AI isn't working for you 💤")
+    render(<Logo working />)
+    expect(screen.getByRole('img', { name: logoLabel(true) })).toBeTruthy()
+  })
+})

--- a/packages/framework-dashboard/components/Logo.tsx
+++ b/packages/framework-dashboard/components/Logo.tsx
@@ -8,39 +8,89 @@
 // Not `currentColor` with per-strand opacity, which is the obvious way to make an SVG theme-aware:
 // a knot's over/under crossings are literal overlaps, painted in order, so any strand below 100%
 // opacity shows the one beneath it through the crossing.
-export function Logo({ className }: { className?: string }) {
+//
+// #875: while an agent is running, the same knot switches to the brand's animated variant — each
+// strand a gradient cycling the six brand hues. Same paths, different fills, so the mark never
+// moves; only its colour tells you the AI is at work.
+
+/** The six brand hues the animated variant cycles through, in cycle order. */
+const HUES = ['#e69875', '#dbbc7f', '#a7c080', '#7fbbb3', '#d699b6', '#e67e80']
+
+/** One strand: its outline, and the gradient axis the animated variant paints it along. */
+const STRANDS: { d: string; axis: [number, number, number, number] }[] = [
+  {
+    d: 'M-160 -166.3 A10 10 0 0 0 -175 -174.9 L-234 -140.9 A10 10 0 0 0 -239 -132.2 L-239 34.1 A10 10 0 0 0 -234 42.7 L-72 136.3 A10 10 0 0 0 -62 136.3 L-21 112.6 A10 10 0 0 0 -21 95.3 L-173 7.5 A10 10 0 0 1 -178 -1.2 L-178 -97 A10 10 0 0 1 -173 -105.7 L-165 -110.3 A10 10 0 0 0 -160 -118.9 Z',
+    axis: [-160, -148.4, -36.5, 121.5],
+  },
+  {
+    d: 'M64 -221.7 A10 10 0 0 0 64 -239 L5 -273.1 A10 10 0 0 0 -5 -273.1 L-149 -189.9 A10 10 0 0 0 -154 -181.3 L-154 5.8 A10 10 0 0 0 -149 14.4 L-108 38.1 A10 10 0 0 0 -93 29.4 L-93 -146.1 A10 10 0 0 1 -88 -154.7 L-5 -202.6 A10 10 0 0 1 5 -202.6 L13 -198 A10 10 0 0 0 23 -198 Z',
+    axis: [48.5, -212.8, -123.5, 29.2],
+  },
+  {
+    d: 'M224 -55.4 A10 10 0 0 0 239 -64.1 L239 -132.2 A10 10 0 0 0 234 -140.9 L90 -224 A10 10 0 0 0 80 -224 L-82 -130.5 A10 10 0 0 0 -87 -121.8 L-87 -74.5 A10 10 0 0 0 -72 -65.8 L80 -153.6 A10 10 0 0 1 90 -153.6 L173 -105.7 A10 10 0 0 1 178 -97 L178 -87.8 A10 10 0 0 0 183 -79.1 Z',
+    axis: [208.5, -64.4, -87, -92.4],
+  },
+  {
+    d: 'M160 166.3 A10 10 0 0 0 175 174.9 L234 140.9 A10 10 0 0 0 239 132.2 L239 -34.1 A10 10 0 0 0 234 -42.7 L72 -136.3 A10 10 0 0 0 62 -136.3 L21 -112.6 A10 10 0 0 0 21 -95.3 L173 -7.5 A10 10 0 0 1 178 1.2 L178 97 A10 10 0 0 1 173 105.7 L165 110.3 A10 10 0 0 0 160 118.9 Z',
+    axis: [160, 148.4, 36.5, -121.5],
+  },
+  {
+    d: 'M-64 221.7 A10 10 0 0 0 -64 239 L-5 273.1 A10 10 0 0 0 5 273.1 L149 189.9 A10 10 0 0 0 154 181.3 L154 -5.8 A10 10 0 0 0 149 -14.4 L108 -38.1 A10 10 0 0 0 93 -29.4 L93 146.1 A10 10 0 0 1 88 154.7 L5 202.6 A10 10 0 0 1 -5 202.6 L-13 198 A10 10 0 0 0 -23 198 Z',
+    axis: [-48.5, 212.8, 123.5, -29.2],
+  },
+  {
+    d: 'M-224 55.4 A10 10 0 0 0 -239 64.1 L-239 132.2 A10 10 0 0 0 -234 140.9 L-90 224 A10 10 0 0 0 -80 224 L82 130.5 A10 10 0 0 0 87 121.8 L87 74.5 A10 10 0 0 0 72 65.8 L-80 153.6 A10 10 0 0 1 -90 153.6 L-173 105.7 A10 10 0 0 1 -178 97 L-178 87.8 A10 10 0 0 0 -183 79.1 Z',
+    axis: [-208.5, 64.4, 87, 92.4],
+  },
+]
+
+/** The mark's label (#875), which is also what the tab's tooltip says. */
+export function logoLabel(working: boolean): string {
+  return working ? 'AI is working for you 🚀' : "AI isn't working for you 💤"
+}
+
+/** The hue `steps` along the cycle, wrapping. */
+function hue(steps: number): string {
+  return HUES[((steps % HUES.length) + HUES.length) % HUES.length]!
+}
+
+/** The hue cycle one stop walks, starting at `offset` and closing back on itself. */
+function cycle(offset: number): string {
+  return HUES.map((_, step) => hue(offset + step))
+    .concat(hue(offset))
+    .join(';')
+}
+
+export function Logo({ className, working = false }: { className?: string; working?: boolean }) {
+  const label = logoLabel(working)
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="-289 -326 578 651.9"
       className={className}
       role="img"
-      aria-label="The Framework"
+      aria-label={label}
     >
-      <path
-        fill="var(--logo-1)"
-        d="M-160 -166.3 A10 10 0 0 0 -175 -174.9 L-234 -140.9 A10 10 0 0 0 -239 -132.2 L-239 34.1 A10 10 0 0 0 -234 42.7 L-72 136.3 A10 10 0 0 0 -62 136.3 L-21 112.6 A10 10 0 0 0 -21 95.3 L-173 7.5 A10 10 0 0 1 -178 -1.2 L-178 -97 A10 10 0 0 1 -173 -105.7 L-165 -110.3 A10 10 0 0 0 -160 -118.9 Z"
-      />
-      <path
-        fill="var(--logo-2)"
-        d="M64 -221.7 A10 10 0 0 0 64 -239 L5 -273.1 A10 10 0 0 0 -5 -273.1 L-149 -189.9 A10 10 0 0 0 -154 -181.3 L-154 5.8 A10 10 0 0 0 -149 14.4 L-108 38.1 A10 10 0 0 0 -93 29.4 L-93 -146.1 A10 10 0 0 1 -88 -154.7 L-5 -202.6 A10 10 0 0 1 5 -202.6 L13 -198 A10 10 0 0 0 23 -198 Z"
-      />
-      <path
-        fill="var(--logo-3)"
-        d="M224 -55.4 A10 10 0 0 0 239 -64.1 L239 -132.2 A10 10 0 0 0 234 -140.9 L90 -224 A10 10 0 0 0 80 -224 L-82 -130.5 A10 10 0 0 0 -87 -121.8 L-87 -74.5 A10 10 0 0 0 -72 -65.8 L80 -153.6 A10 10 0 0 1 90 -153.6 L173 -105.7 A10 10 0 0 1 178 -97 L178 -87.8 A10 10 0 0 0 183 -79.1 Z"
-      />
-      <path
-        fill="var(--logo-4)"
-        d="M160 166.3 A10 10 0 0 0 175 174.9 L234 140.9 A10 10 0 0 0 239 132.2 L239 -34.1 A10 10 0 0 0 234 -42.7 L72 -136.3 A10 10 0 0 0 62 -136.3 L21 -112.6 A10 10 0 0 0 21 -95.3 L173 -7.5 A10 10 0 0 1 178 1.2 L178 97 A10 10 0 0 1 173 105.7 L165 110.3 A10 10 0 0 0 160 118.9 Z"
-      />
-      <path
-        fill="var(--logo-5)"
-        d="M-64 221.7 A10 10 0 0 0 -64 239 L-5 273.1 A10 10 0 0 0 5 273.1 L149 189.9 A10 10 0 0 0 154 181.3 L154 -5.8 A10 10 0 0 0 149 -14.4 L108 -38.1 A10 10 0 0 0 93 -29.4 L93 146.1 A10 10 0 0 1 88 154.7 L5 202.6 A10 10 0 0 1 -5 202.6 L-13 198 A10 10 0 0 0 -23 198 Z"
-      />
-      <path
-        fill="var(--logo-6)"
-        d="M-224 55.4 A10 10 0 0 0 -239 64.1 L-239 132.2 A10 10 0 0 0 -234 140.9 L-90 224 A10 10 0 0 0 -80 224 L82 130.5 A10 10 0 0 0 87 121.8 L87 74.5 A10 10 0 0 0 72 65.8 L-80 153.6 A10 10 0 0 1 -90 153.6 L-173 105.7 A10 10 0 0 1 -178 97 L-178 87.8 A10 10 0 0 0 -183 79.1 Z"
-      />
+      {/* Hovering the mark is the only place the label reads as prose. */}
+      <title>{label}</title>
+      {working && (
+        <defs>
+          {STRANDS.map(({ axis: [x1, y1, x2, y2] }, i) => (
+            <linearGradient key={i} id={`hexknot-${i}`} gradientUnits="userSpaceOnUse" x1={x1} y1={y1} x2={x2} y2={y2}>
+              {/* The two stops sit one hue apart, so the cycle reads as a sweep along the strand. */}
+              <stop offset="0" stopColor={hue(i)}>
+                <animate attributeName="stop-color" dur="6s" repeatCount="indefinite" values={cycle(i)} />
+              </stop>
+              <stop offset="1" stopColor={hue(i - 1)}>
+                <animate attributeName="stop-color" dur="6s" repeatCount="indefinite" values={cycle(i - 1)} />
+              </stop>
+            </linearGradient>
+          ))}
+        </defs>
+      )}
+      {STRANDS.map(({ d }, i) => (
+        <path key={i} fill={working ? `url(#hexknot-${i})` : `var(--logo-${i + 1})`} d={d} />
+      ))}
     </svg>
   )
 }

--- a/packages/framework-dashboard/components/RelayView.tsx
+++ b/packages/framework-dashboard/components/RelayView.tsx
@@ -1,6 +1,8 @@
 import { RunFeed } from './RunFeed.js'
 import { Badge } from './ui/badge.js'
 import { useLiveEvents } from '../lib/use-live-events.js'
+import { isRunActive } from '../lib/live-state.js'
+import { useFavicon } from '../lib/favicon.js'
 import { Logo } from './Logo.js'
 
 // The shared-run watch view (#426/#230): when the dashboard is opened on the relay at
@@ -9,10 +11,14 @@ import { Logo } from './Logo.js'
 // rails and no steering — a teammate with the link watches, they do not drive.
 export function RelayView({ runId }: { runId: string }) {
   const events = useLiveEvents(runId)
+  // The mark and the tab icon (#875) follow the one run being watched, since that is all the
+  // relay knows about — it has no project registry to ask.
+  const working = isRunActive(events)
+  useFavicon(working)
   return (
     <div className="flex h-screen flex-col">
       <header className="flex items-center gap-3 border-b border-border px-4 py-3">
-        <Logo className="h-5 w-auto shrink-0" />
+        <Logo className="h-5 w-auto shrink-0" working={working} />
         <span className="font-semibold">The Framework</span>
         <Badge className="text-muted-foreground">watching</Badge>
         <span className="ml-auto text-xs text-muted-foreground">read-only shared session</span>

--- a/packages/framework-dashboard/lib/favicon.test.ts
+++ b/packages/framework-dashboard/lib/favicon.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { faviconHref, useFavicon, IDLE_FAVICON, WORKING_FAVICON } from './favicon.js'
+
+afterEach(() => {
+  document.head.innerHTML = ''
+})
+
+const icon = () => document.querySelector<HTMLLinkElement>('link[rel~="icon"]')?.getAttribute('href')
+
+// #875: the tab is the half of the signal you see while the dashboard is in the background.
+describe('useFavicon', () => {
+  test('swaps the link Vike emitted rather than adding a second one', () => {
+    document.head.innerHTML = `<link rel="icon" href="${IDLE_FAVICON}" />`
+    const { rerender } = renderHook(({ working }) => useFavicon(working), { initialProps: { working: true } })
+    expect(icon()).toBe(WORKING_FAVICON)
+    expect(document.querySelectorAll('link[rel~="icon"]').length).toBe(1)
+    rerender({ working: false })
+    expect(icon()).toBe(IDLE_FAVICON)
+  })
+
+  test('adds a link when the page has none', () => {
+    renderHook(() => useFavicon(true))
+    expect(icon()).toBe(WORKING_FAVICON)
+  })
+
+  test('leaves the tab alone when it is not the caller\'s to set', () => {
+    document.head.innerHTML = `<link rel="icon" href="${IDLE_FAVICON}" />`
+    renderHook(() => useFavicon(true, false))
+    expect(icon()).toBe(IDLE_FAVICON)
+  })
+
+  test('names the two icon files', () => {
+    expect(faviconHref(true)).toBe(WORKING_FAVICON)
+    expect(faviconHref(false)).toBe(IDLE_FAVICON)
+  })
+})

--- a/packages/framework-dashboard/lib/favicon.ts
+++ b/packages/framework-dashboard/lib/favicon.ts
@@ -1,0 +1,39 @@
+import { useEffect } from 'react'
+
+// The tab icon follows the mark (#875): the black & white knot while nothing is running, the
+// brand's animated colour variant while an agent is working. Vike's `favicon` config only emits
+// the initial `<link rel="icon">` (pages/+config.ts), so the swap is a client-side href write.
+
+/** The mark as shipped: the neutral ramp, with its own dark-mode fills inside the file. */
+export const IDLE_FAVICON = '/logo.svg'
+
+/** The brand's animated variant, plain SVG `<animate>` so it needs no script of its own. */
+export const WORKING_FAVICON = '/logo-animated.svg'
+
+/** Which icon file the given state wants. */
+export function faviconHref(working: boolean): string {
+  return working ? WORKING_FAVICON : IDLE_FAVICON
+}
+
+/**
+ * Point the tab icon at {@link faviconHref} (client-only).
+ *
+ * `enabled` is false where the caller is not the one that knows: the shell hands the tab over to
+ * the relay view, which reads a single run's feed rather than the project registry.
+ */
+export function useFavicon(working: boolean, enabled = true): void {
+  useEffect(() => {
+    if (!enabled || typeof document === 'undefined') return
+    // `rel~=` because the emitted rel can carry more than one token.
+    let link = document.querySelector<HTMLLinkElement>('link[rel~="icon"]')
+    if (!link) {
+      link = document.createElement('link')
+      link.rel = 'icon'
+      document.head.appendChild(link)
+    }
+    const href = faviconHref(working)
+    // Guarded: writing the same href re-fetches the icon in some browsers, which restarts the
+    // animation on every render.
+    if (link.getAttribute('href') !== href) link.setAttribute('href', href)
+  }, [working, enabled])
+}

--- a/packages/framework-dashboard/lib/use-working.ts
+++ b/packages/framework-dashboard/lib/use-working.ts
@@ -1,0 +1,20 @@
+import type { Overview } from '@gemstack/framework'
+import { onOverview } from '../server/reads.telefunc.js'
+import { usePolled } from './use-async.js'
+
+// Is an agent working right now (#875)? Cross-project on purpose: the mark answers "is the AI
+// working for you", which is not "is it working on the project you happen to have selected" —
+// a run left going in another project still means it is working for you.
+//
+// `onOverview` is the read that already answers this (#437, `active` = every running run across
+// the registry); it was registered but had no client. The Overview page's own `onDashboard` poll
+// is a superset of it, so this adds no read the daemon did not already serve.
+
+/** Stable initial, so the poll does not churn on every render. */
+const IDLE: Overview = { active: [], queueOpen: 0, recent: [] }
+
+/** True while any project has a running run. `enabled` false skips the poll and answers false. */
+export function useWorking(enabled = true): boolean {
+  const { value } = usePolled<Overview>(enabled ? onOverview : null, IDLE, 5000, [enabled])
+  return value.active.length > 0
+}

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -25,6 +25,8 @@ import { useActivityNotifications } from '../../lib/use-activity-notifications.j
 import { usePreferences, notificationsEnabled, newActivityEnabled, humanInterventionEnabled } from '../../lib/preferences.js'
 import { pendingChoices, agentViews } from '../../lib/live-state.js'
 import { useDocumentTitle } from '../../lib/document-title.js'
+import { useWorking } from '../../lib/use-working.js'
+import { useFavicon } from '../../lib/favicon.js'
 
 /** Stable, so `files` keeps one identity while no project is selected. */
 const EMPTY_FILES: string[] = []
@@ -186,9 +188,17 @@ export default function Page() {
 
   // On the relay (#426), the URL carries `?run=<id>` and there is no local registry or
   // files — show that one run read-only. `window` is absent during prerender (ssr:false),
-  // so this resolves to the full shell at build time and only flips in the browser. Hooks
-  // above run unconditionally (rules of hooks); this early return is safe after them.
+  // so this resolves to the full shell at build time and only flips in the browser.
   const relayRun = typeof window === 'undefined' ? null : new URLSearchParams(window.location.search).get('run')
+
+  // Is an agent working (#875)? Drives the mark and the tab icon. Both off on the relay: there is
+  // no project registry behind it, so the cross-project read cannot answer, and RelayView owns
+  // both from its one run's feed instead.
+  const local = relayRun === null
+  const working = useWorking(local)
+  useFavicon(working, local)
+
+  // Hooks above run unconditionally (rules of hooks); this early return is safe after them.
   if (relayRun) return <RelayView runId={relayRun} />
 
   // Route the main pane: the Overview dashboard when no project is selected (#471); else the
@@ -245,7 +255,7 @@ export default function Page() {
   return (
     <div className="flex h-screen flex-col">
       <header className="flex items-center gap-3 border-b border-border px-4 py-3">
-        <Logo className="h-5 w-auto shrink-0" />
+        <Logo className="h-5 w-auto shrink-0" working={working} />
         <span className="shrink-0 font-semibold">The Framework</span>
         {/* The project selection lives in the nav now (#772), not in a rail of its own: always
             shown, on every page including the Overview. */}

--- a/packages/framework-dashboard/public/logo-animated.svg
+++ b/packages/framework-dashboard/public/logo-animated.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-289 -326 578 651.9">
+  <defs>
+    <linearGradient id="hk-g0" gradientUnits="userSpaceOnUse" x1="-160" y1="-148.4" x2="-36.5" y2="121.5">
+      <stop offset="0" stop-color="#e69875"><animate attributeName="stop-color" dur="6s" repeatCount="indefinite" values="#e69875;#dbbc7f;#a7c080;#7fbbb3;#d699b6;#e67e80;#e69875"/></stop>
+      <stop offset="1" stop-color="#e67e80"><animate attributeName="stop-color" dur="6s" repeatCount="indefinite" values="#e67e80;#e69875;#dbbc7f;#a7c080;#7fbbb3;#d699b6;#e67e80"/></stop>
+    </linearGradient>
+    <linearGradient id="hk-g1" gradientUnits="userSpaceOnUse" x1="48.5" y1="-212.8" x2="-123.5" y2="29.2">
+      <stop offset="0" stop-color="#dbbc7f"><animate attributeName="stop-color" dur="6s" repeatCount="indefinite" values="#dbbc7f;#a7c080;#7fbbb3;#d699b6;#e67e80;#e69875;#dbbc7f"/></stop>
+      <stop offset="1" stop-color="#e69875"><animate attributeName="stop-color" dur="6s" repeatCount="indefinite" values="#e69875;#dbbc7f;#a7c080;#7fbbb3;#d699b6;#e67e80;#e69875"/></stop>
+    </linearGradient>
+    <linearGradient id="hk-g2" gradientUnits="userSpaceOnUse" x1="208.5" y1="-64.4" x2="-87" y2="-92.4">
+      <stop offset="0" stop-color="#a7c080"><animate attributeName="stop-color" dur="6s" repeatCount="indefinite" values="#a7c080;#7fbbb3;#d699b6;#e67e80;#e69875;#dbbc7f;#a7c080"/></stop>
+      <stop offset="1" stop-color="#dbbc7f"><animate attributeName="stop-color" dur="6s" repeatCount="indefinite" values="#dbbc7f;#a7c080;#7fbbb3;#d699b6;#e67e80;#e69875;#dbbc7f"/></stop>
+    </linearGradient>
+    <linearGradient id="hk-g3" gradientUnits="userSpaceOnUse" x1="160" y1="148.4" x2="36.5" y2="-121.5">
+      <stop offset="0" stop-color="#7fbbb3"><animate attributeName="stop-color" dur="6s" repeatCount="indefinite" values="#7fbbb3;#d699b6;#e67e80;#e69875;#dbbc7f;#a7c080;#7fbbb3"/></stop>
+      <stop offset="1" stop-color="#a7c080"><animate attributeName="stop-color" dur="6s" repeatCount="indefinite" values="#a7c080;#7fbbb3;#d699b6;#e67e80;#e69875;#dbbc7f;#a7c080"/></stop>
+    </linearGradient>
+    <linearGradient id="hk-g4" gradientUnits="userSpaceOnUse" x1="-48.5" y1="212.8" x2="123.5" y2="-29.2">
+      <stop offset="0" stop-color="#d699b6"><animate attributeName="stop-color" dur="6s" repeatCount="indefinite" values="#d699b6;#e67e80;#e69875;#dbbc7f;#a7c080;#7fbbb3;#d699b6"/></stop>
+      <stop offset="1" stop-color="#7fbbb3"><animate attributeName="stop-color" dur="6s" repeatCount="indefinite" values="#7fbbb3;#d699b6;#e67e80;#e69875;#dbbc7f;#a7c080;#7fbbb3"/></stop>
+    </linearGradient>
+    <linearGradient id="hk-g5" gradientUnits="userSpaceOnUse" x1="-208.5" y1="64.4" x2="87" y2="92.4">
+      <stop offset="0" stop-color="#e67e80"><animate attributeName="stop-color" dur="6s" repeatCount="indefinite" values="#e67e80;#e69875;#dbbc7f;#a7c080;#7fbbb3;#d699b6;#e67e80"/></stop>
+      <stop offset="1" stop-color="#d699b6"><animate attributeName="stop-color" dur="6s" repeatCount="indefinite" values="#d699b6;#e67e80;#e69875;#dbbc7f;#a7c080;#7fbbb3;#d699b6"/></stop>
+    </linearGradient>
+  </defs>
+  <path fill="url(#hk-g0)" d="M-160 -166.3 A10 10 0 0 0 -175 -174.9 L-234 -140.9 A10 10 0 0 0 -239 -132.2 L-239 34.1 A10 10 0 0 0 -234 42.7 L-72 136.3 A10 10 0 0 0 -62 136.3 L-21 112.6 A10 10 0 0 0 -21 95.3 L-173 7.5 A10 10 0 0 1 -178 -1.2 L-178 -97 A10 10 0 0 1 -173 -105.7 L-165 -110.3 A10 10 0 0 0 -160 -118.9 Z"/>
+  <path fill="url(#hk-g1)" d="M64 -221.7 A10 10 0 0 0 64 -239 L5 -273.1 A10 10 0 0 0 -5 -273.1 L-149 -189.9 A10 10 0 0 0 -154 -181.3 L-154 5.8 A10 10 0 0 0 -149 14.4 L-108 38.1 A10 10 0 0 0 -93 29.4 L-93 -146.1 A10 10 0 0 1 -88 -154.7 L-5 -202.6 A10 10 0 0 1 5 -202.6 L13 -198 A10 10 0 0 0 23 -198 Z"/>
+  <path fill="url(#hk-g2)" d="M224 -55.4 A10 10 0 0 0 239 -64.1 L239 -132.2 A10 10 0 0 0 234 -140.9 L90 -224 A10 10 0 0 0 80 -224 L-82 -130.5 A10 10 0 0 0 -87 -121.8 L-87 -74.5 A10 10 0 0 0 -72 -65.8 L80 -153.6 A10 10 0 0 1 90 -153.6 L173 -105.7 A10 10 0 0 1 178 -97 L178 -87.8 A10 10 0 0 0 183 -79.1 Z"/>
+  <path fill="url(#hk-g3)" d="M160 166.3 A10 10 0 0 0 175 174.9 L234 140.9 A10 10 0 0 0 239 132.2 L239 -34.1 A10 10 0 0 0 234 -42.7 L72 -136.3 A10 10 0 0 0 62 -136.3 L21 -112.6 A10 10 0 0 0 21 -95.3 L173 -7.5 A10 10 0 0 1 178 1.2 L178 97 A10 10 0 0 1 173 105.7 L165 110.3 A10 10 0 0 0 160 118.9 Z"/>
+  <path fill="url(#hk-g4)" d="M-64 221.7 A10 10 0 0 0 -64 239 L-5 273.1 A10 10 0 0 0 5 273.1 L149 189.9 A10 10 0 0 0 154 181.3 L154 -5.8 A10 10 0 0 0 149 -14.4 L108 -38.1 A10 10 0 0 0 93 -29.4 L93 146.1 A10 10 0 0 1 88 154.7 L5 202.6 A10 10 0 0 1 -5 202.6 L-13 198 A10 10 0 0 0 -23 198 Z"/>
+  <path fill="url(#hk-g5)" d="M-224 55.4 A10 10 0 0 0 -239 64.1 L-239 132.2 A10 10 0 0 0 -234 140.9 L-90 224 A10 10 0 0 0 -80 224 L82 130.5 A10 10 0 0 0 87 121.8 L87 74.5 A10 10 0 0 0 72 65.8 L-80 153.6 A10 10 0 0 1 -90 153.6 L-173 105.7 A10 10 0 0 1 -178 97 L-178 87.8 A10 10 0 0 0 -183 79.1 Z"/>
+</svg>


### PR DESCRIPTION
Closes #875.

The mark in the top bar, and the tab icon beside it, switch to the brand's animated colour variant while an agent is running, and back to the black & white knot when none is. Hovering says which: "AI is working for you 🚀" / "AI isn't working for you 💤".

Same six strands and the same path data in both states, only the fills differ, so the mark never moves.

### The one design call
**The signal is cross-project.** "Is the AI working for you" is not "is it working on whichever project you happen to have selected", so a run left going in another project still colours the mark. It rides `onOverview` (#437) - the read that has answered exactly this all along and until now had no client - polled at 5s. The Overview page's own `onDashboard` poll is a superset of it, so this asks the daemon for nothing it was not already computing. Say the word if you want it scoped to the selected project instead; that is a one-line swap to the runs the shell already polls.

The relay view (`?run=`) has no project registry behind it, so it answers from the one run it is watching (`isRunActive`) rather than polling for an answer it cannot get.

### Notes
- The animated variant is the brand asset as-is: plain SVG `<animate>`, no script and no dependency. The React component builds the same six gradients from one hue table so the strand paths stay a single copy; verified pixel-identical against the brand file with both frozen at the same animation time.
- Whether the *tab* icon actually animates is browser-dependent (it is an SVG favicon). The colour swap is the part that always reads.
- No new colour tokens: the neutral `--logo-1..6` ramp still owns the idle mark in both themes.

### Verified
- 225 dashboard tests (was 217), 884 framework, typecheck + build green.
- 2 mutation checks: ignoring `working` in the mark, and dropping the favicon's `enabled` guard, each fail exactly one new test.
- **Live-driven against a real daemon** (isolated registry, temp repo, port 4399), stepping idle -> working -> idle by faking a live `run.json`:

  | | header fill | label | favicon |
  |---|---|---|---|
  | idle | `var(--logo-1)` | AI isn't working for you 💤 | `/logo.svg` |
  | working | `url(#hexknot-0)` | AI is working for you 🚀 | `/logo-animated.svg` |
  | back | `var(--logo-1)` | AI isn't working for you 💤 | `/logo.svg` |