### PR TITLE
fix(mcp): stop trusting X-Forwarded-Host in the OAuth2 challenge

### DIFF
--- a/.changeset/mcp-oauth2-forwarded-host.md
+++ b/.changeset/mcp-oauth2-forwarded-host.md
@@ -1,0 +1,11 @@
+---
+'@gemstack/mcp': minor
+---
+
+Stop trusting `X-Forwarded-Host` in the OAuth 2.1 challenge, and escape `resource_metadata`.
+
+`absoluteUrl()` read the client-supplied `X-Forwarded-Host` and `X-Forwarded-Proto` first and unconditionally. Its result is the `resource_metadata` URL in the RFC 9728 `WWW-Authenticate` header, which is exactly what a compliant MCP client follows to discover where to authenticate, so anyone able to reach the endpoint could point another client's discovery at a host of their choosing, or downgrade the scheme to `http`. The value was also interpolated unescaped, so a host containing a quote broke out of the RFC 7235 quoted-string and injected `error` and `scope` auth-params ahead of the real ones.
+
+Forwarded headers are now honoured only when the new `trustProxy` option is set (default off), only the first (client-facing) value of each is read, and a forwarded host that is not a bare `host[:port]` is discarded. `resource_metadata` and `scope` now get the same quoted-string escaping `error_description` already had.
+
+If you deploy behind a reverse proxy that overwrites those headers and you rely on the forwarded host appearing in the metadata URL, set `trustProxy: true` in your OAuth2 options.

--- a/docs/packages/mcp.md
+++ b/docs/packages/mcp.md
@@ -293,6 +293,19 @@ registerOAuth2Metadata(app, '/mcp', options)
 
 On success the verified claims are attached to the request as `req.mcpAuth` (`{ sub?, scopes?, claims }`). A missing or invalid token yields `401 invalid_token`; a valid token missing a required scope yields `403 insufficient_scope`. Match your IdP's token config to the `scopes` you require.
 
+### Behind a reverse proxy
+
+The metadata URL in the `WWW-Authenticate` challenge (and the `resource` in the metadata document) is derived from the request's host and scheme. `X-Forwarded-Host` and `X-Forwarded-Proto` are **ignored by default**, because a client can send them itself and thereby point another client's discovery at a host of its choosing. If the endpoint is only reachable through a proxy that overwrites those headers, opt in:
+
+```ts
+const options = {
+  // ...as above
+  trustProxy: true,
+}
+```
+
+Only the client-facing (first) value of each header is read, and a forwarded host that is not a bare `host[:port]` is discarded in favour of the real one.
+
 ## Testing
 
 `McpTestClient` exercises a server's tools, resources, and prompts in-process, with no transport, so assertions run the same dispatch path the HTTP transport uses:

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -166,6 +166,19 @@ registerOAuth2Metadata(app, '/mcp', options)
 
 On success the verified claims are attached to the request as `req.mcpAuth` (`{ sub?, scopes?, claims }`). Missing required `scopes` yields a `403 insufficient_scope`; a missing/invalid token yields `401 invalid_token`.
 
+### Behind a reverse proxy
+
+The metadata URL in the `WWW-Authenticate` challenge (and the `resource` in the metadata document) is derived from the request's host and scheme. `X-Forwarded-Host` and `X-Forwarded-Proto` are **ignored by default**, because a client can send them itself and thereby point another client's discovery at a host of its choosing. If the endpoint is only reachable through a proxy that overwrites those headers, opt in:
+
+```ts
+const options = {
+  // ...as above
+  trustProxy: true,
+}
+```
+
+Only the client-facing (first) value of each header is read, and a forwarded host that is not a bare `host[:port]` is discarded in favour of the real one.
+
 ## Testing
 
 `McpTestClient` exercises a server's tools/resources/prompts in-process, with no transport:

--- a/packages/mcp/src/auth/oauth2.ts
+++ b/packages/mcp/src/auth/oauth2.ts
@@ -41,6 +41,13 @@ export interface OAuth2McpOptions {
   scopesSupported?: string[]
   /** Token verifier. Required for the endpoint to accept any token (see {@link VerifyToken}). */
   verifyToken?: VerifyToken
+  /**
+   * Honour `X-Forwarded-Host` / `X-Forwarded-Proto` when building the metadata
+   * URL. Off by default: those headers are client-supplied unless a trusted
+   * proxy overwrites them, and the URL is what clients follow to authenticate.
+   * Enable it only when this endpoint is reachable solely through such a proxy.
+   */
+  trustProxy?: boolean
 }
 
 /** Minimal Connect-style request shape the middleware reads. */
