### PR TITLE
fix(framework-dashboard): give the chat log back its scrollbar styling (#914)

### DIFF
--- a/.changeset/message-scroller-scrollbar.md
+++ b/.changeset/message-scroller-scrollbar.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Give the chat log back its scrollbar styling (#914). Our port of shadcn's message-scroller dropped the styling upstream puts on its viewport, because those classes come from a Tailwind plugin we do not have. They are back as three small local utilities on plain `scrollbar-width` / `scrollbar-color` / `scrollbar-gutter`: the log's bar is toned like the rest of the app, its width is reserved so arriving output does not shift the text sideways, and it goes quiet while the log is chasing the live edge. The log's bottom edge now fades out while there is more below it, and the fade is gone at the live edge so the newest line is never dimmed.

--- a/packages/framework-dashboard/components/ui/message-scroller.test.tsx
+++ b/packages/framework-dashboard/components/ui/message-scroller.test.tsx
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs'
+import { afterEach, describe, expect, test } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import { MessageScrollerProvider, MessageScrollerViewport } from './message-scroller.js'
+
+afterEach(cleanup)
+
+const viewport = () => {
+  render(
+    <MessageScrollerProvider>
+      <MessageScrollerViewport />
+    </MessageScrollerProvider>,
+  )
+  const el = document.querySelector('[data-slot="message-scroller-viewport"]')
+  if (!el) throw new Error('no viewport')
+  return el
+}
+
+// Read from the package root (vitest's cwd); `import.meta.url` is not a file URL under jsdom.
+const tailwind = readFileSync('layouts/tailwind.css', 'utf8')
+
+// #914: the port dropped upstream's viewport styling because those utilities came from a plugin we
+// do not have. They are local now, so the pairing is what needs pinning: a class the stylesheet
+// does not define is silently nothing, which is exactly how the styling went missing the first time.
+describe('MessageScrollerViewport', () => {
+  test('asks for a toned scrollbar, a stable gutter and a faded bottom edge', () => {
+    const className = viewport().className
+    expect(className).toContain('scrollbar-thin')
+    expect(className).toContain('scrollbar-gutter-stable')
+    expect(className).toContain('scroll-fade-b')
+    // Quiet while the log is chasing the live edge, so the bar is not a twitching distraction.
+    expect(className).toContain('data-autoscrolling:scrollbar-quiet')
+  })
+
+  test('every utility it asks for is one the stylesheet defines', () => {
+    const asked = viewport()
+      .className.split(/\s+/)
+      .map(token => token.split(':').at(-1) ?? '')
+      .filter(token => token.startsWith('scrollbar-') || token.startsWith('scroll-fade'))
+    expect(asked.length).toBeGreaterThan(0)
+    for (const utility of asked) expect(tailwind, utility).toContain(`@utility ${utility} {`)
+  })
+})

--- a/packages/framework-dashboard/components/ui/message-scroller.tsx
+++ b/packages/framework-dashboard/components/ui/message-scroller.tsx
@@ -13,8 +13,12 @@ import { cn } from '../../lib/utils.js'
 // scrollable scroll button — lives in the dependency-free @shadcn/react primitive; these are the
 // styled wrappers. Adapted from the upstream `bases/base` variant: our own `cn`, a native button
 // (our Button is not Base-UI render-ready) rather than `render={<Button/>}`, lucide instead of the
-// icon placeholder, and the scrollbar-plugin utilities dropped (the app paints native scrollbars
-// via color-scheme, #710).
+// icon placeholder.
+//
+// Upstream's viewport also carries `scrollbar-thin` / `scrollbar-thumb-*`, which come from the
+// tailwind-scrollbar plugin rather than from shadcn. #914 puts that back as three local utilities
+// on plain `scrollbar-width` / `scrollbar-color` / `scrollbar-gutter` (see tailwind.css), so the
+// log's bar is toned like the rest of the app instead of being whatever the OS paints.
 
 // The Provider needs no styling (no data-slot / className), so it is the primitive's directly,
 // re-exported for a uniform `message-scroller` import site rather than wrapped for nothing.
@@ -34,7 +38,11 @@ export function MessageScrollerViewport({ className, ...props }: ComponentProps<
   return (
     <MessageScrollerPrimitive.Viewport
       data-slot="message-scroller-viewport"
-      className={cn('size-full min-h-0 min-w-0 overflow-y-auto overscroll-contain', className)}
+      className={cn(
+        'size-full min-h-0 min-w-0 overflow-y-auto overscroll-contain',
+        'scroll-fade-b scrollbar-thin scrollbar-gutter-stable data-autoscrolling:scrollbar-quiet',
+        className,
+      )}
       {...props}
     />
   )

--- a/packages/framework-dashboard/layouts/tailwind.css
+++ b/packages/framework-dashboard/layouts/tailwind.css
@@ -164,3 +164,60 @@ body {
 .ProseMirror-selectednode.pe-token {
   outline: 2px solid var(--primary);
 }
+
+/* The chat log's scrollbar (#914). shadcn's message-scroller styles its viewport with
+   `scrollbar-thin` / `scrollbar-thumb-*`, which are not in their repo at all — they come from the
+   tailwind-scrollbar plugin. Standard `scrollbar-width` + `scrollbar-color` says the same thing in
+   four lines and needs no plugin, and it is not a `::-webkit-scrollbar` rule, so #710's reasoning
+   (let the browser paint, themed by color-scheme) still holds: this only tones what it paints. */
+@utility scrollbar-thin {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in oklab, var(--muted-foreground) 40%, transparent) transparent;
+}
+
+/* The log is following the live edge, so the bar would be a twitching distraction. */
+@utility scrollbar-quiet {
+  scrollbar-color: transparent transparent;
+}
+
+/* Reserve the bar's width always, so arriving output does not shift the text sideways. */
+@utility scrollbar-gutter-stable {
+  scrollbar-gutter: stable;
+}
+
+/* The log's bottom edge fades out while there is more below it (#914), so the cut is a gradient
+   rather than a guillotine. Reduced from shadcn's published `scroll-fade` (packages/shadcn/src/
+   tailwind.css) to the one edge we use: the mask size is animated on a scroll timeline, so it
+   reaches zero at the live edge and the newest line is never dimmed. Browsers without scroll
+   timelines get the static fade, which is only wrong at the very bottom. */
+@property --scroll-fade-b {
+  syntax: '<length-percentage>';
+  inherits: false;
+  initial-value: 0px;
+}
+
+@keyframes scroll-fade-reveal-b {
+  from {
+    --scroll-fade-b: var(--scroll-fade-size);
+  }
+  to {
+    --scroll-fade-b: 0px;
+  }
+}
+
+@utility scroll-fade-b {
+  --scroll-fade-size: min(12%, 2.5rem);
+  mask-image: linear-gradient(to bottom, #000 0, #000 calc(100% - var(--scroll-fade-b, 0px)), transparent 100%);
+  mask-repeat: no-repeat;
+
+  @supports (animation-timeline: scroll()) {
+    animation: scroll-fade-reveal-b 1ms ease-in-out;
+    animation-timeline: scroll(self y);
+    animation-range: calc(100% - 6rem) 100%;
+    animation-fill-mode: both;
+  }
+
+  @supports not (animation-timeline: scroll()) {
+    --scroll-fade-b: var(--scroll-fade-size);
+  }
+}


### PR DESCRIPTION
Closes #914. Sibling of #918 (the rails).

Our port of `message-scroller` (#712) dropped what upstream puts on the viewport:

```
scroll-fade-b scrollbar-thin scrollbar-gutter-stable data-autoscrolling:scrollbar-thumb-transparent
```

**Those scrollbar classes are not shadcn's.** They are nowhere in the shadcn repo - I searched it - they come from the `tailwind-scrollbar` plugin, which is not a dependency here. Plain `scrollbar-width` / `scrollbar-color` / `scrollbar-gutter` say the same thing in a few lines from our own tokens, so they are three local utilities now: `scrollbar-thin`, `scrollbar-quiet`, `scrollbar-gutter-stable`.

`scroll-fade-b` **is** shadcn's, published in `packages/shadcn/src/tailwind.css`, and is reduced here to the one edge we use.

### The limit, stated plainly

On macOS the log's bar still auto-hides. `scrollbar-color` only tones what the browser paints; a bar that is visible while you are *not* scrolling has to be an element, which is what #918 does for the rails. The message-scroller's viewport is a plain `div` with no `render`/`asChild` prop (checked the `@shadcn/react` types - only its Button takes one), so it cannot be composed into a Base UI scroll area. If you want the log's bar to match the rails', that is a separate piece of work and I would file it rather than bodge it.

So what you actually get here: the bar is toned to our palette, its width is reserved so arriving output does not shift the text sideways, it goes quiet while the log chases the live edge, and the bottom edge fades.

### Verified

Against a daemon on your real registry, on a session with a long log:

| | before | after |
|---|---|---|
| `scrollbar-width` | `auto` | `thin` |
| `scrollbar-color` | `auto` | `oklab(0.7 / 0.4)` on transparent |
| `scrollbar-gutter` | `auto` | `stable` |
| mask at the bottom edge | `none` | a 40px fade, **screenshotted** |
| `--scroll-fade-b` at the live edge | - | resolves to `0` - the newest line is never dimmed |

2 new tests (243 total). The second is the one that matters: it reads `layouts/tailwind.css` and asserts every `scrollbar-*` / `scroll-fade-*` class the viewport asks for is actually `@utility`-defined, because a class the stylesheet does not define is silently nothing - which is exactly how this styling went missing in the first place. Mutation-checked by renaming one utility. Typecheck and build green.