### PR TITLE
feat(framework-dashboard): give the rails a scrollbar you can see (#913)

### DIFF
--- a/.changeset/scroll-area.md
+++ b/.changeset/scroll-area.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Give the rails and panels a scrollbar you can see (#913). The Sessions rail, the Docs / Tickets / Log panels, the agent's views and choices, and the Overview all scrolled behind the OS scrollbar, which on macOS hides itself: a rail full of sessions looked like a rail with nothing more in it. They now use shadcn's Base UI scroll area, themed from our own tokens, present for as long as the content overflows and darkening under the pointer. A panel whose content fits still shows no bar at all.

--- a/packages/framework-dashboard/components/ChoicesRail.tsx
+++ b/packages/framework-dashboard/components/ChoicesRail.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react'
 import type { ChoiceRequest } from '@gemstack/framework'
 import { ChoicePanel } from './ChoicePanel.js'
+import { ScrollArea } from './ui/scroll-area.js'
 
 // The choice-gates rail (#440, part of #314): every gate the run is currently parked on,
 // shown at once in the right rail as a long scroll instead of one inline gate. A sticky
@@ -43,7 +44,7 @@ export function ChoicesRail({
           ))}
         </nav>
       )}
-      <div ref={scroller} className="min-h-0 flex-1 overflow-y-auto">
+      <ScrollArea viewportRef={scroller} className="min-h-0 flex-1">
         {choices.map((c, i) => (
           <div
             key={c.id}
@@ -55,7 +56,7 @@ export function ChoicesRail({
             <ChoicePanel projectId={projectId} runId={runId} choice={c} active={i === 0} />
           </div>
         ))}
-      </div>
+      </ScrollArea>
     </div>
   )
 }

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent, CardHeader, CardTitle } from './ui/card.js'
 import { usePolled } from '../lib/use-async.js'
 import { cn } from '../lib/utils.js'
 import { formatDate } from '../lib/format-date.js'
+import { ScrollArea } from './ui/scroll-area.js'
 
 // The Overview dashboard page (#471). What used to be a cramped, collapsible section in the
 // first sidebar is now a proper at-a-glance landing: KPI tiles, a two-week activity chart,
@@ -26,7 +27,7 @@ export function DashboardPage({
   const { value: data } = usePolled<DashboardData | null>(onDashboard, null, 5000, [])
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto">
+    <ScrollArea className="min-h-0 flex-1">
       <div className="mx-auto max-w-6xl space-y-6 p-6">
         <div>
           <h1 className="text-xl font-semibold">Overview</h1>
@@ -102,7 +103,7 @@ export function DashboardPage({
           </>
         )}
       </div>
-    </div>
+    </ScrollArea>
   )
 }
 

--- a/packages/framework-dashboard/components/DocsPanel.tsx
+++ b/packages/framework-dashboard/components/DocsPanel.tsx
@@ -5,6 +5,7 @@ import { Button } from './ui/button.js'
 import { Markdown } from './Markdown.js'
 import { usePolled } from '../lib/use-async.js'
 import { cn } from '../lib/utils.js'
+import { ScrollArea } from './ui/scroll-area.js'
 
 // The surfaced documents (#319/#328): the PLAN/TODO the agent writes, rendered beside
 // the run. Telefunc RPC (server/reads.telefunc.ts), polled so edits mid-run show up.
@@ -31,9 +32,11 @@ export function DocsPanel({ projectId }: { projectId: string | null }) {
           </Button>
         ))}
       </div>
-      <div className="flex-1 overflow-y-auto p-4">
-        <Markdown text={current.content} />
-      </div>
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="p-4">
+          <Markdown text={current.content} />
+        </div>
+      </ScrollArea>
     </div>
   )
 }