@@ -80,7 +87,7 @@ export function oauth2McpMiddleware(mcpPath: string, options: OAuth2McpOptions =
 
   return async function OAuth2McpMiddleware(req, res, next) {
     const authHeader = getHeader(req, 'authorization')
-    const metadataUrl = absoluteUrl(req, metadataPath)
+    const metadataUrl = absoluteUrl(req, metadataPath, options.trustProxy === true)
 
     if (!authHeader?.startsWith('Bearer ')) {
       challenge(res, metadataUrl, 'invalid_token', 'Bearer token required.')
@@ -147,7 +154,7 @@ export function registerOAuth2Metadata(
   const metadataPath = `/.well-known/oauth-protected-resource${mcpPath}`
 
   router.get(metadataPath, (req: unknown, res: unknown) => {
-    const origin = absoluteUrl(req as OAuth2Request, '')
+    const origin = absoluteUrl(req as OAuth2Request, '', options.trustProxy === true)
     const resource = options.resource ?? `${origin}${mcpPath}`
     const authServers = options.authorizationServers && options.authorizationServers.length > 0
       ? options.authorizationServers
@@ -168,16 +175,43 @@ export function registerOAuth2Metadata(
 
 // ─── helpers ──────────────────────────────────────────────
 
-function absoluteUrl(req: OAuth2Request, path: string): string {
-  const host = getHeader(req, 'x-forwarded-host')
-    ?? req.host
-    ?? getHeader(req, 'host')
-    ?? req.hostname
+/** A bare `host[:port]`, either a registered name / IPv4 or a bracketed IPv6 literal. */
+const HOST_PATTERN = /^(?:[a-zA-Z0-9._-]+|\[[0-9a-fA-F:.]+\])(?::\d{1,5})?$/
+
+function absoluteUrl(req: OAuth2Request, path: string, trustProxy: boolean): string {
+  const host = (trustProxy ? validHost(firstValue(getHeader(req, 'x-forwarded-host'))) : undefined)
+    ?? validHost(req.host)
+    ?? validHost(getHeader(req, 'host'))
+    ?? validHost(req.hostname)
     ?? 'localhost'
-  const proto = getHeader(req, 'x-forwarded-proto')
-    ?? req.protocol
+  const proto = (trustProxy ? validProto(firstValue(getHeader(req, 'x-forwarded-proto'))) : undefined)
+    ?? validProto(req.protocol)
     ?? 'http'
   return `${proto}://${host}${path}`
+}
+
+/** A chain of proxies appends to `X-Forwarded-*`; the client-facing hop is first. */
+function firstValue(raw: string | undefined): string | undefined {
+  return raw?.split(',')[0]?.trim() || undefined
+}
+
+function validHost(raw: string | undefined): string | undefined {
+  return raw !== undefined && HOST_PATTERN.test(raw) ? raw : undefined
+}
+
+function validProto(raw: string | undefined): string | undefined {
+  const proto = raw?.replace(/:$/, '').toLowerCase()
+  return proto === 'http' || proto === 'https' ? proto : undefined
+}
+
+/**
+ * Escape a value for an RFC 7235 quoted-string. Backslashes go BEFORE quotes:
+ * otherwise a value ending in `\` would let the trailing backslash escape the
+ * closing quote and inject extra auth-params. Order matters, `\` → `\\`, then
+ * `"` → `\"`.
+ */
+function escapeQuoted(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
 }
 
 function getHeader(req: OAuth2Request, name: string): string | undefined {
@@ -193,15 +227,9 @@ function challenge(
   description: string,
   scope?: string,
 ): void {
-  const parts: string[] = [`resource_metadata="${metadataUrl}"`, `error="${error}"`]
-  // Escape backslashes BEFORE quotes — otherwise a description ending in `\`
-  // would let the trailing backslash escape the closing quote and break out of
-  // the RFC 7235 quoted-string. Order matters: `\` → `\\`, then `"` → `\"`.
-  if (description) {
-    const escaped = description.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
-    parts.push(`error_description="${escaped}"`)
-  }
-  if (scope) parts.push(`scope="${scope}"`)
+  const parts: string[] = [`resource_metadata="${escapeQuoted(metadataUrl)}"`, `error="${error}"`]
+  if (description) parts.push(`error_description="${escapeQuoted(description)}"`)
+  if (scope) parts.push(`scope="${escapeQuoted(scope)}"`)
   res.header?.('WWW-Authenticate', `Bearer ${parts.join(', ')}`)
 
   const statusCode = error === 'insufficient_scope' ? 403 : 401

--- a/packages/mcp/src/index.test.ts
+++ b/packages/mcp/src/index.test.ts
@@ -1408,6 +1408,97 @@ describe('registerOAuth2Metadata', () => {
   })
 })
 
+// ─── oauth2 challenge — forwarded headers and header injection ──
+
+describe('oauth2McpMiddleware — the WWW-Authenticate challenge is not client-steerable', () => {
+  function mockRes() {
+    const calls: { status?: number; body?: unknown; headers: Record<string, string> } = { headers: {} }
+    const res = {
+      status(code: number) { calls.status = code; return res },
+      header(key: string, value: string) { calls.headers[key.toLowerCase()] = value; return res },
+      json(data: unknown) { calls.body = data },
+    }
+    return { res, calls }
+  }
+
+  async function challengeFor(
+    req: Record<string, unknown>,
+    options: Record<string, unknown> = {},
+    mcpPath = '/mcp/secure',
+  ): Promise<string> {
+    const { oauth2McpMiddleware } = await import('./auth/oauth2.js')
+    const mw = oauth2McpMiddleware(mcpPath, options)
+    const { res, calls } = mockRes()
+    await mw(req as never, res as never, async () => {})
+    return calls.headers['www-authenticate'] ?? ''
+  }
+
+  it('ignores X-Forwarded-Host by default, so discovery cannot be pointed at an attacker', async () => {
+    const header = await challengeFor({
+      headers: { host: 'app.test', 'x-forwarded-host': 'evil.attacker.test' },
+    })
+    assert.ok(header.includes('resource_metadata="http://app.test/.well-known/oauth-protected-resource/mcp/secure"'),
+      `expected the real host in the challenge, got: ${header}`)
+    assert.ok(!header.includes('evil.attacker.test'), `attacker host leaked into: ${header}`)
+  })
+
+  it('ignores X-Forwarded-Proto by default, so the scheme cannot be downgraded to http', async () => {
+    const header = await challengeFor({
+      headers: { host: 'app.test', 'x-forwarded-proto': 'http' },
+      protocol: 'https',
+    })
+    assert.ok(header.includes('resource_metadata="https://app.test/'), `scheme downgraded: ${header}`)
+  })
+
+  it('honours X-Forwarded-Host and X-Forwarded-Proto once trustProxy is opted into', async () => {
+    const header = await challengeFor(
+      { headers: { host: 'internal:3000', 'x-forwarded-host': 'api.example.com', 'x-forwarded-proto': 'https' } },
+      { trustProxy: true },
+    )
+    assert.ok(header.includes('resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp/secure"'),
+      `expected the forwarded host, got: ${header}`)
+  })
+
+  it('rejects a forwarded host that is not a bare host[:port], even with trustProxy on', async () => {
+    const header = await challengeFor(
+      { headers: { host: 'app.test', 'x-forwarded-host': 'a", error="insufficient_scope", scope="admin' } },
+      { trustProxy: true },
+    )
+    assert.ok(header.includes('resource_metadata="http://app.test/'), `bad host was used: ${header}`)
+    assert.equal(header.match(/error="/g)?.length, 1, `injected an extra error param: ${header}`)
+    assert.ok(!header.includes('scope="admin"'), `injected a scope param: ${header}`)
+  })
+
+  it('escapes resource_metadata so a quote in the URL cannot inject auth-params', async () => {
+    const header = await challengeFor(
+      { headers: { host: 'app.test' } },
+      {},
+      '/mcp/a", error="insufficient_scope", scope="admin',
+    )
+    // The quote must survive only as an escaped one inside the quoted-string.
+    assert.ok(!/resource_metadata="[^"\\]*"\s*,\s*error="insufficient_scope"/.test(header),
+      `resource_metadata broke out of its quoted-string: ${header}`)
+    assert.ok(header.includes('\\"'), `expected an escaped quote, got: ${header}`)
+    assert.equal(header.match(/error="/g)?.length, 1, `injected an extra error param: ${header}`)
+  })
+
+  it('the metadata document ignores X-Forwarded-Host by default too', async () => {
+    const { registerOAuth2Metadata } = await import('./auth/oauth2.js')
+    type Handler = (req: unknown, res: unknown) => unknown
+    let registeredHandler: Handler | null = null
+    const router = { get(_path: string, handler: Handler) { registeredHandler = handler } }
+    registerOAuth2Metadata(router, '/mcp/secure', {})
+
+    let body: Record<string, unknown> | null = null
+    const req = { headers: { host: 'app.test', 'x-forwarded-host': 'evil.attacker.test' } }
+    ;(registeredHandler as unknown as Handler)(req, { json: (d: Record<string, unknown>) => { body = d } })
+
+    const b = body as unknown as Record<string, unknown>
+    assert.equal(b['resource'], 'http://app.test/mcp/secure')
+    assert.deepStrictEqual(b['authorization_servers'], ['http://app.test'])
+  })
+})
+
 describe('Mcp servers registry on globalThis', () => {
   it('state lives on globalThis so it survives a second copy of @gemstack/mcp', () => {
     // Vite-bundled server apps inline `@gemstack/mcp` (the route mounter


### PR DESCRIPTION
Closes #969

## The defect

`absoluteUrl()` in `packages/mcp/src/auth/oauth2.ts` read the client-supplied `X-Forwarded-Host` first and unconditionally, ahead of `req.host` and the real `host` header. Its result becomes `metadataUrl`, which six `challenge()` call sites put into `WWW-Authenticate: Bearer resource_metadata="..."`, the RFC 9728 header a spec-compliant MCP client follows to discover where to authenticate. Any client could therefore point another client's discovery at a host of its choosing. `X-Forwarded-Proto` was trusted the same way, allowing a downgrade to `http`. The same value is the `resource` origin in the metadata document body.

Independently, the value was interpolated unescaped while `error_description` immediately below it was carefully escaped with a comment explaining why. With `X-Forwarded-Host: a", error="insufficient_scope", scope="admin` the emitted header was:

```
Bearer resource_metadata="http://a", error="insufficient_scope", scope="admin/.well-known/oauth-protected-resource/mcp/secure", error="invalid_token", error_description="Bearer token required."
```

The injected auth-params precede the real ones, so an RFC 7235 parser taking the first occurrence of a repeated param reads a different error and scope than the server sent.

## The fix

- New `trustProxy` option on `OAuth2McpOptions`, **default off**. `X-Forwarded-Host` / `X-Forwarded-Proto` are only consulted when it is set, and only the client-facing (first) value of each is read.
- Every host candidate is validated against a bare `host[:port]` pattern (registered name / IPv4, or a bracketed IPv6 literal) and discarded in favour of the next candidate when it does not match. The scheme is constrained to `http` / `https`.
- Extracted the existing quoted-string escaping into `escapeQuoted()` and applied it to `resource_metadata` and `scope` as well as `error_description`.
- README + `docs/packages/mcp.md` gained a "Behind a reverse proxy" section documenting the opt-in.

## Proof

Each test was proven by reverting only that half of the source fix (keeping the `trustProxy` type surface so the tests still compile, so these are behavioural failures, not compile failures) and re-running.

| Test | Reverted | Failure |
|---|---|---|
| ignores X-Forwarded-Host by default | `absoluteUrl` | `expected the real host in the challenge, got: Bearer resource_metadata="http://evil.attacker.test/.well-known/oauth-protected-resource/mcp/secure", error="invalid_token", ...` |
| ignores X-Forwarded-Proto by default | `absoluteUrl` | `scheme downgraded: Bearer resource_metadata="http://app.test/..."` |
| rejects a forwarded host that is not a bare host[:port] | `absoluteUrl` | ``bad host was used: Bearer resource_metadata="http://a\", error=\"insufficient_scope\", scope=\"admin/..."`` |
| the metadata document ignores X-Forwarded-Host too | `absoluteUrl` | `resource` was `http://evil.attacker.test/mcp/secure`, expected `http://app.test/mcp/secure` |
| escapes resource_metadata | `challenge` | `resource_metadata broke out of its quoted-string: Bearer resource_metadata="http://app.test/.well-known/oauth-protected-resource/mcp/a", error="insufficient_scope", scope="admin", error="invalid_token", ...` |

The sixth new test (`honours X-Forwarded-Host once trustProxy is opted into`) pins the new option's contract rather than a regression.

`@gemstack/mcp`: **113 -> 119** tests, all passing. Full root `pnpm test` green (21/21 tasks), `pnpm build` exit 0.

## Changeset

`minor`, not patch: `trustProxy` is new public surface on an exported option type. It is also a behaviour change for anyone currently relying on the forwarded host reaching the metadata URL, and the changeset calls out that they now need `trustProxy: true`.