### PR TITLE
feat(framework-dashboard): add a toggle for the Discord chatbot (#916)

### DIFF
--- a/.changeset/feat-916-discord-bot-toggle.md
+++ b/.changeset/feat-916-discord-bot-toggle.md
@@ -1,0 +1,13 @@
+---
+'@gemstack/framework-dashboard': minor
+---
+
+A toggle for the Discord chatbot (#916)
+
+The Discord chatbot (#680) is gated on a `discordBot` preference that had no UI, so turning it on
+meant hand-editing `~/.the-framework.json`. It now sits in the notifications popover.
+
+It gets its own "Chat" group rather than joining the delivery methods. Everything else in that menu
+posts outward; this one takes messages in and lets them start and steer sessions, which is worth
+keeping visually apart. For the same reason it stays off by default and does not light the bell,
+which is about notifications.

--- a/packages/framework-dashboard/components/NotificationsMenu.test.tsx
+++ b/packages/framework-dashboard/components/NotificationsMenu.test.tsx
@@ -9,6 +9,7 @@ vi.mock('../lib/preferences.js', () => ({
   updatePreferences,
   notificationsEnabled: (p: Preferences) => p.notifyBrowser ?? true,
   discordEnabled: (p: Preferences) => p.notifyDiscord ?? false,
+  discordBotEnabled: (p: Preferences) => p.discordBot ?? false,
   newActivityEnabled: (p: Preferences) => p.notifyNewActivity ?? false,
   humanInterventionEnabled: (p: Preferences) => p.notifyHumanIntervention ?? true,
 }))
@@ -75,5 +76,30 @@ describe('NotificationsMenu (#676)', () => {
     render(<NotificationsMenu />)
     open()
     expect(screen.getByText('Blocked in your browser settings')).toBeTruthy()
+  })
+
+  test('the Discord bot is its own group, not a delivery method (#916)', () => {
+    render(<NotificationsMenu />)
+    open()
+    // Everything under "Deliver to" posts outward; the bot takes messages in and acts on them,
+    // so it is grouped apart rather than sitting next to the Discord notification toggle.
+    expect(screen.getByText('Chat')).toBeTruthy()
+    expect(screen.getByText('Discord bot')).toBeTruthy()
+  })
+
+  test('the Discord bot toggle is off by default and writes the preference (#916)', () => {
+    render(<NotificationsMenu />)
+    open()
+    const item = screen.getByText('Discord bot').closest('[role="menuitemcheckbox"]')
+    expect(item?.getAttribute('aria-checked')).toBe('false')
+
+    fireEvent.click(screen.getByText('Discord bot'))
+    expect(updatePreferences).toHaveBeenCalledWith({ discordBot: true })
+  })
+
+  test('turning the bot on does not light the bell, which is about notifications (#916)', () => {
+    prefs = { discordBot: true, notifyBrowser: false, notifyDiscord: false }
+    render(<NotificationsMenu />)
+    expect(screen.getByRole('button', { name: /notifications/i }).getAttribute('title')).toBe('Notifications')
   })
 })

--- a/packages/framework-dashboard/components/NotificationsMenu.tsx
+++ b/packages/framework-dashboard/components/NotificationsMenu.tsx
@@ -1,6 +1,6 @@
 import { useSyncExternalStore } from 'react'
 import { Bell, BellOff } from 'lucide-react'
-import { usePreferences, updatePreferences, notificationsEnabled, discordEnabled, newActivityEnabled, humanInterventionEnabled } from '../lib/preferences.js'
+import { usePreferences, updatePreferences, notificationsEnabled, discordEnabled, discordBotEnabled, newActivityEnabled, humanInterventionEnabled } from '../lib/preferences.js'
 import { cn } from '../lib/utils.js'
 import {
   DropdownMenu,
@@ -17,7 +17,8 @@ import {
 // (where a notification goes), "New activity" is a *category* on top of the always-on "needs you"
 // pings. The trigger shows an active state + dot when a method is effectively on; the popover
 // groups and labels every toggle. The underlying prefs and hooks are unchanged — this is purely
-// the header control that writes them.
+// the header control that writes them. The Discord *bot* (#680) sits in its own "Chat" group
+// rather than under a delivery method: it is the one control here that takes messages in.
 
 /** Subscribe to `Notification.permission` changes where the browser supports it, else 'unsupported'. */
 function usePermission(): NotificationPermission | 'unsupported' {
@@ -51,6 +52,7 @@ export function NotificationsMenu() {
   const discord = discordEnabled(preferences)
   const activity = newActivityEnabled(preferences)
   const needsYou = humanInterventionEnabled(preferences)
+  const discordBot = discordBotEnabled(preferences)
   const permission = usePermission()
   const browserSupported = permission !== 'unsupported'
   const blocked = permission === 'denied'
@@ -130,6 +132,20 @@ export function NotificationsMenu() {
             className="items-start"
           >
             <NotifLabel label="New activity" hint="A session started or finished" />
+          </DropdownMenuCheckboxItem>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          {/* Its own group, not a delivery method (#916): everything above posts outward, this
+              takes messages back in and lets them start and steer sessions (#680). */}
+          <DropdownMenuLabel>Chat</DropdownMenuLabel>
+          <DropdownMenuCheckboxItem
+            checked={discordBot}
+            onCheckedChange={next => updatePreferences({ discordBot: next })}
+            title="Lets Discord messages start and steer sessions (needs DISCORD_BOT_TOKEN on the daemon)"
+            className="items-start"
+          >
+            <NotifLabel label="Discord bot" hint="Start and steer sessions from Discord" />
           </DropdownMenuCheckboxItem>
         </DropdownMenuGroup>
       </DropdownMenuContent>

--- a/packages/framework-dashboard/lib/preferences.test.ts
+++ b/packages/framework-dashboard/lib/preferences.test.ts
@@ -273,3 +273,11 @@ describe('preferences', () => {
     expect(resolvedDark('system', false)).toBe(false)
   })
 })
+
+test('the Discord bot is off unless asked for (#916)', async () => {
+  // It acts on what it reads, so an absent preference must never mean on.
+  const { discordBotEnabled } = await import('./preferences.js')
+  expect(discordBotEnabled({})).toBe(false)
+  expect(discordBotEnabled({ discordBot: false })).toBe(false)
+  expect(discordBotEnabled({ discordBot: true })).toBe(true)
+})

--- a/packages/framework-dashboard/lib/preferences.ts
+++ b/packages/framework-dashboard/lib/preferences.ts
@@ -287,6 +287,13 @@ export function discordEnabled(preferences: Preferences): boolean {
   return preferences.notifyDiscord ?? false
 }
 
+/** The Discord chatbot (#680) defaults off, and for a stronger reason than the toggles around it:
+ * those post outward, this one takes in messages that start and steer sessions. The daemon's
+ * `DISCORD_BOT_TOKEN` is the other gate (how to connect; this is whether to). */
+export function discordBotEnabled(preferences: Preferences): boolean {
+  return preferences.discordBot ?? false
+}
+
 /** "New activity" notifications default off (#627): the category that pings on a run starting or
  * finishing, not just on things that need you. Composes with the method toggles above — activity
  * reaches the browser when {@link notificationsEnabled}, Discord when {@link discordEnabled}. */


### PR DESCRIPTION
Closes #916.

The Discord chatbot (#680) is gated on a `discordBot` preference that had no UI, so enabling it meant hand-editing `~/.the-framework.json`. It now sits in the notifications popover.

## The one judgement call

It gets its own **"Chat"** group rather than joining "Deliver to" next to the Discord notification toggle. Everything else in that menu posts outward; this one takes messages in and lets them start and steer sessions, so grouping it with the delivery methods would have understated what it does.

For the same reason it stays off by default, and turning it on does **not** light the bell. The bell means "notifications are on", and the bot is not a notification. There is a test pinning that, since it is the sort of thing a later refactor would quietly change.

## Verification

- `packages/framework-dashboard`: **251 tests across 45 files, all pass**; `tsc --noEmit` clean.
- Ran the two changed test files verbosely to confirm the four new tests actually execute rather than trusting the total. The default reporter prints no test names, and this branch's baseline differs from the last one, so the count alone proved nothing.
- Checked the value survives the preference whitelist, which is the real failure mode here: `sanitizePreferences` copies only registered keys and silently drops anything else, so a toggle can look fine and persist nothing. Wrote `discordBot: true` through `writePreferences` and read it back from a temp config: it round-trips. (`discordBot` was registered in `PREFERENCE_KEYS` with #680; this confirms it.)

## Not covered

The toggle writes the preference and the daemon reads it per message, but I still have no bot token, so the full path from clicking this to a Discord message being answered remains unverified live, exactly as noted on #680.
