### PR TITLE
feat(framework): Import tickets from GitHub preset, always in a new session (#959)

### DIFF
--- a/.changeset/import-tickets-preset.md
+++ b/.changeset/import-tickets-preset.md
@@ -1,0 +1,14 @@
+---
+'@gemstack/framework': minor
+'@gemstack/framework-dashboard': minor
+---
+
+New preset: Import tickets from GitHub, and it always opens a session of its own (#959)
+
+The triage and planning presets all read `tickets/`, so a repo with an empty one has nothing
+for them to work from. This fills it from the repo's GitHub issues.
+
+It is the first preset marked `newSession`. Loaded from inside a session, every other preset
+is a message to that session; this one is not about the conversation at all, and appending it
+would put the import on that session's branch, behind its context. So both in-session
+composers send it as a new run instead, and the view follows it.

--- a/packages/framework-dashboard/components/Composer.test.tsx
+++ b/packages/framework-dashboard/components/Composer.test.tsx
@@ -24,7 +24,15 @@ vi.mock('../server/projects.telefunc.js', () => ({ onProjects: () => Promise.res
 vi.mock('./PromptEditor.js', async () => {
   const { forwardRef, useImperativeHandle } = await import('react')
   const PromptEditor = forwardRef((props: any, ref: any) => {
-    useImperativeHandle(ref, () => ({ clear: () => props.onChange(''), focus: () => {} }))
+    useImperativeHandle(ref, () => ({
+      clear: () => props.onChange(''),
+      focus: () => {},
+      // Loading a preset puts its text in the box, which is what makes a loaded preset submittable.
+      loadTemplate: (text: string) => {
+        props.onChange(text)
+        return false
+      },
+    }))
     return (
       <div>
         <input aria-label="prompt" onChange={e => props.onChange(e.target.value)} disabled={props.disabled} />
@@ -81,7 +89,7 @@ describe('Composer (#721)', () => {
     // The editor + submit still work (so `/` `<` `@` `#` triggers remain live in the editor).
     fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'quick run' } })
     fireEvent.click(screen.getByRole('button', { name: 'Start' }))
-    expect(onSubmit).toHaveBeenCalledWith('quick run', 'build')
+    expect(onSubmit).toHaveBeenCalledWith('quick run', 'build', { newSession: false })
   })
 
   test('showAgentModel={false} (#831) drops the agent/model select, keeping the rest of the row', () => {
@@ -92,7 +100,7 @@ describe('Composer (#721)', () => {
     expect(screen.getByRole('button', { name: 'Session options' })).toBeTruthy()
     fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'follow-up' } })
     fireEvent.click(screen.getByRole('button', { name: 'Send' }))
-    expect(onSubmit).toHaveBeenCalledWith('follow-up', 'build')
+    expect(onSubmit).toHaveBeenCalledWith('follow-up', 'build', { newSession: false })
   })
 
   test('option labels promise only what the code delivers (#801)', () => {
@@ -131,14 +139,14 @@ describe('Composer (#721)', () => {
     fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'ship it' } })
     expect(submit.hasAttribute('disabled')).toBe(false)
     fireEvent.click(submit)
-    expect(onSubmit).toHaveBeenCalledWith('ship it', 'build')
+    expect(onSubmit).toHaveBeenCalledWith('ship it', 'build', { newSession: false })
   })
 
   test('the editor shortcut (Cmd/Ctrl+Enter) submits too', () => {
     const { onSubmit } = renderComposer()
     fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'go' } })
     fireEvent.click(screen.getByText('editor-submit'))
-    expect(onSubmit).toHaveBeenCalledWith('go', 'build')
+    expect(onSubmit).toHaveBeenCalledWith('go', 'build', { newSession: false })
   })
 
   test('mirrors prompt changes out via onPromptChange', () => {
@@ -146,5 +154,37 @@ describe('Composer (#721)', () => {
     renderComposer({ onPromptChange })
     fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'hi' } })
     expect(onPromptChange).toHaveBeenLastCalledWith('hi', 'build')
+  })
+
+  // #959: a preset can declare that it never belongs in the open session. The Composer does not
+  // act on that itself — it carries the flag out to the host, which is the only thing that knows
+  // whether "new session" means anything on its surface.
+  test('a new-session preset marks its submit, and a normal one does not (#959)', () => {
+    const { onSubmit } = renderComposer()
+    fireEvent.click(screen.getByRole('button', { name: /Presets/ }))
+    fireEvent.click(screen.getByText('Import tickets from GitHub'))
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(onSubmit).toHaveBeenCalledWith('Import tickets from GitHub', 'prompt', { newSession: true })
+
+    cleanup()
+    const second = renderComposer()
+    fireEvent.click(screen.getByRole('button', { name: /Presets/ }))
+    fireEvent.click(screen.getByText('Security audit'))
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(second.onSubmit).toHaveBeenCalledWith(expect.stringContaining('Security audit'), 'prompt', { newSession: false })
+  })
+
+  test('emptying the box drops the preset\'s new-session rule with the preset (#959)', () => {
+    const { onSubmit } = renderComposer()
+    fireEvent.click(screen.getByRole('button', { name: /Presets/ }))
+    fireEvent.click(screen.getByText('Import tickets from GitHub'))
+    // The stub editor does not mirror the loaded text into the DOM input, and jsdom drops a
+    // change event whose value did not actually change — so give it something to clear.
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'edited' } })
+    // Clearing it back to a typed prompt is a fresh start: a plain build run, in this session.
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: '' } })
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'just a question' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(onSubmit).toHaveBeenCalledWith('just a question', 'build', { newSession: false })
   })
 })

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -72,8 +72,10 @@ export const Composer = forwardRef<ComposerHandle, {
   addContext: (path: string) => void
   /** Drop a path from the run Context when its `@`/`#` chip leaves the editor (#948). */
   removeContext?: ((path: string) => void) | undefined
-  /** Run the composed text. `kind` is `prompt` once a preset was loaded, else `build`. */
-  onSubmit: (text: string, kind: 'build' | 'prompt') => void | Promise<void>
+  /** Run the composed text. `kind` is `prompt` once a preset was loaded, else `build`.
+   *  `newSession` (#959) says the loaded preset must open a session of its own, so the two
+   *  in-session hosts send it as a new run instead of into the session they sit in. */
+  onSubmit: (text: string, kind: 'build' | 'prompt', opts: { newSession: boolean }) => void | Promise<void>
   /** Mirror the live prompt + kind out, so the launcher can drive its disclosure/context UI. */
   onPromptChange?: ((prompt: string, kind: 'build' | 'prompt') => void) | undefined
   /** A preset was loaded (so the launcher can flag it in its note); `replaced` says a typed
@@ -106,6 +108,8 @@ export const Composer = forwardRef<ComposerHandle, {
 ) {
   const [prompt, setPrompt] = useState('')
   const [kind, setKind] = useState<'build' | 'prompt'>('build')
+  // Set by the loaded preset, not by the surface (#959). Cleared with the box, like `kind`.
+  const [newSession, setNewSession] = useState(false)
   const [addingPreset, setAddingPreset] = useState(false)
   const editorRef = useRef<PromptEditorHandle>(null)
   // The registered projects for the `@` picker — the same list the launcher reads.
@@ -128,6 +132,7 @@ export const Composer = forwardRef<ComposerHandle, {
         label: p.label,
         ...(p.tooltip ? { tooltip: p.tooltip } : {}),
         render: () => p.render(undefined, { session_name: sessionName, settings: { technical_control: technical } }),
+        ...(p.newSession ? { newSession: true } : {}),
       })),
     [sessionName, technical],
   )
@@ -169,23 +174,24 @@ export const Composer = forwardRef<ComposerHandle, {
     const text = prompt.trim()
     if (!text || busy || submittingRef.current) return
     submittingRef.current = true
-    void Promise.resolve(onSubmit(text, kind)).finally(() => {
+    void Promise.resolve(onSubmit(text, kind, { newSession })).finally(() => {
       submittingRef.current = false
     })
   }
 
   // A preset (from the `/` menu or the Presets button) loads the rendered template into the
   // editor, which chip-ifies its tags; the run then goes verbatim as a `prompt` kind.
-  const loadPreset = (label: string, replaced: boolean) => {
+  const loadPreset = (label: string, replaced: boolean, presetNewSession = false) => {
     setKind('prompt')
+    setNewSession(presetNewSession)
     onPreset?.(label, replaced)
   }
 
   // The Presets button's load path (#948): through the imperative handle rather than the
   // suggestion plugin, then the same bookkeeping as the `/` menu.
-  const loadPresetFromMenu = (text: string, label: string) => {
+  const loadPresetFromMenu = (text: string, label: string, presetNewSession?: boolean) => {
     const replaced = editorRef.current?.loadTemplate(text) ?? false
-    loadPreset(label, replaced)
+    loadPreset(label, replaced, presetNewSession)
   }
 
   const onPromptEdit = (value: string) => {
@@ -193,6 +199,8 @@ export const Composer = forwardRef<ComposerHandle, {
     // An emptied box is a fresh start: back to a normal build run.
     const nextKind = !value.trim() && kind !== 'build' ? 'build' : kind
     if (nextKind !== kind) setKind(nextKind)
+    // Emptying the box drops the preset, and with it its new-session rule.
+    if (nextKind === 'build' && newSession) setNewSession(false)
     onPromptChange?.(value, nextKind)
   }
 

--- a/packages/framework-dashboard/components/PresetsMenu.test.tsx
+++ b/packages/framework-dashboard/components/PresetsMenu.test.tsx
@@ -26,7 +26,7 @@ describe('PresetsMenu', () => {
   test('lists built-ins and loads the rendered prompt', () => {
     const { onLoad } = mount()
     fireEvent.click(screen.getByText('[Research]'))
-    expect(onLoad).toHaveBeenCalledWith('RESEARCH PROMPT', '[Research]')
+    expect(onLoad).toHaveBeenCalledWith('RESEARCH PROMPT', '[Research]', undefined)
   })
 
   test('a saved preset loads verbatim', () => {

--- a/packages/framework-dashboard/components/PresetsMenu.tsx
+++ b/packages/framework-dashboard/components/PresetsMenu.tsx
@@ -19,6 +19,8 @@ export interface PresetEntry {
   label: string
   render: () => string
   tooltip?: string | undefined
+  /** Runs in a session of its own, even when loaded from inside one (#959). */
+  newSession?: boolean | undefined
 }
 
 // The visible face of the presets (#948). Loading used to live only behind typing `/` in the
