### PR TITLE
feat(framework): send a session's answers back to Discord (#932)

### DIFF
--- a/.changeset/discord-agent-replies.md
+++ b/.changeset/discord-agent-replies.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+A session's answers now come back to the Discord channel that asked for them. Until now the bot acknowledged a message and nothing else followed, so you could talk to an agent from Discord but had to open the dashboard to read what it said. The bot binds a run to the channel it was addressed from, and a watcher posts each new agent turn there as it lands, reusing the committed conversation as the source since that holds the settled reply rather than raw console output. Binding adopts whatever the session has already said, so attaching to a long-running session never replays its backlog into a channel, and while the bot is switched off the cursor still advances, so turning it on starts from now rather than flushing everything said meanwhile. A run nobody addressed from Discord is not mirrored at all.

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -46,7 +46,10 @@ import { loadFrameworkConfig } from './config.js'
 import { installProject, enumerateGitRepos } from './install.js'
 import { JsonlTailer } from './jsonl-tail.js'
 import { startDiscordBot, DISCORD_VIA } from './discord/bot.js'
+import { startDiscordReplyMirror } from './discord/reply-mirror.js'
 import { snapshotLiveRun } from './discord/live-run.js'
+import { readConversation } from './conversations.js'
+import { postMessage } from './discord/rest.js'
 import { sendChoice, sendMessage, sendStop } from './dashboard-rpc/control.telefunc.js'
 
 /**
@@ -668,6 +671,26 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
   // picker, so a message with no run to join starts one here.
   const botHomeId = projectId(resolve(cwd))
   const botProjectPath = async (id: string) => (await listSummaries()).find(p => p.id === id)?.path ?? cwd
+  // Send a session's answers back to the channel that asked (#932). The conversation (#908) is the
+  // source: it holds the settled reply the user would have read, which is what belongs in chat.
+  // Bound per run by the bot, since the channel is only known when a message arrives.
+  const replyMirror = botToken
+    ? startDiscordReplyMirror({
+        readConversation: async runId => {
+          // A run's transcript lives in the checkout the run used, which for a daemon-spawned run
+          // is its own worktree rather than the project root.
+          for (const project of await listSummaries()) {
+            const meta = (await readLiveMetas(project.path).catch(() => [])).find(run => run.id === runId)
+            if (meta) return readConversation(meta.cwd, runId).catch(() => [])
+          }
+          return []
+        },
+        post: (channelId, text) => postMessage(botToken, channelId, text),
+        enabled: async () => (await readPrefs()).discordBot === true,
+        onLog: message => console.log(`[framework] ${message}`),
+      })
+    : undefined
+
   const discordBot = botToken
     ? startDiscordBot({
         token: botToken,
@@ -690,6 +713,7 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
         sendMessage: (id, text, runId) => sendMessage(id, text, runId, DISCORD_VIA),
         sendChoice: (id, gateId, pick, runId) => sendChoice(id, gateId, pick, 'user', runId),
         sendStop: (id, runId) => sendStop(id, runId),
+        ...(replyMirror ? { onRunBound: (runId, channelId) => replyMirror.bind(runId, channelId) } : {}),
         enabled: async () => (await readPrefs()).discordBot === true,
         ...(env.DISCORD_CHANNEL_ID ? { channelId: env.DISCORD_CHANNEL_ID } : {}),
         onLog: message => console.log(`[framework] ${message}`),
@@ -701,6 +725,7 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
   // Ctrl+C takes the bot offline (#680). Its gateway socket is the one connection here that
   // would otherwise hold the event loop open on its own.
   discordBot?.stop()
+  replyMirror?.stop()
   autoPm.stop()
   // Stop the runs this daemon spawned (#923), before the previews they may be serving. Left
   // running they are orphans nothing tracks; stopped here they are recorded and resumed on the

--- a/packages/framework/src/discord/bot.ts
+++ b/packages/framework/src/discord/bot.ts
@@ -34,6 +34,12 @@ export interface DiscordBotOptions {
   sendChoice: (projectId: string, gateId: string, pick: string | string[], runId: string) => Promise<void>
   sendStop: (projectId: string, runId: string) => Promise<void>
   /**
+   * Bind a run to the channel this message came from (#932), so the session's answers are posted
+   * back where it was asked. Awaited *before* the run is handed the message: binding first is what
+   * makes the reply reliably count as new rather than being baselined away.
+   */
+  onRunBound?: (runId: string, channelId: string) => Promise<void>
+  /**
    * Whether the bot should act, read per message rather than at start, so turning it off takes
    * effect without restarting the daemon — the same contract the notification watchers follow.
    */
