### PR TITLE
fix(framework): compiler-enforce PREFERENCE_KEYS completeness against Preferences

### DIFF
--- a/.changeset/preference-keys-guard.md
+++ b/.changeset/preference-keys-guard.md
@@ -1,0 +1,10 @@
+---
+'@gemstack/framework': patch
+---
+
+PREFERENCE_KEYS is compiler-enforced complete against Preferences (#944)
+
+The boolean key list is now derived from a Record over the boolean keys of the Preferences type,
+so omitting a newly added boolean preference fails the build instead of making
+sanitizePreferences silently drop it on every save (write-then-vanish). No runtime behavior
+changes today; this closes the failure shape for every future preference.

--- a/packages/framework/src/registry.test.ts
+++ b/packages/framework/src/registry.test.ts
@@ -15,6 +15,7 @@ import {
   writePreferences,
   writeProjectPreferences,
   REGISTRY_FILE,
+  type Preferences,
   type ProjectRecord,
   type RegistryFs,
 } from './registry.js'
@@ -164,6 +165,36 @@ test('readRegistry reads the object form with preferences and drops unknown/non-
     preferences: { autopilot: false, eco: true, onBeforeMergeableQuality: true, browser: true }, // ecoPlanning (non-boolean) + bogus dropped
     projectPreferences: {},
   })
+})
+
+test('every boolean preference survives a save; the sanitizer cannot silently drop one (#944)', async () => {
+  // `allOn` is typed over the boolean keys computed from `Preferences` itself, so adding a
+  // boolean preference without listing it here is a compile error in this test — and a key the
+  // sanitizer's list misses fails the round-trip below, the write-then-vanish shape #944 closes.
+  type BooleanKey = {
+    [K in keyof Preferences]-?: NonNullable<Preferences[K]> extends boolean ? K : never
+  }[keyof Preferences]
+  const allOn: Record<BooleanKey, boolean> = {
+    autopilot: true,
+    technical: true,
+    vanilla: true,
+    eco: true,
+    ecoPlanning: true,
+    ecoResearch: true,
+    ecoMaintenance: true,
+    onBeforeMergeableQuality: true,
+    browser: true,
+    transparent: true,
+    notifyBrowser: true,
+    notifyDiscord: true,
+    discordBot: true,
+    notifyNewActivity: true,
+    notifyHumanIntervention: true,
+    autoPm: true,
+  }
+  const fs = memFs()
+  await writePreferences(allOn, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), allOn)
 })
 
 // Per-project run options (#840): a project overrides only what it sets, the rest falls through.

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -215,24 +215,38 @@ function dedupeProjects(values: unknown[]): ProjectRecord[] {
   return projects
 }
 
-const PREFERENCE_KEYS = [
-  'autopilot',
-  'technical',
-  'vanilla',
-  'eco',
-  'ecoPlanning',
-  'ecoResearch',
-  'ecoMaintenance',
-  'onBeforeMergeableQuality',
-  'browser',
-  'transparent',
-  'notifyBrowser',
-  'notifyDiscord',
-  'discordBot',
-  'notifyNewActivity',
-  'notifyHumanIntervention',
-  'autoPm',
-] as const
+/** The boolean keys of {@link Preferences}, computed so the table below cannot drift from the type. */
+type BooleanPreferenceKey = {
+  [K in keyof Preferences]-?: NonNullable<Preferences[K]> extends boolean ? K : never
+}[keyof Preferences]
+
+/**
+ * Every boolean preference, as a `Record` over {@link BooleanPreferenceKey} so the compiler
+ * enforces completeness in both directions (#944): a typo fails as an unknown property, and
+ * omitting a newly added boolean preference fails as a missing one. A plain `as const` array
+ * only caught the first — an omission made {@link sanitizePreferences} silently drop the new
+ * preference on every save, the write-then-vanish failure shape for a settings file.
+ */
+const BOOLEAN_PREFERENCES: Record<BooleanPreferenceKey, true> = {
+  autopilot: true,
+  technical: true,
+  vanilla: true,
+  eco: true,
+  ecoPlanning: true,
+  ecoResearch: true,
+  ecoMaintenance: true,
+  onBeforeMergeableQuality: true,
+  browser: true,
+  transparent: true,
+  notifyBrowser: true,
+  notifyDiscord: true,
+  discordBot: true,
+  notifyNewActivity: true,
+  notifyHumanIntervention: true,
+  autoPm: true,
+}
+
+const PREFERENCE_KEYS = Object.keys(BOOLEAN_PREFERENCES) as BooleanPreferenceKey[]
 
 /** Keep only the known preference fields, so a hand-edited or browser-supplied
  * object never lands junk (or the wrong type) in the user's home file. */


### PR DESCRIPTION
Closes #944

Verified at head of main: PREFERENCE_KEYS is a hand-maintained as-const array of 16 entries. A typo is type-caught, but omitting a newly added boolean preference makes sanitizePreferences silently drop it on every save: write-then-vanish, the worst failure shape for a settings file.

Fix (registry.ts): the list is now derived from a Record over the boolean keys of Preferences (computed with a mapped type), so the compiler enforces completeness in both directions. Removing a key from the table is a missing-property error; adding a junk key is an unknown-property error. The single Record also removes the concern about the 10 entries repeating PROJECT_PREFERENCE_KEYS: there is one list, and it cannot drift.

Pinned two ways (both mutation-checked):

- Compile guard: deleting autoPm from the table fails the build with TS2741.
- registry.test.ts: an all-booleans-on object (typed over the boolean keys of Preferences, so the test itself must stay complete) round-trips through writePreferences/readPreferences. Reverting to the old array with one key omitted fails exactly this test.