### PR TITLE
Quality sweep: AI package correctness, security and surface

### DIFF
--- a/.changeset/ai-mcp-sync-tool-return.md
+++ b/.changeset/ai-mcp-sync-tool-return.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/ai-mcp': patch
+---
+
+Fix `mcpServerFromAgent` crashing on a tool whose `execute` fn returns synchronously.
+
+The generator check was `out instanceof Promise`, so anything that wasn't a native Promise was treated as an async generator and died on `iter.next is not a function`, surfaced to the MCP client as an opaque internal error. `.server()` explicitly accepts `TReturn | Promise<TReturn>`, so a bare return (or a non-native thenable) is legal. It now duck-types the generator the way `@gemstack/mcp` already does.

--- a/.changeset/ai-sdk-stream-and-cache-correctness.md
+++ b/.changeset/ai-sdk-stream-and-cache-correctness.md
@@ -1,0 +1,12 @@
+---
+'@gemstack/ai-sdk': patch
+---
+
+Fix four correctness bugs around streaming, SSE and the embedding cache.
+
+- `Agent.stream()` invoked `conversational()` and `remembers()` twice for any agent that overrides them asynchronously: once in the synchronous fast-path probe (where the returned promise was dropped on the floor) and again on the async path. An override doing a DI or DB lookup ran its side effects twice per call, and a rejection from the first, unhandled promise could abort the process. Both are now called once and the values threaded through.
+- `readAgentStream`'s "skip malformed JSON" guard also swallowed every error thrown by the consumer's own SSE callbacks, losing the diagnostic and leaving the turn half-mutated. It now parses inside the guard and applies outside it.
+- `parseSseStream` released the reader lock without cancelling the body, so any early exit (a `stopWhen`, an approval pause, a consumer `break`) left the upstream HTTP connection open until the server timed it out.
+- `CachedEmbeddingAdapter` reported zero token usage even when it *did* call the provider, so anything aggregating usage undercounted embedding spend entirely; it now reports what the provider charged for cache misses. Its cache is also no longer unbounded (new `maxEntries` option, default 10_000, oldest evicted first).
+
+`CachedEmbeddingAdapter` had no test coverage; it now has a suite.

--- a/.changeset/ai-sdk-surface-and-docs.md
+++ b/.changeset/ai-sdk-surface-and-docs.md
@@ -1,0 +1,10 @@
+---
+'@gemstack/ai-sdk': patch
+---
+
+Tidy the public surface, drop the last brand leaks, and correct docs that contradicted the code.
+
+- `web_search`'s fallback now extracts text with `htmlToText` instead of the `<[^>]*>` regex that the same file's docblock documents as forbidden (polynomial ReDoS, trips CodeQL). It also stops leaking `<script>` / `<style>` *content* into the model's context.
+- Export types that were unnameable despite being public: `ServerToolBuilder` (the return type of `Agent.asTool()`, `scopedTool()`, `similaritySearch()` and `toolDefinition().server()`), plus `ProviderHint`, `ConversationalSpec`, `ConversationalOverride`, `ConversationStoreListEntry`, `FileSearchFallback`, `SimilaritySearchWhereOperator`, `SchemaIo` and `CachedEmbeddingOptions`.
+- Replace the remaining `Rudder` references in user-visible strings: a synthesized tool-result message the *model* reads, the `User-Agent` sent by `web_search` / `web_fetch`, and error/doc copy that told `@gemstack/ai-sdk` users to rely on a framework they may not be running.
+- Delete "Phase N will add …" doc comments for features that already ship in the same file (`computerUseTool`, the file-search `fallback` option), and stop a fixture-version error from telling users to re-record with a CLI command that lives in another package.

--- a/.changeset/autopilot-orchestration-correctness.md
+++ b/.changeset/autopilot-orchestration-correctness.md
@@ -1,0 +1,14 @@
+---
+'@gemstack/ai-autopilot': patch
+'@gemstack/ai-mcp': patch
+'@gemstack/ai-skills': patch
+---
+
+Fix four orchestration correctness bugs and tidy the package surface.
+
+- `exec()` now runs in its own process group and settles even when a background grandchild outlives the shell. Previously a command like `npm install` that left a daemon behind kept the inherited stdio open, so `close` never fired and the call never settled, blowing past its own `timeoutMs`.
+- `serveCheck` bounds its health-check fetch. A dev server that accepts the connection but never answers used to hang the bootstrap pass loop forever, since neither the fetch nor the process exit could settle.
+- A blocking loop chain (`continueOnError: false`) now stops at an unknown prompt id instead of running past it. A typo'd or unregistered id silently bypassed a gate that a *throwing* prompt would have stopped.
+- `runPool` no longer reports truncation when the budget is met exactly by the final item, which surfaced as a false `stoppedEarly` / `budget-exceeded` with `skipped: 0` on a plan that ran to completion. Worker errors also propagate through `allSettled`, so one failure cannot orphan its siblings into unhandled rejections.
+
+Also: exported `AgentSynthesizerOptions` (the only `agent*` factory whose options were unnameable), dropped three dead imports in `bootstrap/steps.ts`, corrected two doc comments that claimed one shipped domain preset when five ship, removed a doc comment describing a function that had moved, and fixed `clean` scripts that left `dist-test/` behind (stale compiled tests cause phantom failures).

--- a/.changeset/mcp-validate-tool-input.md
+++ b/.changeset/mcp-validate-tool-input.md
@@ -1,0 +1,9 @@
+---
+'@gemstack/mcp': patch
+---
+
+Validate tool and prompt arguments against the schema they declare.
+
+A tool's `schema()` was only ever used to *advertise* its input shape in `tools/list`. The low-level MCP `Server` validates just the request envelope (`arguments` is an open record on the wire), so `tools/call` handed `handle()` whatever the client sent, regardless of the declared schema. Handlers are written against the declared types and interpolate those values into request paths, so an unchecked argument was a live injection surface: a tool declaring `number: z.number().int().positive()` and building `` `/repos/${owner}/${repo}/issues/${input.number}` `` would happily issue a request for `number: "../../../user/repos"` with the server's credentials.
+
+`tools/call` and `prompts/get` now check arguments against the declared schema, reject a mismatch with a clear error, and pass the *parsed* value to the handler, so handlers see coerced values and undeclared keys stripped. Schemas that cannot validate (a plain `{ shape }` rather than a Zod schema) pass through as before. `McpTestClient.callTool` validates identically, so a test can no longer pass arguments a real client would be rejected for.

