### PR TITLE
feat(framework): make the project log the complete session list (#898)

### DIFF
--- a/.changeset/feat-898-logs-session-list.md
+++ b/.changeset/feat-898-logs-session-list.md
@@ -1,0 +1,14 @@
+---
+'@gemstack/framework': minor
+---
+
+The project log is the complete list of sessions (#898)
+
+`.the-framework/LOGS.md` is the one part of a project's run history that git keeps, but it only
+recorded runs that finished cleanly: a stopped or crashed session left nothing behind, even
+though the transient `runs/` archive had it. The entry is now written as the run settles, on
+every path out, so the committed log stops disagreeing with the machine's own record.
+
+Each entry also carries the run id, the name the agent gave the session, and the branch the
+work landed on, read from the checkout while it is still there. So an entry now says where to
+find the session and its code, rather than only that it happened.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -6,6 +6,7 @@ import { join, dirname } from 'node:path'
 import { appendControl } from './control.js'
 import { daemonStatePath } from './daemon.js'
 import { EVENTS_FILE, FRAMEWORK_DIR, RUNS_DIR, type StoreFs } from './store/index.js'
+import { nodeGitRunner } from './project.js'
 import {
   activeModes,
   buildDeployTarget,
@@ -242,6 +243,57 @@ test('runLogEntry maps the end event to a status and carries the session (#379)'
   assert.equal(withSession.sessionLink, 'http://x/s1')
   // No session captured -> the fields are omitted, not set to undefined.
   assert.equal('sessionId' in runLogEntry({ ...base, end: { kind: 'end', ok: true } }), false)
+})
+
+test('runLogEntry records a run that never reached its end event (#898)', () => {
+  const base = { at: '2026-07-11T00:00:00.000Z', kind: 'build' as const, title: 'a blog' }
+  // No `end` to read the outcome from: the run was stopped, or it died.
+  assert.equal(runLogEntry({ ...base, stopped: true }).status, 'stopped')
+  assert.equal(runLogEntry({ ...base }).status, 'failed')
+  // An `end` still wins over the fallback, so a stopped-then-ended run is not double-guessed.
+  assert.equal(runLogEntry({ ...base, end: { kind: 'end', ok: true }, stopped: true }).status, 'done')
+})
+
+test('runLogEntry carries the run id, session name and branch (#898)', () => {
+  const entry = runLogEntry({
+    at: '2026-07-11T00:00:00.000Z',
+    kind: 'build',
+    title: 'a blog',
+    end: { kind: 'end', ok: true },
+    id: '2026-07-11T00-00-00-000Z',
+    sessionName: 'a-blog',
+    branch: 'the-framework/a-blog',
+  })
+  assert.equal(entry.id, '2026-07-11T00-00-00-000Z')
+  assert.equal(entry.sessionName, 'a-blog')
+  assert.equal(entry.branch, 'the-framework/a-blog')
+  // Absent -> omitted, not set to undefined.
+  const bare = runLogEntry({ at: entry.at, kind: 'build', title: 'a blog', end: { kind: 'end', ok: true } })
+  assert.deepEqual(Object.keys(bare).sort(), ['at', 'kind', 'status', 'title'])
+})
+
+test('a run in a git repo records the branch its work landed on (#898)', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'framework-logs-branch-'))
+  const git = nodeGitRunner()
+  try {
+    await git(['init'], dir)
+    await git(['config', 'user.email', 'test@example.com'], dir)
+    await git(['config', 'user.name', 'Test'], dir)
+    await writeFile(join(dir, 'README.md'), '# app\n')
+    await git(['add', '-A'], dir)
+    await git(['commit', '-m', 'init'], dir)
+    await git(['checkout', '-b', 'the-framework/auth-flow'], dir)
+
+    // --unattended so the run settles and exits: inside a git repo it otherwise stays open for
+    // live chat (#714), which has nothing to do with what this asserts.
+    const { io } = capture()
+    const args = ['prompt', 'review the auth flow', '--fake', '--no-dashboard', '--unattended', '--cwd', dir]
+    assert.equal(await runCli(args, io), 0)
+    const logs = await readLogs(dir)
+    assert.equal(logs[0]!.branch, 'the-framework/auth-flow')
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
 })
 
 test('a finished run records itself in .the-framework/LOGS.md (#379)', async () => {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -47,7 +47,7 @@ import { loadUserSystemPrompt, SYSTEM_PROMPT_FILE } from './system-prompt-file.j
 import { checkForUpdate, formatUpdateStatus, nodeVersionFetcher } from './update-check.js'
 import { appendLog, type LogEntry } from './logs.js'
 import { preflight } from './preflight.js'
-import { RunStore, nodeStoreFs, renameRunBranch, runBranchName, type StoreFs } from './store/index.js'
+import { RunStore, currentBranch, nodeStoreFs, renameRunBranch, runBranchName, type StoreFs } from './store/index.js'
 import { materializePresets } from './presets.js'
 import { daemonStatus, ensureDaemon, registerHomeProject, runDaemon, stopDaemon, DEFAULT_DAEMON_PORT } from './daemon.js'
 import { resetControl, watchControl, type ControlWatcher } from './control.js'
@@ -689,23 +689,42 @@ export function runLogKind(opts: Pick<CliOptions, 'directPrompt' | 'research'>, 
  * Build the project-log entry (#379) for a finished run from its `end` event and
  * the session captured along the way. Pure, so the status mapping is unit-testable
  * without a live run.
+ *
+ * A run that never emitted `end` still gets an entry (#898) — it was stopped, or it died
+ * mid-flight, and either way it happened and belongs in the committed log. `stopped` then
+ * decides between the two, since there is no event left to ask.
  */
 export function runLogEntry(input: {
   at: string
   kind: LogEntry['kind']
   title: string
-  end: Extract<FrameworkEvent, { kind: 'end' }>
+  end?: Extract<FrameworkEvent, { kind: 'end' }> | undefined
+  stopped?: boolean | undefined
+  id?: string | undefined
   sessionId?: string | undefined
   sessionLink?: string | undefined
+  sessionName?: string | undefined
+  branch?: string | undefined
 }): LogEntry {
-  const status: LogEntry['status'] = input.end.ok ? 'done' : input.end.stopped ? 'stopped' : 'failed'
+  const status: LogEntry['status'] = input.end
+    ? input.end.ok
+      ? 'done'
+      : input.end.stopped
+        ? 'stopped'
+        : 'failed'
+    : input.stopped
+      ? 'stopped'
+      : 'failed'
   return {
     at: input.at,
     kind: input.kind,
     title: input.title,
     status,
+    ...(input.id ? { id: input.id } : {}),
     ...(input.sessionId ? { sessionId: input.sessionId } : {}),
     ...(input.sessionLink ? { sessionLink: input.sessionLink } : {}),
+    ...(input.sessionName ? { sessionName: input.sessionName } : {}),
+    ...(input.branch ? { branch: input.branch } : {}),
   }
 }
 
@@ -769,6 +788,8 @@ interface RunEpilogue {
   browserStream: BrowserStream | undefined
   clearInterrupt: () => void
   maybeFireOnBeforeMergeable: () => Promise<void>
+  /** Write the run's `.the-framework/LOGS.md` entry (#898). Idempotent: called on every exit path. */
+  finishLog: () => Promise<void>
   /** True once the run stopped cleanly (interrupt / budget cap) rather than failed. */
   isStopped: () => boolean
   /** How a real failure is labelled: "run", "research", or "prompt run". */
@@ -797,6 +818,7 @@ async function settleRun(
     // Before the close, not after (#835): close() archives the log into `runs/`, so an
     // outcome appended afterwards would miss the copy the dashboard's history reads.
     await ctx.maybeFireOnBeforeMergeable()
+    await ctx.finishLog()
     await ctx.store?.close() // flush the event log; best-effort
     // Stay up while the dashboard and/or the app are live, then tear both down.
     if (dashboard || preview) {
@@ -809,6 +831,9 @@ async function settleRun(
     return 0
   } catch (err) {
     ctx.clearInterrupt()
+    // Before the close, like the success path: a run that stopped or blew up is still a session,
+    // and this is the only place the failing path can record it (#898).
+    await ctx.finishLog()
     await ctx.store?.close()
     // A clean stop (Stop button, Ctrl+C, or a budget cap #322) is not a failure: report it,
     // keep the dashboard up so the stopped state stays visible, and exit 0.
@@ -1172,12 +1197,13 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   let sessionName: string | undefined
   // Record the finished run in the project log `.the-framework/LOGS.md` (#379). The
   // kind + title are known up front; the session id/link arrive mid-run, and the
-  // `end` event (fired once by both run paths) closes the entry. Best-effort: the
-  // project DB is committed history, so it must never break a run.
+  // `end` event holds the outcome. Best-effort: the project DB is committed history,
+  // so it must never break a run.
   const logKind = runLogKind(opts, transparent)
   const logTitle = intent || (opts.research ? defaultWhat() : '')
   let logSessionId: string | undefined
   let logSessionLink: string | undefined
+  let logEnd: Extract<FrameworkEvent, { kind: 'end' }> | undefined
   // The browser preview's port, announced on the first `session` event rather than when the
   // bridge opens (#829). The dashboard renders only the tail from the last `session` event, so
   // anything emitted ahead of it is dropped from the run's view.
@@ -1197,15 +1223,10 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     }
     if (event.kind === 'end') {
       if (event.stopped) stoppedCleanly = true
-      const entry = runLogEntry({
-        at: new Date().toISOString(),
-        kind: logKind,
-        title: logTitle,
-        end: event,
-        sessionId: logSessionId,
-        sessionLink: logSessionLink,
-      })
-      void appendLog(cwd, entry).catch(() => {})
+      // Held, not logged here (#898): the entry is written as the run settles, which is both
+      // after every run reaches it (an `end` is not guaranteed) and the last moment the branch
+      // can still be read off the checkout.
+      logEnd = event
     }
     io.out(formatFrameworkEvent(event))
     void store?.append(event)
@@ -1249,6 +1270,30 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
       opts.eco,
     )
     onEvent({ kind: 'on-before-mergeable', outcome })
+  }
+
+  // Write the run's entry into `.the-framework/LOGS.md` as it settles (#898). Once per run, and
+  // on every path out — a stopped or crashed run is still a session that happened, and leaving it
+  // out is what made the committed log an incomplete record of the transient `runs/` archive.
+  let logged = false
+  const finishLog = async (): Promise<void> => {
+    if (logged) return
+    logged = true
+    const entry = runLogEntry({
+      at: new Date().toISOString(),
+      kind: logKind,
+      title: logTitle,
+      end: logEnd,
+      stopped: stoppedCleanly,
+      id: opts.runId,
+      sessionId: logSessionId,
+      sessionLink: logSessionLink,
+      sessionName,
+      // The last moment it can be observed (#799): a run worktree is torn down after this
+      // process exits, and the agent may have branched itself, so neither name is derivable later.
+      branch: await currentBranch(cwd),
+    })
+    await appendLog(cwd, entry).catch(() => {})
   }
 
   // A mode/kind given with no preset in effect has nothing to act on: note it.
@@ -1331,6 +1376,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     browserStream,
     clearInterrupt,
     maybeFireOnBeforeMergeable,
+    finishLog,
     isStopped: () => controller.signal.aborted || stoppedCleanly,
     failLabel,
   })

--- a/packages/framework/src/logs.test.ts
+++ b/packages/framework/src/logs.test.ts
@@ -164,6 +164,35 @@ test('a multi-line prompt bullet stays on one line and round-trips (#897)', () =
   assert.deepEqual(parseLogs(renderLogEntry(entry)), [entry])
 })
 
+test('the run id, session name and branch round-trip (#898)', () => {
+  const entry: LogEntry = {
+    ...PROMPT,
+    id: '2026-07-10T09-00-00-000Z',
+    sessionName: 'login-page',
+    branch: 'the-framework/login-page',
+  }
+  assert.equal(
+    renderLogEntry(entry),
+    [
+      '## 2026-07-10T09:00:00.000Z · prompt · Add a login page',
+      '',
+      '- status: done',
+      '- run: 2026-07-10T09-00-00-000Z',
+      '- session: [sess-1](https://claude.ai/code/sess-1)',
+      '- name: login-page',
+      '- branch: the-framework/login-page',
+    ].join('\n'),
+  )
+  assert.deepEqual(parseLogs(renderLogEntry(entry)), [entry])
+})
+
+test('an entry written before #898 parses without the new fields', () => {
+  const parsed = parseLogs(renderLogEntry(PROMPT))
+  assert.deepEqual(parsed, [PROMPT])
+  assert.equal('id' in parsed[0]!, false)
+  assert.equal('branch' in parsed[0]!, false)
+})
+
 test('an entry written before #897 still parses', () => {
   const md = ['## 2026-07-10T12:00:00.000Z · build · A blog', '', '- status: failed'].join('\n')
   assert.deepEqual(parseLogs(md), [MINIMAL])

--- a/packages/framework/src/logs.ts
+++ b/packages/framework/src/logs.ts
@@ -33,10 +33,23 @@ export interface LogEntry {
   /** The run's intent/prompt. Escaped to one line on write (#897), so it may hold a whole prompt. */
   title: string
   status: 'done' | 'stopped' | 'failed' | 'running'
+  /**
+   * The run's id (#898): the join key from this committed entry to the rest of the run, whose
+   * `runs/<id>.json` meta and `runs/<id>.jsonl` events are transient and stay out of git.
+   */
+  id?: string
   /** Claude Code session id. */
   sessionId?: string
   /** e.g. `https://claude.ai/code/<id>` */
   sessionLink?: string
+  /** The name the agent gave the session (#326), also its `the-framework/<name>` branch. */
+  sessionName?: string
+  /**
+   * The branch the run's work landed on (#799). Read from the checkout as the run settles,
+   * because it is not derivable later: a clean run loses its worktree, and the agent may have
+   * branched itself.
+   */
+  branch?: string
   /** For a loop: constituent prompt summaries. */
   prompts?: string[]
 }
@@ -83,6 +96,7 @@ export function renderLogEntry(entry: LogEntry): string {
     '',
     `- status: ${entry.status}`,
   ]
+  if (entry.id) lines.push(`- run: ${encodeField(entry.id)}`)
   if (entry.sessionId) {
     lines.push(
       entry.sessionLink
@@ -90,6 +104,8 @@ export function renderLogEntry(entry: LogEntry): string {
         : `- session: ${entry.sessionId}`,
     )
   }
+  if (entry.sessionName) lines.push(`- name: ${encodeField(entry.sessionName)}`)
+  if (entry.branch) lines.push(`- branch: ${encodeField(entry.branch)}`)
   if (entry.prompts && entry.prompts.length > 0) {
     lines.push('- prompts:')
     for (const prompt of entry.prompts) lines.push(`  - ${encodeField(prompt)}`)
@@ -133,8 +149,11 @@ function parseEntry(lines: string[]): LogEntry | undefined {
   if (!at || !kind || !title || !KINDS.includes(kind)) return undefined
 
   let status: string | undefined
+  let id: string | undefined
   let sessionId: string | undefined
   let sessionLink: string | undefined
+  let sessionName: string | undefined
+  let branch: string | undefined
   let prompts: string[] | undefined
   let inPrompts = false
   for (const line of lines.slice(1)) {
@@ -145,6 +164,12 @@ function parseEntry(lines: string[]): LogEntry | undefined {
     inPrompts = false
     if (line.startsWith('- status: ')) {
       status = line.slice('- status: '.length).trim()
+    } else if (line.startsWith('- run: ')) {
+      id = decodeField(line.slice('- run: '.length).trim())
+    } else if (line.startsWith('- name: ')) {
+      sessionName = decodeField(line.slice('- name: '.length).trim())
+    } else if (line.startsWith('- branch: ')) {
+      branch = decodeField(line.slice('- branch: '.length).trim())
     } else if (line.startsWith('- session: ')) {
       const value = line.slice('- session: '.length).trim()
       const linked = /^\[(.+)\]\((.+)\)$/.exec(value)
@@ -167,8 +192,11 @@ function parseEntry(lines: string[]): LogEntry | undefined {
     title,
     status: status as LogEntry['status'],
   }
+  if (id) entry.id = id
   if (sessionId) entry.sessionId = sessionId
   if (sessionLink) entry.sessionLink = sessionLink
+  if (sessionName) entry.sessionName = sessionName
+  if (branch) entry.branch = branch
   if (prompts && prompts.length > 0) entry.prompts = prompts
   return entry
 }


### PR DESCRIPTION
Closes #898.

`.the-framework/LOGS.md` is the one part of a run's history git keeps, but it was not the list the dashboard shows. Two gaps closed:

**It was incomplete.** The entry was written from the `end` event, so a stopped or crashed run left nothing behind while `runs/<id>.json` still had it. This repo's own log has 3 entries for 5 archived runs. It is now written as the run settles, on both the success and the failure path, once per run.

**It could not be joined to anything.** An entry now carries the run id (the key to `runs/<id>.json` and the run's worktree), the name the agent gave the session (#326), and the branch the work landed on (#799). The branch is read off the checkout at settle time because it is not derivable later: a worktree run loses its checkout after this process exits, and the agent may have branched itself.

Rendered as `- run:` / `- name:` / `- branch:` lines. Entries written before this parse unchanged.

Note: a `kill -9` still leaves no entry, since the process that would write it is gone. Reconciling LOGS.md from the `runs/` metas would close that, and it is now possible because entries have an id. Left out here.

For #857: this is the session-list half. The conversations half (#680) is next.
