### PR TITLE
fix(framework): a malformed request can no longer kill the daemon, relay, or preview server

### DIFF
--- a/.changeset/static-decode-daemon-safe.md
+++ b/.changeset/static-decode-daemon-safe.md
@@ -1,0 +1,11 @@
+---
+'@gemstack/framework': patch
+---
+
+A malformed percent-encoded request no longer kills the daemon or a preview server (#938)
+
+Both static-file paths (the dashboard bundle server and the preview fallback server) called
+`decodeURIComponent` on the raw request path inside a void-dispatched async handler, so a single
+`GET /%zz` became an unhandled rejection that took the whole process down. The dashboard now
+treats a malformed escape as an unknown path (the SPA shell), the preview server answers 400, and
+a trailing-slash cwd no longer fails the preview server's path-prefix check.

--- a/.changeset/static-decode-daemon-safe.md
+++ b/.changeset/static-decode-daemon-safe.md
@@ -2,10 +2,13 @@
 '@gemstack/framework': patch
 ---
 
-A malformed percent-encoded request no longer kills the daemon or a preview server (#938)
+A malformed request can no longer kill the daemon, the relay, or a preview server (#938)
 
-Both static-file paths (the dashboard bundle server and the preview fallback server) called
-`decodeURIComponent` on the raw request path inside a void-dispatched async handler, so a single
-`GET /%zz` became an unhandled rejection that took the whole process down. The dashboard now
-treats a malformed escape as an unknown path (the SPA shell), the preview server answers 400, and
-a trailing-slash cwd no longer fails the preview server's path-prefix check.
+Three request paths crashed the process on hostile-but-trivial input: `decodeURIComponent` on the
+raw path in the dashboard bundle server and the preview fallback server (`GET /%zz` became an
+unhandled rejection out of a void-dispatched handler), and `new URL(req.url, ...)` in the dashboard
+and relay request handlers (an absolute-form request target like `GET http://[ HTTP/1.1` throws
+synchronously; Node passes it through verbatim). The dashboard now treats a malformed escape as an
+unknown path (the SPA shell), the preview server and relay answer 400, an unparseable request
+target answers 400 everywhere, and a trailing-slash cwd no longer fails the preview server's
+path-prefix check.

--- a/packages/framework/src/dashboard/browser-proxy.test.ts
+++ b/packages/framework/src/dashboard/browser-proxy.test.ts
@@ -31,6 +31,13 @@ test('parseBrowserRoute keeps a query string out of the leg', () => {
   assert.equal(parseBrowserRoute('/browser/proj/run/stream?t=1')?.leg, 'stream')
 })
 
+test('parseBrowserRoute survives a malformed escape or target instead of throwing (#938)', () => {
+  // `%zz` passes URL parsing and only explodes at decode time; a throw here escapes the
+  // void-dispatched proxy handler and kills the daemon.
+  assert.equal(parseBrowserRoute('/browser/proj/%zz/stream'), undefined)
+  assert.equal(parseBrowserRoute('http://['), undefined)
+})
+
 /** A stand-in for the run's bridge, recording what reached it. */
 async function fakeBridge(): Promise<{ port: number; hits: { url: string; body: string }[]; close: () => void }> {
   const hits: { url: string; body: string }[] = []

--- a/packages/framework/src/dashboard/browser-proxy.ts
+++ b/packages/framework/src/dashboard/browser-proxy.ts
@@ -35,14 +35,22 @@ export const BROWSER_PROXY_PREFIX = '/browser'
  */
 export function parseBrowserRoute(url: string | undefined): BrowserRoute | undefined {
   if (!url) return undefined
-  const { pathname } = new URL(url, 'http://localhost')
-  if (!pathname.startsWith(`${BROWSER_PROXY_PREFIX}/`)) return undefined
-  const parts = pathname.slice(BROWSER_PROXY_PREFIX.length + 1).split('/')
-  if (parts.length !== 3) return undefined
-  const [projectId, runId, leg] = parts
-  if (!projectId || !runId) return undefined
-  if (leg !== 'stream' && leg !== 'input') return undefined
-  return { projectId, runId: decodeURIComponent(runId), leg }
+  // Parse and decode defensively: a malformed target or escape (`/browser/p/%zz/stream`) names
+  // no run, and a throw here would escape the void-dispatched proxy handler as an unhandled
+  // rejection that kills the daemon (#938). Unparseable falls through to the bundle like any
+  // other unrecognized shape.
+  try {
+    const { pathname } = new URL(url, 'http://localhost')
+    if (!pathname.startsWith(`${BROWSER_PROXY_PREFIX}/`)) return undefined
+    const parts = pathname.slice(BROWSER_PROXY_PREFIX.length + 1).split('/')
+    if (parts.length !== 3) return undefined
+    const [projectId, runId, leg] = parts
+    if (!projectId || !runId) return undefined
+    if (leg !== 'stream' && leg !== 'input') return undefined
+    return { projectId, runId: decodeURIComponent(runId), leg }
+  } catch {
+    return undefined
+  }
 }
 
 /** How the proxy finds the run's bridge. Injectable so a test needs no registry and no run. */

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -75,6 +75,24 @@ test('serves the prerendered SPA shell at / and hashed assets, with an SPA fallb
   }
 })
 
+test('a malformed percent-encoded path serves the SPA shell and the server survives (#938)', async () => {
+  const bundle = await fakeBundle()
+  const dash = await startDashboard({ port: 0, clientBundleDir: bundle })
+  try {
+    // `decodeURIComponent('/%zz')` throws; unguarded it is an unhandled rejection that kills the process.
+    const bad = await fetchText(dash.url + '/%zz')
+    assert.equal(bad.status, 200)
+    assert.match(bad.body, /<div id="root">/)
+
+    // The server is still alive and serving afterwards.
+    const after = await fetchText(dash.url + '/assets/app.js')
+    assert.equal(after.status, 200)
+  } finally {
+    await dash.close()
+    await rm(bundle, { recursive: true, force: true })
+  }
+})
+
 test('the Telefunc mount rejects a cross-origin POST (CSRF guard)', async () => {
   const bundle = await fakeBundle()
   const dash = await startDashboard({ port: 0, clientBundleDir: bundle })

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -109,6 +109,24 @@ test('a malformed percent-encoded path serves the SPA shell and the server survi
   }
 })
 
+test('a malformed escape inside a browser-proxy path serves the shell and the server survives (#938)', async () => {
+  const bundle = await fakeBundle()
+  const dash = await startDashboard({ port: 0, clientBundleDir: bundle })
+  try {
+    // Passes the pathname guard (the URL parses), enters the proxy dispatch, and only explodes
+    // at decode time inside parseBrowserRoute — the crash the round-2 pass live-repro'd.
+    const bad = await fetchText(dash.url + '/browser/p/%zz/stream')
+    assert.equal(bad.status, 200)
+    assert.match(bad.body, /<div id="root">/)
+
+    const after = await fetchText(dash.url + '/')
+    assert.equal(after.status, 200)
+  } finally {
+    await dash.close()
+    await rm(bundle, { recursive: true, force: true })
+  }
+})
+
 test('an unparseable absolute-form request target gets a 400 and the server survives (#938)', async () => {
   const bundle = await fakeBundle()
   const dash = await startDashboard({ port: 0, clientBundleDir: bundle })

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { get, request } from 'node:http'
+import { connect } from 'node:net'
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -17,6 +18,21 @@ function fetchText(url: string): Promise<{ status: number; body: string; type: s
         resolvePromise({ status: res.statusCode ?? 0, body, type: String(res.headers['content-type'] ?? '') }),
       )
     }).on('error', rejectPromise)
+  })
+}
+
+/** Send a raw request line over a socket — for request targets `http.get` refuses to send. */
+function rawRequest(url: string, requestLine: string): Promise<string> {
+  const port = Number(new URL(url).port)
+  return new Promise((resolvePromise, rejectPromise) => {
+    const sock = connect(port, '127.0.0.1', () => {
+      sock.write(`${requestLine}\r\nHost: x\r\nConnection: close\r\n\r\n`)
+    })
+    let data = ''
+    sock.on('data', c => (data += c))
+    sock.on('close', () => resolvePromise(data))
+    sock.on('error', rejectPromise)
+    sock.setTimeout(5000, () => sock.destroy())
   })
 }
 