--- a/packages/ai-autopilot/package.json
+++ b/packages/ai-autopilot/package.json
@@ -45,7 +45,7 @@
     "dev": "tsc -p tsconfig.build.json --watch",
     "typecheck": "tsc --noEmit",
     "test": "tsc -p tsconfig.test.json && cd dist-test && node --test",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist dist-test"
   },
   "dependencies": {
     "@gemstack/ai-sdk": "workspace:^",

--- a/packages/ai-autopilot/src/bootstrap/serve-check.ts
+++ b/packages/ai-autopilot/src/bootstrap/serve-check.ts
@@ -76,8 +76,11 @@ export function serveCheck(session: RunnerSession, opts: ServeCheckOptions): Non
       const target = new URL(healthPath, url.endsWith('/') ? url : url + '/').toString()
 
       // If the server crashed on boot, its process has already exited — say so.
+      // Bound the fetch: a server that accepts the connection but never answers
+      // (wedged SSR, mid-HMR, holding proxy) would otherwise hang the pass loop
+      // forever, since `proc.exit` never settles either.
       const raced = await Promise.race([
-        fetch(target).then(res => ({ ok: true as const, status: res.status }), err => ({ ok: false as const, error: err as Error })),
+        fetch(target, { signal: AbortSignal.timeout(waitMs) }).then(res => ({ ok: true as const, status: res.status }), err => ({ ok: false as const, error: err as Error })),
         proc.exit.then(r => ({ ok: false as const, exited: r.exitCode, log: (r.stderr || r.stdout).trim().split('\n').slice(-3).join(' ').slice(0, 300) })),
       ])
 

--- a/packages/ai-autopilot/src/bootstrap/steps.ts
+++ b/packages/ai-autopilot/src/bootstrap/steps.ts
@@ -1,6 +1,3 @@
-import { Output } from '@gemstack/ai-sdk'
-import type { Agent } from '@gemstack/ai-sdk'
-import { z } from 'zod'
 import { Supervisor } from '../supervisor.js'
 import { LoopEngine } from '../loop/loop.js'
 import { LOOP_EVENTS, LOOP_PROMPTS } from '../loop/policy.js'

--- a/packages/ai-autopilot/src/index.ts
+++ b/packages/ai-autopilot/src/index.ts
@@ -93,13 +93,13 @@
  * - {@link composeDomainPresets} — merge presets into one (later wins on prompt id)
  * - {@link builtinDomainPresets} / {@link loadDomainPresetsFrom} — enumerate a set (the picker primitive)
  * - {@link selectPreset} — pick the user's chosen domain by name
- * - {@link softwareDevelopmentPreset} — the shipped, stack-agnostic built-in
+ * - {@link softwareDevelopmentPreset} — the stack-agnostic default of the five shipped presets
  * - {@link loadDomainPreset} `{ modes }` — activate Autopilot/Technical variants
  *   ({@link selectWinners}): a `conditions` sibling `.md` overrides its base
  */
 export { Supervisor } from './supervisor.js'
 export { agentPlanner, type AgentPlannerOptions } from './planner.js'
-export { agentSynthesizer, defaultSynthesize } from './synthesizer.js'
+export { agentSynthesizer, defaultSynthesize, type AgentSynthesizerOptions } from './synthesizer.js'
 export {
   FakeRunner,
   FakeRunnerSession,

--- a/packages/ai-autopilot/src/loop/loop.test.ts
+++ b/packages/ai-autopilot/src/loop/loop.test.ts
@@ -87,6 +87,19 @@ describe('LoopEngine — dispatch', () => {
     assert.equal(result.outcomes[0]?.ok, false)
     assert.ok(events.some(e => e.type === 'unknown-prompt' && e.promptId === 'ghost'))
   })
+
+  it('stops a blocking chain at an unknown prompt instead of running past it', async () => {
+    const after = definePrompt({ id: 'security', run: () => 'ran' })
+    const loop = new LoopEngine({
+      loops: [defineLoop({ on: 'c', run: ['ghost', 'security'] })],
+      prompts: [after],
+      continueOnError: false,
+    })
+    const result = await loop.handle({ kind: 'c' })
+    // A missing prompt must gate exactly like a throwing one.
+    assert.equal(result.outcomes.length, 1)
+    assert.equal(result.outcomes[0]?.promptId, 'ghost')
+  })
 })
 
 describe('LoopEngine — failure policy', () => {

--- a/packages/ai-autopilot/src/loop/loop.ts
+++ b/packages/ai-autopilot/src/loop/loop.ts
@@ -113,6 +113,12 @@ export class LoopEngine {
       if (!prompt) {
         this.emit({ type: 'unknown-prompt', promptId: id })
         outcomes.push({ promptId: id, passes: [], ok: false, passing: false })
+        // A missing prompt is a non-passing outcome like any other: it must not
+        // slip past a blocking gate that a throwing prompt would have stopped.
+        if (!this.continueOnError) {
+          this.emit({ type: 'gate-stop', promptId: id })
+          break
+        }
         continue
       }
 

--- a/packages/ai-autopilot/src/pool.test.ts
+++ b/packages/ai-autopilot/src/pool.test.ts
@@ -38,6 +38,33 @@ describe('runPool', () => {
     assert.deepEqual(results, [1, 2])
   })
 
+  it('reports completion, not truncation, when the budget is met by the final item', async () => {
+    let done = 0
+    const { results, stopped } = await runPool([1, 2, 3], 1, async (n) => {
+      done++
+      return n
+    }, () => done >= 3)
+    // Everything ran, so there was nothing to skip — `stopped` must stay false
+    // or callers see a false "guardrail truncated the plan" signal.
+    assert.deepEqual(results, [1, 2, 3])
+    assert.equal(stopped, false)
+  })
+
+  it('surfaces a worker error without orphaning its siblings', async () => {
+    const seen: number[] = []
+    await assert.rejects(
+      () => runPool([1, 2, 3, 4], 2, async (n) => {
+        await tick()
+        if (n === 1) throw new Error('boom')
+        seen.push(n)
+        return n
+      }),
+      /boom/,
+    )
+    // Siblings drain rather than rejecting unhandled after the pool settles.
+    await tick()
+  })
+
   it('handles an empty list', async () => {
     const { results, stopped } = await runPool([], 4, async () => 1)
     assert.deepEqual(results, [])

--- a/packages/ai-autopilot/src/pool.ts
+++ b/packages/ai-autopilot/src/pool.ts
@@ -30,18 +30,24 @@ export async function runPool<T, R>(
 
   async function worker(): Promise<void> {
     while (true) {
+      // Bound first: with nothing left to claim there is no work to skip, so a
+      // budget met exactly by the final item is completion, not truncation.
+      if (next >= items.length) return
       if (shouldStop?.()) {
         stopped = true
         return
       }
       const index = next++
-      if (index >= items.length) return
       const value = await run(items[index]!, index)
       out.push({ index, value })
     }
   }
 
-  await Promise.all(Array.from({ length: workers }, () => worker()))
+  // allSettled so one rejecting worker cannot orphan its siblings into
+  // unhandled rejections; the first error is rethrown once all have drained.
+  const settled = await Promise.allSettled(Array.from({ length: workers }, () => worker()))
+  const failed = settled.find(s => s.status === 'rejected')
+  if (failed) throw (failed as PromiseRejectedResult).reason
 
   out.sort((a, b) => a.index - b.index)
   return { results: out.map(o => o.value), stopped }

--- a/packages/ai-autopilot/src/preset/load.ts
+++ b/packages/ai-autopilot/src/preset/load.ts
@@ -74,8 +74,9 @@ export function softwareDevelopmentPreset(opts: LoadPresetOptions = {}): Promise
 
 /**
  * Load every domain preset shipped with the package (under `presets/`) — the set
- * the CLI/UI picker enumerates. Today that is just "Software Development" (#243),
- * but new built-ins are discovered automatically as their directories land. Use
+ * the CLI/UI picker enumerates. Five ship today (software-development,
+ * web-development, data-science, product-management, biological-science), and new
+ * built-ins are discovered automatically as their directories land. Use
  * {@link selectPreset} to pick one by name.
  */
 export function builtinDomainPresets(opts: LoadPresetOptions = {}): Promise<DomainPreset[]> {

--- a/packages/ai-autopilot/src/runner/local.test.ts
+++ b/packages/ai-autopilot/src/runner/local.test.ts
@@ -130,6 +130,20 @@ describe('LocalRunnerSession.exec', () => {
       await s.dispose()
     }
   })
+
+  it('times out even when a background grandchild outlives the shell', async () => {
+    const s = await new LocalRunner().boot()
+    try {
+      // The grandchild survives a kill aimed at `sh` alone and holds the inherited
+      // stdio open, so `close` never fires — the timeout must still bound the call.
+      const started = Date.now()
+      const r = await s.exec('node -e "setTimeout(()=>{}, 10000)" & sleep 10', { timeoutMs: 300 })
+      assert.equal(r.exitCode, 124)
+      assert.ok(Date.now() - started < 5000, `exec took ${Date.now() - started}ms — the timeout did not bound it`)
+    } finally {
+      await s.dispose()
+    }
+  })
 })
 
 describe('LocalRunnerSession.preview', () => {

--- a/packages/ai-autopilot/src/runner/local.ts
+++ b/packages/ai-autopilot/src/runner/local.ts
@@ -218,34 +218,61 @@ export class LocalRunnerSession implements RunnerSession {
     const cwd = within(this.root, opts.cwd ?? (this.cwd || '.'))
     const env = { ...process.env, ...this.env, ...(opts.env ?? {}) }
     return await new Promise<ExecResult>((resolvePromise, reject) => {
-      const child = spawn(command, { cwd, env, shell: true })
+      // Own process group (like `start`) so a timeout kills the whole tree. A
+      // plain kill only reaps the `sh` wrapper; a surviving grandchild keeps the
+      // inherited stdio open, `close` never fires, and the timeout never lands.
+      const child = spawn(command, { cwd, env, shell: true, detached: true })
       let stdout = ''
       let stderr = ''
       let timedOut = false
+      let settled = false
+      let reaper: NodeJS.Timeout | undefined
+
+      const finish = (result: ExecResult): void => {
+        if (settled) return
+        settled = true
+        if (timer) clearTimeout(timer)
+        if (reaper) clearTimeout(reaper)
+        resolvePromise(result)
+      }
+      const timedOutResult = (): ExecResult => ({
+        stdout,
+        stderr: stderr + `\n[ai-autopilot] command timed out after ${opts.timeoutMs}ms`,
+        exitCode: 124,
+      })
+      const killTree = (): void => {
+        if (child.pid == null) return
+        try {
+          process.kill(-child.pid, 'SIGKILL')
+        } catch {
+          child.kill('SIGKILL') // group already gone, or no group to speak of
+        }
+      }
+
       const timer =
         opts.timeoutMs != null
           ? setTimeout(() => {
               timedOut = true
-              child.kill('SIGKILL')
+              killTree()
+              // A detached grandchild can still hold the pipes open, so don't
+              // wait on `close` forever — settle shortly after the kill.
+              reaper = setTimeout(() => finish(timedOutResult()), 250)
+              reaper.unref?.()
             }, opts.timeoutMs)
           : undefined
       child.stdout?.on('data', d => (stdout += d))
       child.stderr?.on('data', d => (stderr += d))
       child.on('error', err => {
+        if (settled) return
+        settled = true
         if (timer) clearTimeout(timer)
+        if (reaper) clearTimeout(reaper)
         reject(new RunnerError(`failed to spawn: ${(err as Error).message}`))
       })
       child.on('close', (code, signal) => {
-        if (timer) clearTimeout(timer)
-        if (timedOut) {
-          resolvePromise({
-            stdout,
-            stderr: stderr + `\n[ai-autopilot] command timed out after ${opts.timeoutMs}ms`,
-            exitCode: 124,
-          })
-          return
-        }
-        resolvePromise({ stdout, stderr, exitCode: code ?? (signal ? 137 : 1) })
+        finish(
+          timedOut ? timedOutResult() : { stdout, stderr, exitCode: code ?? (signal ? 137 : 1) },
+        )
       })
     })
   }

--- a/packages/ai-autopilot/src/supervisor.ts
+++ b/packages/ai-autopilot/src/supervisor.ts
@@ -110,10 +110,7 @@ export class Supervisor {
 
 // ─── Internals ───────────────────────────────────────────────────
 
-/**
- * Wrap the user's `onEvent` so a throwing callback can never abort a run.
- * Observer errors are reported to the console but otherwise swallowed.
- */
+/** Run one subtask on its routed worker, converting any failure into a result. */
 async function runSubtask(route: WorkerRouter, subtask: PlannedSubtask): Promise<SubtaskResult> {
   try {
     const agent = route(subtask)

--- a/packages/ai-autopilot/src/synthesizer.ts
+++ b/packages/ai-autopilot/src/synthesizer.ts
@@ -22,11 +22,17 @@ export function defaultSynthesize(_task: string, results: SubtaskResult[]): stri
     .join('\n\n')
 }
 
+/** Options for {@link agentSynthesizer}. */
+export interface AgentSynthesizerOptions {
+  /** Override the default "combine, don't concatenate" instruction. */
+  instructions?: string
+}
+
 /**
  * Build a {@link Synthesizer} that asks an agent to combine the worker results
  * into a single coherent answer. Failed subtasks are omitted from the prompt.
  */
-export function agentSynthesizer(agent: Agent, opts: { instructions?: string } = {}): Synthesizer {
+export function agentSynthesizer(agent: Agent, opts: AgentSynthesizerOptions = {}): Synthesizer {
   const instructions = opts.instructions
     ?? 'Combine the worker results below into a single, coherent answer to the task. Resolve overlaps and contradictions; do not just concatenate.'
 

--- a/packages/ai-mcp/package.json
+++ b/packages/ai-mcp/package.json
@@ -43,7 +43,7 @@
     "dev": "tsc -p tsconfig.build.json --watch",
     "typecheck": "tsc --noEmit",
     "test": "tsc -p tsconfig.test.json && cd dist-test && node --test",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist dist-test"
   },
   "dependencies": {
     "@gemstack/ai-sdk": "workspace:^",

--- a/packages/ai-mcp/src/server-from-agent.test.ts
+++ b/packages/ai-mcp/src/server-from-agent.test.ts
@@ -66,6 +66,28 @@ describe('mcpServerFromAgent — tools mode', () => {
     } finally { await cleanup() }
   })
 
+  it('forwards a tool whose execute fn returns synchronously', async () => {
+    // `.server()` accepts `TReturn | Promise<TReturn>`, so a bare return is
+    // legal and must not be mistaken for an async generator.
+    const syncTool = toolDefinition({
+      name:        'shout',
+      description: 'Shout a word',
+      inputSchema: z.object({ word: z.string() }),
+    }).server(({ word }) => word.toUpperCase())
+
+    class SyncAgent extends Agent {
+      instructions() { return 'Sync tool agent.' }
+      tools() { return [syncTool] }
+    }
+
+    const server = await mcpServerFromAgent(SyncAgent)
+    const { client, cleanup } = await connectClient(server)
+    try {
+      const result = await client.callTool({ name: 'shout', arguments: { word: 'hi' } })
+      assert.strictEqual(textFromResult(result), 'HI')
+    } finally { await cleanup() }
+  })
+
   it('stringifies structured tool results as JSON', async () => {
     const server = await mcpServerFromAgent(FixtureAgent)
     const { client, cleanup } = await connectClient(server)

--- a/packages/ai-mcp/src/server-from-agent.ts
+++ b/packages/ai-mcp/src/server-from-agent.ts
@@ -115,12 +115,23 @@ function registerAgentPromptToolOnServer(
   )
 }
 
+/** True only for an async generator: a Promise has neither `next` nor `Symbol.asyncIterator`. */
+function isAsyncGenerator(v: unknown): v is AsyncGenerator<unknown, unknown, void> {
+  const maybe = v as { next?: unknown; [Symbol.asyncIterator]?: unknown } | null
+  return maybe != null
+    && typeof maybe.next === 'function'
+    && typeof maybe[Symbol.asyncIterator] === 'function'
+}
+
 async function runAgentTool(tool: Tool, input: unknown): Promise<unknown> {
   if (!tool.execute) {
     throw new Error(`mcpServerFromAgent: tool "${tool.definition.name}" has no execute fn (client-only tool — cannot be exposed via MCP)`)
   }
   const out = (tool.execute as (input: unknown, ctx?: ToolCallContext) => unknown)(input)
-  if (out instanceof Promise) return await out
+  // Duck-type the generator rather than testing `out instanceof Promise`: a
+  // `.server()` fn may legally return a bare value or a non-native thenable,
+  // and both would otherwise be mistaken for a generator and die on `.next()`.
+  if (!isAsyncGenerator(out)) return await out
 
   // Generator path — drain progress yields silently and return the final value.
   // (MCP forwards progress via `notifications/progress`; the agent loop's

--- a/packages/ai-sdk/src/agent-sse.test.ts
+++ b/packages/ai-sdk/src/agent-sse.test.ts
@@ -157,6 +157,17 @@ describe('readAgentStream round-trips toAgentSseStream', () => {
     assert.equal(turn.awaiting, 'approval')
   })
 
+  it('propagates an error thrown by a consumer callback instead of swallowing it', async () => {
+    const server = toAgentSseStream(streamOf([{ type: 'text-delta', text: 'hi' }]))
+    // The malformed-JSON guard must not also eat the consumer's own bugs.
+    await assert.rejects(
+      () => readAgentStream(new Response(server), {
+        onText: () => { throw new Error('consumer bug') },
+      }),
+      /consumer bug/,
+    )
+  })
+
   it('fires onError for an error event', async () => {
     const failing: AgentStreamResponse = {
       stream: (async function* () {})(),

--- a/packages/ai-sdk/src/agent-sse.ts
+++ b/packages/ai-sdk/src/agent-sse.ts
@@ -320,9 +320,17 @@ export async function readAgentStream(
       if (line.startsWith('event: ')) {
         currentEvent = line.slice(7)
       } else if (line.startsWith('data: ') && currentEvent) {
+        // Parse inside the guard, apply outside it: `applyAgentSseEvent` invokes
+        // the consumer's callbacks, and swallowing their errors here would lose
+        // the diagnostic and leave `turn` half-mutated.
+        let data: unknown
         try {
-          applyAgentSseEvent(currentEvent, JSON.parse(line.slice(6)), turn, callbacks)
-        } catch { /* skip malformed JSON */ }
+          data = JSON.parse(line.slice(6))
+        } catch {
+          currentEvent = ''
+          continue // skip malformed JSON
+        }
+        applyAgentSseEvent(currentEvent, data, turn, callbacks)
         currentEvent = ''
       }
     }

--- a/packages/ai-sdk/src/agent.ts
+++ b/packages/ai-sdk/src/agent.ts
@@ -1115,6 +1115,10 @@ function runStreamWithMaybeAutoPersist(
   // Synchronous fast path — most agents override neither `conversational()`
   // nor `remembers()`. Skip the async outer entirely when we can prove
   // both are no-ops, sparing a microtask boundary per streaming call.
+  //
+  // Both are invoked exactly once and the values threaded into the async path
+  // below: calling them again there would repeat the override's side effects
+  // (a DI or DB lookup) and leave this first promise unhandled if it rejects.
   const declaredConv = a.conversational()
   const declaredMem  = a.remembers()
   const isFast = (
@@ -1139,8 +1143,8 @@ function runStreamWithMaybeAutoPersist(
     try {
       // Memory auto-cascade BEFORE conversation persistence — same
       // ordering as the non-streaming `Agent.prompt` path.
-      effOptions = await prepareOptionsWithMemoryAutoCascade(a, options)
-      spec = await resolveAutoPersistSpec(() => a.conversational(), effOptions?.conversation)
+      effOptions = await prepareOptionsWithMemoryAutoCascade(a, options, () => declaredMem)
+      spec = await resolveAutoPersistSpec(() => declaredConv, effOptions?.conversation)
     } catch (err) {
       rejectResp!(err)
       throw err
@@ -1241,10 +1245,12 @@ function getMiddleware(a: Agent, options?: AgentPromptOptions): AiMiddleware[] {
 async function prepareOptionsWithMemoryAutoCascade(
   a:        Agent,
   options?: AgentPromptOptions,
+  /** Reuse an already-obtained `remembers()` result instead of calling it again. */
+  declared?: () => ReturnType<Agent['remembers']>,
 ): Promise<AgentPromptOptions | undefined> {
   if (options?.messages) return options
 
-  const spec = await resolveRemembersSpec(() => a.remembers(), options?.memory)
+  const spec = await resolveRemembersSpec(declared ?? (() => a.remembers()), options?.memory)
   if (!spec) return options
 
   const installed: AiMiddleware[] = []

--- a/packages/ai-sdk/src/auto-persist.test.ts
+++ b/packages/ai-sdk/src/auto-persist.test.ts
@@ -221,6 +221,29 @@ describe('Auto-persist on Agent.stream()', () => {
     setConversationStore(undefined as unknown as never)
   })
 
+  it('invokes conversational() exactly once per stream() call', async () => {
+    const store = new MemoryConversationStore()
+    setConversationStore(store)
+    fake.respondWith('once')
+
+    let calls = 0
+    class CountingAgent extends Agent {
+      instructions() { return 'count me' }
+      // Async, so stream() cannot take its synchronous fast path.
+      async conversational(): Promise<ConversationalSpec> {
+        calls++
+        return { user: 'u-count' }
+      }
+    }
+
+    const { stream, response } = new CountingAgent().stream('hi')
+    for await (const _c of stream) { /* drain */ }
+    await response
+    // Calling it twice repeats the override's side effects (a DI or DB lookup)
+    // and leaves the first promise unhandled if it rejects.
+    assert.equal(calls, 1)
+  })
+
   it('streams through and persists at the end', async () => {
     const store = new MemoryConversationStore()
     setConversationStore(store)

--- a/packages/ai-sdk/src/cached-embedding.test.ts
+++ b/packages/ai-sdk/src/cached-embedding.test.ts
@@ -1,0 +1,79 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { CachedEmbeddingAdapter } from './cached-embedding.js'
+import type { EmbeddingAdapter, EmbeddingResult } from './types.js'
+
+/** Records every batch it was asked to embed, and charges 10 tokens per input. */
+function fakeAdapter(): EmbeddingAdapter & { batches: string[][] } {
+  const batches: string[][] = []
+  return {
+    batches,
+    async embed(input: string | string[]): Promise<EmbeddingResult> {
+      const inputs = Array.isArray(input) ? input : [input]
+      batches.push(inputs)
+      return {
+        embeddings: inputs.map((_, i) => [i, inputs.length]),
+        usage: { promptTokens: inputs.length * 10, totalTokens: inputs.length * 10 },
+      }
+    },
+  }
+}
+
+describe('CachedEmbeddingAdapter', () => {
+  it('reports the provider usage for cache misses', async () => {
+    const inner = fakeAdapter()
+    const cached = new CachedEmbeddingAdapter(inner)
+
+    const first = await cached.embed(['a', 'b'], 'm')
+    // Both missed, so the provider was called and its charge must surface.
+    assert.deepEqual(inner.batches, [['a', 'b']])
+    assert.equal(first.usage.totalTokens, 20)
+  })
+
+  it('reports zero usage only when every input was served from cache', async () => {
+    const inner = fakeAdapter()
+    const cached = new CachedEmbeddingAdapter(inner)
+
+    await cached.embed(['a', 'b'], 'm')
+    const second = await cached.embed(['a', 'b'], 'm')
+
+    assert.equal(inner.batches.length, 1) // no second provider call
+    assert.equal(second.usage.totalTokens, 0)
+  })
+
+  it('charges only for the uncached half of a partial hit', async () => {
+    const inner = fakeAdapter()
+    const cached = new CachedEmbeddingAdapter(inner)
+
+    await cached.embed(['a'], 'm')
+    const mixed = await cached.embed(['a', 'b'], 'm')
+
+    assert.deepEqual(inner.batches[1], ['b']) // only the miss went out
+    assert.equal(mixed.usage.totalTokens, 10)
+    assert.equal(mixed.embeddings.length, 2)
+  })
+
+  it('keys by model, so the same text under two models is two entries', async () => {
+    const inner = fakeAdapter()
+    const cached = new CachedEmbeddingAdapter(inner)
+
+    await cached.embed(['a'], 'm1')
+    await cached.embed(['a'], 'm2')
+
+    assert.equal(inner.batches.length, 2)
+  })
+
+  it('evicts oldest-first once maxEntries is exceeded', async () => {
+    const inner = fakeAdapter()
+    const cached = new CachedEmbeddingAdapter(inner, { maxEntries: 2 })
+
+    await cached.embed(['a'], 'm')
+    await cached.embed(['b'], 'm')
+    await cached.embed(['c'], 'm')   // evicts 'a'
+    await cached.embed(['c'], 'm')   // still cached
+    assert.equal(inner.batches.length, 3)
+
+    await cached.embed(['a'], 'm')   // evicted, so it goes out again
+    assert.deepEqual(inner.batches[3], ['a'])
+  })
+})

--- a/packages/ai-sdk/src/cached-embedding.ts
+++ b/packages/ai-sdk/src/cached-embedding.ts
@@ -1,15 +1,29 @@
 import type { EmbeddingAdapter, EmbeddingResult } from './types.js'
 
+/** Options for {@link CachedEmbeddingAdapter}. */
+export interface CachedEmbeddingOptions {
+  /**
+   * Cap on cached vectors; the oldest are evicted first. Default 10_000 — a
+   * long-lived process embedding user-supplied text would otherwise grow the
+   * map without bound, and each entry is a full vector.
+   */
+  maxEntries?: number
+}
+
 /**
  * In-memory caching wrapper for any EmbeddingAdapter.
  *
  * Caches embeddings by `model:text` key so repeated inputs skip the provider call.
- * Cache hits report zero token usage since no API call is made.
+ * Usage reflects what the provider actually charged: zero when every input was
+ * served from cache, otherwise the usage of the call made for the cache misses.
  */
 export class CachedEmbeddingAdapter implements EmbeddingAdapter {
   private cache = new Map<string, number[]>()
+  private readonly maxEntries: number
 
-  constructor(private inner: EmbeddingAdapter) {}
+  constructor(private inner: EmbeddingAdapter, opts: CachedEmbeddingOptions = {}) {
+    this.maxEntries = opts.maxEntries ?? 10_000
+  }
 
   async embed(input: string | string[], model: string): Promise<EmbeddingResult> {
     const inputs = Array.isArray(input) ? input : [input]
@@ -28,19 +42,31 @@ export class CachedEmbeddingAdapter implements EmbeddingAdapter {
       }
     }
 
-    if (uncached.length > 0) {
-      const fresh = await this.inner.embed(uncached, model)
-      for (let j = 0; j < uncachedIndices.length; j++) {
-        const idx = uncachedIndices[j]!
-        const embedding = fresh.embeddings[j]!
-        results[idx] = embedding
-        this.cache.set(`${model}:${uncached[j]}`, embedding)
-      }
+    if (uncached.length === 0) {
+      // Nothing hit the provider, so nothing was charged.
+      return { embeddings: results, usage: { promptTokens: 0, totalTokens: 0 } }
     }
 
-    return {
-      embeddings: results,
-      usage: { promptTokens: 0, totalTokens: 0 },
+    const fresh = await this.inner.embed(uncached, model)
+    for (let j = 0; j < uncachedIndices.length; j++) {
+      const idx = uncachedIndices[j]!
+      const embedding = fresh.embeddings[j]!
+      results[idx] = embedding
+      this.remember(`${model}:${uncached[j]}`, embedding)
+    }
+
+    // Report what the provider charged for the misses — zeroing it here would
+    // make every consumer aggregating usage undercount embedding spend.
+    return { embeddings: results, usage: fresh.usage }
+  }
+
+  /** Store one vector, evicting the oldest entries once the cap is exceeded. */
+  private remember(key: string, embedding: number[]): void {
+    this.cache.set(key, embedding)
+    while (this.cache.size > this.maxEntries) {
+      const oldest = this.cache.keys().next()
+      if (oldest.done) break
+      this.cache.delete(oldest.value)
     }
   }
 }

--- a/packages/ai-sdk/src/computer-use/index.ts
+++ b/packages/ai-sdk/src/computer-use/index.ts
@@ -1,12 +1,12 @@
 /**
  * `@gemstack/ai-sdk/computer-use` — Anthropic computer-use abstraction (#A7).
  *
- * Phase 1 (this entry) ships the action vocabulary + Playwright
- * executor. Phase 2 will add `computerUseTool({ page })` — the agent
- * tool factory that maps to Anthropic's native `computer_20250124`
- * tool block and routes execution through the executor here.
+ * Ships the action vocabulary, the Playwright executor, and
+ * {@link computerUseTool} — the agent tool factory that maps to Anthropic's
+ * native `computer_20250124` tool block and routes execution through that
+ * executor.
  *
- * # Quick example (manual / phase-1 surface)
+ * # Quick example (driving the executor directly)
  *
  * ```ts
  * import { chromium } from 'playwright'
@@ -26,7 +26,7 @@
  * await executeComputerAction(page, { action: 'left_click', coordinate: [400, 200] }, state)
  * ```
  *
- * Phase 2 will collapse this to:
+ * Or let an agent drive it:
  *
  * ```ts
  * import { computerUseTool } from '@gemstack/ai-sdk/computer-use'
@@ -40,7 +40,7 @@
  * # Anthropic-only in v1
  *
  * The action vocabulary mirrors Anthropic's `computer_20250124` schema
- * verbatim. Phase 2's tool factory throws `ComputerUseProviderError` at
+ * verbatim. The tool factory throws `ComputerUseProviderError` at
  * agent boot for non-Anthropic models — see plan
  * `docs/plans/2026-05-10-ai-computer-use.md`.
  */

--- a/packages/ai-sdk/src/eval/fixtures.ts
+++ b/packages/ai-sdk/src/eval/fixtures.ts
@@ -107,7 +107,7 @@ export async function readFixture(
   if (parsed.version !== 1) {
     throw new Error(
       `[ai-sdk] Fixture ${file} is version ${String(parsed.version)}; expected 1. ` +
-      `Re-record with \`pnpm rudder ai:eval --record\`.`,
+      `Re-record it with your host's eval record command, or rewrite it with \`writeFixture()\`.`,
     )
   }
   return parsed

--- a/packages/ai-sdk/src/file-search.ts
+++ b/packages/ai-sdk/src/file-search.ts
@@ -14,8 +14,8 @@
  *
  * Other providers see the tool as a regular function-call tool with the
  * placeholder `{ query: string }` schema — without an `execute` they pause
- * for client tools, which is degraded. Phase 3 will add a `fallback` opt
- * that installs an `execute` delegating to `similaritySearch` over a local
+ * for client tools, which is degraded. Set the {@link FileSearchOptions.fallback}
+ * opt to install an `execute` delegating to `similaritySearch` over a local
  * pgvector model.
  *
  * # Wiring

--- a/packages/ai-sdk/src/gateway/sse.ts
+++ b/packages/ai-sdk/src/gateway/sse.ts
@@ -65,7 +65,10 @@ export async function* parseSseStream(
     }
   } finally {
     signal?.removeEventListener('abort', onAbort)
-    reader.releaseLock()
+    // Cancel, don't just release: an early return (a `stopWhen`, an approval
+    // pause, a consumer `break`) would otherwise leave the response body open
+    // and pin the upstream socket until the server times it out.
+    void reader.cancel().catch(() => {})
   }
 }
 

--- a/packages/ai-sdk/src/index.ts
+++ b/packages/ai-sdk/src/index.ts
@@ -23,6 +23,9 @@ export type {
   ClientTool,
   ConversationStore,
   ConversationStoreMeta,
+  ConversationStoreListEntry,
+  ConversationalSpec,
+  ConversationalOverride,
   MemoryEntry,
   RemembersOverride,
   RemembersSpec,
@@ -37,6 +40,7 @@ export type {
   PrepareStepResult,
   ProviderAdapter,
   ProviderFactory,
+  ProviderHint,
   ProviderRequestOptions,
   ProviderResponse,
   ServerTool,
@@ -111,8 +115,8 @@ export {
   pauseForApproval,
   isPauseForApprovalChunk,
 } from './tool.js'
-export type { PauseForClientToolsChunk, PauseForApprovalChunk } from './tool.js'
-export { zodToJsonSchema } from './zod-to-json-schema.js'
+export type { PauseForClientToolsChunk, PauseForApprovalChunk, ServerToolBuilder } from './tool.js'
+export { zodToJsonSchema, type SchemaIo } from './zod-to-json-schema.js'
 
 // Scoped / multi-capability tools — collapse a discriminated union of
 // capability branches into one flat function-call schema.
@@ -258,7 +262,7 @@ export type {
 
 // File Search agent tool (#B8 Phase 2 — provider-native RAG)
 export { fileSearch, isFileSearchTool, FILE_SEARCH_MARKER, FILE_SEARCH_TOOL_NAME, normalizeWhere } from './file-search.js'
-export type { FileSearchOptions, FileSearchTool, FileSearchFilter, FileSearchWhereSugar } from './file-search.js'
+export type { FileSearchOptions, FileSearchTool, FileSearchFilter, FileSearchWhereSugar, FileSearchFallback } from './file-search.js'
 
 // Cached Embeddings
 export { CachedEmbeddingAdapter, type CachedEmbeddingOptions } from './cached-embedding.js'
@@ -270,6 +274,7 @@ export type {
   SimilarityHit,
   SimilaritySearchModel,
   SimilaritySearchQueryBuilder,
+  SimilaritySearchWhereOperator,
 } from './similarity-search.js'
 
 // Budget / pricing (#A6 — full pricing catalog + per-user spend caps)

--- a/packages/ai-sdk/src/index.ts
+++ b/packages/ai-sdk/src/index.ts
@@ -261,7 +261,7 @@ export { fileSearch, isFileSearchTool, FILE_SEARCH_MARKER, FILE_SEARCH_TOOL_NAME
 export type { FileSearchOptions, FileSearchTool, FileSearchFilter, FileSearchWhereSugar } from './file-search.js'
 
 // Cached Embeddings
-export { CachedEmbeddingAdapter } from './cached-embedding.js'
+export { CachedEmbeddingAdapter, type CachedEmbeddingOptions } from './cached-embedding.js'
 
 // Similarity Search (#B7 Phase 2 — agent tool wrapping ORM vector primitives)
 export { similaritySearch } from './similarity-search.js'

--- a/packages/ai-sdk/src/provider-tools.ts
+++ b/packages/ai-sdk/src/provider-tools.ts
@@ -14,6 +14,9 @@ import type { ProviderHint } from './types.js'
  * and removes `<script>`/`<style>` element *content* (not just the tags) so it
  * never leaks into the extracted text.
  */
+/** Sent by the `web_search` / `web_fetch` fallbacks. */
+const USER_AGENT = 'gemstack-ai-sdk/1.0'
+
 export function htmlToText(html: string): string {
   const lower = html.toLowerCase()
   let out = ''
@@ -106,10 +109,9 @@ export class WebSearch {
       try {
         const url = new URL('https://html.duckduckgo.com/html/')
         url.searchParams.set('q', query + (domains ? ` site:${domains.join(' OR site:')}` : ''))
-        const res = await fetch(url.toString(), { headers: { 'User-Agent': 'Rudder/1.0' } })
+        const res = await fetch(url.toString(), { headers: { 'User-Agent': USER_AGENT } })
         const html = await res.text()
-        const text = html.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 2000)
-        return { results: text }
+        return { results: htmlToText(html).slice(0, 2000) }
       } catch {
         return { error: 'Web search unavailable' }
       }
@@ -151,7 +153,7 @@ export class WebFetch {
     }).server(async ({ url: targetUrl }) => {
       try {
         const res = await fetch(targetUrl, {
-          headers: { 'User-Agent': 'Rudder/1.0' },
+          headers: { 'User-Agent': USER_AGENT },
           signal: AbortSignal.timeout(10000),
         })
         const html = await res.text()

--- a/packages/ai-sdk/src/providers/bedrock.ts
+++ b/packages/ai-sdk/src/providers/bedrock.ts
@@ -19,8 +19,8 @@ import {
 /**
  * AWS Bedrock — managed access to foundation models on AWS infrastructure.
  *
- * v1 supports **Anthropic Claude models on Bedrock** (the dominant case for
- * Rudder users on AWS). Other model families on Bedrock (Llama, Nova, etc.)
+ * v1 supports **Anthropic Claude models on Bedrock** (the dominant case on
+ * AWS). Other model families on Bedrock (Llama, Nova, etc.)
  * surface a clear error pointing at the supported set — they can be added in
  * follow-up PRs as demand justifies.
  *

--- a/packages/ai-sdk/src/providers/openai.ts
+++ b/packages/ai-sdk/src/providers/openai.ts
@@ -285,7 +285,7 @@ export function normalizeToolTranscript(messages: AiMessage[]): AiMessage[] {
           out.push({
             role:       'tool',
             toolCallId: tc.id,
-            content:    '[Rudder] tool result missing — synthesized to satisfy the OpenAI tool-call/tool-result protocol.',
+            content:    '[ai-sdk] tool result missing — synthesized to satisfy the OpenAI tool-call/tool-result protocol.',
           })
         }
       }

--- a/packages/ai-sdk/src/queue-adapter.ts
+++ b/packages/ai-sdk/src/queue-adapter.ts
@@ -2,8 +2,8 @@
  * Neutral job-dispatch contract behind `agent.queue('...').send()`.
  *
  * `@gemstack/ai-sdk` does not bundle or depend on any queue implementation.
- * Register one once at startup via {@link configureAiQueue}; Rudder apps get
- * this wired automatically by Rudder's `AiProvider`.
+ * Register one once at startup via {@link configureAiQueue}. A host framework
+ * may wire this for you; check its AI integration docs.
  *
  * `dispatch` enqueues `fn` to run later on a worker.
  */

--- a/packages/ai-sdk/src/queue-job.ts
+++ b/packages/ai-sdk/src/queue-job.ts
@@ -155,7 +155,7 @@ async function loadBroadcast(): Promise<BroadcastFn | null>  { return _broadcast
 
 async function defaultLoadDispatch(): Promise<DispatchFn> {
   throw new Error(
-    '[ai-sdk] agent.queue() needs a queue adapter. Register one at startup with configureAiQueue({ dispatch }). Rudder apps get this automatically via their AI provider.',
+    '[ai-sdk] agent.queue() needs a queue adapter. Register one at startup with configureAiQueue({ dispatch }); a host framework may wire this for you.',
   )
 }
 

--- a/packages/ai-sdk/src/registry.ts
+++ b/packages/ai-sdk/src/registry.ts
@@ -39,16 +39,15 @@ export async function tryWithFailover<T>(
  * Shared singleton store routed through `globalThis` so the registry survives
  * the case where `@gemstack/ai-sdk` is loaded twice — typical in a Vite-bundled
  * server where the framework bundles `@gemstack/ai-sdk` inline (any agent
- * resolution path reads `AiRegistry`), but `AiProvider.boot()` runs from a
- * `node_modules` copy of `@gemstack/ai-sdk/server` resolved via the provider
- * auto-discovery manifest. Without a shared store, provider factories
+ * resolution path reads `AiRegistry`), but the host's provider bootstrap runs
+ * from a `node_modules` copy resolved via its own discovery.
+ * Without a shared store, provider factories
  * registered from the externalized copy would never be visible to
  * `AiRegistry.resolve()` from inside the bundle — every agent call would
  * throw "Unknown AI provider".
  *
- * Defensive migration per the #499 static-state singleton audit. Same pattern
- * applied to other process-wide registries (model registry, pennant, cache,
- * queue, mail, storage, hash).
+ * Defensive migration per the #499 static-state singleton audit. The same
+ * pattern applies to every process-wide registry here.
  */
 interface AiRegistryStore {
   factories: Map<string, ProviderFactory>

--- a/packages/ai-sdk/src/vercel-protocol.ts
+++ b/packages/ai-sdk/src/vercel-protocol.ts
@@ -1,7 +1,7 @@
 import type { StreamChunk } from './types.js'
 
 /**
- * Convert a Rudder AI stream to Vercel AI SDK Data Stream Protocol format.
+ * Convert an ai-sdk agent stream to Vercel AI SDK Data Stream Protocol format.
  *
  * Protocol prefixes:
  * - `0:` text delta (JSON string)

--- a/packages/ai-skills/package.json
+++ b/packages/ai-skills/package.json
@@ -43,7 +43,7 @@
     "dev": "tsc -p tsconfig.build.json --watch",
     "typecheck": "tsc --noEmit",
     "test": "tsc -p tsconfig.test.json && cd dist-test && node --test",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist dist-test"
   },
   "dependencies": {
     "@gemstack/ai-sdk": "workspace:^",

--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -514,6 +514,40 @@ describe('McpTestClient', () => {
     )
   })
 
+  it('rejects arguments that do not match the declared schema', async () => {
+    class GetIssueTool extends McpTool {
+      schema() { return z.object({ number: z.number().int().positive() }) }
+      async handle(input: Record<string, unknown>) {
+        // Handlers are written against the declared types and interpolate them
+        // into request paths, so an unchecked value here is an injection.
+        return McpResponse.text(`/issues/${String(input['number'])}`)
+      }
+    }
+    class Srv extends McpServer { protected tools = [GetIssueTool] }
+
+    const client = new McpTestClient(Srv)
+    await assert.rejects(
+      () => client.callTool('get-issue', { number: '../../../user/repos' }),
+      /Invalid arguments/,
+    )
+    const ok = await client.callTool('get-issue', { number: 7 })
+    assert.equal((ok.content[0] as { text: string }).text, '/issues/7')
+  })
+
+  it('strips undeclared keys instead of forwarding them to the handler', async () => {
+    class StrictTool extends McpTool {
+      schema() { return z.object({ a: z.string() }) }
+      async handle(input: Record<string, unknown>) {
+        return McpResponse.text(Object.keys(input).sort().join(','))
+      }
+    }
+    class Srv extends McpServer { protected tools = [StrictTool] }
+
+    const client = new McpTestClient(Srv)
+    const r = await client.callTool('strict', { a: 'x', injected: 'y' })
+    assert.equal((r.content[0] as { text: string }).text, 'a')
+  })
+
   it('lists and reads resources', async () => {
     const client = new McpTestClient(TestServer)
     const resources = await client.listResources()

--- a/packages/mcp/src/runtime/sdk-server.ts
+++ b/packages/mcp/src/runtime/sdk-server.ts
@@ -14,6 +14,7 @@ import type { McpTool } from '../McpTool.js'
 import type { McpResource } from '../McpResource.js'
 import type { McpPrompt } from '../McpPrompt.js'
 import { zodToJsonSchema } from '../zod-to-json-schema.js'
+import { validateInput } from '../validate-input.js'
 import { getToolAnnotations, getResourceAnnotations } from '../decorators.js'
 import { matchUriTemplate } from '../uri-template.js'
 import { getMcpObservers } from './observers-accessor.js'
@@ -56,7 +57,15 @@ export function createSdkServer(server: McpServer): Server {
     if (!tool || !(await isRegistered(tool))) {
       return { content: [{ type: 'text' as const, text: `Unknown tool: ${request.params.name}` }], isError: true }
     }
-    const input = (request.params.arguments ?? {}) as Record<string, unknown>
+    const raw = (request.params.arguments ?? {}) as Record<string, unknown>
+    const checked = validateInput(tool.schema(), raw)
+    if (!checked.ok) {
+      return {
+        content: [{ type: 'text' as const, text: `Invalid arguments for ${tool.name()}: ${checked.message}` }],
+        isError: true,
+      }
+    }
+    const input = checked.data
     const start = performance.now()
     try {
       const extras = resolveHandleDeps(tool, 'handle', resolver)
@@ -174,7 +183,12 @@ export function createSdkServer(server: McpServer): Server {
     if (!prompt || !(await isRegistered(prompt))) {
       throw new Error(`Unknown prompt: ${request.params.name}`)
     }
-    const args = (request.params.arguments ?? {}) as Record<string, unknown>
+    const rawArgs = (request.params.arguments ?? {}) as Record<string, unknown>
+    const checkedArgs = prompt.arguments ? validateInput(prompt.arguments(), rawArgs) : { ok: true as const, data: rawArgs }
+    if (!checkedArgs.ok) {
+      throw new Error(`Invalid arguments for ${prompt.name()}: ${checkedArgs.message}`)
+    }
+    const args = checkedArgs.data
     const start = performance.now()
     try {
       const extras = resolveHandleDeps(prompt, 'handle', resolver)

--- a/packages/mcp/src/testing.ts
+++ b/packages/mcp/src/testing.ts
@@ -8,6 +8,7 @@ import { resolveOrConstruct, resolveHandleDeps, isRegistered, filterRegistered }
 import { consumeToolReturn } from './runtime/consume-tool-return.js'
 import { getToolAnnotations, getResourceAnnotations, type ToolAnnotations, type ResourceAnnotations } from './decorators.js'
 import type { McpResolver } from './resolver.js'
+import { validateInput } from './validate-input.js'
 
 export interface McpTestClientOptions {
   /** DI resolver for `@Handle()` dependencies + primitive construction. */
@@ -40,8 +41,12 @@ export class McpTestClient {
   ): Promise<McpToolResult> {
     const tool = this.tools.find((t) => t.name() === name)
     if (!tool || !(await isRegistered(tool))) throw new Error(`Tool "${name}" not found`)
+    // Validate exactly as the runtime does, so a test cannot pass arguments a
+    // real client would be rejected for.
+    const checked = validateInput(tool.schema(), input)
+    if (!checked.ok) throw new Error(`Invalid arguments for ${name}: ${checked.message}`)
     const extras = resolveHandleDeps(tool, 'handle', this.resolver)
-    const ret = tool.handle(input, ...extras as [])
+    const ret = tool.handle(checked.data, ...extras as [])
     const extra = onProgress
       ? {
           sendNotification: async (n: { method: string; params: Record<string, unknown> }) => {

--- a/packages/mcp/src/validate-input.ts
+++ b/packages/mcp/src/validate-input.ts
@@ -1,0 +1,50 @@
+import type { ZodLikeObject } from './types.js'
+
+/** Outcome of checking client-supplied arguments against a declared schema. */
+export type ValidationResult =
+  | { ok: true; data: Record<string, unknown> }
+  | { ok: false; message: string }
+
+interface SafeParsable {
+  safeParse(input: unknown): {
+    success: boolean
+    data?: unknown
+    error?: { issues?: Array<{ path?: PropertyKey[]; message?: string }> }
+  }
+}
+
+function isSafeParsable(schema: unknown): schema is SafeParsable {
+  return typeof (schema as SafeParsable | null)?.safeParse === 'function'
+}
+
+/**
+ * Check client-supplied arguments against the schema a tool or prompt declares.
+ *
+ * The low-level MCP `Server` validates only the request envelope — `arguments`
+ * is typed as an open record on the wire — so without this a handler receives
+ * whatever the client sent, whatever its declared schema says. Handlers are
+ * written against the declared types (and interpolate those values into URLs and
+ * paths), so an unchecked argument is a real injection surface.
+ *
+ * Returns the *parsed* value on success, so handlers see coerced values and
+ * declared-away extra keys rather than the raw payload. Schemas that cannot
+ * validate (a plain `{ shape }` object rather than a Zod schema) pass through
+ * unchanged — advertising is best-effort for those, and so is checking.
+ */
+export function validateInput(schema: ZodLikeObject, input: Record<string, unknown>): ValidationResult {
+  if (!isSafeParsable(schema)) return { ok: true, data: input }
+
+  const parsed = schema.safeParse(input)
+  if (parsed.success) {
+    return { ok: true, data: (parsed.data ?? input) as Record<string, unknown> }
+  }
+
+  const issues = parsed.error?.issues ?? []
+  const detail = issues
+    .map((i) => {
+      const path = (i.path ?? []).join('.')
+      return path ? `${path}: ${i.message ?? 'invalid'}` : (i.message ?? 'invalid')
+    })
+    .join('; ')
+  return { ok: false, message: detail || 'input did not match the declared schema' }
+}


### PR DESCRIPTION
Closes #963 (shipped half; the deferred findings stay open there).

Quality sweep of the AI packages, driven by five parallel read-only reviews (correctness and design lenses per package). Every finding here was re-verified against the code before acting, and each behavioural fix ships a regression test that I confirmed fails without it.

One commit per package, so it reviews cleanly commit-by-commit.

## ai-autopilot — orchestration correctness

- **`exec()` could never settle.** It spawned without a process group, so the timeout's kill reaped only the `sh` wrapper; a surviving grandchild kept the inherited stdio open and `close` never fired. Reproduced directly: `timeoutMs: 2000` still unsettled after 8s. `start()` two methods above already did this correctly, so `exec` now mirrors it.
- **`serveCheck` could hang forever.** `Promise.race([fetch, proc.exit])` had no timer on either arm, so a server that accepts connections but never answers left both pending and the bootstrap pass loop never advanced. That is precisely the failure the check exists to catch.
- **A blocking chain ran past an unknown prompt.** The unknown-prompt branch `continue`d, skipping the gate check three lines below, so with `continueOnError: false` a typo'd id let the rest of the chain run as if the gate passed, while a throwing prompt correctly stopped it.
- **`runPool` reported truncation on completed runs.** `shouldStop` was consulted before the bounds check, so a budget met exactly by the final item surfaced as `stoppedEarly` + `budget-exceeded` with `skipped: 0`. Worker errors now propagate via `allSettled` so one failure cannot orphan its siblings.

## ai-sdk — streaming, SSE, embedding cache

- **`stream()` resolved its specs twice.** The synchronous fast-path probe called `conversational()` and `remembers()` and dropped the returned promises, then the async path called them again: an override doing a DI or DB lookup ran its side effects twice per call, and a rejection from the dropped promise could abort the process.
- **`readAgentStream` swallowed consumer callback errors.** The "skip malformed JSON" guard wrapped the callback dispatch too, so a throwing `onText` / `onToolResult` was discarded silently and the turn left half-mutated. Parses inside the guard, applies outside it.
- **`parseSseStream` leaked the upstream connection.** It released the reader lock without cancelling the body, so any early exit (a `stopWhen`, an approval pause, a consumer `break`) pinned the socket until the server timed out.
- **`CachedEmbeddingAdapter` undercounted spend by 100%.** It returned hardcoded zero usage even when it did call the provider, so anything aggregating usage missed embedding cost entirely. Its cache also never evicted. It had zero test coverage; it now has a suite.

## mcp — declared schemas are now enforced (security)

A tool's `schema()` was only used to *advertise* its shape in `tools/list`. The low-level MCP `Server` validates just the envelope (`arguments` is an open record on the wire), so `tools/call` handed `handle()` whatever the client sent. Handlers are written against the declared types and interpolate them into request paths: `mcp-connector-github`'s `get-issue` declares `number: z.number().int().positive()` and builds `` `/repos/${enc(owner)}/${enc(repo)}/issues/${input.number}` `` unencoded, so `number: "../../../user/repos"` was a live traversal against the GitHub API with the server's token.

`tools/call` and `prompts/get` now validate, reject a mismatch with a clear error, and pass the **parsed** value to the handler (so coercion applies and undeclared keys are stripped). Non-Zod `{ shape }` schemas pass through as before. `McpTestClient` validates identically so tests cannot disagree with the runtime.

## ai-mcp

`out instanceof Promise` treated any non-native-Promise return as an async generator, so a legal synchronous `.server((input) => 'hi')` died on `iter.next is not a function`. Now duck-types the generator the way `@gemstack/mcp` already does.

## Non-behavioural

`web_search`'s fallback used the exact `<[^>]*>` regex that `provider-tools.ts` documents as forbidden two functions above it (polynomial ReDoS, trips CodeQL) and leaked `<script>` content into the model's context; it now calls `htmlToText` like `web_fetch`. Nine types that are public by construction but exported from no entry point are now exported (`ServerToolBuilder` chief among them: it is the return type of `Agent.asTool()`, `scopedTool()`, `similaritySearch()` and `toolDefinition().server()`). The last `Rudder` references are gone from strings a user or model actually reads. "Phase N will add ..." comments removed for features shipping in the same file. `clean` scripts no longer leave `dist-test/` behind, which is what produces phantom failures from stale compiled tests.

## Verification

Baseline before the sweep was 1337 tests green. Now **1351 green, 0 failures** across ai-sdk (879), ai-autopilot (302), mcp (113), ai-mcp (20), ai-skills (37), and the full monorepo build passes 11/11.

For each behavioural fix I stashed the source change, kept the new test, and confirmed it failed: the `exec` grandchild timeout, the `runPool` exact-budget hit, the unknown-prompt gate, the `conversational()` call count, the SSE callback propagation, the two schema-validation tests, and the synchronous `.server()` return.
