### PR TITLE
fix(mcp): only an initialize may open a web-handler session

### DIFF
--- a/.changeset/fix-970-web-handler-leak.md
+++ b/.changeset/fix-970-web-handler-leak.md
@@ -1,0 +1,9 @@
+---
+'@gemstack/mcp': minor
+---
+
+fix(mcp): stop the web handler attaching an SDK per unauthenticated POST
+
+`createWebRequestHandler` built a transport + SDK pair and called `attachSdk` for any POST without a known `mcp-session-id`, not just an `initialize`. Nothing ever detached those pairs, so the server's notification set grew by one entry per unauthenticated request. Only an `initialize` opens a session now; anything else is answered `400`/`404` per the streamable-HTTP spec without allocating. A pair that ends up with no registered session (rejected initialize, failed connect) is always released.
+
+Also: stateful sessions now expire after 30 minutes idle (`sessionIdleMs`), both handlers expose `close()` to tear every live session down, and stateless mode builds one transport per request (the SDK rejects a reused stateless transport) instead of sharing one racily created pair.

--- a/docs/packages/mcp.md
+++ b/docs/packages/mcp.md
@@ -242,7 +242,7 @@ const app = new Hono()
 app.all('/mcp', (c) => handler(c.req.raw))
 ```
 
-By default each new client gets its own transport (stateful sessions). Pass `sessionIdGenerator: undefined` for **stateless** mode, where a single transport is created lazily and reused for the handler's lifetime. `createMcpHttpHandler` is built on top of this Web handler.
+By default each new client gets its own transport (stateful sessions). Only an `initialize` POST opens one: any other request without a live `mcp-session-id` is answered `400`/`404` and allocates nothing. Idle sessions are dropped after 30 minutes (`sessionIdleMs`), and both handlers expose `close()` to tear every live session down on shutdown. Pass `sessionIdGenerator: undefined` for **stateless** mode, where each request gets its own transport, released once its response ends. `createMcpHttpHandler` is built on top of this Web handler.
 
 ### stdio
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -27,7 +27,7 @@ export type {
 // Express, Connect, etc. The SDK-wiring runtime primitives (createSdkServer,
 // startStdio, createWebRequestHandler) live at `@gemstack/mcp/runtime` so the
 // main entry doesn't pull `@modelcontextprotocol/sdk` into the boot path.
-export { createMcpHttpHandler } from './runtime/node-handler.js'
+export { createMcpHttpHandler, type McpHttpHandler } from './runtime/node-handler.js'
 export { McpTestClient } from './testing.js'
 export type { McpTestClientOptions } from './testing.js'
 export type { McpObserverEvent, McpObserver, McpObserverRegistry } from './observers.js'

--- a/packages/mcp/src/runtime.ts
+++ b/packages/mcp/src/runtime.ts
@@ -6,7 +6,7 @@
 // stable.
 
 export { createSdkServer, startStdio } from './runtime/sdk-server.js'
-export { createWebRequestHandler, type WebRequestHandlerOptions } from './runtime/web-handler.js'
-export { createMcpHttpHandler } from './runtime/node-handler.js'
+export { createWebRequestHandler, type WebRequestHandlerOptions, type WebRequestHandler } from './runtime/web-handler.js'
+export { createMcpHttpHandler, type McpHttpHandler } from './runtime/node-handler.js'
 export { consumeToolReturn } from './runtime/consume-tool-return.js'
 export { resolveOrConstruct, resolveHandleDeps, isRegistered, filterRegistered } from './runtime/handle-deps.js'

--- a/packages/mcp/src/runtime/node-handler.ts
+++ b/packages/mcp/src/runtime/node-handler.ts
@@ -2,6 +2,12 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { McpServer } from '../McpServer.js'
 import { createWebRequestHandler, type WebRequestHandlerOptions } from './web-handler.js'
 
+export interface McpHttpHandler {
+  (req: IncomingMessage, res: ServerResponse): Promise<void>
+  /** Tear down every live session and refuse further requests. Idempotent. */
+  close(): Promise<void>
+}
+
 /**
  * A framework-neutral `node:http` request handler for an MCP server. Mount it
  * on a raw `http.createServer(...)`, or anywhere a `(req, res)` handler fits
@@ -22,10 +28,10 @@ import { createWebRequestHandler, type WebRequestHandlerOptions } from './web-ha
 export function createMcpHttpHandler(
   server: McpServer,
   options?: WebRequestHandlerOptions,
-): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
+): McpHttpHandler {
   const handle = createWebRequestHandler(server, options)
 
-  return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+  const handler = (async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     try {
       const request = await toWebRequest(req)
       const response = await handle(request)
@@ -37,7 +43,10 @@ export function createMcpHttpHandler(
       const message = err instanceof Error ? err.message : String(err)
       res.end(JSON.stringify({ error: 'internal_error', message }))
     }
-  }
+  }) as McpHttpHandler
+
+  handler.close = () => handle.close()
+  return handler
 }
 
 /** Build a Web Standard `Request` from a Node `IncomingMessage`. */

--- a/packages/mcp/src/runtime/web-handler.test.ts
+++ b/packages/mcp/src/runtime/web-handler.test.ts
@@ -1,0 +1,141 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { z } from 'zod'
+import { McpServer } from '../McpServer.js'
+import { McpTool } from '../McpTool.js'
+import { McpResponse } from '../McpResponse.js'
+import type { McpNotificationTarget } from '../McpServer.js'
+import { createWebRequestHandler } from './web-handler.js'
+
+class EchoTool extends McpTool {
+  schema() { return z.object({ message: z.string() }) }
+  async handle(input: Record<string, unknown>) { return McpResponse.text(String(input['message'])) }
+}
+class TestServer extends McpServer { protected tools = [EchoTool] }
+
+/** Counts attach/detach so a leaked SDK is visible without reaching into the server's private set. */
+function countingServer() {
+  const server = new TestServer()
+  const counts = { attached: 0, detached: 0 }
+  const attach = server.attachSdk.bind(server)
+  server.attachSdk = (target: McpNotificationTarget) => {
+    counts.attached++
+    const detach = attach(target)
+    return () => { counts.detached++; detach() }
+  }
+  return { server, counts }
+}
+
+const MCP_HEADERS = {
+  accept: 'application/json, text/event-stream',
+  'content-type': 'application/json',
+}
+
+function post(body: unknown, headers: Record<string, string> = {}): Request {
+  return new Request('http://localhost/mcp', {
+    method: 'POST',
+    headers: { ...MCP_HEADERS, ...headers },
+    body: JSON.stringify(body),
+  })
+}
+
+const INITIALIZE = {
+  jsonrpc: '2.0', id: 1, method: 'initialize',
+  params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 't', version: '1.0.0' } },
+}
+const TOOLS_CALL = {
+  jsonrpc: '2.0', id: 2, method: 'tools/call',
+  params: { name: 'echo', arguments: { message: 'hi' } },
+}
+
+test('a non-initialize POST never builds or attaches an SDK (#970)', async () => {
+  const { server, counts } = countingServer()
+  const handler = createWebRequestHandler(server)
+
+  for (let i = 0; i < 5; i++) {
+    const res = await handler(post(TOOLS_CALL))
+    assert.equal(res.status, 400)
+  }
+  assert.equal(counts.attached, 0, 'unauthenticated requests must not attach an SDK')
+
+  // ...and a bogus session id is a 404, not a fresh session.
+  const bogus = await handler(post(TOOLS_CALL, { 'mcp-session-id': 'nope' }))
+  assert.equal(bogus.status, 404)
+  assert.equal(counts.attached, 0, 'a bogus session id must not attach an SDK')
+  await handler.close()
+})
+
+test('an initialize opens exactly one session, and close() detaches it', async () => {
+  const { server, counts } = countingServer()
+  const handler = createWebRequestHandler(server)
+
+  const res = await handler(post(INITIALIZE))
+  assert.equal(res.status, 200)
+  const sessionId = res.headers.get('mcp-session-id')
+  assert.ok(sessionId, 'initialize must mint a session id')
+  await res.body?.cancel()
+  assert.equal(counts.attached, 1)
+  assert.equal(counts.detached, 0)
+
+  await handler.close()
+  assert.equal(counts.detached, 1, 'close() must detach every live session')
+  assert.equal((await handler(post(INITIALIZE))).status, 503)
+})
+
+test('a rejected initialize leaves nothing attached', async () => {
+  const { server, counts } = countingServer()
+  const handler = createWebRequestHandler(server)
+
+  // No `text/event-stream` in Accept: the transport rejects it and no session is registered.
+  const res = await handler(post(INITIALIZE, { accept: 'application/json' }))
+  assert.equal(res.status, 406)
+  assert.equal(counts.attached, 1, 'the pair is built for an initialize')
+  assert.equal(counts.detached, 1, 'and released again when no session is registered')
+  await handler.close()
+})
+
+test('stateless mode gives every request its own transport and releases it (#970)', async () => {
+  const { server, counts } = countingServer()
+  const handler = createWebRequestHandler(server, { sessionIdGenerator: undefined })
+
+  // Concurrent first requests: sharing one pair orphaned the loser (and the SDK
+  // rejects a reused stateless transport outright).
+  const responses = await Promise.all([handler(post(INITIALIZE)), handler(post(INITIALIZE))])
+  for (const res of responses) {
+    assert.equal(res.status, 200)
+    await res.text()
+  }
+  // A later request must still be served rather than reusing a spent transport.
+  const third = await handler(post(INITIALIZE))
+  assert.equal(third.status, 200)
+  await third.text()
+
+  assert.equal(counts.attached, 3)
+  assert.equal(counts.detached, 3, 'every stateless pair must be released with its response')
+  await handler.close()
+})
+
+test('an idle session expires and is detached', async () => {
+  const { server, counts } = countingServer()
+  let clock = 1_000
+  const handler = createWebRequestHandler(server, { sessionIdleMs: 60_000, now: () => clock })
+
+  const res = await handler(post(INITIALIZE))
+  const sessionId = res.headers.get('mcp-session-id')!
+  await res.body?.cancel()
+  assert.equal(counts.attached, 1)
+
+  // Still fresh: the session survives and keeps serving.
+  clock += 30_000
+  const fresh = await handler(post(TOOLS_CALL, { 'mcp-session-id': sessionId }))
+  assert.notEqual(fresh.status, 404)
+  await fresh.body?.cancel()
+  assert.equal(counts.detached, 0)
+
+  // Past the idle window: the next request sweeps it.
+  clock += 60_001
+  const gone = await handler(post(TOOLS_CALL, { 'mcp-session-id': sessionId }))
+  assert.equal(gone.status, 404)
+  assert.equal(counts.detached, 1, 'an expired session must be detached, not just forgotten')
+  await handler.close()
+})

--- a/packages/mcp/src/runtime/web-handler.ts
+++ b/packages/mcp/src/runtime/web-handler.ts
@@ -5,13 +5,40 @@ import { createSdkServer } from './sdk-server.js'
 
 type WebTransport = WebStandardStreamableHTTPServerTransport
 
+interface Session {
+  transport: WebTransport
+  sdk: Server
+  detach: () => void
+  lastSeen: number
+}
+
+/** 30 minutes. The streamable-HTTP spec lets a server end a session at any time; the client re-initializes on the 404. */
+const DEFAULT_SESSION_IDLE_MS = 30 * 60_000
+
 export interface WebRequestHandlerOptions {
   /**
    * Session-id generator for stateful mode (defaults to `crypto.randomUUID`).
-   * Pass `sessionIdGenerator: undefined` explicitly for **stateless** mode — a
-   * single transport is created lazily and reused for the handler's lifetime.
+   * Pass `sessionIdGenerator: undefined` explicitly for **stateless** mode —
+   * every request gets its own transport, as the SDK requires.
    */
   sessionIdGenerator?: (() => string) | undefined
+  /**
+   * How long a stateful session may go without a request before it is dropped
+   * (default 30 minutes). A client that vanishes without a `DELETE` would
+   * otherwise stay resident forever. `0` or `Infinity` disables expiry.
+   */
+  sessionIdleMs?: number
+  /** @internal Clock hook so tests can age sessions without waiting. */
+  now?: () => number
+}
+
+export interface WebRequestHandler {
+  (request: Request): Promise<Response>
+  /**
+   * Tear down every live session (detach, close the SDK and the transport) and
+   * refuse further requests. Idempotent.
+   */
+  close(): Promise<void>
 }
 
 /**
@@ -21,60 +48,202 @@ export interface WebRequestHandlerOptions {
  * hand it a `Request` (Hono, Vike, the Fetch API, edge runtimes).
  *
  * ### Session lifecycle
- * - **Stateful** (default) — each new client gets a fresh transport + SDK pair,
- *   stored once the SDK fires `onsessioninitialized`; both are torn down on
- *   `onsessionclosed`.
- * - **Stateless** (`sessionIdGenerator: undefined`) — one transport + SDK pair,
- *   created on the first request and reused (never detached).
+ * - **Stateful** (default) — only an `initialize` POST may open a session; any
+ *   other request without a live session id is answered `400`/`404` without
+ *   building anything. A session is torn down on `onsessionclosed`, on idle
+ *   expiry ({@link WebRequestHandlerOptions.sessionIdleMs}), or on `close()`.
+ * - **Stateless** (`sessionIdGenerator: undefined`) — a transport + SDK pair per
+ *   request, released once that request's response body ends. The SDK rejects a
+ *   reused stateless transport (request-id collisions), so no pair is shared.
  */
 export function createWebRequestHandler(
   server: McpServer,
   options?: WebRequestHandlerOptions,
-): (request: Request) => Promise<Response> {
-  const sessions = new Map<string, { transport: WebTransport; sdk: Server }>()
+): WebRequestHandler {
+  const sessions = new Map<string, Session>()
   const stateless = !!options && 'sessionIdGenerator' in options && options.sessionIdGenerator === undefined
   const sessionIdGen = stateless ? undefined : (options?.sessionIdGenerator ?? (() => crypto.randomUUID()))
+  const now = options?.now ?? (() => Date.now())
+  const idleMs = options?.sessionIdleMs ?? DEFAULT_SESSION_IDLE_MS
 
+  const transient = new Set<Session>()
   let TransportCtor: typeof WebStandardStreamableHTTPServerTransport | undefined
+  let closed = false
 
-  return async (request: Request): Promise<Response> => {
+  async function transportCtor(): Promise<typeof WebStandardStreamableHTTPServerTransport> {
     if (!TransportCtor) {
       ({ WebStandardStreamableHTTPServerTransport: TransportCtor } = await import(
         '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
       ))
     }
+    return TransportCtor
+  }
 
-    // Stateless: one transport reused for the handler's lifetime.
-    if (!sessionIdGen) {
-      let entry = sessions.get('__stateless__')
-      if (!entry) {
-        const transport = new TransportCtor()
-        const sdk = createSdkServer(server)
-        await sdk.connect(transport)
-        server.attachSdk(sdk)
-        entry = { transport, sdk }
-        sessions.set('__stateless__', entry)
-      }
-      return entry.transport.handleRequest(request)
+  /** Connect an SDK to a transport and attach it, releasing both if connecting throws. */
+  async function connect(transport: WebTransport): Promise<Session> {
+    const sdk = createSdkServer(server)
+    let detach: (() => void) | undefined
+    try {
+      await sdk.connect(transport)
+      detach = server.attachSdk(sdk)
+      return { transport, sdk, detach, lastSeen: now() }
+    } catch (err) {
+      detach?.()
+      await sdk.close().catch(() => {})
+      await transport.close().catch(() => {})
+      throw err
     }
+  }
+
+  /** The one place a pair is released, so `detach` can never be skipped. */
+  async function discard(session: Session): Promise<void> {
+    transient.delete(session)
+    session.detach()
+    await session.sdk.close().catch(() => {})
+    await session.transport.close().catch(() => {})
+  }
+
+  /** Release the pair when its response body ends, so a streaming reply is not cut short. */
+  function releaseWithBody(response: Response, session: Session): Response {
+    if (!response.body) {
+      void discard(session)
+      return response
+    }
+    const release = (): void => { void discard(session) }
+    const reader = response.body.getReader()
+    const body = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        try {
+          const chunk = await reader.read()
+          if (chunk.done) {
+            controller.close()
+            release()
+            return
+          }
+          controller.enqueue(chunk.value)
+        } catch (err) {
+          controller.error(err)
+          release()
+        }
+      },
+      cancel(reason) {
+        void reader.cancel(reason)
+        release()
+      },
+    })
+    return new Response(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    })
+  }
+
+  function sweepExpired(): void {
+    if (!(idleMs > 0) || !Number.isFinite(idleMs)) return
+    const cutoff = now() - idleMs
+    for (const [id, session] of sessions) {
+      if (session.lastSeen <= cutoff) {
+        sessions.delete(id)
+        void discard(session)
+      }
+    }
+  }
+
+  const handler = (async (request: Request): Promise<Response> => {
+    if (closed) return jsonRpcError(503, -32000, 'Service Unavailable: handler closed')
+    const Transport = await transportCtor()
+
+    // Stateless: a pair per request. Sharing one was both racy and, since SDK
+    // 1.29, fatal — a reused stateless transport throws on the second request.
+    if (!sessionIdGen) {
+      const transport = new Transport()
+      const session = await connect(transport)
+      transient.add(session)
+      try {
+        return releaseWithBody(await transport.handleRequest(request), session)
+      } catch (err) {
+        await discard(session)
+        throw err
+      }
+    }
+
+    sweepExpired()
 
     // Stateful: route by session-id header.
     const sessionId = request.headers.get('mcp-session-id')
-    if (sessionId && sessions.has(sessionId)) {
-      return sessions.get(sessionId)!.transport.handleRequest(request)
+    const live = sessionId ? sessions.get(sessionId) : undefined
+    if (live) {
+      live.lastSeen = now()
+      return live.transport.handleRequest(request)
     }
 
-    // New session — `detach` is captured in a closure so `onsessionclosed` can
-    // release the attached SDK without holding a stale reference.
-    let detach: () => void = () => {}
-    const transport = new TransportCtor({
+    // Only an `initialize` may open a session. Building the pair for anything
+    // else attached an SDK that nothing ever detached (#970).
+    if (request.method !== 'POST') return unknownSession(sessionId)
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return jsonRpcError(400, -32700, 'Parse error: Invalid JSON')
+    }
+    if (!opensSession(body)) return unknownSession(sessionId)
+
+    // `detach` is captured in a closure so `onsessionclosed` can release the
+    // attached SDK without holding a stale reference.
+    let opened: Session | undefined
+    const transport = new Transport({
       sessionIdGenerator: sessionIdGen,
-      onsessioninitialized: (id: string) => { sessions.set(id, { transport, sdk }) },
-      onsessionclosed: (id: string) => { sessions.delete(id); detach() },
+      onsessioninitialized: (id: string) => { if (opened) sessions.set(id, opened) },
+      onsessionclosed: (id: string) => {
+        sessions.delete(id)
+        opened?.detach()
+      },
     })
-    const sdk = createSdkServer(server)
-    await sdk.connect(transport)
-    detach = server.attachSdk(sdk)
-    return transport.handleRequest(request)
+    const session = await connect(transport)
+    opened = session
+
+    let response: Response
+    try {
+      response = await transport.handleRequest(request, { parsedBody: body })
+    } catch (err) {
+      await discard(session)
+      throw err
+    }
+
+    // A rejected initialize (bad Accept header, malformed params, ...) registers
+    // no session, so nothing else would ever release this pair.
+    const id = transport.sessionId
+    if (!id || sessions.get(id) !== session) await discard(session)
+    return response
+  }) as WebRequestHandler
+
+  handler.close = async (): Promise<void> => {
+    closed = true
+    const live = [...sessions.values(), ...transient]
+    sessions.clear()
+    await Promise.all(live.map(discard))
   }
+
+  return handler
+}
+
+/** Loose check: the transport still validates the payload, this only decides whether a session may open. */
+function opensSession(body: unknown): boolean {
+  const isInit = (message: unknown): boolean =>
+    !!message && typeof message === 'object' && (message as { method?: unknown }).method === 'initialize'
+  return Array.isArray(body) ? body.some(isInit) : isInit(body)
+}
+
+/** Mirrors the transport's own session errors so clients see one wire format. */
+function unknownSession(sessionId: string | null): Response {
+  return sessionId
+    ? jsonRpcError(404, -32001, 'Session not found')
+    : jsonRpcError(400, -32000, 'Bad Request: Mcp-Session-Id header is required')
+}
+
+function jsonRpcError(status: number, code: number, message: string): Response {
+  return new Response(JSON.stringify({ jsonrpc: '2.0', error: { code, message }, id: null }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
 }


### PR DESCRIPTION
## The defect

`createWebRequestHandler` reached its "new session" branch for **any** request without a known `mcp-session-id`, not just an `initialize`. It built a transport + SDK pair and called `server.attachSdk(sdk)`. `sessions` is only ever populated from `onsessioninitialized`, which the SDK fires for a valid `initialize` only, so a `tools/call` with a bogus or absent session id was never registered, `onsessionclosed` never fired, and the captured `detach` closure was never called. `attachSdk` retains into a `Set` on the server instance, so the set grew by one entry per unauthenticated request and every later notification broadcast iterated the dead entries. Unauthenticated remote heap exhaustion.

Two more, both confirmed:

- No shutdown path and no session expiry. A client that vanished without a `DELETE` stayed resident forever and the handler exposed no teardown.
- Stateless mode built its shared pair between a `get` and a `set` separated by `await sdk.connect(...)`, so two concurrent first requests both built and both attached, the second overwrote the entry and the first was orphaned while still attached. That path also dropped the detach closure entirely.

## The fix

- Nothing is constructed until the request is known to be an `initialize`. Any other request without a live session gets `400 Bad Request: Mcp-Session-Id header is required` or `404 Session not found`, mirroring the transport's own wire format, which is what the streamable-HTTP spec prescribes. That removes the leak at the source.
- One `discard()` path releases a pair (detach, close SDK, close transport). It runs on a failed `sdk.connect`, on a throw from `handleRequest`, and after `handleRequest` returns whenever no session was registered, which covers a rejected `initialize` (bad Accept header, malformed params).
- Stateful sessions carry a `lastSeen` and are swept on the next request after `sessionIdleMs` (default 30 minutes; `0`/`Infinity` disables). The spec lets a server end a session at any time and the client re-initializes on the 404.
- `close()` on the returned handler tears every live session down and makes further requests `503`. `createMcpHttpHandler` forwards it.

### One change beyond the issue's fix shape

The issue asked for the stateless lazy-init to be made single-flight. Since SDK 1.29 that is not implementable: `handleRequest` throws `Stateless transport cannot be reused across requests` on the **second** request to a stateless transport, so the current shared-pair design is broken past request one regardless of the race. Stateless mode now builds a pair per request and releases it when that request's response body ends (the body is wrapped so a streaming reply is not cut short). The docblock and `docs/packages/mcp.md`, which both promised a single reused transport, are corrected.

## Proof

Each test was re-run with only its own fix reverted, keeping the test and keeping the file compiling.

| Test | Fix reverted | Failure without the fix |
|---|---|---|
| a non-initialize POST never builds or attaches an SDK (#970) | the `initialize` gate | `unauthenticated requests must not attach an SDK: 5 !== 0` |
| an idle session expires and is detached | the `sweepExpired()` call | `Expected values to be strictly equal: 200 !== 404` |
| stateless mode gives every request its own transport and releases it (#970) | per-request transports, back to a shared pair | `Error: Stateless transport cannot be reused across requests. Create a new transport per request.` |
| a rejected initialize leaves nothing attached | the post-`handleRequest` discard | `and released again when no session is registered: 0 !== 1` |
| an initialize opens exactly one session, and close() detaches it | the discard loop in `close()` | `close() must detach every live session: 0 !== 1` |

The tests count attaches and detaches through a wrapped `server.attachSdk`, so a leaked SDK is visible without reaching into the server's private set. `@gemstack/mcp` goes 113 to 118 tests; root `pnpm test` and `pnpm build` are green.

## Nothing deferred

Changeset is `minor` rather than `patch`: this adds public API (`close()` on both handlers, `sessionIdleMs`, the `WebRequestHandler` / `McpHttpHandler` types) and changes stateless mode's transport lifetime.

Closes #970
