### PR TITLE
fix(ai-autopilot): the checklist default event kind resolves against defaultLoops()

### DIFF
--- a/.changeset/fix-974-production-check-loop.md
+++ b/.changeset/fix-974-production-check-loop.md
@@ -1,0 +1,21 @@
+---
+'@gemstack/ai-autopilot': minor
+---
+
+The bootstrap checklist's default event kind now resolves against `defaultLoops()` (#974)
+
+`loopChecklist` fires `production-check` by default, but `defaultLoops()` only defined
+`major-change` and `ui-flow`. The event matched no loop, so the checklist never saw a
+`production-grade` verdict, treated the missing verdict as a blocker, and
+`BootstrapResult.productionGrade` could never be `true` on the documented default path.
+Every caller had to hand-write the missing loop.
+
+`LOOP_EVENTS` gains `productionCheck: 'production-check'` and `defaultLoops()` now returns a
+third loop, `production-check -> [production-grade]`. The shipped `production-grade` prompt
+declares that event too, so `library.byEvent('production-check')` returns it.
+
+Behaviour change for anyone spreading `defaultLoops()`: the returned array now has three
+entries instead of two, and an event of kind `production-check` that previously fell through
+as unmatched now runs the `production-grade` prompt. If you already added your own
+`production-check` loop, both fire and the prompt ids are de-duped across matching loops, so
+the chain is unchanged. To keep the old policy, filter the gate out.

