### PR TITLE
feat(framework): commit conversations from the daemon, debounced and path-scoped (#912)

### DIFF
--- a/.changeset/commit-conversations-from-daemon.md
+++ b/.changeset/commit-conversations-from-daemon.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+The daemon now commits the conversations it records on a project's main checkout, so a chat reaches the Git repo without waiting for someone to commit it by hand. A run's own worktree already swept its transcript on teardown; a conversation held in the checkout itself had nothing doing the same, and sat as an uncommitted change indefinitely. The commit is scoped to `.the-framework/conversations` and never stages anything else, so work in progress elsewhere in the checkout, staged or not, is left exactly as it was. It is debounced on an idle window rather than committed per turn, batching a burst of chat into one commit, with a cap so a conversation that never falls idle still lands. A repo that is mid-rebase, mid-merge or holding its index lock is skipped and retried later rather than committed into, and the daemon flushes anything still pending as it shuts down.

--- a/packages/framework/src/conversation-commit.test.ts
+++ b/packages/framework/src/conversation-commit.test.ts
@@ -1,0 +1,307 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import type { ProjectSummary } from './dashboard/projects.js'
+import type { GitRunner } from './project.js'
+import {
+  commitConversations,
+  commitMessage,
+  gitBusy,
+  pendingConversations,
+  startConversationCommitter,
+  CONVERSATIONS_PATHSPEC,
+  type PathProbe,
+} from './conversation-commit.js'
+
+const project = (path: string): ProjectSummary => ({ id: path, path, name: path, activated: true })
+
+/** A git seam that records every invocation and answers from a per-subcommand script. */
+function fakeGit(answers: Record<string, string | (() => string)> = {}) {
+  const calls: string[][] = []
+  const git: GitRunner = async args => {
+    calls.push(args)
+    const answer = answers[args[0] ?? '']
+    if (answer === undefined) return ''
+    return typeof answer === 'function' ? answer() : answer
+  }
+  const commits = () => calls.filter(args => args[0] === 'commit').length
+  return { git, calls, commits }
+}
+
+const noLocks: PathProbe = async () => false
+
+/** Let the constructor's immediate baseline poll finish, the way the watcher tests do. */
+const settle = () => new Promise(resolve => setTimeout(resolve, 0))
+
+test('the pathspec names only the conversations directory (#912)', () => {
+  assert.equal(CONVERSATIONS_PATHSPEC, '.the-framework/conversations')
+})
+
+test('pending conversations are parsed from porcelain and sorted (#912)', async () => {
+  const { git, calls } = fakeGit({
+    status: ['?? .the-framework/conversations/b.md', ' M .the-framework/conversations/a.md', ''].join('\n'),
+  })
+  assert.deepEqual(await pendingConversations('/repo', git), [
+    '.the-framework/conversations/a.md',
+    '.the-framework/conversations/b.md',
+  ])
+  assert.deepEqual(
+    calls[0],
+    ['status', '--porcelain', '-uall', '--', CONVERSATIONS_PATHSPEC],
+    'the status read is path-scoped, and -uall names each untracked file',
+  )
+})
+
+test('-uall is passed, or an untracked dir collapses to one unchanging entry (#912)', async () => {
+  // Real git reports a wholly-untracked directory as a single `?? dir/` entry unless -uall is
+  // given, which would make every burst look identical to the debounce and commit mid-write.
+  const { git, calls } = fakeGit({ status: '' })
+  await pendingConversations('/repo', git)
+  assert.ok(calls[0]?.includes('-uall'), `status must ask for every untracked file, got ${JSON.stringify(calls[0])}`)
+})
+
+test('a rename reports the destination, and a quoted path is unquoted (#912)', async () => {
+  const { git } = fakeGit({
+    status: [
+      'R  .the-framework/conversations/old.md -> .the-framework/conversations/new.md',
+      '?? ".the-framework/conversations/sp ace.md"',
+    ].join('\n'),
+  })
+  assert.deepEqual(await pendingConversations('/repo', git), [
+    '.the-framework/conversations/new.md',
+    '.the-framework/conversations/sp ace.md',
+  ])
+})
+
+test('an unreadable repo reads as no changes rather than throwing (#912)', async () => {
+  const git: GitRunner = async () => {
+    throw new Error('not a git repository')
+  }
+  assert.deepEqual(await pendingConversations('/repo', git), [])
+})
+
+test('a locked index or an in-flight rebase means busy, so nothing is committed (#912)', async () => {
+  const { git } = fakeGit({ 'rev-parse': '/repo/.git\n' })
+  const only = (marker: string): PathProbe => async path => path === `/repo/.git/${marker}`
+
+  assert.equal(await gitBusy('/repo', git, only('index.lock')), 'another git process holds the index lock')
+  assert.equal(await gitBusy('/repo', git, only('rebase-merge')), 'a rebase is in progress')
+  assert.equal(await gitBusy('/repo', git, only('rebase-apply')), 'a rebase is in progress')
+  assert.equal(await gitBusy('/repo', git, only('MERGE_HEAD')), 'a merge is in progress')
+  assert.equal(await gitBusy('/repo', git, only('CHERRY_PICK_HEAD')), 'a cherry-pick is in progress')
+  assert.equal(await gitBusy('/repo', git, noLocks), undefined, 'a quiet repo is not busy')
+})
+
+test('the busy check resolves the real git dir, so a linked worktree is checked correctly (#912)', async () => {
+  const { git } = fakeGit({ 'rev-parse': '/main/.git/worktrees/wt-1\n' })
+  const probed: string[] = []
+  const probe: PathProbe = async path => {
+    probed.push(path)
+    return false
+  }
+  await gitBusy('/wt-1', git, probe)
+  assert.ok(probed.length > 0, 'the markers were probed')
+  assert.ok(
+    probed.every(path => path.startsWith('/main/.git/worktrees/wt-1/')),
+    `markers are looked for in the resolved git dir, got ${probed[0]}`,
+  )
+})
+
+test('a non-repo is busy rather than committed into (#912)', async () => {
+  const git: GitRunner = async () => {
+    throw new Error('fatal: not a git repository')
+  }
+  assert.equal(await gitBusy('/tmp/x', git, noLocks), 'not a git repository')
+})
+
+test('a commit stages and commits the pathspec, and never add -A (#912)', async () => {
+  const { git, calls } = fakeGit({
+    'rev-parse': '/repo/.git\n',
+    status: '?? .the-framework/conversations/a.md',
+  })
+  const outcome = await commitConversations('/repo', git, noLocks)
+  assert.deepEqual(outcome, { committed: true, files: ['.the-framework/conversations/a.md'] })
+
+  assert.deepEqual(
+    calls.find(args => args[0] === 'add'),
+    ['add', '--', CONVERSATIONS_PATHSPEC],
+    'staging is scoped to the pathspec',
+  )
+  assert.deepEqual(calls.find(args => args[0] === 'commit'), [
+    'commit',
+    '-m',
+    '[The Framework] a conversation',
+    '--',
+    CONVERSATIONS_PATHSPEC,
+  ])
+  assert.ok(
+    !calls.some(args => args.includes('-A') || args.includes('--all')),
+    'the user checkout is never swept wholesale',
+  )
+})
+
+test('a busy repo is skipped without staging anything (#912)', async () => {
+  const { git, calls } = fakeGit({ 'rev-parse': '/repo/.git\n', status: '?? .the-framework/conversations/a.md' })
+  const locked: PathProbe = async path => path.endsWith('index.lock')
+  const outcome = await commitConversations('/repo', git, locked)
+  assert.deepEqual(outcome, { committed: false, reason: 'another git process holds the index lock' })
+  assert.ok(!calls.some(args => args[0] === 'add' || args[0] === 'commit'), 'nothing touched the index')
+})
+
+test('a clean checkout commits nothing (#912)', async () => {
+  const { git, calls } = fakeGit({ 'rev-parse': '/repo/.git\n', status: '' })
+  assert.deepEqual(await commitConversations('/repo', git, noLocks), {
+    committed: false,
+    reason: 'no conversation changes',
+  })
+  assert.ok(!calls.some(args => args[0] === 'commit'))
+})
+
+test('a failed commit is swallowed and reported, not thrown (#912)', async () => {
+  const git: GitRunner = async args => {
+    if (args[0] === 'rev-parse') return '/repo/.git\n'
+    if (args[0] === 'status') return '?? .the-framework/conversations/a.md'
+    if (args[0] === 'commit') throw new Error('nothing to commit')
+    return ''
+  }
+  assert.deepEqual(await commitConversations('/repo', git, noLocks), {
+    committed: false,
+    reason: 'nothing to commit',
+  })
+})
+
+test('the commit message counts the batch (#912)', () => {
+  assert.equal(commitMessage(['a']), '[The Framework] a conversation')
+  assert.equal(commitMessage(['a', 'b']), '[The Framework] 2 conversations')
+})
+
+test('a conversation still being written is not committed until it settles (#912)', async () => {
+  let listing = '?? .the-framework/conversations/a.md'
+  const { git, commits } = fakeGit({ 'rev-parse': '/repo/.git\n', status: () => listing })
+  const committer = startConversationCommitter({
+    projects: async () => [project('/repo')],
+    git,
+    exists: noLocks,
+    intervalMs: 1_000_000, // effectively disable the timer; drive via poll()
+  })
+  try {
+    await settle() // the constructor's baseline poll opens the idle window on {a}
+    assert.equal(commits(), 0, 'the first sighting only starts the idle window')
+
+    listing = ['?? .the-framework/conversations/a.md', '?? .the-framework/conversations/b.md'].join('\n')
+    await committer.poll()
+    assert.equal(commits(), 0, 'a changed pending set restarts the window rather than committing mid-burst')
+
+    await committer.poll()
+    assert.equal(commits(), 1, 'an unchanged pending set is settled, so the batch commits')
+
+    listing = ''
+    await committer.poll()
+    assert.equal(commits(), 1, 'a now-clean checkout adds no further commits')
+  } finally {
+    committer.stop()
+  }
+})
+
+test('a conversation that never goes idle still commits once max wait lapses (#912)', async () => {
+  let n = 0
+  let clock = 0
+  const { git, commits } = fakeGit({
+    'rev-parse': '/repo/.git\n',
+    // Every poll sees a different pending set, so the idle window alone would never fire.
+    status: () => `?? .the-framework/conversations/${n++}.md`,
+  })
+  const committer = startConversationCommitter({
+    projects: async () => [project('/repo')],
+    git,
+    exists: noLocks,
+    intervalMs: 1_000_000,
+    maxWaitMs: 100,
+    now: () => clock,
+  })
+  try {
+    await settle()
+    clock = 50
+    await committer.poll()
+    assert.equal(commits(), 0, 'still inside the cap, and never idle')
+
+    clock = 150
+    await committer.poll()
+    assert.equal(commits(), 1, 'the cap forces the batch through')
+  } finally {
+    committer.stop()
+  }
+})
+
+test('a busy repo keeps its place, so the next window retries it (#912)', async () => {
+  let locked = true
+  const { git, commits } = fakeGit({ 'rev-parse': '/repo/.git\n', status: '?? .the-framework/conversations/a.md' })
+  const exists: PathProbe = async path => locked && path.endsWith('index.lock')
+  const committer = startConversationCommitter({
+    projects: async () => [project('/repo')],
+    git,
+    exists,
+    intervalMs: 1_000_000,
+  })
+  try {
+    await settle()
+    await committer.poll() // settled, but the repo is busy
+    assert.equal(commits(), 0, 'a locked index blocks the commit')
+
+    locked = false
+    await committer.poll()
+    assert.equal(commits(), 1, 'the retry lands as soon as the repo is free')
+  } finally {
+    committer.stop()
+  }
+})
+
+test('a project scan that throws costs one window rather than the committer (#912)', async () => {
+  const { git } = fakeGit({ 'rev-parse': '/repo/.git\n', status: '?? .the-framework/conversations/a.md' })
+  const committer = startConversationCommitter({
+    projects: async () => {
+      throw new Error('registry unreadable')
+    },
+    git,
+    exists: noLocks,
+    intervalMs: 1_000_000,
+  })
+  try {
+    await settle()
+    await committer.poll() // must not reject
+  } finally {
+    committer.stop()
+  }
+})
+
+test('flush commits immediately, skipping the idle window, and counts projects (#912)', async () => {
+  const { git, commits } = fakeGit({ 'rev-parse': '/repo/.git\n', status: '?? .the-framework/conversations/a.md' })
+  const committer = startConversationCommitter({
+    projects: async () => [project('/a'), project('/b')],
+    git,
+    exists: noLocks,
+    intervalMs: 1_000_000,
+  })
+  try {
+    await settle()
+    assert.equal(commits(), 0, 'the baseline poll alone commits nothing')
+    assert.equal(await committer.flush(), 2, 'both projects committed on the first call, with no settling')
+    assert.equal(commits(), 2)
+  } finally {
+    committer.stop()
+  }
+})
+
+test('a stopped committer does not poll again (#912)', async () => {
+  const { git, commits } = fakeGit({ 'rev-parse': '/repo/.git\n', status: '?? .the-framework/conversations/a.md' })
+  const committer = startConversationCommitter({
+    projects: async () => [project('/repo')],
+    git,
+    exists: noLocks,
+    intervalMs: 1_000_000,
+  })
+  await settle()
+  committer.stop()
+  await committer.poll()
+  await committer.poll()
+  assert.equal(commits(), 0, 'a stopped committer commits nothing, however often it is driven')
+})

--- a/packages/framework/src/conversation-commit.ts
+++ b/packages/framework/src/conversation-commit.ts
@@ -1,0 +1,300 @@
+import { join } from 'node:path'
+import type { ProjectSummary } from './dashboard/projects.js'
+import { CONVERSATIONS_DIR } from './conversations.js'
+import { THE_FRAMEWORK_DIR } from './framework-dir.js'
+import type { GitRunner } from './project.js'
+import { nodeGitRunner } from './project.js'
+
+/**
+ * Committing the conversations the daemon records (#912) into the project checkout.
+ *
+ * #908 made `.the-framework/conversations/<runId>.md` tracked files, and the paths that already
+ * commit pick them up: a run's worktree sweeps its own on teardown (`store/worktree.ts`). The main
+ * checkout has no such path — `install.ts` commits once at activation and nothing after — so a
+ * conversation held there sat as a working-tree change until a human happened to commit it. That
+ * is the one gap between "the chat is in Git" (#857) and "the chat reaches Git by itself".
+ *
+ * Two rules shape the whole module, both about writing into a repo somebody else is using.
+ *
+ * Path-scoped, never `git add -A`. The pathspec names the conversations directory and nothing
+ * else, the way `queue-promote.ts` names the queue file, so whatever the user has in progress
+ * cannot ride along in our commit. A pathspec commit also leaves their index alone: what they had
+ * staged is still staged afterwards.
+ *
+ * Debounced on an idle window rather than committed per turn. A chat turn is seconds apart, and a
+ * commit each would bury the project's real history under transcript noise. A poll that sees the
+ * same pending set twice running treats the conversation as settled and commits the batch; a burst
+ * keeps resetting it. {@link ConversationCommitterOptions.maxWaitMs} caps that, so a conversation
+ * that never goes idle still lands instead of being starved forever.
+ *
+ * Tolerates not being alone (the #605 question this waited on). One daemon per machine is the rule
+ * today (#393), but the committer never assumes it: a locked index or a rebase/merge in progress
+ * means somebody else is mid-operation, so it skips rather than commits into their work, and a
+ * failed commit is swallowed and retried on the next window. That way #605's eventual answer about
+ * who owns the chat bot does not invalidate any of this.
+ */
+
+/** The pathspec every commit here is scoped to. Posix separators: it is a git pathspec, not a path. */
+export const CONVERSATIONS_PATHSPEC = `${THE_FRAMEWORK_DIR}/${CONVERSATIONS_DIR}`
+
+/** How often the committer looks for settled conversations. */
+export const COMMIT_POLL_MS = 30_000
+
+/** How long a conversation may keep changing before it is committed anyway. */
+export const COMMIT_MAX_WAIT_MS = 5 * 60_000
+
+/** What one attempt did, or why it did nothing. */
+export type CommitOutcome =
+  | { committed: true; files: string[] }
+  | { committed: false; reason: string }
+
+/** Whether a path exists. Injectable so the busy check is testable without real lock files. */
+export type PathProbe = (path: string) => Promise<boolean>
+
+/** A {@link PathProbe} over `fs.access`. */
+export function nodePathProbe(): PathProbe {
+  return async path => {
+    const { access } = await import('node:fs/promises')
+    return access(path).then(
+      () => true,
+      () => false,
+    )
+  }
+}
+
+/** The commit message a batch writes. Says how many conversations moved, so the log line stands alone. */
+export function commitMessage(files: string[]): string {
+  const what = files.length === 1 ? 'a conversation' : `${files.length} conversations`
+  return `[The Framework] ${what}`
+}
+
+/**
+ * The conversation files with uncommitted changes, as repo-relative paths, sorted so the result is
+ * a stable fingerprint the debounce can compare across polls.
+ *
+ * `--porcelain` v1 is parsed rather than `--short` because its two status columns are fixed-width
+ * and its paths are quoted consistently. A rename (`R  old -> new`) reports the destination, which
+ * is the path we would commit. Anything unreadable — not a repo, no git — reads as no changes.
+ *
+ * `-uall` is load-bearing, not a detail. By default git collapses a wholly-untracked directory into
+ * one entry (`?? .the-framework/conversations/`) instead of naming the files under it, which makes
+ * the fingerprint identical whether one conversation is being written or ten. The debounce compares
+ * fingerprints, so without this the idle window could never see a burst and would commit straight
+ * through the middle of one. Only a real repo shows this; a per-file fake does not.
+ */
+export async function pendingConversations(cwd: string, git: GitRunner = nodeGitRunner()): Promise<string[]> {
+  const out = await git(['status', '--porcelain', '-uall', '--', CONVERSATIONS_PATHSPEC], cwd).catch(() => '')
+  const files = new Set<string>()
+  for (const line of out.split('\n')) {
+    if (line.length < 4) continue
+    // Columns 0-1 are the status codes, 2 is a space, the path starts at 3.
+    const entry = line.slice(3)
+    const arrow = entry.indexOf(' -> ')
+    files.add(unquotePath(arrow === -1 ? entry : entry.slice(arrow + ' -> '.length)))
+  }
+  return [...files].sort()
+}
+
+/**
+ * Undo git's C-style quoting of a path holding non-ASCII or special characters. Only the escapes
+ * git actually emits are handled; anything else is left as written rather than mangled.
+ */
+function unquotePath(entry: string): string {
+  if (!entry.startsWith('"') || !entry.endsWith('"')) return entry
+  return entry
+    .slice(1, -1)
+    .replace(/\\([\\"])/g, '$1')
+    .replace(/\\t/g, '\t')
+    .replace(/\\n/g, '\n')
+}
+
+/** The markers that mean another git operation owns this repo right now. */
+const BUSY_MARKERS: ReadonlyArray<readonly [string, string]> = [
+  ['index.lock', 'another git process holds the index lock'],
+  ['rebase-merge', 'a rebase is in progress'],
+  ['rebase-apply', 'a rebase is in progress'],
+  ['MERGE_HEAD', 'a merge is in progress'],
+  ['CHERRY_PICK_HEAD', 'a cherry-pick is in progress'],
+  ['REVERT_HEAD', 'a revert is in progress'],
+  ['BISECT_LOG', 'a bisect is in progress'],
+]
+
+/**
+ * Why the repo is in no state to be committed into, or `undefined` when it is fine.
+ *
+ * The git dir is resolved through git rather than assumed to be `<cwd>/.git`, so this is right in a
+ * linked worktree, where `.git` is a file pointing elsewhere and the markers live in the real dir.
+ */
+export async function gitBusy(
+  cwd: string,
+  git: GitRunner = nodeGitRunner(),
+  exists: PathProbe = nodePathProbe(),
+): Promise<string | undefined> {
+  const gitDir = await git(['rev-parse', '--absolute-git-dir'], cwd).then(
+    out => out.trim(),
+    () => '',
+  )
+  if (!gitDir) return 'not a git repository'
+  for (const [name, reason] of BUSY_MARKERS) {
+    if (await exists(join(gitDir, name))) return reason
+  }
+  return undefined
+}
+
+/**
+ * Stage and commit the pending conversations under `cwd`, scoped to {@link CONVERSATIONS_PATHSPEC}.
+ *
+ * `add` before `commit` because a brand-new conversation is untracked, and `git commit -- <path>`
+ * only knows paths git already knows. Both are pathspec-scoped, so the staging is as narrow as the
+ * commit and the user's own staged work is neither swept in nor disturbed.
+ *
+ * Never throws: this runs on a background tick with nothing to catch it.
+ */
+export async function commitConversations(
+  cwd: string,
+  git: GitRunner = nodeGitRunner(),
+  exists: PathProbe = nodePathProbe(),
+): Promise<CommitOutcome> {
+  const busy = await gitBusy(cwd, git, exists)
+  if (busy) return { committed: false, reason: busy }
+
+  const files = await pendingConversations(cwd, git)
+  if (files.length === 0) return { committed: false, reason: 'no conversation changes' }
+
+  try {
+    await git(['add', '--', CONVERSATIONS_PATHSPEC], cwd)
+    await git(['commit', '-m', commitMessage(files), '--', CONVERSATIONS_PATHSPEC], cwd)
+    return { committed: true, files }
+  } catch (err) {
+    return { committed: false, reason: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+/** A running committer; call {@link ConversationCommitter.stop} to end it. */
+export interface ConversationCommitter {
+  stop: () => void
+  /** Run one poll now. Exposed so the daemon and tests can drive it deterministically. */
+  poll: () => Promise<void>
+  /**
+   * Commit every project's pending conversations now, skipping the idle window. For shutdown: the
+   * daemon is going away, so waiting for quiet would just defer the work to the next boot. Returns
+   * how many projects committed.
+   */
+  flush: () => Promise<number>
+}
+
+/** Options for {@link startConversationCommitter}. */
+export interface ConversationCommitterOptions {
+  /** The projects to sweep each poll (the daemon passes the registry, mapped to summaries). */
+  projects: () => Promise<ProjectSummary[]>
+  /** Poll cadence and idle window, ms. Default {@link COMMIT_POLL_MS}. */
+  intervalMs?: number
+  /** Commit anyway once a project has been pending this long, ms. Default {@link COMMIT_MAX_WAIT_MS}. */
+  maxWaitMs?: number
+  /** Injectable git (tests). */
+  git?: GitRunner
+  /** Injectable existence probe for the busy check (tests). */
+  exists?: PathProbe
+  /** Clock, injectable for the max-wait cap (tests). */
+  now?: () => number
+  /** Where a committed batch is announced. */
+  log?: (message: string) => void
+}
+
+/**
+ * One project's debounce state: the pending set the last poll saw, and when the project first went
+ * dirty. `since` deliberately survives a changing fingerprint — it is what makes the max-wait cap
+ * reachable, since a conversation being written to every poll would otherwise reset its own clock
+ * forever and never commit.
+ */
+interface Pending {
+  fingerprint: string
+  since: number
+}
+
+/**
+ * Start committing settled conversations, and return the handle that stops it.
+ *
+ * The idle window is the poll itself: a project whose pending set is byte-identical to the previous
+ * poll's has stopped being written to, so its batch is committed. Anything still moving is recorded
+ * and reconsidered next time, unless it has been dirty past `maxWaitMs`, which forces it through.
+ *
+ * Forgiving throughout — a failed project scan, a busy repo or a rejected commit costs one window
+ * and is retried, never a throw. Runs immediately, then every `intervalMs`; the timer is unref'd so
+ * it never keeps the daemon alive past shutdown.
+ */
+export function startConversationCommitter(opts: ConversationCommitterOptions): ConversationCommitter {
+  const git = opts.git ?? nodeGitRunner()
+  const exists = opts.exists ?? nodePathProbe()
+  const now = opts.now ?? Date.now
+  const intervalMs = opts.intervalMs ?? COMMIT_POLL_MS
+  const maxWaitMs = opts.maxWaitMs ?? COMMIT_MAX_WAIT_MS
+  const pending = new Map<string, Pending>()
+  let stopped = false
+  let running = false
+
+  const poll = async (): Promise<void> => {
+    if (stopped || running) return
+    running = true
+    try {
+      const projects = await opts.projects().catch(() => [])
+      const seen = new Set<string>()
+      for (const project of projects) {
+        if (stopped) break
+        seen.add(project.path)
+        const files = await pendingConversations(project.path, git).catch((): string[] => [])
+        if (files.length === 0) {
+          pending.delete(project.path)
+          continue
+        }
+        const fingerprint = files.join('\n')
+        const previous = pending.get(project.path)
+        const since = previous?.since ?? now()
+        // Settled (nothing changed since the last poll), or dirty long enough that waiting for
+        // quiet is no longer worth it.
+        const settled = previous?.fingerprint === fingerprint || now() - since >= maxWaitMs
+        if (!settled) {
+          pending.set(project.path, { fingerprint, since })
+          continue
+        }
+        const outcome = await commitConversations(project.path, git, exists)
+        if (outcome.committed) {
+          pending.delete(project.path)
+          opts.log?.(`[framework] committed ${outcome.files.length} conversation(s) in ${project.name}`)
+        } else {
+          // A busy repo or a rejected commit keeps its place, so the next window retries it
+          // rather than starting the idle count over.
+          pending.set(project.path, { fingerprint, since })
+        }
+      }
+      // Drop state for projects that went away, so the map cannot grow without bound.
+      for (const path of [...pending.keys()]) if (!seen.has(path)) pending.delete(path)
+    } finally {
+      running = false
+    }
+  }
+
+  const flush = async (): Promise<number> => {
+    let committed = 0
+    for (const project of await opts.projects().catch(() => [])) {
+      const outcome = await commitConversations(project.path, git, exists)
+      if (outcome.committed) {
+        pending.delete(project.path)
+        committed++
+      }
+    }
+    return committed
+  }
+
+  void poll()
+  const timer = setInterval(() => void poll(), intervalMs)
+  timer.unref?.()
+  return {
+    stop: () => {
+      stopped = true
+      clearInterval(timer)
+    },
+    poll,
+    flush,
+  }
+}

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -34,6 +34,7 @@ import { defaultQuotaSource } from './dashboard/quota.js'
 import { startAutoPm, AUTO_PM_JOBS } from './auto-pm.js'
 import { maintenanceDue, readMaintenanceState, mergeMaintenanceState } from './maintenance.js'
 import { promoteQueue } from './queue-promote.js'
+import { startConversationCommitter, type ConversationCommitter } from './conversation-commit.js'
 import { findTodoBacklog } from './todo-loop.js'
 import { startPreview, detectServeTargets, type PreviewHandle, type ServeTarget } from './preview.js'
 import { resolveDashboardBundle } from './dashboard/bundle.js'
@@ -636,6 +637,15 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     log: message => console.log(message),
   })
 
+  // Commit the conversations recorded on the main checkout (#912). A run's own worktree already
+  // sweeps its transcript on teardown; nothing did the same for a chat held in the checkout itself,
+  // so it sat as an uncommitted change until a human noticed. Path-scoped and debounced, and it
+  // skips a repo that is mid-rebase or index-locked rather than committing into someone's work.
+  const conversationCommitter = startConversationCommitter({
+    projects: listSummaries,
+    log: message => console.log(message),
+  })
+
   // The Discord chatbot (#680): chat to The Framework from Discord. Two gates, mirroring the
   // notification watchers above — a `DISCORD_BOT_TOKEN` (a bot can read replies; the #627 webhook
   // cannot) and the per-user `discordBot` preference, read per message so the toggle takes effect
@@ -690,6 +700,13 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
   // next boot. Auto PM is stopped first so nothing starts a run while we are stopping them.
   const suspended = await runtime.suspendRuns().catch(() => 0)
   if (suspended > 0) console.log(`[framework] suspended ${suspended} session(s); they resume when the daemon starts again`)
+  // Commit whatever conversation the shutdown just ended (#912), after the runs have been stopped
+  // so their last turns are on disk. Stop the timer first, then flush once past the idle window:
+  // there is no next poll to wait for, and an uncommitted chat would otherwise sit until a human
+  // committed it by hand -- the exact gap this service exists to close.
+  conversationCommitter.stop()
+  const conversations = await conversationCommitter.flush().catch(() => 0)
+  if (conversations > 0) console.log(`[framework] committed conversations in ${conversations} project(s)`)
   // Stopped here as well as by the dashboard: a broken install serves 503s without ever taking
   // ownership of the source we handed in, and that poller would go on reading by itself.
   quota.stop()

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -174,6 +174,21 @@ export {
   type ConversationRole,
 } from './conversations.js'
 export {
+  startConversationCommitter,
+  commitConversations,
+  pendingConversations,
+  gitBusy,
+  commitMessage,
+  nodePathProbe,
+  CONVERSATIONS_PATHSPEC,
+  COMMIT_POLL_MS,
+  COMMIT_MAX_WAIT_MS,
+  type ConversationCommitter,
+  type ConversationCommitterOptions,
+  type CommitOutcome,
+  type PathProbe,
+} from './conversation-commit.js'
+export {
   theFrameworkDir,
   isActivated,
   nodeProjectFs,


### PR DESCRIPTION
Closes #912

## What

The daemon now commits the conversations it records on a project's main checkout.

#908 made `.the-framework/conversations/<runId>.md` tracked files, and a run's own worktree already sweeps its transcript on teardown (`store/worktree.ts`). The main checkout had no equivalent -- `install.ts` commits once at activation and nothing after -- so a conversation held there sat as an uncommitted working-tree change until someone happened to commit it.

## Why it was unblocked

#912 waited on #605's "exactly one instance must manage the AI chat bot". That does not gate the shape of the work:

- One agent works in its own worktree, so the main checkout has no agent writing to it, and a run's own conversation is already committed by its worktree.
- The "two daemons race each other" premise is false today: a second daemon fails `listen` with EADDRINUSE inside `startDashboard` before writing state or starting a service, and with #922 fixed `ensureDaemon` finds the live one.

Rather than assume it is alone, the committer tolerates not being: a locked index or an in-progress rebase/merge is skipped and retried next window. So #605's eventual answer does not invalidate this.

## Shape

- `conversation-commit.ts` -- `startConversationCommitter()` alongside the other services in `runDaemon`, following the house contract: injectable seams, unref'd timer, swallows errors.
- **Path-scoped.** `git add -- <pathspec>` then `git commit -- <pathspec>`, the way `queue-promote.ts` does. Never `add -A`. A pathspec commit also leaves the user's index alone, so what they had staged is still staged.
- **Debounced.** A poll that sees the same pending set twice treats it as settled and commits the batch; a burst keeps resetting it. `maxWaitMs` (5 min) caps that so a conversation that never goes idle is not starved.
- **Flushes on shutdown**, after runs are suspended, so the last turns are not deferred to the next boot.

## The bug the fakes missed

`git status --porcelain` collapses a wholly-untracked directory into one entry (`?? .the-framework/conversations/`) instead of naming the files under it. That made the fingerprint identical whether one conversation was being written or ten, so the debounce could never detect a burst and committed straight through the middle of one. Fixed with `-uall`, and pinned by a test.

Unit tests could not have caught it -- a per-file fake is exactly what git does not do. It only showed up driving the built `dist` against a real repo.

## Verification

19 unit tests. Full suite: **994 tests, 0 failures**; `tsc --noEmit` clean.

Real-git e2e against the built `dist` -- a temp repo with the user holding one modified tracked file, one untracked file, and one **staged** file:

```
PASS  the first sighting does not commit
PASS  a changed pending set does not commit mid-burst
PASS  a settled conversation commits
PASS  the commit names ONLY conversation paths
PASS  the user modified file is still dirty
PASS  the user untracked file is still untracked
PASS  the user staged file is STILL STAGED, not committed
PASS  staged.txt did not land in our commit
PASS  a locked index skips instead of committing
PASS  the retry commits once the lock is gone
```

Resulting history, showing the debounce batching two conversations into one commit and touching nothing else:

```
[The Framework] 2 conversations
 .the-framework/conversations/run-1.md | 5 +++++
 .the-framework/conversations/run-2.md | 1 +
```