### PR TITLE
feat(framework): UX preset rates every UI flow and fixes the low scorers (#962)

### DIFF
--- a/.changeset/ux-preset-auto.md
+++ b/.changeset/ux-preset-auto.md
@@ -1,0 +1,15 @@
+---
+'@gemstack/framework': minor
+---
+
+The UX preset now rates every UI flow and fixes the low scorers on its own (#962)
+
+It used to enumerate findings, show them as choices, and stop at `<AWAIT>` for a human to
+pick from. That made it unusable unattended, and the ratings it produced were mostly 10/10,
+which is the failure mode where a review reports that everything is fine and changes nothing.
+
+The new prompt demands 100% coverage of the UI flows, a rated reason for each one, a separate
+commit per flow it improves, and a closing table of old rating => new rating. It names the
+all-10s answer as laziness up front, which is the part that makes the ratings honest. It runs
+to completion, so the launcher button is now labelled "UX (auto)"; a gated sibling that offers
+its ratings as choices is tracked separately.

--- a/packages/framework/prompts/presets/ux.md
+++ b/packages/framework/prompts/presets/ux.md
@@ -1,6 +1,9 @@
-Thoroughly review UX of ${{ tf.params.what }} and make proposals to improve. Focus your review from a usability perspective: is using the UI and all the functionalities a nice user experience?
-1. Enumerate *all* your findings (in a sensible order and categorized), with reference numbers (so that it's easy to reference each point in follow up conversations), and make it a list of choices shown via `showChoices()`
-2. <AWAIT>
-3. Work on all accepted proposals
-
-AWAIT: Stop, await user answer before resuming
+Review all UI flows of ${{ tf.params.what }}
+1. Before starting to work: list *ALL* UI flows
+   - DON'T skip any UI flow (100% coverage)
+2. Then, give a UX rating for each UI flow (10: perfect UX, 0: unusable UX), and give a reason for your rating
+3. Improve UI flows with bad UX rating
+   - Separate commit for each UI flow you improved
+   - Work until it's exceptionally good. We as an expert team will check against every little detail.
+     - If we see that you gave mostly a 10/10 rating, that's a sign you've been lazy... so make sure you scrutinize everything and spend a substantial amount of time. We don't want to prompt you again and again to achieve quality — autonomously strive for quality on your own without us pushing you.
+   - Give summary of what you worked on: print the UI flow list again with old rating => new rating with link to commits

--- a/packages/framework/src/preset-catalog.test.ts
+++ b/packages/framework/src/preset-catalog.test.ts
@@ -13,7 +13,7 @@ const PARAMETERIZED = [
   { preset: presets.readability, defaultOut: /^Refactor entire codebase to make it/, custom: 'the dashboard package', customOut: /^Refactor the dashboard package to make it/ },
   { preset: presets.research, defaultOut: /problem variability" of entire codebase/, custom: 'the auth flow', customOut: /problem variability" of the auth flow/ },
   { preset: presets.securityAudit, defaultOut: /^Security audit entire codebase/, custom: 'the auth package', customOut: /^Security audit the auth package/ },
-  { preset: presets.ux, defaultOut: /^Thoroughly review UX of entire codebase/, custom: 'the settings page', customOut: /^Thoroughly review UX of the settings page/ },
+  { preset: presets.ux, defaultOut: /^Review all UI flows of entire codebase/, custom: 'the settings page', customOut: /^Review all UI flows of the settings page/ },
   { preset: presets.maintenance, defaultOut: /^Analyze entire codebase and/, custom: 'the auth package', customOut: /^Analyze the auth package and/ },
 ] as const
 
@@ -86,11 +86,23 @@ test('the quality presets carry their #326 instructions', () => {
   assert.match(presets.securityAudit.template, /verdict/)
   assert.match(presets.securityAudit.template, /each security issue in a separate commit/)
 
-  assert.match(presets.ux.template, /^Thoroughly review UX/)
-  assert.match(presets.ux.template, /usability perspective/)
-  assert.match(presets.ux.template, /showChoices\(\)/)
-  assert.match(presets.ux.template, /<AWAIT>/)
-  assert.match(presets.ux.template, /Work on all accepted proposals/)
+  assert.match(presets.ux.template, /^Review all UI flows/)
+  assert.match(presets.ux.template, /DON'T skip any UI flow \(100% coverage\)/)
+  assert.match(presets.ux.template, /10: perfect UX, 0: unusable UX/)
+  assert.match(presets.ux.template, /Separate commit for each UI flow you improved/)
+  assert.match(presets.ux.template, /old rating => new rating with link to commits/)
+})
+
+test('UX runs to completion instead of gating on a human (#962)', () => {
+  // The "(auto)" in the label is the contract: it rates, then fixes, so a run started from it
+  // finishes on its own. The gated sibling that offers its ratings as choices is #962's follow-up.
+  const out = presets.ux.render()
+  assert.equal(out.includes('<AWAIT>'), false)
+  assert.equal(out.includes('<SHOW_CHOICES>'), false)
+  assert.equal(out.includes('showChoices'), false)
+  // The laziness guard is the load-bearing half of the prompt: without it the ratings come back
+  // all-10s and nothing gets fixed.
+  assert.match(out, /that's a sign you've been lazy/)
 })
 
 test('Research gates on a multi-select and writes its own review/TODO files (#331)', () => {

--- a/packages/framework/src/preset-catalog.ts
+++ b/packages/framework/src/preset-catalog.ts
@@ -50,8 +50,13 @@ export const presets = {
   /** [Security audit] (#461). */
   securityAudit: definePreset({ name: 'security-audit', template: PRESETS_SECURITY_AUDIT, what: 'What to security-audit', label: 'Security audit' }),
 
-  /** [UX review] (#472). */
-  ux: definePreset({ name: 'ux', template: PRESETS_UX, what: 'What to review the UX of', label: 'UX' }),
+  /**
+   * [UX (auto)] (#962, replacing #472's gated prompt): rate every UI flow, then fix the low
+   * scorers. Unattended by design — it ends in work rather than in `<AWAIT>`, so a run started
+   * from it finishes on its own. A gated sibling that offers its ratings as choices is #962's
+   * stated follow-up and belongs beside this row, not inside it.
+   */
+  ux: definePreset({ name: 'ux', template: PRESETS_UX, what: 'What to review the UX of', label: 'UX (auto)' }),
 
   /**
    * [Maintenance] (#881/#882): the periodic codebase sweep. Note `${{ }}` fragments cannot nest (the
@@ -64,7 +69,7 @@ export const presets = {
 
   /**
    * [Market research] (#694). Its prompt defines `<SESSION_NAME>` itself rather than reading
-   * `${{ tf.session_name }}`: the session name does not exist yet when a preset renders.
+   * `${{ tf.session_name }}`: it is launched from the launcher, where no session exists yet.
    */
   marketResearch: definePreset({ name: 'market-research', template: PRESETS_MARKET_RESEARCH, label: 'Market research' }),
 


### PR DESCRIPTION
Closes #962

## What changed

`prompts/presets/ux.md` is replaced with the prompt from the issue, verbatim.

The old preset enumerated findings, offered them via `showChoices()`, and stopped at `<AWAIT>`. The new one rates *every* UI flow (100% coverage demanded up front), fixes the ones that score badly, commits each flow separately, and closes with an `old rating => new rating` table linking the commits.

The launcher label becomes **UX (auto)**, matching the issue title and leaving room for the `UX (choices)` sibling.

## The default already existed

The issue asks for `tf.params.what` to default to `${{ tf.session_name || "entire codebase" }}`. That is character-for-character `DEFAULT_WHAT` in `preset-prompt.ts`, added by #874, and `definePreset` already renders it against the same context as the body. So no template or param work was needed. Verified against the built bundle rather than assumed:

| call | first line |
|---|---|
| `render()` (launcher, no session) | `Review all UI flows of entire codebase` |
| `render(undefined, { session_name: 'the dashboard' })` | `Review all UI flows of the dashboard` |
| `render('the settings page')` | `Review all UI flows of the settings page` |

## Two judgement calls

- **It stays out of `AUTO_PM_JOBS`.** Dropping `<AWAIT>` makes it eligible, but that rotation is an explicit list, and putting a codebase-wide UI sweep on every idle tick is a product decision rather than a side effect of this change. Say the word and it is one line.
- **The em-dash and the `...` in the prompt body are yours, kept verbatim** rather than normalised to the repo's prose style, since the prompt is the spec.

## Housekeeping

- A stale comment in `preset-catalog.ts` claimed the session name does not exist when a preset renders. It does, since the Composer passes it; corrected to say why market research still names itself.
- Changeset added (minor: user-facing prompt behaviour).

## Verification

`pnpm build` + `pnpm test` from root: 21/21 tasks, framework **1041 pass / 0 fail**. The catalog test now pins the new prompt's load-bearing lines (100% coverage, the rating scale, per-flow commits, the old => new summary) plus a new test asserting the preset never gates on a human and keeps the anti-laziness clause.