@@ -78,6 +84,8 @@ export function startDiscordBot(opts: DiscordBotOptions): DiscordBot {
           await opts.sendChoice(action.projectId, action.gateId, action.pick, action.runId)
           break
         case 'message':
+          // Bind before sending (#932): the answer to this message must land after the baseline.
+          await opts.onRunBound?.(action.runId, message.channelId).catch(() => {})
           await opts.sendMessage(action.projectId, action.text, action.runId)
           break
         case 'stop':
@@ -89,6 +97,9 @@ export function startDiscordBot(opts: DiscordBotOptions): DiscordBot {
             await reply(message, 'Could not start a session. It may already be busy.')
             return
           }
+          // A run that did not exist a moment ago has nothing to adopt, so binding after the start
+          // is still a clean baseline, and it is the first point its id is known.
+          await opts.onRunBound?.(runId, message.channelId).catch(() => {})
           break
         }
         case 'reply':

--- a/packages/framework/src/discord/reply-mirror.test.ts
+++ b/packages/framework/src/discord/reply-mirror.test.ts
@@ -1,0 +1,238 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import type { ConversationMessage } from '../conversations.js'
+import { startDiscordReplyMirror } from './reply-mirror.js'
+
+const turn = (role: 'user' | 'agent', text: string): ConversationMessage => ({
+  at: '2026-07-21T00:00:00.000Z',
+  role,
+  via: 'discord',
+  text,
+})
+
+/** A mirror over an in-memory transcript, recording everything posted. */
+function harness(seed: ConversationMessage[] = [], enabled?: () => Promise<boolean>) {
+  let transcript = seed
+  const posted: Array<{ channelId: string; text: string }> = []
+  let deliver = true
+  const logs: string[] = []
+  const mirror = startDiscordReplyMirror({
+    readConversation: async () => transcript,
+    post: async (channelId, text) => {
+      if (deliver) posted.push({ channelId, text })
+      return deliver
+    },
+    ...(enabled ? { enabled } : {}),
+    intervalMs: 1_000_000, // drive by hand
+    onLog: m => logs.push(m),
+  })
+  return {
+    mirror,
+    posted,
+    logs,
+    say: (...messages: ConversationMessage[]) => (transcript = [...transcript, ...messages]),
+    set deliver(v: boolean) {
+      deliver = v
+    },
+  }
+}
+
+test('an agent reply is posted to the channel that asked (#932)', async () => {
+  const h = harness()
+  try {
+    await h.mirror.bind('run-1', 'chan-1')
+    h.say(turn('user', 'add dark mode'), turn('agent', 'Done, I changed two files.'))
+    await h.mirror.poll()
+    assert.deepEqual(h.posted, [{ channelId: 'chan-1', text: 'Done, I changed two files.' }])
+  } finally {
+    h.mirror.stop()
+  }
+})
+
+test('the user own message is not echoed back at them (#932)', async () => {
+  const h = harness()
+  try {
+    await h.mirror.bind('run-1', 'chan-1')
+    h.say(turn('user', 'add dark mode'))
+    await h.mirror.poll()
+    assert.equal(h.posted.length, 0, 'only the agent side is mirrored')
+  } finally {
+    h.mirror.stop()
+  }
+})
+
+test('binding adopts the existing transcript instead of replaying it (#932)', async () => {
+  // The whole backlog problem: binding to a run that has been going for an hour must not dump
+  // an hour of answers into the channel.
+  const h = harness([turn('user', 'earlier'), turn('agent', 'an old answer'), turn('agent', 'another old one')])
+  try {
+    await h.mirror.bind('run-1', 'chan-1')
+    await h.mirror.poll()
+    assert.equal(h.posted.length, 0, 'nothing said before the bind is posted')
+
+    h.say(turn('agent', 'a new answer'))
+    await h.mirror.poll()
+    assert.deepEqual(h.posted, [{ channelId: 'chan-1', text: 'a new answer' }])
+  } finally {
+    h.mirror.stop()
+  }
+})
+
+test('a reply that lands before the first poll is still posted (#932)', async () => {
+  // The race the bind-time baseline exists to close: a fast agent answers between the bind and the
+  // first tick. Baselining on first poll instead would swallow exactly this reply.
+  const h = harness()
+  try {
+    await h.mirror.bind('run-1', 'chan-1')
+    h.say(turn('agent', 'answered immediately'))
+    await h.mirror.poll()
+    assert.deepEqual(h.posted, [{ channelId: 'chan-1', text: 'answered immediately' }])
+  } finally {
+    h.mirror.stop()
+  }
+})
+
+test('each answer is posted once, however often it polls (#932)', async () => {
+  const h = harness()
+  try {
+    await h.mirror.bind('run-1', 'chan-1')
+    h.say(turn('agent', 'one'))
+    await h.mirror.poll()
+    await h.mirror.poll()
+    await h.mirror.poll()
+    assert.deepEqual(h.posted.map(p => p.text), ['one'])
+  } finally {
+    h.mirror.stop()
+  }
+})
+
+test('while the bot is off the cursor still advances, so turning it on starts from now (#932)', async () => {
+  let on = false
+  const h = harness([], async () => on)
+  try {
+    await h.mirror.bind('run-1', 'chan-1')
+    h.say(turn('agent', 'said while off'))
+    await h.mirror.poll()
+    assert.equal(h.posted.length, 0, 'nothing is posted while off')
+
+    on = true
+    await h.mirror.poll()
+    assert.equal(h.posted.length, 0, 'and the backlog is not flushed when it comes back on')
+
+    h.say(turn('agent', 'said while on'))
+    await h.mirror.poll()
+    assert.deepEqual(h.posted.map(p => p.text), ['said while on'])
+  } finally {
+    h.mirror.stop()
+  }
+})
+
+test('an unbound run is not mirrored (#932)', async () => {
+  const h = harness()
+  try {
+    h.say(turn('agent', 'nobody asked for this'))
+    await h.mirror.poll()
+    assert.equal(h.posted.length, 0, 'a dashboard-started run posts into no channel')
+    assert.equal(h.mirror.isBound('run-1'), false)
+  } finally {
+    h.mirror.stop()
+  }
+})
+
+test('unbind stops mirroring a finished run (#932)', async () => {
+  const h = harness()
+  try {
+    await h.mirror.bind('run-1', 'chan-1')
+    assert.equal(h.mirror.isBound('run-1'), true)
+    h.mirror.unbind('run-1')
+    assert.equal(h.mirror.isBound('run-1'), false)
+
+    h.say(turn('agent', 'after the end'))
+    await h.mirror.poll()
+    assert.equal(h.posted.length, 0)
+  } finally {
+    h.mirror.stop()
+  }
+})
+
+test('a blank answer is not posted (#932)', async () => {
+  const h = harness()
+  try {
+    await h.mirror.bind('run-1', 'chan-1')
+    h.say(turn('agent', '   \n  '))
+    await h.mirror.poll()
+    assert.equal(h.posted.length, 0)
+  } finally {
+    h.mirror.stop()
+  }
+})
+
+test('a failed delivery is logged and never retried into a duplicate (#932)', async () => {
+  const h = harness()
+  try {
+    await h.mirror.bind('run-1', 'chan-1')
+    h.deliver = false
+    h.say(turn('agent', 'undeliverable'))
+    await h.mirror.poll()
+    assert.equal(h.logs.length, 1, h.logs.join(','))
+
+    h.deliver = true
+    await h.mirror.poll()
+    assert.equal(h.posted.length, 0, 'the cursor moved on rather than re-posting later')
+  } finally {
+    h.mirror.stop()
+  }
+})
+
+test('an unreadable conversation costs one poll, not the mirror (#932)', async () => {
+  const mirror = startDiscordReplyMirror({
+    readConversation: async () => {
+      throw new Error('unreadable')
+    },
+    post: async () => true,
+    intervalMs: 1_000_000,
+  })
+  try {
+    await mirror.bind('run-1', 'chan-1') // must not reject
+    await mirror.poll() // must not reject
+  } finally {
+    mirror.stop()
+  }
+})
+
+test('stop clears the bindings so nothing is mirrored afterwards (#932)', async () => {
+  const h = harness()
+  await h.mirror.bind('run-1', 'chan-1')
+  h.mirror.stop()
+  assert.equal(h.mirror.isBound('run-1'), false)
+  h.say(turn('agent', 'after stop'))
+  await h.mirror.poll()
+  assert.equal(h.posted.length, 0)
+})
+
+test('two runs post to their own channels (#932)', async () => {
+  let a: ConversationMessage[] = []
+  let b: ConversationMessage[] = []
+  const posted: Array<{ channelId: string; text: string }> = []
+  const mirror = startDiscordReplyMirror({
+    readConversation: async runId => (runId === 'run-a' ? a : b),
+    post: async (channelId, text) => {
+      posted.push({ channelId, text })
+      return true
+    },
+    intervalMs: 1_000_000,
+  })
+  try {
+    await mirror.bind('run-a', 'chan-a')
+    await mirror.bind('run-b', 'chan-b')
+    a = [turn('agent', 'from a')]
+    b = [turn('agent', 'from b')]
+    await mirror.poll()
+    assert.deepEqual(posted.sort((x, y) => x.channelId.localeCompare(y.channelId)), [
+      { channelId: 'chan-a', text: 'from a' },
+      { channelId: 'chan-b', text: 'from b' },
+    ])
+  } finally {
+    mirror.stop()
+  }
+})

