### PR TITLE
docs(framework): state the one-live-run-per-project constraint of chat routing

### DIFF
--- a/packages/framework/src/discord/live-run.ts
+++ b/packages/framework/src/discord/live-run.ts
@@ -11,11 +11,12 @@ import type { Gate, RunSnapshot } from './routing.js'
  * the store's own reader, so this surface cannot keep a drifted copy of the torn-line policy.
  *
  * Known constraint (#945): chat models ONE live run per project. A project can run several
- * sessions at once since #736, and `snapshotLiveRun` picks whichever running meta lists first,
- * so a chat message routes to an arbitrary one of them. This is an accepted MVP limit of the
- * chat surface, not an oversight — lifting it means letting the bot list and target runs, which
- * is #945's real fix. Do not "fix" the pick order here; a deterministic-but-wrong run is no
- * better than an arbitrary one.
+ * sessions at once since #736, and `snapshotLiveRun` picks the first running meta the store
+ * lists — the newest by id, since `readLiveMetas` sorts newest-first — so a chat message always
+ * routes to the newest running run, which is not necessarily the one the user means. This is an
+ * accepted MVP limit of the chat surface, not an oversight — lifting it means letting the bot
+ * list and target runs, which is #945's real fix. Do not "fix" the pick order here; a different
+ * deterministic pick is no better when the user cannot choose.
  */
 
 /**

--- a/packages/framework/src/discord/live-run.ts
+++ b/packages/framework/src/discord/live-run.ts
@@ -9,6 +9,13 @@ import type { Gate, RunSnapshot } from './routing.js'
  * only the gate's id and title, because that is all the dashboard's rail needed. The options live
  * in the `choice` event, so answering "2" from chat means reading the run's event log — through
  * the store's own reader, so this surface cannot keep a drifted copy of the torn-line policy.
+ *
+ * Known constraint (#945): chat models ONE live run per project. A project can run several
+ * sessions at once since #736, and `snapshotLiveRun` picks whichever running meta lists first,
+ * so a chat message routes to an arbitrary one of them. This is an accepted MVP limit of the
+ * chat surface, not an oversight — lifting it means letting the bot list and target runs, which
+ * is #945's real fix. Do not "fix" the pick order here; a deterministic-but-wrong run is no
+ * better than an arbitrary one.
  */
 
 /**


### PR DESCRIPTION
For #945 (which stays open; this is deliberately NOT a Closes).

The minimum fix from the issue OP: snapshotLiveRuns module comment now states that chat routing models one live run per project, that the pick among several running metas is arbitrary, and that the real fix is letting the bot list/target runs. No behavior change, no changeset.