### PR TITLE
feat(framework): surface a finished run whose work was never pushed (#860)

### DIFF
--- a/.changeset/feat-860-surface-unpushed-work.md
+++ b/.changeset/feat-860-surface-unpushed-work.md
@@ -3,26 +3,20 @@
 '@gemstack/framework-dashboard': minor
 ---
 
-Tell the human when a finished run left work nobody pushed (#860)
+Tell the user when a finished run left work nobody pushed (#860)
 
-An unattended run writes real code, commits it to its own branch, and then nothing surfaces it. The
-"needs you" queue knew about exactly two things: a pull request that is *already on GitHub*, and a
-run parked on a choice gate. A run that finished with committed work and no PR was neither, so the
-notification only fired after a human had already clicked "Open PR" — which they would only do if
-they already knew the work was there. The overview drops the run too, since it lists only what is
-still running, and the push/open-PR panel is behind clicking into that specific archived run.
+An unattended run writes code, commits it to its own branch, and stops. Nothing says so.
 
-The queue now has a third kind: a finished run whose branch still holds commits that were never
-pushed and never merged. It rides the existing watcher, so it reaches the browser notification and
-the Discord message like any other item.
+The "needs you" queue only knew two things: a pull request already on GitHub, and a run parked on a
+choice gate. A finished run with committed work and no PR was neither, so nothing fired until
+someone had already opened the PR by hand. The overview lists only running runs, and the push
+button sits inside that one archived run.
 
-Surfacing only. Pushing publishes the agent's work under the user's name to a shared remote, and
-that stays a deliberate click rather than something a run ending does on its own — this only says
-there is a decision waiting.
+The queue now has a third kind: a finished run whose branch holds commits that were never pushed
+and never merged. It rides the existing watcher, so it reaches browser notifications and Discord
+like any other item.
 
-Only the most recent finished runs per project are inspected, since each costs several git reads on
-a poll and work that has sat unpushed for dozens of runs is not news. The per-branch `gh` PR lookup
-is skipped for this: an open PR means the branch was pushed, which already excludes it.
+It only tells you. Pushing publishes the agent's work under your name, so that stays your click.
 
-This became reachable when unattended runs started shipping diffs, and the Discord chatbot (#680)
-widened it further — a run started from chat is unattended too.
+Only the most recent finished runs per project are checked, since each one costs a few git reads on
+every poll.

--- a/.changeset/feat-860-surface-unpushed-work.md
+++ b/.changeset/feat-860-surface-unpushed-work.md
@@ -1,0 +1,28 @@
+---
+'@gemstack/framework': minor
+'@gemstack/framework-dashboard': minor
+---
+
+Tell the human when a finished run left work nobody pushed (#860)
+
+An unattended run writes real code, commits it to its own branch, and then nothing surfaces it. The
+"needs you" queue knew about exactly two things: a pull request that is *already on GitHub*, and a
+run parked on a choice gate. A run that finished with committed work and no PR was neither, so the
+notification only fired after a human had already clicked "Open PR" — which they would only do if
+they already knew the work was there. The overview drops the run too, since it lists only what is
+still running, and the push/open-PR panel is behind clicking into that specific archived run.
+
+The queue now has a third kind: a finished run whose branch still holds commits that were never
+pushed and never merged. It rides the existing watcher, so it reaches the browser notification and
+the Discord message like any other item.
+
+Surfacing only. Pushing publishes the agent's work under the user's name to a shared remote, and
+that stays a deliberate click rather than something a run ending does on its own — this only says
+there is a decision waiting.
+
+Only the most recent finished runs per project are inspected, since each costs several git reads on
+a poll and work that has sat unpushed for dozens of runs is not news. The per-branch `gh` PR lookup
+is skipped for this: an open PR means the branch was pushed, which already excludes it.
+
+This became reachable when unattended runs started shipping diffs, and the Discord chatbot (#680)
+widened it further — a run started from chat is unattended too.

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react'
 import type { DashboardData, ActiveRun, ProjectStat, ProjectQueue, Intervention } from '@gemstack/framework'
-import { FolderGit2, Zap, ListChecks, History, GitPullRequest, Inbox, MessageCircleQuestion } from 'lucide-react'
+import { FolderGit2, Zap, ListChecks, History, GitBranch, GitPullRequest, Inbox, MessageCircleQuestion } from 'lucide-react'
 import { onDashboard } from '../server/reads.telefunc.js'
 import { interventionKey } from '../lib/interventions.js'
 import { ActivityChart } from './ActivityChart.js'
@@ -142,6 +142,21 @@ function NeedsYou({ items, onSelectProject }: { items: Intervention[]; onSelectP
                     <MessageCircleQuestion className="h-4 w-4 shrink-0 text-amber-500" />
                     <span className="shrink-0 text-xs font-medium text-amber-500">Awaiting</span>
                     <span className="truncate font-medium">{item.title}</span>
+                    <span className="ml-auto shrink-0 text-xs text-muted-foreground">{item.projectName}</span>
+                  </button>
+                ) : item.kind === 'unpushed' ? (
+                  <button
+                    type="button"
+                    onClick={() => onSelectProject(item.projectId)}
+                    className="flex w-full items-center gap-2 py-2 text-left hover:opacity-80"
+                    title={`Open the session: work on ${item.branch ?? ''} was never pushed`}
+                  >
+                    <GitBranch className="h-4 w-4 shrink-0 text-sky-500" />
+                    <span className="shrink-0 text-xs font-medium text-sky-500">Unpushed</span>
+                    <span className="truncate font-medium">{item.title}</span>
+                    <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                      {item.commits === 1 ? '1 commit' : `${item.commits ?? 0} commits`}
+                    </span>
                     <span className="ml-auto shrink-0 text-xs text-muted-foreground">{item.projectName}</span>
                   </button>
                 ) : (

--- a/packages/framework-dashboard/lib/interventions.ts
+++ b/packages/framework-dashboard/lib/interventions.ts
@@ -6,12 +6,15 @@ import type { Intervention } from '@gemstack/framework'
 // the `Intervention` type is borrowed (types are erased), and that logic is a couple of lines.
 
 /**
- * The stable identity of an intervention. A PR is its url (survives title edits and re-sorts);
- * an awaiting run (#636) is its project + gate id, since its url is the shared dashboard URL and
- * would otherwise collide across projects. Mirrors the server's `interventionKey`.
+ * The stable identity of an intervention. A PR is its url (survives title edits and re-sorts); an
+ * awaiting run (#636) and a run with unpushed work (#860) are keyed on the project plus the thing
+ * waiting, since their url is the shared dashboard URL and would otherwise collide across
+ * projects. Mirrors the server's `interventionKey`.
  */
 export function interventionKey(item: Intervention): string {
-  return item.kind === 'awaiting' ? `awaiting:${item.projectId}:${item.awaitId ?? ''}` : item.url
+  if (item.kind === 'awaiting') return `awaiting:${item.projectId}:${item.awaitId ?? ''}`
+  if (item.kind === 'unpushed') return `unpushed:${item.projectId}:${item.runId ?? ''}`
+  return item.url
 }
 
 /**

--- a/packages/framework-dashboard/lib/use-intervention-notifications.ts
+++ b/packages/framework-dashboard/lib/use-intervention-notifications.ts
@@ -12,9 +12,16 @@ import { interventionKey, pickNewInterventions } from './interventions.js'
 /** Observations to treat as baseline before notifying: the initial `[]` plus the first fetch. */
 const WARMUP = 2
 
-/** How a single intervention reads in a notification body: a PR by number, a paused run by its question (#636). */
+/**
+ * How a single intervention reads in a notification body: a PR by number, a paused run by its
+ * question (#636), a finished run by what is sitting unpushed on its branch (#860).
+ */
 function label(item: Intervention): string {
-  return item.kind === 'awaiting' ? item.title : `#${item.number} ${item.title}`
+  if (item.kind === 'awaiting') return item.title
+  if (item.kind === 'unpushed') {
+    return `${item.title} — ${item.commits === 1 ? '1 commit' : `${item.commits ?? 0} commits`} not pushed`
+  }
+  return `#${item.number} ${item.title}`
 }
 
 function fire(items: Intervention[]): void {
@@ -26,9 +33,10 @@ function fire(items: Intervention[]): void {
   const body = single ? label(first) : items.map(label).join('\n')
   const notification = new Notification(title, { body })
   notification.onclick = () => {
-    // A PR opens on GitHub; a paused run lives in this dashboard, so just bring the tab forward
-    // (project selection is client state, not a URL) — the "needs you" card takes it from there.
-    if (first.kind === 'awaiting') window.focus()
+    // A PR opens on GitHub; a paused run and unpushed work both live in this dashboard, so just
+    // bring the tab forward (project selection is client state, not a URL) — the "needs you" card
+    // takes it from there.
+    if (first.kind === 'awaiting' || first.kind === 'unpushed') window.focus()
     else window.open(first.url, '_blank', 'noopener')
     notification.close()
   }

--- a/packages/framework/src/dashboard/intervention-watcher.test.ts
+++ b/packages/framework/src/dashboard/intervention-watcher.test.ts
@@ -91,3 +91,50 @@ test('startInterventionWatcher announces only items that appear after the first 
     watcher.stop()
   }
 })
+
+test('postDiscord names the branch for unpushed work, not a PR number (#860)', async () => {
+  let body: unknown
+  const fetchImpl = (async (_url: string, init?: RequestInit) => {
+    body = JSON.parse(String(init!.body))
+    return new Response(null, { status: 204 })
+  }) as typeof fetch
+
+  await postDiscord(
+    'https://discord/hook',
+    [
+      {
+        projectId: 'p',
+        projectName: 'gemstack',
+        kind: 'unpushed',
+        title: 'add the cart',
+        url: 'http://localhost:4300',
+        runId: 'r1',
+        branch: 'the-framework/add-cart',
+        commits: 2,
+      },
+    ],
+    fetchImpl,
+  )
+
+  const content = String((body as { content: string }).content)
+  assert.match(content, /add the cart/)
+  assert.match(content, /2 commits/)
+  assert.match(content, /the-framework\/add-cart/)
+  assert.match(content, /never pushed/)
+  assert.doesNotMatch(content, /#undefined/, 'must not fall through to the PR shape')
+})
+
+test('postDiscord says "1 commit" rather than "1 commits" (#860)', async () => {
+  let body: unknown
+  const fetchImpl = (async (_url: string, init?: RequestInit) => {
+    body = JSON.parse(String(init!.body))
+    return new Response(null, { status: 204 })
+  }) as typeof fetch
+
+  await postDiscord(
+    'https://discord/hook',
+    [{ projectId: 'p', projectName: 'g', kind: 'unpushed', title: 't', url: '', runId: 'r', branch: 'b', commits: 1 }],
+    fetchImpl,
+  )
+  assert.match(String((body as { content: string }).content), /1 commit(?!s)/)
+})

--- a/packages/framework/src/dashboard/intervention-watcher.ts
+++ b/packages/framework/src/dashboard/intervention-watcher.ts
@@ -34,10 +34,15 @@ export async function postDiscord(
   if (items.length === 0) return
   // A PR reads `#123 Title — url`; a paused run (#636) has no number and only the dashboard url,
   // so it reads `Title — awaiting your answer` with the link appended when the daemon knows it.
-  const line = (i: Intervention): string =>
-    i.kind === 'awaiting'
-      ? `${i.title} — awaiting your answer${i.url ? ` — ${i.url}` : ''}`
-      : `#${i.number} ${i.title} — ${i.url}`
+  // Unpushed work (#860) names the branch, since that is the actionable part.
+  const line = (i: Intervention): string => {
+    if (i.kind === 'awaiting') return `${i.title} — awaiting your answer${i.url ? ` — ${i.url}` : ''}`
+    if (i.kind === 'unpushed') {
+      const count = i.commits === 1 ? '1 commit' : `${i.commits ?? 0} commits`
+      return `${i.title} — ${count} on ${i.branch ?? ''}, never pushed${i.url ? ` — ${i.url}` : ''}`
+    }
+    return `#${i.number} ${i.title} — ${i.url}`
+  }
   const content =
     items.length === 1
       ? `🔔 Needs you (${items[0]!.projectName}): ${line(items[0]!)}`

--- a/packages/framework/src/dashboard/interventions.test.ts
+++ b/packages/framework/src/dashboard/interventions.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { buildInterventions, interventionKey, type OpenPr } from './interventions.js'
+import type { RunHandoff } from './run-handoff.js'
 import type { ProjectSummary } from './projects.js'
 import type { LiveRun, RunMeta } from '../store/index.js'
 
@@ -111,5 +112,122 @@ test('interventionKey is the url for a PR and project+gate for an awaiting run',
   assert.equal(
     interventionKey({ projectId: 'a', projectName: 'a', kind: 'awaiting', title: 't', url: '', awaitId: 'g1' }),
     'awaiting:a:g1',
+  )
+})
+
+// #860: a finished run whose branch still holds unpushed, unmerged commits.
+
+const doneMeta = (over: Partial<RunMeta> = {}): RunMeta => ({
+  version: 1,
+  status: 'done',
+  id: 'r1',
+  startedAt: '2026-07-16T00:00:00Z',
+  updatedAt: '2026-07-16T01:00:00Z',
+  passes: 0,
+  branch: 'the-framework/add-cart',
+  intent: 'add the cart',
+  ...over,
+})
+
+/** A branch with work on it that never left the machine. */
+const waiting = (over: Partial<RunHandoff> = {}): RunHandoff => ({
+  branch: 'the-framework/add-cart',
+  exists: true,
+  base: 'main',
+  commits: [{ sha: 'abc1234', short: 'abc1234', subject: 'add the cart' }],
+  files: [],
+  insertions: 0,
+  deletions: 0,
+  empty: false,
+  hasRemote: true,
+  pushed: false,
+  merged: false,
+  ...over,
+})
+
+/** Only the unpushed source: no PRs, no paused runs. */
+const onlyUnpushed = (runs: RunMeta[], handoff: (cwd: string, branch: string) => Promise<RunHandoff | undefined>) => ({
+  prs: async () => [],
+  liveRuns: noRuns,
+  runs: async () => runs,
+  handoff,
+})
+
+test('a finished run with unpushed commits lands on the queue (#860)', async () => {
+  const items = await buildInterventions(
+    [project('a', '/a')],
+    onlyUnpushed([doneMeta()], async () => waiting()),
+  )
+
+  assert.equal(items.length, 1)
+  assert.equal(items[0]?.kind, 'unpushed')
+  assert.equal(items[0]?.title, 'add the cart', 'what was asked, not the branch name')
+  assert.equal(items[0]?.branch, 'the-framework/add-cart')
+  assert.equal(items[0]?.commits, 1)
+  assert.equal(items[0]?.runId, 'r1')
+})
+
+test('nothing is waiting when the work already went somewhere (#860)', async () => {
+  // Each of these is a reason it is NOT waiting on a human.
+  const cases: [string, Partial<RunHandoff>][] = [
+    ['already pushed', { pushed: true }],
+    ['already merged', { merged: true }],
+    ['the session wrote nothing', { empty: true, commits: [] }],
+    ['the branch is gone', { exists: false }],
+    ['there is nowhere to push', { hasRemote: false }],
+  ]
+  for (const [why, over] of cases) {
+    const items = await buildInterventions(
+      [project('a', '/a')],
+      onlyUnpushed([doneMeta()], async () => waiting(over)),
+    )
+    assert.deepEqual(items, [], `should not be surfaced: ${why}`)
+  }
+})
+
+test('a still-running run is not unpushed work (#860)', async () => {
+  // It is still writing; the overview already shows it.
+  const items = await buildInterventions(
+    [project('a', '/a')],
+    onlyUnpushed([doneMeta({ status: 'running' })], async () => waiting()),
+  )
+  assert.deepEqual(items, [])
+})
+
+test('an unreadable branch is skipped rather than throwing (#860)', async () => {
+  const items = await buildInterventions(
+    [project('a', '/a')],
+    onlyUnpushed([doneMeta()], async () => {
+      throw new Error('not a repo')
+    }),
+  )
+  assert.deepEqual(items, [])
+})
+
+test('only the most recent finished runs are inspected (#860)', async () => {
+  // Each inspection costs several git reads on a poll, and work sitting unpushed for dozens of
+  // runs is not news.
+  const runs = Array.from({ length: 12 }, (_, i) =>
+    doneMeta({ id: `r${i}`, startedAt: `2026-07-${String(i + 1).padStart(2, '0')}T00:00:00Z`, branch: `b${i}` }),
+  )
+  const inspected: string[] = []
+  const items = await buildInterventions(
+    [project('a', '/a')],
+    { ...onlyUnpushed(runs, async (_cwd, branch) => (inspected.push(branch), waiting({ branch }))), handoffLimit: 3 },
+  )
+
+  assert.equal(inspected.length, 3)
+  assert.deepEqual(inspected, ['b11', 'b10', 'b9'], 'the newest three, by start time')
+  assert.equal(items.length, 3)
+})
+
+test('unpushed items key on the run, so each notifies once (#860)', () => {
+  const base = { projectId: 'p', projectName: 'p', kind: 'unpushed' as const, title: 't', url: '' }
+  assert.equal(interventionKey({ ...base, runId: 'r1' }), 'unpushed:p:r1')
+  assert.notEqual(interventionKey({ ...base, runId: 'r1' }), interventionKey({ ...base, runId: 'r2' }))
+  // And never collides with the other kinds, whose url is the same shared dashboard URL.
+  assert.notEqual(
+    interventionKey({ ...base, runId: 'r1' }),
+    interventionKey({ ...base, kind: 'awaiting', awaitId: 'r1' }),
   )
 })

--- a/packages/framework/src/dashboard/interventions.ts
+++ b/packages/framework/src/dashboard/interventions.ts
@@ -1,5 +1,6 @@
-import { readLiveMetas, type LiveRun } from '../store/index.js'
+import { listRuns, readLiveMetas, type LiveRun, type RunMeta } from '../store/index.js'
 import type { ProjectSummary } from './projects.js'
+import { readRunHandoff, runBranchFor, type RunHandoff } from './run-handoff.js'
 
 // The interventions queue (#632, part of the Queue #624): the cross-project "needs you" list.
 // Rom's design (#624): proposals and finished work are both just PRs, so the bulk of what
@@ -16,18 +17,25 @@ import type { ProjectSummary } from './projects.js'
 export interface Intervention {
   projectId: string
   projectName: string
-  /** `pr` = an open PR to review/merge or close; `awaiting` = a run paused on a choice gate (#636). */
-  kind: 'pr' | 'awaiting'
+  /**
+   * `pr` = an open PR to review/merge or close; `awaiting` = a run paused on a choice gate (#636);
+   * `unpushed` = a finished run whose branch has commits that were never pushed (#860).
+   */
+  kind: 'pr' | 'awaiting' | 'unpushed'
   title: string
-  /** Where to act: the PR on GitHub (`pr`), or the dashboard (`awaiting`, when the URL is known). */
+  /** Where to act: the PR on GitHub (`pr`), or the dashboard (the other two, when the URL is known). */
   url: string
   /** The PR number (`pr` only). */
   number?: number
   /** The parked gate's id (`awaiting` only) — its stable identity, so it notifies exactly once. */
   awaitId?: string
-  /** Which run is asking (`awaiting` only, #738): a project can have several parked at once. */
+  /** Which run this is about (`awaiting` #738 / `unpushed`): a project has several runs. */
   runId?: string
-  /** When the PR was opened (`pr`) or the run last updated (`awaiting`), ISO, for ordering. */
+  /** The branch the work is sitting on (`unpushed` only). */
+  branch?: string
+  /** How many commits are waiting (`unpushed` only). */
+  commits?: number
+  /** When the PR was opened (`pr`) or the run last updated (the other two), ISO, for ordering. */
   createdAt?: string
 }
 
@@ -67,6 +75,16 @@ export interface InterventionsDeps {
   prs?: PrLister
   /** The live-run reader (default {@link readLiveMetas}); drives the `awaiting` source (#636). */
   liveRuns?: (cwd: string) => Promise<LiveRun[]>
+  /** The finished-run reader (default {@link listRuns}); drives the `unpushed` source (#860). */
+  runs?: (cwd: string) => Promise<RunMeta[]>
+  /** Reads a branch's state (default {@link readRunHandoff}); drives the `unpushed` source (#860). */
+  handoff?: (cwd: string, branch: string) => Promise<RunHandoff | undefined>
+  /**
+   * How many of a project's most recent finished runs to inspect for unpushed work. Each one costs
+   * a handful of git reads, and this runs on a poll, so old history is not re-walked every minute:
+   * work that has sat unpushed for dozens of runs is not news, and the run list stays the record.
+   */
+  handoffLimit?: number
   /**
    * The dashboard's own URL, so an `awaiting` item can link back to it. Only the daemon knows
    * it (the card path resolves the project client-side and needs no URL), so it is optional; an
@@ -74,6 +92,9 @@ export interface InterventionsDeps {
    */
   dashboardUrl?: string
 }
+
+/** How many recent finished runs are inspected per project by default. */
+export const HANDOFF_LIMIT = 5
 
 /**
  * Build the cross-project interventions queue: every registered project's open, non-draft PRs,
@@ -119,6 +140,14 @@ export async function buildInterventions(
         ...(meta.updatedAt ? { createdAt: meta.updatedAt } : {}),
       })
     }
+    // A finished run whose work never left the machine is a "needs you" too (#860). Until now the
+    // queue only knew about a PR that is *already on GitHub* and a run parked on a gate, so a run
+    // that committed real code and stopped produced neither, and nothing told anyone: the overview
+    // drops it (it filters on `running`) and the handoff panel is behind clicking into that run.
+    //
+    // Surfacing only. Pushing publishes the agent's work under the user's name, which stays their
+    // click (see `pushRunBranch`) — this just says there is a decision waiting.
+    for (const item of await unpushedFor(project, deps).catch(() => [])) items.push(item)
   }
   items.sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''))
   // The same repo can be registered under two projects (e.g. a monorepo root + a subdir), so a
@@ -128,12 +157,57 @@ export async function buildInterventions(
 }
 
 /**
+ * The finished runs of a project whose branch still holds unpushed, unmerged commits (#860).
+ *
+ * Only the most recent {@link InterventionsDeps.handoffLimit} finished runs are inspected: each
+ * costs several git reads and this runs on a poll.
+ */
+async function unpushedFor(project: ProjectSummary, deps: InterventionsDeps): Promise<Intervention[]> {
+  const runs = deps.runs ?? listRuns
+  const handoff =
+    deps.handoff ??
+    // The default skips the `gh` PR lookup `readRunHandoff` would otherwise do per branch: an open
+    // PR means the branch was pushed, so `pushed` already excludes it, and the `pr` kind above is
+    // what surfaces it. Paying an 8s-timeout network call per run on every poll to learn that
+    // would be the most expensive part of this whole queue.
+    ((cwd: string, branch: string) => readRunHandoff(cwd, branch, { pr: async () => undefined }))
+
+  const finished = (await runs(project.path))
+    .filter(run => run.status !== 'running')
+    .sort((a, b) => (b.startedAt ?? '').localeCompare(a.startedAt ?? ''))
+    .slice(0, deps.handoffLimit ?? HANDOFF_LIMIT)
+
+  const items: Intervention[] = []
+  for (const run of finished) {
+    const branch = runBranchFor(run)
+    const state = await handoff(project.path, branch).catch(() => undefined)
+    // Every condition is a reason this is *not* waiting on anyone: the branch is gone, the session
+    // wrote nothing, it already landed, it is already on the remote, or there is nowhere to push.
+    if (!state || !state.exists || state.empty || state.merged || state.pushed || !state.hasRemote) continue
+    items.push({
+      projectId: project.id,
+      projectName: project.name,
+      kind: 'unpushed',
+      title: run.intent?.trim() || branch,
+      url: deps.dashboardUrl ?? '',
+      runId: run.id,
+      branch,
+      commits: state.commits.length,
+      ...(run.updatedAt ? { createdAt: run.updatedAt } : {}),
+    })
+  }
+  return items
+}
+
+/**
  * The stable identity of an intervention. A PR is its url (survives title edits and re-sorts);
- * an awaiting run is its project + gate id, since its url is the shared dashboard URL and would
- * otherwise collide across projects.
+ * the other two are keyed on the project plus the thing waiting — the gate id, or the run whose
+ * branch is unpushed — since their url is the shared dashboard URL and would otherwise collide.
  */
 export function interventionKey(item: Intervention): string {
-  return item.kind === 'awaiting' ? `awaiting:${item.projectId}:${item.awaitId ?? ''}` : item.url
+  if (item.kind === 'awaiting') return `awaiting:${item.projectId}:${item.awaitId ?? ''}`
+  if (item.kind === 'unpushed') return `unpushed:${item.projectId}:${item.runId ?? ''}`
+  return item.url
 }
 
 /**


### PR DESCRIPTION
Closes #860.

## The gap

An unattended run writes real code, commits it to its own branch, and then nothing tells anyone it exists.

The "needs you" queue knew about exactly two things: a pull request **already on GitHub**, and a run parked on a choice gate. A run that finished with committed work and no PR is neither — so the notification only fired *after* a human had already clicked "Open PR", which they would only do if they already knew the work was there. The overview drops the run as well (it lists only `status === 'running'`), and the push/open-PR panel renders in one place: after you click into that specific archived run.

## What this adds

A third intervention kind: a finished run whose branch still holds commits that were never pushed and never merged. It rides the existing watcher, so it reaches the browser notification and the Discord message like any other item — and since #680 just landed, you can be told in the same place you asked.

**Surfacing only.** Pushing publishes the agent's work under the user's name to a shared remote, and the existing reasoning at `pushRunBranch` holds: that stays a deliberate click, not a side effect of a run ending. This only says a decision is waiting. I did not touch that design.

## Notes for review

**All five exclusions are "this is not waiting on anyone":** the branch is gone, the session wrote nothing, it already merged, it is already on the remote, or there is no remote to push to. The last is a judgement call — a local-only repo has no push action to offer, so surfacing it would be noise you cannot act on.

**Cost.** This runs on the 60s intervention poll, so it is bounded to the most recent finished runs per project (default 5), and the per-branch `gh pr view` lookup that `readRunHandoff` does by default is skipped: an open PR implies the branch was pushed, which `pushed` already excludes, and the `pr` kind is what surfaces it. Leaving it in would have put an 8s-timeout network call per run on every poll — easily the most expensive thing in the queue.

**Every client branch had to change.** The dashboard code was written as `kind === 'awaiting' ? … : (assume pr)` in three places, so a third kind would have rendered as `#undefined`. Updated: the queue card, the notification label, and the notification click target. There is a regression test asserting the Discord line does not fall through to the PR shape.

## Verification

- `packages/framework`: **960 tests, 959 pass, 0 fail** (1 pre-existing skip). `packages/framework-dashboard`: **241 tests, 43 files, all pass**. Both packages `tsc --noEmit` clean.
- **Driven against a real git repo, not just fakes.** Built a repo with a bare origin, one branch holding two unpushed commits and a second branch already pushed, plus run metas for both. `buildInterventions` with real `listRuns`/`readRunHandoff` surfaced exactly the unpushed one, with `commits: 2` and the right branch, and ignored the pushed one. Then pushed the branch and re-ran: empty. Then merged it and re-ran: still empty. So the item appears when the work is waiting and clears once it has gone somewhere.

## One thing worth a second opinion

#860 notes this overlaps the "auto evaluate whether human intervention is needed" item on #538, and says it was filed as evidence rather than a design decision. I kept to the surfacing-only shape the issue proposed, which leaves the publishing call untouched, but if that item is meant to subsume this then this is the slice of it that exists today rather than its own thing.
