### PR TITLE
feat(framework): record the originating surface on a conversation turn (#917)

### DIFF
--- a/.changeset/conversation-turn-origin.md
+++ b/.changeset/conversation-turn-origin.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+A committed conversation now records the surface each turn came through, so a chat held in Discord reads as `discord` instead of being filed under the dashboard. The control channel's message entries carry an optional origin, the run attributes each turn to it, and an agent's reply inherits the origin of the message it answers, so a question and its answer stay one exchange. A run the daemon starts on a surface's behalf is tagged with `--via`, which keeps a chat-started session's opening turn from being attributed to the wrong place. Turns that name no surface fall back to the local one exactly as before, and entries written before this still parse. Transport names are validated where they enter, since they are written into a line-parsed conversation heading and a forged one could otherwise fake a turn.

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -46,7 +46,7 @@ import { type EcoOptions } from './system-prompt.js'
 import { loadUserSystemPrompt, SYSTEM_PROMPT_FILE } from './system-prompt-file.js'
 import { checkForUpdate, formatUpdateStatus, nodeVersionFetcher } from './update-check.js'
 import { appendLog, type LogEntry } from './logs.js'
-import { appendMessage } from './conversations.js'
+import { appendMessage, isSafeVia } from './conversations.js'
 import type { RecordMessage } from './run.js'
 import { preflight } from './preflight.js'
 import { RunStore, currentBranch, nodeStoreFs, renameRunBranch, runBranchName, type StoreFs } from './store/index.js'
@@ -161,6 +161,8 @@ Options:
                          the session says so at startup rather than imply a guard.
   --cwd <dir>            Workspace the agent builds in (default: current directory).
   --model <id>           Model to pass through to the wrapped agent.
+  --via <surface>        Surface this run was started from (e.g. discord); recorded
+                         on the session's conversation turns.
   --scope <prototype|full>   How much app to build (default: full).
   --preset <name>        Run under an Open Loop domain preset (its loops + prompts
                          + skills frame the build), e.g. software-development.
@@ -273,6 +275,8 @@ export interface CliOptions {
   model?: string | undefined
   /** `--resume-session <id>` (#720): continue a finished run's agent session — the prompt resumes that conversation (full prior context). Set by the dashboard when you message a run that has ended. */
   resumeSession?: string | undefined
+  /** `--via <surface>` (#917): the surface this run was started from, recorded on its conversation turns. Set by the daemon when a non-local surface (e.g. Discord) asked for the run. */
+  via?: string | undefined
   /** `--unattended`: no human is watching, so choice gates take the recommended option (#846). */
   unattended?: boolean
   scope: 'prototype' | 'full'
@@ -495,6 +499,9 @@ export function parseArgs(argv: string[]): CliOptions {
         break
       case '--resume-session':
         opts.resumeSession = argv[++i]
+        break
+      case '--via':
+        opts.via = argv[++i]
         break
       case '--unattended':
         opts.unattended = true
@@ -1217,7 +1224,8 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
           return
         }
         if (entry.kind === 'message') {
-          messages.push(entry.text)
+          // Carry the origin the sender named (#917), so the turn is recorded where it happened.
+          messages.push(entry.text, entry.via)
           return
         }
         const resolve = pendingChoices.get(entry.id)
@@ -1266,10 +1274,16 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // Appends are chained rather than fired in parallel: each one creates the dir/header before it
   // writes, so two overlapping turns race and can land the reply above the message it answers.
   let conversationTail: Promise<void> = Promise.resolve()
+  // The surface this run is being driven from, when nothing more specific is known. `--via` names
+  // it for a run the daemon started on a surface's behalf (#917), so a Discord-started session's
+  // opening turn is not filed under the dashboard; otherwise it is whichever local surface is here.
+  const localVia = isSafeVia(opts.via) ? opts.via : requestChoice ? 'dashboard' : 'cli'
   const recordMessage: RecordMessage | undefined =
     opts.persist && conversationId
-      ? (role, text) => {
-          const message = { at: new Date().toISOString(), role, via: requestChoice ? 'dashboard' : 'cli', text }
+      ? (role, text, via) => {
+          // A per-turn origin wins, but only a safe one: it arrives from a chat surface over the
+          // control channel, and the heading it lands in is line-parsed (#897's threat model).
+          const message = { at: new Date().toISOString(), role, via: isSafeVia(via) ? via : localVia, text }
           conversationTail = conversationTail.then(() => appendMessage(cwd, conversationId, message)).catch(() => {})
         }
       : undefined

--- a/packages/framework/src/control.test.ts
+++ b/packages/framework/src/control.test.ts
@@ -106,3 +106,30 @@ test('watchControl delivers live-chat messages and drops empty ones (#714)', asy
     await rm(cwd, { recursive: true, force: true })
   }
 })
+
+test('a message carries the surface it came through, and a forged one is dropped (#917)', async () => {
+  const cwd = await tmpWorkspace()
+  const seen: ControlEntry[] = []
+  const watcher = watchControl(cwd, e => seen.push(e), 20)
+  try {
+    await resetControl(cwd)
+    await appendFile(
+      controlPath(cwd),
+      JSON.stringify({ kind: 'message', text: 'from discord', via: 'discord' }) + '\n' +
+        // An entry written before #917 still parses, and is simply unattributed.
+        JSON.stringify({ kind: 'message', text: 'older entry' }) + '\n' +
+        // A via carrying the heading separator would forge a conversation heading (#897): dropped.
+        JSON.stringify({ kind: 'message', text: 'forged', via: 'discord \u00b7 user \u00b7 x' }) + '\n' +
+        JSON.stringify({ kind: 'message', text: 'newline', via: 'a\nb' }) + '\n' +
+        JSON.stringify({ kind: 'message', text: 'not a string', via: 7 }) + '\n',
+    )
+    assert.ok(await until(() => seen.length === 2), `saw ${seen.length}`)
+    assert.deepEqual(seen, [
+      { kind: 'message', text: 'from discord', via: 'discord' },
+      { kind: 'message', text: 'older entry' },
+    ])
+  } finally {
+    watcher.close()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})

--- a/packages/framework/src/control.ts
+++ b/packages/framework/src/control.ts
@@ -1,5 +1,6 @@
 import { appendFile, mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { isSafeVia } from './conversations.js'
 import type { ChoiceBy } from './events.js'
 import { FRAMEWORK_DIR } from './store/index.js'
 import { JsonlTailer, followFile } from './jsonl-tail.js'
@@ -22,8 +23,14 @@ export type ControlEntry =
   | { kind: 'stop' }
   /** Resolve a parked choice gate: the pick for the pending {@link ChoiceRequest} id. */
   | { kind: 'choice'; id: string; pick: string | string[]; by: ChoiceBy }
-  /** A live-chat message the user sent to the running run (#714). */
-  | { kind: 'message'; text: string }
+  /**
+   * A live-chat message the user sent to the running run (#714).
+   *
+   * `via` names the surface it came through (#917), so the conversation records where it happened
+   * rather than assuming the local one. Optional: entries written before this existed still parse,
+   * and a run reading one falls back to its own surface exactly as before.
+   */
+  | { kind: 'message'; text: string; via?: string }
 
 /** The control log path for a workspace. */
 export function controlPath(cwd: string): string {
@@ -74,7 +81,12 @@ function isControlEntry(value: unknown): value is ControlEntry {
   if (!value || typeof value !== 'object') return false
   const v = value as Record<string, unknown>
   if (v['kind'] === 'stop') return true
-  if (v['kind'] === 'message') return typeof v['text'] === 'string' && v['text'].length > 0
+  // `via` is optional (older entries have none), but a present one must be a safe transport name:
+  // it is written into a line-parsed conversation heading, and a surface names itself (#917).
+  if (v['kind'] === 'message') {
+    if (typeof v['text'] !== 'string' || v['text'].length === 0) return false
+    return v['via'] === undefined || isSafeVia(v['via'])
+  }
   if (v['kind'] !== 'choice') return false
   if (typeof v['id'] !== 'string' || !v['id']) return false
   const pick = v['pick']

--- a/packages/framework/src/conversations.test.ts
+++ b/packages/framework/src/conversations.test.ts
@@ -7,6 +7,7 @@ import {
   conversationsDir,
   ensureConversationsIgnored,
   escapeBody,
+  isSafeVia,
   listConversations,
   parseConversation,
   readConversation,
@@ -207,4 +208,25 @@ test('a torn or foreign block is skipped, never thrown', () => {
   const messages = parseConversation(md)
   assert.equal(messages.length, 1)
   assert.equal(messages[0]?.text, 'the good one')
+})
+
+test('isSafeVia accepts a plain transport name and rejects anything that could forge a heading (#917)', () => {
+  assert.equal(isSafeVia('discord'), true)
+  assert.equal(isSafeVia('dashboard'), true)
+  assert.equal(isSafeVia('slack-2'), true)
+  assert.equal(isSafeVia('my_surface'), true)
+
+  // The heading is `## <at> · <role> · <via>`, line-parsed, so these must never reach it.
+  assert.equal(isSafeVia('discord · user · nope'), false, 'the field separator')
+  assert.equal(isSafeVia('a\nb'), false, 'a newline')
+  assert.equal(isSafeVia('a b'), false, 'a space')
+  assert.equal(isSafeVia(''), false, 'empty')
+  assert.equal(isSafeVia(undefined), false)
+  assert.equal(isSafeVia(7), false)
+})
+
+test('a turn records the surface it came through, and it round-trips (#917)', () => {
+  const md = renderMessage(msg({ via: 'discord' }))
+  assert.ok(md.includes(' · discord'), md)
+  assert.deepEqual(parseConversation(md), [msg({ via: 'discord' })])
 })

--- a/packages/framework/src/conversations.ts
+++ b/packages/framework/src/conversations.ts
@@ -55,6 +55,17 @@ const SEP = ' · '
 const VIA = /^[A-Za-z0-9_-]+$/
 
 /**
+ * Whether a transport name is safe to record. Exported because #917 lets a surface name itself
+ * over the control channel, so the name now arrives from outside this module: a `via` carrying
+ * the heading separator, a newline or a `#` would forge structure in a file whose entries are
+ * line-parsed, exactly the way #897 forged a LOGS.md title. Checked at the boundary rather than
+ * trusted, and the same predicate {@link parseConversation} reads back with.
+ */
+export function isSafeVia(via: unknown): via is string {
+  return typeof via === 'string' && VIA.test(via)
+}
+
+/**
  * Escape a message body so it cannot forge structure (#897's threat model, applied to a
  * transcript). LOGS.md collapses free text to one line, which is right for a line-parsed record
  * and wrong here: a multi-paragraph reply has to stay readable in a `git diff`. So the text stays

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -34,6 +34,7 @@ import { defaultQuotaSource } from './dashboard/quota.js'
 import { startAutoPm, AUTO_PM_JOBS } from './auto-pm.js'
 import { maintenanceDue, readMaintenanceState, mergeMaintenanceState } from './maintenance.js'
 import { promoteQueue } from './queue-promote.js'
+import { isSafeVia } from './conversations.js'
 import { startConversationCommitter, type ConversationCommitter } from './conversation-commit.js'
 import { findTodoBacklog } from './todo-loop.js'
 import { startPreview, detectServeTargets, type PreviewHandle, type ServeTarget } from './preview.js'
@@ -44,7 +45,7 @@ import { runOptionsFromPreferences, preferencesFromFileConfig } from './run-opti
 import { loadFrameworkConfig } from './config.js'
 import { installProject, enumerateGitRepos } from './install.js'
 import { JsonlTailer } from './jsonl-tail.js'
-import { startDiscordBot } from './discord/bot.js'
+import { startDiscordBot, DISCORD_VIA } from './discord/bot.js'
 import { snapshotLiveRun } from './discord/live-run.js'
 import { sendChoice, sendMessage, sendStop } from './dashboard-rpc/control.telefunc.js'
 
@@ -177,6 +178,9 @@ export function startOptionFlags(options: StartRunOptions): string[] {
   // Unattended (#846): nobody is at the keyboard, so gates take the recommended option
   // rather than park for an answer that is not coming.
   if (options.unattended) flags.push('--unattended')
+  // The originating surface (#917): only a safe transport name is forwarded, since it reaches the
+  // conversation heading, which is line-parsed.
+  if (isSafeVia(options.via)) flags.push('--via', options.via)
   // Resume a finished run's session (#720): the spawned run continues that conversation.
   if (typeof options.resumeSession === 'string' && options.resumeSession.trim()) {
     flags.push('--resume-session', options.resumeSession.trim())
@@ -677,10 +681,13 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
           // watching a chat-started run either, so a parked gate would hang it. The gate is then
           // answered from Discord by number instead.
           const options = await resolvedRunOptions(id)
-          const result = await runtime.onStart(text, 'prompt', { ...options, unattended: true }, id)
+          // `via` so the opening turn is filed under Discord too (#917). Without it a chat-started
+          // session reads as if its first message came from the dashboard and only the follow-ups
+          // came from Discord, which is a worse record than attributing none of it.
+          const result = await runtime.onStart(text, 'prompt', { ...options, unattended: true, via: DISCORD_VIA }, id)
           return result.ok ? result.runId : undefined
         },
-        sendMessage: (id, text, runId) => sendMessage(id, text, runId),
+        sendMessage: (id, text, runId) => sendMessage(id, text, runId, DISCORD_VIA),
         sendChoice: (id, gateId, pick, runId) => sendChoice(id, gateId, pick, 'user', runId),
         sendStop: (id, runId) => sendStop(id, runId),
         enabled: async () => (await readPrefs()).discordBot === true,

--- a/packages/framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/control.telefunc.ts
@@ -1,5 +1,6 @@
 import { getContext } from 'telefunc'
 import { appendControl, type ControlEntry } from '../control.js'
+import { isSafeVia } from '../conversations.js'
 import { openInApp, type OpenTarget, type OpenResult } from '../dashboard/open-in-app.js'
 import { resolveProjectPath, resolveRunPath, contextPreferences, contextPreview } from './context.js'
 import { appendFlatTodoEntry } from '../todo-loop.js'
@@ -70,11 +71,17 @@ export async function sendChoice(
  * Send a live-chat message to the project's running run (#714): append a `message` entry
  * that the run drains between turns, continuing the same session via `--resume`. Empty
  * messages are dropped.
+ *
+ * `via` names the surface the message came through (#917), so the run records the turn where it
+ * actually happened. The dashboard omits it and keeps its own default; the Discord bot passes
+ * `discord`. An unsafe name is dropped rather than forwarded: it would reach a line-parsed
+ * conversation heading, and the browser can call this, so it is not trusted input.
  */
-export async function sendMessage(projectId: string, text: string, runId?: string): Promise<void> {
+export async function sendMessage(projectId: string, text: string, runId?: string, via?: string): Promise<void> {
   const message = text.trim()
   if (!message) return
-  await appendControlFor(projectId, { kind: 'message', text: message }, runId)
+  const origin = isSafeVia(via) ? { via } : {}
+  await appendControlFor(projectId, { kind: 'message', text: message, ...origin }, runId)
 }
 
 /**

--- a/packages/framework/src/dashboard/types.ts
+++ b/packages/framework/src/dashboard/types.ts
@@ -47,6 +47,12 @@ export interface StartRunOptions {
    * Stop still works — that aborts the run controller, not a gate.
    */
   unattended?: boolean
+  /**
+   * The surface this run was asked for from (#917), e.g. `discord`; maps to `--via`. Recorded on
+   * the session's conversation turns so a run started from a chat surface is not filed under the
+   * dashboard. Absent = the local surface, exactly as before.
+   */
+  via?: string
   /** Resume a finished run's conversation (#720): its captured agent session id; maps to `--resume-session`. The run's prompt continues that session (full prior context) instead of starting fresh. Sent with `kind: 'prompt'` when you message a run that has ended. */
   resumeSession?: string
   /**

--- a/packages/framework/src/discord/bot.ts
+++ b/packages/framework/src/discord/bot.ts
@@ -14,6 +14,12 @@ import { decideAction, type ProjectTarget, type RunSnapshot } from './routing.js
  * That is the answer to the question #680 asked — the Git repo, via the run that received it.
  */
 
+/**
+ * How a turn that arrived here is attributed in the committed conversation (#917). Named once,
+ * here, so the surface owns its own name rather than the daemon spelling it inline twice.
+ */
+export const DISCORD_VIA = 'discord'
+
 /** Everything the bot needs from the daemon. */
 export interface DiscordBotOptions {
   /** The bot token. Distinct from the notification webhook (#627), which cannot read replies. */

--- a/packages/framework/src/run-messages.test.ts
+++ b/packages/framework/src/run-messages.test.ts
@@ -6,15 +6,15 @@ test('RunMessageQueue drains already-queued messages in order (between turns)', 
   const q = new RunMessageQueue()
   q.push('one')
   q.push('two')
-  assert.equal(await q.next(), 'one')
-  assert.equal(await q.next(), 'two')
+  assert.deepEqual(await q.next(), { text: 'one' })
+  assert.deepEqual(await q.next(), { text: 'two' })
 })
 
 test('RunMessageQueue hands a message to a parked waiter (stay-open)', async () => {
   const q = new RunMessageQueue()
   const pending = q.next() // parks: nothing queued yet
   q.push('later')
-  assert.equal(await pending, 'later')
+  assert.deepEqual(await pending, { text: 'later' })
 })
 
 test('RunMessageQueue close() wakes a parked waiter with undefined', async () => {
@@ -51,5 +51,20 @@ test('RunMessageQueue next() returns a queued message even if the signal is abor
   ac.abort()
   q.push('queued')
   // A message already in hand wins over the aborted signal: it is not lost.
-  assert.equal(await q.next(ac.signal), 'queued')
+  assert.deepEqual(await q.next(ac.signal), { text: 'queued' })
+})
+
+test('RunMessageQueue carries the originating surface with the message (#917)', async () => {
+  const q = new RunMessageQueue()
+  q.push('from discord', 'discord')
+  q.push('from here')
+  assert.deepEqual(await q.next(), { text: 'from discord', via: 'discord' })
+  assert.deepEqual(await q.next(), { text: 'from here' }, 'no via means the run attributes it locally')
+})
+
+test('RunMessageQueue hands the surface to a parked waiter too (#917)', async () => {
+  const q = new RunMessageQueue()
+  const pending = q.next()
+  q.push('later', 'discord')
+  assert.deepEqual(await pending, { text: 'later', via: 'discord' })
 })

--- a/packages/framework/src/run-messages.ts
+++ b/packages/framework/src/run-messages.ts
@@ -13,6 +13,19 @@
  * loop ends when the agent stops asking — byte-identical to before this existed.
  */
 
+/**
+ * One user chat message, plus the surface it arrived through (#917).
+ *
+ * The origin travels with the text rather than being read off the run, because one run can be
+ * spoken to from more than one surface: a session started in the dashboard and then answered from
+ * Discord is a single conversation whose turns have different origins.
+ */
+export interface ChatMessage {
+  text: string
+  /** The originating surface, when the sender named one. Absent means "the run's own surface". */
+  via?: string
+}
+
 /** A source of user chat messages for a running run. */
 export interface RunMessages {
   /**
@@ -21,7 +34,7 @@ export interface RunMessages {
    * the run should stop waiting — the signal aborted (Stop / budget cap) or the
    * source was closed — so the loop ends cleanly rather than hanging.
    */
-  next(signal?: AbortSignal): Promise<string | undefined>
+  next(signal?: AbortSignal): Promise<ChatMessage | undefined>
 }
 
 /**
@@ -30,33 +43,37 @@ export interface RunMessages {
  * directly; otherwise it queues until the next `next()`. FIFO in both directions.
  */
 export class RunMessageQueue implements RunMessages {
-  private readonly pending: string[] = []
-  private readonly waiters: Array<(text: string | undefined) => void> = []
+  private readonly pending: ChatMessage[] = []
+  private readonly waiters: Array<(message: ChatMessage | undefined) => void> = []
   private closed = false
 
-  /** Enqueue a user message (or hand it to a parked waiter). No-op once closed. */
-  push(text: string): void {
+  /**
+   * Enqueue a user message (or hand it to a parked waiter). No-op once closed. `via` names the
+   * surface it came through (#917); omitted, the run attributes it to its own.
+   */
+  push(text: string, via?: string): void {
     if (this.closed) return
+    const message: ChatMessage = via === undefined ? { text } : { text, via }
     const waiter = this.waiters.shift()
-    if (waiter) waiter(text)
-    else this.pending.push(text)
+    if (waiter) waiter(message)
+    else this.pending.push(message)
   }
 
   /** Stop the chat: wake every parked waiter with `undefined` so their loops end. */
   close(): void {
     this.closed = true
-    let waiter: ((text: string | undefined) => void) | undefined
+    let waiter: ((message: ChatMessage | undefined) => void) | undefined
     while ((waiter = this.waiters.shift())) waiter(undefined)
   }
 
-  next(signal?: AbortSignal): Promise<string | undefined> {
+  next(signal?: AbortSignal): Promise<ChatMessage | undefined> {
     const queued = this.pending.shift()
     if (queued !== undefined) return Promise.resolve(queued)
     if (this.closed || signal?.aborted) return Promise.resolve(undefined)
-    return new Promise<string | undefined>(resolve => {
-      const waiter = (text: string | undefined): void => {
+    return new Promise<ChatMessage | undefined>(resolve => {
+      const waiter = (message: ChatMessage | undefined): void => {
         if (signal) signal.removeEventListener('abort', onAbort)
-        resolve(text)
+        resolve(message)
       }
       const onAbort = (): void => {
         const i = this.waiters.indexOf(waiter)

--- a/packages/framework/src/run.ts
+++ b/packages/framework/src/run.ts
@@ -696,8 +696,13 @@ export interface AwaitRoundsOptions {
   recordMessage?: RecordMessage | undefined
 }
 
-/** Persist one chat turn. See {@link AwaitRoundsOptions.recordMessage}. */
-export type RecordMessage = (role: 'user' | 'agent', text: string) => void
+/**
+ * Persist one chat turn. See {@link AwaitRoundsOptions.recordMessage}.
+ *
+ * `via` names the surface the turn happened on (#917). Omitted, the recorder falls back to the
+ * run's own surface, which is what every turn did before a message could arrive from elsewhere.
+ */
+export type RecordMessage = (role: 'user' | 'agent', text: string, via?: string) => void
 
 /** The shared deps of a turn that may hit an await gate or a chat message. */
 interface AwaitTurnDeps {
@@ -752,15 +757,17 @@ export async function runChatPhase(session: DriverSession, messages: RunMessages
     deps.emit({ kind: 'settled' })
     const message = await messages.next(deps.signal)
     if (message === undefined) return { turn, exhausted } // Stop / budget cap: end the conversation.
-    deps.emit({ kind: 'log', message: `You: ${message}` })
-    deps.recordMessage?.('user', message)
-    turn = await session.prompt(message, { ...signalOpt, resume: true })
+    deps.emit({ kind: 'log', message: `You: ${message.text}` })
+    deps.recordMessage?.('user', message.text, message.via)
+    turn = await session.prompt(message.text, { ...signalOpt, resume: true })
     deps.emitTurnSignals(turn.text)
     const drained = await drainGates(session, turn, deps)
     turn = drained.turn
     exhausted = drained.exhausted
-    // The settled text, so the recorded reply is what the user actually read (#908).
-    deps.recordMessage?.('agent', turn.text)
+    // The settled text, so the recorded reply is what the user actually read (#908). Attributed to
+    // the surface that asked (#917): a reply belongs to the conversation it answers, so a Discord
+    // question and its answer read as one exchange rather than two different places.
+    deps.recordMessage?.('agent', turn.text, message.via)
     if (drained.declined) return { turn, exhausted }
   }
 }


### PR DESCRIPTION
Closes #917

## What

A committed conversation now records the surface each turn came through, so a chat held in Discord reads as `discord` rather than being filed under the dashboard.

#908 gives every turn a `via`, and #680 routes Discord messages into a run over the control channel. But a `message` control entry carried only `{ kind, text }`, so the origin was gone by the time the run recorded the turn, and it was written as whatever local surface the run had. The conversation was right in content and wrong in attribution.

## Shape

| | |
|---|---|
| `control.ts` | `message` entries carry an optional `via` |
| `run-messages.ts` | the queue yields `ChatMessage { text, via? }` instead of a bare string |
| `run.ts` | `RecordMessage` takes the origin; the **reply inherits the origin of the message it answers** |
| `cli.ts` | per-turn origin wins, else the run's own surface |
| `--via <surface>` | tags a run the daemon started for a surface |
| `discord/bot.ts` | owns its own name (`DISCORD_VIA`), passed on both the message and the start path |

**Why `--via` and not just the message path.** A Discord-*started* session goes through `onStart`, not the control channel, so without it the opening turn was attributed to the dashboard while only the follow-ups said `discord`. One conversation split across two surfaces is a worse record than attributing none of it.

**Backwards compatible.** `via` is optional everywhere: entries written before this still parse, and a turn that names no surface falls back exactly as before.

## Validation, not trust

`via` lands in a `## <at> · <role> · <via>` heading, and conversations are line-parsed. An origin carrying the field separator or a newline could forge a turn, which is #897's threat model applied to a transcript. Since a surface now names itself, it is checked at every boundary it crosses (control entry, telefunc, flag emission, recorder) with the same predicate the parser reads back with, exported rather than duplicated.

## Verification

Full suite: **999 tests, 0 failures**; `tsc --noEmit` clean.

Real e2e driving the built `dist/bin.js`, reading the conversation file it wrote:

```
PASS  a conversation file was written
PASS  every turn is attributed to discord
PASS  both roles are recorded
PASS  the reply inherits the surface of the message it answers
PASS  an unattributed session still records turns
PASS  and falls back to the local surface, never blank
PASS  a discord turn is attributed to discord on a locally-started run
PASS  --via sets the fallback surface for turns that name none
PASS  a forged via gets the whole entry rejected, so no turn is recorded
PASS  and no fragment of the forged origin reaches the file
```

Resulting heading, from the real file:

```
## 2026-07-20T22:36:50.486Z · user · discord
## 2026-07-20T22:36:50.487Z · agent · discord
```

### Noted while verifying, not fixed here

In the `--fake` build path the **opening prompt is not recorded at all** (only `runAwaitRounds` records an opening; the build flow does not go through it). Pre-existing and unrelated to this change, but it means a build-flow session's conversation starts at the first chat turn. Worth a separate issue if that is not intended.