### PR TITLE
fix(mcp): apply the URI template separator guard to the decoded value

### DIFF
--- a/.changeset/uri-template-decode-guard.md
+++ b/.changeset/uri-template-decode-guard.md
@@ -10,6 +10,11 @@ handler `../../../etc/passwd`, while the literal-slash form was correctly reject
 resource handler that treats a template param as a path segment read outside its root.
 The guard now applies to the decoded value.
 
+A malformed percent-escape now reports a non-match as well. `decodeURIComponent` was
+called unguarded, so a one-character body like `file://docs/%` threw a `URIError` out of
+the matcher and into the `resources/read` template loop, where a URI that simply does not
+match should fall through cleanly to the next template.
+
 The same pass escapes the literal parts of the template before they reach the `RegExp`.
 A `.` in a template used to match any character (`weather://a.b/{city}` matched
 `weather://aXb/paris`), and a literal `(` created a capture group that shifted every

--- a/.changeset/uri-template-decode-guard.md
+++ b/.changeset/uri-template-decode-guard.md
@@ -1,0 +1,17 @@
+---
+'@gemstack/mcp': patch
+---
+
+`matchUriTemplate` no longer lets a percent-encoded separator slip a path traversal past its `[^/]` guard (#968)
+
+The matcher decoded the captured params after the match had already been accepted, so
+`file://docs/..%2F..%2F..%2Fetc%2Fpasswd` matched `file://docs/{name}` and handed the
+handler `../../../etc/passwd`, while the literal-slash form was correctly rejected. Any
+resource handler that treats a template param as a path segment read outside its root.
+The guard now applies to the decoded value.
+
+The same pass escapes the literal parts of the template before they reach the `RegExp`.
+A `.` in a template used to match any character (`weather://a.b/{city}` matched
+`weather://aXb/paris`), and a literal `(` created a capture group that shifted every
+param onto the wrong value. Templates without regex metacharacters behave exactly as
+before.

--- a/packages/mcp/src/uri-template.test.ts
+++ b/packages/mcp/src/uri-template.test.ts
@@ -42,6 +42,14 @@ describe('matchUriTemplate', () => {
     assert.deepEqual(matchUriTemplate('file://docs/{name}', 'file://docs/a.b'), { name: 'a.b' })
   })
 
+  it('treats a malformed percent-escape as a non-match rather than throwing (#968)', () => {
+    assert.equal(matchUriTemplate('file://docs/{name}', 'file://docs/%'), null)
+    assert.equal(matchUriTemplate('file://docs/{name}', 'file://docs/%zz'), null)
+    assert.equal(matchUriTemplate('file://docs/{name}', 'file://docs/%E0%A4%A'), null)
+    // A well-formed URI still matches, so the guard did not swallow the good path with it.
+    assert.deepEqual(matchUriTemplate('file://docs/{name}', 'file://docs/ok'), { name: 'ok' })
+  })
+
   // ─── #968 defect 2: literal segments are regex-escaped ───
 
   it('treats regex metacharacters in the template as literals (#968)', () => {

--- a/packages/mcp/src/uri-template.test.ts
+++ b/packages/mcp/src/uri-template.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { matchUriTemplate } from './uri-template.js'
+
+// ─── matchUriTemplate ─────────────────────────────────────
+
+describe('matchUriTemplate', () => {
+  it('extracts a single param and percent-decodes it', () => {
+    assert.deepEqual(matchUriTemplate('weather://location/{city}', 'weather://location/paris'), { city: 'paris' })
+    assert.deepEqual(matchUriTemplate('doc://{id}', 'doc://a%20b'), { id: 'a b' })
+  })
+
+  it('extracts several params in order', () => {
+    assert.deepEqual(
+      matchUriTemplate('repo://{owner}/{name}/blob', 'repo://acme/widgets/blob'),
+      { owner: 'acme', name: 'widgets' },
+    )
+  })
+
+  it('returns null when the URI does not match the template', () => {
+    assert.equal(matchUriTemplate('doc://{id}', 'other://42'), null)
+    assert.equal(matchUriTemplate('doc://{id}', 'doc://'), null)
+    assert.equal(matchUriTemplate('doc://{id}/x', 'doc://42'), null)
+  })
+
+  it('matches a template with no placeholders exactly', () => {
+    assert.deepEqual(matchUriTemplate('config://app', 'config://app'), {})
+    assert.equal(matchUriTemplate('config://app', 'config://app/extra'), null)
+  })
+
+  // ─── #968 defect 1: the separator guard must survive decoding ───
+
+  it('rejects a percent-encoded separator instead of decoding it after the match (#968)', () => {
+    assert.equal(matchUriTemplate('file://docs/{name}', 'file://docs/..%2F..%2F..%2Fetc%2Fpasswd'), null)
+    assert.equal(matchUriTemplate('file://docs/{name}', 'file://docs/a%2Fb'), null)
+    // The literal-slash form was always rejected; the encoded form must agree.
+    assert.equal(matchUriTemplate('file://docs/{name}', 'file://docs/../../../etc/passwd'), null)
+  })
+
+  it('still allows dot segments that stay inside one path segment (#968)', () => {
+    assert.deepEqual(matchUriTemplate('file://docs/{name}', 'file://docs/..'), { name: '..' })
+    assert.deepEqual(matchUriTemplate('file://docs/{name}', 'file://docs/a.b'), { name: 'a.b' })
+  })
+
+  // ─── #968 defect 2: literal segments are regex-escaped ───
+
+  it('treats regex metacharacters in the template as literals (#968)', () => {
+    assert.equal(matchUriTemplate('weather://a.b/{city}', 'weather://aXb/paris'), null)
+    assert.deepEqual(matchUriTemplate('weather://a.b/{city}', 'weather://a.b/paris'), { city: 'paris' })
+    assert.equal(matchUriTemplate('doc://a+/{id}', 'doc://aaa/1'), null)
+    assert.deepEqual(matchUriTemplate('doc://a+/{id}', 'doc://a+/1'), { id: '1' })
+  })
+
+  // ─── #968 defect 3: capture indexes stay aligned with param names ───
+
+  it('keeps params aligned when the template contains a literal group (#968)', () => {
+    assert.equal(matchUriTemplate('x://(a|.*)/{p}', 'x://zzzz/v'), null)
+    assert.deepEqual(matchUriTemplate('x://(a|.*)/{p}', 'x://(a|.*)/v'), { p: 'v' })
+  })
+})

--- a/packages/mcp/src/uri-template.ts
+++ b/packages/mcp/src/uri-template.ts
@@ -28,7 +28,13 @@ export function matchUriTemplate(template: string, uri: string): Record<string, 
   if (!match) return null
   const params: Record<string, string> = {}
   for (let i = 0; i < paramNames.length; i++) {
-    const value = decodeURIComponent(match[i + 1]!)
+    let value: string
+    try {
+      value = decodeURIComponent(match[i + 1]!)
+    } catch {
+      // A malformed escape like `%zz` is a non-match, not a crash out of the caller's template loop.
+      return null
+    }
     // The guard has to hold after decoding too, or `%2F` smuggles a traversal past `([^/]+)`.
     if (value.includes('/')) return null
     params[paramNames[i]!] = value

--- a/packages/mcp/src/uri-template.ts
+++ b/packages/mcp/src/uri-template.ts
@@ -1,3 +1,9 @@
+const PLACEHOLDER = /\{(\w+)\}/g
+
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 /**
  * Match a URI against a template pattern like `weather://location/{city}`.
  * Returns extracted params or null if no match.
@@ -7,16 +13,25 @@
  * subtle drift in earlier revisions.
  */
 export function matchUriTemplate(template: string, uri: string): Record<string, string> | null {
+  // Escape between placeholders: an unescaped `.` widens the match and a stray `(` shifts the capture indexes.
   const paramNames: string[] = []
-  const regexStr = template.replace(/\{(\w+)\}/g, (_, name: string) => {
-    paramNames.push(name)
-    return '([^/]+)'
-  })
+  let regexStr = ''
+  let cursor = 0
+  for (const m of template.matchAll(PLACEHOLDER)) {
+    regexStr += escapeRegExp(template.slice(cursor, m.index)) + '([^/]+)'
+    paramNames.push(m[1]!)
+    cursor = m.index + m[0].length
+  }
+  regexStr += escapeRegExp(template.slice(cursor))
+
   const match = uri.match(new RegExp(`^${regexStr}$`))
   if (!match) return null
   const params: Record<string, string> = {}
   for (let i = 0; i < paramNames.length; i++) {
-    params[paramNames[i]!] = decodeURIComponent(match[i + 1]!)
+    const value = decodeURIComponent(match[i + 1]!)
+    // The guard has to hold after decoding too, or `%2F` smuggles a traversal past `([^/]+)`.
+    if (value.includes('/')) return null
+    params[paramNames[i]!] = value
   }
   return params
 }


### PR DESCRIPTION
Closes #968

`matchUriTemplate` built its matcher by string-substituting the template into a `RegExp`, then percent-decoded the captures *after* the match had already been accepted. Three defects fell out of those two lines, plus a fourth found in review.

### 1. The `[^/]` guard was defeated by percent-encoding (the security one)

```
matchUriTemplate('file://docs/{name}', 'file://docs/..%2F..%2F..%2Fetc%2Fpasswd')
  => { name: '../../../etc/passwd' }      // before
  => null                                 // after
matchUriTemplate('file://docs/{name}', 'file://docs/../../../etc/passwd')
  => null                                 // both
```

The literal-slash form was correctly rejected, which is the entire point of `([^/]+)`, and then `decodeURIComponent` handed the caller the traversal anyway. Any resource handler that treats a template param as a path segment (exactly what a template like `file://docs/{name}` invites) read outside its root. There is no other validation layer: no caller re-checks the returned params.

### 2. Literal segments reached the regex unescaped

```
matchUriTemplate('weather://a.b/{city}', 'weather://aXb/paris')
  => { city: 'paris' }   // before, `.` matched `X`
  => null                // after
```

### 3. Capture groups mapped to param names positionally

```
matchUriTemplate('x://(a|.*)/{p}', 'x://zzzz/v')
  => { p: 'zzzz' }   // before, the stray group shifted every index
  => null            // after, the template's `(` is a literal
```

### 4. A malformed percent-escape threw instead of not matching

```
matchUriTemplate('file://docs/{name}', 'file://docs/%')
  => throws URIError: URI malformed   // before
  => null                             // after
```

Pre-existing rather than introduced here, but it belongs in this PR: the URI is client-supplied, and the throw escaped into the `resources/read` template loop in `runtime/sdk-server.ts`, where a URI that simply does not match should be a clean fall-through to the next template. One character (`%`) was enough.

## The fix

- The template is split on the `{name}` boundaries, each literal chunk is escaped, and the chunks are joined with the `([^/]+)` capture pattern. That fixes 2 and 3 together, since the escape runs before the placeholder substitution.
- The separator guard is applied to the *decoded* value: a param that decodes to something containing `/` is not a match, so the matcher falls through to the next template rather than returning a smuggled path.
- The decode is wrapped so a malformed escape returns `null`. The `try` covers only the `decodeURIComponent` call, so nothing else is swallowed.

Signature and behaviour are unchanged for every template that contains no regex metacharacters, and for every param that decodes cleanly to something without a separator. Both callers (the SDK runtime's `resources/read` template matching in `runtime/sdk-server.ts` and the package entry re-export used by inspector tooling) are unaffected apart from the corrected results.

## Tests

New `packages/mcp/src/uri-template.test.ts`: 9 cases, 4 of them covering existing behaviour (single param, several params, non-matches, placeholder-free templates) as a regression floor.

Each defect test was proved by reverting only its part of the source fix while keeping the test and re-running:

| Test | Proved | Failure against the unfixed code |
|---|---|---|
| rejects a percent-encoded separator instead of decoding it after the match (#968) | yes | `actual: { name: '../../../etc/passwd' }, expected: null` |
| treats regex metacharacters in the template as literals (#968) | yes | `actual: { city: 'paris' }, expected: null` |
| keeps params aligned when the template contains a literal group (#968) | yes | `actual: { p: 'zzzz' }, expected: null` |
| treats a malformed percent-escape as a non-match rather than throwing (#968) | yes | `URIError: URI malformed` |

The fourth was proved on its own: with only the `try`/`catch` reverted and the other fixes in place, exactly that one test failed (121 pass / 1 fail).

The 5 other cases (including `still allows dot segments that stay inside one path segment`, which pins that `..` and `a.b` are still legal single-segment values) pass against both versions by design.

`@gemstack/mcp` tests: 113 before, 122 after, 0 failures. Root `pnpm test` green across all 21 tasks, `pnpm build` exits 0.