--- a/packages/framework/src/discord/reply-mirror.ts
+++ b/packages/framework/src/discord/reply-mirror.ts
@@ -1,0 +1,134 @@
+import type { ConversationMessage } from '../conversations.js'
+
+/**
+ * Sending a session's answers back to the Discord channel that asked (#932).
+ *
+ * #680 delivered the inbound half: a message in Discord reaches a run over the control channel.
+ * Nothing carried the answer back, so the bot only ever acknowledged ("Sent to the running
+ * session.") and the reply itself was visible in the dashboard alone. That makes a chat
+ * integration write-only: you can talk to the agent and never hear it.
+ *
+ * The source is the committed conversation (#908), not the event log. `events.jsonl` has no
+ * "agent reply" kind -- `log` carries rendered console lines and `driver` carries raw driver
+ * events, neither of which is the settled answer. A conversation turn is exactly the settled text
+ * the user actually read, which is precisely what belongs in a chat channel.
+ *
+ * Which channel is a binding, not a guess: the bot records `runId -> channelId` when it starts or
+ * messages a run, because that is the only moment the channel is known. A run nobody bound is
+ * simply not mirrored, so a dashboard-started session never posts into a channel that never asked
+ * about it (routing that generally is #606's job, not this).
+ *
+ * Two rules keep it from being a nuisance:
+ *
+ * The baseline is taken when the run is bound, not on the first poll. Adopting the transcript at
+ * bind time is what stops a backlog being replayed into a channel, and taking it at bind rather
+ * than at first poll closes the race where a fast agent answers before the first tick and its
+ * reply is baselined away unseen.
+ *
+ * While the bot is switched off the cursor still advances without posting, the same contract the
+ * notification watchers follow: turning it on starts from now instead of flushing everything said
+ * while it was off.
+ */
+
+/** Where a run's answers go. */
+export interface RunBinding {
+  channelId: string
+}
+
+/** What a mirror needs from the daemon. */
+export interface ReplyMirrorOptions {
+  /** A bound run's conversation, oldest-first. Anything unreadable should resolve `[]`, not throw. */
+  readConversation: (runId: string) => Promise<ConversationMessage[]>
+  /** Post one answer into a channel. Resolves whether it was delivered. */
+  post: (channelId: string, text: string) => Promise<boolean>
+  /** Whether the bot should speak, read per poll so the toggle needs no daemon restart. */
+  enabled?: () => Promise<boolean>
+  /** Poll cadence, ms. Default 3s: a chat reply that lands a minute late is not a reply. */
+  intervalMs?: number
+  onLog?: (message: string) => void
+}
+
+/** A running mirror. */
+export interface DiscordReplyMirror {
+  /**
+   * Start mirroring a run's answers into a channel, adopting whatever it has already said.
+   * Awaitable so the caller can bind *before* handing the run a message, which is what makes the
+   * next reply reliably new.
+   */
+  bind: (runId: string, channelId: string) => Promise<void>
+  /** Stop mirroring a run (it ended, or its channel went away). */
+  unbind: (runId: string) => void
+  /** Whether a run is currently mirrored. */
+  isBound: (runId: string) => boolean
+  /** Run one poll now. Exposed so the daemon and tests can drive it deterministically. */
+  poll: () => Promise<void>
+  stop: () => void
+}
+
+/** Per-run state: where to post, and how far down the transcript we have already posted. */
+interface Mirrored extends RunBinding {
+  /** Index into the conversation; everything before it is either posted or deliberately skipped. */
+  next: number
+}
+
+/** How often answers are checked for. A chat reply has to feel like a reply. */
+export const REPLY_POLL_MS = 3_000
+
+export function startDiscordReplyMirror(opts: ReplyMirrorOptions): DiscordReplyMirror {
+  const bound = new Map<string, Mirrored>()
+  let stopped = false
+  let running = false
+
+  const bind = async (runId: string, channelId: string): Promise<void> => {
+    if (stopped) return
+    // Adopt the transcript as it stands, so only what is said from here on is mirrored. Read at
+    // bind time on purpose: deferring it to the first poll would swallow a reply that beat the tick.
+    const existing = await opts.readConversation(runId).catch((): ConversationMessage[] => [])
+    bound.set(runId, { channelId, next: existing.length })
+  }
+
+  const poll = async (): Promise<void> => {
+    if (stopped || running) return
+    running = true
+    try {
+      // Read once per poll rather than per run: it gates posting, not observing.
+      const on = opts.enabled ? await opts.enabled().catch(() => false) : true
+      for (const [runId, state] of [...bound]) {
+        if (stopped) break
+        const messages = await opts.readConversation(runId).catch((): ConversationMessage[] => [])
+        if (messages.length <= state.next) continue
+        const fresh = messages.slice(state.next)
+        // Advance first, and unconditionally: a turn we chose not to post (the bot is off, or it
+        // is the user's own message coming back) must not be reconsidered next poll.
+        state.next = messages.length
+        if (!on) continue
+        for (const message of fresh) {
+          // Only the agent's side. Echoing the user's own message back at them is noise, and a
+          // turn that arrived *from* Discord is already on their screen.
+          if (message.role !== 'agent') continue
+          const text = message.text.trim()
+          if (!text) continue
+          const delivered = await opts.post(state.channelId, text).catch(() => false)
+          if (!delivered) opts.onLog?.(`could not deliver a reply for ${runId}`)
+        }
+      }
+    } finally {
+      running = false
+    }
+  }
+
+  const timer = setInterval(() => void poll(), opts.intervalMs ?? REPLY_POLL_MS)
+  timer.unref?.()
+
+  return {
+    bind,
+    unbind: runId => void bound.delete(runId),
+    isBound: runId => bound.has(runId),
+    poll,
+    stop: () => {
+      stopped = true
+      bound.clear()
+      clearInterval(timer)
+    },
+  }
+}


