### PR TITLE
fix(framework): stop auto PM's in-flight sweep, not just its timer

### DIFF
--- a/.changeset/auto-pm-stop-flag.md
+++ b/.changeset/auto-pm-stop-flag.md
@@ -1,0 +1,15 @@
+---
+'@gemstack/framework': patch
+---
+
+Stopping auto PM now stops an in-flight sweep, not just its timer (#983)
+
+`stop()` only cleared the interval, so a sweep already inside its per-project loop kept
+going: it finished awaiting the git calls and queue reads, then spawned a run. During
+shutdown the daemon quiesces the background services and then clears its live-run map,
+so a run started in that window was tracked by nobody. It was never suspended and never
+terminated, leaving an orphan process holding a worktree and quota spent on a run that
+would never be seen.
+
+The sweep now carries a stopped flag, checked at the top of a tick and again immediately
+before a run is started, so the awaited window between the two no longer leaks a run.

--- a/packages/framework/src/auto-pm.test.ts
+++ b/packages/framework/src/auto-pm.test.ts
@@ -9,6 +9,7 @@ import {
   AUTO_PM_MAINTENANCE_JOB,
   type AutoPmDeps,
   type AutoPmJob,
+  type AutoPmLoop,
   type AutoPmProject,
 } from './auto-pm.js'
 import { quotaBoundaryStatus, type QuotaBoundaryStatus } from './quota-boundary.js'
@@ -401,6 +402,37 @@ test('a queue with work in it is drained rather than swept (#882)', async () => 
   await loop.tick()
   loop.stop()
   assert.deepEqual(ran, [AUTO_PM_DRAIN_JOB.name])
+})
+
+test('a sweep stopped mid-flight starts nothing (#983)', async () => {
+  // stop() used to only clear the timer, so a tick already inside its per-project loop kept
+  // awaiting (git calls, the queue read) and then spawned a run anyway. By then the daemon has
+  // quiesced and cleared its live-run map, so that run is tracked by nobody: an orphan holding a
+  // worktree, and quota spent on a run nobody will ever see.
+  const both: AutoPmProject[] = [
+    { id: 'p1', path: '/repo' },
+    { id: 'p2', path: '/other' },
+  ]
+  let loop!: AutoPmLoop
+  const h = harness({
+    projects: async () => both,
+    // The daemon shutting down while the sweep sits between its readings and the spawn.
+    backlogEmpty: async () => {
+      loop.stop()
+      return true
+    },
+  })
+  loop = h.loop
+  await loop.tick()
+  // p2 neither: stopping is a verdict on the whole sweep, not on one project.
+  assert.deepEqual(h.started, [])
+})
+
+test('a stopped sweep does not tick again (#983)', async () => {
+  const { loop, started } = harness()
+  loop.stop()
+  await loop.tick()
+  assert.deepEqual(started, [])
 })
 
 test('an unreadable sweep schedule falls back to the rotation (#882)', async () => {

--- a/packages/framework/src/auto-pm.ts
+++ b/packages/framework/src/auto-pm.ts
@@ -290,9 +290,10 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
   // should each work through the rotation, not take alternate halves of it.
   const nextJob = new Map<string, number>()
   let sweeping = false
+  let stopped = false
 
   const tick = async (): Promise<void> => {
-    if (sweeping) return
+    if (stopped || sweeping) return
     sweeping = true
     try {
       // The preference is the cheapest gate and the one the user flips most, so it is read
@@ -349,6 +350,10 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
             ? (deps.drainJob ?? AUTO_PM_DRAIN_JOB)
             : deps.jobs[index % deps.jobs.length]
         if (!job) continue
+        // Re-checked here because everything above is awaited: a run spawned past a `stop()` is
+        // missing from the live-run map the daemon has by then cleared, so nothing suspends or
+        // terminates it (#983). Break, not continue: stopping is a verdict on the whole sweep.
+        if (stopped) break
         // Armed before the spawn, not after: starting is slow, and a tick that overlapped the
         // spawn would otherwise see no live run yet and start a second one.
         lastStart.set(project.id, now())
@@ -379,5 +384,11 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
 
   const timer = setInterval(() => void tick(), deps.intervalMs ?? DEFAULT_AUTO_PM_INTERVAL_MS)
   timer.unref?.() // a background sweep must never be the reason the process stays up
-  return { tick, stop: () => clearInterval(timer) }
+  return {
+    tick,
+    stop: () => {
+      stopped = true
+      clearInterval(timer)
+    },
+  }
 }


### PR DESCRIPTION
## The defect

`startAutoPm` returned `{ tick, stop: () => clearInterval(timer) }`, and the file had no `stopped` flag at all. So `stop()` only cancelled the next tick: a `tick()` already inside its per-project loop kept running, finished awaiting `promote` (several git calls) and the queue read, then called `deps.start` and spawned a detached run.

That matters at shutdown. `daemon.ts:378` calls `services.quiesce()` and then `runtime.suspendRuns()`, which does `activeRuns.clear()`. A run spawned by the surviving tick is never in that map, so it is never terminated and gets no `suspended.json` entry: an orphan on `ppid 1` holding a worktree, plus quota spent on a run nobody will ever see. That is exactly the outcome the comment at `daemon.ts:376` says quiesce prevents.

Auto PM was the only poll service without this guard. `conversation-commit.ts`, `discord/reply-mirror.ts` and `dashboard/keyed-watcher.ts` all set `stopped = true` in `stop()` and check it in the loop.

## The fix

`packages/framework/src/auto-pm.ts`: add `let stopped = false`, set it in `stop()` alongside `clearInterval`, and check it twice.

- Top of `tick`: `if (stopped || sweeping) return`.
- Immediately before the spawn (after the job is picked, before `lastStart` is stamped): `if (stopped) break`. This is the load-bearing one, since the whole window between the two checks is awaited.

`break`, not `continue`: stopping is a verdict on the whole sweep, not on one project. Placing it before `lastStart.set` also avoids leaving a cooldown stamp and a "doing X" log line for a run that was never started.

## The proof

Two regression tests in `auto-pm.test.ts`, in the house pattern (drive `tick()` by hand, never rely on the timer):

- `a sweep stopped mid-flight starts nothing (#983)` calls `loop.stop()` from inside an awaited `backlogEmpty`, with two projects registered, and asserts `start` was called for neither.
- `a stopped sweep does not tick again (#983)` covers the top-of-tick check.

Reverting the source fix while keeping both tests fails them:

```
✖ a sweep stopped mid-flight starts nothing (#983)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
    actual: [ 'p1', 'p2' ],
    expected: []

✖ a stopped sweep does not tick again (#983)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
    actual: [ 'p1' ],
    expected: []

ℹ tests 1049
ℹ pass 1046
ℹ fail 2
```

With the fix restored: framework 1049 tests, 1048 pass, 0 fail, 1 skipped (1047 before this PR, so the two new tests are the whole delta). Root `pnpm test` green across all 21 tasks and `pnpm build` exit 0.

Closes #983