### PR TITLE
feat(framework-dashboard): make the logo the way home (#909)

### DIFF
--- a/.changeset/brand-home-link.md
+++ b/.changeset/brand-home-link.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Make the logo the way home (#909). Clicking the mark or "The Framework" in the top bar goes to the Overview. It is a real link, so cmd-click and middle-click open a second Overview in a new tab and "copy link address" gives you a URL, while a plain click stays an in-app navigation with no reload.

--- a/packages/framework-dashboard/components/BrandLink.test.tsx
+++ b/packages/framework-dashboard/components/BrandLink.test.tsx
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { BrandLink } from './BrandLink.js'
+
+afterEach(cleanup)
+
+const brand = () => screen.getByRole('link', { name: /The Framework/ })
+
+// #909: the mark is the way home. These pin both halves of that — the client-side navigation on a
+// plain click, and that it is still a real link, which is what cmd-click and "copy link address"
+// need. A button could not have the second half.
+describe('BrandLink', () => {
+  test('is a link to the Overview', () => {
+    render(<BrandLink working={false} onNavigate={vi.fn()} />)
+    expect(brand().getAttribute('href')).toBe('/')
+  })
+
+  test('a plain click navigates in-app rather than reloading', () => {
+    const onNavigate = vi.fn()
+    render(<BrandLink working={false} onNavigate={onNavigate} />)
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+    fireEvent(brand(), event)
+    expect(onNavigate).toHaveBeenCalledOnce()
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  test('leaves a modified click to the browser, so it can open a second Overview', () => {
+    const onNavigate = vi.fn()
+    render(<BrandLink working={false} onNavigate={onNavigate} />)
+    for (const modifier of ['metaKey', 'ctrlKey', 'shiftKey', 'altKey']) {
+      const event = new MouseEvent('click', { bubbles: true, cancelable: true, [modifier]: true })
+      fireEvent(brand(), event)
+      expect(event.defaultPrevented, modifier).toBe(false)
+    }
+    // The middle click a new tab is usually opened with.
+    const middle = new MouseEvent('click', { bubbles: true, cancelable: true, button: 1 })
+    fireEvent(brand(), middle)
+    expect(middle.defaultPrevented).toBe(false)
+    expect(onNavigate).not.toHaveBeenCalled()
+  })
+
+  test('carries the working state through to the mark', () => {
+    const { container, rerender } = render(<BrandLink working onNavigate={vi.fn()} />)
+    expect(container.querySelector('path')?.getAttribute('fill')).toBe('url(#hexknot-0)')
+    rerender(<BrandLink working={false} onNavigate={vi.fn()} />)
+    expect(container.querySelector('path')?.getAttribute('fill')).toBe('var(--logo-1)')
+  })
+})

--- a/packages/framework-dashboard/components/BrandLink.tsx
+++ b/packages/framework-dashboard/components/BrandLink.tsx
@@ -1,0 +1,24 @@
+import { Logo } from './Logo.js'
+
+// The mark and the wordmark are the way home (#909): clicking them goes to `/`, the Overview.
+//
+// A real `<a href="/">` rather than a button, so cmd-click and middle-click open a second Overview
+// and "copy link address" gives a URL. A plain left click is handled here instead, as a client-side
+// navigation through the shell's own router (#784) — the same `go` every other selection uses.
+export function BrandLink({ working, onNavigate }: { working: boolean; onNavigate: () => void }) {
+  return (
+    <a
+      href="/"
+      onClick={event => {
+        // A modified click is the browser's to handle: a new tab, a new window, a download.
+        if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) return
+        event.preventDefault()
+        onNavigate()
+      }}
+      className="flex shrink-0 items-center gap-3 rounded-md transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
+    >
+      <Logo className="h-5 w-auto shrink-0" working={working} />
+      <span className="shrink-0 font-semibold">The Framework</span>
+    </a>
+  )
+}

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -3,7 +3,7 @@ import type { Intervention, Activity, ProjectSummary } from '@gemstack/framework
 import { onProjectFiles, onInterventions, onActivity } from '../../server/reads.telefunc.js'
 import { onProjects } from '../../server/projects.telefunc.js'
 import { ProjectPicker } from '../../components/ProjectPicker.js'
-import { Logo } from '../../components/Logo.js'
+import { BrandLink } from '../../components/BrandLink.js'
 import { ThemeToggle } from '../../components/ThemeToggle.js'
 import { NotificationsMenu } from '../../components/NotificationsMenu.js'
 import { Button } from '../../components/ui/button.js'
@@ -255,8 +255,7 @@ export default function Page() {
   return (
     <div className="flex h-screen flex-col">
       <header className="flex items-center gap-3 border-b border-border px-4 py-3">
-        <Logo className="h-5 w-auto shrink-0" working={working} />
-        <span className="shrink-0 font-semibold">The Framework</span>
+        <BrandLink working={working} onNavigate={showDashboard} />
         {/* The project selection lives in the nav now (#772), not in a rail of its own: always
             shown, on every page including the Overview. */}
         <ProjectPicker


### PR DESCRIPTION
Closes #909.

Clicking the mark or "The Framework" goes to `/`, the Overview.

A real `<a href="/">` rather than a button: cmd-click and middle-click open a second Overview, and "copy link address" gives a URL. A plain left click is intercepted and handed to the shell's own router (#784), so it stays a client-side navigation with no reload, and Back returns to the session you came from.

Lifted into `BrandLink` rather than left inline in the shell, because the click rule is real logic and the shell has no test harness of its own.

The relay view keeps its inert mark: one shared session, no Overview behind it.

### Verified

Driven in a real browser against a daemon on the live registry, starting from a project page:

| | result |
|---|---|
| plain click | url `/gemstack` -> `/`, **no page reload**, Overview rendered |
| Back | returns to `/gemstack` (a history entry, not a state swap) |
| cmd-click | opens a second tab at `/`, current tab stays on `/gemstack` |
| `href` | `/` |

4 new tests (241 dashboard total), 2 mutation checks: preventing default unconditionally, and dropping the `href`, each fail the tests that exist to catch them. Typecheck and build green.

### One judgement call

The mark keeps its own `aria-label` from #875, so a screen reader announces the link as "AI isn't working for you 💤, The Framework". Slightly wordy, but it keeps the working state announced rather than trading it for a tidier link name. Say if you would rather the link were labelled plainly and the state dropped to a tooltip.