### PR TITLE
feat(framework): suspend the daemon's runs on shutdown and resume them on start (#923)

### DIFF
--- a/.changeset/olive-jars-jump.md
+++ b/.changeset/olive-jars-jump.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Runs no longer outlive the daemon that spawned them. A shutting-down daemon stops the runs it started and records each one as resumable; the next daemon picks them back up in the same worktree, continuing the same agent conversation. Previously a stopped daemon left every in-flight run running on `ppid 1`, holding a worktree and sometimes a headless browser, with nothing left that knew about it. Runs suspended more than a day ago are dropped rather than resumed, and a run the daemon merely steers rather than spawned is left alone.

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -21,6 +21,10 @@ import {
   pruneWorktrees,
   readLiveMetas,
   isSafeRunId,
+  readSuspendedRuns,
+  writeSuspendedRuns,
+  resumableRuns,
+  type SuspendedRun,
 } from './store/index.js'
 import { startDashboard, type Dashboard, type StartRunKind, type StartRunOptions, type StartRunResult, type AddProjectResult, type PreviewResult, type PreviewStatus } from './dashboard/index.js'
 import { startInterventionWatcher, postDiscord, type InterventionWatcher } from './dashboard/intervention-watcher.js'
@@ -68,6 +72,13 @@ export const DAEMON_STATE_FILE = 'the-framework-daemon.json'
 
 /** The default dashboard port the daemon binds. Matches the per-run dashboard. */
 export const DEFAULT_DAEMON_PORT = 4200
+
+/**
+ * What a resumed run is asked to do (#923). The agent comes back with its own session, so it has
+ * the whole conversation: the only thing it is missing is why it suddenly stopped mid-task.
+ */
+export const RESUME_PROMPT =
+  'This session was interrupted when The Framework restarted, not by anyone asking you to stop. Look at what you had already done, then carry on from there.'
 
 /** What a running daemon writes so a later `framework` invocation can find it. */
 export interface DaemonState {
@@ -518,6 +529,42 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
       resolvePreferences({ ...global, ...preferencesFromFileConfig(file) }, project),
     )
   }
+  // Resume what the last daemon suspended (#923). A run does not outlive its daemon: it is stopped
+  // at shutdown and its id + agent session recorded, so a restart continues the same conversation
+  // in the same worktree instead of leaving an orphan behind. The state survives the process, which
+  // is the #857 direction; the process does not. Capped by age (SUSPEND_MAX_AGE_MS) so a machine
+  // that has been off for a week does not wake up spending a day's quota on stale work, and cleared
+  // as it is read, so a run that fails to resume is not retried on every boot.
+  void (async () => {
+    for (const record of await listProjects(undefined, env).catch(() => [])) {
+      const suspended = await readSuspendedRuns(record.path).catch(() => [])
+      if (suspended.length === 0) continue
+      await writeSuspendedRuns(record.path, []).catch(() => {})
+      const resumable = resumableRuns(suspended, Date.now())
+      const dropped = suspended.length - resumable.length
+      if (dropped > 0) console.log(`[framework] ${dropped} suspended session(s) in ${basename(record.path)} are too old to resume`)
+      for (const run of resumable) {
+        const options = await resolvedRunOptions(record.id)
+        const result = await runtime.onStart(
+          RESUME_PROMPT,
+          'prompt',
+          {
+            ...options,
+            unattended: true,
+            continueRunId: run.runId,
+            ...(run.sessionId ? { resumeSession: run.sessionId } : {}),
+          },
+          record.id,
+        )
+        console.log(
+          result.ok
+            ? `[framework] resumed session ${run.runId} in ${basename(record.path)}`
+            : `[framework] could not resume session ${run.runId}: ${result.error}`,
+        )
+      }
+    }
+  })()
+
   let watcher: InterventionWatcher | undefined
   let activityWatcher: ActivityWatcher | undefined
   if (webhook) {
@@ -638,6 +685,11 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
   // would otherwise hold the event loop open on its own.
   discordBot?.stop()
   autoPm.stop()
+  // Stop the runs this daemon spawned (#923), before the previews they may be serving. Left
+  // running they are orphans nothing tracks; stopped here they are recorded and resumed on the
+  // next boot. Auto PM is stopped first so nothing starts a run while we are stopping them.
+  const suspended = await runtime.suspendRuns().catch(() => 0)
+  if (suspended > 0) console.log(`[framework] suspended ${suspended} session(s); they resume when the daemon starts again`)
   // Stopped here as well as by the dashboard: a broken install serves 503s without ever taking
   // ownership of the source we handed in, and that poller would go on reading by itself.
   quota.stop()
@@ -670,6 +722,11 @@ interface ProjectRuntime {
   onPreviewStatus: (targetProjectId?: string) => PreviewStatus
   /** Live runs on a project (#685), so a background job can tell an idle project from a busy one. */
   activeRunCount: (targetProjectId: string) => number
+  /**
+   * Stop the runs this daemon spawned and record each as resumable (#923). Returns how many
+   * were suspended. Called on shutdown, before the previews go.
+   */
+  suspendRuns: (graceMs?: number) => Promise<number>
   /** Stop every live preview so their dev servers do not outlive the daemon (#475). */
   dispose: () => Promise<void>
 }
@@ -986,12 +1043,68 @@ function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): Pro
     return live + [...starting].filter(key => key === targetProjectId || key.startsWith(`${targetProjectId}::`)).length
   }
 