### PR DESCRIPTION
Closes #932

## What

A session's answers now reach the Discord channel that asked for them. #680 delivered the inbound half; the bot only ever acked (`Sent to the running session.`) and the reply itself lived in the dashboard. The integration was write-only: you could talk to the agent and never hear it.

## Why the conversation, not the event log

`events.jsonl` has no "agent reply" kind. `log` carries rendered console lines and `driver` carries raw driver events, neither of which is the settled answer. `.the-framework/conversations/<runId>.md` (#908) records exactly the text the user would have read, which is what belongs in a chat channel.

## Design

| | |
|---|---|
| **Which channel** | a binding, not a guess. The bot records `runId -> channelId` when it starts or messages a run, the only moment the channel is known |
| **Unaddressed runs** | not mirrored at all. Routing a dashboard-started session into some channel is #606's job |
| **Backlog** | binding adopts the transcript, so attaching to an hour-old session does not dump an hour of answers into the channel |
| **Bot switched off** | the cursor still advances without posting, so turning it on starts from now (same contract as the notification watchers) |
| **Delivery** | existing `postMessage` + `clampContent` (Discord hard-rejects over 2000 chars) |

**The baseline is taken at bind, not at first poll.** That is the one subtle bit: deferring it to the first tick would swallow a reply from a fast agent that answered before the tick. The bot awaits `bind()` *before* handing the run the message, which makes the answer reliably new. There is a test for exactly this race.

## Correction to the issue

The issue proposed filtering on `via: discord` from #917. That turned out to be unnecessary: the binding already decides where to post, so `via` adds nothing here, and dropping it means this does **not** depend on unmerged #931 and works on `main` today.

## Verification

Full suite: **1007 tests, 0 failures**; `tsc --noEmit` clean. 13 unit tests covering the backlog rule, the pre-first-poll race, the off-switch cursor, dedup across polls, per-run channel isolation, and failure paths.

Real e2e driving the built `dist`: a real `framework` run writes a real transcript, and the built mirror reads that file and posts from it (Discord itself stubbed).

```
PASS  the run reached its chat phase
PASS  binding adopts the transcript so far, posting nothing
PASS  the agent answer was posted to the bound channel
PASS  it went to the channel that asked
PASS  the posted text is the agent reply, not the user message
PASS  re-polling does not repost the same answer
```

### Not yet verified

**Against live Discord.** The gateway path is exercised only by fakes here. Token + MESSAGE CONTENT intent have been confirmed working out-of-band; a live end-to-end run against a real server is the remaining check before this leaves draft.