### PR TITLE
feat(framework): add a worktrees CLI: list, rm, prune (#752)

### DIFF
--- a/.changeset/olive-pandas-shave.md
+++ b/.changeset/olive-pandas-shave.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Add `framework worktrees` for the checkouts sessions leave behind. `framework worktrees` lists them with the session's status, size on disk and branch; `framework worktrees rm <sessionId>` removes one, refusing while that session is still running; `framework worktrees prune` removes every one whose session is no longer running. Until now this cleanup existed only as a per-row button in the dashboard, so it could not be scripted, and a machine that had been running sessions for a while accumulated checkouts with no way to clear them from a terminal.

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -64,6 +64,12 @@ import {
   short,
   type RepoReview,
 } from './maintenance.js'
+import {
+  listProjectWorktrees,
+  removeProjectWorktree,
+  pruneProjectWorktrees,
+  formatWorktreeList,
+} from './worktrees.js'
 import { defaultWhat } from './preset-prompt.js'
 import { renderMaintainabilityPrompt } from './maintainability-preset.js'
 import { renderOnBeforeMergeablePrompt, type OnBeforeMergeableContext } from './on-before-mergeable-prompt.js'
@@ -140,6 +146,9 @@ Usage:
   framework maintain              Sweep the registered repos: run the maintainability
                                  loop on any that grew un-reviewed commits (#298).
                                  --dry-run to preview; --max-repos / --max-cost to bound.
+  framework worktrees             List the checkouts this project's sessions kept.
+                                 rm <sessionId> removes one; prune removes every one
+                                 whose session is no longer running.
   framework --fake                Run the offline demo (no CLI, no model, deterministic).
   framework doctor                Check prerequisites (Claude Code installed, etc.).
   framework relay                 Host a session relay so teammates can watch a session (#230).
@@ -323,6 +332,8 @@ export interface CliOptions {
   directPrompt: boolean
   /** `framework maintain`: sweep the registered repos, running the maintenance loop on un-reviewed commits (#298). */
   maintain: boolean
+  /** `framework worktrees [rm <id> | prune]`: the retained-worktree cleanup the dashboard has (#752). */
+  worktrees?: WorktreesCommand
   /** `--dry-run`: for `maintain`, list what would be reviewed without running anything. */
   dryRun: boolean
   /** `--max-repos <n>`: cap how many repos one maintenance sweep reviews. */
@@ -591,6 +602,18 @@ export function parseArgs(argv: string[]): CliOptions {
   } else if (words[0] === 'maintain') {
     opts.maintain = true
     words.shift() // maintain takes no positional args; the target is the registry
+  } else if (words[0] === 'worktrees') {
+    // `worktrees` / `worktrees prune` / `worktrees rm <sessionId>` (#752). Bare = list; an
+    // unknown sub-verb is a usage error rather than a silent list of something else.
+    words.shift()
+    const sub = words.shift()
+    if (sub === undefined || sub === 'list') opts.worktrees = { action: 'list' }
+    else if (sub === 'prune') opts.worktrees = { action: 'prune' }
+    else if (sub === 'rm') {
+      const runId = words.shift()
+      opts.worktrees = { action: 'rm', ...(runId ? { runId } : {}) }
+    }
+    else opts.error = `unknown worktrees command: ${sub}`
   }
   opts.intent = words.join(' ').trim()
   return opts
@@ -1005,6 +1028,9 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // `framework maintain` sweeps the registered repos, running the maintenance loop on
   // any that grew un-reviewed commits (#298). No dashboard, no intent.
   if (opts.maintain) return maintainCmd(opts, io)
+
+  // `framework worktrees` is the CLI half of the dashboard's retained-worktree cleanup (#752).
+  if (opts.worktrees) return worktreesCmd(opts.worktrees, opts.cwd ?? process.cwd(), io)
 
   const fake = opts.fake
   const intent = opts.intent || (fake ? FAKE_INTENT : '')
@@ -1640,6 +1666,46 @@ async function ensureDaemonCmd(opts: CliOptions, io: CliIO): Promise<number> {
   const line = formatUpdateStatus(status)
   if (line) io.out(line)
   return 0
+}
+
+/** What `framework worktrees` was asked to do (#752). */
+export type WorktreesCommand = { action: 'list' } | { action: 'rm'; runId?: string } | { action: 'prune' }
+
+/**
+ * `framework worktrees` (#752): the retained-worktree cleanup the dashboard already has (#737),
+ * from the terminal, so it is scriptable and available without opening a browser.
+ *
+ * Scoped to the cwd's project, like the rest of the CLI. A run that failed or was stopped keeps
+ * its checkout so you can look at what it was holding, and nothing removes those on a timer — so
+ * without this the only way to clear them was the dashboard, one click at a time.
+ */
+async function worktreesCmd(command: WorktreesCommand, cwd: string, io: CliIO): Promise<number> {
+  if (command.action === 'list') {
+    for (const line of formatWorktreeList(await listProjectWorktrees(cwd))) io.out(line)
+    return 0
+  }
+  if (command.action === 'rm') {
+    if (!command.runId) {
+      io.err('usage: framework worktrees rm <sessionId>')
+      return 2
+    }
+    const result = await removeProjectWorktree(cwd, command.runId)
+    if (!result.ok) {
+      io.err(result.error)
+      return 1
+    }
+    io.out(`◆ removed the worktree for session ${command.runId}.`)
+    return 0
+  }
+  const { removed, skipped } = await pruneProjectWorktrees(cwd)
+  for (const skip of skipped) io.out(`  kept ${skip.runId}: ${skip.reason}`)
+  io.out(
+    removed.length === 0
+      ? 'Nothing to prune.'
+      : `◆ removed ${removed.length} worktree${removed.length === 1 ? '' : 's'}.`,
+  )
+  // A worktree that could not be removed is a failure to report, not a silent partial success.
+  return skipped.some(skip => skip.reason !== 'still running') ? 1 : 0
 }
 
 /** `framework stop`: stop the machine's background dashboard, if any (#393). */

--- a/packages/framework/src/worktrees.test.ts
+++ b/packages/framework/src/worktrees.test.ts
@@ -1,0 +1,36 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { formatSize, formatWorktreeList, type WorktreeRow } from './worktrees.js'
+
+const row = (over: Partial<WorktreeRow> & { runId: string }): WorktreeRow => ({ live: false, ...over })
+
+test('formatSize scales, and keeps one decimal only where it reads better (#752)', () => {
+  assert.equal(formatSize(undefined), '-')
+  assert.equal(formatSize(0), '0B')
+  assert.equal(formatSize(900), '900B')
+  assert.equal(formatSize(1536), '1.5KB')
+  assert.equal(formatSize(20 * 1024), '20KB')
+  assert.equal(formatSize(1024 * 1024 * 3.25), '3.3MB')
+  assert.equal(formatSize(1024 ** 3 * 2), '2.0GB')
+})
+
+test('the worktrees table pads its columns and names every session (#752)', () => {
+  const lines = formatWorktreeList([
+    row({ runId: '2026-07-20T10-00-00-000Z', status: 'stopped', sizeBytes: 1536, branch: 'the-framework/add-login' }),
+    row({ runId: '2026-07-19T09-00-00-000Z', status: 'failed' }),
+    row({ runId: '2026-07-18T08-00-00-000Z', status: 'running', live: true }),
+  ])
+  assert.equal(lines[0], 'SESSION                   STATUS   SIZE   BRANCH')
+  assert.equal(lines[1], '2026-07-20T10-00-00-000Z  stopped  1.5KB  the-framework/add-login')
+  assert.equal(lines[2], '2026-07-19T09-00-00-000Z  failed   -      -', 'no size and no branch still line up')
+  assert.equal(lines[3], '2026-07-18T08-00-00-000Z  running  -      -', 'a live session is listed, not hidden')
+})
+
+test('an empty list says why there is nothing rather than printing a bare header (#752)', () => {
+  assert.deepEqual(formatWorktreeList([]), ['No worktrees. A session that finished cleanly does not keep one.'])
+})
+
+test('a worktree whose run left no meta is listed as unknown, not skipped (#752)', () => {
+  const lines = formatWorktreeList([row({ runId: 'orphan' })])
+  assert.equal(lines[1], 'orphan   unknown  -     -')
+})

--- a/packages/framework/src/worktrees.ts
+++ b/packages/framework/src/worktrees.ts
@@ -1,0 +1,156 @@
+import {
+  listWorktreeDirs,
+  listRuns,
+  readLiveMetas,
+  removeWorktree,
+  pruneWorktrees,
+  worktreePath,
+  worktreeSize,
+  isSafeRunId,
+  type RunStatus,
+} from './store/index.js'
+
+/** A retained worktree and the run that left it behind (#752). */
+export interface WorktreeRow {
+  /** The run id, which is also the worktree's directory name. */
+  runId: string
+  /** The branch the run's work landed on, when its meta recorded one (#799). */
+  branch?: string
+  /** How the run that left this checkout ended, or `running` while it is still going. */
+  status?: RunStatus
+  /** Size on disk in bytes, absent for a live run (its tree is still changing) or when unreadable. */
+  sizeBytes?: number
+  /** True while the run owning this checkout is still going: it is in use, not retained. */
+  live: boolean
+}
+
+/** Why a worktree was left in place by {@link pruneProjectWorktrees}. */
+export interface SkippedWorktree {
+  runId: string
+  reason: string
+}
+
+/** What {@link pruneProjectWorktrees} did. */
+export interface PruneResult {
+  removed: string[]
+  skipped: SkippedWorktree[]
+}
+
+/** The outcome of {@link removeProjectWorktree}. */
+export type RemoveResult = { ok: true } | { ok: false; error: string }
+
+/**
+ * The worktrees a project still has on disk (#752), newest first — the same view the dashboard's
+ * retained-worktrees list is built from, through the same store reads, so the CLI is a second
+ * surface rather than a second behaviour.
+ *
+ * A live run's checkout is included and flagged rather than hidden: "what is this directory and
+ * why can I not remove it" is exactly the question the list has to answer.
+ */
+export async function listProjectWorktrees(cwd: string): Promise<WorktreeRow[]> {
+  const [names, live, archived] = await Promise.all([
+    listWorktreeDirs(cwd).catch(() => []),
+    readLiveMetas(cwd).catch(() => []),
+    listRuns(cwd).catch(() => []),
+  ])
+  const rows: WorktreeRow[] = []
+  for (const runId of names) {
+    const meta = live.find(run => run.id === runId) ?? archived.find(run => run.id === runId)
+    const isLive = meta?.status === 'running'
+    rows.push({
+      runId,
+      live: isLive,
+      ...(meta?.branch ? { branch: meta.branch } : {}),
+      ...(meta?.status ? { status: meta.status } : {}),
+      // Sizing a tree an agent is writing to gives a number that is wrong by the time it prints.
+      ...(isLive ? {} : await sizeOf(cwd, runId)),
+    })
+  }
+  return rows.sort((a, b) => (a.runId < b.runId ? 1 : a.runId > b.runId ? -1 : 0))
+}
+
+async function sizeOf(cwd: string, runId: string): Promise<{ sizeBytes?: number }> {
+  const bytes = await worktreeSize(worktreePath(cwd, runId)).catch(() => undefined)
+  return bytes === undefined ? {} : { sizeBytes: bytes }
+}
+
+/**
+ * Remove one retained worktree (#752/#737), refusing while its run is still going — a run's
+ * checkout is where its agent is working, and Stop is how you end a run, not pulling the floor
+ * out from under it. The run's history was archived into the repo when it finished, so removal
+ * costs no history.
+ *
+ * Unlike the dashboard's Remove, this cannot stop a preview serving that checkout: previews live
+ * in the daemon, and the CLI is a different process. A worktree being served is still removed;
+ * the dev server is the daemon's to notice.
+ */
+export async function removeProjectWorktree(cwd: string, runId: string): Promise<RemoveResult> {
+  if (!isSafeRunId(runId)) return { ok: false, error: `invalid session id: ${runId}` }
+  const names = await listWorktreeDirs(cwd).catch((): string[] => [])
+  if (!names.includes(runId)) return { ok: false, error: `no worktree for session ${runId}` }
+  const live = await readLiveMetas(cwd).catch(() => [])
+  if (live.some(run => run.id === runId && run.status === 'running')) {
+    return { ok: false, error: 'that session is still going; stop it before removing its worktree' }
+  }
+  try {
+    await removeWorktree(cwd, worktreePath(cwd, runId))
+    await pruneWorktrees(cwd)
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+/**
+ * Remove every retained worktree whose run is not live (#752): the "clean all of this up" case.
+ * A live run keeps its checkout and is reported as skipped, so the count always adds up to what
+ * the list showed.
+ */
+export async function pruneProjectWorktrees(cwd: string): Promise<PruneResult> {
+  const result: PruneResult = { removed: [], skipped: [] }
+  for (const row of await listProjectWorktrees(cwd)) {
+    if (row.live) {
+      result.skipped.push({ runId: row.runId, reason: 'still running' })
+      continue
+    }
+    const outcome = await removeProjectWorktree(cwd, row.runId)
+    if (outcome.ok) result.removed.push(row.runId)
+    else result.skipped.push({ runId: row.runId, reason: outcome.error })
+  }
+  return result
+}
+
+/** Human sizes for the list. Whole units below 10 so the column stays narrow. */
+export function formatSize(bytes: number | undefined): string {
+  if (bytes === undefined) return '-'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let value = bytes
+  let unit = 0
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit++
+  }
+  return `${value < 10 && unit > 0 ? value.toFixed(1) : Math.round(value)}${units[unit]}`
+}
+
+/**
+ * The `framework worktrees` table (#752). Pure so the layout is testable: columns padded to the
+ * widest cell, and a message rather than an empty table when a project has no worktrees.
+ */
+export function formatWorktreeList(rows: WorktreeRow[]): string[] {
+  if (rows.length === 0) return ['No worktrees. A session that finished cleanly does not keep one.']
+  const header = ['SESSION', 'STATUS', 'SIZE', 'BRANCH']
+  const body = rows.map(row => [
+    row.runId,
+    row.live ? 'running' : (row.status ?? 'unknown'),
+    formatSize(row.sizeBytes),
+    row.branch ?? '-',
+  ])
+  const widths = header.map((_, column) => Math.max(...[header, ...body].map(cells => (cells[column] ?? '').length)))
+  const line = (cells: string[]): string =>
+    cells
+      .map((cell, column) => (column === cells.length - 1 ? cell : cell.padEnd(widths[column] ?? 0)))
+      .join('  ')
+      .trimEnd()
+  return [line(header), ...body.map(line)]
+}


### PR DESCRIPTION
Closes #752. Part of #453, follow-up to #737.

## Why

A run that failed or was stopped keeps its checkout so you can inspect what it was holding, and nothing removes those on a timer. The only cleanup was the dashboard's per-row Remove, so it was not scriptable and needed a browser. This is the same thing from the terminal.

## The three verbs

```
framework worktrees                    list
framework worktrees rm <sessionId>     remove one
framework worktrees prune              remove every one whose session is not running
```

```
SESSION                   STATUS   SIZE   BRANCH
2026-07-20T10-00-00-000Z  running  -      the-framework/run-live
2026-07-19T09-00-00-000Z  stopped  4.0KB  the-framework/run-2026-07-19T09-00-00-000Z
```

All three go through the same store functions the RPCs use (`listWorktreeDirs`, `readLiveMetas`, `removeWorktree`, `pruneWorktrees`), so this is a second surface rather than a second behaviour, as the issue asked. cwd-scoped, matching the rest of the CLI.

Decisions worth flagging:

- **A live session is listed, not hidden.** "What is this directory and why can I not remove it" is exactly what the list has to answer. Its size is left blank, since sizing a tree an agent is writing to gives a number that is wrong by the time it prints.
- **rm and prune both refuse a running session**, the same guard `sendRemoveWorktree` applies. Stop is how a run ends.
- **prune's exit code** is non-zero only when something it should have removed failed, not when it deliberately kept a running session. It prints what it kept either way.
- **A worktree whose run left no meta** lists as `unknown` rather than being skipped, so the list always accounts for every directory on disk.

## What it cannot do that the dashboard can

Stop a preview serving the checkout before removing it (#797). Previews live in the daemon and the CLI is a different process, so the worktree is removed and the dev server is the daemon's to notice. Called out in the code.

## Verification

Unit tests cover the pure formatting. The behaviour was driven against the built `dist/bin.js` on a temp repo with three real `git worktree` checkouts, one of them owned by a live pid:

| command | result |
|---|---|
| `worktrees` | all three listed, the live one flagged `running` with no size |
| `worktrees rm <live>` | refused, exit 1 |
| `worktrees rm <stopped>` | removed, exit 0 |
| `worktrees rm nope-not-here` | `no worktree for session nope-not-here`, exit 1 |
| `worktrees prune` | kept the running one, removed the rest, exit 0 |

`git worktree list` afterwards shows only the live one, so the removals were real.

Suite: 974 pass, 0 fail.