@@ -86,6 +102,23 @@ test('a malformed percent-encoded path serves the SPA shell and the server survi
 
     // The server is still alive and serving afterwards.
     const after = await fetchText(dash.url + '/assets/app.js')
+    assert.equal(after.status, 200)
+  } finally {
+    await dash.close()
+    await rm(bundle, { recursive: true, force: true })
+  }
+})
+
+test('an unparseable absolute-form request target gets a 400 and the server survives (#938)', async () => {
+  const bundle = await fakeBundle()
+  const dash = await startDashboard({ port: 0, clientBundleDir: bundle })
+  try {
+    // Node's parser passes absolute-form targets through verbatim; `new URL('http://[', ...)`
+    // throws synchronously in the request handler, which unguarded kills the process.
+    const raw = await rawRequest(dash.url, 'GET http://[ HTTP/1.1')
+    assert.match(raw, /^HTTP\/1\.1 400 /)
+
+    const after = await fetchText(dash.url + '/')
     assert.equal(after.status, 200)
   } finally {
     await dash.close()

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -135,9 +135,13 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
     // The browser preview (#813) is proxied, not Telefunc'd: it is an endless MJPEG body and a
     // raw input POST, neither of which is an RPC.
     if (pathname.startsWith(`${BROWSER_PROXY_PREFIX}/`)) {
-      void handleBrowserProxy(req, res).then(handled => {
-        if (!handled) void serveClientBundle(req, res, clientBundleDir)
-      })
+      void handleBrowserProxy(req, res)
+        .then(handled => {
+          if (!handled) void serveClientBundle(req, res, clientBundleDir)
+        })
+        // Whatever the proxy throws must not become an unhandled rejection that kills the
+        // daemon (#938); tear the socket down rather than leave the request hanging.
+        .catch(() => res.destroy())
       return
     }
     void serveClientBundle(req, res, clientBundleDir)

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -6,6 +6,7 @@ import { defaultQuotaSource, type QuotaSource } from './quota.js'
 import { serveClientBundle } from './static.js'
 import { BROWSER_PROXY_PREFIX, handleBrowserProxy } from './browser-proxy.js'
 import { makeTelefuncMount } from './telefunc-serve.js'
+import { requestPathname } from '../request-path.js'
 import type { AddProjectResult, PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from './types.js'
 import type { PreviewHandlers } from './telefunc-serve.js'
 
@@ -122,7 +123,11 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
   })
 
   const server = createServer((req, res) => {
-    const { pathname } = new URL(req.url ?? '/', 'http://localhost')
+    const pathname = requestPathname(req)
+    if (pathname === undefined) {
+      res.writeHead(400, { 'content-type': 'text/plain' }).end('bad request')
+      return
+    }
     if (pathname === '/_telefunc' || pathname.startsWith('/_telefunc/')) {
       void telefuncMount(req, res)
       return

--- a/packages/framework/src/dashboard/static.ts
+++ b/packages/framework/src/dashboard/static.ts
@@ -14,6 +14,15 @@ async function isFile(path: string): Promise<boolean> {
   return stat(path).then(s => s.isFile()).catch(() => false)
 }
 
+/** Decode a percent-encoded path; a malformed escape names no file, so it decodes to nothing. */
+function tryDecode(pathname: string): string {
+  try {
+    return decodeURIComponent(pathname)
+  } catch {
+    return ''
+  }
+}
+
 /**
  * Serve `dir`'s static bundle for this request: the requested file when it exists,
  * otherwise `index.html` (the SPA fallback, so client routes and unknown paths still
@@ -22,7 +31,9 @@ async function isFile(path: string): Promise<boolean> {
  */
 export async function serveClientBundle(req: IncomingMessage, res: ServerResponse, dir: string): Promise<void> {
   const { pathname } = new URL(req.url ?? '/', 'http://localhost')
-  const rel = decodeURIComponent(pathname).replace(/^\/+/, '')
+  // A malformed escape (`/%zz`) must not throw: this runs void-dispatched, so an
+  // exception here would be an unhandled rejection that takes the daemon down (#938).
+  const rel = tryDecode(pathname).replace(/^\/+/, '')
   const root = normalize(dir)
   const candidate = normalize(join(root, rel))
   const within = candidate === root || candidate.startsWith(root + sep)

--- a/packages/framework/src/dashboard/static.ts
+++ b/packages/framework/src/dashboard/static.ts
@@ -2,6 +2,7 @@ import { readFile, stat } from 'node:fs/promises'
 import { join, normalize, sep } from 'node:path'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { contentTypeFor } from './content-type.js'
+import { requestPathname } from '../request-path.js'
 
 // Serve the prerendered dashboard bundle (#405). The new dashboard is a Vike `ssr:false`
 // SPA prerendered to a static `index.html` + `assets/**`, so the daemon serves it as
@@ -30,9 +31,10 @@ function tryDecode(pathname: string): string {
  * `index.html` rather than reading outside the bundle.
  */
 export async function serveClientBundle(req: IncomingMessage, res: ServerResponse, dir: string): Promise<void> {
-  const { pathname } = new URL(req.url ?? '/', 'http://localhost')
-  // A malformed escape (`/%zz`) must not throw: this runs void-dispatched, so an
-  // exception here would be an unhandled rejection that takes the daemon down (#938).
+  // Neither an unparseable request target nor a malformed escape (`/%zz`) may throw: this
+  // runs void-dispatched, so an exception here would be an unhandled rejection that takes
+  // the daemon down (#938). Both fall back to the SPA shell like any other unknown path.
+  const pathname = requestPathname(req) ?? '/'
   const rel = tryDecode(pathname).replace(/^\/+/, '')
   const root = normalize(dir)
   const candidate = normalize(join(root, rel))

--- a/packages/framework/src/preview.test.ts
+++ b/packages/framework/src/preview.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { mkdir, mkdtemp, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, sep } from 'node:path'
 import { detectDevScript, detectServeTargets, parsePreviewUrl, startPreview, PREVIEW_SCRIPTS } from './preview.js'
 
 async function withTmp(prefix: string, fn: (dir: string) => Promise<void>): Promise<void> {
@@ -60,6 +60,36 @@ test('startPreview falls back to a static server for a plain index.html and serv
       assert.match(handle.url, /^http:\/\/localhost:\d+$/)
       const body = await fetch(handle.url).then(r => r.text())
       assert.match(body, /hello preview/)
+    } finally {
+      await handle.stop()
+    }
+  })
+})
+
+test('a malformed percent-encoded path gets a 400 and the static server survives (#938)', async () => {
+  await withTmp('bad-escape', async dir => {
+    await writeFile(join(dir, 'index.html'), '<h1>still here</h1>')
+    const handle = await startPreview({ cwd: dir })
+    try {
+      // `decodeURIComponent('/%zz')` throws; unguarded it is an unhandled rejection that kills the process.
+      const bad = await fetch(handle.url + '/%zz')
+      assert.equal(bad.status, 400)
+
+      const after = await fetch(handle.url).then(r => r.text())
+      assert.match(after, /still here/)
+    } finally {
+      await handle.stop()
+    }
+  })
+})
+
+test('a trailing-slash cwd still serves instead of refusing every path (#938)', async () => {
+  await withTmp('trailing-slash', async dir => {
+    await writeFile(join(dir, 'index.html'), '<h1>slash ok</h1>')
+    const handle = await startPreview({ cwd: dir + sep })
+    try {
+      const body = await fetch(handle.url).then(r => r.text())
+      assert.match(body, /slash ok/)
     } finally {
       await handle.stop()
     }

--- a/packages/framework/src/preview.ts
+++ b/packages/framework/src/preview.ts
@@ -332,10 +332,21 @@ async function startStaticServer(cwd: string): Promise<PreviewHandle> {
 
 /** Serve one file from `root`, defaulting `/` to `index.html`, refusing path traversal. */
 async function serveStaticFile(root: string, urlPath: string, res: ServerResponse): Promise<void> {
-  const rel = normalize(decodeURIComponent(urlPath.split('?')[0]!)).replace(/^(\.\.[/\\])+/, '')
-  const target = join(root, rel === '/' || rel === '.' || rel === '' ? 'index.html' : rel)
+  // A malformed escape (`/%zz`) must not throw: this runs void-dispatched, so an
+  // exception here would be an unhandled rejection that takes the process down (#938).
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(urlPath.split('?')[0]!)
+  } catch {
+    res.writeHead(400, { 'content-type': 'text/plain' }).end('bad request')
+    return
+  }
+  const rel = normalize(decoded).replace(/^(\.\.[/\\])+/, '')
+  // `join(root, '.')` drops a trailing separator, so a `dir/`-shaped cwd cannot fail the prefix check.
+  const base = join(root, '.')
+  const target = join(base, rel === '/' || rel === '.' || rel === '' ? 'index.html' : rel)
   // Refuse anything that escaped the root after normalization.
-  if (target !== root && !target.startsWith(root + sep)) {
+  if (target !== base && !target.startsWith(base + sep)) {
     res.writeHead(403, { 'content-type': 'text/plain' }).end('forbidden')
     return
   }

--- a/packages/framework/src/relay.test.ts
+++ b/packages/framework/src/relay.test.ts
@@ -70,6 +70,20 @@ test('a viewer GET of a run redirects to the SPA viewer URL /?run=:id (#426)', a
   }
 })
 
+test('a malformed escape in the run id segment gets a 400 and the relay survives (#938)', async () => {
+  const relay = await startRelay({ ...local, clientBundleDir: '/no/such/bundle' })
+  try {
+    // `decodeURIComponent('%zz')` throws; unguarded it is an uncaught exception in the handler.
+    const bad = await fetchFull(`${relay.url}/r/%zz/`)
+    assert.equal(bad.status, 400)
+
+    const health = await fetchFull(`${relay.url}/healthz`)
+    assert.equal(health.status, 200)
+  } finally {
+    await relay.close()
+  }
+})
+
 test('the relay serves the dashboard SPA at / (and its viewer URL); missing bundle is a clean 404', async () => {
   const bundle = await fakeBundle('spa-here')
   const served = await startRelay({ ...local, clientBundleDir: bundle })

--- a/packages/framework/src/relay.ts
+++ b/packages/framework/src/relay.ts
@@ -5,6 +5,7 @@ import type { FrameworkEvent } from './events.js'
 import { resolveDashboardBundle } from './dashboard/bundle.js'
 import { serveClientBundle } from './dashboard/static.js'
 import { makeTelefuncMount } from './dashboard/telefunc-serve.js'
+import { requestPathname } from './request-path.js'
 import { emptyProjectsProvider } from './dashboard/projects.js'
 
 /**
@@ -141,7 +142,13 @@ interface HandleCtx {
 }
 
 function handle(req: IncomingMessage, res: ServerResponse, ctx: HandleCtx): void {
-  const { pathname } = new URL(req.url ?? '/', 'http://localhost')
+  // A public server: a request no URL parser accepts must get a 400, not crash the relay (#938).
+  const pathname = requestPathname(req)
+  if (pathname === undefined) {
+    res.writeHead(400, { 'content-type': 'text/plain' })
+    res.end('bad request')
+    return
+  }
   if (pathname === '/healthz') {
     res.writeHead(200, { 'content-type': 'text/plain' })
     res.end('ok')
@@ -154,7 +161,15 @@ function handle(req: IncomingMessage, res: ServerResponse, ctx: HandleCtx): void
   }
   const m = RUN_PATH.exec(pathname)
   if (m) {
-    const id = decodeURIComponent(m[1]!)
+    // A malformed escape in the id segment (`/r/%zz/`) must not throw out of the handler (#938).
+    let id: string
+    try {
+      id = decodeURIComponent(m[1]!)
+    } catch {
+      res.writeHead(400, { 'content-type': 'text/plain' })
+      res.end('bad request')
+      return
+    }
     const rest = m[2] ?? ''
     // Ingest is the one thing still under /r/:id/ — the publisher POSTs a run's events here.
     if (rest === '/publish') {

--- a/packages/framework/src/request-path.ts
+++ b/packages/framework/src/request-path.ts
@@ -1,0 +1,16 @@
+import type { IncomingMessage } from 'node:http'
+
+/**
+ * A request's pathname, parsed defensively (#938). Node hands the request target through
+ * verbatim, including absolute-form targets a proxy client may send (`GET http://[ ...`),
+ * and `new URL` throws on those synchronously inside the request handler — an uncaught
+ * exception that takes the whole daemon down. `undefined` means "no parseable path":
+ * answer 400 (or serve the fallback), never throw.
+ */
+export function requestPathname(req: IncomingMessage): string | undefined {
+  try {
+    return new URL(req.url ?? '/', 'http://localhost').pathname
+  } catch {
+    return undefined
+  }
+}


### PR DESCRIPTION
Closes #938

Verified at head of main before fixing: a live daemon (node dist/bin.js --daemon-serve) died to a single GET /%zz, and separately to an absolute-form request target (GET http://[ HTTP/1.1), which Node passes through verbatim and new URL(req.url, ...) throws on synchronously. Both were reproduced with curl / a raw socket against a real daemon.

Three crash sites of the same class, all fixed:

- packages/framework/src/dashboard/static.ts: decodeURIComponent on the raw path in the void-dispatched bundle handler. A malformed escape now falls back to the SPA shell like any unknown path.
- packages/framework/src/preview.ts serveStaticFile: same unguarded decode on its own port; now answers 400. While there, the path-prefix check normalizes a trailing-slash cwd, which previously made it refuse every path (issue OP called this out).
- packages/framework/src/relay.ts + dashboard/server.ts: the synchronous new URL(req.url, ...) parse, plus the relay run-id decodeURIComponent (/r/%zz/). One shared requestPathname() helper parses defensively; unparseable targets answer 400. The relay one matters most: it is the public surface.

Regression tests (each fails without the fix; mutation-checked by reverting the fix files and re-running exactly these):

- dashboard/server.test.ts: GET /%zz serves the SPA shell and the server keeps serving; a raw-socket absolute-form target gets 400 and the server survives.
- preview.test.ts: GET /%zz gets 400 and the server keeps serving; a trailing-slash cwd serves instead of refusing every path.
- relay.test.ts: GET /r/%zz/ gets 400 and healthz still answers.

Live-verified against a real daemon on a scratch repo: GET /%zz answers 200, the absolute-form target answers 400, and the daemon serves normally afterwards.