### PR TITLE
fix(framework): swallow the stdin write error when the agent CLI dies early

### DIFF
--- a/.changeset/stdin-epipe-listener.md
+++ b/.changeset/stdin-epipe-listener.md
@@ -1,0 +1,10 @@
+---
+'@gemstack/framework': patch
+---
+
+An agent CLI that exits before reading its prompt no longer crashes the daemon (#943)
+
+The shared CLI runner wrote the prompt to the child's stdin with no error listener. A CLI that
+dies before draining stdin (bad flag, instant crash) surfaces an async EPIPE on the stream, which
+with no listener is an uncaught exception in the daemon. The write error is now swallowed; the
+close handler already reports the failed turn with the CLI's own stderr.

--- a/packages/framework/src/driver/agent-cli.test.ts
+++ b/packages/framework/src/driver/agent-cli.test.ts
@@ -1,5 +1,6 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
+import { spawn } from 'node:child_process'
 import { Readable, Writable } from 'node:stream'
 import { runAgentCli, type AgentCliParser, type SpawnLike, type SpawnedProcess } from './agent-cli.js'
 import type { DriverEvent } from './types.js'
@@ -39,6 +40,59 @@ test('runAgentCli streams the parser events and resolves the final turn', async 
   assert.equal(events[0]!.type, 'start')
   assert.ok(events.some(e => e.type === 'text'))
   assert.equal(events.at(-1)!.type, 'result')
+})
+
+test('an stdin write error fails the turn cleanly, not as an uncaught exception (#943)', async () => {
+  // stdin that errors asynchronously, the shape a pipe takes when the CLI exited before reading.
+  const stdin = new Writable({ write: (_c, _e, cb) => cb(new Error('EPIPE: broken pipe')) })
+  let fireClose: (code: number | null) => void = () => {}
+  const spawn: SpawnLike = () => {
+    const proc: SpawnedProcess = {
+      stdout: Readable.from([]),
+      stderr: Readable.from([]),
+      stdin,
+      on(event, listener) {
+        if (event === 'close') fireClose = listener as (c: number | null) => void
+        return proc
+      },
+      kill: () => undefined,
+    }
+    return proc
+  }
+  const promise = runAgentCli({
+    bin: 'agent',
+    args: [],
+    cwd: '/ws',
+    env: {},
+    prompt: 'go',
+    spawn,
+    emit: () => {},
+    signals: [],
+    parser: { push: () => [], result: () => ({ text: '' }) },
+  })
+  // Let the stream's async 'error' emission land; with no listener it is an uncaught exception.
+  await new Promise(resolvePromise => setImmediate(resolvePromise))
+  fireClose(1) // the crashed CLI reports its non-zero exit
+  await assert.rejects(promise, /exited/)
+})
+
+test('a real CLI that exits before reading stdin does not crash the process (#943)', async () => {
+  // A prompt larger than the pipe buffer, so the write is still pending when the child dies
+  // and the kernel answers with a real EPIPE.
+  const turn = await runAgentCli({
+    bin: process.execPath,
+    args: ['-e', 'process.exit(0)'],
+    cwd: process.cwd(),
+    env: process.env,
+    prompt: 'x'.repeat(1024 * 1024),
+    spawn: spawn as unknown as SpawnLike,
+    emit: () => {},
+    signals: [],
+    parser: { push: () => [], result: () => ({ text: 'ok' }) },
+  })
+  assert.equal(turn.text, 'ok')
+  // Give the late EPIPE its window inside this test, so an unswallowed one fails here, not elsewhere.
+  await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
 })
 
 test('runAgentCli emits no telemetry when the process closes after an abort', async () => {

--- a/packages/framework/src/driver/agent-cli.ts
+++ b/packages/framework/src/driver/agent-cli.ts
@@ -168,6 +168,11 @@ export function runAgentCli(opts: RunAgentCliOptions): Promise<DriverTurn> {
 
     // Feed the prompt over stdin so long prompts never hit arg-length limits.
     if (child.stdin) {
+      // A CLI that exits before reading stdin (bad flag, instant crash) surfaces an async
+      // EPIPE on the stream; with no listener that is an uncaught exception in the daemon
+      // (#943). The close handler already reports the failed turn, so the error carries
+      // nothing the caller needs.
+      child.stdin.on('error', () => {})
       child.stdin.write(opts.prompt)
       child.stdin.end()
     }


### PR DESCRIPTION
Closes #943

Verified at head of main: a spawned CLI that exits before reading stdin (reproduced with node -e "process.exit(0)" and a 1 MB prompt) surfaces an async EPIPE on child.stdin; with no error listener that is an uncaught exception in the daemon. Both real drivers hit this through the shared runner.

Fix: an error listener on stdin before the write (driver/agent-cli.ts). The close handler already reports the failed turn with the CLI stderr, so the swallowed error carries nothing the caller needs.

Regression tests (mutation-checked: reverting the fix line fails exactly these two):

- driver/agent-cli.test.ts: a fake stdin whose write errors asynchronously fails the turn via the non-zero exit instead of throwing an uncaught exception.
- driver/agent-cli.test.ts: a real spawned process that exits instantly, with a prompt larger than the pipe buffer, resolves the turn and leaves the EPIPE window inside the test.