### PR TITLE
fix(framework): let BrowserPanel recover from a failed stream instead of latching

### DIFF
--- a/.changeset/browserpanel-retry.md
+++ b/.changeset/browserpanel-retry.md
@@ -1,0 +1,10 @@
+---
+'@gemstack/framework': patch
+---
+
+The Browser pane recovers from a failed stream instead of latching "not reachable" (#946)
+
+One img error (e.g. opening the tab before the run's stream endpoint was up) permanently swapped
+in the failure message until a remount. The failure is now keyed to the exact stream it happened
+on, so switching runs starts clean, and a Retry button re-requests the stream. The fix lives in
+the dashboard client, which ships bundled inside this package.

--- a/packages/framework-dashboard/components/BrowserPanel.test.tsx
+++ b/packages/framework-dashboard/components/BrowserPanel.test.tsx
@@ -41,4 +41,13 @@ describe('BrowserPanel failure recovery (#946)', () => {
     rerender(<BrowserPanel projectId="p" runId="r2" />)
     expect(frame().getAttribute('src')).toContain('/browser/p/r2/stream')
   })
+
+  test('returning to a previously failed run tries again instead of replaying the failure', () => {
+    const { rerender } = render(<BrowserPanel projectId="p" runId="r1" />)
+    fireEvent.error(frame())
+    rerender(<BrowserPanel projectId="p" runId="r2" />)
+    // Back to r1: its stream may be up by now, so the failure must not be remembered.
+    rerender(<BrowserPanel projectId="p" runId="r1" />)
+    expect(frame().getAttribute('src')).toContain('/browser/p/r1/stream')
+  })
 })

--- a/packages/framework-dashboard/components/BrowserPanel.test.tsx
+++ b/packages/framework-dashboard/components/BrowserPanel.test.tsx
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { BrowserPanel } from './BrowserPanel.js'
+
+afterEach(cleanup)
+
+const frame = () => screen.getByAltText("The run's browser")
+
+describe('BrowserPanel failure recovery (#946)', () => {
+  test('an img error shows the message with a Retry, and Retry restores the stream', () => {
+    render(<BrowserPanel projectId="p" runId="r1" />)
+    fireEvent.error(frame())
+    expect(screen.queryByAltText("The run's browser")).toBeNull()
+    expect(screen.getByText(/not reachable/)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /Retry/ }))
+    // The stream is back, on a distinct URL so the browser re-issues the request
+    // instead of replaying the failed one.
+    expect(frame().getAttribute('src')).toContain('r=1')
+    expect(screen.queryByRole('button', { name: /Retry/ })).toBeNull()
+  })
+
+  test('a retry that fails again latches only that attempt, and can retry again', () => {
+    render(<BrowserPanel projectId="p" runId="r1" />)
+    fireEvent.error(frame())
+    fireEvent.click(screen.getByRole('button', { name: /Retry/ }))
+    fireEvent.error(frame())
+    expect(screen.getByText(/not reachable/)).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: /Retry/ }))
+    expect(frame().getAttribute('src')).toContain('r=2')
+  })
+
+  test('a failure on one run does not latch for the next run (#946)', () => {
+    const { rerender } = render(<BrowserPanel projectId="p" runId="r1" />)
+    fireEvent.error(frame())
+    expect(screen.getByText(/not reachable/)).toBeTruthy()
+
+    // The parent switches runs without remounting: the failure belonged to the old stream,
+    // so the new run must start clean rather than inherit "not reachable" (the old latch
+    // only ever cleared by the accident of a remount).
+    rerender(<BrowserPanel projectId="p" runId="r2" />)
+    expect(frame().getAttribute('src')).toContain('/browser/p/r2/stream')
+  })
+})

