### PR TITLE
fix(ai-sdk): check the owner before resuming a conversation by id (#984)

### DIFF
--- a/.changeset/fix-984-conversation-owner-check.md
+++ b/.changeset/fix-984-conversation-owner-check.md
@@ -1,0 +1,18 @@
+---
+'@gemstack/ai-sdk': minor
+---
+
+fix(ai-sdk): a resumed conversation id is now checked against the user the run is scoped to
+
+`preparePersistence` loaded a conversation by id without ever reading `spec.user`, so `agent.forUser('alice').continue(bobsConversationId)` read Bob's whole thread into Alice's run and appended Alice's turn back into it. The same reached through `prompt(input, { conversation: { user: 'alice', id: bobsConvId } })` and through the streaming variant. Conversation ids are ordinary identifiers here, not secrets, and a resume endpoint takes one straight off a request.
+
+The owner was already recorded at create time and simply never consulted. It is now read back before the load, and a mismatch throws the new `ConversationOwnershipError` (exported, so a server can answer 403 rather than 500). The error names the conversation and the user the run was scoped to, never the real owner.
+
+`ConversationStore.load()` is unchanged. Ownership is read from `ConversationStoreListEntry.userId`, a new optional field mirroring `ConversationStoreMeta.userId` the way `agent` already does, and `MemoryConversationStore` reports it.
+
+Two deliberately permissive cases:
+
+- A thread whose stored meta carries no `userId`, and any store that does not report `userId` in its listings, stays resumable by whoever holds the id. Existing stored conversations do not become unreadable.
+- A bare `continue(id)` with no user is not a special error; it carries an empty user and fails the same owner check, so it still resumes unowned threads and is refused for owned ones.
+
+That second point changes a documented flow: `myAgent.forUser('u').prompt(...)` followed by `myAgent.continue(id).prompt(...)` now throws. Chain `forUser('u').continue(id)` instead. The docs shipped with the package have been corrected.

--- a/docs/packages/ai-sdk/memory.md
+++ b/docs/packages/ai-sdk/memory.md
@@ -90,9 +90,11 @@ import { Agent, setConversationStore, MemoryConversationStore } from '@gemstack/
 setConversationStore(new MemoryConversationStore())   // in-memory default: dev / tests
 
 const first  = await new AssistantAgent().forUser('user-42').prompt('My name is Alice.')
-const second = await new AssistantAgent().continue(first.conversationId!).prompt("What's my name?")
+const second = await new AssistantAgent().forUser('user-42').continue(first.conversationId!).prompt("What's my name?")
 // second.text -> 'Your name is Alice.'
 ```
+
+Keep `forUser()` on the resume call: a thread is owned by the user it was created for, and resuming it as a different user (or as no user at all) throws `ConversationOwnershipError`. Otherwise a conversation id arriving on a request would let any caller read and extend somebody else's thread. Ownership is read off the `userId` your store reports in `list()`; threads that carry no owner stay resumable by whoever holds the id, so ids minted before this check keep working.
 
 `MemoryConversationStore` is in-process and loses every thread on restart, so it is for tests and dev only. For production, **implement the `ConversationStore` contract against your own database** (Postgres, Redis, an external service). It is five methods:
 
@@ -108,6 +110,8 @@ interface ConversationStore {
 ```
 
 `ConversationStoreMeta` carries `userId`, an optional `agent` thread-segregation key (see [Auto-persist](#auto-persist-conversational) below), and free-form `resourceSlug` / `recordId` fields your backend can index on.
+
+Mirror that `userId` back onto the entries your `list()` returns (`ConversationStoreListEntry.userId`). It is the only owner-aware read in the contract, so it is what the resume-by-id owner check consults; a store that omits it cannot be enforced and stays as permissive as it was.
 
 ### Sanitizing loaded history
 
@@ -156,6 +160,8 @@ Per-call override and explicit-form precedence (high to low):
 1. `agent.forUser(id).prompt()` / `agent.continue(id).prompt()` - explicit always wins.
 2. `agent.prompt(input, { conversation: false | { user, id?, historyLimit? } })` - per-call.
 3. `agent.conversational()` - class declaration.
+
+Whichever layer supplies the `id`, the owner check applies: the resolved `user` must match the thread's stored owner.
 
 Stores that surface the `agent` meta in `list()` results get the per-class thread separation; stores that ignore it fall back to "always create a new thread", which is the conservative behavior.
 

--- a/packages/ai-sdk/boost/guidelines.md
+++ b/packages/ai-sdk/boost/guidelines.md
@@ -132,8 +132,10 @@ Persist multi-turn conversations with `ConversationStore`. Register via `setConv
 ```ts
 setConversationStore(new MemoryConversationStore())
 const response = await myAgent.forUser('user-123').prompt('Hello')  // creates conversation
-const follow = await myAgent.continue(response.conversationId).prompt('Follow up')
+const follow = await myAgent.forUser('user-123').continue(response.conversationId).prompt('Follow up')
 ```
+
+Keep `forUser()` on the resume: a thread may only be resumed by the user it was created for, and a mismatch (including a bare `continue()` with no user) throws `ConversationOwnershipError`. Threads stored without a `userId` stay open to whoever holds the id.
 
 For chat agents that should always auto-persist for the active user, override `conversational()` on the class — `agent.prompt(input)` then auto-loads + auto-saves without each caller passing the user id:
 

--- a/packages/ai-sdk/boost/skills/ai-agents/SKILL.md
+++ b/packages/ai-sdk/boost/skills/ai-agents/SKILL.md
@@ -119,8 +119,9 @@ const myAgent = new ResearchAgent()
 const response1 = await myAgent.forUser('user-123').prompt('What is TypeScript?')
 const convId = response1.conversationId!
 
-// Continue the same conversation
-const response2 = await myAgent.continue(convId).prompt('Tell me more about generics')
+// Continue the same conversation. Keep forUser(): a thread is owned by the
+// user it was created for, and resuming it as anyone else throws.
+const response2 = await myAgent.forUser('user-123').continue(convId).prompt('Tell me more about generics')
 // The agent sees the full conversation history
 
 // Streaming with conversations

--- a/packages/ai-sdk/src/agent.ts
+++ b/packages/ai-sdk/src/agent.ts
@@ -406,7 +406,10 @@ export abstract class Agent {
     return new ConversableAgent(this).forUser(userId)
   }
 
-  /** Continue an existing conversation */
+  /**
+   * Continue an existing conversation. Chain it after `forUser()` when the
+   * thread has an owner — resuming one as another user is refused (#984).
+   */
   continue(conversationId: string): ConversableAgent {
     return new ConversableAgent(this).continue(conversationId)
   }
@@ -1004,6 +1007,10 @@ export class ConversableAgent {
    * into a {@link ConversationalSpec}. The explicit chain bypasses the
    * agent's `conversational()` declaration entirely — `forUser` always
    * wins over class defaults.
+   *
+   * A bare `continue()` still yields an empty user rather than throwing: it
+   * is a legal call for threads that have no owner, and one whose owner
+   * check refuses it for every thread that does (#984).
    */
   private toSpec(): ConversationalSpec {
     if (this._conversationId) return { user: this._userId ?? '', id: this._conversationId }

--- a/packages/ai-sdk/src/auto-persist.test.ts
+++ b/packages/ai-sdk/src/auto-persist.test.ts
@@ -4,8 +4,8 @@ import assert from 'node:assert/strict'
 import { Agent, setConversationStore } from './agent.js'
 import { AiFake } from './fake.js'
 import { MemoryConversationStore } from './conversation.js'
-import { resolveAutoPersistSpec } from './conversation-persistence.js'
-import type { AgentResponse, AiMessage, ConversationalSpec } from './types.js'
+import { ConversationOwnershipError, resolveAutoPersistSpec } from './conversation-persistence.js'
+import type { AgentResponse, AiMessage, ConversationalSpec, ConversationStore } from './types.js'
 
 // Test agents with declarative conversational() opts-in. Each class stores
 // the user it was created with on the instance so tests can drive different
@@ -304,15 +304,147 @@ describe('Explicit forUser / continue precedence', () => {
   it('continue() loads the exact thread regardless of conversational()', async () => {
     const store = new MemoryConversationStore()
     setConversationStore(store)
-    const id = await store.create(undefined, { userId: 'someone-else' })
+    const id = await store.create(undefined, { userId: 'u-owner' })
     await store.append(id, [{ role: 'user', content: 'old' }])
 
     fake.respondWith('continued')
     ChatAgent.lastUser = 'u-class'  // class would route to u-class
-    const r = await new ChatAgent().continue(id).prompt('next')
+    const r = await new ChatAgent().forUser('u-owner').continue(id).prompt('next')
 
     assert.equal(r.conversationId, id, 'continue(id) wins over class declaration')
     const messages = await store.load(id)
     assert.deepStrictEqual(messages.map(m => m.content), ['old', 'next', 'continued'])
+  })
+})
+
+// ─── Ownership of a resumed thread (#984) ─────────────────
+
+describe('Resume-by-id owner check', () => {
+  let fake: AiFake
+
+  beforeEach(() => {
+    fake = AiFake.fake()
+    ChatAgent.lastUser = undefined
+    setConversationStore(undefined as unknown as never)
+  })
+
+  /** Seed a thread owned by `userId` holding one message. */
+  async function seed(store: MemoryConversationStore, userId?: string): Promise<string> {
+    const id = await store.create(undefined, userId ? { userId, agent: 'ChatAgent' } : undefined)
+    await store.append(id, [{ role: 'user', content: 'bob-secret' }])
+    return id
+  }
+
+  it('forUser(alice).continue(bobsThread) is refused and leaves the thread untouched', async () => {
+    const store = new MemoryConversationStore()
+    setConversationStore(store)
+    fake.respondWith('leaked?')
+    const bobs = await seed(store, 'bob')
+
+    await assert.rejects(
+      () => new ChatAgent().forUser('alice').continue(bobs).prompt('what did bob say?'),
+      /is owned by a different user/,
+    )
+
+    // Neither read into the run nor appended to.
+    assert.equal(fake.getCalls().length, 0, 'the provider never saw bob history')
+    const messages = await store.load(bobs)
+    assert.deepStrictEqual(messages.map(m => m.content), ['bob-secret'])
+  })
+
+  it('rejects with ConversationOwnershipError carrying the id and the scoped user', async () => {
+    const store = new MemoryConversationStore()
+    setConversationStore(store)
+    fake.respondWith('leaked?')
+    const bobs = await seed(store, 'bob')
+
+    const err = await new ChatAgent().forUser('alice').continue(bobs).prompt('hi').then(
+      () => null,
+      (e: unknown) => e,
+    )
+    assert.ok(err instanceof ConversationOwnershipError, `expected ConversationOwnershipError, got ${String(err)}`)
+    assert.equal(err.conversationId, bobs)
+    assert.equal(err.userId, 'alice')
+    assert.ok(!err.message.includes('bob'), 'the message must not name the real owner')
+  })
+
+  it('per-call { conversation: { user, id } } is refused across users too', async () => {
+    const store = new MemoryConversationStore()
+    setConversationStore(store)
+    fake.respondWith('leaked?')
+    const bobs = await seed(store, 'bob')
+
+    await assert.rejects(
+      () => new StatelessAgent().prompt('what did bob say?', { conversation: { user: 'alice', id: bobs } }),
+      /is owned by a different user/,
+    )
+    assert.equal(fake.getCalls().length, 0)
+  })
+
+  it('streaming refuses before any chunk is produced', async () => {
+    const store = new MemoryConversationStore()
+    setConversationStore(store)
+    fake.respondWith('leaked?')
+    const bobs = await seed(store, 'bob')
+
+    const { stream, response } = new ChatAgent().forUser('alice').continue(bobs).stream('hi')
+    await assert.rejects(async () => { for await (const _c of stream) { void _c } }, /is owned by a different user/)
+    await assert.rejects(() => response, /is owned by a different user/)
+    assert.equal(fake.getCalls().length, 0)
+  })
+
+  it('the owner still resumes their own thread by id', async () => {
+    const store = new MemoryConversationStore()
+    setConversationStore(store)
+    fake.respondWith('welcome back')
+    const bobs = await seed(store, 'bob')
+
+    const r = await new ChatAgent().forUser('bob').continue(bobs).prompt('me again')
+    assert.equal(r.conversationId, bobs)
+    const messages = await store.load(bobs)
+    assert.deepStrictEqual(messages.map(m => m.content), ['bob-secret', 'me again', 'welcome back'])
+  })
+
+  it('a thread with no stored owner stays resumable by a bare continue()', async () => {
+    const store = new MemoryConversationStore()
+    setConversationStore(store)
+    fake.respondWith('still open')
+    const orphan = await seed(store)  // pre-#984 row: created without meta
+
+    const r = await new ChatAgent().continue(orphan).prompt('resume me')
+    assert.equal(r.conversationId, orphan)
+    const messages = await store.load(orphan)
+    assert.deepStrictEqual(messages.map(m => m.content), ['bob-secret', 'resume me', 'still open'])
+  })
+
+  it('a bare continue() on an owned thread is refused like any other mismatch', async () => {
+    const store = new MemoryConversationStore()
+    setConversationStore(store)
+    fake.respondWith('leaked?')
+    const bobs = await seed(store, 'bob')
+
+    await assert.rejects(
+      () => new ChatAgent().continue(bobs).prompt('no user here'),
+      /chain forUser\(ownerId\)/,
+    )
+  })
+
+  it('a store that does not report userId keeps its old permissive behavior', async () => {
+    // The check reads the owner off list() entries, so a store that omits it
+    // cannot be enforced — it must not start failing closed instead.
+    const store = new MemoryConversationStore()
+    const bobs = await seed(store, 'bob')
+    const blind: ConversationStore = {
+      create: (t, m) => store.create(t, m),
+      load:   id => store.load(id),
+      append: (id, m) => store.append(id, m),
+      setTitle: (id, t) => store.setTitle(id, t),
+      list: async userId => (await store.list(userId)).map(({ userId: _drop, ...rest }) => rest),
+    }
+    setConversationStore(blind)
+    fake.respondWith('as before')
+
+    const r = await new ChatAgent().forUser('alice').continue(bobs).prompt('hi')
+    assert.equal(r.conversationId, bobs)
   })
 })

--- a/packages/ai-sdk/src/conversation-persistence.ts
+++ b/packages/ai-sdk/src/conversation-persistence.ts
@@ -47,6 +47,62 @@ export async function resolveAutoPersistSpec(
   return declared
 }
 
+/**
+ * Thrown when a run scoped to one user tries to resume a thread another user
+ * owns (#984). A distinct type so a server can answer 403 rather than 500,
+ * and so a store failure is never mistaken for a refusal.
+ */
+export class ConversationOwnershipError extends Error {
+  readonly conversationId: string
+  /** The user the run was scoped to. Never carries the real owner's id. */
+  readonly userId: string | undefined
+  constructor(conversationId: string, userId: string | undefined) {
+    const hint = userId
+      ? ''
+      : ' The call carries no user; chain forUser(ownerId) before continue(id).'
+    super(`[ai-sdk] Conversation "${conversationId}" is owned by a different user.${hint}`)
+    this.name = 'ConversationOwnershipError'
+    this.conversationId = conversationId
+    this.userId = userId
+  }
+}
+
+/**
+ * Owner recorded on a thread, or `undefined` when the store reports none.
+ * `undefined` is deliberately permissive: threads written before #984, and
+ * stores that don't mirror `meta.userId` into their listings, carry no owner
+ * and must stay readable by whoever holds the id.
+ */
+async function storedOwner(
+  store:  ConversationStore,
+  convId: string,
+  user:   string | undefined,
+): Promise<string | undefined> {
+  // Scoped listing first — the indexed read every store already supports, and
+  // a hit settles ownership without enumerating every thread in the backend.
+  if (user) {
+    const mine = await store.list(user)
+    if (mine.some(t => t.id === convId)) return user
+  }
+  const entry = (await store.list()).find(t => t.id === convId)
+  return entry?.userId || undefined
+}
+
+/**
+ * Resuming by id must be scoped to the user the run runs as (#984), otherwise
+ * any caller holding a thread id reads that thread's history into their run
+ * and appends their turn back into it.
+ */
+async function assertOwnership(
+  store:  ConversationStore,
+  convId: string,
+  user:   string | undefined,
+): Promise<void> {
+  const owner = await storedOwner(store, convId, user)
+  if (owner === undefined) return
+  if (owner !== (user || undefined)) throw new ConversationOwnershipError(convId, user)
+}
+
 interface PersistenceContext {
   spec:    ConversationalSpec
   store:   ConversationStore
@@ -65,7 +121,8 @@ interface PersistenceContext {
 /**
  * Run the load-or-create-thread half of the persistence flow. Resolves
  * the conversation id, loads history, applies `historyLimit`, and merges
- * with any caller-supplied `options.history`.
+ * with any caller-supplied `options.history`. An explicit id is owner-checked
+ * first (#984); the lookup-by-user branch is scoped by the store already.
  */
 async function preparePersistence(
   spec:           ConversationalSpec,
@@ -77,6 +134,7 @@ async function preparePersistence(
   let loaded: AiMessage[] = []
 
   if (convId) {
+    await assertOwnership(store, convId, spec.user)
     loaded = await store.load(convId)
   } else if (spec.user) {
     const agentKey = spec.agent ?? agentClassName

--- a/packages/ai-sdk/src/conversation.ts
+++ b/packages/ai-sdk/src/conversation.ts
@@ -55,6 +55,8 @@ export class MemoryConversationStore implements ConversationStore {
         createdAt: conv.createdAt,
         updatedAt: conv.updatedAt,
         ...(conv.meta?.agent ? { agent: conv.meta.agent } : {}),
+        // Reported so the resume-by-id owner check can see it (#984).
+        ...(conv.meta?.userId ? { userId: conv.meta.userId } : {}),
       }))
       .sort((a, b) => b.updatedAt!.getTime() - a.updatedAt!.getTime())
   }

--- a/packages/ai-sdk/src/index.ts
+++ b/packages/ai-sdk/src/index.ts
@@ -150,6 +150,7 @@ export { Output, type OutputWrapper } from './output.js'
 
 // Conversation
 export { MemoryConversationStore } from './conversation.js'
+export { ConversationOwnershipError } from './conversation-persistence.js'
 export { sanitizeConversation } from './sanitize-conversation.js'
 export {
   validateContinuation,

--- a/packages/ai-sdk/src/types.ts
+++ b/packages/ai-sdk/src/types.ts
@@ -942,6 +942,14 @@ export interface ConversationStoreListEntry {
   updatedAt?: Date
   /** Mirrors {@link ConversationStoreMeta.agent} on the source row. */
   agent?: string
+  /**
+   * Mirrors {@link ConversationStoreMeta.userId} on the source row — the only
+   * owner-aware read in the contract, so it is what the resume-by-id owner
+   * check reads (#984). A store that reports it gets threads only their owner
+   * can resume; a store that omits it stays as permissive as it was before,
+   * i.e. whoever holds the id can resume.
+   */
+  userId?: string
 }
 
 export interface ConversationStore {


### PR DESCRIPTION
Closes #984

`preparePersistence` loaded a conversation by id without ever reading `spec.user`, so `agent.forUser('alice').continue(bobsConversationId)` read Bob's whole thread into Alice's run and appended Alice's turn back into it. Same reach through `prompt(input, { conversation: { user: 'alice', id: bobsConvId } })` and through the streaming variant.

## What changed

The owner was already recorded at create time and simply never consulted. It is now read back and compared before the load; a mismatch throws `ConversationOwnershipError` (newly exported, so a server can answer 403 rather than 500). The error names the conversation and the user the run was scoped to, never the real owner.

`ConversationStore.load()` is untouched, as decided. Ownership is read from a new optional `ConversationStoreListEntry.userId` that mirrors `ConversationStoreMeta.userId` exactly the way `agent` already does. The scoped `list(user)` is consulted first (the indexed read every store already supports, and a hit settles it); the unscoped listing is only reached when that misses, i.e. on the refusal and unowned paths.

### One correction to the issue

The issue assumes the stored meta is already readable. It is not: `ConversationStoreListEntry` had `id`, `title`, `createdAt`, `updatedAt`, `agent` and no `userId`, and there is no other meta accessor on the contract. Without adding that field there is no way to tell "owned by someone else" from "owned by nobody", and telling those apart is exactly what the back-compat requirement needs. The field is optional and additive, so no existing implementation breaks.

### Empty user

A bare `continue(id)` is **not** made a special error. It keeps synthesizing `{ user: '', id }` and fails the same owner check as any other mismatch. Reasons:

- One rule, no special case, and the refusal message tells the caller to chain `forUser(ownerId)`.
- Making the absent user skip the check instead would leave a trivial bypass: `prompt(input, { conversation: { id: requestSuppliedId } })` resolves to a spec with no user, which is a perfectly plausible endpoint shape.
- Making it a hard error would break more than the owner check does: it would also refuse unowned threads, which single-user and CLI apps legitimately resume by id.

Net effect: a bare `continue()` resumes unowned threads exactly as before, and is refused for every thread that has an owner.

### No stored owner (back-compat)

Deliberately permissive, in two places:

- A thread whose meta carries no `userId` (created before this change, or by `store.create('title')` with no meta) resolves to "no owner" and stays resumable by whoever holds the id. No stored conversation becomes unreadable to its own user.
- A store that does not report `userId` in its listings cannot be enforced at all, so it stays as permissive as it was rather than failing closed and breaking every resume. There is a test pinning that.

### Docs

The package's own docs taught the now-refused idiom (`forUser('u').prompt()` then `continue(id).prompt()`) in three places. All three now chain `forUser('u').continue(id)` and state the rule. `docs/packages/ai-sdk/memory.md` also documents mirroring `userId` into `list()`.

## Tests

Baseline `packages/ai-sdk`: **885 tests / 0 fail**. After: **893 tests / 0 fail**. Root `pnpm test`: 21/21 turbo tasks pass.

One pre-existing test, `continue() loads the exact thread regardless of conversational()`, encoded the bug itself: it seeded a thread with `userId: 'someone-else'` and then bare-continued into it. It now seeds `u-owner` and resumes as `u-owner`, so it still asserts what it was written to assert (explicit form beats `conversational()`).

### Proof by revert

With the tests kept and only the enforcement call in `preparePersistence` disabled, rebuilt and re-run, 5 of the 8 new tests fail at runtime on their assertions (`Missing expected rejection.`, not a compile error):

```
ℹ tests 893
ℹ pass 888
ℹ fail 5

✖ forUser(alice).continue(bobsThread) is refused and leaves the thread untouched
✖ rejects with ConversationOwnershipError carrying the id and the scoped user
✖ per-call { conversation: { user, id } } is refused across users too
✖ streaming refuses before any chunk is produced
✖ a bare continue() on an owned thread is refused like any other mismatch
```

The other 3 (`the owner still resumes their own thread by id`, `a thread with no stored owner stays resumable by a bare continue()`, `a store that does not report userId keeps its old permissive behavior`) pass with and without the fix by design: they pin the paths that must not change.

## Changeset

`minor`, not patch. No signature changed and nothing breaks at compile time, but the release adds public surface (`ConversationOwnershipError`, `ConversationStoreListEntry.userId`) and changes documented runtime behavior: code that resumes an owned thread without the owner now throws. That is more than a patch says.
