### PR TITLE
fix(framework-dashboard): stop the page growing a second scrollbar (#904)

### DIFF
--- a/.changeset/phantom-scrollbar.md
+++ b/.changeset/phantom-scrollbar.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Stop the dashboard growing a second, phantom scrollbar (#904). The document itself was scrollable next to the content pane's own scrollbar, and dragging it slid the whole app, header and all, off the top of the window. Visually-hidden labels are absolutely positioned, and with no positioned ancestor they escaped the workspace row's clipping and kept their place deep inside the scrolled content, which is what the browser measured the page against. Only the pane scrolls now.

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -281,8 +281,13 @@ export default function Page() {
         </div>
       </header>
       {/* The workspace row is fixed-height: each column scrolls internally, so the row itself
-          must never scroll. overflow-hidden clips any stray horizontal bleed (no page X-scroll). */}
-      <div className="flex min-h-0 flex-1 overflow-hidden">
+          must never scroll. overflow-hidden clips any stray horizontal bleed (no page X-scroll).
+          `relative` is load-bearing (#904): overflow only clips a descendant this box is the
+          containing block for, and Tailwind's `.sr-only` is position:absolute. Without it those
+          labels resolve against the initial containing block, keep their static position deep in
+          the scrolled content, and give the document a phantom scrollbar that slides the whole
+          app off-screen. */}
+      <div className="relative flex min-h-0 flex-1 overflow-hidden">
         <RunHistory
           projectId={projectId}
           runs={runs}


### PR DESCRIPTION
Closes #904.

The Overview had two scrollbars: the content pane's real one, and a full-height one on the document. The outer one scrolled nothing - it slid the whole app, header included, off the top of the window.

### Cause

Every box in the shell is correctly sized and clipped, so nothing in normal flow overflowed. What escaped was `.sr-only`: Tailwind makes it `position: absolute`, and nothing in the shell was a positioned ancestor, so its containing block was the *initial* containing block. `overflow-hidden` only clips descendants the box is the containing block for, so those labels kept their static position deep inside the scrolled content. The deepest one, in the Overview's session table, sat at y≈1369 in a 600px viewport - exactly the document scroll height the browser reported.

That is also why it read as a nested-scroller bug: hiding the Overview pane made the phantom scrollbar disappear, because its labels went with it.

### Fix

One class: the workspace row becomes a containing block, so `overflow-hidden` applies to those labels too. The only absolutely positioned thing inside that row - the sessions rail's floating panel (#862) - already has its own `relative` parent, so it does not move.

Rejected on evidence: `html { overflow: hidden }` does not fix it (measured - the escapee is still laid out past the viewport, and the page still scrolls).

### Verified

Two daemons on the same real project registry, before on :4200 and after on :4401, 1000x600 viewport:

| | document scrollHeight | `scrollTo(0, 500)` lands at | pane still scrolls |
|---|---|---|---|
| Overview, before | 1347 | 500 | yes |
| Overview, after | **600** | **0** | yes |
| Project page, before | 600 | 0 | yes |
| Project page, after | 600 | 0 | yes |

Screenshots of the Overview and a project page before/after are pixel-equivalent apart from the missing outer scrollbar.

**No unit test:** jsdom has no layout engine, so it cannot see a containing block, a clipped overflow, or a scroll height - a test here could only assert the class string back at itself. The comment on the line says why it is load-bearing so it does not get tidied away; the reproduction above is the real check. 884 framework + 225 dashboard tests still pass, typecheck and build green.