--- a/packages/ai-autopilot/README.md
+++ b/packages/ai-autopilot/README.md
@@ -212,7 +212,7 @@ command-driven and not run-on-every-PR.
 import { LoopEngine, definePrompt, defaultLoops } from '@gemstack/ai-autopilot'
 
 const loop = new LoopEngine({
-  loops: defaultLoops(),                 // major-change → [review, code-quality, security]; ui-flow → [qa, ux]
+  loops: defaultLoops(),                 // major-change → [review, code-quality, security]; ui-flow → [qa, ux]; production-check → [production-grade]
   prompts: [
     definePrompt({ id: 'review', passes: 2, run: ctx => runReview(ctx.event) }),
     definePrompt({ id: 'code-quality', run: ctx => runQuality(ctx.event) }),
@@ -261,7 +261,7 @@ import { LoopEngine, defaultLoops, builtinLibrary, loopPromptsFor, runnerTools }
 
 const library = await builtinLibrary()          // the shipped bodies
 const loop = new LoopEngine({
-  loops: defaultLoops(),                     // review / code-quality / security / qa / ux ids
+  loops: defaultLoops(),                     // review / code-quality / security / qa / ux / production-grade ids
   prompts: loopPromptsFor(library, ctx =>        // a FRESH agent per pass
     agent({ instructions: ctx.instructions, tools: runnerTools(session) })),
   ledger,                                         // ctx.instructions already includes the decisions briefing

--- a/packages/ai-autopilot/prompts/production-grade.md
+++ b/packages/ai-autopilot/prompts/production-grade.md
@@ -6,6 +6,7 @@ metadata:
   title: Production-grade checklist
   loopId: production-grade
   passes: 1
+  event: production-check
 ---
 
 You are the production-grade **gate** for a Vike + universal-orm app. Judge the

--- a/packages/ai-autopilot/src/bootstrap/steps.test.ts
+++ b/packages/ai-autopilot/src/bootstrap/steps.test.ts
@@ -6,6 +6,7 @@ import { agentDeploy, FakeDeployTarget } from './deploy.js'
 import { Bootstrap } from './bootstrap.js'
 import { LoopEngine } from '../loop/loop.js'
 import { definePrompt, defineLoop } from '../loop/define.js'
+import { defaultLoops, LOOP_PROMPTS } from '../loop/policy.js'
 import type { BootstrapEvent } from './types.js'
 import type { SupervisorEvent } from '../types.js'
 import type { BuildContext, LoopPassContext } from './types.js'
@@ -74,6 +75,15 @@ describe('loopChecklist / loopImprove (default full-fledged loop steps)', () => 
     assert.match(verdict.blockers[0]!, /did not return a verdict/)
   })
 
+  it('defaults to an event kind defaultLoops() actually defines (#974)', async () => {
+    const loop = new LoopEngine({
+      loops: defaultLoops(),
+      prompts: [definePrompt({ id: LOOP_PROMPTS.productionGrade, run: () => '```json\n{ "blockers": [] }\n```' })],
+    })
+    const verdict = await loopChecklist({ loop })(passCtx())
+    assert.deepEqual(verdict.blockers, [])
+  })
+
   it('fires the change events so the review chain runs', async () => {
     let reviewRan = 0
     const loop = new LoopEngine({
@@ -86,6 +96,32 @@ describe('loopChecklist / loopImprove (default full-fledged loop steps)', () => 
 })
 
 describe('Bootstrap end-to-end with the default steps (offline)', () => {
+  it('reaches productionGrade on the documented default path: defaultLoops() + no explicit kind (#974)', async () => {
+    const loop = new LoopEngine({
+      loops: defaultLoops(),
+      prompts: [definePrompt({ id: LOOP_PROMPTS.productionGrade, run: () => '```json\n{ "blockers": [] }\n```' })],
+    })
+    const boot = new Bootstrap({
+      steps: {
+        scope: () => ({ scope: 'full', intent: 'a bookstore' }),
+        build: () => ({
+          text: 'built',
+          plan: [],
+          results: [],
+          usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+          stoppedEarly: false,
+        }),
+        checklist: loopChecklist({ loop }),
+      },
+    })
+
+    const result = await boot.run()
+
+    assert.equal(result.productionGrade, true)
+    assert.deepEqual(result.blockers, [])
+    assert.equal(result.passes, 1) // the gate cleared on the first check, no improve rounds
+  })
+
   it('runs scope → build → full-fledged loop against real primitives', async () => {
     const fake = AiFake.fake()
     try {

--- a/packages/ai-autopilot/src/bootstrap/steps.ts
+++ b/packages/ai-autopilot/src/bootstrap/steps.ts
@@ -57,7 +57,7 @@ export interface LoopStepOptions {
 
 /** Options for {@link loopChecklist}. */
 export interface LoopChecklistOptions extends LoopStepOptions {
-  /** The event kind whose chain runs the checklist prompt. Default `production-check`. */
+  /** The event kind whose chain runs the checklist prompt. Default `production-check`, which `defaultLoops()` defines. */
   kind?: string
   /** The prompt id to read the `{ blockers }` verdict from. Default `production-grade`. */
   promptId?: string
@@ -69,7 +69,7 @@ export interface LoopChecklistOptions extends LoopStepOptions {
  * treated as a blocker (the checklist must return one to pass).
  */
 export function loopChecklist(opts: LoopChecklistOptions): NonNullable<BootstrapSteps['checklist']> {
-  const kind = opts.kind ?? 'production-check'
+  const kind = opts.kind ?? LOOP_EVENTS.productionCheck
   const promptId = opts.promptId ?? LOOP_PROMPTS.productionGrade
   return async ({ intent, blockers }) => {
     const summary = blockers.length ? `Re-check after addressing: ${blockers.join('; ')}` : intent

--- a/packages/ai-autopilot/src/loop/policy.test.ts
+++ b/packages/ai-autopilot/src/loop/policy.test.ts
@@ -11,6 +11,11 @@ describe('defaultLoops', () => {
     assert.deepEqual(ui?.run, [LOOP_PROMPTS.qa, LOOP_PROMPTS.ux])
   })
 
+  it('defines the production-check gate the bootstrap checklist defaults to (#974)', () => {
+    const gate = defaultLoops().find(r => r.on.includes(LOOP_EVENTS.productionCheck))
+    assert.deepEqual(gate?.run, [LOOP_PROMPTS.productionGrade])
+  })
+
   it('returns fresh arrays each call (safe to extend)', () => {
     assert.notEqual(defaultLoops(), defaultLoops())
   })

--- a/packages/ai-autopilot/src/loop/policy.ts
+++ b/packages/ai-autopilot/src/loop/policy.ts
@@ -10,6 +10,8 @@ export const LOOP_EVENTS = {
   majorChange: 'major-change',
   /** A new user-facing flow (auth, checkout, ...): fires QA + UX. */
   uiFlow: 'ui-flow',
+  /** The bootstrap checklist gate: fires the production-grade verdict prompt. */
+  productionCheck: 'production-check',
 } as const
 
 /**
@@ -29,8 +31,9 @@ export const LOOP_PROMPTS = {
 
 /**
  * The built-in loop policy as data: a major change runs review then code-quality
- * then security; a new UI flow runs QA then UX. Extend it by concatenating your
- * own {@link defineLoop} results, or replace it wholesale.
+ * then security; a new UI flow runs QA then UX; a production check runs the
+ * production-grade gate. Extend it by concatenating your own {@link defineLoop}
+ * results, or replace it wholesale.
  */
 export function defaultLoops(): Loop[] {
   return [
@@ -41,6 +44,11 @@ export function defaultLoops(): Loop[] {
     defineLoop({
       on: LOOP_EVENTS.uiFlow,
       run: [LOOP_PROMPTS.qa, LOOP_PROMPTS.ux],
+    }),
+    // The kind `loopChecklist` fires by default, so the bootstrap gate resolves out of the box.
+    defineLoop({
+      on: LOOP_EVENTS.productionCheck,
+      run: [LOOP_PROMPTS.productionGrade],
     }),
   ]
 }

--- a/packages/ai-autopilot/src/prompts/library.test.ts
+++ b/packages/ai-autopilot/src/prompts/library.test.ts
@@ -24,6 +24,7 @@ describe('builtin prompts', () => {
     assert.ok(majorIds.includes('security'))
     const uiIds = library.byEvent(LOOP_EVENTS.uiFlow).map(p => p.id)
     assert.deepEqual(uiIds.sort(), ['qa', 'ux'])
+    assert.deepEqual(library.byEvent(LOOP_EVENTS.productionCheck).map(p => p.id), [LOOP_PROMPTS.productionGrade])
   })
 
   it('also ships the standalone bodies (refactor, knowledge-base, tldr)', async () => {


### PR DESCRIPTION
## The defect

`loopChecklist` defaults its event kind to `production-check` (`steps.ts:72`, documented at `:60`), but `defaultLoops()` defined only `major-change` and `ui-flow`. On the documented default path:

1. `loop.handle({ kind: 'production-check' })` matches no loop, so `result.outcomes` is `[]`.
2. `outcomes.find(o => o.promptId === 'production-grade')` is `undefined`, so the step returns the fallback verdict `{ blockers: ['checklist "production-grade" did not return a verdict'] }`.
3. `bootstrap.ts:113`'s `passes > 0 && blockers.length === 0` is therefore never true. The gate could not be passed, ever, only exhausted at `maxPasses`.

Nobody hit it because every caller hand-wrote the missing loop: both examples and all three call sites in `steps.test.ts` do `defineLoop({ on: 'production-check', run: ['production-grade'] })` themselves, so the tests exercised a configuration the default never produces.

## Which option, and why

Option **(a)**: add `productionCheck` to `LOOP_EVENTS` and a `production-check -> [production-grade]` loop to `defaultLoops()`.

Option (b), changing the default to one of the two existing kinds, does not actually fix the bug. The checklist reads its verdict by prompt id, and `production-grade` is in neither existing chain, so `major-change` would match a loop and still return no verdict. I verified this rather than assuming it (proof B below): the two new tests still fail, and it additionally breaks the existing end-to-end test, because the checklist would then fire the same event as `loopImprove` and run the review chain as the gate. Making (b) work would mean appending `production-grade` to the `major-change` chain, which conflates the bootstrap gate with the review chain and makes every major change run the full production checklist. (a) keeps the gate its own event, which is what the doc comment already described.

Two small consistency changes ride along: `steps.ts` now uses the constant instead of the bare string literal, and the shipped `prompts/production-grade.md` declares `event: production-check` so `library.byEvent()` returns the gate for its own canonical event instead of an empty set.

The examples were checked and left alone: they do not spread `defaultLoops()`, they build a private `LoopEngine` with their own scripted prompts, so their `defineLoop` is genuinely their own policy, not a workaround that the fix makes redundant.

## Proof

Each test was run against reverted source, keeping the test.

| Proof | Source state | Result |
|---|---|---|
| A | `defaultLoops()` gate entry removed (`LOOP_EVENTS` member kept so it compiles) | 3 fail / 302 pass. All three new tests fail. |
| B | Option (b) simulated: gate entry removed, default kind set to `LOOP_EVENTS.majorChange` | 5 fail / 300 pass. Both new `steps.test.ts` tests still fail, plus the pre-existing `runs scope -> build -> full-fledged loop against real primitives`. |
| fixed | as committed | 305 pass / 0 fail |

Proof A failure text:

```
✖ defaults to an event kind defaultLoops() actually defines (#974)
  AssertionError: Expected values to be strictly deep-equal:
  + actual - expected
  + [ 'checklist "production-grade" did not return a verdict' ]
  - []

✖ reaches productionGrade on the documented default path: defaultLoops() + no explicit kind (#974)
  AssertionError: Expected values to be strictly equal:
  false !== true          // result.productionGrade

✖ defines the production-check gate the bootstrap checklist defaults to (#974)
  AssertionError: Expected values to be strictly deep-equal:
  + undefined
  - [ 'production-grade' ]
```

The first two drive the real default: they build the engine from `defaultLoops()` and call `loopChecklist({ loop })` with no `kind`, so they only pass if the default resolves against the shipped policy.

## Counts

- `@gemstack/ai-autopilot`: 302 -> 305 tests, 0 fail. Three new tests, one existing test extended.
- Full root `pnpm test` green (21 tasks, every package `fail 0`, dashboard 47 files / 288 tests). Root `pnpm build` exit 0.

## Changeset

`minor`, not patch: `LOOP_EVENTS.productionCheck` is a new exported member and `defaultLoops()` returns a third entry. The changeset calls out the behaviour change for `defaultLoops()` spreaders, including that a pre-existing hand-written `production-check` loop stays harmless (`matches()` de-dupes prompt ids across matching loops).

Closes #974
