### PR TITLE
fix(framework): back off and retry when the gateway socket factory throws synchronously

### DIFF
--- a/.changeset/gateway-sync-throw-backoff.md
+++ b/.changeset/gateway-sync-throw-backoff.md
@@ -1,0 +1,10 @@
+---
+'@gemstack/framework': patch
+---
+
+A synchronously-failing gateway socket factory no longer kills the Discord bot permanently (#942)
+
+When the socket factory threw synchronously (e.g. a malformed URL), open() logged and returned:
+no socket exists, so no onClose ever fires and no reconnect is ever scheduled — zero loop instead
+of the backed-off one reopen() was designed for. The catch now falls through to the same backoff
+path a failed connection takes; stop() still cancels it.

--- a/packages/framework/src/discord/gateway.test.ts
+++ b/packages/framework/src/discord/gateway.test.ts
@@ -100,6 +100,63 @@ function messageEvent(over: Record<string, unknown> = {}) {
   }
 }
 
+test('a synchronously-failing socket factory backs off and retries instead of dying (#942)', () => {
+  const socket = fakeSocket()
+  const delay = fakeDelay()
+  const clock = fakeInterval()
+  const logs: string[] = []
+  let calls = 0
+  const gateway = new DiscordGateway(
+    'tok',
+    { onMessage: () => {}, onLog: m => logs.push(m) },
+    {
+      socket: () => {
+        calls++
+        if (calls === 1) throw new Error('Invalid URL')
+        return socket.socket
+      },
+      interval: clock.factory,
+      delay: delay.factory,
+      url: 'wss://test',
+    },
+  )
+  gateway.connect()
+  assert.equal(calls, 1)
+  assert.ok(logs.some(l => /could not open/.test(l)), logs.join(','))
+  // The bug: no socket means no onClose, so without falling through to the backoff the
+  // bot is offline for the daemon's lifetime — zero loop instead of a tight one.
+  assert.equal(delay.waits.length, 1, 'a backed-off reconnect is scheduled')
+
+  delay.fire()
+  assert.equal(calls, 2, 'the backoff retried the connect')
+  socket.receive(HELLO)
+  assert.ok(socket.sent.some(p => p['op'] === OP.identify), 'the retried connection identifies')
+  gateway.stop()
+})
+
+test('stop() cancels the reconnect a sync-throwing factory scheduled (#942)', () => {
+  const delay = fakeDelay()
+  let calls = 0
+  const gateway = new DiscordGateway(
+    'tok',
+    { onMessage: () => {} },
+    {
+      socket: () => {
+        calls++
+        throw new Error('Invalid URL')
+      },
+      interval: fakeInterval().factory,
+      delay: delay.factory,
+      url: 'wss://test',
+    },
+  )
+  gateway.connect()
+  assert.equal(delay.waits.length, 1)
+  gateway.stop()
+  delay.fire()
+  assert.equal(calls, 1, 'no retry after stop')
+})
+
 test('HELLO triggers an identify with the chat intents', () => {
   const { socket } = connect()
   socket.receive(HELLO)

--- a/packages/framework/src/discord/gateway.ts
+++ b/packages/framework/src/discord/gateway.ts
@@ -197,6 +197,10 @@ export class DiscordGateway {
       socket = factory(url)
     } catch (err) {
       this.log(`could not open the Discord gateway: ${errText(err)}`)
+      // No socket means no onClose will ever fire, so returning here would end reconnection
+      // for the daemon's lifetime (#942). Fall through to the same backoff a failed
+      // connection takes; `stop()` still wins because reopen() checks `stopped`.
+      this.reopen()
       return
     }
     this.socket = socket


### PR DESCRIPTION
Closes #942

Verified at head of main: in discord/gateway.ts open(), a socket factory that throws synchronously (e.g. a malformed gateway URL) is logged and swallowed with a plain return. No socket exists, so no onClose ever fires, and no reconnect is ever scheduled: the bot is offline for the daemon lifetime. That contradicts reopen()s own backoff design (a failed connect must not become a tight loop; here it became zero loop).

Fix: the catch falls through to the same backoff reopen() path a failed connection takes. stop() still wins because reopen() checks the stopped flag and cancels the pending timer.

Regression tests (mutation-checked: reverting gateway.ts fails exactly these two):

- discord/gateway.test.ts: a factory that throws on the first call schedules a backed-off reconnect, and the fired retry connects and identifies.
- discord/gateway.test.ts: stop() during that backoff cancels the pending reconnect, so a stopped bot never retries.