### PR TITLE
fix(framework): write the registry atomically and serialize its mutators (#991)

### DIFF
--- a/.changeset/atomic-registry-write.md
+++ b/.changeset/atomic-registry-write.md
@@ -1,0 +1,20 @@
+---
+'@gemstack/framework': patch
+---
+
+The user registry (`~/.the-framework.json`) is now written atomically, and its mutators are
+serialized.
+
+The file holds the project list, the global preferences and every per-project override, and it
+was written with a plain truncate-then-write while the reader treated a malformed file as an
+empty registry. A crash, a kill or a full disk mid-write therefore erased all of it silently and
+the next read reported a clean slate. The write now goes to a temp file beside the real one and
+is renamed over it, the same shape the daemon state file got in #922, so a reader sees either
+the whole old file or the whole new one and a failed write only damages the temp.
+
+`addProject`, `removeProject`, `writePreferences` and `writeProjectPreferences` each read the
+whole registry, edit it and write it back, and one daemon runs several concurrently. Interleaved,
+the later write was computed from a read taken before the earlier one landed and silently dropped
+it. They now queue through a single tail promise.
+
+`RegistryFs` gains an optional `rename`; the node-backed implementation always provides it.

--- a/packages/framework/src/node-fs.ts
+++ b/packages/framework/src/node-fs.ts
@@ -23,6 +23,8 @@ export interface NodeFs {
   mkdir(path: string): Promise<void>
   /** List a directory's entries (names only). Missing dir yields `[]`. */
   readdir(path: string): Promise<string[]>
+  /** Replace `to` with `from`. Atomic within one filesystem, which is the point of having it. */
+  rename(from: string, to: string): Promise<void>
 }
 
 /** The `node:fs/promises` implementation of {@link NodeFs}. */
@@ -67,6 +69,10 @@ export function nodeFs(): NodeFs {
       } catch {
         return []
       }
+    },
+    async rename(from, to) {
+      const { rename } = await import('node:fs/promises')
+      await rename(from, to)
     },
   }
 }

--- a/packages/framework/src/registry.test.ts
+++ b/packages/framework/src/registry.test.ts
@@ -21,23 +21,50 @@ import {
   type RegistryFs,
 } from './registry.js'
 
