### PR TITLE
fix(framework): release reply-mirror bindings once their run is gone

### DIFF
--- a/.changeset/reply-mirror-release-bindings.md
+++ b/.changeset/reply-mirror-release-bindings.md
@@ -1,0 +1,12 @@
+---
+'@gemstack/framework': patch
+---
+
+Reply-mirror bindings are released once their run is gone (#941)
+
+Nothing ever unbound a chat-touched run, so every binding stayed in the map for the daemon's
+lifetime and each 3s poll scanned every project's live metas per bound run — IO that only ever
+grew. The daemon's conversation reader now answers `undefined` for a run with no live meta
+anywhere (archived, or its project removed), and after a few consecutive misses the mirror drops
+the binding and logs it. A transient miss (or a throwing read) still costs one poll, not the
+binding, and a fresh bind gets the same grace against the meta-not-yet-on-disk race.

--- a/packages/framework/src/daemon-services.ts
+++ b/packages/framework/src/daemon-services.ts
@@ -200,7 +200,9 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
             const meta = (await readLiveMetas(project.path).catch(() => [])).find(run => run.id === runId)
             if (meta) return readConversation(meta.cwd, runId).catch(() => [])
           }
-          return []
+          // No live meta anywhere: the run archived (or its project was removed). The mirror
+          // counts these and releases the binding, so per-poll IO stops growing (#941).
+          return undefined
         },
         post: (channelId, text) => postMessage(botToken, channelId, text),
         enabled: botEnabled,

