### PR TITLE
feat(framework): dashboard UX sweep, all flows rated and the low scorers fixed (#948)

### DIFF
--- a/.changeset/dashboard-ux-sweep.md
+++ b/.changeset/dashboard-ux-sweep.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Dashboard UX sweep (#948): every UI flow reviewed and the low scorers fixed. A lost live stream and a dead daemon now announce themselves (with automatic recovery), a session that crashed or was stopped no longer reads "finished", the replay opens at the outcome, choice gates and chat sends show sending/queued/error states instead of failing silently, presets get a visible menu with one management home, deleted @/# chips release their context focus, agent views render tables and links, the prompt preview includes the repo SYSTEM.md (#872), the browser panel recovers from a transient stream error (#946), the in-session gear stops offering spawn-time options as session state (#833), Discord toggles say when the daemon cannot deliver, and a broad accessibility pass (labels, roles, focus management) across menus, dialogs and icon buttons.

--- a/packages/framework-dashboard/components/ActivityChart.tsx
+++ b/packages/framework-dashboard/components/ActivityChart.tsx
@@ -1,10 +1,19 @@
 import { useState } from 'react'
 import type { ActivityDay } from '@gemstack/framework'
 
+/** The local calendar day as the chart's date keys are written (YYYY-MM-DD). */
+function localDateKey(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+}
+
 // Runs-per-day over the activity window (#471). A single-series magnitude-over-time chart,
 // so: bars, one hue (the primary token), no legend, a hover read-out. Dependency-free — the
 // bars are flex columns anchored to the baseline, each over a faint full-height track so a
 // quiet day still reads as an empty slot rather than a gap. Hovering a column names its day.
+// The columns are plain divs (#948): they act on nothing, so as buttons a keyboard user
+// tabbed through 14 focusable controls that did nothing on Enter. The read-out data rides
+// each column's title and the group's accessible description instead.
 export function ActivityChart({ data }: { data: ActivityDay[] }) {
   const [hover, setHover] = useState<number | null>(null)
   const max = Math.max(1, ...data.map(d => d.count))
@@ -12,19 +21,19 @@ export function ActivityChart({ data }: { data: ActivityDay[] }) {
   const active = hover !== null ? data[hover] : null
 
   const runs = (n: number) => `${n} session${n === 1 ? '' : 's'}`
+  // Say "today" only when the last column is actually today — a stale board must not claim it.
+  const lastDate = data[data.length - 1]?.date
+  const endLabel = lastDate === localDateKey(new Date()) ? 'today' : lastDate?.slice(5)
 
   return (
     <div>
-      <div className="flex h-32 items-end gap-[3px]">
+      <div role="img" aria-label={`Session activity: ${runs(total)} in ${data.length} days`} className="flex h-32 items-end gap-[3px]">
         {data.map((d, i) => (
-          <button
+          <div
             key={d.date}
-            type="button"
-            aria-label={`${d.date}: ${runs(d.count)}`}
+            title={`${d.date}: ${runs(d.count)}`}
             onMouseEnter={() => setHover(i)}
             onMouseLeave={() => setHover(null)}
-            onFocus={() => setHover(i)}
-            onBlur={() => setHover(null)}
             className="flex h-full flex-1 items-end rounded-sm bg-muted/40"
           >
             {d.count > 0 && (
@@ -33,7 +42,7 @@ export function ActivityChart({ data }: { data: ActivityDay[] }) {
                 style={{ height: `${(d.count / max) * 100}%` }}
               />
             )}
-          </button>
+          </div>
         ))}
       </div>
       <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
@@ -41,7 +50,7 @@ export function ActivityChart({ data }: { data: ActivityDay[] }) {
         <span className="font-medium text-foreground">
           {active ? `${active.date.slice(5)} · ${runs(active.count)}` : `${runs(total)} in ${data.length} days`}
         </span>
-        <span>today</span>
+        <span>{endLabel}</span>
       </div>
     </div>
   )

--- a/packages/framework-dashboard/components/AddProjectPanel.tsx
+++ b/packages/framework-dashboard/components/AddProjectPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from 'react'
+import { useEffect, useRef, useState, type FormEvent, type KeyboardEvent } from 'react'
 import { sendAddProject } from '../server/projects.telefunc.js'
 import { useAction } from '../lib/use-action.js'
 import { Button } from './ui/button.js'
@@ -9,6 +9,9 @@ import { Button } from './ui/button.js'
 //
 // Lifted out of the projects sidebar when #772 replaced that rail with a navbar dropdown:
 // the picker has no room for a two-step form, so it opens this as a small modal instead.
+// It behaves like the dialog it claims to be (#948): Esc closes, Tab stays inside, focus
+// returns to the opener on close, and a directory add reports how many repos it registered
+// instead of silently vanishing.
 export function AddProjectPanel({ onAdded, onClose }: { onAdded: () => void; onClose: () => void }) {
   const [path, setPath] = useState('')
   const [directory, setDirectory] = useState(false)
@@ -16,6 +19,25 @@ export function AddProjectPanel({ onAdded, onClose }: { onAdded: () => void; onC
   // Trust gate (#439/#314): adding a repo lets the agent read its files, so an untrusted
   // repo is a prompt-injection risk. Confirm trust before actually installing.
   const [confirming, setConfirming] = useState(false)
+  // What actually got registered, shown before closing — a folder-of-repos add used to
+  // register any number of projects with zero feedback.
+  const [added, setAdded] = useState<{ added: number; alreadyActivated: number } | null>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Give focus back to the control that opened the dialog (the picker's Add item is gone by
+  // then, so its trigger is the stable target).
+  useEffect(() => {
+    const opener = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    return () => opener?.focus()
+  }, [])
+
+  // Auto-close a beat after success; Done closes sooner.
+  useEffect(() => {
+    if (!added) return
+    const timer = setTimeout(onClose, 2500)
+    return () => clearTimeout(timer)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [added])
 
   // Step 1: the user submits the path -> show the trust confirmation, don't add yet.
   const review = (e: FormEvent) => {
@@ -30,27 +52,69 @@ export function AddProjectPanel({ onAdded, onClose }: { onAdded: () => void; onC
     if (busy) return
     const result = await run(() => sendAddProject(path.trim(), directory), 'Failed to add the project.')
     if (result?.ok) {
-      setPath('')
-      setDirectory(false)
       setConfirming(false)
+      setAdded({ added: result.added, alreadyActivated: result.alreadyActivated })
       onAdded()
-      onClose()
     } else {
       setConfirming(false)
     }
   }
 
+  // The dialog contract: Esc closes; Tab cycles inside rather than escaping to the page.
+  const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      onClose()
+      return
+    }
+    if (e.key !== 'Tab' || !panelRef.current) return
+    const focusable = [...panelRef.current.querySelectorAll<HTMLElement>('button, input, [tabindex]:not([tabindex="-1"])')].filter(
+      el => !el.hasAttribute('disabled'),
+    )
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    if (!first || !last) return
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault()
+      last.focus()
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault()
+      first.focus()
+    }
+  }
+
+  const summary =
+    added &&
+    [
+      `Added ${added.added} project${added.added === 1 ? '' : 's'}`,
+      added.alreadyActivated > 0 ? `${added.alreadyActivated} already added` : null,
+    ]
+      .filter(Boolean)
+      .join(' · ')
+
   return (
-    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 pt-24">
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 pt-24" onKeyDown={onKeyDown}>
       {/* Click-away closes, same as dismissing the dropdown it was opened from. */}
       <div className="absolute inset-0" onClick={onClose} />
       <div
+        ref={panelRef}
         role="dialog"
         aria-modal="true"
         aria-label="Add project"
         className="relative w-96 max-w-[90vw] rounded-lg border border-border bg-background p-4 shadow-lg"
       >
-        {confirming ? (
+        {added ? (
+          <>
+            <p role="status" className="mb-3 text-sm font-medium">
+              {summary}
+            </p>
+            <div className="flex justify-end">
+              <Button type="button" size="sm" autoFocus onClick={onClose}>
+                Done
+              </Button>
+            </div>
+          </>
+        ) : confirming ? (
           // The trust confirmation (#439): a plain-language prompt-injection warning before adding.
           <>
             <p className="mb-2 text-sm font-medium">Do you trust this repository?</p>

--- a/packages/framework-dashboard/components/BrowserPanel.tsx
+++ b/packages/framework-dashboard/components/BrowserPanel.tsx
@@ -1,19 +1,28 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { Button } from './ui/button.js'
 
 /**
- * The run's browser, live in the right rail (#813).
+ * The session's browser, live in the right rail (#813).
  *
- * The run serves its headless Chrome as MJPEG (#802) and takes clicks and keys back over POST;
- * the daemon proxies both so this stays same-origin. An `<img>` renders
+ * The session serves its headless Chrome as MJPEG (#802) and takes clicks and keys back over
+ * POST; the daemon proxies both so this stays same-origin. An `<img>` renders
  * `multipart/x-mixed-replace` natively, so there is no player here — the browser is the player.
  *
- * This is the half that makes the `await-browser` gate (#796) actionable: the run parks asking a
- * human to get past a login wall, and until now that human had no way to reach the page.
+ * This is the half that makes the `await-browser` gate (#796) actionable: the session parks
+ * asking a human to get past a login wall, and until now that human had no way to reach the page.
  */
 export function BrowserPanel({ projectId, runId }: { projectId: string; runId: string }) {
   const img = useRef<HTMLImageElement>(null)
   const [failed, setFailed] = useState(false)
+  // Bumped by Retry to remount the stream URL: one transient img error (opening the tab
+  // before the stream endpoint is up) used to latch "not reachable" until a remount (#946).
+  const [attempt, setAttempt] = useState(0)
   const base = `/browser/${encodeURIComponent(projectId)}/${encodeURIComponent(runId)}`
+
+  // A new session gets a fresh verdict; the failure belongs to the stream it came from.
+  useEffect(() => {
+    setFailed(false)
+  }, [projectId, runId])
 
   /**
    * Where the click landed on the real page. The frame is capped at 1280x720 by the screencast
@@ -39,23 +48,37 @@ export function BrowserPanel({ projectId, runId }: { projectId: string; runId: s
 
   if (failed) {
     return (
-      <p className="p-3 text-xs text-muted-foreground">
-        The preview is not reachable. It ends with the run, and a run only has one when it was started with Browser
-        on.
-      </p>
+      <div className="p-3 text-xs text-muted-foreground">
+        <p className="mb-2">
+          The preview is not reachable. It ends with the session, and a session only has one when it was started with
+          Browser on. If it just started, the stream may not be up yet.
+        </p>
+        <Button
+          variant="outline"
+          size="xs"
+          onClick={() => {
+            setFailed(false)
+            setAttempt(a => a + 1)
+          }}
+        >
+          Retry
+        </Button>
+      </div>
     )
   }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="min-h-0 flex-1 overflow-auto p-2">
-        {/* tabIndex makes the frame focusable so keystrokes have somewhere to land. */}
+        {/* tabIndex makes the frame focusable so keystrokes have somewhere to land; the ring
+            shows where they will land. */}
         <img
+          key={attempt}
           ref={img}
-          src={`${base}/stream`}
-          alt="The run's browser"
+          src={`${base}/stream${attempt > 0 ? `?retry=${attempt}` : ''}`}
+          alt="The session's browser"
           tabIndex={0}
-          className="w-full cursor-crosshair rounded border border-border bg-muted"
+          className="w-full cursor-crosshair rounded border border-border bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
           onError={() => setFailed(true)}
           onClick={event => send({ type: 'click', ...toPageCoords(event) })}
           onWheel={event => send({ type: 'scroll', ...toPageCoords(event), deltaY: event.deltaY })}

--- a/packages/framework-dashboard/components/ChoicePanel.tsx
+++ b/packages/framework-dashboard/components/ChoicePanel.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { ChoiceRequest } from '@gemstack/framework'
 import { sendChoice } from '../server/control.telefunc.js'
+import { useAction } from '../lib/use-action.js'
 import { usePreferences, updatePreferences, autopilotEnabled } from '../lib/preferences.js'
 import { Button } from './ui/button.js'
 import { cn } from '../lib/utils.js'
@@ -25,22 +26,30 @@ export function ChoicePanel({
   choice: ChoiceRequest
   active?: boolean
 }) {
-  const [busy, setBusy] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const { busy, error, run } = useAction()
+  // Posted and accepted by the daemon; the panel stays parked (buttons off, status shown)
+  // until the `choice-resolved` event unmounts it (#948) — before, the buttons just greyed
+  // out with no word on why.
+  const [sent, setSent] = useState(false)
   const [checked, setChecked] = useState<Set<string>>(
     () => new Set(choice.multi ? choice.options.filter(o => o.default).map(o => o.id) : []),
   )
+  // The countdown's auto-accept fires from a closure captured when the countdown started;
+  // the ref keeps it reading the boxes as they are at fire time (#948).
+  const checkedRef = useRef(checked)
+  checkedRef.current = checked
   const autopilot = autopilotEnabled(usePreferences())
   const [secondsLeft, setSecondsLeft] = useState<number | null>(null)
   const [cancelled, setCancelled] = useState(false)
 
+  const parked = busy || sent
+
   const post = (pick: string | string[], by: 'user' | 'autopilot' = 'user') => {
-    setBusy(true)
-    setError(null)
-    void sendChoice(projectId, choice.id, pick, by, runId ?? undefined).catch(() => {
-      setBusy(false)
-      setError('Could not send your choice — try again.')
-    })
+    void run(() => sendChoice(projectId, choice.id, pick, by, runId ?? undefined), 'Could not send your choice — try again.').then(
+      result => {
+        if (result !== undefined) setSent(true)
+      },
+    )
   }
 
   const toggle = (id: string) =>
@@ -55,7 +64,7 @@ export function ChoicePanel({
 
   // What Accept picks: the checked subset for a multi-select, else the recommended option
   // (an Approve for a confirm gate). Shared by the button, the countdown, and Ctrl+Enter.
-  const autoPick = (): string | string[] => (choice.multi ? [...checked] : (approveId ?? ''))
+  const autoPick = (): string | string[] => (choice.multi ? [...checkedRef.current] : (approveId ?? ''))
   const accept = (by: 'user' | 'autopilot' = 'user') => post(autoPick(), by)
 
   // Any mouse movement cancels the auto-accept — the human is here, so let them pick.
@@ -70,7 +79,7 @@ export function ChoicePanel({
   useEffect(() => {
     if (!active) return
     const onKey = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && !busy) {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && !parked) {
         e.preventDefault()
         accept()
       }
@@ -78,12 +87,12 @@ export function ChoicePanel({
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [active, busy, checked])
+  }, [active, parked])
 
   // The countdown: tick down once a second while autopilot is on and uncancelled, then
   // auto-accept. Restarts if autopilot is toggled back on before a pick is made.
   useEffect(() => {
-    if (!autopilot || cancelled || busy) {
+    if (!autopilot || cancelled || parked) {
       setSecondsLeft(null)
       return
     }
@@ -101,12 +110,12 @@ export function ChoicePanel({
     }, 1000)
     return () => clearInterval(timer)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autopilot, cancelled, busy])
+  }, [autopilot, cancelled, parked])
 
   const toggleAutopilot = (on: boolean) => updatePreferences({ autopilot: on }) // shared with the Start form (#410)
 
   return (
-    <section className="border-b border-border bg-accent/40 p-4">
+    <section role="region" aria-label={choice.title} className="border-b border-border bg-accent/40 p-4">
       <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Your call</div>
       <h2 className="mb-3 text-sm font-medium">{choice.title}</h2>
 
@@ -114,7 +123,7 @@ export function ChoicePanel({
         <div className="flex gap-2">
           <Button
             className="bg-emerald-600 text-white hover:bg-emerald-600 hover:opacity-90"
-            disabled={busy || !approveId}
+            disabled={parked || !approveId}
             onClick={() => approveId && post(approveId)}
           >
             Approve
@@ -122,7 +131,7 @@ export function ChoicePanel({
           <Button
             variant="outline"
             className="border-red-500/50 text-red-500 hover:bg-red-500/10 hover:text-red-500"
-            disabled={busy || !declineId}
+            disabled={parked || !declineId}
             onClick={() => declineId && post(declineId)}
           >
             Decline
@@ -134,7 +143,7 @@ export function ChoicePanel({
             {choice.options.map(o => (
               <li key={o.id}>
                 <label className="flex cursor-pointer items-start gap-2 text-sm">
-                  <input type="checkbox" className="mt-1" checked={checked.has(o.id)} onChange={() => toggle(o.id)} disabled={busy} />
+                  <input type="checkbox" className="mt-1" checked={checked.has(o.id)} onChange={() => toggle(o.id)} disabled={parked} />
                   <span>
                     {o.label}
                     {o.detail && <span className="block text-xs text-muted-foreground">{o.detail}</span>}
@@ -143,8 +152,9 @@ export function ChoicePanel({
               </li>
             ))}
           </ul>
-          <Button disabled={busy} onClick={() => post([...checked])}>
-            Accept
+          {/* The label says what Accept will post, so an empty pick is a choice, not a surprise. */}
+          <Button disabled={parked} onClick={() => post([...checked])}>
+            {checked.size === 0 ? 'Accept none' : `Accept ${checked.size} selected`}
           </Button>
         </>
       ) : (
@@ -154,10 +164,13 @@ export function ChoicePanel({
               key={o.id}
               variant={o.id === choice.recommended ? 'default' : 'outline'}
               className={cn('h-auto flex-col items-start gap-0.5 py-2 text-left')}
-              disabled={busy}
+              disabled={parked}
               onClick={() => post(o.id)}
             >
-              <span className="font-medium">{o.label}</span>
+              <span className="font-medium">
+                {o.label}
+                {o.id === choice.recommended && <span className="ml-2 text-xs font-normal opacity-80">Recommended</span>}
+              </span>
               {o.detail && <span className="text-xs font-normal opacity-80">{o.detail}</span>}
             </Button>
           ))}
@@ -167,17 +180,23 @@ export function ChoicePanel({
       {error && <p className="mt-2 text-xs text-red-500">{error}</p>}
 
       <div className="mt-3 flex items-center gap-3 text-xs text-muted-foreground">
-        <label className="flex cursor-pointer items-center gap-1.5">
-          <input type="checkbox" checked={autopilot} onChange={e => toggleAutopilot(e.target.checked)} disabled={busy} /> Autopilot
-        </label>
-        {autopilot && !busy && (
-          <span>
-            {cancelled
-              ? 'Auto accept canceled — pick manually'
-              : secondsLeft !== null && `● Auto accept in ${secondsLeft}s — move the mouse to cancel`}
-          </span>
+        {parked ? (
+          <span role="status">{busy ? 'Sending your choice…' : 'Choice sent — waiting for the session to pick it up…'}</span>
+        ) : (
+          <>
+            <label className="flex cursor-pointer items-center gap-1.5">
+              <input type="checkbox" checked={autopilot} onChange={e => toggleAutopilot(e.target.checked)} /> Autopilot
+            </label>
+            {autopilot && (
+              <span className={cn(secondsLeft !== null && !cancelled && 'font-medium text-foreground')}>
+                {cancelled
+                  ? 'Auto accept canceled — pick manually'
+                  : secondsLeft !== null && `● Auto accept in ${secondsLeft}s — move the mouse to cancel`}
+              </span>
+            )}
+            {active && <span className="ml-auto">Ctrl+Enter to accept</span>}
+          </>
         )}
-        {active && !busy && <span className="ml-auto">Ctrl+Enter to accept</span>}
       </div>
     </section>
   )

--- a/packages/framework-dashboard/components/Composer.test.tsx
+++ b/packages/framework-dashboard/components/Composer.test.tsx
@@ -64,8 +64,9 @@ afterEach(cleanup)
 describe('Composer (#721)', () => {
   test('renders the full control row: agent/model, options gear, and the submit button', () => {
     renderComposer({ submitLabel: 'Start session' })
-    // The standalone Presets dropdown is gone (#722): presets load from the editor's `/` menu.
-    expect(screen.queryByText('Presets')).toBeNull()
+    // Presets have a visible surface again (#948): the `/` menu stays the fast path, the
+    // button is the discoverable one.
+    expect(screen.getByRole('button', { name: /Presets/ })).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Session options' })).toBeTruthy()
     expect(screen.getByTitle(/Agent: Claude Code/)).toBeTruthy() // the agent/model trigger
     expect(screen.getByRole('button', { name: /Start session/ })).toBeTruthy()

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -154,11 +154,18 @@ export const Composer = forwardRef<ComposerHandle, {
     focus: () => editorRef.current?.focus(),
   }))
 
+  // A synchronous latch alongside the async `busy` prop (#948): two fast ⌘↵ presses both read
+  // `busy === false` (React state lags), fired two starts, and the second surfaced a spurious
+  // "already active" error. The ref flips before any await.
+  const submittingRef = useRef(false)
   const submit = (e?: FormEvent) => {
     e?.preventDefault()
     const text = prompt.trim()
-    if (!text || busy) return
-    void onSubmit(text, kind)
+    if (!text || busy || submittingRef.current) return
+    submittingRef.current = true
+    void Promise.resolve(onSubmit(text, kind)).finally(() => {
+      submittingRef.current = false
+    })
   }
 
   // A preset (from the `/` menu or the Presets button) loads the rendered template into the

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -14,6 +14,7 @@ import { useLoaded } from '../lib/use-async.js'
 import { onProjects } from '../server/projects.telefunc.js'
 import { PromptEditor, type PromptEditorHandle } from './PromptEditor.js'
 import { PresetCreatePanel } from './PresetCreatePanel.js'
+import { PresetsMenu } from './PresetsMenu.js'
 import { AgentModelMenu, type AgentOption } from './AgentModelMenu.js'
 import { OptionsMenu, type OptionRow } from './OptionsMenu.js'
 import { ResolvedOptions } from './ResolvedOptions.js'
@@ -73,8 +74,9 @@ export const Composer = forwardRef<ComposerHandle, {
   onSubmit: (text: string, kind: 'build' | 'prompt') => void | Promise<void>
   /** Mirror the live prompt + kind out, so the launcher can drive its disclosure/context UI. */
   onPromptChange?: ((prompt: string, kind: 'build' | 'prompt') => void) | undefined
-  /** A preset was loaded (so the launcher can flag it in its note). */
-  onPreset?: ((label: string) => void) | undefined
+  /** A preset was loaded (so the launcher can flag it in its note); `replaced` says a typed
+   *  draft was overwritten (undo brings it back). */
+  onPreset?: ((label: string, replaced: boolean) => void) | undefined
   busy: boolean
   submitLabel: string
   submitBusyLabel: string
@@ -157,11 +159,18 @@ export const Composer = forwardRef<ComposerHandle, {
     void onSubmit(text, kind)
   }
 
-  // A preset button (or the `/` menu) loads the rendered template into the editor, which chip-ifies
-  // its tags; the run then goes verbatim as a `prompt` kind.
-  const loadPreset = (label: string) => {
+  // A preset (from the `/` menu or the Presets button) loads the rendered template into the
+  // editor, which chip-ifies its tags; the run then goes verbatim as a `prompt` kind.
+  const loadPreset = (label: string, replaced: boolean) => {
     setKind('prompt')
-    onPreset?.(label)
+    onPreset?.(label, replaced)
+  }
+
+  // The Presets button's load path (#948): through the imperative handle rather than the
+  // suggestion plugin, then the same bookkeeping as the `/` menu.
+  const loadPresetFromMenu = (text: string, label: string) => {
+    const replaced = editorRef.current?.loadTemplate(text) ?? false
+    loadPreset(label, replaced)
   }
 
   const onPromptEdit = (value: string) => {
@@ -232,6 +241,19 @@ export const Composer = forwardRef<ComposerHandle, {
           busy={busy}
         />
       )}
+      {/* Presets get a visible surface (#948): load, create and delete in one menu, instead of
+          loading only behind typing `/` and deleting off in the options gear. Not in the compact
+          row, which has no room and no create panel. */}
+      {!compact && (
+        <PresetsMenu
+          presets={presets}
+          customPresets={customPresets}
+          busy={busy}
+          onLoad={loadPresetFromMenu}
+          onNew={() => setAddingPreset(true)}
+          onDelete={id => updatePreferences({ customPresets: customPresets.filter(p => p.id !== id) })}
+        />
+      )}
       <OptionsMenu
         options={mainOptions}
         ecoOptions={ecoOptions}
@@ -240,10 +262,6 @@ export const Composer = forwardRef<ComposerHandle, {
         editor={editor}
         editors={detectedEditors}
         onEditorChange={e => updatePreferences({ editor: e ?? '' })}
-        // Preset loading + "New preset…" moved to the `/` menu (#722); the gear keeps the manage
-        // side, deleting a saved preset.
-        customPresets={customPresets}
-        onDeleteCustomPreset={id => updatePreferences({ customPresets: customPresets.filter(p => p.id !== id) })}
       />
     </>
   )
@@ -308,10 +326,14 @@ export const Composer = forwardRef<ComposerHandle, {
         <PresetCreatePanel
           currentPrompt={prompt}
           busy={busy}
-          onCancel={() => setAddingPreset(false)}
+          onCancel={() => {
+            setAddingPreset(false)
+            editorRef.current?.focus()
+          }}
           onSave={preset => {
             updatePreferences({ customPresets: [...customPresets, preset] })
             setAddingPreset(false)
+            editorRef.current?.focus()
           }}
         />
       )}

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -70,6 +70,8 @@ export const Composer = forwardRef<ComposerHandle, {
   files: string[]
   /** Add a path to the run Context (from an `@`/`#` mention). */
   addContext: (path: string) => void
+  /** Drop a path from the run Context when its `@`/`#` chip leaves the editor (#948). */
+  removeContext?: ((path: string) => void) | undefined
   /** Run the composed text. `kind` is `prompt` once a preset was loaded, else `build`. */
   onSubmit: (text: string, kind: 'build' | 'prompt') => void | Promise<void>
   /** Mirror the live prompt + kind out, so the launcher can drive its disclosure/context UI. */
@@ -95,7 +97,7 @@ export const Composer = forwardRef<ComposerHandle, {
    *  session exists yet. */
   sessionName?: string | undefined
 }>(function Composer(
-  { files, addContext, onSubmit, onPromptChange, onPreset, busy, submitLabel, submitBusyLabel, placeholder, showShortcutHint = false, compact = false, showAgentModel = true, sessionName },
+  { files, addContext, removeContext, onSubmit, onPromptChange, onPreset, busy, submitLabel, submitBusyLabel, placeholder, showShortcutHint = false, compact = false, showAgentModel = true, sessionName },
   ref,
 ) {
   const [prompt, setPrompt] = useState('')
@@ -214,6 +216,7 @@ export const Composer = forwardRef<ComposerHandle, {
       onPreset={loadPreset}
       onMentionProject={addContext}
       onMentionFile={addContext}
+      {...(removeContext ? { onMentionRemoved: removeContext } : {})}
       projects={projects}
       files={files}
       presets={presets}

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -92,12 +92,16 @@ export const Composer = forwardRef<ComposerHandle, {
   /** Off inside a session (#831): a session is bound to the agent it started with, so the select
    *  would only ever rewrite the *next* session's default. Chosen at the launcher instead. */
   showAgentModel?: boolean | undefined
+  /** Inside a running/finished session (#833): every run option is baked in at spawn, so the
+   *  gear drops them (keeping the genuinely global editor pick) and the "In play" strip goes —
+   *  both would otherwise read as controls over *this* session that only rewrite the next one. */
+  inSession?: boolean | undefined
   /** The session this composer sits in, if any (#874): a preset launched from a run page targets
    *  that session by default, instead of the whole codebase. Absent at the launcher, where no
    *  session exists yet. */
   sessionName?: string | undefined
 }>(function Composer(
-  { files, addContext, removeContext, onSubmit, onPromptChange, onPreset, busy, submitLabel, submitBusyLabel, placeholder, showShortcutHint = false, compact = false, showAgentModel = true, sessionName },
+  { files, addContext, removeContext, onSubmit, onPromptChange, onPreset, busy, submitLabel, submitBusyLabel, placeholder, showShortcutHint = false, compact = false, showAgentModel = true, inSession = false, sessionName },
   ref,
 ) {
   const [prompt, setPrompt] = useState('')
@@ -136,6 +140,8 @@ export const Composer = forwardRef<ComposerHandle, {
   const browser = preferences.browser ?? false
   const model = preferences.model ?? '' // #628: empty = the driver's default model
   const agent = preferences.agent ?? 'claude' // #650: which coding agent drives the run
+  // The stored agent as a display name; an unknown stored value falls back to Claude Code.
+  const agentLabel = AGENT_LABELS[AGENTS.includes(agent as AgentName) ? (agent as AgentName) : 'claude']
   const customPresets = preferences.customPresets ?? [] // #626: the user's own saved prompts
   const editor = preferences.editor // #727: preferred editor; undefined = $FRAMEWORK_EDITOR / code
   const detectedEditors = useDetectedEditors() // #727: editors installed on the daemon's machine
@@ -193,7 +199,8 @@ export const Composer = forwardRef<ComposerHandle, {
   // The Global options as one table (#314). Autopilot's default-on lives in `autopilotEnabled`; Eco
   // is disabled + dimmed under Vanilla; the Eco sub-drops show only while Eco is on.
   const mainOptions: OptionRow[] = [
-    { key: 'transparent', label: 'Transparent', description: 'Raw Claude Code — turns the whole framework off.', title: 'Fully transparent (#625): run the agent exactly like plain Claude Code, with no framework system prompt, controls, dashboard, guard, or TODO loop. Overrides the options below.', checked: transparent },
+    // Named for the agent actually selected (#948): under Codex, "Raw Claude Code" was a lie.
+    { key: 'transparent', label: 'Transparent', description: `Raw ${agentLabel} — turns the whole framework off.`, title: `Fully transparent (#625): run the agent exactly like plain ${agentLabel}, with no framework system prompt, controls, dashboard, guard, or TODO loop. Overrides the options below.`, checked: transparent },
     // Says only what it does (#801): the maintenance stance it used to relax left the system prompt
     // with that section (#556), so the countdown is the whole feature.
     { key: 'autopilot', label: 'Autopilot', description: 'Auto-accepts the recommended choice after a countdown.', title: 'Auto-accept the recommended choice after a countdown, instead of waiting for you to pick', checked: autopilot && !transparent, disabled: transparent, disabledReason: 'off while Transparent is on' },
@@ -265,13 +272,16 @@ export const Composer = forwardRef<ComposerHandle, {
         />
       )}
       <OptionsMenu
-        options={mainOptions}
-        ecoOptions={ecoOptions}
-        showEco={eco && !ecoDisabled}
+        // In-session (#833): the run options were baked into the session at spawn, so offering
+        // them here only rewrote the next session's defaults while reading as session state.
+        options={inSession ? [] : mainOptions}
+        ecoOptions={inSession ? [] : ecoOptions}
+        showEco={!inSession && eco && !ecoDisabled}
         busy={busy}
         editor={editor}
         editors={detectedEditors}
         onEditorChange={e => updatePreferences({ editor: e ?? '' })}
+        {...(inSession ? { label: 'Preferences' } : {})}
       />
     </>
   )
@@ -329,8 +339,9 @@ export const Composer = forwardRef<ComposerHandle, {
       </div>
 
       {/* What the session resolves to, without opening the gear (#842). Off in the compact row
-          above, which is one line on purpose. */}
-      <ResolvedOptions options={mainOptions} sources={sources} fileConfig={fileConfig} />
+          above, which is one line on purpose, and in-session (#833), where it described the
+          *global* options rather than the ones this session actually runs with. */}
+      {!inSession && <ResolvedOptions options={mainOptions} sources={sources} fileConfig={fileConfig} />}
 
       {addingPreset && (
         <PresetCreatePanel

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -9,7 +9,7 @@ import { UsagePanel } from './UsagePanel.js'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card.js'
 import { usePolled } from '../lib/use-async.js'
 import { cn } from '../lib/utils.js'
-import { formatDate } from '../lib/format-date.js'
+import { formatDateTime, formatRelative } from '../lib/format-date.js'
 import { ScrollArea } from './ui/scroll-area.js'
 
 // The Overview dashboard page (#471). What used to be a cramped, collapsible section in the
@@ -155,9 +155,12 @@ function NeedsYou({ items, onSelectProject }: { items: Intervention[]; onSelectP
                     <GitBranch className="h-4 w-4 shrink-0 text-sky-500" />
                     <span className="shrink-0 text-xs font-medium text-sky-500">Unpushed</span>
                     <span className="truncate font-medium">{item.title}</span>
-                    <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
-                      {item.commits === 1 ? '1 commit' : `${item.commits ?? 0} commits`}
-                    </span>
+                    {/* An unknown count says nothing rather than the contradictory "0 commits". */}
+                    {item.commits !== undefined && item.commits > 0 && (
+                      <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                        {item.commits === 1 ? '1 commit' : `${item.commits} commits`}
+                      </span>
+                    )}
                     <span className="ml-auto shrink-0 text-xs text-muted-foreground">{item.projectName}</span>
                   </button>
                 ) : (
@@ -269,7 +272,7 @@ function Backlog({ queue, onSelectProject }: { queue: ProjectQueue[]; onSelectPr
                   <span className="truncate" title={item.text}>{item.text}</span>
                 </li>
               ))}
-            {q.open > 3 && <li className="pl-5 text-xs text-muted-foreground/60">+{q.open - 3} more</li>}
+            {q.open > 3 && <li className="pl-5 text-xs text-muted-foreground">+{q.open - 3} more</li>}
           </ul>
         </li>
       ))}
@@ -324,8 +327,8 @@ function ProjectsTable({ projects, onSelectProject }: { projects: ProjectStat[];
               </td>
               <td className="py-2 pr-4 text-right tabular-nums">{p.runs}</td>
               <td className="py-2 pr-4 text-right tabular-nums">{p.openTodos || '—'}</td>
-              <td className="py-2 text-right text-xs text-muted-foreground">
-                {formatDate(p.lastActivityAt)}
+              <td className="py-2 text-right text-xs text-muted-foreground" title={formatDateTime(p.lastActivityAt, '')}>
+                {formatRelative(p.lastActivityAt)}
               </td>
             </tr>
           ))}

--- a/packages/framework-dashboard/components/DocsPanel.tsx
+++ b/packages/framework-dashboard/components/DocsPanel.tsx
@@ -10,10 +10,13 @@ import { ScrollArea } from './ui/scroll-area.js'
 // The surfaced documents (#319/#328): the PLAN/TODO the agent writes, rendered beside
 // the run. Telefunc RPC (server/reads.telefunc.ts), polled so edits mid-run show up.
 export function DocsPanel({ projectId }: { projectId: string | null }) {
-  const { value: docs } = usePolled<WorkspaceDoc[]>(projectId ? () => onDocs(projectId) : null, [], 4000, [projectId])
+  const { value: docs, loaded } = usePolled<WorkspaceDoc[]>(projectId ? () => onDocs(projectId) : null, [], 4000, [projectId])
   const [active, setActive] = useState(0)
 
   if (!projectId) return null
+  // Loading and empty are different facts (#948): without the guard, a project with docs
+  // flashed "No PLAN/TODO docs yet." on every open while the first read was still out.
+  if (!loaded) return <p className="p-4 text-sm text-muted-foreground">Loading…</p>
   if (docs.length === 0) return <p className="p-4 text-sm text-muted-foreground">No PLAN/TODO docs yet.</p>
 
   const current = docs[Math.min(active, docs.length - 1)]!

--- a/packages/framework-dashboard/components/EventList.tsx
+++ b/packages/framework-dashboard/components/EventList.tsx
@@ -1,5 +1,6 @@
 import type { FrameworkEvent } from '@gemstack/framework'
 import { formatFrameworkEvent } from '@gemstack/framework/client'
+import { receivedAt } from '../lib/event-times.js'
 import { Badge } from './ui/badge.js'
 import {
   MessageScroller,
@@ -11,9 +12,12 @@ import {
 } from './ui/message-scroller.js'
 
 // Presentational event log, shared by the live stream and past-run replay. Each
-// FrameworkEvent is a kind badge + its human-readable line (the same formatter the
-// terminal uses, so a `driver` turn reads "· Read" / "‹ turn complete" rather than raw
-// JSON). Scrolling rides shadcn's Base UI message-scroller (#712): live follows the edge
+// FrameworkEvent renders as its human-readable line (the same formatter the terminal
+// uses, so a `driver` turn reads "· Read" / "‹ turn complete" rather than raw JSON),
+// with the kind badge shown once per run of same-kind lines — a 200-line driver turn
+// used to be 200 identical "DRIVER" badges (#948). Live rows carry their arrival time
+// at each kind boundary; replayed events were never live, so they show none.
+// Scrolling rides shadcn's Base UI message-scroller (#712): live follows the edge
 // (`autoScroll`) but yields the moment the reader scrolls up, replay renders static from the
 // top, and the "Jump to latest" chip is the scroller's own inert-when-not-scrollable button —
 // replacing the hand-rolled U19 stick/jump logic.
@@ -32,6 +36,11 @@ function isTurnBoundary(e: FrameworkEvent): boolean {
   return e.kind === 'driver' && e.event.type === 'start'
 }
 
+/** HH:MM:SS in the reader's locale, for the arrival-time column. */
+function formatTime(ms: number): string {
+  return new Date(ms).toLocaleTimeString()
+}
+
 export function EventList({ events, stick = true }: { events: FrameworkEvent[]; stick?: boolean }) {
   return (
     <MessageScrollerProvider autoScroll={stick} defaultScrollPosition={stick ? 'end' : 'start'}>
@@ -40,9 +49,14 @@ export function EventList({ events, stick = true }: { events: FrameworkEvent[]; 
           <MessageScrollerContent className="gap-1 p-4 font-mono text-xs">
             {events.map((e, i) => {
               const disclosable = disclosableText(e)
+              const chunkHead = i === 0 || events[i - 1]?.kind !== e.kind
+              const at = receivedAt(e)
               return (
                 <MessageScrollerItem key={i} messageId={String(i)} scrollAnchor={isTurnBoundary(e)} className="flex items-start gap-2">
-                  <Badge className="mt-0.5 shrink-0 text-[10px] uppercase text-muted-foreground">{e.kind}</Badge>
+                  {/* Fixed-width badge column so the text lines up whether or not this row repeats the kind. */}
+                  <span className="w-20 shrink-0">
+                    {chunkHead && <Badge className="mt-0.5 text-[10px] uppercase text-muted-foreground">{e.kind}</Badge>}
+                  </span>
                   {disclosable ? (
                     <details className="min-w-0 flex-1">
                       <summary className="cursor-pointer text-foreground marker:text-muted-foreground">
@@ -51,7 +65,12 @@ export function EventList({ events, stick = true }: { events: FrameworkEvent[]; 
                       <pre className="mt-1 max-h-96 overflow-auto whitespace-pre-wrap break-words rounded bg-muted p-2 text-foreground">{disclosable.text}</pre>
                     </details>
                   ) : (
-                    <span className="whitespace-pre-wrap break-words text-foreground">{(formatFrameworkEvent(e) ?? '').trim()}</span>
+                    <span className="min-w-0 flex-1 whitespace-pre-wrap break-words text-foreground">{(formatFrameworkEvent(e) ?? '').trim()}</span>
+                  )}
+                  {chunkHead && at !== undefined && (
+                    <span className="ml-auto shrink-0 pt-0.5 text-[10px] tabular-nums text-muted-foreground" title={new Date(at).toLocaleString()}>
+                      {formatTime(at)}
+                    </span>
                   )}
                 </MessageScrollerItem>
               )

--- a/packages/framework-dashboard/components/EventList.tsx
+++ b/packages/framework-dashboard/components/EventList.tsx
@@ -41,9 +41,18 @@ function formatTime(ms: number): string {
   return new Date(ms).toLocaleTimeString()
 }
 
-export function EventList({ events, stick = true }: { events: FrameworkEvent[]; stick?: boolean }) {
+export function EventList({
+  events,
+  stick = true,
+  openAt,
+}: {
+  events: FrameworkEvent[]
+  stick?: boolean
+  /** Where a non-following log opens; a replay opens at the outcome (#948), not page one. */
+  openAt?: 'start' | 'end'
+}) {
   return (
-    <MessageScrollerProvider autoScroll={stick} defaultScrollPosition={stick ? 'end' : 'start'}>
+    <MessageScrollerProvider autoScroll={stick} defaultScrollPosition={openAt ?? (stick ? 'end' : 'start')}>
       <MessageScroller className="flex-1">
         <MessageScrollerViewport aria-label="Session output">
           <MessageScrollerContent className="gap-1 p-4 font-mono text-xs">

--- a/packages/framework-dashboard/components/FileTree.tsx
+++ b/packages/framework-dashboard/components/FileTree.tsx
@@ -157,9 +157,22 @@ export function FileTree({
         value={query}
         onChange={e => setQuery(e.target.value)}
         placeholder="Filter files…"
+        aria-label="Filter files"
         className="mb-2 w-full rounded border border-border bg-background px-2 py-1 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-[var(--color-primary)]"
       />
-      <Files className="min-h-0 flex-1 text-sm">{renderNode(tree)}</Files>
+      {/* A query with zero hits used to render an empty pane, which reads as broken (#948). */}
+      {query.trim() && visible.length === 0 ? (
+        <p className="px-1 py-2 text-xs text-muted-foreground">No files match &ldquo;{query.trim()}&rdquo;.</p>
+      ) : (
+        <>
+          {query.trim() && (
+            <p className="px-1 pb-1 text-[10px] text-muted-foreground">
+              {visible.length} of {files.length} files
+            </p>
+          )}
+          <Files className="min-h-0 flex-1 text-sm">{renderNode(tree)}</Files>
+        </>
+      )}
     </div>
   )
 }

--- a/packages/framework-dashboard/components/Logo.test.tsx
+++ b/packages/framework-dashboard/components/Logo.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from 'vitest'
 import { cleanup, render, screen } from '@testing-library/react'
-import { Logo, logoLabel } from './Logo.js'
+import { Logo, logoLabel, logoSpokenLabel } from './Logo.js'
 
 afterEach(cleanup)
 
@@ -37,6 +37,6 @@ describe('Logo', () => {
     expect(logoLabel(true)).toBe('AI is working for you 🚀')
     expect(logoLabel(false)).toBe("AI isn't working for you 💤")
     render(<Logo working />)
-    expect(screen.getByRole('img', { name: logoLabel(true) })).toBeTruthy()
+    expect(screen.getByRole('img', { name: logoSpokenLabel(true) })).toBeTruthy()
   })
 })

--- a/packages/framework-dashboard/components/Logo.tsx
+++ b/packages/framework-dashboard/components/Logo.tsx
@@ -49,6 +49,11 @@ export function logoLabel(working: boolean): string {
   return working ? 'AI is working for you 🚀' : "AI isn't working for you 💤"
 }
 
+/** The label without the emoji (#948): a screen reader saying "rocket" helps nobody. */
+export function logoSpokenLabel(working: boolean): string {
+  return working ? 'AI is working for you' : "AI isn't working for you"
+}
+
 /** The hue `steps` along the cycle, wrapping. */
 function hue(steps: number): string {
   return HUES[((steps % HUES.length) + HUES.length) % HUES.length]!
@@ -69,7 +74,7 @@ export function Logo({ className, working = false }: { className?: string; worki
       viewBox="-289 -326 578 651.9"
       className={className}
       role="img"
-      aria-label={label}
+      aria-label={logoSpokenLabel(working)}
     >
       {/* Hovering the mark is the only place the label reads as prose. */}
       <title>{label}</title>

--- a/packages/framework-dashboard/components/Markdown.test.tsx
+++ b/packages/framework-dashboard/components/Markdown.test.tsx
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { Markdown } from './Markdown.js'
+
+afterEach(cleanup)
+
+// #869 + #948: the dependency-free renderer grew pipe tables and links without giving up
+// the no-injected-HTML property.
+describe('Markdown tables (#869)', () => {
+  test('a pipe table renders as a real table', () => {
+    render(<Markdown text={'| col a | col b |\n| --- | --- |\n| one | two |'} />)
+    expect(screen.getByRole('table')).toBeTruthy()
+    expect(screen.getByRole('columnheader', { name: 'col a' })).toBeTruthy()
+    expect(screen.getByRole('cell', { name: 'two' })).toBeTruthy()
+  })
+
+  test('pipes without a separator row stay prose, not a mangled table', () => {
+    render(<Markdown text={'| just | pipes |\n| in prose |'} />)
+    expect(screen.queryByRole('table')).toBeNull()
+    expect(screen.getByText('| just | pipes |')).toBeTruthy()
+  })
+
+  test('a short row leaves its missing cells empty instead of collapsing the column', () => {
+    render(<Markdown text={'| a | b |\n| --- | --- |\n| only |'} />)
+    expect(screen.getAllByRole('cell')).toHaveLength(2)
+  })
+})
+
+describe('Markdown links (#948)', () => {
+  test('[text](url) renders an anchor', () => {
+    render(<Markdown text={'See [the PR](https://github.com/x/y/pull/1) for detail'} />)
+    const a = screen.getByRole('link', { name: 'the PR' })
+    expect(a.getAttribute('href')).toBe('https://github.com/x/y/pull/1')
+    expect(a.getAttribute('rel')).toContain('noreferrer')
+  })
+
+  test('a bare URL autolinks', () => {
+    render(<Markdown text={'Deployed at https://example.com/app now'} />)
+    expect(screen.getByRole('link', { name: 'https://example.com/app' })).toBeTruthy()
+  })
+
+  test('a javascript: target stays plain text', () => {
+    render(<Markdown text={'[click](javascript:alert(1))'} />)
+    expect(screen.queryByRole('link')).toBeNull()
+  })
+
+  test('a URL inside backticks stays literal code', () => {
+    render(<Markdown text={'run `curl https://example.com` locally'} />)
+    expect(screen.queryByRole('link')).toBeNull()
+    expect(screen.getByText('curl https://example.com')).toBeTruthy()
+  })
+})

--- a/packages/framework-dashboard/components/Markdown.tsx
+++ b/packages/framework-dashboard/components/Markdown.tsx
@@ -1,9 +1,12 @@
 import { Fragment, type ReactNode } from 'react'
 
-// A tiny, dependency-free Markdown renderer for the surfaced PLAN/TODO docs. Builds
-// React nodes (never injects HTML), so agent-written content can't smuggle markup.
-// Handles what those docs use: headings, bullet + task lists, fenced/inline code,
-// bold/italic. Anything else falls through as a paragraph.
+// A tiny, dependency-free Markdown renderer for the surfaced PLAN/TODO docs and the agent's
+// pushed views (#441). Builds React nodes (never injects HTML), so agent-written content
+// can't smuggle markup. Handles what that content uses: headings, bullet + task lists,
+// fenced/inline code, bold/italic, links (#948 — plans and summaries carry PR/issue URLs
+// the reader wants to click; http(s) only, so no javascript: smuggling), and pipe tables
+// (#869 — an agent comparing options or listing files reaches for one, and it rendered as
+// raw pipes). Anything else falls through as a paragraph.
 export function Markdown({ text }: { text: string }) {
   return <div className="space-y-2 text-sm leading-relaxed">{renderBlocks(text)}</div>
 }
@@ -18,11 +21,25 @@ function codeBlock(lines: string[], key: number): ReactNode {
   )
 }
 
+/** A pipe-table row's cells, outer empties dropped (`| a | b |` -> ['a', 'b']). */
+function tableCells(row: string): string[] {
+  const cells = row.trim().split('|')
+  if (cells[0]?.trim() === '') cells.shift()
+  if (cells[cells.length - 1]?.trim() === '') cells.pop()
+  return cells.map(c => c.trim())
+}
+
+/** The GFM header separator (`| --- | :-: |`), which is what makes pipe rows a table. */
+function isTableSeparator(row: string): boolean {
+  return tableCells(row).length > 0 && tableCells(row).every(c => /^:?-{3,}:?$/.test(c))
+}
+
 function renderBlocks(text: string): ReactNode[] {
   const lines = text.replace(/\r\n/g, '\n').split('\n')
   const blocks: ReactNode[] = []
   let list: ReactNode[] = []
   let code: string[] | null = null
+  let table: string[] = []
   let key = 0
 
   const flushList = () => {
@@ -33,6 +50,46 @@ function renderBlocks(text: string): ReactNode[] {
         </ul>,
       )
       list = []
+    }
+  }
+
+  const flushTable = () => {
+    if (table.length === 0) return
+    const rows = table
+    table = []
+    // A real table needs the separator as its second row; anything else was just prose
+    // with pipes, rendered as the paragraphs it would have been.
+    if (rows.length >= 2 && isTableSeparator(rows[1]!)) {
+      const header = tableCells(rows[0]!)
+      const body = rows.slice(2).map(tableCells)
+      blocks.push(
+        <div key={key++} className="overflow-x-auto">
+          <table className="w-full border-collapse text-xs">
+            <thead>
+              <tr>
+                {header.map((cell, i) => (
+                  <th key={i} className="border-b border-border px-2 py-1 text-left font-semibold">
+                    {inline(cell)}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {body.map((cells, r) => (
+                <tr key={r}>
+                  {header.map((_, c) => (
+                    <td key={c} className="border-b border-border/50 px-2 py-1 align-top">
+                      {inline(cells[c] ?? '')}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>,
+      )
+    } else {
+      for (const row of rows) blocks.push(<p key={key++}>{inline(row)}</p>)
     }
   }
 
@@ -51,6 +108,14 @@ function renderBlocks(text: string): ReactNode[] {
       code.push(line)
       continue
     }
+
+    // Consecutive `| … |` rows buffer into a table candidate; anything else flushes it.
+    if (/^\s*\|.*\|\s*$/.test(line)) {
+      flushList()
+      table.push(line)
+      continue
+    }
+    flushTable()
 
     const heading = /^(#{1,6})\s+(.*)$/.exec(line)
     if (heading) {
@@ -86,14 +151,27 @@ function renderBlocks(text: string): ReactNode[] {
     if (line.trim()) blocks.push(<p key={key++}>{inline(line)}</p>)
   }
   flushList()
+  flushTable()
   if (code !== null) blocks.push(codeBlock(code, key++))
   return blocks
 }
 
-// Inline spans: `code`, **bold**, *italic*. Applied left-to-right, non-overlapping.
+// Inline spans: `code`, [text](url), **bold**, *italic*, bare URLs. Applied left-to-right,
+// non-overlapping; code wins over the rest so a URL inside backticks stays literal. Links
+// render only for http(s) targets — anything else stays plain text.
+const LINK_CLASS = 'text-primary underline underline-offset-2 break-all'
+
+function link(href: string, label: string, key: number): ReactNode {
+  return (
+    <a key={key} href={href} target="_blank" rel="noreferrer" className={LINK_CLASS}>
+      {label}
+    </a>
+  )
+}
+
 function inline(text: string): ReactNode {
   const parts: ReactNode[] = []
-  const re = /(`[^`]+`|\*\*[^*]+\*\*|\*[^*]+\*)/g
+  const re = /(`[^`]+`|\[[^\]]+\]\(https?:\/\/[^\s)]+\)|\*\*[^*]+\*\*|\*[^*]+\*|https?:\/\/[^\s<>)\]]+)/g
   let last = 0
   let m: RegExpExecArray | null
   let key = 0
@@ -101,8 +179,13 @@ function inline(text: string): ReactNode {
     if (m.index > last) parts.push(<Fragment key={key++}>{text.slice(last, m.index)}</Fragment>)
     const token = m[0]
     if (token.startsWith('`')) parts.push(<code key={key++} className="rounded bg-muted px-1 text-xs">{token.slice(1, -1)}</code>)
-    else if (token.startsWith('**')) parts.push(<strong key={key++}>{token.slice(2, -2)}</strong>)
-    else parts.push(<em key={key++}>{token.slice(1, -1)}</em>)
+    else if (token.startsWith('[')) {
+      const parsed = /^\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)$/.exec(token)
+      if (parsed) parts.push(link(parsed[2]!, parsed[1]!, key++))
+      else parts.push(<Fragment key={key++}>{token}</Fragment>)
+    } else if (token.startsWith('**')) parts.push(<strong key={key++}>{token.slice(2, -2)}</strong>)
+    else if (token.startsWith('*')) parts.push(<em key={key++}>{token.slice(1, -1)}</em>)
+    else parts.push(link(token, token, key++))
     last = m.index + token.length
   }
   if (last < text.length) parts.push(<Fragment key={key++}>{text.slice(last)}</Fragment>)

--- a/packages/framework-dashboard/components/NotificationsMenu.test.tsx
+++ b/packages/framework-dashboard/components/NotificationsMenu.test.tsx
@@ -1,8 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { Preferences } from '@gemstack/framework'
 
 const updatePreferences = vi.hoisted(() => vi.fn())
+// The daemon's channel capability (#948): both configured unless a test overrides it.
+const onNotifyChannels = vi.hoisted(() => vi.fn(async () => ({ discordWebhook: true, discordBot: true })))
+vi.mock('../server/preferences.telefunc.js', () => ({ onNotifyChannels }))
 let prefs: Preferences = {}
 vi.mock('../lib/preferences.js', () => ({
   usePreferences: () => prefs,
@@ -101,5 +104,27 @@ describe('NotificationsMenu (#676)', () => {
     prefs = { discordBot: true, notifyBrowser: false, notifyDiscord: false }
     render(<NotificationsMenu />)
     expect(screen.getByRole('button', { name: /notifications/i }).getAttribute('title')).toBe('Notifications')
+  })
+
+  // #948: the toggle is a preference; delivery needs the daemon env var. An unconfigured
+  // channel must neither light the bell nor read as if it will page you.
+  test('Discord on without DISCORD_WEBHOOK does not light the bell and says why', async () => {
+    onNotifyChannels.mockResolvedValueOnce({ discordWebhook: false, discordBot: false })
+    prefs = { notifyDiscord: true, notifyBrowser: false }
+    render(<NotificationsMenu />)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /notifications/i }).getAttribute('title')).toBe('Notifications'),
+    )
+    open()
+    expect(screen.getByText('Not configured — DISCORD_WEBHOOK is not set on the daemon')).toBeTruthy()
+    expect(screen.getByText('Not configured — DISCORD_BOT_TOKEN is not set on the daemon')).toBeTruthy()
+  })
+
+  test('a configured webhook keeps the bell lit for Discord delivery', async () => {
+    prefs = { notifyDiscord: true, notifyBrowser: false }
+    render(<NotificationsMenu />)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /notifications/i }).getAttribute('title')).toBe('Notifications on'),
+    )
   })
 })

--- a/packages/framework-dashboard/components/NotificationsMenu.tsx
+++ b/packages/framework-dashboard/components/NotificationsMenu.tsx
@@ -1,6 +1,8 @@
 import { useSyncExternalStore } from 'react'
 import { Bell, BellOff } from 'lucide-react'
 import { usePreferences, updatePreferences, notificationsEnabled, discordEnabled, discordBotEnabled, newActivityEnabled, humanInterventionEnabled } from '../lib/preferences.js'
+import { onNotifyChannels, type NotifyChannels } from '../server/preferences.telefunc.js'
+import { useLoaded } from '../lib/use-async.js'
 import { cn } from '../lib/utils.js'
 import { OptionLabel } from './OptionsMenu.js'
 import {
@@ -47,10 +49,17 @@ export function NotificationsMenu() {
   const permission = usePermission()
   const browserSupported = permission !== 'unsupported'
   const blocked = permission === 'denied'
-  // Browser only actually fires once the browser has granted permission; Discord is delivered
-  // daemon-side, so it counts as active whenever it's on. "Active" drives the bell + dot.
+  // Whether the daemon can actually deliver on Discord (#948): the toggle is a preference,
+  // the env var is the capability. `null` until the one-shot read lands — treated as capable
+  // so the bell does not flicker for a properly configured setup.
+  const channels = useLoaded<NotifyChannels | null>(onNotifyChannels, null, [])
+  const webhookReady = channels === null || channels.discordWebhook
+  const botReady = channels === null || channels.discordBot
+  // Browser only actually fires once the browser has granted permission; Discord counts once
+  // it is both on and deliverable — a toggle without the daemon env var lit the bell for a
+  // channel delivering nothing (#948). "Active" drives the bell + dot.
   const browserActive = browser && permission === 'granted'
-  const anyActive = browserActive || discord
+  const anyActive = browserActive || (discord && webhookReady)
 
   const toggleBrowser = (next: boolean) => {
     updatePreferences({ notifyBrowser: next })
@@ -97,10 +106,13 @@ export function NotificationsMenu() {
           <DropdownMenuCheckboxItem
             checked={discord}
             onCheckedChange={next => updatePreferences({ notifyDiscord: next })}
-            title="Reaches you with no dashboard open (needs DISCORD_WEBHOOK on the daemon)"
+            title={webhookReady ? 'Reaches you with no dashboard open' : 'Set DISCORD_WEBHOOK on the daemon, then restart it, to deliver here'}
             className="items-start"
           >
-            <OptionLabel label="Discord" description="Needs DISCORD_WEBHOOK on the daemon" />
+            <OptionLabel
+              label="Discord"
+              description={webhookReady ? 'Reaches you with no dashboard open' : 'Not configured — DISCORD_WEBHOOK is not set on the daemon'}
+            />
           </DropdownMenuCheckboxItem>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
@@ -133,10 +145,13 @@ export function NotificationsMenu() {
           <DropdownMenuCheckboxItem
             checked={discordBot}
             onCheckedChange={next => updatePreferences({ discordBot: next })}
-            title="Lets Discord messages start and steer sessions (needs DISCORD_BOT_TOKEN on the daemon)"
+            title={botReady ? 'Lets Discord messages start and steer sessions' : 'Set DISCORD_BOT_TOKEN on the daemon, then restart it, to enable the bot'}
             className="items-start"
           >
-            <OptionLabel label="Discord bot" description="Start and steer sessions from Discord" />
+            <OptionLabel
+              label="Discord bot"
+              description={botReady ? 'Start and steer sessions from Discord' : 'Not configured — DISCORD_BOT_TOKEN is not set on the daemon'}
+            />
           </DropdownMenuCheckboxItem>
         </DropdownMenuGroup>
       </DropdownMenuContent>

--- a/packages/framework-dashboard/components/OptionsMenu.test.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.test.tsx
@@ -136,21 +136,3 @@ describe('OptionsMenu editor picker (#727)', () => {
     expect(screen.getAllByText('mate').length).toBeGreaterThan(0)
   })
 })
-
-describe('OptionsMenu saved presets (#722)', () => {
-  const base = () => ({ options: mainOptions(), ecoOptions: ecoOptions(), showEco: false, busy: false, ...editorProps })
-
-  test('deletes a saved preset by id', () => {
-    const onDeleteCustomPreset = vi.fn()
-    render(<OptionsMenu {...base()} customPresets={[{ id: 'a', label: 'Deep review', prompt: 'x' }]} onDeleteCustomPreset={onDeleteCustomPreset} />)
-    open()
-    fireEvent.click(screen.getByRole('button', { name: 'Delete preset Deep review' }))
-    expect(onDeleteCustomPreset).toHaveBeenCalledWith('a')
-  })
-
-  test('omits the "Your presets" section when there are none', () => {
-    render(<OptionsMenu {...base()} customPresets={[]} onDeleteCustomPreset={() => {}} />)
-    open()
-    expect(screen.queryByText('Your presets')).toBeNull()
-  })
-})

--- a/packages/framework-dashboard/components/OptionsMenu.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.tsx
@@ -1,5 +1,5 @@
-import type { Preferences, CustomPreset } from '@gemstack/framework'
-import { Settings, Check, X } from 'lucide-react'
+import type { Preferences } from '@gemstack/framework'
+import { Settings, Check } from 'lucide-react'
 import { updatePreferences } from '../lib/preferences.js'
 import type { EditorInfo } from '../server/preferences.telefunc.js'
 import { cn } from '../lib/utils.js'
@@ -38,16 +38,10 @@ function setOption(key: keyof Preferences, checked: boolean) {
   updatePreferences({ [key]: checked } as Partial<Preferences>)
 }
 
-/** A menu item's label with a short one-line description under it (#654). Shared with the
- * notifications menu, so the two dropdowns read identically. */
-export function OptionLabel({ label, description }: { label: string; description?: string | undefined }) {
-  return (
-    <span className="flex flex-col gap-0.5">
-      <span className="leading-tight">{label}</span>
-      {description && <span className="text-xs font-normal text-[var(--color-muted-foreground)]">{description}</span>}
-    </span>
-  )
-}
+// Moved to ui/option-label.tsx (#948) so menus without preference wiring can share it;
+// re-exported to keep this module the import site the other menus already use.
+import { OptionLabel } from './ui/option-label.js'
+export { OptionLabel }
 
 /** One preference checkbox row. The disabled reason rides the description (the `title`
  * tooltip is suppressed on disabled dropdown items), so a greyed row isn't a mystery. */
@@ -76,8 +70,6 @@ export function OptionsMenu({
   editor,
   editors,
   onEditorChange,
-  customPresets = [],
-  onDeleteCustomPreset = () => {},
 }: {
   options: OptionRow[]
   ecoOptions: OptionRow[]
@@ -90,10 +82,6 @@ export function OptionsMenu({
   editors: EditorInfo[]
   /** Pick an editor CLI, or `undefined` to fall back to `$FRAMEWORK_EDITOR` / `code`. */
   onEditorChange: (editor: string | undefined) => void
-  /** The user's saved presets (#626); managed here now the Presets dropdown is gone (#722). */
-  customPresets?: CustomPreset[]
-  /** Delete a saved preset by id. */
-  onDeleteCustomPreset?: (id: string) => void
 }) {
   const activeCount = options.filter(o => o.checked && !o.disabled).length
   // Detected editors, plus the stored one as a "custom" row when it isn't auto-detected (e.g. a
@@ -155,29 +143,6 @@ export function OptionsMenu({
             </DropdownMenuItem>
           ))}
         </DropdownMenuGroup>
-        {customPresets.length > 0 && (
-          <DropdownMenuGroup>
-            <DropdownMenuSeparator />
-            <DropdownMenuLabel>Your presets</DropdownMenuLabel>
-            {customPresets.map(p => (
-              // Loading moved to the `/` menu (#722); this row is manage-only, so its sole action is
-              // the trailing delete. Keep the menu open so several can be removed in one go.
-              <DropdownMenuItem key={p.id} closeOnClick={false} className="items-center gap-2">
-                <span className="flex-1 truncate">{p.label}</span>
-                <button
-                  type="button"
-                  disabled={busy}
-                  onClick={() => onDeleteCustomPreset(p.id)}
-                  title={`Delete "${p.label}"`}
-                  aria-label={`Delete preset ${p.label}`}
-                  className="rounded p-0.5 text-[var(--color-muted-foreground)] hover:text-red-500"
-                >
-                  <X className="h-3.5 w-3.5" />
-                </button>
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuGroup>
-        )}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/packages/framework-dashboard/components/OptionsMenu.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.tsx
@@ -70,12 +70,16 @@ export function OptionsMenu({
   editor,
   editors,
   onEditorChange,
+  label = 'Session options',
 }: {
   options: OptionRow[]
   ecoOptions: OptionRow[]
   /** Whether Eco's sub-drops apply right now (Eco on and not disabled by Vanilla). */
   showEco: boolean
   busy: boolean
+  /** The trigger's name. In-session composers pass no run options (#833), so theirs says
+   *  "Preferences" rather than promising session control it does not have. */
+  label?: string
   /** The current preferred-editor CLI (#727), or undefined for the default. */
   editor: string | undefined
   /** The editors detected on the daemon's machine; empty on a public host. */
@@ -93,8 +97,8 @@ export function OptionsMenu({
       <DropdownMenuTrigger
         type="button"
         disabled={busy}
-        title={activeCount > 0 ? `Session options — ${activeCount} on` : 'Session options'}
-        aria-label="Session options"
+        title={activeCount > 0 ? `${label} — ${activeCount} on` : label}
+        aria-label={label}
         className={cn(buttonVariants({ variant: 'outline', size: 'icon-sm' }), 'relative')}
       >
         <Settings className="h-4 w-4" />

--- a/packages/framework-dashboard/components/PresetCreatePanel.tsx
+++ b/packages/framework-dashboard/components/PresetCreatePanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, type KeyboardEvent } from 'react'
 import type { CustomPreset } from '@gemstack/framework'
 import { Button } from './ui/button.js'
 
@@ -35,8 +35,20 @@ export function PresetCreatePanel({
     onSave({ id: newId(), label: trimmedLabel, prompt: trimmedPrompt })
   }
 
+  // Keyboard parity with the composer (#948): Esc cancels, ⌘/Ctrl+Enter saves.
+  const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      onCancel()
+    }
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      e.preventDefault()
+      save()
+    }
+  }
+
   return (
-    <div className="mt-1.5 flex w-full flex-col gap-1.5 rounded-md border border-border p-2">
+    <div className="mt-1.5 flex w-full flex-col gap-1.5 rounded-md border border-border p-2" onKeyDown={onKeyDown}>
       <input
         type="text"
         value={label}

--- a/packages/framework-dashboard/components/PresetsMenu.test.tsx
+++ b/packages/framework-dashboard/components/PresetsMenu.test.tsx
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { PresetsMenu } from './PresetsMenu.js'
+
+afterEach(cleanup)
+
+const presets = [
+  { id: 'research', label: '[Research]', render: () => 'RESEARCH PROMPT', tooltip: 'Spike it' },
+  { id: 'maintenance', label: '[Maintenance]', render: () => 'MAINTENANCE PROMPT' },
+]
+const custom = [{ id: 'c1', label: 'My sweep', prompt: 'sweep it' }]
+
+function mount(over: Partial<Parameters<typeof PresetsMenu>[0]> = {}) {
+  const onLoad = vi.fn()
+  const onNew = vi.fn()
+  const onDelete = vi.fn()
+  render(
+    <PresetsMenu presets={presets} customPresets={custom} busy={false} onLoad={onLoad} onNew={onNew} onDelete={onDelete} {...over} />,
+  )
+  fireEvent.click(screen.getByRole('button', { name: /presets/i }))
+  return { onLoad, onNew, onDelete }
+}
+
+// #948: presets used to load only behind typing `/`, and delete lived in the options gear.
+describe('PresetsMenu', () => {
+  test('lists built-ins and loads the rendered prompt', () => {
+    const { onLoad } = mount()
+    fireEvent.click(screen.getByText('[Research]'))
+    expect(onLoad).toHaveBeenCalledWith('RESEARCH PROMPT', '[Research]')
+  })
+
+  test('a saved preset loads verbatim', () => {
+    const { onLoad } = mount()
+    fireEvent.click(screen.getByText('My sweep'))
+    expect(onLoad).toHaveBeenCalledWith('sweep it', 'My sweep')
+  })
+
+  test('the delete button deletes without loading', () => {
+    const { onLoad, onDelete } = mount()
+    fireEvent.click(screen.getByRole('button', { name: 'Delete preset My sweep' }))
+    expect(onDelete).toHaveBeenCalledWith('c1')
+    expect(onLoad).not.toHaveBeenCalled()
+  })
+
+  test('"New preset…" opens the create panel', () => {
+    const { onNew } = mount()
+    fireEvent.click(screen.getByText('New preset…'))
+    expect(onNew).toHaveBeenCalled()
+  })
+
+  test('no create item where no panel exists', () => {
+    mount({ onNew: undefined })
+    expect(screen.queryByText('New preset…')).toBeNull()
+  })
+})

--- a/packages/framework-dashboard/components/PresetsMenu.tsx
+++ b/packages/framework-dashboard/components/PresetsMenu.tsx
@@ -1,0 +1,110 @@
+import type { CustomPreset } from '@gemstack/framework'
+import { BookMarked, Plus, X } from 'lucide-react'
+import { cn } from '../lib/utils.js'
+import { buttonVariants } from './ui/button.js'
+import { OptionLabel } from './ui/option-label.js'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from './ui/dropdown-menu.js'
+
+/** A built-in preset as the composer prepares it: render() gives the prompt for this surface. */
+export interface PresetEntry {
+  id: string
+  label: string
+  render: () => string
+  tooltip?: string | undefined
+}
+
+// The visible face of the presets (#948). Loading used to live only behind typing `/` in the
+// editor — with the preset cards and dropdown gone (#722), an empty box gave a first-time user
+// no sign that 13 launcher presets exist — and deleting lived in the options gear, a different
+// menu. This button is the one surface that loads, creates, and deletes; the `/` menu stays as
+// the fast path for those who know it.
+export function PresetsMenu({
+  presets,
+  customPresets,
+  busy,
+  onLoad,
+  onNew,
+  onDelete,
+}: {
+  presets: PresetEntry[]
+  customPresets: CustomPreset[]
+  busy: boolean
+  /** Load a preset's prompt into the editor. */
+  onLoad: (text: string, label: string) => void
+  /** Open the create panel; absent where no panel renders. */
+  onNew?: (() => void) | undefined
+  /** Delete a saved preset by id. */
+  onDelete: (id: string) => void
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        type="button"
+        disabled={busy}
+        title="Load a preset prompt — also available by typing / in the editor"
+        className={cn(buttonVariants({ variant: 'outline', size: 'sm' }))}
+      >
+        <BookMarked className="h-4 w-4" aria-hidden />
+        Presets
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-[16rem] max-w-[20rem]">
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Presets</DropdownMenuLabel>
+          {presets.map(p => (
+            <DropdownMenuItem
+              key={p.id}
+              disabled={busy}
+              onClick={() => onLoad(p.render(), p.label)}
+              {...(p.tooltip ? { title: p.tooltip } : {})}
+              className="items-start"
+            >
+              <OptionLabel label={p.label} description={`/${p.id}`} />
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuGroup>
+        {customPresets.length > 0 && (
+          <DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel>Your presets</DropdownMenuLabel>
+            {customPresets.map(p => (
+              <DropdownMenuItem key={p.id} disabled={busy} onClick={() => onLoad(p.prompt, p.label)} className="items-center gap-2">
+                <span className="flex-1 truncate">{p.label}</span>
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={e => {
+                    // Delete, not load — keep the row's own click out of it.
+                    e.stopPropagation()
+                    onDelete(p.id)
+                  }}
+                  title={`Delete "${p.label}"`}
+                  aria-label={`Delete preset ${p.label}`}
+                  className="rounded p-0.5 text-[var(--color-muted-foreground)] hover:text-red-500"
+                >
+                  <X className="h-3.5 w-3.5" aria-hidden />
+                </button>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuGroup>
+        )}
+        {onNew && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem disabled={busy} onClick={onNew}>
+              <Plus className="h-3.5 w-3.5" aria-hidden />
+              New preset…
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/packages/framework-dashboard/components/ProjectHome.tsx
+++ b/packages/framework-dashboard/components/ProjectHome.tsx
@@ -14,6 +14,7 @@ export function ProjectHome({
   files,
   context,
   addContext,
+  removeContext,
   toggleContext,
 }: {
   projectId: string
@@ -22,6 +23,7 @@ export function ProjectHome({
   files: string[]
   context: Set<string>
   addContext: (path: string) => void
+  removeContext: (path: string) => void
   toggleContext: (path: string) => void
 }) {
   return (
@@ -33,6 +35,7 @@ export function ProjectHome({
         files={files}
         context={context}
         addContext={addContext}
+        removeContext={removeContext}
         toggleContext={toggleContext}
       />
       {events.length > 0 && <RunOverview events={events} />}

--- a/packages/framework-dashboard/components/ProjectLogPanel.tsx
+++ b/packages/framework-dashboard/components/ProjectLogPanel.tsx
@@ -12,9 +12,11 @@ import { ScrollArea } from './ui/scroll-area.js'
 // Polled like the sibling rail panels, so an entry a run appends on finishing shows up
 // without a project switch.
 export function ProjectLogPanel({ projectId }: { projectId: string | null }) {
-  const logs = usePolled<LogEntry[]>(projectId ? () => onProjectLog(projectId) : null, [], 10_000, [projectId]).value
+  const { value: logs, loaded } = usePolled<LogEntry[]>(projectId ? () => onProjectLog(projectId) : null, [], 10_000, [projectId])
 
   if (!projectId) return null
+  // Loading and empty are different facts (#948) — same guard as the Tickets panel.
+  if (!loaded) return <p className="p-4 text-sm text-muted-foreground">Loading…</p>
   if (logs.length === 0) return <p className="p-4 text-sm text-muted-foreground">No committed log entries yet.</p>
 
   return (

--- a/packages/framework-dashboard/components/ProjectPicker.test.tsx
+++ b/packages/framework-dashboard/components/ProjectPicker.test.tsx
@@ -29,10 +29,11 @@ describe('ProjectPicker (#772)', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: /^project:/i }).textContent).toContain('beta'))
   })
 
-  test('no selection reads as all projects, not as a blank', () => {
+  test('no selection reads as the Overview, not as a blank', () => {
     onProjects.mockResolvedValue(PROJECTS)
     render(<ProjectPicker selectedId={null} onSelect={() => {}} onDashboard={() => {}} />)
-    expect(screen.getByRole('button', { name: /^project:/i }).textContent).toContain('All projects')
+    // One name for one place (#948): the trigger matches the menu entry it maps to.
+    expect(screen.getByRole('button', { name: /^project:/i }).textContent).toContain('Overview')
   })
 
   test('picking a project reports it', async () => {

--- a/packages/framework-dashboard/components/ProjectPicker.tsx
+++ b/packages/framework-dashboard/components/ProjectPicker.tsx
@@ -51,7 +51,10 @@ export function ProjectPicker({
   // (#784), so silently rewriting it would read as "the link worked, you clicked the wrong one".
   // The shell says so instead; this control only reports what it was given.
   const selected = selectedId === null ? null : projects?.find(p => p.id === selectedId)
-  const label = selectedId === null ? 'All projects' : (selected?.name ?? selectedId)
+  // One name for the no-project state (#948): the trigger used to say "All projects" while the
+  // menu entry it maps to says "Overview" — two names for one place. While the list is still
+  // loading, an ellipsis stands in rather than flashing the raw project id.
+  const label = selectedId === null ? 'Overview' : (selected?.name ?? (projects === null ? '…' : selectedId))
 
   return (
     <>

--- a/packages/framework-dashboard/components/PromptEditor.tsx
+++ b/packages/framework-dashboard/components/PromptEditor.tsx
@@ -237,6 +237,7 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
       makeTrigger({
         char: '@',
         key: 'at',
+        emptyNote: 'No projects to reference yet.',
         items: query =>
           projectsRef.current
             .filter(p => p.name.toLowerCase().includes(query))
@@ -255,6 +256,7 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
       makeTrigger({
         char: '#',
         key: 'hash',
+        emptyNote: 'No files indexed here yet.',
         items: query =>
           filesRef.current
             .filter(f => f.toLowerCase().includes(query.toLowerCase()))

--- a/packages/framework-dashboard/components/PromptEditor.tsx
+++ b/packages/framework-dashboard/components/PromptEditor.tsx
@@ -20,14 +20,17 @@ import type { SuggestionItem } from './prompt-editor/SuggestionList.js'
 export interface PromptEditorHandle {
   clear: () => void
   focus: () => void
+  /** Load a template (a preset's prompt) into the editor. Returns whether it replaced a draft. */
+  loadTemplate: (text: string) => boolean
 }
 
 interface PromptEditorProps {
   onChange: (markdown: string) => void
   /** Cmd/Ctrl+Enter. */
   onSubmit: () => void
-  /** A preset picked from the `/` menu (so the form can flip to a `prompt` run). */
-  onPreset?: (label: string) => void
+  /** A preset picked from the `/` menu (so the form can flip to a `prompt` run). `replaced` says
+   *  whether a typed draft was overwritten — undo brings it back, and the form's note says so. */
+  onPreset?: (label: string, replaced: boolean) => void
   /** A project referenced via `@` (so the form can add it to the run context). */
   onMentionProject?: (path: string) => void
   /** A file referenced via `#` (so the form can add its repo-relative path to the run context). */
@@ -101,13 +104,15 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
   // Load a template into the live editor and sync the derived state (the empty flag + the
   // markdown out). Takes the editor as an argument so the `/` menu — whose closures are built
   // once, before useEditor resolves — can call it too, not only the imperative handle.
-  const loadTemplateInto = (ed: Editor, text: string): void => {
-    // Loading a preset replaces the whole editor, so guard typed work (#695/U11): a non-empty
-    // editor gets one confirm before its content is discarded. An empty editor loads silently.
-    if (!ed.isEmpty && typeof window !== 'undefined' && !window.confirm('Replace your current prompt with this preset?')) return
+  // Replacing a typed draft loads without a blocking confirm (#948): the replacement is one
+  // undo step (history groups the draft separately after its ~500ms window), and the caller
+  // gets `replaced` back so its note can say "undo brings it back".
+  const loadTemplateInto = (ed: Editor, text: string): boolean => {
+    const replaced = !ed.isEmpty
     applyTemplate(ed, text)
     setIsEmpty(ed.isEmpty)
     onChangeRef.current(ed.storage.markdown.getMarkdown())
+    return replaced
   }
 
   const editor = useEditor({
@@ -151,16 +156,19 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
           if (item.id.startsWith('preset:')) {
             const preset = presetsRef.current.find(p => `preset:${p.id}` === item.id)
             if (preset) {
-              loadTemplateInto(ed, preset.render())
-              onPresetRef.current?.(preset.label)
+              // Drop the `/query` trigger first so it does not count as a replaced draft.
+              ed.chain().focus().deleteRange(range).run()
+              const replaced = loadTemplateInto(ed, preset.render())
+              onPresetRef.current?.(preset.label, replaced)
             }
             return
           }
           if (item.id.startsWith('custom-preset:')) {
             const preset = customPresetsRef.current.find(p => `custom-preset:${p.id}` === item.id)
             if (preset) {
-              loadTemplateInto(ed, preset.prompt)
-              onPresetRef.current?.(preset.label)
+              ed.chain().focus().deleteRange(range).run()
+              const replaced = loadTemplateInto(ed, preset.prompt)
+              onPresetRef.current?.(preset.label, replaced)
             }
             return
           }
@@ -250,6 +258,7 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
       onChangeRef.current('')
     },
     focus: () => editor?.commands.focus('end'),
+    loadTemplate: (text: string) => (editor ? loadTemplateInto(editor, text) : false),
   }))
 
   useEffect(() => {

--- a/packages/framework-dashboard/components/PromptEditor.tsx
+++ b/packages/framework-dashboard/components/PromptEditor.tsx
@@ -35,6 +35,9 @@ interface PromptEditorProps {
   onMentionProject?: (path: string) => void
   /** A file referenced via `#` (so the form can add its repo-relative path to the run context). */
   onMentionFile?: (relPath: string) => void
+  /** An `@`/`#` chip left the editor (deleted, or replaced by a preset) — undo the context
+   *  focus it added, so the prompt and the Context set cannot diverge (#948). */
+  onMentionRemoved?: (path: string) => void
   projects: ProjectSummary[]
   /** The current project's files, repo-relative, for the `#` picker (#504). */
   files?: string[]
@@ -72,7 +75,7 @@ function applyTemplate(editor: Editor, text: string): void {
 }
 
 export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(function PromptEditor(
-  { onChange, onSubmit, onPreset, onMentionProject, onMentionFile, projects, files = [], presets, customPresets = [], onNewPreset, disabled = false, placeholder = 'Describe what to build…  ( / commands · < tags · @ projects · # files )', compact = false },
+  { onChange, onSubmit, onPreset, onMentionProject, onMentionFile, onMentionRemoved, projects, files = [], presets, customPresets = [], onNewPreset, disabled = false, placeholder = 'Describe what to build…  ( / commands · < tags · @ projects · # files )', compact = false },
   ref,
 ) {
   const [isEmpty, setIsEmpty] = useState(true)
@@ -86,6 +89,7 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
   const onPresetRef = useRef(onPreset)
   const onMentionRef = useRef(onMentionProject)
   const onMentionFileRef = useRef(onMentionFile)
+  const onMentionRemovedRef = useRef(onMentionRemoved)
   const onChangeRef = useRef(onChange)
   const onSubmitRef = useRef(onSubmit)
   useEffect(() => {
@@ -97,9 +101,36 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
     onPresetRef.current = onPreset
     onMentionRef.current = onMentionProject
     onMentionFileRef.current = onMentionFile
+    onMentionRemovedRef.current = onMentionRemoved
     onChangeRef.current = onChange
     onSubmitRef.current = onSubmit
   })
+
+  // The `@`/`#` chips currently in the doc, as their serialized texts. Deleting a chip must
+  // also undo the context focus it added (#948): the chip was the only visible sign of that
+  // focus, so a chipless prompt silently carrying it was a lie. Compared on every doc change;
+  // additions are handled by the pickers' own callbacks.
+  const mentionsRef = useRef<Set<string>>(new Set())
+  const syncMentions = (ed: Editor): void => {
+    const now = new Set<string>()
+    ed.state.doc.descendants(node => {
+      if (node.type.name === 'token' && (node.attrs.kind === 'project' || node.attrs.kind === 'file')) {
+        now.add(String(node.attrs.text))
+      }
+      return true
+    })
+    for (const gone of mentionsRef.current) {
+      if (now.has(gone)) continue
+      if (gone.startsWith('#')) {
+        onMentionRemovedRef.current?.(gone.slice(1))
+      } else if (gone.startsWith('@')) {
+        // A project chip carries its name; the context holds its path.
+        const project = projectsRef.current.find(p => p.name === gone.slice(1))
+        if (project) onMentionRemovedRef.current?.(project.path)
+      }
+    }
+    mentionsRef.current = now
+  }
 
   // Load a template into the live editor and sync the derived state (the empty flag + the
   // markdown out). Takes the editor as an argument so the `/` menu — whose closures are built
@@ -112,6 +143,8 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
     applyTemplate(ed, text)
     setIsEmpty(ed.isEmpty)
     onChangeRef.current(ed.storage.markdown.getMarkdown())
+    // setContent does not emit an update, so reconcile the mention chips here too.
+    syncMentions(ed)
     return replaced
   }
 
@@ -248,6 +281,7 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
     onUpdate: ({ editor: ed }) => {
       setIsEmpty(ed.isEmpty)
       onChangeRef.current(ed.storage.markdown.getMarkdown())
+      syncMentions(ed)
     },
   })
 
@@ -256,6 +290,7 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
       editor?.commands.clearContent()
       setIsEmpty(true)
       onChangeRef.current('')
+      if (editor) syncMentions(editor)
     },
     focus: () => editor?.commands.focus('end'),
     loadTemplate: (text: string) => (editor ? loadTemplateInto(editor, text) : false),

--- a/packages/framework-dashboard/components/PromptEditor.tsx
+++ b/packages/framework-dashboard/components/PromptEditor.tsx
@@ -268,7 +268,15 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
       }),
     ],
     editorProps: {
-      attributes: { class: 'pe-prose focus:outline-none' },
+      // The bare contenteditable needs its textbox semantics spelled out (#948): without them a
+      // screen reader gets an unlabeled editable region, and the placeholder span is decorative.
+      attributes: {
+        class: 'pe-prose focus:outline-none',
+        role: 'textbox',
+        'aria-multiline': 'true',
+        'aria-label': 'Prompt',
+        'aria-placeholder': placeholder,
+      },
       handleKeyDown: (_view, event) => {
         if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
           event.preventDefault()

--- a/packages/framework-dashboard/components/RelayView.tsx
+++ b/packages/framework-dashboard/components/RelayView.tsx
@@ -11,7 +11,7 @@ import { Logo } from './Logo.js'
 // rails and no steering — a teammate with the link watches, they do not drive.
 export function RelayView({ runId }: { runId: string }) {
   // The run id rides in the projectId slot: the relay keys `onEvents` by it (no registry).
-  const { events, lost } = useLiveEvents(runId)
+  const { events, lost, done } = useLiveEvents(runId)
   // The mark and the tab icon (#875) follow the one run being watched, since that is all the
   // relay knows about — it has no project registry to ask.
   const working = isRunActive(events)
@@ -25,7 +25,15 @@ export function RelayView({ runId }: { runId: string }) {
         <span className="ml-auto text-xs text-muted-foreground">read-only shared session</span>
       </header>
       <main className="flex min-w-0 flex-1 flex-col">
-        <RunFeed events={events} lost={lost} />
+        {/* An unknown or ended run closes the channel cleanly with nothing streamed; saying so
+            beats "Waiting for the session to start…" forever (#948). */}
+        {events.length === 0 && done ? (
+          <div className="grid flex-1 place-items-center px-6 text-center text-sm text-muted-foreground">
+            This shared session isn&rsquo;t available — it may have ended, or the link may be wrong.
+          </div>
+        ) : (
+          <RunFeed events={events} lost={lost} />
+        )}
       </main>
     </div>
   )

--- a/packages/framework-dashboard/components/RelayView.tsx
+++ b/packages/framework-dashboard/components/RelayView.tsx
@@ -10,7 +10,8 @@ import { Logo } from './Logo.js'
 // feed over the same Telefunc `onEvents` Channel the daemon uses. No Projects/Runs/Docs
 // rails and no steering — a teammate with the link watches, they do not drive.
 export function RelayView({ runId }: { runId: string }) {
-  const events = useLiveEvents(runId)
+  // The run id rides in the projectId slot: the relay keys `onEvents` by it (no registry).
+  const { events, lost } = useLiveEvents(runId)
   // The mark and the tab icon (#875) follow the one run being watched, since that is all the
   // relay knows about — it has no project registry to ask.
   const working = isRunActive(events)
@@ -24,7 +25,7 @@ export function RelayView({ runId }: { runId: string }) {
         <span className="ml-auto text-xs text-muted-foreground">read-only shared session</span>
       </header>
       <main className="flex min-w-0 flex-1 flex-col">
-        <RunFeed events={events} />
+        <RunFeed events={events} lost={lost} />
       </main>
     </div>
   )

--- a/packages/framework-dashboard/components/RemoveWorktreeButton.tsx
+++ b/packages/framework-dashboard/components/RemoveWorktreeButton.tsx
@@ -31,6 +31,7 @@ export function RemoveWorktreeButton({
           <Button
             variant="outline"
             size="icon-sm"
+            aria-label="Remove this session's worktree"
             disabled={busy}
             onClick={() =>
               void run(() => sendRemoveWorktree(projectId, runId), 'Could not remove the worktree.').then(

--- a/packages/framework-dashboard/components/RightRail.test.tsx
+++ b/packages/framework-dashboard/components/RightRail.test.tsx
@@ -50,7 +50,7 @@ describe('RightRail wide mode (#862)', () => {
   test('leaving the view gives the room back', () => {
     const onWideChange = vi.fn()
     const { container } = render(<RightRail {...baseProps} views={[view]} onWideChange={onWideChange} />)
-    fireEvent.click(screen.getByRole('button', { name: /docs/i }))
+    fireEvent.click(screen.getByRole('tab', { name: /docs/i }))
     expect(rail(container).className).toContain('w-80')
     expect(onWideChange).toHaveBeenLastCalledWith(false)
   })

--- a/packages/framework-dashboard/components/RightRail.tsx
+++ b/packages/framework-dashboard/components/RightRail.tsx
@@ -123,10 +123,14 @@ export function RightRail({
         wide ? 'w-[32rem]' : 'w-80',
       )}
     >
-      <div className="flex gap-1 border-b border-border p-2">
+      {/* flex-wrap: up to 7 tabs share a w-80 rail, and without it the tail clipped (#948).
+          Announced as the tabset it visually is. */}
+      <div role="tablist" aria-label="Rail panels" className="flex flex-wrap gap-1 border-b border-border p-2">
         {tabs.map(t => (
           <Button
             key={t}
+            role="tab"
+            aria-selected={tab === t}
             variant="ghost"
             size="sm"
             className={cn('h-7 gap-1.5 text-xs', tab === t && 'bg-accent text-accent-foreground')}

--- a/packages/framework-dashboard/components/RightRail.tsx
+++ b/packages/framework-dashboard/components/RightRail.tsx
@@ -29,6 +29,7 @@ export function RightRail({
   toggleContext,
   hasBrowser = false,
   onWideChange,
+  onRunStarted,
 }: {
   projectId: string | null
   /** The selected run: resolves a choice pick's gate (#749) and scopes the tree to its worktree (#815). */
@@ -45,6 +46,8 @@ export function RightRail({
   hasBrowser?: boolean
   /** Told when the rail takes its wide form (#862), so the shell can free the room for it. */
   onWideChange?: (wide: boolean) => void
+  /** Told when a panel starts a session (the tickets import, #948), so the shell shows it. */
+  onRunStarted?: ((intent: string, runId?: string) => void) | undefined
 }) {
   const [tab, setTab] = useState<Tab>('docs')
   // Once the user picks a tab, stop auto-defaulting (#695/U22) — only a genuinely new choice
@@ -151,7 +154,7 @@ export function RightRail({
         ) : tab === 'browser' && hasBrowser && runId ? (
           <BrowserPanel projectId={projectId} runId={runId} />
         ) : tab === 'tickets' ? (
-          <TicketsPanel projectId={projectId} />
+          <TicketsPanel projectId={projectId} onRunStarted={onRunStarted} />
         ) : tab === 'log' ? (
           <ProjectLogPanel projectId={projectId} />
         ) : (

--- a/packages/framework-dashboard/components/RunActionBar.tsx
+++ b/packages/framework-dashboard/components/RunActionBar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import type { FrameworkEvent } from '@gemstack/framework'
 import { sessionInfo } from '@gemstack/framework/client'
 import { Square, ExternalLink } from 'lucide-react'
@@ -9,6 +10,7 @@ import { RemoveWorktreeButton } from './RemoveWorktreeButton.js'
 import { WorkspaceActions } from './WorkspaceActions.js'
 import { GitStatusBar } from './GitStatusBar.js'
 import { Button, buttonVariants } from './ui/button.js'
+import { CopyButton } from './ui/copy-button.js'
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './ui/tooltip.js'
 
 // One run's action bar: Serve, Stop, and Open session as a single row of icon buttons with
@@ -37,9 +39,16 @@ export function RunActionBar({
   // and a failed stop surfaces instead of silently doing nothing.
   const { busy, error, run } = useAction()
   const active = isRunActive(events)
-  // Only a real per-session deep link is shown; the generic claude.ai/code entry is a dead end,
-  // so Claude Code runs get no Open button (the session id is still in the event log).
-  const session = describeSessionLink(sessionInfo(events))
+  // A landed stop keeps the button parked until the end event flips `active` (#948): useAction
+  // resets busy on success, and for that gap the enabled button invited a redundant second stop.
+  const [stopRequested, setStopRequested] = useState(false)
+  useEffect(() => setStopRequested(false), [runId])
+  const stopping = busy || (stopRequested && active)
+  // Only a real per-session deep link is shown; the generic claude.ai/code entry is a dead end.
+  // A session with an id but no deep link still gets its id offered for copy (#948): it is the
+  // exact string a --resume takes, and it used to live only as a mono line buried in the feed.
+  const info = sessionInfo(events)
+  const session = describeSessionLink(info)
 
   return (
     <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-2">
@@ -62,19 +71,27 @@ export function RunActionBar({
                 <Button
                   variant="outline"
                   size="icon-sm"
-                  disabled={busy}
-                  onClick={() => void run(() => sendStop(projectId, runId ?? undefined), 'Could not stop the session.')}
+                  aria-label="Stop session"
+                  disabled={stopping}
+                  onClick={() =>
+                    void run(() => sendStop(projectId, runId ?? undefined).then(() => true), 'Could not stop the session.').then(
+                      result => result && setStopRequested(true),
+                    )
+                  }
                 />
               }
             >
               <Square className="h-3 w-3 fill-current" />
             </TooltipTrigger>
-            <TooltipContent>{busy ? 'Stopping…' : 'Stop session'}</TooltipContent>
+            <TooltipContent>{stopping ? 'Stopping…' : 'Stop session'}</TooltipContent>
           </Tooltip>
         )}
         {/* A retained worktree only exists for a finished run, so this never sits beside Stop. */}
         {retainedWorktree && !active && runId && (
           <RemoveWorktreeButton projectId={projectId} runId={runId} onRemoved={() => onWorktreeRemoved?.()} />
+        )}
+        {!session && info?.sessionId && (
+          <CopyButton text={info.sessionId} label={`Copy session id (${info.sessionId})`} className="p-1.5" />
         )}
         {session && (
           <Tooltip>
@@ -84,6 +101,7 @@ export function RunActionBar({
                   href={session.href}
                   target="_blank"
                   rel="noreferrer"
+                  aria-label={session.label.replace(' ↗', '')}
                   className={buttonVariants({ variant: 'outline', size: 'icon-sm' })}
                 />
               }

--- a/packages/framework-dashboard/components/RunChat.tsx
+++ b/packages/framework-dashboard/components/RunChat.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react'
 import { Composer, type ComposerHandle } from './Composer.js'
 import { sendMessage } from '../server/control.telefunc.js'
+import { useAction } from '../lib/use-action.js'
 
 // The live-chat composer (#714/#721): send more messages to a running run. Reuses the same shared
 // Composer the launcher uses, so `/` presets, `<` tags, and `@`/`#` mentions work here too. On
@@ -26,30 +27,40 @@ export function RunChat({
   sessionName?: string | undefined
 }) {
   const composerRef = useRef<ComposerHandle>(null)
-  const [sending, setSending] = useState(false)
+  const { busy, error, run } = useAction()
+  // The last message that went through: a queued control entry is invisible until the agent
+  // drains it between turns, so without this the send looked like nothing happened (#948).
+  const [queued, setQueued] = useState<string | null>(null)
 
   const send = async (text: string): Promise<void> => {
-    if (sending) return
-    setSending(true)
-    try {
-      await sendMessage(projectId, text, runId ?? undefined)
+    if (busy) return
+    // sendMessage resolves void; map success to `true` so it is tellable from useAction's
+    // failure `undefined`.
+    const result = await run(
+      () => sendMessage(projectId, text, runId ?? undefined).then(() => true),
+      'Could not send — the session may have just ended. Your text is kept, try again.',
+    )
+    if (result) {
+      setQueued(text)
       composerRef.current?.clear()
-    } catch {
-      // Leave the text in place so the user can retry; the run may have just ended.
-    } finally {
-      setSending(false)
-      composerRef.current?.focus()
     }
+    composerRef.current?.focus()
   }
 
   return (
     <div className="border-t border-border p-2">
+      {queued && !error && (
+        <p role="status" className="mb-1 truncate px-2 text-xs text-muted-foreground">
+          Queued — the session reads it between turns: &ldquo;{queued}&rdquo;
+        </p>
+      )}
+      {error && <p role="alert" className="mb-1 px-2 text-xs text-red-500">{error}</p>}
       <Composer
         ref={composerRef}
         files={files}
         addContext={addContext}
         onSubmit={send}
-        busy={sending}
+        busy={busy}
         submitLabel="Send"
         submitBusyLabel="Sending…"
         showAgentModel={false}

--- a/packages/framework-dashboard/components/RunChat.tsx
+++ b/packages/framework-dashboard/components/RunChat.tsx
@@ -14,6 +14,7 @@ export function RunChat({
   runId,
   files,
   addContext,
+  removeContext,
   sessionName,
 }: {
   projectId: string
@@ -23,6 +24,8 @@ export function RunChat({
   files: string[]
   /** Add a path to the run Context (from an `@`/`#` mention). */
   addContext: (path: string) => void
+  /** Drop a path from the run Context when its chip leaves the editor (#948). */
+  removeContext?: ((path: string) => void) | undefined
   /** This session's name (#874), so a preset launched here targets it by default. */
   sessionName?: string | undefined
 }) {
@@ -59,6 +62,7 @@ export function RunChat({
         ref={composerRef}
         files={files}
         addContext={addContext}
+        removeContext={removeContext}
         onSubmit={send}
         busy={busy}
         submitLabel="Send"

--- a/packages/framework-dashboard/components/RunChat.tsx
+++ b/packages/framework-dashboard/components/RunChat.tsx
@@ -68,6 +68,7 @@ export function RunChat({
         submitLabel="Send"
         submitBusyLabel="Sending…"
         showAgentModel={false}
+        inSession
         sessionName={sessionName}
         placeholder="Message the session…  ( / commands · < tags · @ projects · # files )"
       />

--- a/packages/framework-dashboard/components/RunFeed.tsx
+++ b/packages/framework-dashboard/components/RunFeed.tsx
@@ -1,17 +1,40 @@
 import type { FrameworkEvent } from '@gemstack/framework'
+import { TriangleAlert } from 'lucide-react'
 import { EventList } from './EventList.js'
 import { RunOverview } from './RunOverview.js'
 
 // One run's feed: the run overview plus the live/replayed event log, or a waiting placeholder
 // before anything has streamed. Shared by the run's own view (RunLive, which shows the session
 // link in its action bar instead — `showSessionLink={false}`) and the read-only relay watch view
-// (RelayView, which keeps it since it has no action bar).
-export function RunFeed({ events, showSessionLink = true }: { events: FrameworkEvent[]; showSessionLink?: boolean }) {
+// (RelayView, which keeps it since it has no action bar). `lost` is the live channel's health
+// (#948): while the stream is down the feed is behind reality, and saying so beats letting
+// "the agent went quiet" and "the connection died" look identical.
+export function RunFeed({
+  events,
+  showSessionLink = true,
+  lost = false,
+}: {
+  events: FrameworkEvent[]
+  showSessionLink?: boolean
+  lost?: boolean
+}) {
+  const lostBanner = lost && (
+    <div role="status" className="flex items-center gap-2 border-b border-border bg-amber-500/10 px-4 py-2 text-xs text-amber-600 dark:text-amber-400">
+      <TriangleAlert className="h-3.5 w-3.5 shrink-0" aria-hidden />
+      Live stream lost — reconnecting. The session keeps running; this view may be behind.
+    </div>
+  )
   if (events.length === 0) {
-    return <div className="grid flex-1 place-items-center text-sm text-muted-foreground">Waiting for the session to start…</div>
+    return (
+      <>
+        {lostBanner}
+        <div className="grid flex-1 place-items-center text-sm text-muted-foreground">Waiting for the session to start…</div>
+      </>
+    )
   }
   return (
     <>
+      {lostBanner}
       <RunOverview events={events} showSessionLink={showSessionLink} />
       <EventList events={events} />
     </>

--- a/packages/framework-dashboard/components/RunHandoffPanel.tsx
+++ b/packages/framework-dashboard/components/RunHandoffPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { RunHandoff } from '@gemstack/framework'
 import { GitBranch, GitPullRequest, Upload } from 'lucide-react'
 import { onRunHandoff } from '../server/reads.telefunc.js'
@@ -6,6 +7,7 @@ import { usePolled } from '../lib/use-async.js'
 import { useAction } from '../lib/use-action.js'
 import { DiffStat } from './DiffView.js'
 import { Button } from './ui/button.js'
+import { CopyButton } from './ui/copy-button.js'
 
 // The end-of-session handoff (#799): what this session produced, and the next step offered rather
 // than described. Before this, a finished session showed no branch, no commits and no diff, so
@@ -27,13 +29,19 @@ export function RunHandoffPanel({ projectId, runId }: { projectId: string; runId
     [projectId, runId],
   )
   const { busy, error, run } = useAction()
+  // Which button is in flight, so it can say "Pushing…" rather than silently greying (#948).
+  const [pending, setPending] = useState<'push' | 'pr' | null>(null)
 
   // Nothing read yet, or nothing to report (no git repo, unknown session): say nothing rather
   // than flash a wrong empty state.
   if (!loaded || !handoff) return null
 
-  const act = (fn: () => Promise<unknown>, fallback: string): void => {
-    void run(fn, fallback).then(result => result !== undefined && reload())
+  const act = (which: 'push' | 'pr', fn: () => Promise<unknown>, fallback: string): void => {
+    setPending(which)
+    void run(fn, fallback).then(result => {
+      setPending(null)
+      if (result !== undefined) reload()
+    })
   }
 
   return (
@@ -44,11 +52,12 @@ export function RunHandoffPanel({ projectId, runId }: { projectId: string; runId
           <span className="truncate font-medium text-foreground" title={handoff.branch}>
             {handoff.branch}
           </span>
+          <CopyButton text={handoff.branch} label="Copy branch name" />
         </span>
         <Summary handoff={handoff} />
         <div className="min-w-0 flex-1" />
         {error && <span className="text-red-500">{error}</span>}
-        <Actions handoff={handoff} busy={busy} act={act} projectId={projectId} runId={runId} />
+        <Actions handoff={handoff} busy={busy} pending={pending} act={act} projectId={projectId} runId={runId} />
       </div>
       {!handoff.empty && handoff.exists && (
         <div className="mt-3 grid gap-3 sm:grid-cols-2">
@@ -78,6 +87,8 @@ function Summary({ handoff }: { handoff: RunHandoff }) {
       <span>·</span>
       <span>{files}</span>
       <DiffStat added={handoff.insertions} removed={handoff.deletions} className="text-xs" />
+      {/* Whether the work is on the remote yet is the first handoff question — say it. */}
+      {handoff.pushed && !handoff.pr && <span className="text-muted-foreground">· pushed</span>}
       {handoff.merged && <span className="text-muted-foreground">· merged</span>}
     </span>
   )
@@ -93,13 +104,15 @@ function Summary({ handoff }: { handoff: RunHandoff }) {
 function Actions({
   handoff,
   busy,
+  pending,
   act,
   projectId,
   runId,
 }: {
   handoff: RunHandoff
   busy: boolean
-  act: (fn: () => Promise<unknown>, fallback: string) => void
+  pending: 'push' | 'pr' | null
+  act: (which: 'push' | 'pr', fn: () => Promise<unknown>, fallback: string) => void
   projectId: string
   runId: string
 }) {
@@ -131,19 +144,19 @@ function Actions({
           variant="outline"
           size="xs"
           disabled={busy}
-          onClick={() => act(() => sendPushBranch(projectId, runId), 'Could not push the branch.')}
+          onClick={() => act('push', () => sendPushBranch(projectId, runId), 'Could not push the branch.')}
         >
           <Upload className="h-3.5 w-3.5" />
-          Push branch
+          {pending === 'push' ? 'Pushing…' : 'Push branch'}
         </Button>
       )}
       <Button
         size="xs"
         disabled={busy}
-        onClick={() => act(() => sendOpenPullRequest(projectId, runId), 'Could not open the pull request.')}
+        onClick={() => act('pr', () => sendOpenPullRequest(projectId, runId), 'Could not open the pull request.')}
       >
         <GitPullRequest className="h-3.5 w-3.5" />
-        Open PR
+        {pending === 'pr' ? 'Opening PR…' : 'Open PR'}
       </Button>
     </div>
   )

--- a/packages/framework-dashboard/components/RunHistory.tsx
+++ b/packages/framework-dashboard/components/RunHistory.tsx
@@ -53,6 +53,14 @@ export function RunHistory({
   useEffect(() => {
     setOptimistic(null)
   }, [projectId])
+  // A failed start has no running run to hand over to, so without a deadline the row said
+  // "starting…" forever (#948). The Start form surfaces the actual error; this just stops
+  // the rail pretending.
+  useEffect(() => {
+    if (optimistic === null || hasRunning) return
+    const timer = setTimeout(() => setOptimistic(null), 20_000)
+    return () => clearTimeout(timer)
+  }, [optimistic, hasRunning])
 
   if (!projectId) return null
 
@@ -168,6 +176,9 @@ function RunRow({
         dim && 'opacity-70',
       )}
       onClick={onClick}
+      // Collapsed, the visible labels fade and the row is carried by a colour dot; keep the
+      // whole story reachable by hover and assistive tech (#948).
+      {...(collapsed ? { title: `${parked ? 'waiting' : status}: ${intent || '(no prompt)'}`, 'aria-label': `${parked ? 'waiting' : status}: ${intent || '(no prompt)'}` } : {})}
     >
       <span className="flex w-full items-center gap-2">
         {/* The dot means "the agent is working", so a run parked on you gets a still one (#785):

--- a/packages/framework-dashboard/components/RunLive.tsx
+++ b/packages/framework-dashboard/components/RunLive.tsx
@@ -18,6 +18,7 @@ export function RunLive({
   events,
   files,
   addContext,
+  lost = false,
 }: {
   projectId: string
   /** Which run to steer (#749); absent right after Start, before the poll adopts its id. */
@@ -25,6 +26,8 @@ export function RunLive({
   events: FrameworkEvent[]
   files: string[]
   addContext: (path: string) => void
+  /** The live channel's health (#948) — surfaced as a banner over the feed. */
+  lost?: boolean
 }) {
   // The session's own name, once the agent has set it (#874): presets in the chat below default
   // to targeting this session rather than the whole codebase.
@@ -35,7 +38,7 @@ export function RunLive({
       {/* What it has changed so far (#817). Only once the run's id is known: without one the read
           falls back to the project root and would report the user's own dirty files as the run's. */}
       {runId && <RunChanges projectId={projectId} runId={runId} />}
-      <RunFeed events={events} showSessionLink={false} />
+      <RunFeed events={events} showSessionLink={false} lost={lost} />
       <RunChat projectId={projectId} runId={runId} files={files} addContext={addContext} sessionName={sessionName} />
     </>
   )

--- a/packages/framework-dashboard/components/RunLive.tsx
+++ b/packages/framework-dashboard/components/RunLive.tsx
@@ -18,6 +18,7 @@ export function RunLive({
   events,
   files,
   addContext,
+  removeContext,
   lost = false,
 }: {
   projectId: string
@@ -26,6 +27,7 @@ export function RunLive({
   events: FrameworkEvent[]
   files: string[]
   addContext: (path: string) => void
+  removeContext?: ((path: string) => void) | undefined
   /** The live channel's health (#948) — surfaced as a banner over the feed. */
   lost?: boolean
 }) {
@@ -39,7 +41,7 @@ export function RunLive({
           falls back to the project root and would report the user's own dirty files as the run's. */}
       {runId && <RunChanges projectId={projectId} runId={runId} />}
       <RunFeed events={events} showSessionLink={false} lost={lost} />
-      <RunChat projectId={projectId} runId={runId} files={files} addContext={addContext} sessionName={sessionName} />
+      <RunChat projectId={projectId} runId={runId} files={files} addContext={addContext} removeContext={removeContext} sessionName={sessionName} />
     </>
   )
 }

--- a/packages/framework-dashboard/components/RunOverview.tsx
+++ b/packages/framework-dashboard/components/RunOverview.tsx
@@ -1,7 +1,7 @@
 import type { FrameworkEvent } from '@gemstack/framework'
 import { loopStatus, sessionInfo, deployPlan, runProgress } from '@gemstack/framework/client'
 import { Badge } from './ui/badge.js'
-import { isRunActive } from '../lib/live-state.js'
+import { isRunActive, runOutcome } from '../lib/live-state.js'
 import { describeSessionLink } from '../lib/session-link.js'
 import { cn } from '../lib/utils.js'
 
@@ -15,10 +15,24 @@ export function RunOverview({ events, showSessionLink = true }: { events: Framew
   const session = sessionInfo(events)
   const deploy = deployPlan(events)
   const progress = runProgress(events)
-  const hasProgress = Boolean(progress.sessionName) || progress.readyForMerge
   // A run only pulses "building…" while it's live (#695/U20): once the `end` event lands the
-  // pill must settle to the final state ("ready for merge" or "finished") instead of pulsing on.
+  // pill must settle to the final state instead of pulsing on. How it ended matters (#948):
+  // a crash or a user stop must not read as a plain "finished", and it outranks an earlier
+  // ready-for-merge — the green would be a lie about a run that then failed.
   const active = isRunActive(events)
+  const outcome = runOutcome(events)
+  const failed = outcome !== undefined && !outcome.ok && !outcome.stopped
+  const stopped = outcome?.stopped === true
+  const hasProgress = Boolean(progress.sessionName) || progress.readyForMerge || failed || stopped
+  const status = failed
+    ? { dot: 'bg-red-500', label: outcome?.detail ? `failed — ${outcome.detail}` : 'failed', tone: 'text-red-500' }
+    : stopped
+      ? { dot: 'bg-amber-500', label: 'stopped', tone: 'text-amber-600 dark:text-amber-400' }
+      : progress.readyForMerge
+        ? { dot: 'bg-green-500', label: 'ready for merge', tone: 'text-muted-foreground' }
+        : active
+          ? { dot: 'animate-pulse bg-amber-500', label: 'building…', tone: 'text-muted-foreground' }
+          : { dot: 'bg-muted-foreground', label: 'finished', tone: 'text-muted-foreground' }
 
   // The "Open session" link, labeled honestly: a headless Claude Code run has no per-session
   // URL, so the generic app entry (claude.ai/code) is shown as "Open Claude Code" with the id
@@ -32,25 +46,19 @@ export function RunOverview({ events, showSessionLink = true }: { events: Framew
     <div className="grid gap-3 border-b border-border p-4 md:grid-cols-2">
       {hasProgress && (
         <div className="flex items-center gap-2 text-sm md:col-span-2">
-          <span
-            className={cn(
-              'h-2.5 w-2.5 shrink-0 rounded-full',
-              progress.readyForMerge ? 'bg-green-500' : active ? 'animate-pulse bg-amber-500' : 'bg-muted-foreground',
-            )}
-            aria-hidden
-          />
+          <span className={cn('h-2.5 w-2.5 shrink-0 rounded-full', status.dot)} aria-hidden />
           {progress.sessionName && <span className="font-medium">{progress.sessionName}</span>}
-          <span className="text-xs text-muted-foreground">
-            {progress.readyForMerge ? 'ready for merge' : active ? 'building…' : 'finished'}
-          </span>
+          <span className={cn('text-xs', status.tone)}>{status.label}</span>
         </div>
       )}
       {loop && (
         <section className="rounded-lg border border-border p-3">
           <h3 className="mb-1 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             Loop status
+            {/* "ended early", not "stopped": the loop finishing without passing is not the user
+                stopping the session, and the status pill above may say "stopped" for that. */}
             <Badge className={loop.productionGrade ? 'text-primary' : loop.finished ? 'text-muted-foreground' : ''}>
-              {loop.productionGrade ? 'production-grade' : loop.finished ? 'stopped' : `pass ${loop.pass}`}
+              {loop.productionGrade ? 'production-grade' : loop.finished ? 'ended early' : `pass ${loop.pass}`}
             </Badge>
           </h3>
           {loop.blockers.length > 0 ? (

--- a/packages/framework-dashboard/components/RunReplay.tsx
+++ b/packages/framework-dashboard/components/RunReplay.tsx
@@ -19,12 +19,14 @@ export function RunReplay({
   runId,
   files,
   addContext,
+  removeContext,
   onRunStarted,
 }: {
   projectId: string
   runId: string
   files: string[]
   addContext: (path: string) => void
+  removeContext?: ((path: string) => void) | undefined
   onRunStarted: (intent: string) => void
 }) {
   // null until the first answer: "Loading session…" and "no events" are different things.
@@ -65,7 +67,7 @@ export function RunReplay({
         <EventList events={events} stick={false} openAt="end" />
       )}
       {sessionId ? (
-        <RunResumeChat projectId={projectId} runId={runId} sessionId={sessionId} driver={session?.driver} files={files} addContext={addContext} onRunStarted={onRunStarted} sessionName={sessionName} outcome={runOutcome(events)} />
+        <RunResumeChat projectId={projectId} runId={runId} sessionId={sessionId} driver={session?.driver} files={files} addContext={addContext} removeContext={removeContext} onRunStarted={onRunStarted} sessionName={sessionName} outcome={runOutcome(events)} />
       ) : (
         events.length > 0 && (
           // Say why there is no composer here, instead of a wordless dead-end (#948).

--- a/packages/framework-dashboard/components/RunReplay.tsx
+++ b/packages/framework-dashboard/components/RunReplay.tsx
@@ -7,6 +7,7 @@ import { RunActionBar } from './RunActionBar.js'
 import { RunHandoffPanel } from './RunHandoffPanel.js'
 import { RunResumeChat } from './RunResumeChat.js'
 import { useLoaded } from '../lib/use-async.js'
+import { runOutcome } from '../lib/live-state.js'
 
 // Replay one archived run: load its event log over a Telefunc RPC and render it in the same
 // EventList the live stream uses (no auto-scroll — it is a static log). The action bar rides
@@ -59,10 +60,19 @@ export function RunReplay({
       {events.length === 0 ? (
         <div className="grid flex-1 place-items-center text-sm text-muted-foreground">This session has no events.</div>
       ) : (
-        <EventList events={events} stick={false} />
+        // Open at the end: the outcome, the final spend, and the last changes live there, and
+        // they are what a finished session gets opened for (#948). Scroll up for the history.
+        <EventList events={events} stick={false} openAt="end" />
       )}
-      {sessionId && (
-        <RunResumeChat projectId={projectId} runId={runId} sessionId={sessionId} driver={session?.driver} files={files} addContext={addContext} onRunStarted={onRunStarted} sessionName={sessionName} />
+      {sessionId ? (
+        <RunResumeChat projectId={projectId} runId={runId} sessionId={sessionId} driver={session?.driver} files={files} addContext={addContext} onRunStarted={onRunStarted} sessionName={sessionName} outcome={runOutcome(events)} />
+      ) : (
+        events.length > 0 && (
+          // Say why there is no composer here, instead of a wordless dead-end (#948).
+          <p className="border-t border-border p-3 text-xs text-muted-foreground">
+            This session can&rsquo;t be continued — it ended before the agent reported a session id to resume.
+          </p>
+        )
       )}
     </>
   )

--- a/packages/framework-dashboard/components/RunResumeChat.tsx
+++ b/packages/framework-dashboard/components/RunResumeChat.tsx
@@ -18,6 +18,7 @@ export function RunResumeChat({
   driver,
   files,
   addContext,
+  removeContext,
   onRunStarted,
   sessionName,
   outcome,
@@ -31,6 +32,8 @@ export function RunResumeChat({
   driver?: string | undefined
   files: string[]
   addContext: (path: string) => void
+  /** Drop a path from the run Context when its chip leaves the editor (#948). */
+  removeContext?: ((path: string) => void) | undefined
   onRunStarted: (intent: string, runId?: string) => void
   /** This session's name (#874), so a preset launched here targets it by default. */
   sessionName?: string | undefined
@@ -79,6 +82,7 @@ export function RunResumeChat({
         ref={composerRef}
         files={files}
         addContext={addContext}
+        removeContext={removeContext}
         onSubmit={send}
         busy={busy}
         submitLabel="Send"

--- a/packages/framework-dashboard/components/RunResumeChat.tsx
+++ b/packages/framework-dashboard/components/RunResumeChat.tsx
@@ -88,6 +88,7 @@ export function RunResumeChat({
         submitLabel="Send"
         submitBusyLabel="Resuming…"
         showAgentModel={false}
+        inSession
         sessionName={sessionName}
         placeholder="Message the session to continue it…  ( / commands · < tags · @ projects · # files )"
       />

--- a/packages/framework-dashboard/components/RunResumeChat.tsx
+++ b/packages/framework-dashboard/components/RunResumeChat.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react'
 import { Composer, type ComposerHandle } from './Composer.js'
 import { agentForDriver } from '@gemstack/framework/client'
 import { useStartRun } from '../lib/use-start-run.js'
+import type { RunOutcome } from '../lib/live-state.js'
 
 // The finished-run composer (#720): keep talking to a run that has ended. A live run drains
 // messages in-process (RunChat + sendMessage), but a finished run has no process — so sending here
@@ -19,6 +20,7 @@ export function RunResumeChat({
   addContext,
   onRunStarted,
   sessionName,
+  outcome,
 }: {
   projectId: string
   /** The run being continued (#762), so the follow-up reopens it instead of starting a new one. */
@@ -32,6 +34,8 @@ export function RunResumeChat({
   onRunStarted: (intent: string, runId?: string) => void
   /** This session's name (#874), so a preset launched here targets it by default. */
   sessionName?: string | undefined
+  /** How the run ended (#948), so the note does not call a crash "ended". */
+  outcome?: RunOutcome | undefined
 }) {
   const composerRef = useRef<ComposerHandle>(null)
   const { busy, error, start } = useStartRun()
@@ -64,7 +68,13 @@ export function RunResumeChat({
 
   return (
     <div className="border-t border-border p-2">
-      <p className="mb-2 text-xs text-muted-foreground">Session ended — your next message continues it.</p>
+      <p className="mb-2 text-xs text-muted-foreground">
+        {outcome && !outcome.ok && !outcome.stopped
+          ? 'Session failed — your next message resumes it where it stopped.'
+          : outcome?.stopped
+            ? 'Session stopped — your next message resumes it.'
+            : 'Session ended — your next message continues it.'}
+      </p>
       <Composer
         ref={composerRef}
         files={files}

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -21,6 +21,7 @@ export function StartRunForm({
   files,
   context,
   addContext,
+  removeContext,
   toggleContext,
 }: {
   projectId: string
@@ -31,6 +32,8 @@ export function StartRunForm({
   context: Set<string>
   /** Add a path to the Context (from an `@`/`#` mention). */
   addContext: (path: string) => void
+  /** Drop a path from the Context when its `@`/`#` chip leaves the editor (#948). */
+  removeContext: (path: string) => void
   /** Toggle a path in the Context (from a repo checkbox). */
   toggleContext: (path: string) => void
 }) {
@@ -90,6 +93,7 @@ export function StartRunForm({
         ref={composerRef}
         files={files}
         addContext={addContext}
+        removeContext={removeContext}
         onSubmit={submit}
         onPromptChange={value => {
           setPrompt(value)
@@ -125,8 +129,9 @@ export function StartRunForm({
         busy={busy}
       />
 
-      {(otherProjects.length > 0 || contextFiles.length > 0) && (
-        <div className="mt-3 text-xs text-muted-foreground">
+      {/* Always rendered (#948): hiding the whole section for a single-project setup also hid
+          the only place that teaches the `#` / Files-tab focus flow. */}
+      <div className="mt-3 text-xs text-muted-foreground">
           <DisclosureToggle open={showContext} onToggle={() => setShowContext(s => !s)}>
             Context{contextSummary && <span className="text-primary"> · {contextSummary}</span>}
           </DisclosureToggle>
@@ -162,8 +167,7 @@ export function StartRunForm({
               </div>
             </div>
           )}
-        </div>
-      )}
+      </div>
 
       {error && <p className="mt-2 text-xs text-red-500">{error}</p>}
       {note && !error && <p className="mt-2 text-xs text-muted-foreground">{note}</p>}

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -98,6 +98,8 @@ export function StartRunForm({
         onPromptChange={value => {
           setPrompt(value)
           if (!value.trim() && note) setNote(null)
+          // Editing after a failed start: the red error described the old attempt, drop it (#948).
+          if (error) reset()
         }}
         onPreset={(label, replaced) => {
           reset()
@@ -112,6 +114,11 @@ export function StartRunForm({
         submitBusyLabel="Starting…"
         showShortcutHint
       />
+
+      {/* Feedback right where the action is (#948): the error used to render below the (possibly
+          expanded, tall) Context disclosure, past the fold from the Start button that caused it. */}
+      {error && <p role="alert" className="mt-2 text-xs text-red-500">{error}</p>}
+      {note && !error && <p role="status" className="mt-2 text-xs text-muted-foreground">{note}</p>}
 
       <SystemPromptDisclosure
         prompt={prompt}
@@ -168,9 +175,6 @@ export function StartRunForm({
             </div>
           )}
       </div>
-
-      {error && <p className="mt-2 text-xs text-red-500">{error}</p>}
-      {note && !error && <p className="mt-2 text-xs text-muted-foreground">{note}</p>}
     </form>
   )
 }

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -95,9 +95,13 @@ export function StartRunForm({
           setPrompt(value)
           if (!value.trim() && note) setNote(null)
         }}
-        onPreset={label => {
+        onPreset={(label, replaced) => {
           reset()
-          setNote(`${label} preset loaded — review or edit, then Start`)
+          setNote(
+            replaced
+              ? `${label} preset loaded over your draft — undo (⌘Z) brings the draft back`
+              : `${label} preset loaded — review or edit, then Start`,
+          )
         }}
         busy={busy}
         submitLabel="Start session"

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react'
 import type { ProjectSummary } from '@gemstack/framework'
 import { runOptionsFromPreferences } from '@gemstack/framework/client'
 import { onProjects } from '../server/projects.telefunc.js'
+import { onSystemPromptUser } from '../server/reads.telefunc.js'
 import { usePreferences, updatePreferences, autopilotEnabled } from '../lib/preferences.js'
 import { useStartRun } from '../lib/use-start-run.js'
 import { useLoaded } from '../lib/use-async.js'
@@ -52,6 +53,9 @@ export function StartRunForm({
   // narrows its focus — the picked paths become one `Context:` line in the system prompt.
   const projects = useLoaded<ProjectSummary[]>(onProjects, [], [])
   const [showContext, setShowContext] = useState(false)
+  // The repo's own SYSTEM.md (#872): composition takes it as `user`, but reading it is
+  // Node-bound, so without this read the "entire system prompt" preview under-reported.
+  const userSystemPrompt = useLoaded<string | null>(() => onSystemPromptUser(projectId), null, [projectId])
 
   // The Context set mixes whole repos (registered project paths) and individual files (relative
   // paths). Split out the files so they can be shown + removed, and count each kind separately.
@@ -133,6 +137,7 @@ export function StartRunForm({
         autopilot={autopilot}
         eco={options.eco}
         context={[...context]}
+        user={userSystemPrompt}
         busy={busy}
       />
 

--- a/packages/framework-dashboard/components/SystemPromptDisclosure.tsx
+++ b/packages/framework-dashboard/components/SystemPromptDisclosure.tsx
@@ -31,6 +31,7 @@ export function SystemPromptDisclosure({
   autopilot,
   eco,
   context,
+  user,
   busy,
 }: {
   /** What the user has typed. It rides inside the prompt, so it shapes the preview. */
@@ -47,6 +48,8 @@ export function SystemPromptDisclosure({
   autopilot: boolean
   eco: EcoOptions | undefined
   context: string[]
+  /** The repo's own SYSTEM.md text (#872), so the preview shows the prompt the run sends. */
+  user?: string | null | undefined
   busy: boolean
 }) {
   const [open, setOpen] = useState(false)
@@ -57,6 +60,7 @@ export function SystemPromptDisclosure({
     ...(browser ? { browser: true } : {}),
     tf: { prompt, params: { autopilot, ...(eco ? { eco } : {}) } },
     ...(context.length ? { context } : {}),
+    ...(user ? { user } : {}),
   })
 
   // Transparent is the master off-switch, so it turns the built-in block off whatever

--- a/packages/framework-dashboard/components/ThemeToggle.test.tsx
+++ b/packages/framework-dashboard/components/ThemeToggle.test.tsx
@@ -35,12 +35,12 @@ describe('ThemeToggle (#754)', () => {
   test('the trigger shows the current theme, so the header says which is on', () => {
     usePreferences.mockReturnValue({ theme: 'dark' })
     render(<ThemeToggle />)
-    expect(screen.getByRole('button', { name: /theme/i }).getAttribute('title')).toBe('Theme: dark')
+    expect(screen.getByRole('button', { name: /theme/i }).getAttribute('title')).toBe('Theme: Dark')
   })
 
   test('an unset preference reads as system, the default', () => {
     usePreferences.mockReturnValue({})
     render(<ThemeToggle />)
-    expect(screen.getByRole('button', { name: /theme/i }).getAttribute('title')).toBe('Theme: system')
+    expect(screen.getByRole('button', { name: /theme/i }).getAttribute('title')).toBe('Theme: System')
   })
 })

--- a/packages/framework-dashboard/components/ThemeToggle.tsx
+++ b/packages/framework-dashboard/components/ThemeToggle.tsx
@@ -22,13 +22,14 @@ export function ThemeToggle() {
   const preferences = usePreferences()
   const theme = themePreference(preferences)
   // The trigger wears the current choice, so the header says which theme is on without opening it.
-  const Current = (THEME_OPTIONS.find(t => t.value === theme) ?? THEME_OPTIONS[0]!).icon
+  const current = THEME_OPTIONS.find(t => t.value === theme) ?? THEME_OPTIONS[0]!
+  const Current = current.icon
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
         className={cn(buttonVariants({ variant: 'ghost', size: 'icon-sm' }), 'shrink-0 text-muted-foreground')}
-        title={`Theme: ${theme}`}
+        title={`Theme: ${current.label}`}
         aria-label="Theme"
       >
         <Current className="h-4 w-4" />

--- a/packages/framework-dashboard/components/TicketsPanel.tsx
+++ b/packages/framework-dashboard/components/TicketsPanel.tsx
@@ -29,7 +29,15 @@ const PRIORITY_TONE: Record<string, string> = {
 // The tickets view (#697): the project's `tickets/*.md`, so the backlog the agent plans from
 // is readable without opening the repo. Each row can be put on the agent queue, and an empty
 // `tickets/` offers to import the repo's GitHub issues instead of just saying "nothing here".
-export function TicketsPanel({ projectId }: { projectId: string | null }) {
+export function TicketsPanel({
+  projectId,
+  onRunStarted,
+}: {
+  projectId: string | null
+  /** Told when the import session starts, so the shell can show it (#948) — the button used
+   *  to flip "Starting…" and leave you staring at the still-empty panel. */
+  onRunStarted?: ((intent: string, runId?: string) => void) | undefined
+}) {
   const { value: tickets, loaded } = usePolled<WorkspaceTicket[]>(
     projectId ? () => onTickets(projectId) : null,
     [],
@@ -50,8 +58,12 @@ export function TicketsPanel({ projectId }: { projectId: string | null }) {
     if (result?.ok) setQueued(prev => new Set(prev).add(ticket.file))
   }
 
-  const importFromGithub = () =>
-    run(() => sendStart(projectId, IMPORT_PROMPT, 'prompt'), 'The import could not be started.')
+  const importFromGithub = async () => {
+    const result = await run(() => sendStart(projectId, IMPORT_PROMPT, 'prompt'), 'The import could not be started.')
+    // Jump to the session doing the import, so its progress is watchable instead of the
+    // panel sitting empty until files land.
+    if (result?.ok) onRunStarted?.(IMPORT_PROMPT, result.runId)
+  }
 
   if (tickets.length === 0) {
     return (

--- a/packages/framework-dashboard/components/ViewsRail.tsx
+++ b/packages/framework-dashboard/components/ViewsRail.tsx
@@ -1,15 +1,28 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { AgentView } from '../lib/live-state.js'
 import { Markdown } from './Markdown.js'
 import { cn } from '../lib/utils.js'
 import { ScrollArea } from './ui/scroll-area.js'
+import { CopyButton } from './ui/copy-button.js'
 
 // The agent-views rail (#441, part of #314): the ad-hoc markdown the agent pushed to the
 // side panel via showMarkdown() (a plan, a summary, a writeup), each a first-class view
 // with a sticky top-nav to jump between them. Unlike the choice gates it never blocks the
-// run; views arrive over the live event stream and update in place when re-shown.
+// run; views arrive over the live event stream and update in place when re-shown. A newly
+// pushed view selects itself (#948) — the rail's tab badge only counts, so view 3 landing
+// while you read view 0 used to be invisible. A view is also copy-bait (it is the plan or
+// summary you paste elsewhere), so it gets a copy button.
 export function ViewsRail({ views }: { views: AgentView[] }) {
   const [active, setActive] = useState(0)
+
+  // Jump to a view we have not seen before; re-shown views update in place without stealing
+  // the selection.
+  const known = useRef<Set<string>>(new Set())
+  useEffect(() => {
+    const fresh = views.findIndex(v => !known.current.has(v.id))
+    for (const v of views) known.current.add(v.id)
+    if (fresh >= 0) setActive(fresh)
+  }, [views])
 
   // A view can vanish (a new run truncates the stream); keep the selection in range.
   const current = views[Math.min(active, views.length - 1)]
@@ -39,7 +52,10 @@ export function ViewsRail({ views }: { views: AgentView[] }) {
       )}
       <ScrollArea viewportRef={scroller} className="min-h-0 flex-1">
         <div className="p-4">
-          <h2 className="mb-2 text-sm font-semibold">{current.title}</h2>
+          <h2 className="mb-2 flex items-center gap-1.5 text-sm font-semibold">
+            {current.title}
+            <CopyButton text={current.markdown} label="Copy this view as markdown" />
+          </h2>
           <Markdown text={current.markdown} />
         </div>
       </ScrollArea>

--- a/packages/framework-dashboard/components/prompt-editor/SuggestionList.tsx
+++ b/packages/framework-dashboard/components/prompt-editor/SuggestionList.tsx
@@ -4,6 +4,8 @@ import { cn } from '../../lib/utils.js'
 // The floating command/reference menu (#470) the `/` and `@` triggers open. A shadcn-style
 // popover surface driven imperatively by @tiptap/suggestion (which owns positioning), so it
 // is a plain list here: arrow keys move, Enter/Tab pick, and items may carry a group header.
+// It reads as a listbox to assistive tech (#948): options carry ids the editor's
+// aria-activedescendant points at, since focus never leaves the contenteditable.
 export interface SuggestionItem {
   id: string
   label: string
@@ -17,20 +19,35 @@ export interface SuggestionItem {
 export interface SuggestionListProps {
   items: SuggestionItem[]
   command: (item: SuggestionItem) => void
+  /** Shown when there are no items on a fresh trigger (nothing typed yet) — an empty source
+   *  (projects/files not loaded, or none exist) otherwise looks like the feature is broken. */
+  emptyNote?: string | undefined
+  /** The highlighted option's DOM id, for the editor's aria-activedescendant (#948). */
+  onActiveChange?: ((id: string | null) => void) | undefined
 }
 
 export interface SuggestionListRef {
   onKeyDown: (event: KeyboardEvent) => boolean
 }
 
+/** The DOM id for an option row; unique within the one menu that can be open at a time. */
+function optionDomId(index: number): string {
+  return `prompt-suggestion-option-${index}`
+}
+
 export const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>(function SuggestionList(
-  { items, command },
+  { items, command, emptyNote, onActiveChange },
   ref,
 ) {
   const [selected, setSelected] = useState(0)
 
   // Reset the highlight whenever the filtered list changes so it never points past the end.
   useEffect(() => setSelected(0), [items])
+
+  // Mirror the highlight out for aria-activedescendant on the editor.
+  useEffect(() => {
+    onActiveChange?.(items.length > 0 ? optionDomId(selected) : null)
+  }, [items, selected, onActiveChange])
 
   useImperativeHandle(ref, () => ({
     onKeyDown: event => {
@@ -53,15 +70,17 @@ export const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>
   }))
 
   if (items.length === 0) {
+    // Only rendered when the trigger has an emptyNote and nothing was typed yet (suggestion.ts
+    // hides the portal otherwise), so a mistyped query still just closes the menu.
     return (
-      <div className="w-64 rounded-md border border-border bg-card p-2 text-sm text-muted-foreground shadow-md">
-        No matches
+      <div role="status" className="w-64 rounded-md border border-border bg-card p-2 text-sm text-muted-foreground shadow-md">
+        {emptyNote ?? 'No matches'}
       </div>
     )
   }
 
   return (
-    <div className="max-h-72 w-64 overflow-y-auto rounded-md border border-border bg-card p-1 text-sm shadow-md">
+    <div role="listbox" aria-label="Suggestions" className="max-h-72 w-64 overflow-y-auto rounded-md border border-border bg-card p-1 text-sm shadow-md">
       {items.map((item, i) => (
         <div key={item.id}>
           {item.group && (i === 0 || items[i - 1]?.group !== item.group) && (
@@ -71,6 +90,9 @@ export const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>
           )}
           <button
             type="button"
+            id={optionDomId(i)}
+            role="option"
+            aria-selected={i === selected}
             {...(item.title ? { title: item.title } : {})}
             onMouseDown={e => {
               e.preventDefault()

--- a/packages/framework-dashboard/components/prompt-editor/suggestion.ts
+++ b/packages/framework-dashboard/components/prompt-editor/suggestion.ts
@@ -8,7 +8,8 @@ import { SuggestionList, type SuggestionItem, type SuggestionListRef } from './S
 // Wire @tiptap/suggestion (the `/` and `@` triggers, #470) to the floating SuggestionList.
 // The suggestion plugin owns detection + positioning; this renders the React menu into a
 // fixed portal at the caret and forwards key events to it. Each trigger gets its own
-// PluginKey so the two menus never clash.
+// PluginKey so the two menus never clash. The open menu also announces itself to assistive
+// tech (#948): the editor gets aria-expanded + aria-activedescendant while it shows.
 export interface TriggerConfig {
   /** The trigger character: `/` for commands, `@` for references. */
   char: string
@@ -18,6 +19,9 @@ export interface TriggerConfig {
   items: (query: string) => SuggestionItem[]
   /** Perform the insertion when an item is picked. */
   onSelect: (item: SuggestionItem, ctx: { editor: Editor; range: Range }) => void
+  /** Shown when the source is empty on a fresh trigger (nothing typed yet). Without it an
+   *  unloaded/empty source makes the trigger look broken — nothing appears at all (#948). */
+  emptyNote?: string
 }
 
 /** Position a fixed portal just below the caret rect, flipping up near the viewport bottom. */
@@ -38,24 +42,39 @@ type RenderProps = {
   items: SuggestionItem[]
   command: (item: SuggestionItem) => void
   clientRect?: (() => DOMRect | null) | null
+  query?: string
+  editor?: Editor
 }
 
-function makeRender() {
+function makeRender(config: TriggerConfig) {
   let el: HTMLDivElement | null = null
   let root: Root | null = null
   let listRef: SuggestionListRef | null = null
   // The latest caret-rect getter, re-read on scroll/resize so the menu tracks the caret
   // instead of staying pinned where it first opened.
   let getRect: (() => DOMRect | null) | null = null
+  // The editor's contenteditable, for the aria combobox wiring while the menu is open.
+  let editorDom: HTMLElement | null = null
 
-  const draw = (items: SuggestionItem[], command: (item: SuggestionItem) => void): void => {
-    // Close the menu when nothing matches, so a `<`/`@`/`/` with no hit (or a stray `<` in
-    // prose) is not a trap. The plugin stays active — it reappears if a later key matches.
-    if (el) el.style.display = items.length === 0 ? 'none' : ''
+  const setActive = (id: string | null): void => {
+    if (!editorDom) return
+    if (id) editorDom.setAttribute('aria-activedescendant', id)
+    else editorDom.removeAttribute('aria-activedescendant')
+  }
+
+  const draw = (props: RenderProps): void => {
+    const { items, command } = props
+    // An empty-source fresh trigger shows the note; a mistyped query closes the menu, so a
+    // stray `<`/`@` in prose is not a trap. The plugin stays active — the menu reappears if
+    // a later key matches.
+    const note = items.length === 0 && !props.query ? config.emptyNote : undefined
+    if (el) el.style.display = items.length === 0 && !note ? 'none' : ''
     root?.render(
       createElement(SuggestionList, {
         items,
         command,
+        emptyNote: note,
+        onActiveChange: setActive,
         ref: (r: SuggestionListRef | null) => {
           listRef = r
         },
@@ -75,8 +94,10 @@ function makeRender() {
       document.body.appendChild(el)
       root = createRoot(el)
       getRect = props.clientRect ?? null
+      editorDom = props.editor?.view.dom ?? null
+      editorDom?.setAttribute('aria-expanded', 'true')
       reposition()
-      draw(props.items, props.command)
+      draw(props)
       // Capture-phase scroll catches the editor's own scroll container, not just the window.
       window.addEventListener('scroll', reposition, true)
       window.addEventListener('resize', reposition)
@@ -84,7 +105,7 @@ function makeRender() {
     onUpdate(props: RenderProps) {
       getRect = props.clientRect ?? null
       reposition()
-      draw(props.items, props.command)
+      draw(props)
     },
     onKeyDown(props: { event: KeyboardEvent }) {
       if (props.event.key === 'Escape') return false
@@ -93,6 +114,9 @@ function makeRender() {
     onExit() {
       window.removeEventListener('scroll', reposition, true)
       window.removeEventListener('resize', reposition)
+      editorDom?.setAttribute('aria-expanded', 'false')
+      setActive(null)
+      editorDom = null
       root?.unmount()
       el?.remove()
       root = null
@@ -116,7 +140,7 @@ export function makeTrigger(config: TriggerConfig): Extension {
           items: ({ query }: { query: string }) => config.items(query.toLowerCase()),
           command: ({ editor, range, props }: { editor: Editor; range: Range; props: SuggestionItem }) =>
             config.onSelect(props, { editor, range }),
-          render: makeRender,
+          render: () => makeRender(config),
         }),
       ]
     },

--- a/packages/framework-dashboard/components/ui/copy-button.tsx
+++ b/packages/framework-dashboard/components/ui/copy-button.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useRef, useState } from 'react'
+import { Check, Copy } from 'lucide-react'
+import { cn } from '../../lib/utils.js'
+
+// A small copy-to-clipboard affordance (#948) for the strings users take to a terminal:
+// branch names, session ids, URLs. Flashes a check for a beat so the click visibly landed.
+export function CopyButton({ text, label, className }: { text: string; label: string; className?: string }) {
+  const [copied, setCopied] = useState(false)
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  useEffect(() => () => clearTimeout(timer.current), [])
+
+  const copy = () => {
+    void navigator.clipboard?.writeText(text).then(() => {
+      setCopied(true)
+      clearTimeout(timer.current)
+      timer.current = setTimeout(() => setCopied(false), 1500)
+    })
+  }
+
+  const Icon = copied ? Check : Copy
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      aria-label={label}
+      title={label}
+      className={cn(
+        'inline-flex shrink-0 items-center rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground',
+        copied && 'text-emerald-600',
+        className,
+      )}
+    >
+      <Icon className="h-3 w-3" aria-hidden />
+    </button>
+  )
+}

--- a/packages/framework-dashboard/components/ui/option-label.tsx
+++ b/packages/framework-dashboard/components/ui/option-label.tsx
@@ -1,0 +1,11 @@
+// A menu item's label with a short one-line description under it (#654). Shared by the
+// options, notifications, and presets menus so they read identically. Lives in ui/ so a menu
+// can use it without dragging in another menu's module (and its preference wiring).
+export function OptionLabel({ label, description }: { label: string; description?: string | undefined }) {
+  return (
+    <span className="flex flex-col gap-0.5">
+      <span className="leading-tight">{label}</span>
+      {description && <span className="text-xs font-normal text-[var(--color-muted-foreground)]">{description}</span>}
+    </span>
+  )
+}

--- a/packages/framework-dashboard/lib/event-times.ts
+++ b/packages/framework-dashboard/lib/event-times.ts
@@ -1,0 +1,18 @@
+import type { FrameworkEvent } from '@gemstack/framework'
+
+// Arrival times for the live feed (#948). A FrameworkEvent carries no timestamp, so the
+// dashboard stamps each one as it comes off the channel. A side table rather than a field:
+// the event type stays the framework's, and everything downstream (live-state selectors,
+// the replay path, tests) keeps passing plain FrameworkEvent[] around. Replayed events are
+// never stamped, so a past run simply shows no times instead of wrong ones.
+const receivedTimes = new WeakMap<FrameworkEvent, number>()
+
+/** Stamp an event with "now" as it arrives off the live channel. */
+export function stampReceived(event: FrameworkEvent): void {
+  receivedTimes.set(event, Date.now())
+}
+
+/** When the event arrived, or undefined for one that was never live (replay). */
+export function receivedAt(event: FrameworkEvent): number | undefined {
+  return receivedTimes.get(event)
+}

--- a/packages/framework-dashboard/lib/format-date.ts
+++ b/packages/framework-dashboard/lib/format-date.ts
@@ -22,3 +22,21 @@ export function formatDate(value: string | undefined, fallback = '—'): string 
   const date = parse(value)
   return date ? date.toLocaleDateString() : fallback
 }
+
+/**
+ * A timestamp as freshness (#948): "just now" / "12m ago" / "3h ago" / "2d ago", falling back
+ * to the local date past a week. An at-a-glance board wants "2m ago", not today's date.
+ */
+export function formatRelative(value: string | undefined, fallback = '—'): string {
+  const date = parse(value)
+  if (!date) return fallback
+  const seconds = Math.round((Date.now() - date.getTime()) / 1000)
+  if (seconds < 60) return 'just now'
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.round(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.round(hours / 24)
+  if (days <= 7) return `${days}d ago`
+  return date.toLocaleDateString()
+}

--- a/packages/framework-dashboard/lib/live-state.test.ts
+++ b/packages/framework-dashboard/lib/live-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import type { FrameworkEvent } from '@gemstack/framework'
-import { agentViews, pendingChoices, isRunActive, currentRunEvents } from './live-state.js'
+import { agentViews, pendingChoices, isRunActive, currentRunEvents, runOutcome } from './live-state.js'
 
 const view = (id: string, title: string, markdown: string): FrameworkEvent => ({ kind: 'view', id, title, markdown })
 const choice = (id: string, title: string): FrameworkEvent => ({
@@ -102,5 +102,28 @@ describe('currentRunEvents', () => {
       { kind: 'log', message: 'run 2' },
       { kind: 'end', ok: false, stopped: true },
     ])
+  })
+})
+
+// #948: the overview pill must tell a crash, a user stop, and a clean finish apart.
+describe('runOutcome', () => {
+  test('undefined while the run is still going', () => {
+    expect(runOutcome([{ kind: 'log', message: 'hi' }])).toBeUndefined()
+  })
+
+  test('a clean end', () => {
+    expect(runOutcome([{ kind: 'end', ok: true }])).toEqual({ ok: true, stopped: false })
+  })
+
+  test('a failure carries its detail', () => {
+    expect(runOutcome([{ kind: 'end', ok: false, detail: 'driver exited 1' }])).toEqual({
+      ok: false,
+      stopped: false,
+      detail: 'driver exited 1',
+    })
+  })
+
+  test('a user stop is a stop, not a failure', () => {
+    expect(runOutcome([{ kind: 'end', ok: false, stopped: true }])).toEqual({ ok: false, stopped: true })
   })
 })

--- a/packages/framework-dashboard/lib/live-state.ts
+++ b/packages/framework-dashboard/lib/live-state.ts
@@ -64,6 +64,24 @@ export function isRunActive(events: readonly FrameworkEvent[]): boolean {
   return events.length > 0 && !events.some(event => event.kind === 'end')
 }
 
+/** How a run ended, off its single `end` event. */
+export interface RunOutcome {
+  ok: boolean
+  stopped: boolean
+  detail?: string
+}
+
+/**
+ * The run's ending, or undefined while it is still going (#948). The most important bit
+ * about a finished run used to live only in one small `✗ failed` feed line — the overview
+ * pill said "finished" for a crash and a clean pass alike.
+ */
+export function runOutcome(events: readonly FrameworkEvent[]): RunOutcome | undefined {
+  const end = events.find(event => event.kind === 'end')
+  if (!end || end.kind !== 'end') return undefined
+  return { ok: end.ok, stopped: end.stopped === true, ...(end.detail !== undefined ? { detail: end.detail } : {}) }
+}
+
 /**
  * The current run's slice of an accumulated live feed. The dashboard's live channel keeps
  * one long-lived subscription per project and appends every streamed event, but each run

--- a/packages/framework-dashboard/lib/use-context-set.ts
+++ b/packages/framework-dashboard/lib/use-context-set.ts
@@ -7,11 +7,20 @@ import { useState } from 'react'
 export function useContextSet(): {
   context: Set<string>
   add: (path: string) => void
+  remove: (path: string) => void
   toggle: (path: string) => void
   reset: () => void
 } {
   const [context, setContext] = useState<Set<string>>(new Set())
   const add = (path: string) => setContext(prev => (prev.has(path) ? prev : new Set(prev).add(path)))
+  // For a deleted `@`/`#` chip (#948): the editor and the Context set must not diverge.
+  const remove = (path: string) =>
+    setContext(prev => {
+      if (!prev.has(path)) return prev
+      const next = new Set(prev)
+      next.delete(path)
+      return next
+    })
   const toggle = (path: string) =>
     setContext(prev => {
       const next = new Set(prev)
@@ -19,5 +28,5 @@ export function useContextSet(): {
       return next
     })
   const reset = () => setContext(new Set())
-  return { context, add, toggle, reset }
+  return { context, add, remove, toggle, reset }
 }

--- a/packages/framework-dashboard/lib/use-daemon-health.test.tsx
+++ b/packages/framework-dashboard/lib/use-daemon-health.test.tsx
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+
+const onProjects = vi.hoisted(() => vi.fn())
+vi.mock('../server/projects.telefunc.js', () => ({ onProjects }))
+
+const { useDaemonHealth } = await import('./use-daemon-health.js')
+
+afterEach(() => {
+  cleanup()
+  onProjects.mockReset()
+})
+
+function Probe({ enabled = true }: { enabled?: boolean }) {
+  return <span>{useDaemonHealth(enabled) ? 'healthy' : 'down'}</span>
+}
+
+// #948: a dead daemon froze every surface silently — the probe is what lets the shell say so.
+describe('useDaemonHealth', () => {
+  test('an answering daemon reads healthy', async () => {
+    onProjects.mockResolvedValue([])
+    render(<Probe />)
+    await waitFor(() => expect(onProjects).toHaveBeenCalled())
+    expect(screen.getByText('healthy')).toBeTruthy()
+  })
+
+  test('a failing probe flips to down', async () => {
+    onProjects.mockRejectedValue(new Error('ECONNREFUSED'))
+    render(<Probe />)
+    await waitFor(() => expect(screen.getByText('down')).toBeTruthy())
+  })
+
+  test('disabled (the relay) never probes and stays healthy', async () => {
+    render(<Probe enabled={false} />)
+    await new Promise(resolve => setTimeout(resolve, 50))
+    expect(onProjects).not.toHaveBeenCalled()
+    expect(screen.getByText('healthy')).toBeTruthy()
+  })
+})

--- a/packages/framework-dashboard/lib/use-daemon-health.ts
+++ b/packages/framework-dashboard/lib/use-daemon-health.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react'
+import { onProjects } from '../server/projects.telefunc.js'
+
+/** How often the liveness probe asks, healthy or not. */
+const PROBE_MS = 5000
+
+// Is the daemon answering (#948)? A dead daemon is otherwise invisible: the live channel's
+// transport retries silently without a channel-level verdict until a server answers, and the
+// polled reads keep their last value on failure — so every surface just froze, indistinguishable
+// from a quiet agent. One cheap read on a fixed cadence turns "unreachable" into a fact the
+// shell can say out loud. Recovery needs no action here: the channels reconcile and the polls
+// resume on their own once the daemon answers again.
+export function useDaemonHealth(enabled = true): boolean {
+  const [healthy, setHealthy] = useState(true)
+
+  useEffect(() => {
+    if (!enabled) return
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const probe = () => {
+      onProjects().then(
+        () => {
+          if (cancelled) return
+          setHealthy(true)
+          timer = setTimeout(probe, PROBE_MS)
+        },
+        () => {
+          if (cancelled) return
+          setHealthy(false)
+          timer = setTimeout(probe, PROBE_MS)
+        },
+      )
+    }
+    probe()
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [enabled])
+
+  return healthy
+}

--- a/packages/framework-dashboard/lib/use-live-events.test.tsx
+++ b/packages/framework-dashboard/lib/use-live-events.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import { cleanup, render, waitFor } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 
 // Record what the feed subscribes to. The channel never sends; we only care about addressing.
 const onEvents = vi.hoisted(() => vi.fn())
@@ -10,11 +10,25 @@ const { useLiveEvents } = await import('./use-live-events.js')
 afterEach(() => {
   cleanup()
   onEvents.mockReset()
+  vi.useRealTimers()
 })
 
+/** A channel stub that records its onClose callback so a test can drop the stream. */
+function fakeChannel() {
+  const callbacks: Array<(err?: Error) => void> = []
+  return {
+    channel: {
+      listen: () => {},
+      close: () => {},
+      onClose: (cb: (err?: Error) => void) => callbacks.push(cb),
+    },
+    dropWith: (err?: Error) => callbacks.forEach(cb => cb(err)),
+  }
+}
+
 function Probe({ projectId, runId }: { projectId: string | null; runId?: string | null }) {
-  useLiveEvents(projectId, runId)
-  return null
+  const { lost } = useLiveEvents(projectId, runId)
+  return <span>{lost ? 'lost' : 'live'}</span>
 }
 
 // #770: right after Start, the run's row does not exist yet. The feed used to subscribe with no run
@@ -23,13 +37,13 @@ function Probe({ projectId, runId }: { projectId: string | null; runId?: string 
 // from Start, so there is no window where the feed is pointed at the wrong log.
 describe('useLiveEvents addressing (#770)', () => {
   test('subscribes to the run it was given', async () => {
-    onEvents.mockResolvedValue({ listen: () => {}, close: () => {} })
+    onEvents.mockResolvedValue(fakeChannel().channel)
     render(<Probe projectId="p1" runId="2026-07-19T13-00-00-000Z" />)
     await waitFor(() => expect(onEvents).toHaveBeenCalledWith('p1', '2026-07-19T13-00-00-000Z'))
   })
 
   test('resubscribes when the selected run changes, so two runs never share a feed', async () => {
-    onEvents.mockResolvedValue({ listen: () => {}, close: () => {} })
+    onEvents.mockResolvedValue(fakeChannel().channel)
     const { rerender } = render(<Probe projectId="p1" runId="run-a" />)
     await waitFor(() => expect(onEvents).toHaveBeenCalledWith('p1', 'run-a'))
     rerender(<Probe projectId="p1" runId="run-b" />)
@@ -37,8 +51,44 @@ describe('useLiveEvents addressing (#770)', () => {
   })
 
   test('no run id still subscribes per project (the non-git fallback path)', async () => {
-    onEvents.mockResolvedValue({ listen: () => {}, close: () => {} })
+    onEvents.mockResolvedValue(fakeChannel().channel)
     render(<Probe projectId="p1" />)
     await waitFor(() => expect(onEvents).toHaveBeenCalledWith('p1', undefined))
+  })
+})
+
+// #948: a dead stream used to be silent — events just stopped. An errored close must flip `lost`
+// and retry; a clean close is the server being done on purpose (relay ended, unknown project) and
+// must do neither.
+describe('useLiveEvents stream loss (#948)', () => {
+  test('an errored close reports the stream lost and resubscribes', async () => {
+    const first = fakeChannel()
+    onEvents.mockResolvedValue(first.channel)
+    render(<Probe projectId="p1" runId="run-a" />)
+    await waitFor(() => expect(onEvents).toHaveBeenCalledTimes(1))
+    first.dropWith(new Error('connection reset'))
+    await waitFor(() => expect(screen.getByText('lost')).toBeTruthy())
+    // The retry resubscribes on its own and recovers.
+    await waitFor(() => expect(onEvents.mock.calls.length).toBeGreaterThan(1), { timeout: 3000 })
+    await waitFor(() => expect(screen.getByText('live')).toBeTruthy(), { timeout: 3000 })
+  })
+
+  test('a clean close neither alarms nor retries', async () => {
+    const first = fakeChannel()
+    onEvents.mockResolvedValue(first.channel)
+    render(<Probe projectId="p1" runId="run-a" />)
+    await waitFor(() => expect(onEvents).toHaveBeenCalledTimes(1))
+    first.dropWith()
+    // Give a would-be retry room to fire, then assert it did not.
+    await new Promise(resolve => setTimeout(resolve, 1200))
+    expect(onEvents).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('live')).toBeTruthy()
+  })
+
+  test('a failed subscribe reports the stream lost and keeps trying', async () => {
+    onEvents.mockRejectedValueOnce(new Error('daemon down')).mockResolvedValue(fakeChannel().channel)
+    render(<Probe projectId="p1" runId="run-a" />)
+    await waitFor(() => expect(screen.getByText('lost')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText('live')).toBeTruthy(), { timeout: 3000 })
   })
 })

--- a/packages/framework-dashboard/lib/use-live-events.ts
+++ b/packages/framework-dashboard/lib/use-live-events.ts
@@ -21,6 +21,8 @@ export interface LiveEvents {
   events: FrameworkEvent[]
   /** True while the stream is lost and being retried — the feed may be behind reality. */
   lost: boolean
+  /** The server closed the channel on purpose (relay stream ended, unknown run) — final. */
+  done: boolean
 }
 
 /** Retry delays for a lost stream: quick first, then settle at a slow poll. */
@@ -33,6 +35,7 @@ function retryDelay(attempt: number): number {
 export function useLiveEvents(projectId: string | null, runId?: string | null, resetKey?: unknown): LiveEvents {
   const [events, setEvents] = useState<FrameworkEvent[]>([])
   const [lost, setLost] = useState(false)
+  const [done, setDone] = useState(false)
 
   // Drop the accumulated feed at a run boundary the caller knows about (a fresh Start bumps
   // `resetKey`), WITHOUT tearing down the subscription. The new run truncates events.jsonl a
@@ -47,6 +50,7 @@ export function useLiveEvents(projectId: string | null, runId?: string | null, r
   useEffect(() => {
     setEvents([])
     setLost(false)
+    setDone(false)
     if (!projectId) return
     let channel: ClientChannel<never, FrameworkEvent> | undefined
     let cancelled = false
@@ -82,6 +86,7 @@ export function useLiveEvents(projectId: string | null, runId?: string | null, r
         })
         ch.onClose(err => {
           if (err) retry()
+          else if (!cancelled) setDone(true)
         })
       }, retry)
     }
@@ -99,5 +104,5 @@ export function useLiveEvents(projectId: string | null, runId?: string | null, r
   // boundaries (it only resets on a project switch), so without this a second run would show
   // the previous run's log until it finished. See {@link currentRunEvents}.
   const scoped = useMemo(() => currentRunEvents(events), [events])
-  return { events: scoped, lost }
+  return { events: scoped, lost, done }
 }

--- a/packages/framework-dashboard/lib/use-live-events.ts
+++ b/packages/framework-dashboard/lib/use-live-events.ts
@@ -3,6 +3,7 @@ import type { FrameworkEvent } from '@gemstack/framework'
 import type { ClientChannel } from 'telefunc'
 import { onEvents } from '../server/events.telefunc.js'
 import { currentRunEvents } from './live-state.js'
+import { stampReceived } from './event-times.js'
 
 // The live run feed (#405), shared. The dashboard is a projection of the selected project's
 // `.the-framework/events.jsonl`, streamed over a Telefunc Channel that pushes one
@@ -14,8 +15,24 @@ import { currentRunEvents } from './live-state.js'
 // so the selected run id picks the log to follow. Changing it resubscribes, which is what makes
 // selecting run A vs run B show different output. Omitted (the relay, or a Start whose id has not
 // been adopted yet) falls back to the project root.
-export function useLiveEvents(projectId: string | null, runId?: string | null, resetKey?: unknown): FrameworkEvent[] {
+
+/** The live feed plus whether its channel is currently down (#948). */
+export interface LiveEvents {
+  events: FrameworkEvent[]
+  /** True while the stream is lost and being retried — the feed may be behind reality. */
+  lost: boolean
+}
+
+/** Retry delays for a lost stream: quick first, then settle at a slow poll. */
+const RETRY_DELAYS_MS = [1000, 2000, 4000, 8000]
+
+function retryDelay(attempt: number): number {
+  return RETRY_DELAYS_MS[Math.min(attempt, RETRY_DELAYS_MS.length - 1)] as number
+}
+
+export function useLiveEvents(projectId: string | null, runId?: string | null, resetKey?: unknown): LiveEvents {
   const [events, setEvents] = useState<FrameworkEvent[]>([])
+  const [lost, setLost] = useState(false)
 
   // Drop the accumulated feed at a run boundary the caller knows about (a fresh Start bumps
   // `resetKey`), WITHOUT tearing down the subscription. The new run truncates events.jsonl a
@@ -29,19 +46,50 @@ export function useLiveEvents(projectId: string | null, runId?: string | null, r
 
   useEffect(() => {
     setEvents([])
+    setLost(false)
     if (!projectId) return
     let channel: ClientChannel<never, FrameworkEvent> | undefined
     let cancelled = false
-    void onEvents(projectId, runId ?? undefined).then(ch => {
-      if (cancelled) {
-        void ch.close()
-        return
-      }
-      channel = ch
-      ch.listen(event => setEvents(prev => [...prev, event]))
-    })
+    let attempt = 0
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    // A dead stream used to be silent: the daemon restarts, events just stop, and "the agent
+    // went quiet" is indistinguishable from "the feed died" (#948). Now an errored close (or a
+    // failed subscribe) flips `lost` and retries with backoff. A clean close is the server being
+    // done with the channel on purpose (relay stream ended, unknown project) — not an outage —
+    // so it neither retries nor alarms, matching the old behavior.
+    const retry = () => {
+      if (cancelled) return
+      setLost(true)
+      timer = setTimeout(subscribe, retryDelay(attempt++))
+    }
+
+    const subscribe = () => {
+      void onEvents(projectId, runId ?? undefined).then(ch => {
+        if (cancelled) {
+          void ch.close()
+          return
+        }
+        channel = ch
+        attempt = 0
+        setLost(false)
+        // The tail replays the whole log on subscribe, so a reconnect starts from an empty
+        // buffer rather than appending a duplicate history.
+        setEvents([])
+        ch.listen(event => {
+          stampReceived(event)
+          setEvents(prev => [...prev, event])
+        })
+        ch.onClose(err => {
+          if (err) retry()
+        })
+      }, retry)
+    }
+
+    subscribe()
     return () => {
       cancelled = true
+      if (timer) clearTimeout(timer)
       void channel?.close()
     }
     // runId is a dependency: selecting another run must resubscribe to that run's log (#749).
@@ -50,5 +98,6 @@ export function useLiveEvents(projectId: string | null, runId?: string | null, r
   // Scope the accumulated feed to the run in progress. The subscription lives across run
   // boundaries (it only resets on a project switch), so without this a second run would show
   // the previous run's log until it finished. See {@link currentRunEvents}.
-  return useMemo(() => currentRunEvents(events), [events])
+  const scoped = useMemo(() => currentRunEvents(events), [events])
+  return { events: scoped, lost }
 }

--- a/packages/framework-dashboard/lib/use-notifications.ts
+++ b/packages/framework-dashboard/lib/use-notifications.ts
@@ -70,7 +70,9 @@ const INTERVENTIONS: NotificationSpec<Intervention> = {
   label: item => {
     if (item.kind === 'awaiting') return item.title
     if (item.kind === 'unpushed') {
-      return `${item.title} — ${item.commits === 1 ? '1 commit' : `${item.commits ?? 0} commits`} not pushed`
+      return item.commits === undefined || item.commits === 0
+        ? `${item.title} — work not pushed`
+        : `${item.title} — ${item.commits === 1 ? '1 commit' : `${item.commits} commits`} not pushed`
     }
     return `#${item.number} ${item.title}`
   },

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -310,6 +310,7 @@ export default function Page() {
           toggleContext={toggleContext}
           hasBrowser={selectedRun?.status === 'running' && selectedRun.browserStreamPort !== undefined}
           onWideChange={setWideRail}
+          onRunStarted={onRunStarted}
         />
       </div>
     </div>

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -26,6 +26,8 @@ import { pendingChoices, agentViews } from '../../lib/live-state.js'
 import { useDocumentTitle } from '../../lib/document-title.js'
 import { useWorking } from '../../lib/use-working.js'
 import { useFavicon } from '../../lib/favicon.js'
+import { useDaemonHealth } from '../../lib/use-daemon-health.js'
+import { TriangleAlert } from 'lucide-react'
 
 /** Stable, so `files` keeps one identity while no project is selected. */
 const EMPTY_FILES: string[] = []
@@ -199,6 +201,11 @@ export default function Page() {
   const working = useWorking(local)
   useFavicon(working, local)
 
+  // Whether the daemon answers at all (#948). Without this, a dead daemon froze every surface
+  // silently: the channels retry their transport without a verdict and the polls keep their
+  // last value, so "the agent went quiet" and "nothing on this page is live" looked identical.
+  const healthy = useDaemonHealth(local)
+
   // Hooks above run unconditionally (rules of hooks); this early return is safe after them.
   if (relayRun) return <RelayView runId={relayRun} />
 
@@ -281,6 +288,12 @@ export default function Page() {
           <NotificationsMenu />
         </div>
       </header>
+      {!healthy && (
+        <div role="alert" className="flex items-center gap-2 border-b border-border bg-amber-500/10 px-4 py-2 text-xs text-amber-600 dark:text-amber-400">
+          <TriangleAlert className="h-3.5 w-3.5 shrink-0" aria-hidden />
+          The daemon is not answering — retrying. Everything on this page is frozen until it returns.
+        </div>
+      )}
       {/* The workspace row is fixed-height: each column scrolls internally, so the row itself
           must never scroll. overflow-hidden clips any stray horizontal bleed (no page X-scroll).
           `relative` is load-bearing (#904): overflow only clips a descendant this box is the

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -78,7 +78,7 @@ export default function Page() {
   // The run Context set lives in the shell (#492/#504) so the two surfaces that feed it share
   // one source of truth: the `#` file chips + whole-repo Context selector in the Start form
   // (main pane), and the file tree in the right rail.
-  const { context, add: addContext, toggle: toggleContext, reset: resetContext } = useContextSet()
+  const { context, add: addContext, remove: removeContext, toggle: toggleContext, reset: resetContext } = useContextSet()
 
   // The picked context is one project's, so changing projects starts fresh. Keyed off the route
   // rather than the click, because Back/Forward change projects too.
@@ -132,6 +132,8 @@ export default function Page() {
   const onRunStarted = (intent: string, startedId?: string) => {
     setRunStart(prev => ({ tick: prev.tick + 1, intent, id: startedId ?? null }))
     setAdopting(startedId === undefined)
+    // The picked context went with that run; the next launch starts from a clean focus (#948).
+    resetContext()
     // Go to the run we just started — a real history entry, so Back returns to where you launched
     // from. Its row does not exist yet; the main pane shows it live on the strength of the id.
     if (startedId !== undefined) go({ projectId, runId: startedId })
@@ -218,7 +220,7 @@ export default function Page() {
     if (runId === null) {
       // Just pressed Start on a project with no worktree: follow the live output until the poll
       // surfaces the run and the effect above adopts its id.
-      if (adopting) return <RunLive projectId={projectId} runId={null} events={events} files={files} addContext={addContext} lost={lost} />
+      if (adopting) return <RunLive projectId={projectId} runId={null} events={events} files={files} addContext={addContext} removeContext={removeContext} lost={lost} />
       return (
         <ProjectHome
           projectId={projectId}
@@ -227,6 +229,7 @@ export default function Page() {
           files={files}
           context={context}
           addContext={addContext}
+          removeContext={removeContext}
           toggleContext={toggleContext}
         />
       )
@@ -236,7 +239,7 @@ export default function Page() {
       // list we have not read yet. Both are live views; only a session that is genuinely absent
       // from a list we did read is gone.
       if (runId === runStart.id || !runsLoaded)
-        return <RunLive projectId={projectId} runId={runId} events={events} files={files} addContext={addContext} lost={lost} />
+        return <RunLive projectId={projectId} runId={runId} events={events} files={files} addContext={addContext} removeContext={removeContext} lost={lost} />
       return (
         <NotFound
           title="This session is gone"
@@ -247,8 +250,8 @@ export default function Page() {
       )
     }
     if (selectedRun.status === 'running')
-      return <RunLive projectId={projectId} runId={runId} events={events} files={files} addContext={addContext} lost={lost} />
-    return <RunReplay projectId={projectId} runId={runId} files={files} addContext={addContext} onRunStarted={onRunStarted} />
+      return <RunLive projectId={projectId} runId={runId} events={events} files={files} addContext={addContext} removeContext={removeContext} lost={lost} />
+    return <RunReplay projectId={projectId} runId={runId} files={files} addContext={addContext} removeContext={removeContext} onRunStarted={onRunStarted} />
   }
 
   return (

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -181,7 +181,7 @@ export default function Page() {
   // (#440) read one shared Telefunc Channel. Hooks run before the relay early return below.
   // The run whose feed and controls are in play is simply the one in the URL; in the no-id
   // fallback there is none yet, and a null id resolves to the project root, as before.
-  const events = useLiveEvents(projectId, runId, runStart.tick)
+  const { events, lost } = useLiveEvents(projectId, runId, runStart.tick)
   const choices = projectId ? pendingChoices(events) : []
   const views = projectId ? agentViews(events) : []
 
@@ -218,7 +218,7 @@ export default function Page() {
     if (runId === null) {
       // Just pressed Start on a project with no worktree: follow the live output until the poll
       // surfaces the run and the effect above adopts its id.
-      if (adopting) return <RunLive projectId={projectId} runId={null} events={events} files={files} addContext={addContext} />
+      if (adopting) return <RunLive projectId={projectId} runId={null} events={events} files={files} addContext={addContext} lost={lost} />
       return (
         <ProjectHome
           projectId={projectId}
@@ -236,7 +236,7 @@ export default function Page() {
       // list we have not read yet. Both are live views; only a session that is genuinely absent
       // from a list we did read is gone.
       if (runId === runStart.id || !runsLoaded)
-        return <RunLive projectId={projectId} runId={runId} events={events} files={files} addContext={addContext} />
+        return <RunLive projectId={projectId} runId={runId} events={events} files={files} addContext={addContext} lost={lost} />
       return (
         <NotFound
           title="This session is gone"
@@ -247,7 +247,7 @@ export default function Page() {
       )
     }
     if (selectedRun.status === 'running')
-      return <RunLive projectId={projectId} runId={runId} events={events} files={files} addContext={addContext} />
+      return <RunLive projectId={projectId} runId={runId} events={events} files={files} addContext={addContext} lost={lost} />
     return <RunReplay projectId={projectId} runId={runId} files={files} addContext={addContext} onRunStarted={onRunStarted} />
   }
 

--- a/packages/framework-dashboard/server/preferences.telefunc.ts
+++ b/packages/framework-dashboard/server/preferences.telefunc.ts
@@ -10,5 +10,6 @@ export {
   onProjectPreferences,
   saveProjectPreferences,
   onEditors,
+  onNotifyChannels,
 } from '@gemstack/framework/dashboard-rpc'
-export type { EditorInfo } from '@gemstack/framework/dashboard-rpc'
+export type { EditorInfo, NotifyChannels } from '@gemstack/framework/dashboard-rpc'

--- a/packages/framework-dashboard/server/reads.telefunc.ts
+++ b/packages/framework-dashboard/server/reads.telefunc.ts
@@ -3,4 +3,4 @@
 // the client bakes the RPC key `/server/reads.telefunc.ts` — the exact key the daemon
 // registers the impls under (see framework's dashboard-rpc/register.ts). The telefunc
 // Vite transform turns these named re-exports into client RPC stubs.
-export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent, onTickets, onRetainedWorktrees, onRunWorktree, onRunHandoff } from '@gemstack/framework/dashboard-rpc'
+export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent, onTickets, onRetainedWorktrees, onRunWorktree, onRunHandoff, onSystemPromptUser } from '@gemstack/framework/dashboard-rpc'

--- a/packages/framework/src/dashboard-rpc/index.ts
+++ b/packages/framework/src/dashboard-rpc/index.ts
@@ -12,7 +12,9 @@ export {
   onProjectPreferences,
   saveProjectPreferences,
   onEditors,
+  onNotifyChannels,
   type SavePreferencesResult,
+  type NotifyChannels,
 } from './preferences.telefunc.js'
 export { type EditorInfo } from '../dashboard/open-in-app.js'
 export { onQuota } from './quota.telefunc.js'

--- a/packages/framework/src/dashboard-rpc/index.ts
+++ b/packages/framework/src/dashboard-rpc/index.ts
@@ -2,7 +2,7 @@
 // implementations live here in @gemstack/framework so `sendStart` (added with the serve
 // wiring) can reach the daemon's `startRun`; the framework-dashboard client imports
 // these through thin re-export shims so the baked RPC keys stay `/server/*.telefunc.ts`.
-export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent, onTickets, onRetainedWorktrees, onRunWorktree, onRunHandoff } from './reads.telefunc.js'
+export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent, onTickets, onRetainedWorktrees, onRunWorktree, onRunHandoff, onSystemPromptUser } from './reads.telefunc.js'
 export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendPushBranch, sendOpenPullRequest, sendQueueTicket, type QueueTicketResult } from './control.telefunc.js'
 export { onEvents } from './events.telefunc.js'
 export { onProjects, sendAddProject } from './projects.telefunc.js'

--- a/packages/framework/src/dashboard-rpc/preferences.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/preferences.telefunc.ts
@@ -68,3 +68,26 @@ export async function onEditors(): Promise<EditorInfo[]> {
   if (!contextPreferences()) return []
   return detectEditors().catch(() => [])
 }
+
+/** Which notification channels the daemon can actually deliver on (#948). */
+export interface NotifyChannels {
+  /** `DISCORD_WEBHOOK` is set, so Discord delivery can fire. */
+  discordWebhook: boolean
+  /** `DISCORD_BOT_TOKEN` is set, so the Discord chatbot can answer. */
+  discordBot: boolean
+}
+
+/**
+ * Whether the daemon has the Discord env vars (#948). The toggles are per-user preferences,
+ * but delivery needs `DISCORD_WEBHOOK` / `DISCORD_BOT_TOKEN` on the daemon — without this
+ * read the dashboard let you switch on a channel that delivers nothing and lit the bell for
+ * it. Only presence is reported, never the values. Gated like the other preference RPCs, so
+ * a public host reports both absent.
+ */
+export async function onNotifyChannels(): Promise<NotifyChannels> {
+  if (!contextPreferences()) return { discordWebhook: false, discordBot: false }
+  return {
+    discordWebhook: Boolean(process.env.DISCORD_WEBHOOK),
+    discordBot: Boolean(process.env.DISCORD_BOT_TOKEN),
+  }
+}

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -1,4 +1,5 @@
 import { findRun, readLiveMetas, readAllRuns, loadRunEvents, worktreeSize, isSafeRunId, type RunMeta } from '../store/index.js'
+import { loadUserSystemPrompt } from '../system-prompt-file.js'
 import { listProjectWorktrees } from '../worktrees.js'
 import { readLogs, type LogEntry } from '../logs.js'
 import { readDocs, type WorkspaceDoc } from '../dashboard/docs.js'
@@ -264,4 +265,15 @@ export async function onRunHandoff(projectId: string, runId: string): Promise<Ru
   const run = await findRun(cwd, runId).catch(() => undefined)
   if (!run) return null
   return (await readRunHandoff(cwd, runBranchFor(run)).catch(() => undefined)) ?? null
+}
+
+/**
+ * The project's own `SYSTEM.md` text, or null when it has none (#872). The prompt preview
+ * claims to show the entire system prompt; composition takes this text as `opts.user`, but
+ * reading it is Node-bound, so the browser needs this read to keep that claim true.
+ */
+export async function onSystemPromptUser(projectId: string): Promise<string | null> {
+  const cwd = await resolveProjectPath(projectId)
+  if (!cwd) return null
+  return (await loadUserSystemPrompt(cwd)) ?? null
 }

--- a/packages/framework/src/dashboard-rpc/register.ts
+++ b/packages/framework/src/dashboard-rpc/register.ts
@@ -3,7 +3,7 @@ import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventio
 import { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendPushBranch, sendOpenPullRequest, sendQueueTicket } from './control.telefunc.js'
 import { onEvents } from './events.telefunc.js'
 import { onProjects, sendAddProject } from './projects.telefunc.js'
-import { onPreferences, savePreferences, onProjectPreferences, saveProjectPreferences, onEditors } from './preferences.telefunc.js'
+import { onPreferences, savePreferences, onProjectPreferences, saveProjectPreferences, onEditors, onNotifyChannels } from './preferences.telefunc.js'
 import { onQuota } from './quota.telefunc.js'
 
 // The client bakes each RPC key from the dashboard's source path (relative to its Vite
@@ -89,5 +89,6 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(onProjectPreferences, 'onProjectPreferences', preferences)
   reg(saveProjectPreferences, 'saveProjectPreferences', preferences)
   reg(onEditors, 'onEditors', preferences)
+  reg(onNotifyChannels, 'onNotifyChannels', preferences)
   reg(onQuota, 'onQuota', quota)
 }

--- a/packages/framework/src/dashboard-rpc/register.ts
+++ b/packages/framework/src/dashboard-rpc/register.ts
@@ -1,5 +1,5 @@
 import { __decorateTelefunction } from 'telefunc'
-import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent, onTickets, onRetainedWorktrees, onRunWorktree, onRunHandoff } from './reads.telefunc.js'
+import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent, onTickets, onRetainedWorktrees, onRunWorktree, onRunHandoff, onSystemPromptUser } from './reads.telefunc.js'
 import { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendPushBranch, sendOpenPullRequest, sendQueueTicket } from './control.telefunc.js'
 import { onEvents } from './events.telefunc.js'
 import { onProjects, sendAddProject } from './projects.telefunc.js'
@@ -62,6 +62,7 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(onRetainedWorktrees, 'onRetainedWorktrees', reads)
   reg(onRunWorktree, 'onRunWorktree', reads)
   reg(onRunHandoff, 'onRunHandoff', reads)
+  reg(onSystemPromptUser, 'onSystemPromptUser', reads)
   reg(onProjectFiles, 'onProjectFiles', reads)
   reg(onProjectFileStatus, 'onProjectFileStatus', reads)
   reg(onFileDiff, 'onFileDiff', reads)


### PR DESCRIPTION
Closes #948. Also fixes #946, #872, #869 (option 1) and implements #833 (option 1).

A full UX review of every dashboard flow: enumerated all flows, rated each 0-10, then fixed the low scorers. One commit per flow. Verified against a live daemon driven with a stub agent, including a real daemon kill/restart to prove the outage and recovery behavior. Both test suites green (framework 1020, dashboard 264, 19 tests added).

## All UI flows, old => new rating

Ratings before the sweep reflect the audit findings cited on each commit.

### Shell and navigation
| Flow | Rating | Commit |
|---|---|---|
| Land on the Overview, read system state | 6 => 8 | 7fe958e, deb3389 |
| Pick / switch a project | 6 => 8 | 59291fe |
| Add a project | 5 => 8 | b7ed4e2 |
| New session button | 8 | unchanged |
| Theme toggle | 8 => 9 | d24c011 |
| Notifications incl. Discord | 4 => 8 | a822d37 |
| Working indicator (logo, favicon, tab title) | 8 => 9 | d24c011 |
| Unknown-project / gone-session pages | 7 | unchanged (rails still render beside the 404, noted below) |
| Daemon outage visibility | 2 => 8 | deb3389 (new: it was simply invisible) |

### Launcher
| Flow | Rating | Commit |
|---|---|---|
| Type a prompt and start a session | 5 => 8 | 91df5b9 |
| Use a preset | 4 => 8 | afc8cbf |
| Create / manage presets | 4 => 8 | afc8cbf |
| Pick agent / model | 7 | unchanged (hover submenu is still touch-hostile) |
| Session options gear | 5 => 8 | 95dbc87 (#833) |
| Attach context via # / @ / file tree | 4 => 8 | 8679173 |
| Suggestion menus (/ < @ #) | 6 => 8 | abc6b7b |
| Enhanced System Prompt preview | 6 => 8 | ea6678b (#872) |
| Project actions / git status / serve | 7 | unchanged |

### Watching and steering a session
| Flow | Rating | Commit |
|---|---|---|
| Watch live output | 4 => 8 | cd58905, deb3389 |
| Answer a choice gate | 5 => 8 | 3f2aaa3 |
| Message a running session | 4 => 8 | 484acee |
| Stop a session | 6 => 8 | 73fbd6c |
| Live changes panel | 8 | unchanged |
| Files / preview / diff rail | 7 => 8 | 6660de2 |
| Embedded browser | 5 => 8 | 4ba0024 (#946) |
| Replay a finished session | 5 => 8 | 777e809 |
| Resume / continue a session | 6 => 8 | 777e809 |
| Handoff: push / open PR | 5 => 8 | 1333c44 |
| Agent views (showMarkdown) | 5 => 8 | 8d98d85 (#869) |
| Session link / read-only relay | 5 => 8 | 73fbd6c, 891131e |

### Rails
| Flow | Rating | Commit |
|---|---|---|
| Sessions rail | 6 => 8 | 33d09b2 |
| Docs panel | 6 => 8 | 600062e |
| Log panel | 6 => 8 | 600062e |
| Tickets panel | 6 => 8 | be1f168 |
| Usage / quota panel | 8 | unchanged |
| Right-rail tab bar | 6 => 8 | d24c011 |

## The themes behind the low scores
- Silent failure everywhere: a dead live stream, a dead daemon, a failed chat send, a failed choice post, a failed start's immortal "starting" row, Discord toggles without the daemon env var. All of these now speak.
- Dishonest state: crashed sessions labeled "finished", "In play" showing global prefs inside a session, the prompt preview omitting SYSTEM.md, "All projects" vs "Overview", the loop badge overloading "stopped".
- Hidden features: presets only behind typing "/", preset delete in a different menu, no copy affordance for branch / session id / views.
- Accessibility: unnamed icon buttons, menus invisible to AT, fake dialog, emoji spoken by screen readers, dead chart buttons.

## Verified live, not just by tests
Drove a daemon from this branch with a stub agent: started sessions from the composer, hit the choice gate, killed the daemon mid-watch (banner within 4s, recovery within 4s of restart, screenshots taken), stopped a session from the bar, and checked the launcher, presets menu, slash menu, replay, handoff and Overview by screenshot.

## Known gaps left on the table (intentionally)
- No narrow-viewport / mobile layout; the three-column shell needs a design decision (relates to #772's direction).
- Events carry no original timestamps; the feed stamps arrival client-side. Real per-event times need a framework event change.
- Preference writes are still fire-and-forget.
- The 404 pages render beside live-looking rails.
- Revisits #722 in one respect: presets get a visible button again, with the "/" menu kept as the primary fast path. Shout if that should be rolled back.
