### PR TITLE
fix(ai-mcp): close the transport on a failed connect, and stream progress live

### DIFF
--- a/.changeset/fix-977-streaming-is-live.md
+++ b/.changeset/fix-977-streaming-is-live.md
@@ -1,0 +1,9 @@
+---
+'@gemstack/ai-mcp': patch
+---
+
+`mcpClientTools({ streaming: true })` now forwards progress while the remote tool runs, instead of replaying it at the end.
+
+Progress notifications were collected into an array during `callTool()` and only yielded once it had resolved, so no `tool-update` chunk could reach a consumer while the remote tool was still working: a progress bar driven by them jumped from empty straight to complete, which is nothing the non-streaming path does not already do. Each notification is now yielded as it lands.
+
+The batching had been protecting the chunk order, and that guarantee still holds: the generator only returns after the call settles, and drains anything still queued first, so every `tool-update` chunk still precedes the tool's result.

--- a/.changeset/fix-978-connect-leak.md
+++ b/.changeset/fix-978-connect-leak.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/ai-mcp': patch
+---
+
+Fix `mcpClientTools()` leaking a transport (and any stdio subprocess) when `connect()` fails.
+
+The connect path had no cleanup: if the handshake rejected, nothing closed the transport the bridge had just built, so an HTTP session or a spawned child process was orphaned and a retrying caller leaked one per attempt. The MCP SDK does not cover this either, since it never cleans up when `transport.start()` rejects and only fires an unawaited `close()` on an initialize failure. The connect is now wrapped, the client and the transport are both closed best-effort, and the original error is rethrown unchanged.

--- a/packages/ai-mcp/README.md
+++ b/packages/ai-mcp/README.md
@@ -55,7 +55,7 @@ await tools.close?.()
 |---|---|---|
 | `filter` | all tools | `(toolName) => boolean` — drop remote tools you don't want to expose. |
 | `namePrefix` | `''` | Prefix every tool name, to avoid collisions when wiring several remote servers. |