--- a/packages/framework-dashboard/components/ProjectLogPanel.tsx
+++ b/packages/framework-dashboard/components/ProjectLogPanel.tsx
@@ -4,6 +4,7 @@ import { Badge } from './ui/badge.js'
 import { usePolled } from '../lib/use-async.js'
 import { cn } from '../lib/utils.js'
 import { formatDateTime } from '../lib/format-date.js'
+import { ScrollArea } from './ui/scroll-area.js'
 
 const STATUS_TONE: Record<string, string> = {
   running: 'text-primary',
@@ -23,7 +24,8 @@ export function ProjectLogPanel({ projectId }: { projectId: string | null }) {
   if (logs.length === 0) return <p className="p-4 text-sm text-muted-foreground">No committed log entries yet.</p>
 
   return (
-    <ul className="flex-1 divide-y divide-border overflow-y-auto">
+    <ScrollArea className="min-h-0 flex-1">
+      <ul className="divide-y divide-border">
       {logs.map((log, i) => (
         <li key={i} className="px-4 py-2">
           <div className="flex items-center gap-2">
@@ -34,6 +36,7 @@ export function ProjectLogPanel({ projectId }: { projectId: string | null }) {
           <p className="mt-1 text-sm">{log.title}</p>
         </li>
       ))}
-    </ul>
+      </ul>
+    </ScrollArea>
   )
 }

--- a/packages/framework-dashboard/components/RunHistory.tsx
+++ b/packages/framework-dashboard/components/RunHistory.tsx
@@ -4,6 +4,7 @@ import { Button } from './ui/button.js'
 import { Badge } from './ui/badge.js'
 import { cn } from '../lib/utils.js'
 import { formatDateTime } from '../lib/format-date.js'
+import { ScrollArea } from './ui/scroll-area.js'
 
 const STATUS_TONE: Record<string, string> = {
   running: 'text-primary',
@@ -94,7 +95,8 @@ export function RunHistory({
       <div className={cn('whitespace-nowrap px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground', label)}>
         Sessions
       </div>
-      <div className="flex-1 overflow-y-auto px-2">
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="px-2">
         {/* Permanent home / launcher — always present, never a run. */}
         <Button
           variant="ghost"
@@ -128,7 +130,8 @@ export function RunHistory({
             onClick={() => onSelect(run.id)}
           />
         ))}
-      </div>
+        </div>
+      </ScrollArea>
       </div>
     </aside>
   )

--- a/packages/framework-dashboard/components/TicketsPanel.tsx
+++ b/packages/framework-dashboard/components/TicketsPanel.tsx
@@ -8,6 +8,7 @@ import { Badge } from './ui/badge.js'
 import { usePolled } from '../lib/use-async.js'
 import { useAction } from '../lib/use-action.js'
 import { cn } from '../lib/utils.js'
+import { ScrollArea } from './ui/scroll-area.js'
 
 /**
  * The prompt behind "Import tickets from GitHub" (#697). Deliberately short: the agent has
@@ -70,7 +71,8 @@ export function TicketsPanel({ projectId }: { projectId: string | null }) {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {error && <p className="border-b border-border p-2 text-xs text-red-500">{error}</p>}
-      <div className="flex-1 overflow-y-auto p-2">
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="p-2">
         {tickets.map(ticket => (
           <div key={ticket.file} className="mb-1 rounded border border-border p-2">
             <div className="flex items-start gap-2">
@@ -112,7 +114,8 @@ export function TicketsPanel({ projectId }: { projectId: string | null }) {
             </div>
           </div>
         ))}
-      </div>
+        </div>
+      </ScrollArea>
     </div>
   )
 }

--- a/packages/framework-dashboard/components/ViewsRail.tsx
+++ b/packages/framework-dashboard/components/ViewsRail.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react'
 import type { AgentView } from '../lib/live-state.js'
 import { Markdown } from './Markdown.js'
 import { cn } from '../lib/utils.js'
+import { ScrollArea } from './ui/scroll-area.js'
 
 // The agent-views rail (#441, part of #314): the ad-hoc markdown the agent pushed to the
 // side panel via showMarkdown() (a plan, a summary, a writeup), each a first-class view
@@ -36,10 +37,12 @@ export function ViewsRail({ views }: { views: AgentView[] }) {
           ))}
         </nav>
       )}
-      <div ref={scroller} className="min-h-0 flex-1 overflow-y-auto p-4">
-        <h2 className="mb-2 text-sm font-semibold">{current.title}</h2>
-        <Markdown text={current.markdown} />
-      </div>
+      <ScrollArea viewportRef={scroller} className="min-h-0 flex-1">
+        <div className="p-4">
+          <h2 className="mb-2 text-sm font-semibold">{current.title}</h2>
+          <Markdown text={current.markdown} />
+        </div>
+      </ScrollArea>
     </div>
   )
 }

--- a/packages/framework-dashboard/components/ui/scroll-area.test.tsx
+++ b/packages/framework-dashboard/components/ui/scroll-area.test.tsx
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { ScrollArea } from './scroll-area.js'
+
+afterEach(cleanup)
+
+// #913: the panels' scrolled content moved inside a component, so the thing worth pinning is that
+// it is still one scrolled box with the content in it, and that the bar is themed rather than the
+// OS's. Anything about the bar's size or visibility is layout, which jsdom does not do.
+describe('ScrollArea', () => {
+  test('puts its children in the scrolled viewport', () => {
+    render(
+      <ScrollArea className="flex-1">
+        <p>a session row</p>
+      </ScrollArea>,
+    )
+    const viewport = document.querySelector('[data-slot="scroll-area-viewport"]')
+    expect(viewport?.contains(screen.getByText('a session row'))).toBe(true)
+  })
+
+  test('hands the viewport out by ref, for a rail that scrolls itself', () => {
+    let viewport: HTMLDivElement | null = null
+    render(<ScrollArea viewportRef={el => void (viewport = el)}>content</ScrollArea>)
+    expect(viewport).toBe(document.querySelector('[data-slot="scroll-area-viewport"]'))
+  })
+
+  test('the thumb is drawn from our tokens, not the OS scrollbar', () => {
+    // A scrollbar reads its root's context, so it is rendered inside one rather than bare.
+    render(<ScrollArea>content</ScrollArea>)
+    const thumb = document.querySelector('[data-slot="scroll-area-thumb"]')
+    // muted-foreground rather than border: a border-toned thumb vanishes on the dark canvas.
+    expect(thumb?.className).toContain('bg-muted-foreground/40')
+    expect(thumb?.className).toContain('rounded-full')
+  })
+
+  test('the bar is a slim vertical strip down the edge', () => {
+    render(<ScrollArea>content</ScrollArea>)
+    const bar = document.querySelector('[data-slot="scroll-area-scrollbar"]')
+    expect(bar?.className).toContain('h-full w-2.5')
+    expect(bar?.getAttribute('data-orientation')).toBe('vertical')
+  })
+})

--- a/packages/framework-dashboard/components/ui/scroll-area.tsx
+++ b/packages/framework-dashboard/components/ui/scroll-area.tsx
@@ -1,0 +1,59 @@
+import type { ComponentProps, Ref } from 'react'
+import { ScrollArea as ScrollAreaPrimitive } from '@base-ui-components/react/scroll-area'
+import { cn } from '../../lib/utils.js'
+
+// shadcn's Base UI `scroll-area`, ported (#913) the same way `message-scroller` was (#712): there is
+// no components.json here, so upstream's `cn-scroll-area-*` classes — a stylesheet of `@apply` in
+// their registry — are inlined on the parts instead, and the focus ring uses our own token.
+//
+// Why a component rather than styling the native bar: the OS paints an overlay scrollbar that hides
+// itself, so a rail gives no hint that it holds more than it shows. This one belongs to the layout —
+// always there while the content overflows, darkening under the pointer. Its tone is
+// `muted-foreground`, not `border`: a border-toned thumb disappears into the dark canvas.
+//
+// #710 still stands for everything not converted: no `::-webkit-scrollbar` rule comes back.
+//
+// The scrollbar unmounts when the content fits, so a short list has no bar at all.
+//
+// Vertical only: nothing here scrolls sideways, and upstream's horizontal branch would ship
+// untested. Add it with its first use.
+
+export function ScrollArea({
+  className,
+  children,
+  viewportRef,
+  ...props
+}: ScrollAreaPrimitive.Root.Props & {
+  /** The scrolled element, for a rail that scrolls itself (ViewsRail, ChoicesRail). */
+  viewportRef?: Ref<HTMLDivElement>
+}) {
+  return (
+    <ScrollAreaPrimitive.Root data-slot="scroll-area" className={cn('relative', className)} {...props}>
+      <ScrollAreaPrimitive.Viewport
+        ref={viewportRef}
+        data-slot="scroll-area-viewport"
+        className="size-full rounded-[inherit] outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+}
+
+export function ScrollBar({ className, ...props }: ComponentProps<typeof ScrollAreaPrimitive.Scrollbar>) {
+  return (
+    <ScrollAreaPrimitive.Scrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation="vertical"
+      className={cn('flex h-full w-2.5 touch-none select-none border-l border-l-transparent p-px', className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Thumb
+        data-slot="scroll-area-thumb"
+        className="relative flex-1 rounded-full bg-muted-foreground/40 transition-colors hover:bg-muted-foreground/70"
+      />
+    </ScrollAreaPrimitive.Scrollbar>
+  )
+}


### PR DESCRIPTION
Closes #913.

The Sessions rail, the Docs / Tickets / Log panels, the agent's views and choices rails, and the Overview were plain `overflow-y-auto`. On macOS the OS bar hides itself, so a rail holding **37 sessions looked like a rail holding nine** - measured on your own `test-project`, where the rail has 37 rows and rendered zero scrollbar elements.

Ports shadcn's Base UI `scroll-area` as `components/ui/scroll-area.tsx`, the same way `message-scroller` was ported in #712.

### Notes

- **No new dependency.** `@base-ui-components/react` (already here, 1.0.0-rc.0) ships `scroll-area` with all six parts.
- Upstream's styling lives in `cn-scroll-area-*` classes - a stylesheet of `@apply` in their registry, which we have no components.json to pull - so those are inlined on the parts, and the focus ring uses our own token.
- **Two deliberate departures from upstream.** The thumb is `muted-foreground/40`, not `border`: I shipped `bg-border` first, drove it, and it disappears into the dark canvas (thumb `oklch 0.3` on a `oklch 0.16` background). And upstream's horizontal branch is dropped, since nothing here scrolls sideways and it would ship untested - it comes back with its first use.
- **#710 is not contradicted.** That reverted hand-rolled `::-webkit-scrollbar` rules and put `color-scheme` in charge. Nothing here is a webkit pseudo-element, and `color-scheme` still decides what the browser paints everywhere not converted.
- The chat log keeps `message-scroller`, which owns its own viewport and cannot be wrapped. Its styling gap is #914, next.

### Verified

Two daemons on the same registry, before :4200 and after :4403, dark and light:

| | before | after |
|---|---|---|
| Sessions rail (37 rows) | 0 scrollbar elements | a 7px rounded thumb down the rail |
| thumb vs canvas, dark | - | `oklab(0.7 / 0.4)` on `oklch(0.16)` |
| thumb vs canvas, light | - | `oklab(0.556 / 0.4)` on white |
| panel whose content fits | no bar | no bar (the scrollbar unmounts) |

4 new tests (245 total), 2 mutation checks: retoning the thumb to `bg-border`, and dropping the viewport ref that ViewsRail/ChoicesRail scroll through, each fail exactly one. Typecheck and build green.

Everything else - the diff view, the browser panel, the prompt editor, the dropdown - is untouched and still native.