### PR TITLE
fix(framework): commit a retained worktree before removing it (#982)

### DIFF
--- a/.changeset/fix-982-commit-before-worktree-remove.md
+++ b/.changeset/fix-982-commit-before-worktree-remove.md
@@ -1,0 +1,17 @@
+---
+'@gemstack/framework': patch
+---
+
+Removing a retained worktree no longer destroys the uncommitted work it was kept for (#982)
+
+A worktree is only retained when its session failed or was stopped, which is exactly when the
+checkout is still holding an uncommitted diff. Both surfaces that offer to remove one, the
+`framework worktrees rm` verb and the dashboard's Remove button, went straight to a removal that
+falls back to `git worktree remove --force`, so the work was deleted with the directory and there
+was nothing left to recover it from.
+
+Both now commit the checkout to the session's own branch first, the way the daemon's teardown
+already does, and refuse the removal when that commit fails, keeping the checkout instead. The
+two surfaces are now one implementation, so the session-still-running refusal, the unknown-session
+check and the new commit-first behaviour are identical on both. Removing a session that has no
+worktree now reports that instead of the dashboard reporting success.

--- a/packages/framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/control.telefunc.ts
@@ -4,7 +4,8 @@ import { isSafeVia } from '../conversations.js'
 import { openInApp, type OpenTarget, type OpenResult } from '../dashboard/open-in-app.js'
 import { resolveProjectPath, resolveRunPath, contextPreferences, contextPreview } from './context.js'
 import { appendFlatTodoEntry } from '../todo-loop.js'
-import { findRun, isSafeRunId, readLiveMetas, removeWorktree, pruneWorktrees, worktreePath, type RunMeta } from '../store/index.js'
+import { findRun, isSafeRunId, type RunMeta } from '../store/index.js'
+import { removeProjectWorktree } from '../worktrees.js'
 import {
   openRunPullRequest,
   pushRunBranch,
@@ -24,7 +25,6 @@ import type {
 import type { ServeTarget } from '../preview.js'
 import type { DashboardContext } from '../dashboard/telefunc-serve.js'
 import type { Preferences } from '../registry.js'
-import { errorMessage } from '../error-message.js'
 
 // The write side behind the new dashboard (#405): steering a live run. The reverse of
 // the event stream — events flow run -> events.jsonl -> Channel -> browser; steering
@@ -89,9 +89,11 @@ export async function sendMessage(projectId: string, text: string, runId?: strin
  * Remove a retained worktree (#737). A run that failed or was stopped keeps its checkout so you
  * can inspect it; this is the explicit cleanup for one, since nothing removes them on a timer.
  *
- * Refuses while that run is still live: its worktree is the checkout the agent is working in, and
- * Stop is the way to end a run, not pulling the floor out from under it. The run's history was
- * archived into the repo when it finished, so removal costs no history.
+ * The checks and the commit-first removal are {@link removeProjectWorktree}'s, shared with the
+ * `framework worktrees rm` verb (#982) so the two surfaces cannot drift again. All this adds is
+ * the daemon-only step: a retained worktree can still be serving (#797), and that dev server
+ * holds the tree being removed, so it is stopped rather than having the directory pulled out
+ * from under it.
  */
 export async function sendRemoveWorktree(projectId: string, runId: string): Promise<RemoveWorktreeResult> {
   // Read the context before the first await: telefunc only exposes it synchronously, at the top
@@ -99,21 +101,11 @@ export async function sendRemoveWorktree(projectId: string, runId: string): Prom
   const preview = contextPreview()
   const cwd = await resolveProjectPath(projectId)
   if (!cwd) return { ok: false, error: 'this project has no local path on this server' }
-  if (!isSafeRunId(runId)) return { ok: false, error: `invalid session id: ${runId}` }
-  const live = await readLiveMetas(cwd).catch(() => [])
-  if (live.some(run => run.id === runId && run.status === 'running')) {
-    return { ok: false, error: 'that session is still going; stop it before removing its worktree' }
-  }
-  try {
-    // A retained worktree can still be serving (#797), and that dev server holds the tree being
-    // removed. Stop it first rather than pulling the directory out from under it.
-    await preview?.stop(projectId, runId)
-    await removeWorktree(cwd, worktreePath(cwd, runId))
-    await pruneWorktrees(cwd)
-    return { ok: true }
-  } catch (err) {
-    return { ok: false, error: errorMessage(err) }
-  }
+  return removeProjectWorktree(cwd, runId, {
+    beforeRemove: async id => {
+      await preview?.stop(projectId, id)
+    },
+  })
 }
 
 /**

--- a/packages/framework/src/dashboard-rpc/run-addressing.test.ts
+++ b/packages/framework/src/dashboard-rpc/run-addressing.test.ts
@@ -6,8 +6,9 @@ import { tmpdir } from 'node:os'
 import { sendStop, sendMessage, sendChoice, sendRemoveWorktree } from './control.telefunc.js'
 import { onRetainedWorktrees, onRuns } from './reads.telefunc.js'
 import { addProject, projectId as idFor } from '../registry.js'
-import { FRAMEWORK_DIR, WORKTREES_DIR } from '../store/index.js'
+import { FRAMEWORK_DIR, WORKTREES_DIR, addWorktree, runBranchName } from '../store/index.js'
 import { CONTROL_FILE } from '../control.js'
+import { nodeGitRunner } from '../project.js'
 
 // #749: a run tails the control log inside its own worktree (#736), so a steering call has to
 // resolve the RUN, not the project. Addressed at the project root, Stop / messages / choice picks
@@ -124,6 +125,75 @@ test('sendRemoveWorktree rejects an unsafe run id before touching anything (#737
     const result = await sendRemoveWorktree(ctx.projectId, '../../etc')
     assert.equal(result.ok, false)
     assert.match(result.ok === false ? result.error : '', /invalid session id/)
+  } finally {
+    ctx.restore()
+    await rm(ctx.dir, { recursive: true, force: true })
+  }
+})
+
+// #982: the dashboard's Remove and `framework worktrees rm` are now one implementation, so the
+// button gets the commit-first removal and the checks the CLI already had. Before that it went
+// straight to a forcing removeWorktree, which deleted the very diff a retained checkout was kept
+// for, and reported success for a session that had no worktree at all.
+
+/** A registered project whose retained worktree holds an uncommitted edit, in a real git repo. */
+async function projectWithDirtyWorktree(): Promise<{
+  dir: string
+  projectId: string
+  runId: string
+  worktree: string
+  branch: string
+  restore: () => void
+}> {
+  const git = nodeGitRunner()
+  const dir = await realpath(await mkdtemp(join(tmpdir(), 'framework-remove-')))
+  await git(['init'], dir)
+  await git(['config', 'user.email', 't@t'], dir)
+  await git(['config', 'user.name', 't'], dir)
+  await writeFile(join(dir, 'index.html'), '<h1>Hello, world!</h1>\n')
+  await git(['add', '-A'], dir)
+  await git(['commit', '-m', 'init'], dir)
+
+  const runId = 'run1'
+  const { path, branch } = await addWorktree(dir, { runId, branch: runBranchName(runId) }, git)
+  await writeFile(join(path, 'index.html'), '<h1>Welcome!</h1>\n')
+
+  const previous = process.env.XDG_CONFIG_HOME
+  process.env.XDG_CONFIG_HOME = join(dir, 'cfg')
+  await mkdir(process.env.XDG_CONFIG_HOME, { recursive: true })
+  await addProject(dir, new Date().toISOString())
+
+  return {
+    dir,
+    projectId: idFor(dir),
+    runId,
+    worktree: path,
+    branch,
+    restore: () => {
+      if (previous === undefined) delete process.env.XDG_CONFIG_HOME
+      else process.env.XDG_CONFIG_HOME = previous
+    },
+  }
+}
+
+test('the dashboard Remove commits the checkout it takes away, rather than forcing past it (#982)', async () => {
+  const ctx = await projectWithDirtyWorktree()
+  try {
+    assert.deepEqual(await sendRemoveWorktree(ctx.projectId, ctx.runId), { ok: true })
+    const shown = await nodeGitRunner()(['show', `${ctx.branch}:index.html`], ctx.dir)
+    assert.match(shown, /Welcome!/, 'the uncommitted edit survived on the run branch')
+  } finally {
+    ctx.restore()
+    await rm(ctx.dir, { recursive: true, force: true })
+  }
+})
+
+test('the dashboard Remove reports an unknown session instead of claiming success (#982)', async () => {
+  const ctx = await projectWithWorktreeRun()
+  try {
+    const result = await sendRemoveWorktree(ctx.projectId, 'nosuchrun')
+    assert.equal(result.ok, false)
+    assert.match(result.ok === false ? result.error : '', /no worktree for session nosuchrun/)
   } finally {
     ctx.restore()
     await rm(ctx.dir, { recursive: true, force: true })

--- a/packages/framework/src/worktrees.test.ts
+++ b/packages/framework/src/worktrees.test.ts
@@ -1,6 +1,11 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { formatWorktreeList, type WorktreeRow } from './worktrees.js'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises'
+import { formatWorktreeList, removeProjectWorktree, type WorktreeRow } from './worktrees.js'
+import { addWorktree, runBranchName } from './store/index.js'
+import { nodeGitRunner } from './project.js'
 
 const row = (over: Partial<WorktreeRow> & { runId: string }): WorktreeRow => ({ live: false, ...over })
 
@@ -23,4 +28,72 @@ test('an empty list says why there is nothing rather than printing a bare header
 test('a worktree whose run left no meta is listed as unknown, not skipped (#752)', () => {
   const lines = formatWorktreeList([row({ runId: 'orphan' })])
   assert.equal(lines[1], 'orphan   unknown  -     -')
+})
+
+// #982: a worktree is only retained when its run failed or was stopped, which is exactly when it
+// is still holding uncommitted agent work — so the removal both surfaces offer has to commit
+// first, the way teardown does (#786), rather than force past a tree git calls unclean.
+// Against real git, because "was the diff actually destroyed" is not a question a fake answers.
+
+const RUN_ID = 'run1'
+
+/** A repo whose retained worktree holds an uncommitted edit, as a failed run leaves one. */
+async function repoWithDirtyWorktree(): Promise<{ repo: string; path: string; branch: string }> {
+  const git = nodeGitRunner()
+  // realpath so the mkdtemp path matches what git reports (the /var -> /private/var symlink).
+  const repo = await realpath(await mkdtemp(join(tmpdir(), 'framework-worktrees-')))
+  await git(['init'], repo)
+  await git(['config', 'user.email', 't@t'], repo)
+  await git(['config', 'user.name', 't'], repo)
+  await writeFile(join(repo, 'index.html'), '<h1>Hello, world!</h1>\n')
+  await git(['add', '-A'], repo)
+  await git(['commit', '-m', 'init'], repo)
+  const { path, branch } = await addWorktree(repo, { runId: RUN_ID, branch: runBranchName(RUN_ID) }, git)
+  await writeFile(join(path, 'index.html'), '<h1>Welcome!</h1>\n')
+  return { repo, path, branch }
+}
+
+test('removing a retained worktree keeps the work it was holding, on the run branch (#982)', async () => {
+  const { repo, path, branch } = await repoWithDirtyWorktree()
+  try {
+    assert.deepEqual(await removeProjectWorktree(repo, RUN_ID), { ok: true })
+    await assert.rejects(() => stat(path), 'the checkout is gone')
+    const shown = await nodeGitRunner()(['show', `${branch}:index.html`], repo)
+    assert.match(shown, /Welcome!/, 'the uncommitted edit survived on the branch instead of being forced away')
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})
+
+test('a worktree whose work cannot be committed is refused, not force-removed (#982)', async () => {
+  const { repo, path } = await repoWithDirtyWorktree()
+  try {
+    // A refusing pre-commit hook is the reproducible version of "no git identity": the commit
+    // fails, so the work only exists in the working tree and the checkout must survive.
+    const hooks = join(repo, 'hooks')
+    await mkdir(hooks, { recursive: true })
+    await writeFile(join(hooks, 'pre-commit'), '#!/bin/sh\nexit 1\n', { mode: 0o755 })
+    await nodeGitRunner()(['config', 'core.hooksPath', hooks], repo)
+
+    const result = await removeProjectWorktree(repo, RUN_ID)
+    assert.equal(result.ok, false, 'removal is refused rather than forced')
+    assert.match(result.ok === false ? result.error : '', /uncommitted work/)
+    assert.equal((await stat(path)).isDirectory(), true, 'the checkout is still on disk')
+    assert.match(await readFile(join(path, 'index.html'), 'utf8'), /Welcome!/, 'with the work still in it')
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})
+
+test('an unknown session is refused before any git runs (#982)', async () => {
+  const { repo, path } = await repoWithDirtyWorktree()
+  try {
+    assert.deepEqual(await removeProjectWorktree(repo, 'nosuchrun'), {
+      ok: false,
+      error: 'no worktree for session nosuchrun',
+    })
+    assert.equal((await stat(path)).isDirectory(), true, 'the real worktree is untouched')
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
 })

--- a/packages/framework/src/worktrees.ts
+++ b/packages/framework/src/worktrees.ts
@@ -4,6 +4,7 @@ import {
   listWorktreeDirs,
   listRuns,
   readLiveMetas,
+  commitPendingWork,
   removeWorktree,
   pruneWorktrees,
   worktreePath,
@@ -40,6 +41,15 @@ export interface PruneResult {
 
 /** The outcome of {@link removeProjectWorktree}. */
 export type RemoveResult = { ok: true } | { ok: false; error: string }
+
+/** Surface-specific work {@link removeProjectWorktree} does once removal is decided on. */
+export interface RemoveWorktreeOptions {
+  /**
+   * Run after the safety checks pass and the work is committed, just before the checkout goes.
+   * The dashboard stops the preview serving that tree here (#797); the CLI has none to stop.
+   */
+  beforeRemove?: (runId: string) => Promise<void>
+}
 
 /**
  * The worktrees a project still has on disk (#752), newest first — the same view the dashboard's
@@ -78,16 +88,26 @@ async function sizeOf(cwd: string, runId: string): Promise<{ sizeBytes?: number 
 }
 
 /**
- * Remove one retained worktree (#752/#737), refusing while its run is still going — a run's
- * checkout is where its agent is working, and Stop is how you end a run, not pulling the floor
- * out from under it. The run's history was archived into the repo when it finished, so removal
- * costs no history.
+ * Remove one retained worktree (#752/#737): the one implementation behind both surfaces that
+ * offer it, the `framework worktrees rm` verb and the dashboard's Remove button (#982). They were
+ * two copies of the same checks and had already drifted, so a bogus session id read as a raw git
+ * error on one and a plain sentence on the other.
  *
- * Unlike the dashboard's Remove, this cannot stop a preview serving that checkout: previews live
- * in the daemon, and the CLI is a different process. A worktree being served is still removed;
- * the dev server is the daemon's to notice.
+ * Refuses while the run is still going — a run's checkout is where its agent is working, and Stop
+ * is how you end a run, not pulling the floor out from under it. The run's history was archived
+ * into the repo when it finished, so removal costs no history.
+ *
+ * Commits whatever the checkout is still holding before removing it, exactly as teardown does
+ * (#786), and refuses when that commit fails (#982). A worktree is only *retained* when its run
+ * failed or was stopped, which is precisely when it is still holding uncommitted agent work — and
+ * {@link removeWorktree} forces past a dirty tree, so without this both surfaces reliably deleted
+ * the very diff the checkout was kept for.
  */
-export async function removeProjectWorktree(cwd: string, runId: string): Promise<RemoveResult> {
+export async function removeProjectWorktree(
+  cwd: string,
+  runId: string,
+  opts: RemoveWorktreeOptions = {},
+): Promise<RemoveResult> {
   if (!isSafeRunId(runId)) return { ok: false, error: `invalid session id: ${runId}` }
   const names = await listWorktreeDirs(cwd).catch((): string[] => [])
   if (!names.includes(runId)) return { ok: false, error: `no worktree for session ${runId}` }
@@ -95,8 +115,16 @@ export async function removeProjectWorktree(cwd: string, runId: string): Promise
   if (live.some(run => run.id === runId && run.status === 'running')) {
     return { ok: false, error: 'that session is still going; stop it before removing its worktree' }
   }
+  const path = worktreePath(cwd, runId)
   try {
-    await removeWorktree(cwd, worktreePath(cwd, runId))
+    if (!(await commitPendingWork(path))) {
+      return {
+        ok: false,
+        error: `session ${runId} has uncommitted work that could not be committed; its worktree was kept`,
+      }
+    }
+    await opts.beforeRemove?.(runId)
+    await removeWorktree(cwd, path)
     await pruneWorktrees(cwd)
     return { ok: true }
   } catch (err) {


### PR DESCRIPTION
Closes #982

## The bug

A worktree is only **retained** when its run ended `failed` or `stopped` (`daemon-runtime.ts:286` returns early for anything but `done`). That is exactly the case where the checkout is still holding uncommitted agent work, which is why it was kept.

Both surfaces that offer to remove one called `removeWorktree` directly:

- `removeProjectWorktree` (`worktrees.ts`), the `framework worktrees rm` path
- `sendRemoveWorktree` (`dashboard-rpc/control.telefunc.ts`), the dashboard's Remove button

`removeWorktree` tries a plain `git worktree remove` and then falls back to `--force`. Plain removal refuses a dirty tree, so both surfaces reliably fell through to `--force` and deleted the diff. The work was never staged, so nothing in git could bring it back.

The daemon's own teardown already got this right (#786): it calls `commitPendingWork` and keeps the checkout when the commit fails.

## The fix

Commit first, refuse when the commit fails. `removeProjectWorktree` now calls `commitPendingWork(path)` before removing, and returns a failure rather than removing when it comes back false. No `--force` escape hatch was added: the existing option surface has none.

The two surfaces are now **one implementation**. `sendRemoveWorktree` delegates to `removeProjectWorktree`, passing its one daemon-only step (stopping a preview serving that checkout, #797) through a `beforeRemove` hook. The safe-id check, the live-run refusal, the membership check and the commit-first behaviour now live in one place and cannot drift again.

They had already drifted: the telefunc path skipped the `listWorktreeDirs` membership check, and because `removeWorktree` swallows its git failures, removing a session that had no worktree returned `{ ok: true }` from the dashboard. It now reports `no worktree for session <id>`, matching the CLI.

Existing guards are preserved: `run-addressing.test.ts:108,121` (live-run refusal, unsafe-id rejection) still pass unchanged.

## Tests

| | tests | pass | fail | skipped |
|---|---|---|---|---|
| before | 1049 | 1048 | 0 | 1 |
| after | 1054 | 1053 | 0 | 1 |

Root `pnpm build` and root `pnpm test`: 21/21 turbo tasks pass.

Five new tests, all against real git repos, because "was the diff actually destroyed" is not a question a fake git runner can answer.

## Proof by revert

Reverting only `worktrees.ts` + `control.telefunc.ts`, keeping the new tests, recompiling `dist-test` and re-running:

```
✖ the dashboard Remove commits the checkout it takes away, rather than forcing past it (#982)
  AssertionError: the uncommitted edit survived on the run branch
✖ the dashboard Remove reports an unknown session instead of claiming success (#982)
  AssertionError: Expected values to be strictly equal
✖ removing a retained worktree keeps the work it was holding, on the run branch (#982)
  AssertionError: the uncommitted edit survived on the branch instead of being forced away
✖ a worktree whose work cannot be committed is refused, not force-removed (#982)
  AssertionError: removal is refused rather than forced
✔ an unknown session is refused before any git runs (#982)
```

Four fail on their assertions, not on compilation. The fifth passes under the revert by design: the CLI path already had the membership check, so that test pins a guard rather than proving the regression.
