### PR TITLE
fix(framework): clamp Discord webhook posts and surface failed deliveries

### DIFF
--- a/.changeset/webhook-clamp-and-check.md
+++ b/.changeset/webhook-clamp-and-check.md
@@ -1,0 +1,11 @@
+---
+'@gemstack/framework': patch
+---
+
+Discord webhook posts are clamped to the 2000-char limit and failures are logged (#940)
+
+The notification posters (activity, needs-you interventions) sent whatever content they built and
+never looked at the response. Discord rejects a message over 2000 chars with a 400, so a long
+needs-you batch silently posted nothing. The shared webhook transport now clamps with the same
+helper the bot API uses, resolves whether Discord accepted the post, and the daemon logs a failed
+delivery like its other failures.

--- a/packages/framework/src/daemon-services.ts
+++ b/packages/framework/src/daemon-services.ts
@@ -121,7 +121,8 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
           keyOf: interventionKey,
           onNew: async items => {
             if (!discordNotificationEnabled(await prefs(), 'notifyHumanIntervention')) return
-            await postInterventionsDiscord(webhook, items).catch(() => {})
+            const delivered = await postInterventionsDiscord(webhook, items).catch(() => false)
+            if (!delivered) log('[framework] could not post a needs-you batch to the Discord webhook')
           },
         }),
         startKeyedWatcher({
@@ -130,7 +131,8 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
           keyOf: activityKey,
           onNew: async items => {
             if (!discordNotificationEnabled(await prefs(), 'notifyNewActivity')) return
-            await postActivityDiscord(webhook, items).catch(() => {})
+            const delivered = await postActivityDiscord(webhook, items).catch(() => false)
+            if (!delivered) log('[framework] could not post an activity batch to the Discord webhook')
           },
         }),
       ]

--- a/packages/framework/src/dashboard/activity.ts
+++ b/packages/framework/src/dashboard/activity.ts
@@ -93,16 +93,19 @@ export function activityLine(item: Activity): string {
   return `${mark} finished: ${what}`
 }
 
-/** Post the given activity items to a Discord webhook as one message. `fetch` is injectable for tests. */
+/**
+ * Post the given activity items to a Discord webhook as one message, resolving whether Discord
+ * accepted it (#940). `fetch` is injectable for tests.
+ */
 export async function postActivityDiscord(
   webhook: string,
   items: Activity[],
   fetchImpl: typeof fetch = fetch,
-): Promise<void> {
-  if (items.length === 0) return
+): Promise<boolean> {
+  if (items.length === 0) return true
   const content =
     items.length === 1
       ? `📣 Activity (${items[0]!.projectName}): ${activityLine(items[0]!)}`
       : `📣 ${items.length} session updates:\n${items.map(i => `• ${i.projectName}: ${activityLine(i)}`).join('\n')}`
-  await postDiscordWebhook(webhook, content, fetchImpl)
+  return postDiscordWebhook(webhook, content, fetchImpl)
 }

--- a/packages/framework/src/dashboard/discord-webhook.test.ts
+++ b/packages/framework/src/dashboard/discord-webhook.test.ts
@@ -1,0 +1,49 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { postDiscordWebhook } from './discord-webhook.js'
+import { MAX_CONTENT } from '../discord/rest.js'
+import { postInterventionsDiscord, type Intervention } from './interventions.js'
+
+test('content over the Discord limit is clamped, with the cut marked (#940)', async () => {
+  let body: { content: string } | undefined
+  const fetchImpl = (async (_url, init) => {
+    body = JSON.parse(String(init!.body))
+    return new Response(null, { status: 204 })
+  }) as typeof fetch
+  const delivered = await postDiscordWebhook('https://discord/hook', 'x'.repeat(5000), fetchImpl)
+  assert.equal(delivered, true)
+  assert.ok(body!.content.length <= MAX_CONTENT, `sent ${body!.content.length} chars`)
+  assert.match(body!.content, /truncated/)
+})
+
+test('a non-ok response resolves false instead of passing as delivered (#940)', async () => {
+  const fetchImpl = (async () => new Response('{"message":"Request entity too large"}', { status: 400 })) as typeof fetch
+  assert.equal(await postDiscordWebhook('https://discord/hook', 'hi', fetchImpl), false)
+})
+
+test('a network error resolves false rather than throwing out of a watcher (#940)', async () => {
+  const fetchImpl = (async () => {
+    throw new Error('getaddrinfo ENOTFOUND')
+  }) as unknown as typeof fetch
+  assert.equal(await postDiscordWebhook('https://discord/hook', 'hi', fetchImpl), false)
+})
+
+test('a long needs-you batch goes through clamped instead of silently posting nothing (#940)', async () => {
+  // The shape that hit the limit in practice: many interventions with titles and urls in one batch.
+  const items: Intervention[] = Array.from({ length: 40 }, (_, i) => ({
+    projectId: 'p',
+    projectName: 'p',
+    kind: 'pr' as const,
+    number: i,
+    title: `a fairly long pull request title that repeats ${'x'.repeat(40)}`,
+    url: `https://github.com/acme/repo/pull/${i}`,
+  }))
+  let body: { content: string } | undefined
+  const fetchImpl = (async (_url, init) => {
+    body = JSON.parse(String(init!.body))
+    return new Response(null, { status: 204 })
+  }) as typeof fetch
+  const delivered = await postInterventionsDiscord('https://discord/hook', items, fetchImpl)
+  assert.equal(delivered, true)
+  assert.ok(body!.content.length <= MAX_CONTENT, `sent ${body!.content.length} chars`)
+})