-/** An in-memory {@link RegistryFs} so the registry logic is tested without touching disk. */
-function memFs(seed: Record<string, string> = {}): RegistryFs & { files: Map<string, string>; dirs: string[] } {
+/**
+ * An in-memory {@link RegistryFs} so the registry logic is tested without touching disk.
+ *
+ * `write` truncates before it stores, as a real `writeFile` does. That is what makes the
+ * atomicity of #991 observable: `failWritesTo` models a crash or a full disk between the
+ * truncate and the flush, leaving the file it truncated empty.
+ */
+function memFs(
+  seed: Record<string, string> = {},
+  options: { failWritesTo?: string; slow?: boolean } = {},
+): RegistryFs & { files: Map<string, string>; dirs: string[]; written: string[] } {
   const files = new Map<string, string>(Object.entries(seed))
   const dirs: string[] = []
+  const written: string[] = []
+  // An await point inside read and write, so concurrent callers interleave rather than each
+  // running start to finish.
+  const pause = async () => {
+    if (options.slow) await new Promise(resolve => setTimeout(resolve, 1))
+  }
   return {
     files,
     dirs,
+    written,
     async read(path) {
+      await pause()
       const v = files.get(path)
       if (v === undefined) throw new Error(`ENOENT: ${path}`)
       return v
     },
     async write(path, contents) {
+      written.push(path)
+      files.set(path, '') // truncate, as `writeFile` does
+      await pause()
+      if (options.failWritesTo === path) throw new Error(`ENOSPC: ${path}`)
       files.set(path, contents)
     },
     async mkdir(path) {
       dirs.push(path) // no-op: the memory fs has no directories
+    },
+    async rename(from, to) {
+      const contents = files.get(from)
+      if (contents === undefined) throw new Error(`ENOENT: ${from}`)
+      files.delete(from)
+      files.set(to, contents)
     },
   }
 }
@@ -405,5 +432,60 @@ test('registryPreferencesStore round-trips through the same file', async () => {
   assert.deepEqual(await store.read(), {})
   await store.save({ vanilla: true })
   assert.deepEqual(await store.read(), { vanilla: true })
+})
+
+test('the registry file is never written in place, only renamed over (#991)', async () => {
+  const fs = memFs({ [FILE]: JSON.stringify({ projects: [APP_A], preferences: {} }) })
+  await writePreferences({ vanilla: true }, fs, ENV)
+  assert.deepEqual(
+    fs.written.filter(path => path === FILE),
+    [],
+    'the live file must only ever be replaced by a rename, so a reader sees the whole old or the whole new one',
+  )
+  assert.ok(fs.written.every(path => path.startsWith(`${FILE}.`) && path.endsWith('.tmp')))
+  assert.deepEqual(await readRegistry(fs, ENV), {
+    projects: [APP_A],
+    preferences: { vanilla: true },
+    projectPreferences: {},
+  })
+  assert.equal([...fs.files.keys()].length, 1, 'the temp file is renamed away, not left beside the real one')
+})
+
+test('a write that dies partway leaves the previous registry intact (#991)', async () => {
+  const stored = JSON.stringify({ projects: [APP_A, APP_B], preferences: { autopilot: false } })
+  // The disk fills between the truncate and the flush. Whatever it truncated must not be the live file.
+  const fs = memFs({ [FILE]: stored }, { failWritesTo: `${FILE}.${process.pid}.tmp` })
+  await assert.rejects(() => writePreferences({ vanilla: true }, fs, ENV), /ENOSPC/)
+  assert.equal(fs.files.get(FILE), stored, 'the live file is untouched by a failed write')
+  assert.deepEqual(await readRegistry(fs, ENV), {
+    projects: [APP_A, APP_B],
+    preferences: { autopilot: false },
+    projectPreferences: {},
+  })
+})
+
+test('concurrent addProject calls both survive rather than the later one dropping the earlier (#991)', async () => {
+  const fs = memFs({ [FILE]: JSON.stringify({ projects: [], preferences: {} }) }, { slow: true })
+  await Promise.all([addProject('/repos/app-a', APP_A.addedAt, fs, ENV), addProject('/repos/app-b', APP_B.addedAt, fs, ENV)])
+  assert.deepEqual(await listProjects(fs, ENV), [APP_A, APP_B])
+})
+
+test('a concurrent addProject and writePreferences do not drop each other (#991)', async () => {
+  const fs = memFs({ [FILE]: JSON.stringify({ projects: [], preferences: {} }) }, { slow: true })
+  await Promise.all([addProject('/repos/app-a', APP_A.addedAt, fs, ENV), writePreferences({ vanilla: true }, fs, ENV)])
+  assert.deepEqual(await readRegistry(fs, ENV), {
+    projects: [APP_A],
+    preferences: { vanilla: true },
+    projectPreferences: {},
+  })
+})
+
+test('a rejected mutation does not wedge the queue for the next caller (#991)', async () => {
+  const temp = `${FILE}.${process.pid}.tmp`
+  const fs = memFs({ [FILE]: JSON.stringify({ projects: [], preferences: {} }) }, { failWritesTo: temp })
+  await assert.rejects(() => addProject('/repos/app-a', APP_A.addedAt, fs, ENV), /ENOSPC/)
+  const healthy = memFs({ [FILE]: JSON.stringify({ projects: [], preferences: {} }) })
+  await addProject('/repos/app-b', APP_B.addedAt, healthy, ENV)
+  assert.deepEqual(await listProjects(healthy, ENV), [APP_B])
 })
 

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -196,12 +196,18 @@ export interface RegistryFs {
   write(path: string, contents: string): Promise<void>
   /** Recursive; used on the registry file's parent dir. */
   mkdir(path: string): Promise<void>
+  /**
+   * Replace `to` with `from`, atomically. Optional only so an existing implementation of this
+   * seam keeps compiling; without it {@link writeRegistry} falls back to the truncate-then-write
+   * this method exists to avoid (#991).
+   */
+  rename?(from: string, to: string): Promise<void>
 }
 
 /** A {@link RegistryFs} backed by `node:fs/promises`. See {@link nodeFs}. */
 export function nodeRegistryFs(): RegistryFs {
-  const { read, write, mkdir } = nodeFs()
-  return { read, write, mkdir }
+  const { read, write, mkdir, rename } = nodeFs()
+  return { read, write, mkdir, rename }
 }
 
 /** True when `value` is a well-formed {@link ProjectRecord}. */
@@ -386,6 +392,13 @@ export async function readRegistry(
  * Write the registry back as pretty object-form JSON, creating the parent dir. The per-project
  * block is omitted while empty, so a user who never sets a per-project option keeps the file
  * they have today.
+ *
+ * Atomic (#991): the JSON goes to a temp file beside the real one and is then renamed over it,
+ * the same shape #922 gave the daemon state file. A direct write truncates first, so a crash, a
+ * kill or a full disk mid-write left a half file — and {@link readRegistry} reports a malformed
+ * file as an empty registry, so every project and preference vanished silently. A failed write
+ * now only ever damages the temp file. The temp is left behind on failure rather than swept up:
+ * one stray file is the cheaper half of that trade.
  */
 async function writeRegistry(registry: Registry, fs: RegistryFs, env: NodeJS.ProcessEnv): Promise<void> {
   const file = registryPath(env)
@@ -393,8 +406,33 @@ async function writeRegistry(registry: Registry, fs: RegistryFs, env: NodeJS.Pro
   const contents = Object.keys(projectPreferences).length
     ? { projects, preferences, projectPreferences }
     : { projects, preferences }
+  const json = JSON.stringify(contents, null, 2)
   await fs.mkdir(dirname(file))
-  await fs.write(file, JSON.stringify(contents, null, 2))
+  if (!fs.rename) return fs.write(file, json)
+  const temp = `${file}.${process.pid}.tmp`
+  await fs.write(temp, json)
+  await fs.rename(temp, file)
+}
+
+/**
+ * Serializes the read-modify-write mutators below (#991). Each reads the whole registry, edits it
+ * and writes it back, and one daemon runs several concurrently: `daemon.ts` and `daemon-runtime.ts`
+ * both call {@link addProject} while the dashboard's savePreferences RPC writes through
+ * {@link registryPreferencesStore}. Interleaved, the later write was computed from a read taken
+ * before the earlier one landed, so it silently dropped it. One tail promise for the module, not
+ * one per file: the writes are small, and the registry is a single file per machine anyway.
+ */
+let mutations: Promise<void> = Promise.resolve()
+
+function serialize<T>(mutate: () => Promise<T>): Promise<T> {
+  const result = mutations.then(mutate)
+  // A rejected mutation must not poison the queue, and must not surface as an unhandled rejection
+  // here — the caller still gets `result`, which carries the error.
+  mutations = result.then(
+    () => {},
+    () => {},
+  )
+  return result
 }
 
 /**
@@ -419,15 +457,17 @@ export async function addProject(
   fs: RegistryFs = nodeRegistryFs(),
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<ProjectRecord> {
-  const absolute = resolve(path)
-  const registry = await readRegistry(fs, env)
-  const existing = registry.projects.find(project => resolve(project.path) === absolute)
-  if (existing) return existing
+  return serialize(async () => {
+    const absolute = resolve(path)
+    const registry = await readRegistry(fs, env)
+    const existing = registry.projects.find(project => resolve(project.path) === absolute)
+    if (existing) return existing
 
-  const record: ProjectRecord = { id: projectId(absolute), path: absolute, addedAt }
-  registry.projects.push(record)
-  await writeRegistry(registry, fs, env)
-  return record
+    const record: ProjectRecord = { id: projectId(absolute), path: absolute, addedAt }
+    registry.projects.push(record)
+    await writeRegistry(registry, fs, env)
+    return record
+  })
 }
 
 /**
@@ -440,12 +480,14 @@ export async function removeProject(
   fs: RegistryFs = nodeRegistryFs(),
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<boolean> {
-  const registry = await readRegistry(fs, env)
-  const remaining = registry.projects.filter(project => project.id !== id)
-  if (remaining.length === registry.projects.length) return false
-  const { [id]: _dropped, ...projectPreferences } = registry.projectPreferences
-  await writeRegistry({ projects: remaining, preferences: registry.preferences, projectPreferences }, fs, env)
-  return true
+  return serialize(async () => {
+    const registry = await readRegistry(fs, env)
+    const remaining = registry.projects.filter(project => project.id !== id)
+    if (remaining.length === registry.projects.length) return false
+    const { [id]: _dropped, ...projectPreferences } = registry.projectPreferences
+    await writeRegistry({ projects: remaining, preferences: registry.preferences, projectPreferences }, fs, env)
+    return true
+  })
 }
 
 /** The user's dashboard preferences (#410), or `{}` when none are stored. */
@@ -462,8 +504,10 @@ export async function writePreferences(
   fs: RegistryFs = nodeRegistryFs(),
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<void> {
-  const registry = await readRegistry(fs, env)
-  await writeRegistry({ ...registry, preferences: sanitizePreferences(preferences) }, fs, env)
+  return serialize(async () => {
+    const registry = await readRegistry(fs, env)
+    await writeRegistry({ ...registry, preferences: sanitizePreferences(preferences) }, fs, env)
+  })
 }
 
 /** One project's overrides (#840), or `{}` when it has none. */
@@ -486,11 +530,13 @@ export async function writeProjectPreferences(
   fs: RegistryFs = nodeRegistryFs(),
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<void> {
-  const registry = await readRegistry(fs, env)
-  const sanitized = sanitizeProjectPreferences(preferences)
-  const { [projectId]: _previous, ...rest } = registry.projectPreferences
-  const projectPreferences = Object.keys(sanitized).length ? { ...rest, [projectId]: sanitized } : rest
-  await writeRegistry({ ...registry, projectPreferences }, fs, env)
+  return serialize(async () => {
+    const registry = await readRegistry(fs, env)
+    const sanitized = sanitizeProjectPreferences(preferences)
+    const { [projectId]: _previous, ...rest } = registry.projectPreferences
+    const projectPreferences = Object.keys(sanitized).length ? { ...rest, [projectId]: sanitized } : rest
+    await writeRegistry({ ...registry, projectPreferences }, fs, env)
+  })
 }
 
 /** A {@link PreferencesStore} bound to the real registry file, wired by the daemon so the


### PR DESCRIPTION
Closes #991

`~/.the-framework.json` holds the project list, the global preferences and every per-project override, and `writeRegistry` wrote it with a plain truncate-then-write while `readRegistry` treats a malformed file as an empty registry. A crash, a kill or a full disk mid-write therefore erased all of it silently, and the next read reported a clean slate rather than an error. The file is deliberately not synced, so there is no recovery.

The write now goes to a temp file beside the real one and is renamed over it, the same shape #922 gave the daemon state file (which was the only `rename` in the package). A reader sees either the whole old file or the whole new one, and a failed write only ever damages the temp.

Second defect, same file: `addProject`, `removeProject`, `writePreferences` and `writeProjectPreferences` each read the whole registry, edit it and write it back with no serialization, and one daemon runs several concurrently (`daemon.ts:77` and `daemon-runtime.ts:397` both call `addProject` while the dashboard's savePreferences RPC writes through `registryPreferencesStore`). Interleaved, the later write was computed from a read taken before the earlier one landed and dropped it. They now queue through a single module-level tail promise.

`RegistryFs` gains an optional `rename`, optional so any existing implementation of the seam keeps compiling; `nodeRegistryFs` always provides it, and `NodeFs` gains the underlying method.

## Verification

Baseline on `origin/main` in a clean worktree: framework 1049 tests, 0 fail. After: 1054, 0 fail, full monorepo 21/21 turbo tasks green.

The five new tests were proved by reverting the source fix (direct write restored, `serialize` turned into a pass-through) with the tests kept. All five fail at runtime, on their assertions rather than on compilation, and nothing else in the suite breaks:

```
✖ the registry file is never written in place, only renamed over (#991)
✖ a write that dies partway leaves the previous registry intact (#991)
✖ concurrent addProject calls both survive rather than the later one dropping the earlier (#991)
✖ a concurrent addProject and writePreferences do not drop each other (#991)
✖ a rejected mutation does not wedge the queue for the next caller (#991)
ℹ tests 1054  ℹ pass 1048  ℹ fail 5
```

That required teaching the in-memory `RegistryFs` to truncate before it stores, as a real `writeFile` does. Without it the fake was accidentally atomic and the bug was invisible to any test.
