### PR TITLE
fix(framework): Stop does nothing on daemon-spawned runs, and headless runs never exit (#905)

### DIFF
--- a/.changeset/fix-905-control-channel.md
+++ b/.changeset/fix-905-control-channel.md
@@ -1,0 +1,23 @@
+---
+'@gemstack/framework': patch
+---
+
+Fix Stop doing nothing, and headless runs never exiting (#905)
+
+A run decided whether it could be steered by asking whether *a daemon was alive on this machine*.
+That is not a fact about the run, and it was wrong in both directions.
+
+The daemon spawns every run with `--no-dashboard`, so that check was the only thing wiring their
+control channel. When the daemon's state file went missing while the daemon was still running (it
+deletes itself on a stale pid and is never rewritten, #922), spawned runs stopped watching the
+control channel: every Stop press was written to disk and read by nobody, with no error shown.
+
+The same check ran the other way too. A run typed into a terminal with `--no-dashboard` picked up a
+control channel just because a daemon existed somewhere, which handed it the live-chat queue, and
+it waited forever for a message that terminal could never send.
+
+Those are now two separate questions. A run is steerable when it has its own dashboard, when a
+daemon is live (unchanged, so a daemon still steers runs it did not start), or when whoever spawned
+it gave it a run id, which is what the daemon does and what holds when the state file does not. A
+run stays open for chat only when someone is actually waiting in it: its own dashboard, or the
+daemon started it. Stop and choice picks keep working either way.

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -27,6 +27,8 @@ import {
   withBrowser,
   BROWSER_MCP_SERVERS,
   type CliIO,
+  isSteerable,
+  isInteractive,
 } from './cli.js'
 import { readLogs } from './logs.js'
 import { createDriver } from './agent.js'
@@ -876,4 +878,39 @@ test('a run that never asked for the post-merge cleanup stays quiet about it (#8
   } finally {
     await rm(dir, { recursive: true, force: true })
   }
+})
+
+// #905: which runs may be steered, and which stay open for chat. Both used to be the same
+// question answered by "is a daemon alive on this machine", which is not about this run at all.
+
+test('a daemon-spawned run is steerable even with no daemon state file (#905)', () => {
+  // The daemon spawns with --no-dashboard and passes --run-id, and its state file can go missing
+  // while it is very much alive (#922). This is the case where every Stop press was dropped in
+  // silence: written to control.jsonl, tailed by nobody.
+  assert.equal(isSteerable({ persist: true, runId: '2026-07-20T20-20-14-026Z' }, false, false), true)
+})
+
+test('a live daemon still steers a run it did not spawn (#393)', () => {
+  // Its dashboard lists and steers any project's run, so Stop must keep working for a run
+  // started by hand in a terminal.
+  assert.equal(isSteerable({ persist: true }, false, true), true)
+})
+
+test('with no dashboard, no run id and no daemon, nothing can reach the run', () => {
+  assert.equal(isSteerable({ persist: true }, false, false), false)
+})
+
+test('--no-persist is never steerable: there is no control file to tail', () => {
+  assert.equal(isSteerable({ persist: false, runId: 'r1' }, true, true), false)
+})
+
+test('a terminal --no-dashboard run does not stay open for chat, daemon or not (#905/#714)', () => {
+  // The other half of #905: it is reachable, but nobody is waiting in that terminal, so handing
+  // it the live-chat queue parked it forever. #714: "headless / CI runs end when done".
+  assert.equal(isInteractive({}, false), false)
+})
+
+test('a run with a dashboard, or one the daemon started, stays open for chat (#714)', () => {
+  assert.equal(isInteractive({}, true), true)
+  assert.equal(isInteractive({ runId: 'r1' }, false), true)
 })

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -919,6 +919,44 @@ async function resolvePromptConfig(
  * over a live dashboard + terminal narration, and resolves with an exit code.
  * Returns 0 on success, 1 on a run error, 2 on a usage error.
  */
+/**
+ * Whether this run can be steered over `.the-framework/control.jsonl` (#344): Stop, a choice pick,
+ * a live message. True when its own dashboard is up (#427), when the machine's daemon is live
+ * (#393, whose dashboard lists and steers any project's run), or when whoever spawned it handed it
+ * a run id.
+ *
+ * That last clause is the #905 fix. The daemon spawns runs with `--no-dashboard`, so `daemonAlive`
+ * was the only thing wiring their control channel, and it is a machine-global file that goes
+ * missing while the daemon is very much alive: `daemonStatus()` deletes it on a stale pid and
+ * nothing rewrites it (#922). Every Stop press then landed in control.jsonl and was read by
+ * nobody, with no error anywhere. A run id is a fact about this run, so it holds when the file
+ * does not.
+ */
+export function isSteerable(
+  opts: { persist: boolean; runId?: string | undefined },
+  hasDashboard: boolean,
+  daemonAlive: boolean,
+): boolean {
+  return opts.persist && (hasDashboard || opts.runId !== undefined || daemonAlive)
+}
+
+/**
+ * Whether this run should stay open for the user's own messages once it settles (#714).
+ *
+ * Narrower than {@link isSteerable} on purpose, and this is the other half of #905. Being
+ * steerable only means someone *could* reach it; staying open means a human is expected to keep
+ * talking to it. A run typed into a terminal with `--no-dashboard` is neither, but it used to
+ * inherit the chat queue purely because a daemon happened to be alive elsewhere on the machine,
+ * and then parked forever on a message that terminal could never send. #714 said as much:
+ * "headless / CI runs end when done, exactly as today."
+ *
+ * So: this run's own dashboard, or the daemon started it (a run id) and therefore has a UI to
+ * carry on the conversation in. Stop and gate picks keep working either way.
+ */
+export function isInteractive(opts: { runId?: string | undefined }, hasDashboard: boolean): boolean {
+  return hasDashboard || opts.runId !== undefined
+}
+
 export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<number> {
   const opts = parseArgs(argv)
   if (opts.error) {
@@ -1134,11 +1172,17 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // Steer this run through .the-framework/control.jsonl (#344): a Stop button or choice
   // pick appends an entry, we tail the file and abort / resolve the parked gate. Reset
   // first so a previous run's picks can never fire into this one (gate ids repeat across
-  // runs). Wired when the machine's daemon is live (#393, it steers any project's run) or
-  // when this run's own new dashboard is up (#427, it too steers over control.jsonl).
-  // Otherwise headless behavior is identical.
+  // runs).
+  //
+  // Wired when this run's own dashboard is up (#427), or when whoever spawned it said it is
+  // steerable. That second half used to ask `daemonStatus()`, a machine-global file this run has
+  // nothing to do with, and it was wrong in both directions (#905): absent while a daemon is live,
+  // so a daemon-spawned run ignored Stop completely (the daemon spawns with --no-dashboard, so the
+  // file was the only thing wiring it); and present while unrelated to this run, so a headless run
+  // parked in the #714 chat loop forever. The daemon passes --run-id when it spawns, which is a
+  // fact about *this* run rather than about the machine, so that is the signal now.
   let control: ControlWatcher | undefined
-  if (opts.persist && (newDashboard || (await daemonStatus()))) {
+  if (isSteerable(opts, newDashboard, await daemonStatus() !== undefined)) {
     try {
       await resetControl(cwd)
       control = watchControl(cwd, entry => {
@@ -1182,6 +1226,11 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     (dashboard || control) && !opts.unattended
       ? (req: ChoiceRequest): Promise<ChoicePick> => new Promise(resolve => pendingChoices.set(req.id, resolve))
       : undefined
+
+  // Whether to hand the run the live-chat queue (#714) once it settles. Steerable is not enough
+  // (#905): a terminal run with --no-dashboard could be reached by a daemon's dashboard, but
+  // nobody is waiting in it, and it used to park forever on a message that never came.
+  const chatQueue = isInteractive(opts, newDashboard) && requestChoice ? { messages } : {}
 
   // Persist the chat into the committed conversation (#908/#857), so a clone carries what was
   // said and not just the fact a run happened. Keyed by the same run id LOGS.md records, which
@@ -1423,7 +1472,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
         onEvent,
         signal: controller.signal,
         ...(requestChoice ? { requestChoice } : {}),
-        ...(requestChoice ? { messages } : {}),
+        ...chatQueue,
         ...(recordMessage ? { recordMessage } : {}),
         ...(opts.model ? { model: opts.model } : {}),
         ...(opts.maxCost ? { budgetUsd: opts.maxCost } : {}),
@@ -1492,7 +1541,7 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
     signals,
     signal: controller.signal,
     ...(requestChoice ? { requestChoice } : {}),
-    ...(requestChoice ? { messages } : {}),
+    ...chatQueue,
     ...(recordMessage ? { recordMessage } : {}),
     ...(opts.model ? { model: opts.model } : {}),
     ...(opts.maxPasses ? { maxPasses: opts.maxPasses } : {}),


### PR DESCRIPTION
Closes #905.

Found while testing: two sessions started from the dashboard kept working after Stop was pressed five times between them. The Stop presses were delivered correctly and the runs never read them.

## The defect

A run decided whether it could be steered by asking whether *a daemon was alive on this machine*:

```ts
if (opts.persist && (newDashboard || (await daemonStatus()))) {   // cli.ts, before
```

That is not a fact about the run, and it answered wrong in both directions.

**Stop silently dead.** The daemon spawns every run with `--no-dashboard` (daemon.ts:780), so `daemonStatus()` was the only thing wiring their control channel. Its state file goes missing while the daemon is still running, because `daemonStatus()` deletes it on a stale pid and nothing ever rewrites it (filed as #922). After that, every spawned run stops tailing `control.jsonl`: Stop presses pile up on disk, read by nobody, with no error anywhere. Observed live, 3 and 2 unread stop entries in two runs.

**Headless runs never exiting.** The same check the other way: a run typed into a terminal with `--no-dashboard` got a control channel just because a daemon existed elsewhere, which handed it the #714 live-chat queue, and it parked forever on a message that terminal could never send.

## The fix

Two separate questions, because they were always two questions:

- `isSteerable` — can anything reach this run (Stop, a choice pick, a message)? Own dashboard, **or a live daemon** (unchanged: #393's dashboard steers runs it did not start), **or a run id from whoever spawned it**. That last clause is what holds when the state file does not.
- `isInteractive` — is someone actually waiting in it, so it should stay open after settling? Own dashboard, or the daemon started it. This alone gates the chat queue now.

Stop and gate picks keep working in both cases. The only behaviour removed is a terminal `--no-dashboard` run inheriting a chat queue nobody can type into, which is what #714 specified anyway: "headless / CI runs end when done, exactly as today."

## A correction worth flagging

My first attempt dropped `daemonStatus()` from the gate entirely. **An existing test caught it** — `a live daemon steers a dashboard-less run through its gates via control.jsonl (#344)` — which encodes #393: a run started by hand still appears in the daemon's dashboard and its Stop must work. Removing that would have traded one broken Stop for another. It stays, and there is now a test naming #393 so the reason is explicit.

## Verification

- `packages/framework`: **966 tests, 965 pass, 0 fail** (1 pre-existing skip); `tsc --noEmit` clean.
- **Both halves reproduced and fixed against the real binary**, not fakes:
  - *Stop*: with **no daemon state file** (the exact broken condition), a run started with `--run-id` parks as a daemon-spawned run should, stays alive, and exits the moment `{"kind":"stop"}` is appended to `control.jsonl`. Before the fix it would have ignored it.
  - *Hang*: same repo, a **live** daemon state file, `--no-dashboard`, no run id. Against `main` (00e35a9) it was **still running after 25s**. Against this branch it **exited on its own in 1s**.
- Six unit tests pin both directions, including the #393 case and `--no-persist`.

## Not in this PR

- #922 — the state file deleting itself on a stale pid and never being rewritten. This fix makes runs independent of that file, but the file is still the machine-wide answer to "is a daemon running" and should stop lying.
- #923 — orphaned runs outliving their daemon (14 on my machine, some over a day old).
- A dead Stop should still be *visible*: a run with no control channel should say so, and the dashboard should not offer a Stop button for a run that is not listening. Worth its own issue; this PR removes the cause rather than reporting it.