@@ -37,8 +39,9 @@ export function PresetsMenu({
   presets: PresetEntry[]
   customPresets: CustomPreset[]
   busy: boolean
-  /** Load a preset's prompt into the editor. */
-  onLoad: (text: string, label: string) => void
+  /** Load a preset's prompt into the editor. `newSession` marks the ones that never append to
+   *  the open session (#959); a saved preset is always a plain load. */
+  onLoad: (text: string, label: string, newSession?: boolean) => void
   /** Open the create panel; absent where no panel renders. */
   onNew?: (() => void) | undefined
   /** Delete a saved preset by id. */
@@ -62,7 +65,7 @@ export function PresetsMenu({
             <DropdownMenuItem
               key={p.id}
               disabled={busy}
-              onClick={() => onLoad(p.render(), p.label)}
+              onClick={() => onLoad(p.render(), p.label, p.newSession)}
               {...(p.tooltip ? { title: p.tooltip } : {})}
               className="items-start"
             >

--- a/packages/framework-dashboard/components/PromptEditor.tsx
+++ b/packages/framework-dashboard/components/PromptEditor.tsx
@@ -8,6 +8,9 @@ import { Token, MACRO_TOKENS, ACTION_TOKENS, type TokenSpec } from './prompt-edi
 import { makeTrigger } from './prompt-editor/suggestion.js'
 import { tokenizeEditorDoc } from './prompt-editor/tokenize.js'
 import type { SuggestionItem } from './prompt-editor/SuggestionList.js'
+// The same entry the Presets button renders: the `/` menu is the other face of that one list,
+// so it reads the shape rather than restating it structurally.
+import type { PresetEntry } from './PresetsMenu.js'
 
 // The rich prompt editor (#470): a Tiptap surface that replaces the plain textarea. `/` opens
 // commands (load a preset, insert an agent action like `showMultiSelect()`), `@` opens
@@ -30,7 +33,7 @@ interface PromptEditorProps {
   onSubmit: () => void
   /** A preset picked from the `/` menu (so the form can flip to a `prompt` run). `replaced` says
    *  whether a typed draft was overwritten — undo brings it back, and the form's note says so. */
-  onPreset?: (label: string, replaced: boolean) => void
+  onPreset?: (label: string, replaced: boolean, newSession?: boolean) => void
   /** A project referenced via `@` (so the form can add it to the run context). */
   onMentionProject?: (path: string) => void
   /** A file referenced via `#` (so the form can add its repo-relative path to the run context). */
@@ -41,7 +44,7 @@ interface PromptEditorProps {
   projects: ProjectSummary[]
   /** The current project's files, repo-relative, for the `#` picker (#504). */
   files?: string[]
-  presets: { id: string; label: string; render: () => string; tooltip?: string | undefined }[]
+  presets: PresetEntry[]
   /** The user's saved presets (#626), loaded verbatim from the `/` menu (#722). */
   customPresets?: CustomPreset[]
   /** Open the create panel from the `/` menu's "New preset…" (#722). Omit where there is no panel
@@ -192,7 +195,7 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
               // Drop the `/query` trigger first so it does not count as a replaced draft.
               ed.chain().focus().deleteRange(range).run()
               const replaced = loadTemplateInto(ed, preset.render())
-              onPresetRef.current?.(preset.label, replaced)
+              onPresetRef.current?.(preset.label, replaced, preset.newSession)
             }
             return
           }

--- a/packages/framework-dashboard/components/RunChat.test.tsx
+++ b/packages/framework-dashboard/components/RunChat.test.tsx
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+// The two writes this component chooses between: a control-log message into the open session, or
+// a run of its own.
+const sendMessage = vi.hoisted(() => vi.fn())
+const sendStart = vi.hoisted(() => vi.fn())
+vi.mock('../server/control.telefunc.js', () => ({ sendMessage, sendStart }))
+
+// The Composer is exercised by its own tests; here it only has to hand back the two submits, so
+// stub it down to the one prop under test (#959).
+vi.mock('./Composer.js', async () => {
+  const { forwardRef } = await import('react')
+  const Composer = forwardRef((props: any, _ref: any) => (
+    <div>
+      <button type="button" disabled={props.busy} onClick={() => props.onSubmit('hello', 'build', { newSession: false })}>
+        submit-normal
+      </button>
+      <button type="button" disabled={props.busy} onClick={() => props.onSubmit('Import tickets from GitHub', 'prompt', { newSession: true })}>
+        submit-new-session
+      </button>
+    </div>
+  ))
+  return { Composer }
+})
+
+const { RunChat } = await import('./RunChat.js')
+
+function renderChat(over: Partial<Parameters<typeof RunChat>[0]> = {}) {
+  const onRunStarted = vi.fn()
+  render(<RunChat projectId="p1" runId="run-1" files={[]} addContext={vi.fn()} onRunStarted={onRunStarted} {...over} />)
+  return { onRunStarted }
+}
+
+beforeEach(() => {
+  sendMessage.mockReset()
+  sendStart.mockReset()
+})
+afterEach(cleanup)
+
+describe('RunChat (#714)', () => {
+  test('an ordinary submit goes into the open session as a message', async () => {
+    sendMessage.mockResolvedValue(undefined)
+    const { onRunStarted } = renderChat()
+    fireEvent.click(screen.getByText('submit-normal'))
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledWith('p1', 'hello', 'run-1'))
+    expect(sendStart).not.toHaveBeenCalled()
+    expect(onRunStarted).not.toHaveBeenCalled()
+  })
+
+  test('a new-session preset starts its own run instead of messaging this one (#959)', async () => {
+    sendStart.mockResolvedValue({ ok: true, runId: 'run-2' })
+    const { onRunStarted } = renderChat()
+    fireEvent.click(screen.getByText('submit-new-session'))
+    await waitFor(() => expect(sendStart).toHaveBeenCalledTimes(1))
+    // Not a message: the open session never sees it.
+    expect(sendMessage).not.toHaveBeenCalled()
+    const [projectId, text, kind, options] = sendStart.mock.calls[0]!
+    expect(projectId).toBe('p1')
+    expect(text).toBe('Import tickets from GitHub')
+    expect(kind).toBe('prompt')
+    // No continueRunId: a continuation would put it back on this session's branch (#762).
+    expect(options.continueRunId).toBeUndefined()
+    expect(options.resumeSession).toBeUndefined()
+    // And the view follows the run it just started, or the user would be left watching the old one.
+    await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('Import tickets from GitHub', 'run-2'))
+  })
+
+  test('a refused start surfaces the reason and does not navigate (#959)', async () => {
+    sendStart.mockResolvedValue({ ok: false, busy: true })
+    const { onRunStarted } = renderChat()
+    fireEvent.click(screen.getByText('submit-new-session'))
+    await waitFor(() => expect(screen.getByText(/session is already active/i)).toBeTruthy())
+    expect(onRunStarted).not.toHaveBeenCalled()
+  })
+})

--- a/packages/framework-dashboard/components/RunChat.tsx
+++ b/packages/framework-dashboard/components/RunChat.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react'
 import { Composer, type ComposerHandle } from './Composer.js'
 import { sendMessage } from '../server/control.telefunc.js'
 import { useAction } from '../lib/use-action.js'
+import { useStartRun } from '../lib/use-start-run.js'
 
 // The live-chat composer (#714/#721): send more messages to a running run. Reuses the same shared
 // Composer the launcher uses, so `/` presets, `<` tags, and `@`/`#` mentions work here too. On
@@ -9,6 +10,8 @@ import { useAction } from '../lib/use-action.js'
 // session via --resume. No agent/model select (#831): the run's driver is created once at spawn and
 // a message carries only text, so the select could not change this session, only the next one.
 // Only rendered inside RunLive, i.e. while the run is running — a finished run replays without it.
+// The one exception to "everything typed here goes to this session" is a new-session preset (#959),
+// which starts its own run instead.
 export function RunChat({
   projectId,
   runId,
@@ -16,6 +19,7 @@ export function RunChat({
   addContext,
   removeContext,
   sessionName,
+  onRunStarted,
 }: {
   projectId: string
   /** Which run the message goes to (#749); absent falls back to the project's control log. */
@@ -28,15 +32,29 @@ export function RunChat({
   removeContext?: ((path: string) => void) | undefined
   /** This session's name (#874), so a preset launched here targets it by default. */
   sessionName?: string | undefined
+  /** Jump to the run a new-session preset just started (#959). */
+  onRunStarted?: ((intent: string, runId?: string) => void) | undefined
 }) {
   const composerRef = useRef<ComposerHandle>(null)
   const { busy, error, run } = useAction()
+  // A new-session preset does not go into this session at all (#959): it spawns its own run, the
+  // same way the launcher does, so it gets its own worktree, branch and transcript.
+  const { busy: starting, error: startError, start } = useStartRun()
   // The last message that went through: a queued control entry is invisible until the agent
   // drains it between turns, so without this the send looked like nothing happened (#948).
   const [queued, setQueued] = useState<string | null>(null)
 
-  const send = async (text: string): Promise<void> => {
-    if (busy) return
+  const send = async (text: string, _kind: 'build' | 'prompt', opts: { newSession: boolean }): Promise<void> => {
+    if (busy || starting) return
+    if (opts.newSession) {
+      const started = await start(projectId, text, 'prompt', {})
+      if (started) {
+        composerRef.current?.clear()
+        onRunStarted?.(text, started.runId)
+      }
+      composerRef.current?.focus()
+      return
+    }
     // sendMessage resolves void; map success to `true` so it is tellable from useAction's
     // failure `undefined`.
     const result = await run(
@@ -57,14 +75,14 @@ export function RunChat({
           Queued — the session reads it between turns: &ldquo;{queued}&rdquo;
         </p>
       )}
-      {error && <p role="alert" className="mb-1 px-2 text-xs text-red-500">{error}</p>}
+      {(error ?? startError) && <p role="alert" className="mb-1 px-2 text-xs text-red-500">{error ?? startError}</p>}
       <Composer
         ref={composerRef}
         files={files}
         addContext={addContext}
         removeContext={removeContext}
         onSubmit={send}
-        busy={busy}
+        busy={busy || starting}
         submitLabel="Send"
         submitBusyLabel="Sending…"
         showAgentModel={false}

--- a/packages/framework-dashboard/components/RunLive.tsx
+++ b/packages/framework-dashboard/components/RunLive.tsx
@@ -20,6 +20,7 @@ export function RunLive({
   addContext,
   removeContext,
   lost = false,
+  onRunStarted,
 }: {
   projectId: string
   /** Which run to steer (#749); absent right after Start, before the poll adopts its id. */
@@ -30,6 +31,8 @@ export function RunLive({
   removeContext?: ((path: string) => void) | undefined
   /** The live channel's health (#948) — surfaced as a banner over the feed. */
   lost?: boolean
+  /** Jump to the run a new-session preset started from the chat below (#959). */
+  onRunStarted?: ((intent: string, runId?: string) => void) | undefined
 }) {
   // The session's own name, once the agent has set it (#874): presets in the chat below default
   // to targeting this session rather than the whole codebase.
@@ -41,7 +44,7 @@ export function RunLive({
           falls back to the project root and would report the user's own dirty files as the run's. */}
       {runId && <RunChanges projectId={projectId} runId={runId} />}
       <RunFeed events={events} showSessionLink={false} lost={lost} />
-      <RunChat projectId={projectId} runId={runId} files={files} addContext={addContext} removeContext={removeContext} sessionName={sessionName} />
+      <RunChat projectId={projectId} runId={runId} files={files} addContext={addContext} removeContext={removeContext} sessionName={sessionName} onRunStarted={onRunStarted} />
     </>
   )
 }

--- a/packages/framework-dashboard/components/RunResumeChat.tsx
+++ b/packages/framework-dashboard/components/RunResumeChat.tsx
@@ -43,8 +43,18 @@ export function RunResumeChat({
   const composerRef = useRef<ComposerHandle>(null)
   const { busy, error, start } = useStartRun()
 
-  const send = async (text: string): Promise<void> => {
+  const send = async (text: string, _kind: 'build' | 'prompt', opts: { newSession: boolean }): Promise<void> => {
     if (busy) return
+    // A new-session preset is not a continuation (#959): it drops the resume seed and the run id,
+    // so it opens its own run rather than writing more history into this finished one.
+    if (opts.newSession) {
+      const started = await start(projectId, text, 'prompt', {})
+      if (started) {
+        composerRef.current?.clear()
+        onRunStarted(text, started.runId)
+      }
+      return
+    }
     // A continuation is a `prompt` run seeded with the finished run's session id (#720). It
     // resumes on the run's own agent; the model and the system-prompt options are moot here, since
     // the resumed transcript keeps the framing and model it already had.

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -227,7 +227,7 @@ export default function Page() {
     if (runId === null) {
       // Just pressed Start on a project with no worktree: follow the live output until the poll
       // surfaces the run and the effect above adopts its id.
-      if (adopting) return <RunLive projectId={projectId} runId={null} events={events} files={files} addContext={addContext} removeContext={removeContext} lost={lost} />
+      if (adopting) return <RunLive projectId={projectId} runId={null} events={events} files={files} addContext={addContext} removeContext={removeContext} lost={lost} onRunStarted={onRunStarted} />
       return (
         <ProjectHome
           projectId={projectId}
@@ -246,7 +246,7 @@ export default function Page() {
       // list we have not read yet. Both are live views; only a session that is genuinely absent
       // from a list we did read is gone.
       if (runId === runStart.id || !runsLoaded)
-        return <RunLive projectId={projectId} runId={runId} events={events} files={files} addContext={addContext} removeContext={removeContext} lost={lost} />
+        return <RunLive projectId={projectId} runId={runId} events={events} files={files} addContext={addContext} removeContext={removeContext} lost={lost} onRunStarted={onRunStarted} />
       return (
         <NotFound
           title="This session is gone"
@@ -257,7 +257,7 @@ export default function Page() {
       )
     }
     if (selectedRun.status === 'running')
-      return <RunLive projectId={projectId} runId={runId} events={events} files={files} addContext={addContext} removeContext={removeContext} lost={lost} />
+      return <RunLive projectId={projectId} runId={runId} events={events} files={files} addContext={addContext} removeContext={removeContext} lost={lost} onRunStarted={onRunStarted} />
     return <RunReplay projectId={projectId} runId={runId} files={files} addContext={addContext} removeContext={removeContext} onRunStarted={onRunStarted} />
   }
 

--- a/packages/framework/prompts/presets/import_tickets.md
+++ b/packages/framework/prompts/presets/import_tickets.md
@@ -1,0 +1,1 @@
+Import tickets from GitHub

--- a/packages/framework/src/preset-catalog.test.ts
+++ b/packages/framework/src/preset-catalog.test.ts
@@ -20,6 +20,7 @@ const PARAMETERIZED = [
 /** The presets that scope themselves, so there is no blank for a user to fill. */
 const PARAMLESS = [
   presets.marketResearch,
+  presets.importTickets,
   presets.quickWins,
   presets.spikeAndPlan,
   presets.suggestNewTickets,
@@ -35,9 +36,10 @@ test('every preset keeps its exact run-kind name', () => {
   assert.deepEqual(
     Object.values(presets).map(p => p.name).sort(),
     [
-      'drain-queue', 'maintainability', 'maintenance', 'market-research', 'quick-wins',
-      'readability', 'research', 'security-audit', 'spike-and-plan', 'suggest-new-tickets',
-      'suggest-tickets-to-work-on', 'triage-consensual', 'triage-quick', 'ux',
+      'drain-queue', 'import-tickets', 'maintainability', 'maintenance', 'market-research',
+      'quick-wins', 'readability', 'research', 'security-audit', 'spike-and-plan',
+      'suggest-new-tickets', 'suggest-tickets-to-work-on', 'triage-consensual', 'triage-quick',
+      'ux',
     ],
   )
 })
@@ -188,3 +190,15 @@ test('neither ungated triage preset waits on a human (#891/#892 vs #698)', () =>
   }
   assert.ok(presets.suggestTicketsToWorkOn.template.includes('<AWAIT>'), 'the gated preset still awaits')
 })
+
+test('one preset, and only one, always opens a session of its own (#959)', () => {
+  // The flag is a property of the work, not of the surface that fires it, so it is pinned here
+  // rather than in the dashboard: the import reads GitHub and writes `tickets/`, which has nothing
+  // to do with whatever session the user happened to be reading when they clicked it.
+  const marked = Object.values(presets).filter(p => p.newSession).map(p => p.name)
+  assert.deepEqual(marked, ['import-tickets'])
+  assert.equal(presets.importTickets.template, 'Import tickets from GitHub')
+  assert.equal(presets.importTickets.render(), 'Import tickets from GitHub')
+  assert.equal(LAUNCHER_PRESETS.includes(presets.importTickets), true)
+})
+

--- a/packages/framework/src/preset-catalog.ts
+++ b/packages/framework/src/preset-catalog.ts
@@ -1,6 +1,7 @@
 import { definePreset, type PresetDef } from './preset-prompt.js'
 import {
   PRESETS_DRAIN_QUEUE,
+  PRESETS_IMPORT_TICKETS,
   PRESETS_MAINTAINABILITY,
   PRESETS_MAINTENANCE,
   PRESETS_MARKET_RESEARCH,
@@ -69,6 +70,17 @@ export const presets = {
   marketResearch: definePreset({ name: 'market-research', template: PRESETS_MARKET_RESEARCH, label: 'Market research' }),
 
   /**
+   * [Import tickets from GitHub] (#959): fill `tickets/` from the repo's own issues, so the
+   * triage and planning presets have a backlog to read. One line of prompt, because the system
+   * prompt already tells the agent what a ticket is and where it goes.
+   *
+   * The only preset marked {@link PresetSpec.newSession}: importing is repo work, not a reply, so
+   * it opens its own session rather than appending to whichever one the user happens to be
+   * reading.
+   */
+  importTickets: definePreset({ name: 'import-tickets', template: PRESETS_IMPORT_TICKETS, label: 'Import tickets from GitHub', newSession: true, tooltip: 'Fill `tickets/` from the GitHub issues. Always runs in a new session.' }),
+
+  /**
    * [Quick wins] (#773): harvest the cheap work out of the plans we already have. Reads the
    * `.plan.md` companions the #684 format defines and appends the quick ones to `TODO_AGENTS.md`.
    * This is the half of auto PM that closes the loop: [Spike & plan] turns tickets into plans,
@@ -130,6 +142,7 @@ export const LAUNCHER_PRESETS: readonly PresetDef[] = [
   presets.spikeAndPlan,
   presets.quickWins,
   presets.marketResearch,
+  presets.importTickets,
   presets.maintenance,
   presets.triageQuick,
   presets.triageConsensual,

--- a/packages/framework/src/preset-prompt.ts
+++ b/packages/framework/src/preset-prompt.ts
@@ -64,6 +64,14 @@ export interface PresetSpec {
   label: string
   /** One line under the label, when the name alone does not say what the preset queues. */
   tooltip?: string
+  /**
+   * Always run in a session of its own (#959), even when picked from inside one. A preset whose
+   * work is about the repo rather than about the conversation has nothing to gain from the current
+   * transcript and something to lose from it: sent to a live session it would land on that
+   * session's branch, behind its context. The flag sits on the preset rather than on the surface
+   * that fires it, because it is a property of the work, not of where the user clicked.
+   */
+  newSession?: boolean
 }
 
 /** A preset's public shape: how it is declared, plus its resolved params and a renderer. */


### PR DESCRIPTION
Closes #959

## The preset

`prompts/presets/import_tickets.md` is the one line from the issue. It shows up as `/import-tickets` and as **Import tickets from GitHub** in the Presets menu, between Market research and Maintenance.

Why it matters beyond being a button: the triage pair, Spike & plan and Quick wins all read `tickets/`, so on a repo with an empty one they have nothing to chew on. This is the thing that fills it.

## The "always a new session" half

That is the real work. Today every preset loaded inside a session is a message to *that* session. This one is not about the conversation at all, and appending it would land the import on that session's branch, behind its context.

The flag lives on the preset, not on the surface that fires it:

```ts
importTickets: definePreset({ ..., newSession: true })
```

because it is a property of the work rather than of where the user happened to click. It then rides from **either** load path (the Presets button and the `/` menu) through the Composer, which hands it to the host on submit:

```ts
onSubmit: (text, kind, opts: { newSession: boolean }) => void | Promise<void>
```

The three hosts each do the obvious thing:

| host | before | with `newSession` |
|---|---|---|
| `StartRunForm` (launcher) | starts a run | unchanged, every run here is already new |
| `RunChat` (live session) | `sendMessage` into the control log | starts its own run, then follows it |
| `RunResumeChat` (finished session) | starts a run seeded with `resumeSession` + `continueRunId` | starts one with neither |

Emptying the box drops the preset and its rule together, the same way it already reverts `kind` to `build`.

**No daemon or RPC change.** The busy guard is keyed per worktree (`scopedKey(projectKey, workspace.runId)`), so a second concurrent session on a project is already legal, and a new run allocates a fresh workspace. On a project running without worktrees the guard is per project, so a start can still come back `busy`; that path shows the existing "A session is already active for this project." message, which is covered by a test.

## Verification

`pnpm build` + `pnpm test`: 21/21 tasks, framework **1041 pass / 0 fail**, dashboard **273 pass** (up from 268).

New tests: the catalog pins that exactly one preset carries the flag and that it is this one; `Composer.test.tsx` pins that the flag reaches `onSubmit` through the menu and is dropped when the box is emptied; a new `RunChat.test.tsx` pins the routing itself (message vs new run, no `continueRunId`, follows the new run, surfaces a refusal without navigating).

Driven in a real browser too, not just jsdom: a daemon on an isolated registry, Presets menu opened, item present in the right position with its tooltip rendering as written.

## One small dedup

`PromptEditor` was restating `PresetEntry` structurally in its props. It now imports the type, so the `/` menu and the Presets button read one shape.