+  /**
+   * Stop the runs this daemon spawned, and record them as resumable (#923).
+   *
+   * A spawned run is detached so it survives the CLI that asked for it, not so it survives the
+   * daemon that owns it: left alone it becomes an orphan on `ppid 1`, holding a worktree and a
+   * headless browser, with no daemon left that knows about it. So each gets a SIGTERM, which the
+   * run already handles by aborting cleanly and group-killing its agent, and a SIGKILL if it will
+   * not go. Only runs in `activeRuns` — a run this daemon merely steers (#393) is not its to stop.
+   *
+   * What is stopped here is not lost: the run keeps its worktree and branch (a run that ends
+   * `stopped` is retained, see tearDownWorktree), and its id + agent session are written to the
+   * project so the next daemon can continue the same conversation in the same checkout. A run that
+   * managed to finish while we were asking is left out — there is nothing to resume.
+   */
+  const suspendRuns = async (graceMs = 5000): Promise<number> => {
+    const byProject = new Map<string, SuspendedRun[]>()
+    const stopping = [...activeRuns.entries()]
+    activeRuns.clear()
+    for (const [key, pid] of stopping) {
+      const separator = key.indexOf('::')
+      const projectKey = separator === -1 ? key : key.slice(0, separator)
+      const runId = separator === -1 ? undefined : key.slice(separator + 2)
+      const projectCwd = await resolveProject(projectKey)
+      if (!isProcessAlive(pid)) continue
+      try {
+        process.kill(pid, 'SIGTERM')
+      } catch {
+        // exited between the check and the signal
+      }
+      if (!(await waitForExit(pid, graceMs))) {
+        try {
+          process.kill(pid, 'SIGKILL')
+        } catch {
+          // raced us to exit
+        }
+        await waitForExit(pid, 1000)
+      }
+      // A fallback run (no worktree, no run id) cannot be continued, so it is stopped and no more.
+      if (!runId || !projectCwd) continue
+      const meta = (await readLiveMetas(projectCwd).catch(() => [])).find(run => run.id === runId)
+      if (meta?.status === 'done') continue
+      const entry: SuspendedRun = {
+        runId,
+        suspendedAt: new Date().toISOString(),
+        ...(meta?.sessionId ? { sessionId: meta.sessionId } : {}),
+      }
+      byProject.set(projectCwd, [...(byProject.get(projectCwd) ?? []), entry])
+    }
+    let suspended = 0
+    for (const [projectCwd, runs] of byProject) {
+      await writeSuspendedRuns(projectCwd, runs).catch(() => {})
+      suspended += runs.length
+    }
+    return suspended
+  }
+
   const dispose = async (): Promise<void> => {
     await Promise.all([...activePreviews.values()].map(p => p.stop().catch(() => {})))
     activePreviews.clear()
   }
 
-  return { onStart, onAddProject, onPreview, onServeTargets, onStopPreview, onPreviewStatus, activeRunCount, dispose }
+  return { onStart, onAddProject, onPreview, onServeTargets, onStopPreview, onPreviewStatus, activeRunCount, suspendRuns, dispose }
 }
 
 /** Resolve on SIGINT/SIGTERM, or when the optional abort signal fires. */

--- a/packages/framework/src/store/index.ts
+++ b/packages/framework/src/store/index.ts
@@ -51,3 +51,11 @@ export {
   nodeLinkFs,
   type LinkFs,
 } from './worktree-deps.js'
+export {
+  readSuspendedRuns,
+  writeSuspendedRuns,
+  resumableRuns,
+  SUSPENDED_FILE,
+  SUSPEND_MAX_AGE_MS,
+  type SuspendedRun,
+} from './suspend.js'

