### PR TITLE
fix(framework): do not reconcile a run whose process is still alive (#926)

### DIFF
--- a/.changeset/lucky-pears-wonder.md
+++ b/.changeset/lucky-pears-wonder.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Stop a daemon boot from marking live runs as finished. The boot reconcile flipped every run meta still at `running` to `stopped`, on the assumption that a fresh daemon drives no in-flight run. That holds only while exactly one daemon ever boots, so a second one marked genuinely live runs as finished, giving them a no-op Stop in the dashboard. A meta whose recorded pid is alive on this host is now left alone; one that is provably gone, on another host, or from before the pid was recorded is reconciled as before.

--- a/packages/framework/src/store/run-store.test.ts
+++ b/packages/framework/src/store/run-store.test.ts
@@ -314,6 +314,31 @@ test('reconcileOrphanedRuns flips a live run and archives it, counting it once (
   assert.deepEqual(runs.map(r => [r.id, r.status]), [['2026-live', 'stopped']])
 })
 
+// #926: it used to flip every `running` meta, on the assumption that a fresh daemon drives no
+// in-flight run. A second daemon boot then marked genuinely live runs as finished.
+test('reconcileOrphanedRuns leaves a run whose pid is alive on this host (#926)', async () => {
+  const owned = (id: string, over: Record<string, unknown> = {}): string =>
+    JSON.stringify({ version: RUN_META_VERSION, status: 'running', id, startedAt: AT, updatedAt: AT, passes: 0, pid: 42, host: hostname(), ...over })
+  const fs = memFs({
+    [META]: owned('live'),
+    [join(RUNS, 'alive.json')]: owned('alive'),
+    [join(RUNS, 'dead.json')]: owned('dead', { pid: 43 }),
+    [join(RUNS, 'elsewhere.json')]: owned('elsewhere', { host: 'another-machine' }),
+    ...worktreeFiles('wt', JSON.parse(owned('wt')) as Record<string, unknown>),
+  })
+  // Only pid 42 is running; 43 is gone, and a pid on another host is unknowable so it is flipped.
+  const fixed = await reconcileOrphanedRuns(CWD, fs, pid => pid === 42)
+  assert.equal(fixed, 2, 'only the two that are not provably alive')
+  // Read the files, not `readLiveMeta`/`listRuns`: those run their own #716 probe against the
+  // real process table, and pid 42 is not alive here.
+  const statusOf = (path: string): string => (JSON.parse(fs.files.get(path)!) as RunMeta).status
+  assert.equal(statusOf(META), 'running', 'the live run is still running')
+  assert.equal(statusOf(join(worktreeAt('wt'), '.the-framework', 'run.json')), 'running', 'and so is the one in a worktree')
+  assert.equal(statusOf(join(RUNS, 'alive.json')), 'running')
+  assert.equal(statusOf(join(RUNS, 'dead.json')), 'stopped')
+  assert.equal(statusOf(join(RUNS, 'elsewhere.json')), 'stopped', 'a pid on another host is unknowable, so it is still flipped')
+})
+
 test('reconcileOrphanedRuns is a no-op on a clean or empty workspace (#642)', async () => {
   assert.equal(await reconcileOrphanedRuns(CWD, memFs()), 0)
   const done = memFs({ [META]: JSON.stringify({ version: RUN_META_VERSION, status: 'done', id: 'd', startedAt: AT, updatedAt: AT, passes: 0 }) })

--- a/packages/framework/src/store/run-store.ts
+++ b/packages/framework/src/store/run-store.ts
@@ -548,16 +548,32 @@ export async function listRuns(cwd: string, fs: StoreFs = nodeStoreFs()): Promis
 }
 
 /**
- * Reconcile runs a dead process left marked `running`. A freshly started daemon
- * drives no in-flight run, so at boot any run still at `running` in this workspace
- * — the live `run.json` or an archived `runs/*.json` — is orphaned: its owning
- * process is gone (a crash, kill, or daemon restart), yet it shows as active and
- * its Stop is a no-op (nothing is left to read `control.jsonl`). Each is flipped to
- * `stopped`; the live run is archived first (idempotent) so its history is kept.
- * Returns how many were reconciled. Best-effort: a read/write error skips that run,
- * never throws.
+ * A `running` meta whose owning process is provably still there: same host, live pid (#926).
+ * The inverse of {@link isDeadRun} rather than its negation — a meta with no `pid` (it predates
+ * the field) is neither, and the boot reconcile is what catches those.
  */
-export async function reconcileOrphanedRuns(cwd: string, fs: StoreFs = nodeStoreFs()): Promise<number> {
+function isLiveRun(meta: RunMeta, isAlive: (pid: number) => boolean): boolean {
+  return meta.status === 'running' && meta.pid !== undefined && meta.host === hostname() && isAlive(meta.pid)
+}
+
+/**
+ * Reconcile runs a dead process left marked `running` — the live `run.json`, an archived
+ * `runs/*.json`, or a run inside a worktree. Such a run shows as active while nothing is left
+ * to read its `control.jsonl`, so its Stop is a no-op. Each is flipped to `stopped`; the live
+ * run is archived first (idempotent) so its history is kept. Returns how many were reconciled.
+ * Best-effort: a read/write error skips that run, never throws.
+ *
+ * A run whose pid is alive on this host is left alone (#926). This used to flip every `running`
+ * meta on the assumption that a fresh daemon drives no in-flight run, which holds only while
+ * exactly one daemon ever boots: a second one (and before #922, every failed `framework --daemon`
+ * spawned one) marked genuinely live runs as finished, giving them a no-op Stop in the dashboard.
+ * A meta with no `pid` keeps the old behaviour, since there is nothing better to go on.
+ */
+export async function reconcileOrphanedRuns(
+  cwd: string,
+  fs: StoreFs = nodeStoreFs(),
+  isAlive: (pid: number) => boolean = isPidAlive,
+): Promise<number> {
   const dir = join(cwd, FRAMEWORK_DIR)
   let fixed = 0
   // Archived runs stuck at `running` (e.g. a prior live run the next run never
@@ -567,7 +583,7 @@ export async function reconcileOrphanedRuns(cwd: string, fs: StoreFs = nodeStore
     const path = join(dir, RUNS_DIR, name)
     try {
       const meta = JSON.parse(await fs.read(path)) as RunMeta
-      if (meta.status !== 'running') continue
+      if (meta.status !== 'running' || isLiveRun(meta, isAlive)) continue
       await fs.write(path, JSON.stringify({ ...meta, status: 'stopped' }, null, 2) + '\n')
       fixed++
     } catch {
@@ -577,7 +593,7 @@ export async function reconcileOrphanedRuns(cwd: string, fs: StoreFs = nodeStore
   // The live run: flip it, then archive so a crash that skipped close() still
   // leaves the stopped run in the history list.
   const live = await readMetaFile(fs, join(dir, META_FILE))
-  if (live?.status === 'running') {
+  if (live?.status === 'running' && !isLiveRun(live, isAlive)) {
     const stopped: RunMeta = { ...live, status: 'stopped' }
     await fs.write(join(dir, META_FILE), JSON.stringify(stopped, null, 2) + '\n').catch(() => {})
     await archivePriorRun(fs, dir).catch(() => {})
@@ -593,7 +609,7 @@ export async function reconcileOrphanedRuns(cwd: string, fs: StoreFs = nodeStore
     if (!isSafeRunId(name)) continue
     const worktreeDir = join(dir, WORKTREES_DIR, name, FRAMEWORK_DIR)
     const meta = await readMetaFile(fs, join(worktreeDir, META_FILE))
-    if (meta?.status !== 'running') continue
+    if (meta?.status !== 'running' || isLiveRun(meta, isAlive)) continue
     await fs.write(join(worktreeDir, META_FILE), JSON.stringify({ ...meta, status: 'stopped' }, null, 2) + '\n').catch(() => {})
     await archiveWorktreeRun(join(dir, WORKTREES_DIR, name), cwd, fs).catch(() => undefined)
     fixed++


### PR DESCRIPTION
Closes #926.

## The bug

`reconcileOrphanedRuns` flips every meta still at `running` to `stopped` at daemon boot, in all three places it looks: the archived `runs/*.json`, the live `run.json`, and the run inside each worktree. None of them consulted the `pid`/`host` the meta has carried since #716.

The assumption behind it, that a fresh daemon drives no in-flight run, holds only while exactly one daemon ever boots. A second one marks live runs as finished: the dashboard shows the row as settled, its Stop becomes a no-op, and #860's `unpushed` intervention can fire on a run that has not finished. Before #922 this was routine, since every failed `framework --daemon` spawned a daemon that ran this reconcile on its way to losing the port.

## The fix

Skip a meta whose recorded pid is alive on this host, the same rule `readLiveMeta` already applies. Everything else keeps the old behaviour:

- a pid that is gone: reconciled
- a pid on another host, which is unknowable from here: reconciled
- a meta with no pid, from before #716: reconciled

`isAlive` is injectable, defaulting to the existing `isPidAlive`, so the test does not depend on the real process table.

## Verification

Real binaries, `XDG_CONFIG_HOME` in a temp dir, a workspace seeded with one run owned by a live pid and one owned by a dead pid, then a daemon booted against it:

| | main | this branch |
|---|---|---|
| live-owner run | `stopped` | `running` |
| dead-owner run | `stopped` | `stopped` |
| daemon log | reconciled 2 orphaned session(s) | reconciled 1 orphaned session(s) |

Suite: 967 pass, 0 fail.