--- a/packages/framework-dashboard/components/BrowserPanel.tsx
+++ b/packages/framework-dashboard/components/BrowserPanel.tsx
@@ -18,6 +18,15 @@ export function BrowserPanel({ projectId, runId }: { projectId: string; runId: s
   // early onError (the tab opened before the run's stream endpoint was up) must not be terminal.
   const [failedKey, setFailedKey] = useState<string | undefined>(undefined)
   const base = `/browser/${encodeURIComponent(projectId)}/${encodeURIComponent(runId)}`
+  // Coming back to a run whose earlier stream failed must try again, not replay the stale
+  // failure: the stream may have come up since. Adjust-during-render is the sanctioned way
+  // to reset state on a prop change without a remount.
+  const [lastBase, setLastBase] = useState(base)
+  if (lastBase !== base) {
+    setLastBase(base)
+    setAttempt(0)
+    setFailedKey(undefined)
+  }
   const streamKey = `${base}#${attempt}`
   const failed = failedKey === streamKey
 

--- a/packages/framework-dashboard/components/BrowserPanel.tsx
+++ b/packages/framework-dashboard/components/BrowserPanel.tsx
@@ -12,8 +12,14 @@ import { useRef, useState } from 'react'
  */
 export function BrowserPanel({ projectId, runId }: { projectId: string; runId: string }) {
   const img = useRef<HTMLImageElement>(null)
-  const [failed, setFailed] = useState(false)
+  const [attempt, setAttempt] = useState(0)
+  // The failure is keyed to the exact stream it happened on, so a different run or a Retry
+  // starts clean instead of inheriting a latched "not reachable" until remount (#946): one
+  // early onError (the tab opened before the run's stream endpoint was up) must not be terminal.
+  const [failedKey, setFailedKey] = useState<string | undefined>(undefined)
   const base = `/browser/${encodeURIComponent(projectId)}/${encodeURIComponent(runId)}`
+  const streamKey = `${base}#${attempt}`
+  const failed = failedKey === streamKey
 
   /**
    * Where the click landed on the real page. The frame is capped at 1280x720 by the screencast
@@ -39,10 +45,20 @@ export function BrowserPanel({ projectId, runId }: { projectId: string; runId: s
 
   if (failed) {
     return (
-      <p className="p-3 text-xs text-muted-foreground">
-        The preview is not reachable. It ends with the run, and a run only has one when it was started with Browser
-        on.
-      </p>
+      <div className="p-3 text-xs text-muted-foreground">
+        <p>
+          The preview is not reachable. It ends with the run, and a run only has one when it was started with Browser
+          on.
+        </p>
+        {/* The stream may simply not be up yet (the tab can open before the run's endpoint does). */}
+        <button
+          type="button"
+          className="mt-2 rounded border border-border px-2 py-1 hover:bg-muted"
+          onClick={() => setAttempt(a => a + 1)}
+        >
+          Retry
+        </button>
+      </div>
     )
   }
 
@@ -52,11 +68,11 @@ export function BrowserPanel({ projectId, runId }: { projectId: string; runId: s
         {/* tabIndex makes the frame focusable so keystrokes have somewhere to land. */}
         <img
           ref={img}
-          src={`${base}/stream`}
+          src={`${base}/stream?r=${attempt}`}
           alt="The run's browser"
           tabIndex={0}
           className="w-full cursor-crosshair rounded border border-border bg-muted"
-          onError={() => setFailed(true)}
+          onError={() => setFailedKey(streamKey)}
           onClick={event => send({ type: 'click', ...toPageCoords(event) })}
           onWheel={event => send({ type: 'scroll', ...toPageCoords(event), deltaY: event.deltaY })}
           onKeyDown={event => {


### PR DESCRIPTION
Closes #946

Verified at head of main: one img onError in BrowserPanel (e.g. opening the Browser tab before the run stream endpoint is up) permanently swaps in the "not reachable" message. Only a remount recovers, and only the right-rail tab switch happens to provide one; that is the parent accident, not this component contract.

Fix (framework-dashboard/components/BrowserPanel.tsx), both affordances from the OP:

- The failed flag is keyed to the exact stream identity it happened on (run base + attempt), so the parent switching runs without a remount starts clean.
- A Retry button bumps the attempt, which clears the latch and cache-busts the stream URL (?r=N; the daemon proxy routes on pathname only) so the browser re-issues the request instead of replaying the failed one.

Regression tests are state-level (jsdom has no layout engine, so no rendering claims), in BrowserPanel.test.tsx, mutation-checked (reverting the component fails all three):

- error swaps in the message + Retry; Retry restores the img on a distinct URL.
- a failed retry latches only that attempt and can be retried again.
- a failure on run A does not latch for run B on a prop change without remount.

No changeset: @gemstack/framework-dashboard is private.