--- a/packages/framework/src/daemon-services.ts
+++ b/packages/framework/src/daemon-services.ts
@@ -3,7 +3,7 @@ import { listProjects, projectId, readPreferences, readProjectPreferences, resol
 import { discordNotificationEnabled, notificationEnabled } from './preference-defaults.js'
 import { runOptionsFromPreferences, preferencesFromFileConfig } from './run-options.js'
 import { loadFrameworkConfig } from './config.js'
-import { readSuspendedRuns, writeSuspendedRuns, resumableRuns, readLiveMetas, listRuns } from './store/index.js'
+import { readSuspendedRuns, writeSuspendedRuns, resumableRuns, readLiveMetas, listRuns, type LiveRun } from './store/index.js'
 import { startKeyedWatcher, type KeyedWatcher } from './dashboard/keyed-watcher.js'
 import { buildInterventions, interventionKey, postInterventionsDiscord } from './dashboard/interventions.js'
 import { buildActivity, activityKey, postActivityDiscord } from './dashboard/activity.js'
@@ -196,13 +196,21 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
         readConversation: async runId => {
           // A run's transcript lives in the checkout the run used, which for a daemon-spawned run
           // is its own worktree rather than the project root.
-          for (const project of await projects()) {
-            const meta = (await readLiveMetas(project.path).catch(() => [])).find(run => run.id === runId)
+          const summaries = await projects()
+          let listed = false
+          for (const project of summaries) {
+            const metas = await readLiveMetas(project.path).then(
+              m => ((listed = true), m),
+              (): LiveRun[] => [],
+            )
+            const meta = metas.find(run => run.id === runId)
             if (meta) return readConversation(meta.cwd, runId).catch(() => [])
           }
-          // No live meta anywhere: the run archived (or its project was removed). The mirror
-          // counts these and releases the binding, so per-poll IO stops growing (#941).
-          return undefined
+          // `undefined` = the listings worked and the run genuinely is not there (archived, or its
+          // project removed); the mirror counts these and releases the binding, so per-poll IO
+          // stops growing (#941). An empty/unreadable registry or all-failing meta reads is a
+          // transient outage, not evidence the run is gone — `[]` keeps the binding alive.
+          return summaries.length > 0 && listed ? undefined : []
         },
         post: (channelId, text) => postMessage(botToken, channelId, text),
         enabled: botEnabled,

--- a/packages/framework/src/discord/reply-mirror.test.ts
+++ b/packages/framework/src/discord/reply-mirror.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import type { ConversationMessage } from '../conversations.js'
-import { startDiscordReplyMirror } from './reply-mirror.js'
+import { startDiscordReplyMirror, UNBIND_AFTER_MISSES } from './reply-mirror.js'
 
 const turn = (role: 'user' | 'agent', text: string): ConversationMessage => ({
   at: '2026-07-21T00:00:00.000Z',
@@ -12,7 +12,7 @@ const turn = (role: 'user' | 'agent', text: string): ConversationMessage => ({
 
 /** A mirror over an in-memory transcript, recording everything posted. */
 function harness(seed: ConversationMessage[] = [], enabled?: () => Promise<boolean>) {
-  let transcript = seed
+  let transcript: ConversationMessage[] | undefined = seed
   const posted: Array<{ channelId: string; text: string }> = []
   let deliver = true
   const logs: string[] = []
@@ -30,7 +30,9 @@ function harness(seed: ConversationMessage[] = [], enabled?: () => Promise<boole
     mirror,
     posted,
     logs,
-    say: (...messages: ConversationMessage[]) => (transcript = [...transcript, ...messages]),
+    say: (...messages: ConversationMessage[]) => (transcript = [...(transcript ?? []), ...messages]),
+    /** The run stops resolving: archived, or its project was removed (#941). */
+    gone: () => (transcript = undefined),
     set deliver(v: boolean) {
       deliver = v
     },
@@ -150,6 +152,47 @@ test('unbind stops mirroring a finished run (#932)', async () => {
     h.say(turn('agent', 'after the end'))
     await h.mirror.poll()
     assert.equal(h.posted.length, 0)
+  } finally {
+    h.mirror.stop()
+  }
+})
+
+test('a binding is released once its run stops resolving (#941)', async () => {
+  const h = harness()
+  try {
+    await h.mirror.bind('run-1', 'chan-1')
+    h.say(turn('agent', 'still here'))
+    await h.mirror.poll()
+    assert.equal(h.posted.length, 1)
+
+    h.gone() // the run archived; nothing ever unbinds it otherwise
+    for (let i = 0; i < UNBIND_AFTER_MISSES; i++) {
+      assert.equal(h.mirror.isBound('run-1'), true, `still bound after ${i} misses`)
+      await h.mirror.poll()
+    }
+    assert.equal(h.mirror.isBound('run-1'), false, 'released after consecutive misses')
+    assert.ok(h.logs.some(l => /no longer resolves/.test(l)), h.logs.join(','))
+  } finally {
+    h.mirror.stop()
+  }
+})
+
+test('a transient miss does not release the binding, and posting resumes (#941)', async () => {
+  const h = harness()
+  try {
+    await h.mirror.bind('run-1', 'chan-1')
+    h.gone() // e.g. the live-meta listing failed this tick
+    await h.mirror.poll()
+    assert.equal(h.mirror.isBound('run-1'), true, 'one miss is not the end')
+
+    h.say(turn('agent', 'back again')) // resolves again, from an empty transcript
+    await h.mirror.poll()
+    assert.deepEqual(h.posted.map(p => p.text), ['back again'])
+
+    // The miss counter reset: it takes the full run of consecutive misses to release.
+    h.gone()
+    for (let i = 0; i < UNBIND_AFTER_MISSES - 1; i++) await h.mirror.poll()
+    assert.equal(h.mirror.isBound('run-1'), true)
   } finally {
     h.mirror.stop()
   }

--- a/packages/framework/src/discord/reply-mirror.ts
+++ b/packages/framework/src/discord/reply-mirror.ts
@@ -28,6 +28,14 @@ import type { ConversationMessage } from '../conversations.js'
  * While the bot is switched off the cursor still advances without posting, the same contract the
  * notification watchers follow: turning it on starts from now instead of flushing everything said
  * while it was off.
+ *
+ * Bindings are released when their run stops resolving (#941): `readConversation` answers
+ * `undefined` for a run that no longer exists (archived, or its project removed), and after a few
+ * consecutive misses the poll drops the binding. Without that, every chat-touched run stayed in
+ * the map for the daemon's lifetime and each poll scanned every project's live metas per bound
+ * run — no misposts (an archived run resolves nothing), but per-poll IO that only ever grew. The
+ * misses are counted, not acted on at first sight, so a freshly bound run whose meta is not on
+ * disk yet is not dropped by the race.
  */
 
 /** Where a run's answers go. */
@@ -37,8 +45,12 @@ export interface RunBinding {
 
 /** What a mirror needs from the daemon. */
 export interface ReplyMirrorOptions {
-  /** A bound run's conversation, oldest-first. Anything unreadable should resolve `[]`, not throw. */
-  readConversation: (runId: string) => Promise<ConversationMessage[]>
+  /**
+   * A bound run's conversation, oldest-first. Anything unreadable should resolve `[]`, not throw.
+   * `undefined` means the run itself no longer resolves (archived / project gone); after
+   * {@link UNBIND_AFTER_MISSES} consecutive misses the mirror drops the binding (#941).
+   */
+  readConversation: (runId: string) => Promise<ConversationMessage[] | undefined>
   /** Post one answer into a channel. Resolves whether it was delivered. */
   post: (channelId: string, text: string) => Promise<boolean>
   /** Whether the bot should speak, read per poll so the toggle needs no daemon restart. */
@@ -69,10 +81,19 @@ export interface DiscordReplyMirror {
 interface Mirrored extends RunBinding {
   /** Index into the conversation; everything before it is either posted or deliberately skipped. */
   next: number
+  /** Consecutive polls on which the run did not resolve; reset whenever it does. */
+  misses: number
 }
 
 /** How often answers are checked for. A chat reply has to feel like a reply. */
 export const REPLY_POLL_MS = 3_000
+
+/**
+ * How many consecutive unresolvable polls release a binding (#941). More than one on purpose:
+ * a run bound the instant it started may not have its live meta on disk for the first tick or
+ * two, and dropping it then would silently unmirror a live chat.
+ */
+export const UNBIND_AFTER_MISSES = 5
 
 export function startDiscordReplyMirror(opts: ReplyMirrorOptions): DiscordReplyMirror {
   const bound = new Map<string, Mirrored>()
@@ -83,8 +104,8 @@ export function startDiscordReplyMirror(opts: ReplyMirrorOptions): DiscordReplyM
     if (stopped) return
     // Adopt the transcript as it stands, so only what is said from here on is mirrored. Read at
     // bind time on purpose: deferring it to the first poll would swallow a reply that beat the tick.
-    const existing = await opts.readConversation(runId).catch((): ConversationMessage[] => [])
-    bound.set(runId, { channelId, next: existing.length })
+    const existing = (await opts.readConversation(runId).catch(() => undefined)) ?? []
+    bound.set(runId, { channelId, next: existing.length, misses: 0 })
   }
 
   const poll = async (): Promise<void> => {
@@ -95,7 +116,18 @@ export function startDiscordReplyMirror(opts: ReplyMirrorOptions): DiscordReplyM
       const on = opts.enabled ? await opts.enabled().catch(() => false) : true
       for (const [runId, state] of [...bound]) {
         if (stopped) break
+        // A throw is a transient read failure and costs one poll; `undefined` is the run itself
+        // being gone, and enough of those in a row release the binding (#941).
         const messages = await opts.readConversation(runId).catch((): ConversationMessage[] => [])
+        if (messages === undefined) {
+          state.misses++
+          if (state.misses >= UNBIND_AFTER_MISSES) {
+            bound.delete(runId)
+            opts.onLog?.(`stopped mirroring ${runId}: its run no longer resolves`)
+          }
+          continue
+        }
+        state.misses = 0
         if (messages.length <= state.next) continue
         const fresh = messages.slice(state.next)
         // Advance first, and unconditionally: a turn we chose not to post (the bot is off, or it

--- a/packages/framework/src/discord/reply-mirror.ts
+++ b/packages/framework/src/discord/reply-mirror.ts
@@ -89,11 +89,12 @@ interface Mirrored extends RunBinding {
 export const REPLY_POLL_MS = 3_000
 
 /**
- * How many consecutive unresolvable polls release a binding (#941). More than one on purpose:
- * a run bound the instant it started may not have its live meta on disk for the first tick or
- * two, and dropping it then would silently unmirror a live chat.
+ * How many consecutive unresolvable polls release a binding (#941). Generous on purpose: a
+ * run bound the instant it started has no live meta on disk until its child process boots and
+ * writes one, and dropping the binding during that window would silently unmirror a live chat.
+ * The cost of waiting longer is only how late a dead binding's poll IO stops.
  */
-export const UNBIND_AFTER_MISSES = 5
+export const UNBIND_AFTER_MISSES = 10
 
 export function startDiscordReplyMirror(opts: ReplyMirrorOptions): DiscordReplyMirror {
   const bound = new Map<string, Mirrored>()


### PR DESCRIPTION
Closes #941

Verified at head of main: reply-mirror exports unbind/isBound but the only production caller is daemon-services (bind on onRunBound); nothing ever unbinds. Every chat-touched run stays in the map for the daemon lifetime, and each 3s poll then scans every project live metas per bound run. No misposts (archived runs resolve to []), but per-poll IO grows monotonically, exactly as filed.

Fix, the poll-drops-a-dead-binding option from the OP:

- daemon-services readConversation now answers undefined when the run has no live meta in any project (archived, or its project removed); a throwing read still resolves [].
- The mirror counts consecutive unresolvable polls per binding and releases it after UNBIND_AFTER_MISSES (5 polls, 15s at the 3s cadence), logging the release. The grace window exists for the freshly bound run whose live meta is not on disk yet; a transient miss resets on the next successful read.

Regression tests (mutation-checked: flattening undefined back to [] in the poll, the pre-fix behavior, fails exactly the release test):

- discord/reply-mirror.test.ts: a run that stops resolving is released after exactly UNBIND_AFTER_MISSES consecutive misses, with a log line.
- discord/reply-mirror.test.ts: a single transient miss keeps the binding, posting resumes, and the miss counter resets.