--- a/packages/framework/src/store/suspend.test.ts
+++ b/packages/framework/src/store/suspend.test.ts
@@ -1,0 +1,65 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { readSuspendedRuns, writeSuspendedRuns, resumableRuns, SUSPEND_MAX_AGE_MS, type SuspendedRun } from './suspend.js'
+import { FRAMEWORK_DIR } from './run-store.js'
+
+const AT = '2026-07-20T10:00:00.000Z'
+const NOW = Date.parse('2026-07-20T12:00:00.000Z')
+
+async function tmpWorkspace(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'framework-suspend-'))
+}
+
+test('a suspended list round-trips, and an absent file reads as nothing to resume (#923)', async () => {
+  const cwd = await tmpWorkspace()
+  try {
+    assert.deepEqual(await readSuspendedRuns(cwd), [])
+    const runs: SuspendedRun[] = [
+      { runId: '2026-a', sessionId: 'sess-1', suspendedAt: AT },
+      { runId: '2026-b', suspendedAt: AT },
+    ]
+    await writeSuspendedRuns(cwd, runs)
+    assert.deepEqual(await readSuspendedRuns(cwd), runs)
+    await writeSuspendedRuns(cwd, []) // consumed by a boot
+    assert.deepEqual(await readSuspendedRuns(cwd), [])
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('a malformed suspended file resumes nothing rather than throwing (#923)', async () => {
+  const cwd = await tmpWorkspace()
+  try {
+    await mkdir(join(cwd, FRAMEWORK_DIR), { recursive: true })
+    await writeFile(join(cwd, FRAMEWORK_DIR, 'suspended.json'), 'not json')
+    assert.deepEqual(await readSuspendedRuns(cwd), [])
+    await writeFile(join(cwd, FRAMEWORK_DIR, 'suspended.json'), JSON.stringify([{ nope: true }, { runId: 'ok', suspendedAt: AT }]))
+    assert.deepEqual(await readSuspendedRuns(cwd), [{ runId: 'ok', suspendedAt: AT }]) // entries without an id are dropped
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('resumableRuns keeps recent work and drops what has gone stale (#923)', () => {
+  const at = (ms: number): string => new Date(NOW - ms).toISOString()
+  const runs: SuspendedRun[] = [
+    { runId: 'minutes-ago', suspendedAt: at(5 * 60 * 1000) },
+    { runId: 'just-inside', suspendedAt: at(SUSPEND_MAX_AGE_MS - 1000) },
+    { runId: 'just-outside', suspendedAt: at(SUSPEND_MAX_AGE_MS + 1000) },
+    { runId: 'a-week-ago', suspendedAt: at(7 * 24 * 60 * 60 * 1000) },
+    { runId: 'unparseable', suspendedAt: 'whenever' },
+  ]
+  assert.deepEqual(
+    resumableRuns(runs, NOW).map(run => run.runId),
+    ['minutes-ago', 'just-inside'],
+  )
+  // A clock that moved backwards leaves a future stamp; that is recent by any reading.
+  assert.deepEqual(
+    resumableRuns([{ runId: 'future', suspendedAt: new Date(NOW + 60_000).toISOString() }], NOW).map(r => r.runId),
+    ['future'],
+  )
+  assert.deepEqual(resumableRuns([], NOW), [])
+})

--- a/packages/framework/src/store/suspend.ts
+++ b/packages/framework/src/store/suspend.ts
@@ -1,0 +1,61 @@
+import { join } from 'node:path'
+import { FRAMEWORK_DIR, nodeStoreFs, type StoreFs } from './run-store.js'
+
+/** Where a project records the runs its daemon suspended (#923). Transient, like the run logs. */
+export const SUSPENDED_FILE = 'suspended.json'
+
+/**
+ * How long a suspended run stays resumable, ms (#923). A daemon restart within the day picks
+ * the work back up; a machine that has been off for a week does not wake up spending a day's
+ * quota on work whose repo has moved on. Older entries are dropped, not resumed.
+ */
+export const SUSPEND_MAX_AGE_MS = 24 * 60 * 60 * 1000
+
+/** A run its daemon stopped at shutdown, and what is needed to pick it up again (#923). */
+export interface SuspendedRun {
+  /** The run's id, which is also its worktree and its row in the dashboard. */
+  runId: string
+  /** The agent conversation to continue, when the run got far enough to report one. */
+  sessionId?: string
+  /** When the daemon stopped it, ISO. */
+  suspendedAt: string
+}
+
+function suspendedPath(cwd: string): string {
+  return join(cwd, FRAMEWORK_DIR, SUSPENDED_FILE)
+}
+
+/** The runs this project's daemon suspended, or `[]` when there are none / the file is unreadable. */
+export async function readSuspendedRuns(cwd: string, fs: StoreFs = nodeStoreFs()): Promise<SuspendedRun[]> {
+  try {
+    const parsed = JSON.parse(await fs.read(suspendedPath(cwd))) as unknown
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(
+      (entry): entry is SuspendedRun =>
+        typeof entry === 'object' && entry !== null && typeof (entry as SuspendedRun).runId === 'string',
+    )
+  } catch {
+    // absent / unreadable / malformed -> nothing to resume
+    return []
+  }
+}
+
+/** Record the runs a shutting-down daemon stopped. Replaces the list; an empty list clears it. */
+export async function writeSuspendedRuns(cwd: string, runs: SuspendedRun[], fs: StoreFs = nodeStoreFs()): Promise<void> {
+  await fs.mkdir(join(cwd, FRAMEWORK_DIR))
+  await fs.write(suspendedPath(cwd), JSON.stringify(runs, null, 2) + '\n')
+}
+
+/**
+ * The entries a booting daemon should pick back up: suspended recently enough to still be worth
+ * resuming (#923). Pure, so the cutoff is testable without a clock. An entry with an unparseable
+ * timestamp is dropped rather than resumed, since its age is exactly what the rule turns on; a
+ * timestamp in the future (a clock that moved) counts as recent, and the entry is consumed by
+ * that boot either way.
+ */
+export function resumableRuns(runs: SuspendedRun[], now: number, maxAgeMs: number = SUSPEND_MAX_AGE_MS): SuspendedRun[] {
+  return runs.filter(run => {
+    const at = Date.parse(run.suspendedAt)
+    return Number.isFinite(at) && now - at <= maxAgeMs
+  })
+}


### PR DESCRIPTION
Closes #923.

## The decision behind it

#923 left the lifetime open: stop runs when the daemon stops, or adopt them because #605 points at a 24/7 headless runtime where outliving a daemon might be intended. This takes a third reading, which is better than either: **a run does not outlive its daemon, but its work does.** The daemon stops what it started, records it, and the next daemon continues the same conversation in the same worktree.

That fits #605 rather than fighting it. The 24/7-ness there comes from the daemon being a long-lived service, not from processes surviving without one, and #857 says the state belongs in the repo. This puts the state in the repo and lets the process go.

Adoption was the weaker option in practice: a re-attached run is not a child process, so there is no `exit` to hook, and that hook is what archives the run and retires its worktree today.

## What it does

- **On shutdown**: SIGTERM each run in `activeRuns`, which a run already handles by aborting cleanly and group-killing its agent tree (so the headless Chrome goes too), escalating to SIGKILL after a grace period. Then it writes `.the-framework/suspended.json` with each run's id and agent session id.
- **On start**: read that file, clear it, and for each entry within the age cap call `onStart` with `continueRunId` + `resumeSession`, which the daemon already supports for the dashboard's continue-a-run (#762/#720). The agent comes back with its full prior context and a short prompt explaining that it was interrupted by a restart rather than by someone stopping it.

Bounds:

- Only runs in `activeRuns`, i.e. runs this daemon spawned. A run it merely steers (#393) is not its to stop.
- Only runs with a worktree; a fallback run has nothing to continue, so it is stopped and no more.
- Only within `SUSPEND_MAX_AGE_MS` (24h), so a machine that has been off for a week does not wake up spending a day's quota on stale work. Older entries are logged and dropped.
- A run that finishes while being asked to stop is not recorded, since there is nothing to resume.
- The file is cleared as it is read, so a run that fails to resume is not retried on every boot.

Nothing is lost in the gap: a run that ends `stopped` keeps its worktree and branch (`tearDownWorktree` only removes a checkout for a run that finished `done`), which is exactly what the resume attaches to.

## Verification

Unit tests cannot prove a process lifecycle, so this was driven against the built `dist`: the real `runDaemon`, with a stub in place of the agent run (a real one would spend quota), started through the daemon's own Telefunc `sendStart`.

| | main | this branch |
|---|---|---|
| run alive after daemon shutdown | 1 orphan | 0 |
| run received SIGTERM | no | yes |
| `suspended.json` | absent | `[{runId, suspendedAt, sessionId}]` |
| next daemon boot | nothing resumed | `resumed session <id>`, respawned with `--continue-run --resume-session sess-stub` |

Suite: 969 pass, 0 fail.

## Follow-ups, deliberately not here

- The existing orphans on a machine are not adopted or killed by this. It stops the accumulation; clearing what is already there is #752's prune verb.
- Whether the age cap should be a preference rather than a constant.