-| `streaming` | `true` | Forward the remote server's `notifications/progress` as `tool-update` chunks during a run. |
+| `streaming` | `true` | Forward the remote server's `notifications/progress` as `tool-update` chunks, each one as it arrives while the remote tool is still running. Every chunk lands before the tool's result. |
 
 ```ts
 const tools = await mcpClientTools('https://api.example.com/mcp', {

--- a/packages/ai-mcp/src/client-tools.test.ts
+++ b/packages/ai-mcp/src/client-tools.test.ts
@@ -164,6 +164,71 @@ describe('mcpClientTools (caller-owned client)', () => {
   })
 })
 
+// ─── Streaming is live, not replayed (#977) ──────────────
+
+describe('mcpClientTools (streaming is live)', () => {
+  it('yields a tool-update chunk while the remote call is still running', async () => {
+    // A fake client whose callTool reports progress, then blocks until we release it.
+    let release: () => void = () => {}
+    const blocked = new Promise<void>((resolve) => { release = resolve })
+    const client = {
+      listTools: async () => ({ tools: [{ name: 'slow', description: '', inputSchema: { type: 'object' } }] }),
+      callTool:  async (
+        _params: unknown,
+        _schema: unknown,
+        opts?: { onprogress?: (p: { progress: number; total?: number }) => void },
+      ) => {
+        opts?.onprogress?.({ progress: 1, total: 2 })
+        await blocked
+        return { content: [{ type: 'text', text: 'finished' }] }
+      },
+      close: async () => {},
+    }
+
+    const tools = await mcpClientTools(client, { streaming: true })
+    const iter = (tools[0]!.execute as (input: unknown) => AsyncGenerator<
+      { progress: number }, string, void
+    >)({})
+
+    try {
+      // The chunk has to arrive before the call resolves, so race it against a
+      // timer rather than awaiting (which would hang if progress is batched).
+      const first = await Promise.race([
+        iter.next(),
+        new Promise<'timeout'>((resolve) => { setTimeout(() => resolve('timeout'), 250) }),
+      ])
+      assert.notEqual(first, 'timeout', 'no tool-update chunk arrived while the remote call was still running')
+      const chunk = first as IteratorResult<{ progress: number }, string>
+      assert.equal(chunk.done, false)
+      assert.equal((chunk as IteratorYieldResult<{ progress: number }>).value.progress, 1)
+    } finally {
+      release()
+      await iter.return('')
+    }
+  })
+
+  it('every progress chunk still lands before the result', async () => {
+    const { client, cleanup } = await buildLoopback()
+    try {
+      const tools = await mcpClientTools(client, { streaming: true })
+      const longTask = tools.find(t => t.definition.name === 'long_task')!
+      const { yields, result } = await runStreamingTool(longTask, { steps: 3 })
+      assert.deepStrictEqual(yields.map(y => y.progress), [1, 2, 3])
+      assert.strictEqual(result, 'done in 3 steps')
+    } finally { await cleanup() }
+  })
+
+  it('propagates a callTool rejection out of the streaming generator', async () => {
+    const client = {
+      listTools: async () => ({ tools: [{ name: 'boom', description: '', inputSchema: { type: 'object' } }] }),
+      callTool:  async () => { throw new Error('remote exploded') },
+      close:     async () => {},
+    }
+    const tools = await mcpClientTools(client, { streaming: true })
+    await assert.rejects(runTool(tools[0]!, {}), /remote exploded/)
+  })
+})
+
 // ─── Connect failures (#978) ─────────────────────────────
 
 describe('mcpClientTools (connect failure)', () => {

--- a/packages/ai-mcp/src/client-tools.test.ts
+++ b/packages/ai-mcp/src/client-tools.test.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
-import { mcpClientTools } from './client-tools.js'
+import { mcpClientTools, connectOrClose } from './client-tools.js'
 import { toolToSchema } from '@gemstack/ai-sdk'
 
 // ─── Helpers ─────────────────────────────────────────────
@@ -161,6 +161,36 @@ describe('mcpClientTools (caller-owned client)', () => {
       const result = await runTool(longTask, { steps: 2 })
       assert.strictEqual(result, 'done in 2 steps')
     } finally { await cleanup() }
+  })
+})
+
+// ─── Connect failures (#978) ─────────────────────────────
+
+describe('mcpClientTools (connect failure)', () => {
+  it('closes the client and the transport when connect() rejects', async () => {
+    let transportClosed = 0
+    let clientClosed    = 0
+    const transport = { close: async () => { transportClosed++ } }
+    const client = {
+      connect: async () => { throw new Error('handshake failed') },
+      close:   async () => { clientClosed++ },
+    }
+
+    await assert.rejects(connectOrClose(client, transport), /handshake failed/)
+    assert.equal(transportClosed, 1, 'transport was left open after a failed connect()')
+    assert.equal(clientClosed, 1, 'client was left open after a failed connect()')
+  })
+
+  it('a client close() that also throws does not mask the connect error', async () => {
+    let transportClosed = 0
+    const transport = { close: async () => { transportClosed++ } }
+    const client = {
+      connect: async () => { throw new Error('protocol mismatch') },
+      close:   async () => { throw new Error('close blew up') },
+    }
+
+    await assert.rejects(connectOrClose(client, transport), /protocol mismatch/)
+    assert.equal(transportClosed, 1)
   })
 })
 

--- a/packages/ai-mcp/src/client-tools.ts
+++ b/packages/ai-mcp/src/client-tools.ts
@@ -80,6 +80,13 @@ export async function mcpClientTools(
 // Internals
 // ─────────────────────────────────────────────────────────────────
 
+/** A single `notifications/progress` payload, as the SDK hands it to `onprogress`. */
+interface McpProgress {
+  progress: number
+  total?:   number
+  message?: string
+}
+
 /** Tool metadata as returned by a remote MCP server's `listTools()`. */
 interface RemoteTool {
   name:        string
@@ -97,7 +104,7 @@ interface MinimalClient {
   callTool(
     params: { name: string; arguments?: Record<string, unknown> },
     resultSchema?: unknown,
-    options?: { onprogress?: (p: { progress: number; total?: number; message?: string }) => void },
+    options?: { onprogress?: (p: McpProgress) => void },
   ): Promise<{ content: unknown[]; isError?: boolean }>
   close(): Promise<void>
 }
@@ -202,18 +209,36 @@ function buildTool(
 
   if (streaming) {
     const built = builder.server(async function* (input: unknown, _ctx?: ToolCallContext) {
-      const collected: Array<{ progress: number; total?: number; message?: string }> = []
-      const result = await client.callTool(
+      const pending: McpProgress[] = []
+      let wake: (() => void) | undefined
+      let settled = false
+      let failed  = false
+      let result:  { content: unknown[]; isError?: boolean } | undefined
+      let failure: unknown
+
+      // Never rejects — the outcome is replayed below, once the queue is drained.
+      const call = client.callTool(
         { name: remote.name, arguments: (input ?? {}) as Record<string, unknown> },
         undefined,
-        { onprogress: (p) => collected.push(p) },
-      )
-      // SDK delivers progress notifications synchronously into onprogress during
-      // the request lifetime, so by the time we're here all progress events have
-      // arrived. Yielding them before returning preserves the observable order
-      // (tool-update chunks land before tool-result).
-      for (const p of collected) yield p
-      return mcpContentToString(result)
+        { onprogress: (p) => { pending.push(p); wake?.() } },
+      ).then(
+        (r) => { result  = r },
+        (e) => { failed = true; failure = e },
+      ).finally(() => { settled = true; wake?.() })
+
+      // Yield each progress event as it lands, so a consumer sees tool-update
+      // chunks while the remote tool is still running. The last drain still runs
+      // before the return, so every chunk keeps landing ahead of the tool-result.
+      for (;;) {
+        while (pending.length > 0) yield pending.shift()!
+        if (settled) break
+        await new Promise<void>((resolve) => { wake = resolve })
+        wake = undefined
+      }
+
+      await call
+      if (failed) throw failure
+      return mcpContentToString(result!)
     })
     return built as unknown as Tool
   }

--- a/packages/ai-mcp/src/client-tools.ts
+++ b/packages/ai-mcp/src/client-tools.ts
@@ -122,8 +122,33 @@ async function resolveClient(
   const sdkTransport = await buildTransport(transport)
 
   const client = new Client(CLIENT_INFO)
-  await (client as unknown as { connect(t: unknown): Promise<void> }).connect(sdkTransport)
+  await connectOrClose(client as unknown as ConnectableClient, sdkTransport)
   return { client, ownsClient: true }
+}
+
+/** The slice of the SDK `Client` the connect path needs. */
+interface ConnectableClient {
+  connect(t: unknown): Promise<void>
+  close():             Promise<void>
+}
+
+/**
+ * Connect, tearing down the transport when the handshake fails. The SDK does not
+ * clean up if `transport.start()` rejects, and only fires an unawaited `close()`
+ * on an initialize failure, so a stdio subprocess or HTTP session can outlive a
+ * failed `connect()` and a retrying caller leaks one per attempt.
+ *
+ * @internal Exported for tests. Not re-exported from the package entry.
+ */
+export async function connectOrClose(client: ConnectableClient, sdkTransport: unknown): Promise<void> {
+  try {
+    await client.connect(sdkTransport)
+  } catch (err) {
+    await safeClose(client)
+    // Also close the transport directly: on an early failure the client may not own it yet.
+    await safeCloseTransport(sdkTransport)
+    throw err
+  }
 }
 
 async function buildTransport(transport: McpClientTransport): Promise<unknown> {
@@ -151,8 +176,14 @@ async function buildTransport(transport: McpClientTransport): Promise<unknown> {
   throw new Error(`mcpClientTools: unsupported transport shape: ${typeof transport}`)
 }
 
-async function safeClose(client: MinimalClient): Promise<void> {
+async function safeClose(client: { close(): Promise<void> }): Promise<void> {
   try { await client.close() } catch { /* best-effort */ }
+}
+
+async function safeCloseTransport(sdkTransport: unknown): Promise<void> {
+  const close = (sdkTransport as { close?: () => unknown } | null | undefined)?.close
+  if (typeof close !== 'function') return
+  try { await close.call(sdkTransport) } catch { /* best-effort */ }
 }
 
 function buildTool(

--- a/packages/ai-mcp/src/types.ts
+++ b/packages/ai-mcp/src/types.ts
@@ -42,7 +42,9 @@ export interface McpClientToolsOptions {
   namePrefix?: string
   /**
    * Forward MCP `notifications/progress` from the remote server as `tool-update`
-   * chunks during agent execution. Defaults to `true`.
+   * chunks during agent execution. Each notification is yielded as it arrives,
+   * while the remote tool is still running, and every chunk lands before the
+   * tool's result. Defaults to `true`.
    */
   streaming?: boolean
 }


### PR DESCRIPTION
Two defects in `packages/ai-mcp/src/client-tools.ts`, batched because they share a file. One commit each.

## #978 — a failed `connect()` orphaned the transport

`resolveClient()` built a transport (a `StreamableHTTPClientTransport`, or a `StdioClientTransport` that spawns a subprocess) and then called `connect()` with no cleanup path. A handshake failure left the HTTP session or the child process running, and a caller that retries leaked one per attempt. The `listTools()` path in the same file already closed on failure; the connect path just never did.

The MCP SDK does not cover this either. `Protocol.connect()` assigns `this._transport` and then `await`s `transport.start()`, with no cleanup if that rejects, and `Client.connect()` only fires an unawaited `void this.close()` when the `initialize` request fails.

The connect is now wrapped in `connectOrClose()`, which closes the client and the transport best-effort and rethrows the original error unchanged. The transport is closed directly as well as through the client, because on an early failure the client may not own it yet. `connectOrClose` is exported `@internal` for the test only; it is not re-exported from `index.ts`, so the published surface (`dist/index.js`, the sole `exports` entry) is unchanged.

## #977 — `streaming` replayed progress after the call finished

Chose **option (a): forward each event as it arrives.**

The generator collected `onprogress` events into an array and yielded them only after `await client.callTool(...)` resolved, so no `tool-update` chunk could reach a consumer while the remote tool was still running. An option named `streaming`, defaulting to `true`, therefore bought the caller nothing over the non-streaming path: a progress bar driven by it jumps from empty to complete.

**Why (a) and not the docs-only (b):** the code comment justified the batching as preserving chunk order relative to `tool-result`, and that concern was real. But it does not force the trade-off. The generator only returns after the call settles, so if it drains anything still queued before returning, live delivery and the ordering guarantee both hold. So there was nothing to trade away, and (b) would have documented a limitation that did not need to exist. Progress now goes into a small queue that the generator drains as events land, waking on a promise between them.

The ordering guarantee is asserted by a test of its own (`every progress chunk still lands before the result`), which passes on both the old and new implementations. That is deliberate: it is the guard proving (a) did not break what the batching protected, not a regression test.

Docs were sharpened rather than corrected. The README row and the `types.ts` docblock said "during a run", which is now true, and both now also state that every chunk precedes the result.

## Proofs

Each behavioural fix was reverted in source with its test kept, to confirm the right test fails.

| Fix | Test | Reverted to | Result |
|---|---|---|---|
| #978 | `closes the client and the transport when connect() rejects` | bare `await client.connect(sdkTransport)` | **fails**: `AssertionError: transport was left open after a failed connect()` / `0 !== 1` |
| #978 | `a client close() that also throws does not mask the connect error` | same | **fails** |
| #977 | `yields a tool-update chunk while the remote call is still running` | the original collect-then-replay loop | **fails**: `AssertionError: no tool-update chunk arrived while the remote call was still running` (`actual: 'timeout'`) |
| #977 | `every progress chunk still lands before the result` | same | passes both ways, by design (ordering guard, not a regression test) |

The #977 test races `iter.next()` against a 250ms timer rather than awaiting it, since under the old code that `next()` never settles until the call completes and a plain `await` would hang instead of failing.

## Counts

- ai-mcp before: 20 passing. After: 25 passing (2 for #978, 3 for #977).
- Full root `pnpm test`: 21/21 tasks green. `pnpm build`: exit 0.

## Changesets

Two, both `@gemstack/ai-mcp: patch`. #977 stays a patch rather than a minor because it changes no documented behaviour: the README and `types.ts` already promised forwarding during the run, and the ordering the implementation guaranteed is preserved. It makes the existing contract true rather than extending it.

Closes #977
Closes #978
