### PR TITLE
feat(framework): chat to The Framework from Discord (#680)

### DIFF
--- a/.changeset/feat-680-discord-chatbot.md
+++ b/.changeset/feat-680-discord-chatbot.md
@@ -1,0 +1,27 @@
+---
+'@gemstack/framework': minor
+---
+
+Chat to The Framework from Discord (#680)
+
+Discord was outbound-only: the daemon posts a webhook message when something needs you (#627), but
+a webhook cannot read a reply, so answering meant leaving Discord and opening the dashboard.
+
+The daemon now runs a Discord bot. Message it and it starts a session; message it again while that
+session is running and the text reaches the run through the same control channel the dashboard's
+live chat uses (#714). When a run parks on a question, the bot posts the numbered options and a
+reply of `2` answers it. `!status`, `!stop` and `!help` do what they say. `Ctrl+C` takes the bot
+offline with the rest of the daemon.
+
+Chat history goes where #857 asked for it: a message routed into a run lands in that run's
+conversation under `.the-framework/conversations/` (#908), committed with the repo. Nothing about
+the chat is stored outside git.
+
+Two gates, mirroring the notification watchers: a `DISCORD_BOT_TOKEN` (how to connect) and the new
+`discordBot` preference (whether to), read per message so the toggle applies without a restart.
+Both absent by default — unlike a notification, this one acts on what it reads. Set
+`DISCORD_CHANNEL_ID` to confine it to one channel.
+
+The gateway client is hand-rolled over node's global `WebSocket` rather than adding `discord.js`,
+keeping the package's three runtime dependencies intact, and reconnects with exponential backoff so
+a refused connection never becomes a tight loop.

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -39,6 +39,9 @@ import { runOptionsFromPreferences, preferencesFromFileConfig } from './run-opti
 import { loadFrameworkConfig } from './config.js'
 import { installProject, enumerateGitRepos } from './install.js'
 import { JsonlTailer } from './jsonl-tail.js'
+import { startDiscordBot } from './discord/bot.js'
+import { snapshotLiveRun } from './discord/live-run.js'
+import { sendChoice, sendMessage, sendStop } from './dashboard-rpc/control.telefunc.js'
 
 /**
  * The persistent background dashboard (#302). Today the dashboard dies with the
@@ -514,8 +517,54 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     log: message => console.log(message),
   })
 
+  // The Discord chatbot (#680): chat to The Framework from Discord. Two gates, mirroring the
+  // notification watchers above — a `DISCORD_BOT_TOKEN` (a bot can read replies; the #627 webhook
+  // cannot) and the per-user `discordBot` preference, read per message so the toggle takes effect
+  // without a daemon restart. Unset token means no bot, exactly as before.
+  const botToken = env.DISCORD_BOT_TOKEN
+  // Say so when the token is set but the toggle is not: the bot would otherwise connect and then
+  // ignore every message, which reads as broken rather than as off.
+  if (botToken) {
+    void readPrefs().then(prefs => {
+      if (prefs.discordBot !== true) {
+        console.log('[framework] Discord bot: DISCORD_BOT_TOKEN is set but the `discordBot` preference is off, so it will not answer.')
+      }
+    })
+  }
+  // The daemon's own project, resolved the same way the runtime resolves it. Chat has no project
+  // picker, so a message with no run to join starts one here.
+  const botHomeId = projectId(resolve(cwd))
+  const botProjectPath = async (id: string) => (await listSummaries()).find(p => p.id === id)?.path ?? cwd
+  const discordBot = botToken
+    ? startDiscordBot({
+        token: botToken,
+        target: async () => {
+          const home = (await listSummaries()).find(p => p.id === botHomeId)
+          return home ? { id: home.id, name: home.name } : { id: botHomeId, name: basename(cwd) }
+        },
+        liveRun: async id => snapshotLiveRun(id, await botProjectPath(id)),
+        start: async (id, text) => {
+          // Same resolution and the same forced `unattended` as auto PM (#846/#858): nobody is
+          // watching a chat-started run either, so a parked gate would hang it. The gate is then
+          // answered from Discord by number instead.
+          const options = await resolvedRunOptions(id)
+          const result = await runtime.onStart(text, 'prompt', { ...options, unattended: true }, id)
+          return result.ok ? result.runId : undefined
+        },
+        sendMessage: (id, text, runId) => sendMessage(id, text, runId),
+        sendChoice: (id, gateId, pick, runId) => sendChoice(id, gateId, pick, 'user', runId),
+        sendStop: (id, runId) => sendStop(id, runId),
+        enabled: async () => (await readPrefs()).discordBot === true,
+        ...(env.DISCORD_CHANNEL_ID ? { channelId: env.DISCORD_CHANNEL_ID } : {}),
+        onLog: message => console.log(`[framework] ${message}`),
+      })
+    : undefined
+
   await waitForShutdown(opts.signal)
 
+  // Ctrl+C takes the bot offline (#680). Its gateway socket is the one connection here that
+  // would otherwise hold the event loop open on its own.
+  discordBot?.stop()
   autoPm.stop()
   // Stopped here as well as by the dashboard: a broken install serves 503s without ever taking
   // ownership of the source we handed in, and that poller would go on reading by itself.

--- a/packages/framework/src/discord/bot.test.ts
+++ b/packages/framework/src/discord/bot.test.ts
@@ -1,0 +1,148 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { startDiscordBot, type DiscordBotOptions } from './bot.js'
+import type { DiscordMessage, GatewaySocket } from './gateway.js'
+import type { RunSnapshot } from './routing.js'
+
+/** A socket that does nothing: these tests drive `handleMessage` directly. */
+const deadSocket: GatewaySocket = {
+  send: () => {},
+  close: () => {},
+  onMessage: () => {},
+  onClose: () => {},
+  onError: () => {},
+}
+
+interface Calls {
+  messages: { projectId: string; text: string; runId: string }[]
+  choices: { projectId: string; gateId: string; pick: string | string[]; runId: string }[]
+  stops: { projectId: string; runId: string }[]
+  starts: { projectId: string; text: string }[]
+  posted: string[]
+}
+
+function bot(over: Partial<DiscordBotOptions> = {}) {
+  const calls: Calls = { messages: [], choices: [], stops: [], starts: [], posted: [] }
+  const fetchImpl = (async (_url: string, init?: RequestInit) => {
+    calls.posted.push(String(JSON.parse(String(init?.body))['content']))
+    return new Response(null, { status: 200 })
+  }) as unknown as typeof fetch
+
+  const handle = startDiscordBot({
+    token: 'tok',
+    target: async () => ({ id: 'p1', name: 'gemstack' }),
+    liveRun: async () => undefined,
+    start: async (projectId, text) => {
+      calls.starts.push({ projectId, text })
+      return 'r-new'
+    },
+    sendMessage: async (projectId, text, runId) => {
+      calls.messages.push({ projectId, text, runId })
+    },
+    sendChoice: async (projectId, gateId, pick, runId) => {
+      calls.choices.push({ projectId, gateId, pick, runId })
+    },
+    sendStop: async (projectId, runId) => {
+      calls.stops.push({ projectId, runId })
+    },
+    fetchImpl,
+    gateway: { socket: () => deadSocket, interval: () => ({ stop: () => {} }), url: 'wss://test' },
+    ...over,
+  })
+  return { handle, calls }
+}
+
+function message(over: Partial<DiscordMessage> = {}): DiscordMessage {
+  return { id: 'm1', channelId: 'c1', content: 'hello', authorId: 'u1', authorName: 'sul', fromBot: false, ...over }
+}
+
+const liveRun = (gate?: RunSnapshot['gate']): DiscordBotOptions['liveRun'] =>
+  async () => ({ projectId: 'p1', runId: 'r1', ...(gate ? { gate } : {}) })
+
+test('a message with no run live starts one and says so', async () => {
+  const { handle, calls } = bot()
+  await handle.handleMessage(message({ content: 'add a hello function' }))
+
+  assert.deepEqual(calls.starts, [{ projectId: 'p1', text: 'add a hello function' }])
+  assert.equal(calls.messages.length, 0)
+  assert.match(calls.posted[0] ?? '', /Starting a session/)
+})
+
+test('a message with a run live reaches the run through the control channel', async () => {
+  const { handle, calls } = bot({ liveRun: liveRun() })
+  await handle.handleMessage(message({ content: 'also add tests' }))
+
+  assert.deepEqual(calls.messages, [{ projectId: 'p1', text: 'also add tests', runId: 'r1' }])
+  assert.equal(calls.starts.length, 0)
+})
+
+test('a numbered reply answers the parked gate', async () => {
+  const gate = { id: 'g1', title: 'Proceed?', options: [{ id: 'yes', label: 'Yes' }, { id: 'no', label: 'No' }] }
+  const { handle, calls } = bot({ liveRun: liveRun(gate) })
+  await handle.handleMessage(message({ content: '2' }))
+
+  assert.deepEqual(calls.choices, [{ projectId: 'p1', gateId: 'g1', pick: 'no', runId: 'r1' }])
+})
+
+test('the bot does nothing while the preference is off', async () => {
+  const { handle, calls } = bot({ enabled: async () => false })
+  await handle.handleMessage(message({ content: 'do a thing' }))
+
+  assert.equal(calls.starts.length, 0)
+  assert.equal(calls.posted.length, 0, 'not even a reply: an off bot is silent')
+})
+
+test('the preference is read per message, so a toggle needs no restart', async () => {
+  let on = false
+  const { handle, calls } = bot({ enabled: async () => on })
+  await handle.handleMessage(message({ content: 'first' }))
+  on = true
+  await handle.handleMessage(message({ content: 'second' }))
+
+  assert.deepEqual(calls.starts, [{ projectId: 'p1', text: 'second' }])
+})
+
+test('a channel filter ignores everything else', async () => {
+  const { handle, calls } = bot({ channelId: 'only-here' })
+  await handle.handleMessage(message({ channelId: 'elsewhere' }))
+  assert.equal(calls.starts.length, 0)
+
+  await handle.handleMessage(message({ channelId: 'only-here', content: 'go' }))
+  assert.deepEqual(calls.starts, [{ projectId: 'p1', text: 'go' }])
+})
+
+test('a run that will not start is reported, not silently dropped', async () => {
+  const { handle, calls } = bot({ start: async () => undefined })
+  await handle.handleMessage(message({ content: 'go' }))
+  assert.match(calls.posted[0] ?? '', /Could not start/)
+})
+
+test('no registered project is reported rather than throwing', async () => {
+  const { handle, calls } = bot({ target: async () => undefined })
+  await handle.handleMessage(message())
+  assert.match(calls.posted[0] ?? '', /No project is registered/)
+})
+
+test('a failing effect is logged, never thrown at the gateway', async () => {
+  const logs: string[] = []
+  const { handle } = bot({
+    start: async () => {
+      throw new Error('boom')
+    },
+    onLog: m => logs.push(m),
+  })
+  await assert.doesNotReject(handle.handleMessage(message({ content: 'go' })))
+  assert.ok(logs.some(l => /boom/.test(l)), `expected the failure logged, got ${JSON.stringify(logs)}`)
+})
+
+test('!stop stops the live run', async () => {
+  const { handle, calls } = bot({ liveRun: liveRun() })
+  await handle.handleMessage(message({ content: '!stop' }))
+  assert.deepEqual(calls.stops, [{ projectId: 'p1', runId: 'r1' }])
+})
+
+test('stop() is safe to call and takes the bot offline', () => {
+  const { handle } = bot()
+  assert.doesNotThrow(() => handle.stop())
+  assert.doesNotThrow(() => handle.stop(), 'idempotent')
+})

--- a/packages/framework/src/discord/bot.ts
+++ b/packages/framework/src/discord/bot.ts
@@ -1,0 +1,123 @@
+import { DiscordGateway, type DiscordMessage, type GatewayDeps } from './gateway.js'
+import { postMessage } from './rest.js'
+import { decideAction, type ProjectTarget, type RunSnapshot } from './routing.js'
+
+/**
+ * The Discord chatbot (#680): chat to The Framework from Discord instead of the dashboard.
+ *
+ * Every effect is an injected function, so the whole bot is testable by handing it a fake
+ * message — the routing decisions live in `routing.ts` and are pure, and this module is only
+ * the wiring. Same seam-and-`stop()` shape as the intervention/activity watchers.
+ *
+ * Chat history is not written here: a message routed into a run reaches that run's conversation
+ * through the control channel, and the run commits it to `.the-framework/conversations/` (#908).
+ * That is the answer to the question #680 asked — the Git repo, via the run that received it.
+ */
+
+/** Everything the bot needs from the daemon. */
+export interface DiscordBotOptions {
+  /** The bot token. Distinct from the notification webhook (#627), which cannot read replies. */
+  token: string
+  /** The project a message belongs to when no run is live. */
+  target: () => Promise<ProjectTarget | undefined>
+  /** That project's live run, if it has one. */
+  liveRun: (projectId: string) => Promise<RunSnapshot | undefined>
+  /** Start a new run; resolves the run id, or `undefined` when it could not start. */
+  start: (projectId: string, text: string) => Promise<string | undefined>
+  sendMessage: (projectId: string, text: string, runId: string) => Promise<void>
+  sendChoice: (projectId: string, gateId: string, pick: string | string[], runId: string) => Promise<void>
+  sendStop: (projectId: string, runId: string) => Promise<void>
+  /**
+   * Whether the bot should act, read per message rather than at start, so turning it off takes
+   * effect without restarting the daemon — the same contract the notification watchers follow.
+   */
+  enabled?: () => Promise<boolean>
+  /** Restrict the bot to one channel. Unset means it answers wherever it is addressed. */
+  channelId?: string | undefined
+  fetchImpl?: typeof fetch
+  onLog?: (message: string) => void
+  /** Gateway seams, for tests. */
+  gateway?: GatewayDeps
+}
+
+/** A running bot. `stop()` is what takes it offline on `Ctrl+C`. */
+export interface DiscordBot {
+  stop(): void
+  /** Handle one message. Exposed so tests drive a cycle without a socket, like the watchers' `poll()`. */
+  handleMessage(message: DiscordMessage): Promise<void>
+}
+
+/**
+ * Connect the bot and route messages. Never throws: a chat integration that can take the daemon
+ * down is worse than one that is quiet.
+ */
+export function startDiscordBot(opts: DiscordBotOptions): DiscordBot {
+  const log = (message: string): void => opts.onLog?.(message)
+
+  const handleMessage = async (message: DiscordMessage): Promise<void> => {
+    try {
+      if (opts.channelId && message.channelId !== opts.channelId) return
+      if (opts.enabled && !(await opts.enabled())) return
+
+      const target = await opts.target()
+      if (!target) {
+        await reply(message, 'No project is registered with The Framework yet.')
+        return
+      }
+      const live = await opts.liveRun(target.id).catch(() => undefined)
+      const action = decideAction(message.content, { live, target })
+
+      switch (action.kind) {
+        case 'choice':
+          await opts.sendChoice(action.projectId, action.gateId, action.pick, action.runId)
+          break
+        case 'message':
+          await opts.sendMessage(action.projectId, action.text, action.runId)
+          break
+        case 'stop':
+          await opts.sendStop(action.projectId, action.runId)
+          break
+        case 'start': {
+          const runId = await opts.start(action.projectId, action.text)
+          if (!runId) {
+            await reply(message, 'Could not start a session. It may already be busy.')
+            return
+          }
+          break
+        }
+        case 'reply':
+          break
+      }
+      await reply(message, action.reply)
+    } catch (err) {
+      log(`Discord bot could not handle a message: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  const reply = async (to: DiscordMessage, content: string): Promise<void> => {
+    const sent = await postMessage(opts.token, to.channelId, content, {
+      replyToId: to.id,
+      ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+    })
+    if (!sent) log('Discord bot could not post a reply')
+  }
+
+  const gateway = new DiscordGateway(
+    opts.token,
+    {
+      onMessage: message => void handleMessage(message),
+      onReady: id => log(`Discord bot online (${id})`),
+      onLog: log,
+    },
+    opts.gateway ?? {},
+  )
+  gateway.connect()
+
+  return {
+    stop: () => {
+      gateway.stop()
+      log('Discord bot offline')
+    },
+    handleMessage,
+  }
+}

--- a/packages/framework/src/discord/gateway.test.ts
+++ b/packages/framework/src/discord/gateway.test.ts
@@ -1,0 +1,257 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import {
+  DiscordGateway,
+  parseMessage,
+  CHAT_INTENTS,
+  INTENTS,
+  OP,
+  type GatewaySocket,
+  type DiscordMessage,
+} from './gateway.js'
+
+/** A fake {@link GatewaySocket}, so the whole protocol is driven with no network. */
+function fakeSocket() {
+  const sent: Record<string, unknown>[] = []
+  let onMessage: ((data: string) => void) | undefined
+  let onClose: (() => void) | undefined
+  let closed = 0
+  const socket: GatewaySocket = {
+    send: data => sent.push(JSON.parse(data)),
+    close: () => {
+      closed++
+      onClose?.()
+    },
+    onMessage: handler => {
+      onMessage = handler
+    },
+    onClose: handler => {
+      onClose = handler
+    },
+    onError: () => {},
+  }
+  return {
+    socket,
+    sent,
+    get closed() {
+      return closed
+    },
+    receive: (payload: unknown) => onMessage?.(JSON.stringify(payload)),
+  }
+}
+
+/** A manual clock: the heartbeat fires only when the test says so. */
+function fakeInterval() {
+  let fn: (() => void) | undefined
+  let stopped = false
+  return {
+    factory: (callback: () => void) => {
+      fn = callback
+      return { stop: () => { stopped = true } }
+    },
+    tick: () => fn?.(),
+    get stopped() {
+      return stopped
+    },
+  }
+}
+
+/** A manual reconnect timer: the test decides when a backed-off reconnect actually fires. */
+function fakeDelay() {
+  const waits: number[] = []
+  let fn: (() => void) | undefined
+  return {
+    factory: (callback: () => void, ms: number) => {
+      waits.push(ms)
+      fn = callback
+      return { stop: () => { fn = undefined } }
+    },
+    waits,
+    fire: () => {
+      const run = fn
+      fn = undefined
+      run?.()
+    },
+  }
+}
+
+function connect(handlers: { onMessage?: (m: DiscordMessage) => void; onLog?: (m: string) => void } = {}) {
+  const socket = fakeSocket()
+  const clock = fakeInterval()
+  const delay = fakeDelay()
+  const gateway = new DiscordGateway(
+    'tok',
+    { onMessage: handlers.onMessage ?? (() => {}), ...(handlers.onLog ? { onLog: handlers.onLog } : {}) },
+    { socket: () => socket.socket, interval: clock.factory, delay: delay.factory, url: 'wss://test' },
+  )
+  gateway.connect()
+  return { gateway, socket, clock, delay }
+}
+
+const HELLO = { op: OP.hello, d: { heartbeat_interval: 41250 } }
+const READY = { op: OP.dispatch, t: 'READY', s: 1, d: { session_id: 's1', resume_gateway_url: 'wss://resume', user: { id: 'self' } } }
+
+function messageEvent(over: Record<string, unknown> = {}) {
+  return {
+    op: OP.dispatch,
+    t: 'MESSAGE_CREATE',
+    s: 2,
+    d: { id: 'm1', channel_id: 'c1', content: 'hello', author: { id: 'u1', username: 'sul' }, ...over },
+  }
+}
+
+test('HELLO triggers an identify with the chat intents', () => {
+  const { socket } = connect()
+  socket.receive(HELLO)
+
+  const identify = socket.sent.find(p => p['op'] === OP.identify)
+  assert.ok(identify, 'identified')
+  const d = identify['d'] as Record<string, unknown>
+  assert.equal(d['token'], 'tok')
+  assert.equal(d['intents'], CHAT_INTENTS)
+  // MESSAGE_CONTENT is privileged; without it every message arrives blank.
+  assert.equal(CHAT_INTENTS & INTENTS.messageContent, INTENTS.messageContent)
+})
+
+test('a chat message reaches the handler', () => {
+  const seen: DiscordMessage[] = []
+  const { socket } = connect({ onMessage: m => seen.push(m) })
+  socket.receive(HELLO)
+  socket.receive(READY)
+  socket.receive(messageEvent())
+
+  assert.equal(seen.length, 1)
+  assert.equal(seen[0]?.content, 'hello')
+  assert.equal(seen[0]?.authorId, 'u1')
+  assert.equal(seen[0]?.channelId, 'c1')
+})
+
+test('our own messages and other bots are ignored, so two bots cannot loop', () => {
+  const seen: DiscordMessage[] = []
+  const { socket } = connect({ onMessage: m => seen.push(m) })
+  socket.receive(HELLO)
+  socket.receive(READY)
+  socket.receive(messageEvent({ author: { id: 'self', username: 'us' } }))
+  socket.receive(messageEvent({ author: { id: 'other', username: 'bot', bot: true } }))
+
+  assert.equal(seen.length, 0)
+})
+
+test('an empty content says the privileged intent is missing rather than failing silently', () => {
+  const logs: string[] = []
+  const { socket } = connect({ onLog: m => logs.push(m) })
+  socket.receive(HELLO)
+  socket.receive(READY)
+  socket.receive(messageEvent({ content: '' }))
+
+  assert.ok(logs.some(l => /MESSAGE CONTENT/.test(l)), `expected an intent hint, got ${JSON.stringify(logs)}`)
+})
+
+test('heartbeats carry the last sequence, and a missed ack drops the zombie connection', () => {
+  const { socket, clock } = connect()
+  socket.receive(HELLO)
+  socket.receive(READY) // s: 1
+
+  clock.tick()
+  const beat = socket.sent.find(p => p['op'] === OP.heartbeat)
+  assert.equal(beat?.['d'], 1, 'heartbeat carries the sequence')
+
+  // No ACK before the next tick: the connection is a zombie and must be dropped.
+  const before = socket.closed
+  clock.tick()
+  assert.ok(socket.closed > before, 'closed the un-acked connection')
+})
+
+test('an acked heartbeat keeps the connection', () => {
+  const { socket, clock } = connect()
+  socket.receive(HELLO)
+  clock.tick()
+  socket.receive({ op: OP.heartbeatAck })
+  const before = socket.closed
+  clock.tick()
+  assert.equal(socket.closed, before, 'still connected')
+})
+
+test('a reconnect resumes with the session, an invalid session identifies fresh', () => {
+  const { socket, delay } = connect()
+  socket.receive(HELLO)
+  socket.receive(READY)
+
+  // op 7: close, reopen, and RESUME rather than start over.
+  socket.receive({ op: OP.reconnect })
+  delay.fire()
+  socket.receive(HELLO)
+  assert.ok(socket.sent.some(p => p['op'] === OP.resume), 'resumed')
+
+  // op 9: the session is gone, so the next HELLO must identify, not resume.
+  const beforeIdentifies = socket.sent.filter(p => p['op'] === OP.identify).length
+  socket.receive({ op: OP.invalidSession })
+  delay.fire()
+  socket.receive(HELLO)
+  assert.equal(socket.sent.filter(p => p['op'] === OP.identify).length, beforeIdentifies + 1, 're-identified')
+})
+
+test('a failing connection backs off instead of looping tight', () => {
+  // A socket that closes as fast as it opens (offline, bad token) reconnected inline would pin a
+  // core and get the bot rate-limited.
+  const { socket, delay } = connect()
+  for (let i = 0; i < 5; i++) {
+    socket.socket.close() // the server hangs up immediately
+    delay.fire()
+  }
+  assert.deepEqual(delay.waits.slice(0, 4), [1_000, 2_000, 4_000, 8_000], 'doubling')
+  assert.ok(Math.max(...delay.waits) <= 60_000, 'capped')
+})
+
+test('a healthy connection resets the backoff', () => {
+  const { socket, delay } = connect()
+  socket.socket.close()
+  delay.fire()
+  socket.socket.close()
+  delay.fire()
+  assert.deepEqual(delay.waits, [1_000, 2_000])
+
+  socket.receive(HELLO)
+  socket.receive(READY) // reached READY: healthy
+  socket.socket.close()
+  assert.equal(delay.waits.at(-1), 1_000, 'backoff started over')
+})
+
+test('stop() cancels a pending reconnect', () => {
+  const { gateway, socket, delay } = connect()
+  socket.socket.close() // schedules a reconnect
+  gateway.stop()
+
+  const before = socket.sent.length
+  delay.fire() // the timer would have fired had it not been cancelled
+  socket.receive(HELLO)
+  assert.equal(socket.sent.length, before, 'stayed offline')
+})
+
+test('stop() closes the socket and does not reconnect (#680 Ctrl+C)', () => {
+  const { gateway, socket, clock } = connect()
+  socket.receive(HELLO)
+  socket.receive(READY)
+
+  const sentBefore = socket.sent.length
+  gateway.stop()
+  assert.ok(clock.stopped, 'heartbeat stopped')
+
+  // The close handler fires; nothing should be re-sent on a socket we closed on purpose.
+  socket.receive(HELLO)
+  assert.equal(socket.sent.length, sentBefore, 'no identify/resume after stop')
+})
+
+test('a malformed frame is ignored, never thrown', () => {
+  const { socket } = connect()
+  assert.doesNotThrow(() => socket.receive('not json' as unknown))
+  socket.receive({ op: 999 })
+})
+
+test('parseMessage narrows the payload and rejects an unusable one', () => {
+  const parsed = parseMessage({ id: 'm', channel_id: 'c', content: 'x', author: { id: 'a', global_name: 'Sul' } })
+  assert.equal(parsed?.authorName, 'Sul')
+  assert.equal(parsed?.fromBot, false)
+  assert.equal(parseMessage({ id: 'm' }), undefined)
+  assert.equal(parseMessage(null), undefined)
+})

--- a/packages/framework/src/discord/gateway.ts
+++ b/packages/framework/src/discord/gateway.ts
@@ -1,0 +1,377 @@
+/**
+ * A minimal Discord gateway client (#680): the inbound half of the Discord integration, which
+ * until now was outbound-only — a webhook `POST` can notify, but it cannot read a reply (#627).
+ *
+ * Deliberately hand-rolled over the global `WebSocket` rather than pulling in `discord.js`. The
+ * package has three runtime dependencies and builds everything else on node builtins behind
+ * injectable seams; a client library for the handful of opcodes below would be the largest
+ * dependency in the package by an order of magnitude.
+ *
+ * Implements only what a chat bot needs: identify, heartbeat, resume, and message events.
+ */
+
+/** Gateway opcodes we act on. */
+export const OP = {
+  dispatch: 0,
+  heartbeat: 1,
+  identify: 2,
+  resume: 6,
+  reconnect: 7,
+  invalidSession: 9,
+  hello: 10,
+  heartbeatAck: 11,
+} as const
+
+/**
+ * Gateway intents. `MESSAGE_CONTENT` is privileged: it must be enabled on the application in
+ * Discord's developer portal, or the gateway connects and every message arrives with an empty
+ * `content`. That failure is silent, which is why {@link DiscordGateway} logs it explicitly.
+ */
+export const INTENTS = {
+  guildMessages: 1 << 9,
+  directMessages: 1 << 12,
+  messageContent: 1 << 15,
+} as const
+
+/** The intents a chat bot needs: messages in channels and DMs, plus their text. */
+export const CHAT_INTENTS = INTENTS.guildMessages | INTENTS.directMessages | INTENTS.messageContent
+
+/** The default gateway endpoint. v10, JSON encoding (no `zlib-stream`, no `etf`). */
+export const GATEWAY_URL = 'wss://gateway.discord.gg/?v=10&encoding=json'
+
+/**
+ * The socket seam. Mirrors the slice of `WebSocket` this uses, so a test drives the protocol
+ * with a fake and no network — the same shape the watchers use for `fetch`.
+ */
+export interface GatewaySocket {
+  send(data: string): void
+  close(): void
+  onMessage(handler: (data: string) => void): void
+  onClose(handler: () => void): void
+  onError(handler: (err: unknown) => void): void
+}
+
+/** Opens a {@link GatewaySocket} for a url. */
+export type SocketFactory = (url: string) => GatewaySocket
+
+/** A cancellable timer, so heartbeats are deterministic under test. */
+export interface Timer {
+  stop(): void
+}
+
+/** Schedules `fn` every `ms`. Default wraps `setInterval` and unrefs it. */
+export type IntervalFactory = (fn: () => void, ms: number) => Timer
+
+/** Schedules `fn` once after `ms`. Default wraps `setTimeout` and unrefs it. */
+export type DelayFactory = (fn: () => void, ms: number) => Timer
+
+/** Reconnect backoff bounds. A failed connect must not become a tight loop against Discord. */
+export const RECONNECT_MS = 1_000
+export const RECONNECT_MAX_MS = 60_000
+
+/** One inbound chat message, narrowed to what routing needs. */
+export interface DiscordMessage {
+  id: string
+  channelId: string
+  /** Message text. Empty when the privileged MESSAGE_CONTENT intent is not enabled. */
+  content: string
+  authorId: string
+  authorName: string
+  /** Whether the author is a bot (including us): never act on these, or two bots loop forever. */
+  fromBot: boolean
+  /** Set when the message replies to another, used to thread an answer back to its gate. */
+  replyToId?: string
+}
+
+/** What {@link DiscordGateway} reports to its owner. */
+export interface GatewayHandlers {
+  onMessage(message: DiscordMessage): void
+  /** Connected and identified; carries our own user id so we can ignore our own messages. */
+  onReady?(selfId: string): void
+  /** Non-fatal diagnostics (a failed resume, a missing intent). */
+  onLog?(message: string): void
+}
+
+/** Injectable seams for {@link DiscordGateway}. */
+export interface GatewayDeps {
+  socket?: SocketFactory
+  interval?: IntervalFactory
+  delay?: DelayFactory
+  url?: string
+}
+
+/** A {@link SocketFactory} over the global `WebSocket` (node >= 22 ships one). */
+export function nodeSocketFactory(): SocketFactory {
+  return url => {
+    const ws = new WebSocket(url)
+    return {
+      send: data => ws.send(data),
+      close: () => ws.close(),
+      onMessage: handler => ws.addEventListener('message', event => handler(String((event as MessageEvent).data))),
+      onClose: handler => ws.addEventListener('close', () => handler()),
+      onError: handler => ws.addEventListener('error', err => handler(err)),
+    }
+  }
+}
+
+/** The default {@link IntervalFactory}: unref'd, so a heartbeat never keeps the daemon alive. */
+export function nodeIntervalFactory(): IntervalFactory {
+  return (fn, ms) => {
+    const timer = setInterval(fn, ms)
+    timer.unref?.()
+    return { stop: () => clearInterval(timer) }
+  }
+}
+
+/** The default {@link DelayFactory}: unref'd, so a pending reconnect never keeps the daemon alive. */
+export function nodeDelayFactory(): DelayFactory {
+  return (fn, ms) => {
+    const timer = setTimeout(fn, ms)
+    timer.unref?.()
+    return { stop: () => clearTimeout(timer) }
+  }
+}
+
+/**
+ * A connected Discord bot session. Owns the socket, the heartbeat, and the resume state; hands
+ * every chat message to its {@link GatewayHandlers}.
+ *
+ * Errors are swallowed into `onLog` rather than thrown: a notifier must never take the daemon
+ * down, which is the same contract the intervention/activity watchers follow.
+ */
+export class DiscordGateway {
+  private socket: GatewaySocket | undefined
+  private heartbeat: Timer | undefined
+  private sequence: number | undefined
+  private sessionId: string | undefined
+  private resumeUrl: string | undefined
+  private acked = true
+  private selfId: string | undefined
+  /** Set by {@link stop}, so a socket closing on our own terms never reconnects. */
+  private stopped = false
+  /** Consecutive reconnects, for the backoff. Reset once a connection actually works. */
+  private attempts = 0
+  private pendingReconnect: Timer | undefined
+
+  constructor(
+    private readonly token: string,
+    private readonly handlers: GatewayHandlers,
+    private readonly deps: GatewayDeps = {},
+  ) {}
+
+  /** Open the connection and identify. Safe to call once; use {@link stop} to end it. */
+  connect(): void {
+    this.stopped = false
+    this.open(this.deps.url ?? GATEWAY_URL)
+  }
+
+  /**
+   * Close the connection for good. This is what takes the bot offline on `Ctrl+C` (#680): the
+   * daemon calls it from its shutdown block, and no reconnect follows.
+   */
+  stop(): void {
+    this.stopped = true
+    this.heartbeat?.stop()
+    this.heartbeat = undefined
+    this.pendingReconnect?.stop()
+    this.pendingReconnect = undefined
+    try {
+      this.socket?.close()
+    } catch {
+      // Already closing; nothing to do.
+    }
+    this.socket = undefined
+  }
+
+  /** Our own user id once READY has landed. */
+  get userId(): string | undefined {
+    return this.selfId
+  }
+
+  private open(url: string): void {
+    const factory = this.deps.socket ?? nodeSocketFactory()
+    let socket: GatewaySocket
+    try {
+      socket = factory(url)
+    } catch (err) {
+      this.log(`could not open the Discord gateway: ${errText(err)}`)
+      return
+    }
+    this.socket = socket
+    socket.onMessage(data => this.receive(data))
+    socket.onError(err => this.log(`Discord gateway error: ${errText(err)}`))
+    socket.onClose(() => this.reopen())
+  }
+
+  /**
+   * A closed socket we did not close ourselves: resume if we can, else identify fresh.
+   *
+   * Backed off, and that is not a nicety: a connection that fails immediately (offline, a bad
+   * token) closes as fast as it opens, so reconnecting inline is a tight loop that pins a core
+   * and gets the bot rate-limited. Doubles to a cap, and resets once a connection works.
+   */
+  private reopen(): void {
+    this.heartbeat?.stop()
+    this.heartbeat = undefined
+    if (this.stopped) return
+
+    const wait = Math.min(RECONNECT_MS * 2 ** this.attempts, RECONNECT_MAX_MS)
+    this.attempts++
+    const schedule = this.deps.delay ?? nodeDelayFactory()
+    this.pendingReconnect?.stop()
+    this.pendingReconnect = schedule(() => {
+      if (this.stopped) return
+      this.open(this.resumeUrl ?? this.deps.url ?? GATEWAY_URL)
+    }, wait)
+  }
+
+  private receive(raw: string): void {
+    let payload: { op?: number; d?: unknown; s?: number; t?: string }
+    try {
+      payload = JSON.parse(raw)
+    } catch {
+      return // A frame we cannot read is not a frame we can act on.
+    }
+    if (typeof payload.s === 'number') this.sequence = payload.s
+
+    switch (payload.op) {
+      case OP.hello:
+        this.onHello(payload.d)
+        return
+      case OP.heartbeatAck:
+        this.acked = true
+        return
+      case OP.heartbeat:
+        this.sendHeartbeat()
+        return
+      case OP.reconnect:
+        // Discord asked us to move; close and let onClose resume us.
+        this.socket?.close()
+        return
+      case OP.invalidSession:
+        // The session is gone: drop it so the reconnect identifies fresh instead of resuming.
+        this.sessionId = undefined
+        this.resumeUrl = undefined
+        this.socket?.close()
+        return
+      case OP.dispatch:
+        this.onDispatch(payload.t, payload.d)
+        return
+      default:
+        return
+    }
+  }
+
+  private onHello(data: unknown): void {
+    const interval = asRecord(data)?.['heartbeat_interval']
+    const ms = typeof interval === 'number' && interval > 0 ? interval : 45_000
+    const schedule = this.deps.interval ?? nodeIntervalFactory()
+    this.acked = true
+    this.heartbeat = schedule(() => {
+      // A missed ACK means the connection is a zombie: drop it and let onClose resume.
+      if (!this.acked) {
+        this.log('Discord gateway missed a heartbeat ack; reconnecting')
+        this.socket?.close()
+        return
+      }
+      this.acked = false
+      this.sendHeartbeat()
+    }, ms)
+
+    if (this.sessionId) this.resume()
+    else this.identify()
+  }
+
+  private identify(): void {
+    this.send({
+      op: OP.identify,
+      d: {
+        token: this.token,
+        intents: CHAT_INTENTS,
+        properties: { os: process.platform, browser: 'the-framework', device: 'the-framework' },
+      },
+    })
+  }
+
+  private resume(): void {
+    this.send({ op: OP.resume, d: { token: this.token, session_id: this.sessionId, seq: this.sequence ?? 0 } })
+  }
+
+  private sendHeartbeat(): void {
+    this.send({ op: OP.heartbeat, d: this.sequence ?? null })
+  }
+
+  private onDispatch(type: string | undefined, data: unknown): void {
+    if (type === 'READY') {
+      this.attempts = 0 // A connection that reached READY is healthy; start the backoff over.
+      const d = asRecord(data)
+      this.sessionId = asString(d?.['session_id'])
+      const resume = asString(d?.['resume_gateway_url'])
+      // Discord's resume url carries no query, so keep our version/encoding on it.
+      if (resume) this.resumeUrl = `${resume}?v=10&encoding=json`
+      this.selfId = asString(asRecord(d?.['user'])?.['id'])
+      if (this.selfId) this.handlers.onReady?.(this.selfId)
+      return
+    }
+    if (type === 'RESUMED') return
+    if (type !== 'MESSAGE_CREATE') return
+
+    const message = parseMessage(data)
+    if (!message) return
+    // Never act on a bot's message, our own most of all: two bots replying to each other is an
+    // unbounded loop that costs real money.
+    if (message.fromBot || message.authorId === this.selfId) return
+    if (!message.content.trim()) {
+      this.log('a Discord message arrived with no content: enable the MESSAGE CONTENT intent for the bot')
+      return
+    }
+    this.handlers.onMessage(message)
+  }
+
+  private send(payload: unknown): void {
+    try {
+      this.socket?.send(JSON.stringify(payload))
+    } catch (err) {
+      this.log(`could not send to the Discord gateway: ${errText(err)}`)
+    }
+  }
+
+  private log(message: string): void {
+    this.handlers.onLog?.(message)
+  }
+}
+
+/** Narrow a MESSAGE_CREATE payload; `undefined` when it is not a shape we can use. */
+export function parseMessage(data: unknown): DiscordMessage | undefined {
+  const d = asRecord(data)
+  if (!d) return undefined
+  const author = asRecord(d['author'])
+  const id = asString(d['id'])
+  const channelId = asString(d['channel_id'])
+  const authorId = asString(author?.['id'])
+  if (!id || !channelId || !authorId) return undefined
+
+  const message: DiscordMessage = {
+    id,
+    channelId,
+    content: asString(d['content']) ?? '',
+    authorId,
+    authorName: asString(author?.['global_name']) ?? asString(author?.['username']) ?? authorId,
+    fromBot: author?.['bot'] === true,
+  }
+  const replyTo = asString(asRecord(d['referenced_message'])?.['id'])
+  if (replyTo) message.replyToId = replyTo
+  return message
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : undefined
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/packages/framework/src/discord/live-run.test.ts
+++ b/packages/framework/src/discord/live-run.test.ts
@@ -1,0 +1,45 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import type { FrameworkEvent } from '../events.js'
+import { openGate } from './live-run.js'
+
+const choice = (id: string): FrameworkEvent =>
+  ({
+    kind: 'choice',
+    id,
+    title: 'Proceed?',
+    options: [
+      { id: 'yes', label: 'Yes' },
+      { id: 'no', label: 'No' },
+    ],
+  }) as FrameworkEvent
+
+const resolved = (id: string): FrameworkEvent => ({ kind: 'choice-resolved', id, picked: 'yes', by: 'user' }) as FrameworkEvent
+
+test('openGate reads the options the run meta does not carry', () => {
+  // `pendingChoice` has only the id and title, so the options come from the event log.
+  const gate = openGate([choice('g1')], 'g1')
+  assert.equal(gate?.title, 'Proceed?')
+  assert.deepEqual(gate?.options, [
+    { id: 'yes', label: 'Yes' },
+    { id: 'no', label: 'No' },
+  ])
+})
+
+test('an already-answered gate is not open', () => {
+  // Otherwise a chat reply would answer a question the dashboard already closed.
+  assert.equal(openGate([choice('g1'), resolved('g1')], 'g1'), undefined)
+})
+
+test('a gate re-asked after being resolved is open again', () => {
+  assert.ok(openGate([choice('g1'), resolved('g1'), choice('g1')], 'g1'))
+})
+
+test('another gate id does not match', () => {
+  assert.equal(openGate([choice('g1')], 'other'), undefined)
+})
+
+test('a multi-select gate is marked as one', () => {
+  const multi = { ...choice('g1'), multi: true } as FrameworkEvent
+  assert.equal(openGate([multi], 'g1')?.multi, true)
+})

--- a/packages/framework/src/discord/live-run.ts
+++ b/packages/framework/src/discord/live-run.ts
@@ -1,0 +1,75 @@
+import { join } from 'node:path'
+import type { FrameworkEvent } from '../events.js'
+import { EVENTS_FILE, FRAMEWORK_DIR, nodeStoreFs, readLiveMetas, type StoreFs } from '../store/index.js'
+import type { Gate, RunSnapshot } from './routing.js'
+
+/**
+ * Turn a project's on-disk run state into the {@link RunSnapshot} routing decides against (#680).
+ *
+ * The parked gate needs its options, and those are not on the run meta: `pendingChoice` carries
+ * only the gate's id and title, because that is all the dashboard's rail needed. The options live
+ * in the `choice` event, so answering "2" from chat means reading the run's event log.
+ */
+
+/** Read a run's live event log. Missing/unreadable yields `[]` — never throws. */
+export async function readLiveEvents(runCwd: string, fs: StoreFs = nodeStoreFs()): Promise<FrameworkEvent[]> {
+  const path = join(runCwd, FRAMEWORK_DIR, EVENTS_FILE)
+  try {
+    if (!(await fs.exists(path))) return []
+    const events: FrameworkEvent[] = []
+    for (const line of (await fs.read(path)).split('\n')) {
+      if (!line.trim()) continue
+      try {
+        events.push(JSON.parse(line) as FrameworkEvent)
+      } catch {
+        // A torn last line is normal while a run is writing; skip it.
+      }
+    }
+    return events
+  } catch {
+    return []
+  }
+}
+
+/**
+ * The still-open gate with this id, or `undefined` when it was already answered. A gate is open
+ * when its `choice` event has no later `choice-resolved` for the same id — otherwise a chat reply
+ * would answer a question the dashboard already closed.
+ */
+export function openGate(events: FrameworkEvent[], gateId: string): Gate | undefined {
+  let gate: Gate | undefined
+  for (const event of events) {
+    if (event.kind === 'choice' && event.id === gateId) {
+      gate = {
+        id: event.id,
+        title: event.title,
+        options: event.options.map(option => ({ id: option.id, label: option.label })),
+        ...(event.multi ? { multi: true } : {}),
+      }
+    } else if (event.kind === 'choice-resolved' && event.id === gateId) {
+      gate = undefined
+    }
+  }
+  return gate
+}
+
+/**
+ * The project's live run, with its parked gate resolved. `undefined` when nothing is running.
+ * Forgiving throughout: a chat integration must never fail on unreadable run state.
+ */
+export async function snapshotLiveRun(
+  projectId: string,
+  projectCwd: string,
+  fs: StoreFs = nodeStoreFs(),
+): Promise<RunSnapshot | undefined> {
+  const metas = await readLiveMetas(projectCwd, fs).catch(() => [])
+  const running = metas.find(meta => meta.status === 'running')
+  if (!running) return undefined
+
+  const snapshot: RunSnapshot = { projectId, runId: running.id }
+  if (running.pendingChoice) {
+    const gate = openGate(await readLiveEvents(running.cwd, fs), running.pendingChoice.id)
+    if (gate) snapshot.gate = gate
+  }
+  return snapshot
+}

--- a/packages/framework/src/discord/rest.ts
+++ b/packages/framework/src/discord/rest.ts
@@ -1,0 +1,47 @@
+/**
+ * The Discord REST calls the bot needs (#680). Separate from the outbound webhook posts in the
+ * intervention/activity watchers (#627): a webhook can only speak into one channel and cannot
+ * reply, so a bot that answers where it was asked has to go through the API with its token.
+ *
+ * `fetch` is a parameter, exactly as in the watchers, so tests never touch the network.
+ */
+
+const API = 'https://discord.com/api/v10'
+
+/** Discord rejects a message over 2000 characters outright, so a long reply is trimmed. */
+export const MAX_CONTENT = 2000
+
+/** Trim to Discord's limit, marking the cut so a truncated answer never reads as a complete one. */
+export function clampContent(text: string): string {
+  if (text.length <= MAX_CONTENT) return text
+  const notice = '\n… (truncated)'
+  return text.slice(0, MAX_CONTENT - notice.length) + notice
+}
+
+/**
+ * Post a message to a channel as the bot. Resolves `false` on any failure — a reply that cannot
+ * be delivered must never take the daemon down.
+ */
+export async function postMessage(
+  token: string,
+  channelId: string,
+  content: string,
+  opts: { replyToId?: string; fetchImpl?: typeof fetch } = {},
+): Promise<boolean> {
+  const fetchImpl = opts.fetchImpl ?? fetch
+  const body: Record<string, unknown> = { content: clampContent(content) }
+  // Thread the answer onto the message that asked, so a busy channel stays readable.
+  if (opts.replyToId) {
+    body['message_reference'] = { message_id: opts.replyToId, fail_if_not_exists: false }
+  }
+  try {
+    const res = await fetchImpl(`${API}/channels/${encodeURIComponent(channelId)}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bot ${token}` },
+      body: JSON.stringify(body),
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}

--- a/packages/framework/src/discord/routing.test.ts
+++ b/packages/framework/src/discord/routing.test.ts
@@ -1,0 +1,108 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { decideAction, renderGate, resolvePick, HELP, type Gate, type RouteContext } from './routing.js'
+
+const TARGET = { id: 'p1', name: 'gemstack' }
+
+function gate(over: Partial<Gate> = {}): Gate {
+  return {
+    id: 'g1',
+    title: 'How should I proceed?',
+    options: [
+      { id: 'proceed', label: 'Proceed' },
+      { id: 'revise', label: 'Revise the plan' },
+    ],
+    ...over,
+  }
+}
+
+function ctx(over: Partial<RouteContext> = {}): RouteContext {
+  return { target: TARGET, ...over }
+}
+
+test('with nothing running, a message starts a session', () => {
+  const action = decideAction('add a hello function', ctx())
+  assert.equal(action.kind, 'start')
+  assert.equal(action.kind === 'start' && action.projectId, 'p1')
+  assert.equal(action.kind === 'start' && action.text, 'add a hello function')
+})
+
+test('with a run live, a message goes to that run (#714 control channel)', () => {
+  const action = decideAction('also add tests', ctx({ live: { projectId: 'p1', runId: 'r1' } }))
+  assert.equal(action.kind, 'message')
+  assert.equal(action.kind === 'message' && action.runId, 'r1')
+  assert.equal(action.kind === 'message' && action.text, 'also add tests')
+})
+
+test('a number answers a parked gate', () => {
+  const action = decideAction('2', ctx({ live: { projectId: 'p1', runId: 'r1', gate: gate() } }))
+  assert.equal(action.kind, 'choice')
+  assert.equal(action.kind === 'choice' && action.gateId, 'g1')
+  assert.equal(action.kind === 'choice' && action.pick, 'revise', 'the option id, not the number')
+})
+
+test('a gate can also be answered by label or id, case-insensitively', () => {
+  for (const text of ['Revise the plan', 'revise the plan', 'REVISE']) {
+    const action = decideAction(text, ctx({ live: { projectId: 'p1', runId: 'r1', gate: gate() } }))
+    assert.equal(action.kind, 'choice', `should answer the gate: ${text}`)
+    assert.equal(action.kind === 'choice' && action.pick, 'revise')
+  }
+})
+
+test('a multi-select gate takes a comma list', () => {
+  const multi = gate({ multi: true, options: [
+    { id: 'a', label: 'Alpha' },
+    { id: 'b', label: 'Beta' },
+    { id: 'c', label: 'Gamma' },
+  ] })
+  const action = decideAction('1,3', ctx({ live: { projectId: 'p1', runId: 'r1', gate: multi } }))
+  assert.equal(action.kind, 'choice')
+  assert.deepEqual(action.kind === 'choice' && action.pick, ['a', 'c'])
+})
+
+test('a message that is not an answer passes through to the run, never a guessed pick', () => {
+  // Guessing an option on someone's behalf is worse than letting them say it again.
+  const action = decideAction('wait, what does option 2 do?', ctx({ live: { projectId: 'p1', runId: 'r1', gate: gate() } }))
+  assert.equal(action.kind, 'message')
+})
+
+test('an out-of-range number is not a pick', () => {
+  assert.equal(resolvePick(gate(), '5'), undefined)
+  assert.equal(resolvePick(gate(), '0'), undefined)
+  const action = decideAction('5', ctx({ live: { projectId: 'p1', runId: 'r1', gate: gate() } }))
+  assert.equal(action.kind, 'message', 'falls through rather than picking something')
+})
+
+test('a partly-valid multi list is rejected whole', () => {
+  const multi = gate({ multi: true })
+  assert.equal(resolvePick(multi, '1,9'), undefined, 'one bad index must not silently pick the other')
+})
+
+test('!stop stops a live run, and says so when there is nothing to stop', () => {
+  const stop = decideAction('!stop', ctx({ live: { projectId: 'p1', runId: 'r1' } }))
+  assert.equal(stop.kind, 'stop')
+  assert.equal(stop.kind === 'stop' && stop.runId, 'r1')
+  assert.equal(decideAction('!stop', ctx()).kind, 'reply')
+})
+
+test('!status reports the run and repeats a parked question', () => {
+  const idle = decideAction('!status', ctx())
+  assert.equal(idle.kind, 'reply')
+  assert.match(idle.reply, /Nothing running/)
+
+  const parked = decideAction('!status', ctx({ live: { projectId: 'p1', runId: 'r1', gate: gate() } }))
+  assert.match(parked.reply, /How should I proceed\?/)
+  assert.match(parked.reply, /^1\. Proceed$/m)
+})
+
+test('!help is a reply and nothing else', () => {
+  const action = decideAction('!HELP', ctx({ live: { projectId: 'p1', runId: 'r1' } }))
+  assert.equal(action.kind, 'reply')
+  assert.equal(action.reply, HELP)
+})
+
+test('renderGate numbers the options from one', () => {
+  const text = renderGate(gate())
+  assert.match(text, /^1\. Proceed$/m)
+  assert.match(text, /^2\. Revise the plan$/m)
+})

--- a/packages/framework/src/discord/routing.ts
+++ b/packages/framework/src/discord/routing.ts
@@ -1,0 +1,143 @@
+/**
+ * What a Discord message should do (#680). Pure: it takes the text plus a snapshot of the
+ * project's state and returns an action, so every routing rule is unit-testable without a
+ * gateway, a daemon, or a run. The side effects live in `bot.ts`.
+ */
+
+/** One option of a parked choice gate, as the run emitted it. */
+export interface GateOption {
+  id: string
+  label: string
+}
+
+/** A gate a run is parked on, waiting for an answer. */
+export interface Gate {
+  id: string
+  title: string
+  options: GateOption[]
+  /** A multi-select gate takes a list of picks rather than one. */
+  multi?: boolean
+}
+
+/** The live run of a project, if it has one. */
+export interface RunSnapshot {
+  projectId: string
+  runId: string
+  /** Present when the run is parked on a choice gate. */
+  gate?: Gate
+}
+
+/** Where a message goes when no run is live. */
+export interface ProjectTarget {
+  id: string
+  name: string
+}
+
+/** The state a routing decision is made against. */
+export interface RouteContext {
+  /** The project's live run, if any. */
+  live?: RunSnapshot | undefined
+  /** The project a new run would start in. */
+  target: ProjectTarget
+}
+
+/** What the bot should do about a message. */
+export type BotAction =
+  | { kind: 'choice'; projectId: string; runId: string; gateId: string; pick: string | string[]; reply: string }
+  | { kind: 'message'; projectId: string; runId: string; text: string; reply: string }
+  | { kind: 'start'; projectId: string; text: string; reply: string }
+  | { kind: 'stop'; projectId: string; runId: string; reply: string }
+  /** Nothing to do but say something (help, status, an unusable message). */
+  | { kind: 'reply'; reply: string }
+
+/** The help text, also sent when a message cannot be understood as an answer to a gate. */
+export const HELP = [
+  'The Framework, at your service:',
+  '· send anything else to start a session, or to message the one already running',
+  '· `!status` — what is running right now',
+  '· `!stop` — stop the running session',
+  '· `!help` — this',
+  'When a session asks a question, reply with the option number.',
+].join('\n')
+
+/** Render a parked gate as a numbered question, so it can be answered by number in chat. */
+export function renderGate(gate: Gate): string {
+  const lines = [`**${gate.title}**`]
+  gate.options.forEach((option, index) => lines.push(`${index + 1}. ${option.label}`))
+  lines.push(gate.multi ? '_Reply with the numbers, e.g. `1,3`._' : '_Reply with the number._')
+  return lines.join('\n')
+}
+
+/**
+ * Resolve an answer to a gate. Accepts option numbers (`2`, or `1,3` for a multi-select) and an
+ * exact option label or id, case-insensitively. `undefined` when the text is not an answer —
+ * the caller then treats it as an ordinary message rather than guessing, because picking the
+ * wrong option on someone's behalf is worse than asking again.
+ */
+export function resolvePick(gate: Gate, text: string): string | string[] | undefined {
+  const trimmed = text.trim()
+  if (!trimmed) return undefined
+
+  const parts = gate.multi ? trimmed.split(',').map(part => part.trim()).filter(Boolean) : [trimmed]
+  const picked: string[] = []
+  for (const part of parts) {
+    const byNumber = /^\d+$/.test(part) ? gate.options[Number(part) - 1] : undefined
+    const byName = gate.options.find(
+      option => option.label.toLowerCase() === part.toLowerCase() || option.id.toLowerCase() === part.toLowerCase(),
+    )
+    const option = byNumber ?? byName
+    if (!option) return undefined
+    picked.push(option.id)
+  }
+  if (picked.length === 0) return undefined
+  return gate.multi ? picked : picked[0]
+}
+
+/** Decide what a message means. See the module comment. */
+export function decideAction(text: string, ctx: RouteContext): BotAction {
+  const trimmed = text.trim()
+  const command = trimmed.toLowerCase()
+
+  if (command === '!help') return { kind: 'reply', reply: HELP }
+
+  if (command === '!status') {
+    if (!ctx.live) return { kind: 'reply', reply: `Nothing running in **${ctx.target.name}**.` }
+    const running = `Running in **${ctx.target.name}** (\`${ctx.live.runId}\`).`
+    return { kind: 'reply', reply: ctx.live.gate ? `${running}\n\n${renderGate(ctx.live.gate)}` : running }
+  }
+
+  if (command === '!stop') {
+    if (!ctx.live) return { kind: 'reply', reply: 'Nothing to stop.' }
+    return { kind: 'stop', projectId: ctx.live.projectId, runId: ctx.live.runId, reply: 'Stopping the session.' }
+  }
+
+  // A parked run is asking something, so read the message as the answer first.
+  if (ctx.live?.gate) {
+    const gate = ctx.live.gate
+    const pick = resolvePick(gate, trimmed)
+    if (pick !== undefined) {
+      const shown = Array.isArray(pick) ? pick.join(', ') : pick
+      return {
+        kind: 'choice',
+        projectId: ctx.live.projectId,
+        runId: ctx.live.runId,
+        gateId: gate.id,
+        pick,
+        reply: `Picked **${shown}**.`,
+      }
+    }
+    // Not an answer: pass it through as a message rather than guessing at the gate.
+  }
+
+  if (ctx.live) {
+    return {
+      kind: 'message',
+      projectId: ctx.live.projectId,
+      runId: ctx.live.runId,
+      text: trimmed,
+      reply: 'Sent to the running session.',
+    }
+  }
+
+  return { kind: 'start', projectId: ctx.target.id, text: trimmed, reply: `Starting a session in **${ctx.target.name}**.` }
+}

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -94,6 +94,13 @@ export interface Preferences {
    */
   notifyDiscord?: boolean
   /**
+   * Run the Discord chatbot (#680): take messages from Discord and drive runs with them, rather
+   * than only posting notifications outward. Absent = off, like {@link notifyDiscord}, and for a
+   * stronger reason — this one *acts* on what it reads. Gates the daemon's bot on top of a
+   * `DISCORD_BOT_TOKEN` being set (the token is how to connect; this is whether to).
+   */
+  discordBot?: boolean
+  /**
    * Auto PM (#685): let the daemon start a PM run by itself when the agent queue has run dry
    * and there is plenty of budget left, so leftover subscription quota goes on the roadmap
    * instead of expiring. **Absent = off**: it spends the user's allowance without being asked,
@@ -232,6 +239,7 @@ const PREFERENCE_KEYS = [
   'transparent',
   'notifyBrowser',
   'notifyDiscord',
+  'discordBot',
   'notifyNewActivity',
   'notifyHumanIntervention',
   'autoPm',


### PR DESCRIPTION
Closes #680. The inbound half of Discord, and the consumer of the conversation storage from #908.

## What it does

Message the bot and it starts a session. Message it again while that session runs and the text reaches the run through the same control channel the dashboard's live chat uses (#714). When a run parks on a question the bot posts the numbered options, and a reply of `2` answers it. `!status`, `!stop`, `!help`. `Ctrl+C` takes it offline.

## Where chat history goes

This was #680's one stated open question, and the answer is the Git repo, as hoped: a message routed into a run reaches that run's conversation and is committed under `.the-framework/conversations/` by #908. Nothing about the chat is stored outside git, so the `~/.config/the-framework/cache/discord` fallback is not needed.

One honest gap: the conversation records the turn's `via` as the local surface, not `discord`, because the transport is not carried through `control.jsonl`. Threading it would make the record exact — noted as a follow-up rather than smuggled into this PR.

## Design notes

**Not `discord.js`.** The package has three runtime dependencies and builds everything else on node builtins behind seams, so a client library for eight opcodes would be the largest dependency in it by an order of magnitude. The gateway is hand-rolled over the global `WebSocket`, following `connectCdp`'s precedent in `browser-stream.ts`.

**Routing is a pure function.** `routing.ts` takes the text plus a state snapshot and returns an action, so every rule is unit-tested with no gateway, daemon, or run. `bot.ts` is only wiring.

**A gate's options are not on the run meta.** `pendingChoice` carries only an id and title, so `live-run.ts` reads the `choice` event from the run's event log — and skips a gate that already has a `choice-resolved`, so a chat reply can never answer a question the dashboard already closed.

**Two gates, matching the notification watchers.** `DISCORD_BOT_TOKEN` (how to connect) and a new `discordBot` preference (whether to), read per message so the toggle applies without a daemon restart. Both default off; unlike a notification this one *acts* on what it reads. `DISCORD_CHANNEL_ID` confines it to one channel.

**`sendStart` could not be reused.** It has a hard `getContext()` dependency and returns "not enabled" off a telefunc request, so new runs go through `runtime.onStart` exactly as auto PM does, with `resolvedRunOptions` and forced `unattended` (#846/#858) — nobody is watching a chat-started run either, so a parked gate would hang it. That gate is then answered from Discord by number.

## Verification

- `pnpm test` in `packages/framework`: **952 tests, 951 pass, 0 fail** (1 pre-existing skip). `tsc --noEmit` clean.
- Ran the real daemon with `DISCORD_BOT_TOKEN` set against the live gateway: it starts, survives a rejected token, sits at **0.0% CPU**, exits cleanly on `SIGINT`, and logs `Discord bot offline`.

**Two bugs the tests-first pass would have shipped, both caught by reasoning about the real deployment rather than the happy path:**

1. **No reconnect backoff.** A connection that fails immediately (offline, bad token) closes as fast as it opens, so reconnecting inline was a tight loop that would pin a core and get the bot rate-limited. Now doubles 1s → 60s, resets on a healthy `READY`, and `stop()` cancels a pending reconnect. The 0.0% CPU measurement above is the check on this.
2. **A bot that connects and ignores you.** With the preference off by default, a user who sets the token would see a live bot that never answers. The daemon now says so at startup.

## What I could not verify

I have no bot token or test server, so **no message has made a round trip through real Discord**. Everything above the socket is tested with a fake gateway, and the protocol itself (identify, heartbeat with zombie detection, resume vs re-identify, intents) is asserted against recorded payload shapes — but the live handshake is unproven. If you point a real bot at it, the first things to watch are the privileged **MESSAGE CONTENT** intent (without it every message arrives blank; the bot logs a hint) and that the token has the `bot` scope.

## Follow-ups, not in scope

- No dashboard toggle for `discordBot` yet, so it is set in `~/.the-framework.json` for now.
- Carrying the transport through `control.jsonl` so conversations record `via: discord`.
- Multi-project routing: messages go to the daemon's home project, since chat has no project picker. #606 is where per-channel/persona routing belongs.
