### PR TITLE
fix(framework): keep a session legitimately named "view"

### DIFF
--- a/.changeset/session-named-view.md
+++ b/.changeset/session-named-view.md
@@ -1,0 +1,10 @@
+---
+'@gemstack/framework': patch
+---
+
+An agent that names its session "view" is no longer silently ignored (#939)
+
+slugify's empty-slug fallback was the literal sentinel `view`, and parseSessionName rejected that
+sentinel, so a legitimate `View` in a set-session-name block was indistinguishable from no name
+and the rename was dropped. slugify now takes its fallback explicitly: parseSessionName tests for
+emptiness, and the `view` fallback stays local to the markdown-view ids where it belongs.

--- a/packages/framework/src/turn-gate.test.ts
+++ b/packages/framework/src/turn-gate.test.ts
@@ -176,6 +176,21 @@ test('parseSessionName keeps the later block when the agent renames mid-turn (#3
   assert.equal(parseSessionName('```set-session-name\nfirst\n```\nthen\n```set-session-name\nsecond\n```'), 'second')
 })
 
+test('a session legitimately named "view" is kept, not dropped as a sentinel (#939)', () => {
+  // `view` used to be slugify's fallback sentinel, and parseSessionName rejected it, so an
+  // agent that wrote View had its rename silently ignored.
+  assert.equal(parseSessionName('```set-session-name\nView\n```'), 'view')
+  assert.equal(parseSessionName('```set-session-name\nview\n```'), 'view')
+})
+
+test('a name with no usable characters is still no name (#939)', () => {
+  assert.equal(parseSessionName('```set-session-name\n!!! ***\n```'), undefined)
+  // The markdown-view fallback is unaffected: a heading with no usable characters still ids as `view`.
+  assert.deepEqual(parseMarkdownViews('```show-markdown\n# !!!\nbody\n```'), [
+    { id: 'view', title: '!!!', markdown: 'body' },
+  ])
+})
+
 test('parseReadyForMerge is true only when a ready-for-merge block is present (#326)', () => {
   assert.equal(parseReadyForMerge('Still building the feature.'), false)
   assert.equal(parseReadyForMerge('All done.\n```ready-for-merge\n```'), true)

--- a/packages/framework/src/turn-gate.ts
+++ b/packages/framework/src/turn-gate.ts
@@ -130,13 +130,13 @@ export interface ParsedMarkdownView {
   markdown: string
 }
 
-/** Slugify a title into a stable id, or `view` when it has no usable characters. */
-function slugify(title: string): string {
+/** Slugify a title into a stable id, or `fallback` when it has no usable characters. */
+function slugify(title: string, fallback: string): string {
   const slug = title
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
-  return slug || 'view'
+  return slug || fallback
 }
 
 /**
@@ -157,7 +157,7 @@ export function parseMarkdownViews(text: string): ParsedMarkdownView[] {
     const title = heading ? heading[1]!.trim() : 'Note'
     const markdown = (heading ? lines.slice(1).join('\n') : body).trim()
     if (!markdown) continue
-    const id = slugify(title)
+    const id = slugify(title, 'view')
     byId.set(id, { id, title, markdown })
   }
   return [...byId.values()]
@@ -174,8 +174,10 @@ export function parseSessionName(text: string): string | undefined {
   let name: string | undefined
   for (const m of text.matchAll(re)) {
     const line = (m[1] ?? '').split('\n').map(l => l.trim()).find(Boolean)
-    const slug = line ? slugify(line) : ''
-    if (slug && slug !== 'view') name = slug
+    // Emptiness is tested directly rather than via a fallback sentinel: a sentinel made a
+    // session legitimately named `view` indistinguishable from no name at all (#939).
+    const slug = line ? slugify(line, '') : ''
+    if (slug) name = slug
   }
   return name
 }


### PR DESCRIPTION
Closes #939

Verified at head of main: turn-gate.ts slugify falls back to the literal sentinel view on an empty slug, and parseSessionName rejects that sentinel (slug && slug !== view), so an agent that writes View in a set-session-name block has its rename silently dropped. The fallback and a real value are indistinguishable.

Fix, exactly the shape the OP suggests: slugify takes its fallback explicitly. parseSessionName passes an empty fallback and tests for emptiness; the view fallback stays local to parseMarkdownViews, whose ids keep their previous behavior byte for byte.

Regression tests (mutation-checked: reverting turn-gate.ts fails exactly the first):

- turn-gate.test.ts: a set-session-name block containing View (and view) parses to the name view instead of being dropped.
- turn-gate.test.ts: a name with no usable characters is still no name, and a markdown view whose heading has no usable characters still ids as view.