### PR TITLE
fix(ai-sdk): correct four provider protocol defects found in the AI package sweep

### DIFF
--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,10 @@
+---
+'@gemstack/ai-sdk': patch
+---
+
+Fix four provider protocol defects found in the AI package sweep.
+
+- Google prompt caching dropped the system instruction and every tool declaration from the request even when the cache markers had not cached them, so a marker set like `{ messages: 2 }` silently sent neither.
+- Google streaming derived its finish reason from Gemini's raw value. Gemini reports `STOP` for a function-call turn, so a streamed tool call ended the run instead of returning the tool results to the model, while a `SAFETY` or `MAX_TOKENS` stop claimed tool calls existed and kept the loop running.
+- Anthropic joined `ContentPart[]` system content with `Array.prototype.join`, sending `[object Object]` as the system prompt.
+- OpenAI never set `stream_options: { include_usage: true }` and discarded the trailing usage chunk, so every streamed call reported no token usage to budget accounting. Truncation and content-filter stops now map to `length` and `content_filter` instead of a clean `stop`.

--- a/packages/ai-sdk/src/provider-protocol-fixes.test.ts
+++ b/packages/ai-sdk/src/provider-protocol-fixes.test.ts
@@ -1,0 +1,161 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { GoogleAdapter } from './providers/google.js'
+import { GoogleCacheRegistry } from './providers/google-cache-registry.js'
+import { splitSystemMessages } from './providers/anthropic.js'
+import { OpenAIProvider } from './providers/openai.js'
+import type { AiMessage, StreamChunk } from './types.js'
+
+async function collect(it: AsyncIterable<StreamChunk>): Promise<StreamChunk[]> {
+  const out: StreamChunk[] = []
+  for await (const c of it) out.push(c)
+  return out
+}
+
+/** A Gemini client double that records request payloads and replays a scripted stream. */
+function fakeGoogleClient(streamChunks: unknown[] = []) {
+  const payloads: Record<string, unknown>[] = []
+  const client = {
+    caches: {
+      async create() { return { name: 'cachedContents/auto-1' } },
+      async delete() { /* no-op */ },
+    },
+    models: {
+      async generateContent(payload: Record<string, unknown>) {
+        payloads.push(payload)
+        return { candidates: [{ content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' }] }
+      },
+      async generateContentStream(payload: Record<string, unknown>) {
+        payloads.push(payload)
+        return (async function* () { for (const c of streamChunks) yield c })()
+      },
+    },
+  }
+  return { client, payloads }
+}
+
+describe('google prompt cache — only the regions actually cached are dropped', () => {
+  it('still sends the system instruction when the markers did not cache it', async () => {
+    const { client, payloads } = fakeGoogleClient()
+    const adapter = new GoogleAdapter({ apiKey: 'k' }, 'gemini-2.5-flash', new GoogleCacheRegistry())
+    ;(adapter as unknown as { client: unknown }).client = client
+
+    await adapter.generate({
+      model: 'gemini-2.5-flash',
+      messages: [
+        { role: 'system', content: 'You are helpful' },
+        { role: 'user', content: 'first' },
+        { role: 'user', content: 'fresh' },
+      ],
+      tools: [{ name: 't', description: 'T', parameters: {} }],
+      // `messages` only: the cache resource receives neither the system
+      // instruction nor the tools, so both must still go on the wire.
+      cache: { messages: 1 },
+    })
+
+    const payload = payloads[0]!
+    const cfg = payload['config'] as Record<string, unknown>
+    assert.ok(cfg['cachedContent'], 'the cached path must be the one under test')
+    assert.ok(payload['systemInstruction'], 'system instruction must be sent when it was not cached')
+    assert.ok(cfg['tools'], 'tools must be sent when they were not cached')
+  })
+})
+
+describe('google streaming finish reason', () => {
+  it('reports tool_calls for a function-call turn, which Gemini labels STOP', async () => {
+    // The agent loop only continues to send tool results back when the finish
+    // reason is `tool_calls`; mapping this to `stop` runs the tools and then
+    // ends the run without the model ever seeing their results.
+    const { client } = fakeGoogleClient([
+      { candidates: [{ content: { parts: [{ functionCall: { name: 'search', args: {} } }] } }] },
+      { candidates: [{ content: { parts: [] }, finishReason: 'STOP' }] },
+    ])
+    const adapter = new GoogleAdapter({ apiKey: 'k' }, 'gemini-2.5-flash')
+    ;(adapter as unknown as { client: unknown }).client = client
+
+    const chunks = await collect(adapter.stream({ model: 'gemini-2.5-flash', messages: [{ role: 'user', content: 'hi' }] }))
+    const finish = chunks.find(c => c.type === 'finish') as { finishReason: string } | undefined
+
+    assert.equal(finish?.finishReason, 'tool_calls')
+  })
+
+  it('does not claim tool calls for a safety stop', async () => {
+    const { client } = fakeGoogleClient([
+      { candidates: [{ content: { parts: [{ text: 'partial' }] }, finishReason: 'SAFETY' }] },
+    ])
+    const adapter = new GoogleAdapter({ apiKey: 'k' }, 'gemini-2.5-flash')
+    ;(adapter as unknown as { client: unknown }).client = client
+
+    const chunks = await collect(adapter.stream({ model: 'gemini-2.5-flash', messages: [{ role: 'user', content: 'hi' }] }))
+    const finish = chunks.find(c => c.type === 'finish') as { finishReason: string } | undefined
+
+    assert.equal(finish?.finishReason, 'content_filter')
+    assert.notEqual(finish?.finishReason, 'tool_calls', 'a blocked turn must not send the loop into a tool phase')
+  })
+})
+
+describe('anthropic splitSystemMessages', () => {
+  it('flattens ContentPart[] system content instead of stringifying the array', () => {
+    const { system } = splitSystemMessages([
+      { role: 'system', content: [{ type: 'text', text: 'You are terse.' }] },
+      { role: 'user', content: 'hi' },
+    ] as AiMessage[])
+
+    assert.equal(system, 'You are terse.')
+    assert.ok(!String(system).includes('[object Object]'), 'system prompt must not be "[object Object]"')
+  })
+})
+
+describe('openai streaming', () => {
+  function adapterWithStream(chunks: unknown[]) {
+    let sent: Record<string, unknown> | undefined
+    const adapter = new OpenAIProvider({ apiKey: 'k' }).create('gpt-4o') as unknown as {
+      getClient: () => Promise<unknown>
+      stream: (o: unknown) => AsyncIterable<StreamChunk>
+    }
+    adapter.getClient = async () => ({
+      chat: {
+        completions: {
+          create: async (params: Record<string, unknown>) => {
+            sent = params
+            return (async function* () { for (const c of chunks) yield c })()
+          },
+        },
+      },
+    })
+    return { adapter, sentParams: () => sent }
+  }
+
+  it('opts in to usage and reports it from the trailing usage-only chunk', async () => {
+    const { adapter, sentParams } = adapterWithStream([
+      { choices: [{ delta: { content: 'hi' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+      // OpenAI sends usage last, on a chunk carrying no choices at all.
+      { choices: [], usage: { prompt_tokens: 11, completion_tokens: 5, total_tokens: 16 } },
+    ])
+
+    const chunks = await collect(adapter.stream({ messages: [{ role: 'user', content: 'hi' }] }))
+
+    assert.deepEqual(
+      sentParams()?.['stream_options'],
+      { include_usage: true },
+      'without this OpenAI never sends usage for a streamed call',
+    )
+
+    const finish = chunks.find(c => c.type === 'finish') as { usage?: { totalTokens: number } } | undefined
+    assert.ok(finish, 'a finish chunk must still be emitted')
+    assert.ok(finish.usage, 'finish chunk must carry the usage from the trailing chunk')
+    assert.equal(finish.usage.totalTokens, 16)
+  })
+
+  it('reports a truncated turn as length rather than a clean stop', async () => {
+    const { adapter } = adapterWithStream([
+      { choices: [{ delta: { content: 'half an ans' }, finish_reason: 'length' }] },
+    ])
+
+    const chunks = await collect(adapter.stream({ messages: [{ role: 'user', content: 'hi' }] }))
+    const finish = chunks.find(c => c.type === 'finish') as { finishReason: string } | undefined
+
+    assert.equal(finish?.finishReason, 'length')
+  })
+})

--- a/packages/ai-sdk/src/providers/anthropic.ts
+++ b/packages/ai-sdk/src/providers/anthropic.ts
@@ -164,7 +164,7 @@ export function splitSystemMessages(messages: AiMessage[]): { system: string | u
   const systemMsgs = messages.filter(m => m.role === 'system')
   const rest = messages.filter(m => m.role !== 'system')
   const system = systemMsgs.length > 0
-    ? systemMsgs.map(m => m.content).join('\n\n')
+    ? systemMsgs.map(m => contentToString(m.content)).join('\n\n')
     : undefined
   return { system, messages: rest }
 }

--- a/packages/ai-sdk/src/providers/google.ts
+++ b/packages/ai-sdk/src/providers/google.ts
@@ -25,6 +25,7 @@ import type {
   VectorStoreListOptions,
   VectorStoreList,
   VectorStoreFileList,
+  FinishReason,
 } from '../types.js'
 import type { FileSearchFilter } from '../file-search.js'
 import { base64ToUtf8 } from '../base64.js'
@@ -135,13 +136,21 @@ export class GoogleAdapter implements ProviderAdapter {
     }
 
     if (cacheName) {
-      // Drop tools / system from the request — they're inherited from the cache resource.
+      // Drop only what the cache resource actually absorbed. The markers above
+      // gate what went in, so a set like `{ messages: 2 }` caches neither the
+      // system instruction nor the tools, and both must still go on the wire.
       const { fresh } = splitContentsAtCache(contents, options.cache)
       const configForCachedRequest: Record<string, unknown> = { ...config }
-      delete configForCachedRequest['tools']
+      if (options.cache?.tools) delete configForCachedRequest['tools']
       configForCachedRequest['cachedContent'] = cacheName
+      const systemIsCached = Boolean(options.cache?.instructions && system)
       return {
-        payload: { model: this.model, contents: fresh, config: configForCachedRequest },
+        payload: {
+          model: this.model,
+          contents: fresh,
+          ...(system && !systemIsCached ? { systemInstruction: { parts: [{ text: system }] } } : {}),
+          config: configForCachedRequest,
+        },
         cacheKey,
       }
     }
@@ -193,6 +202,11 @@ export class GoogleAdapter implements ProviderAdapter {
       }
     }
 
+    // Gemini reports `STOP` even when the turn is a function call, so the finish
+    // reason has to be derived from what was actually streamed — same rule as
+    // `fromGeminiResponse`, which keys off `toolCalls.length`.
+    let sawFunctionCall = false
+
     for await (const chunk of response) {
       const candidate = chunk.candidates?.[0]
       if (!candidate) continue
@@ -202,6 +216,7 @@ export class GoogleAdapter implements ProviderAdapter {
           yield { type: 'text-delta', text: part.text }
         }
         if (part.functionCall) {
+          sawFunctionCall = true
           yield {
             type: 'tool-call',
             toolCall: {
@@ -216,7 +231,7 @@ export class GoogleAdapter implements ProviderAdapter {
       if (candidate.finishReason) {
         yield {
           type: 'finish',
-          finishReason: candidate.finishReason === 'STOP' ? 'stop' : 'tool_calls',
+          finishReason: mapGeminiFinishReason(candidate.finishReason, sawFunctionCall),
           usage: chunk.usageMetadata ? {
             promptTokens: chunk.usageMetadata.promptTokenCount ?? 0,
             completionTokens: chunk.usageMetadata.candidatesTokenCount ?? 0,
@@ -225,6 +240,25 @@ export class GoogleAdapter implements ProviderAdapter {
         }
       }
     }
+  }
+}
+
+/**
+ * Map a Gemini candidate finish reason onto the neutral {@link FinishReason}.
+ * A function-call turn reports `STOP`, so that case is decided by the caller
+ * having seen a `functionCall` part rather than by the reason itself.
+ */
+export function mapGeminiFinishReason(reason: string, sawFunctionCall: boolean): FinishReason {
+  if (sawFunctionCall) return 'tool_calls'
+  switch (reason) {
+    case 'MAX_TOKENS': return 'length'
+    case 'SAFETY':
+    case 'RECITATION':
+    case 'BLOCKLIST':
+    case 'PROHIBITED_CONTENT':
+    case 'SPII':
+      return 'content_filter'
+    default: return 'stop'
   }
 }
 

--- a/packages/ai-sdk/src/providers/openai.ts
+++ b/packages/ai-sdk/src/providers/openai.ts
@@ -20,6 +20,8 @@ import type {
   ProviderRequestOptions,
   ProviderResponse,
   StreamChunk,
+  TokenUsage,
+  FinishReason,
   ToolDefinitionSchema,
   AiMessage,
   ToolCall,
@@ -143,6 +145,9 @@ export class OpenAIAdapter implements ProviderAdapter {
       model: this.model,
       messages,
       stream: true,
+      // OpenAI omits usage from a streamed completion unless this is set, so
+      // without it every streamed call reports nothing to budget accounting.
+      stream_options: { include_usage: true },
     }
     if (options.maxTokens) params['max_tokens'] = options.maxTokens
     if (options.temperature !== undefined) params['temperature'] = options.temperature
@@ -156,7 +161,20 @@ export class OpenAIAdapter implements ProviderAdapter {
 
     const stream = await client.chat.completions.create(params, options.signal ? { signal: options.signal } : undefined)
 
+    let streamUsage: TokenUsage | undefined
+    let streamFinishReason: FinishReason | undefined
+
     for await (const chunk of stream) {
+      // The usage-bearing chunk arrives last and carries an empty `choices`
+      // array, so it has to be read before the guard below discards it.
+      if (chunk.usage) {
+        streamUsage = {
+          promptTokens:     chunk.usage.prompt_tokens ?? 0,
+          completionTokens: chunk.usage.completion_tokens ?? 0,
+          totalTokens:      chunk.usage.total_tokens ?? 0,
+        }
+      }
+
       const choice = chunk.choices?.[0]
       if (!choice) continue
       const delta = choice.delta
@@ -191,15 +209,17 @@ export class OpenAIAdapter implements ProviderAdapter {
       }
 
       if (choice.finish_reason) {
-        yield {
-          type: 'finish',
-          finishReason: choice.finish_reason === 'tool_calls' ? 'tool_calls' : 'stop',
-          usage: chunk.usage ? {
-            promptTokens: chunk.usage.prompt_tokens ?? 0,
-            completionTokens: chunk.usage.completion_tokens ?? 0,
-            totalTokens: chunk.usage.total_tokens ?? 0,
-          } : undefined,
-        }
+        streamFinishReason = mapOpenAIFinishReason(choice.finish_reason)
+      }
+    }
+
+    // Emitted after the loop because usage lands on a later chunk than the one
+    // carrying `finish_reason`.
+    if (streamFinishReason) {
+      yield {
+        type: 'finish',
+        finishReason: streamFinishReason,
+        ...(streamUsage ? { usage: streamUsage } : {}),
       }
     }
   }
@@ -433,7 +453,23 @@ function fromOpenAIResponse(response: any): ProviderResponse {
       completionTokens: response.usage?.completion_tokens ?? 0,
       totalTokens: response.usage?.total_tokens ?? 0,
     },
-    finishReason: choice?.finish_reason === 'tool_calls' ? 'tool_calls' : 'stop',
+    finishReason: choice?.finish_reason ? mapOpenAIFinishReason(choice.finish_reason) : 'stop',
+  }
+}
+
+/**
+ * Map an OpenAI finish reason onto the neutral {@link FinishReason}. Without
+ * this, a `max_tokens` truncation and a content-filter stop both report a clean
+ * `stop`, so a caller cannot tell a complete answer from a cut-off one.
+ */
+export function mapOpenAIFinishReason(reason: string): FinishReason {
+  switch (reason) {
+    case 'tool_calls':
+    case 'function_call':
+      return 'tool_calls'
+    case 'length':          return 'length'
+    case 'content_filter':  return 'content_filter'
+    default:                return 'stop'
   }
 }
 


### PR DESCRIPTION
Code-quality sweep of `ai-sdk`, `framework` and `ai-autopilot`. This PR ships only the ai-sdk provider defects I verified and proved; everything else the sweep surfaced is deferred to issues rather than folded in here.

## Baseline

Green before any change on `a47d2d9`: ai-sdk 879, framework 1042, ai-autopilot 302, framework-dashboard 268, 21/21 turbo tasks. After: **ai-sdk 885**, every other package unchanged, build 0, tests 0 failures.

## What this fixes

**1. Google prompt caching silently stripped the system prompt and every tool.** The cached-request branch dropped `systemInstruction` and `delete`d `tools` unconditionally, but the cache *resource* only received them when `options.cache.instructions` / `.tools` were set. So `cache: { messages: 2 }` created a resource holding neither and then sent a request containing neither: the agent's persona and its whole tool surface vanished from the wire with no error. The existing test only covered `{ instructions: true, tools: true, messages: 1 }`, where dropping is correct.

**2. Google streaming reported the wrong finish reason in both directions.** Gemini reports `STOP` even when the turn is a function call, and the streaming path mapped the raw value (`=== 'STOP' ? 'stop' : 'tool_calls'`). Consequences, both traced through `agent.ts`:

- A streamed tool call executed (the loop keys the tool phase off `currentToolCalls.length`) and then **broke at `finishReason !== 'tool_calls'`**, so the model never received the tool results.
- A `SAFETY` or `RECITATION` block mapped to `tool_calls`, so the loop kept going with no tool calls until `maxIterations`.

The non-streaming twin `fromGeminiResponse` already derives the reason from `toolCalls.length`; the streaming path now follows the same rule. `MAX_TOKENS` and the content-filter reasons now produce `length` / `content_filter`, which were declared in `FinishReason` with zero producers anywhere in the package.

**3. Anthropic sent `[object Object]` as the system prompt.** `splitSystemMessages` did `systemMsgs.map(m => m.content).join('\n\n')` on a `string | ContentPart[]`. The file already imports `contentToString` and uses it 23 lines later; the Google twin does it correctly. Affects Bedrock too, which imports the same function.

**4. Every streamed OpenAI call reported zero token usage.** `stream_options: { include_usage: true }` was never sent (repo-wide grep: zero occurrences), and the usage chunk OpenAI sends last carries `choices: []`, so `if (!choice) continue` discarded it even if it had arrived. Usage feeds `withBudget`'s cost accounting, so streamed spend was invisible and caps could not trip on it. Finish reasons now also distinguish `length` and `content_filter` from a clean `stop`.

## Verification

Each fix has a regression test, and I **proved every one** by reverting the source fix while keeping the test and confirming the right test fails:

| Reverted | Test that failed |
|---|---|
| conditional `delete tools` / `systemInstruction` | still sends the system instruction when the markers did not cache it |
| Gemini finish-reason mapping | reports tool_calls for a function-call turn, which Gemini labels STOP + does not claim tool calls for a safety stop |
| `contentToString` in `splitSystemMessages` | flattens ContentPart[] system content instead of stringifying the array |
| `stream_options` opt-in | opts in to usage and reports it from the trailing usage-only chunk |
| usage read moved after the `!choice` guard | opts in to usage and reports it from the trailing usage-only chunk |
| `mapOpenAIFinishReason` | reports a truncated turn as length rather than a clean stop |

The tests drive the real adapters through a client double rather than calling the new helpers directly, so they genuinely fail against the old source instead of merely failing to compile.

## Not in this PR

The sweep ran six reviewers (three packages x correctness and design lenses) and produced far more than one PR should carry. The rest is filed as issues under epic #967 rather than folded in here, per the "big refactors go in the epic" rule. Notable ones I verified but did not fix, because each is a product decision or a large refactor:

- `framework worktrees rm` and the dashboard Remove button run `git worktree remove --force` on a stopped run's checkout, which is exactly the case that holds uncommitted agent work. The daemon's own teardown commits first; neither of these does.
- Auto PM has no `stopped` flag, so `quiesce()` cannot stop an in-flight sweep from spawning a run after `activeRuns.clear()`. Its three sibling services all guard this.
- The registry (project list plus all preferences) is written non-atomically with read-modify-write races, while the far less valuable daemon state file got temp+rename in #922.

One earlier finding was **dropped rather than re-filed**: ai-mcp "`jsonSchema` ignored" is already fixed on main, and `git log -S` shows it was never broken in this repo.

Closes nothing on its own; contributes to #967.