--- a/packages/framework/src/dashboard/discord-webhook.ts
+++ b/packages/framework/src/dashboard/discord-webhook.ts
@@ -1,14 +1,27 @@
+import { clampContent } from '../discord/rest.js'
+
 /**
  * The one Discord *webhook* transport (#627): a single POST of one message. The two
  * notification posters (activity, interventions) each carried their own copy of this fetch;
  * their line formatters rightly stay beside the types they switch on, but the transport is
  * not per-feed. Deliberately not in discord/rest.ts — that module is the bot-token API
- * (channels, replies), and a webhook needs no token and reaches one fixed channel.
+ * (channels, replies), and a webhook needs no token and reaches one fixed channel — though
+ * it shares that module's clamp: Discord rejects a message over 2000 chars outright, so an
+ * unclamped "needs you" batch would silently post nothing (#940).
+ *
+ * Resolves whether Discord accepted the post. A failed delivery must never throw out of a
+ * daemon watcher, so a non-ok response and a network error both resolve `false` for the
+ * caller to log.
  */
-export async function postDiscordWebhook(webhook: string, content: string, fetchImpl: typeof fetch = fetch): Promise<void> {
-  await fetchImpl(webhook, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ content }),
-  })
+export async function postDiscordWebhook(webhook: string, content: string, fetchImpl: typeof fetch = fetch): Promise<boolean> {
+  try {
+    const res = await fetchImpl(webhook, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: clampContent(content) }),
+    })
+    return res.ok
+  } catch {
+    return false
+  }
 }

--- a/packages/framework/src/dashboard/interventions.ts
+++ b/packages/framework/src/dashboard/interventions.ts
@@ -192,16 +192,19 @@ export function interventionLine(item: Intervention): string {
   return `#${item.number} ${item.title} — ${item.url}`
 }
 
-/** Post the given interventions to a Discord webhook as one message. `fetch` is injectable for tests. */
+/**
+ * Post the given interventions to a Discord webhook as one message, resolving whether Discord
+ * accepted it (#940). `fetch` is injectable for tests.
+ */
 export async function postInterventionsDiscord(
   webhook: string,
   items: Intervention[],
   fetchImpl: typeof fetch = fetch,
-): Promise<void> {
-  if (items.length === 0) return
+): Promise<boolean> {
+  if (items.length === 0) return true
   const content =
     items.length === 1
       ? `🔔 Needs you (${items[0]!.projectName}): ${interventionLine(items[0]!)}`
       : `🔔 ${items.length} items need you:\n${items.map(i => `• ${interventionLine(i)}`).join('\n')}`
-  await postDiscordWebhook(webhook, content, fetchImpl)
+  return postDiscordWebhook(webhook, content, fetchImpl)
 }


### PR DESCRIPTION
Closes #940

Verified at head of main: postDiscordWebhook sent whatever content the posters built and never read the response. Discord rejects a message over 2000 chars with a 400, so a long needs-you batch silently posted nothing, exactly as the issue describes.

Fix, all in the shared transport (dashboard/discord-webhook.ts):

- Clamp with the same clampContent the bot API (discord/rest.ts) already uses, cut marked with a truncation notice.
- Resolve whether Discord accepted the post; a network error resolves false instead of throwing out of a watcher.
- The two posters propagate the boolean and daemon-services logs a failed delivery like the daemon logs its other failures.

Regression tests (mutation-checked: reverting the four touched files fails exactly these):

- dashboard/discord-webhook.test.ts: over-limit content is clamped to 2000 with the cut marked; a 400 resolves false; a thrown fetch resolves false; a realistic 40-item needs-you batch goes out clamped and delivered.