### PR TITLE
fix(ai-autopilot): FakeFs lists the whole workspace for `.` and `/` (#998)

### DIFF
--- a/.changeset/fix-998-fakefs-list-root.md
+++ b/.changeset/fix-998-fakefs-list-root.md
@@ -1,0 +1,11 @@
+---
+'@gemstack/ai-autopilot': patch
+---
+
+`FakeRunner`'s filesystem now lists the whole workspace for `.` and `/`, matching what the local,
+Docker and WebContainer runners return.
+
+It returned `[]` instead. `.` keys to the empty string, so the prefix built for the filter was `/`,
+which no key starts with. Since `list_files` passes the model's `dir` straight through and `.` is
+the most natural thing an agent types for the workspace root, a test could assert agent behaviour
+on an apparently empty workspace where production hands back the full tree.

--- a/packages/ai-autopilot/src/runner/fake.test.ts
+++ b/packages/ai-autopilot/src/runner/fake.test.ts
@@ -56,6 +56,20 @@ describe('FakeRunnerSession.fs', () => {
     assert.equal(await s.fs.read('src/b.txt'), 'B')
     assert.deepEqual(await s.fs.list('src'), ['src/a.txt', 'src/b.txt'])
   })
+
+  it('lists the whole workspace for `.` and `/`, as the real runners do (#998)', async () => {
+    const s = await new FakeRunner().boot()
+    await s.fs.write('src/a.txt', 'A')
+    await s.fs.write('root.txt', 'R')
+    // `list_files` passes the model's `dir` through verbatim, and `.` is the most
+    // natural thing it types for the workspace root.
+    const all = ['root.txt', 'src/a.txt']
+    assert.deepEqual(await s.fs.list('.'), all)
+    assert.deepEqual(await s.fs.list('/'), all)
+    assert.deepEqual(await s.fs.list('./'), all)
+    assert.deepEqual(await s.fs.list(''), all)
+    assert.deepEqual(await s.fs.list(), all)
+  })
 })
 
 describe('FakeRunnerSession.exec', () => {

--- a/packages/ai-autopilot/src/runner/fake.ts
+++ b/packages/ai-autopilot/src/runner/fake.ts
@@ -53,7 +53,10 @@ class FakeFs implements RunnerFs {
   }
 
   async list(dir?: string): Promise<string[]> {
-    const prefix = dir ? fsKey(dir) + '/' : ''
+    // `.` and `/` key to the empty string, the workspace root, so they must list
+    // everything as the real runners do — not `'/'`, which no key starts with (#998).
+    const key = dir === undefined ? '' : fsKey(dir)
+    const prefix = key ? key + '/' : ''
     return [...this.files.keys()].filter(p => p.startsWith(prefix)).sort()
   }
 


### PR DESCRIPTION
Closes #998

`FakeFs.list('.')` returned `[]` where `LocalRunner`, `DockerRunner` and `WebContainerRunner` all return the whole tree.

`fsKey('.')` is the empty string (`safeSegments` drops `.` segments), and `list` built its filter prefix as `fsKey(dir) + '/'`, i.e. `'/'`. Map keys are `safeSegments(...).join('/')` and never carry a leading slash, so nothing matched. Same for `'/'` and `'./'`. Only the no-argument call worked, by hitting the falsy branch.

This matters because `runner/tools.ts:46` exposes `list_files` to the model and passes `dir` through verbatim, and `.` is the most natural thing an LLM types for the workspace root. A test could therefore assert agent behaviour on an apparently empty workspace where production hands back the full tree. `runner/path.ts:5-8` was extracted with a comment naming exactly this failure mode.

## Verification

Baseline `packages/ai-autopilot` on `origin/main`: 305 tests, 0 fail. After: 306, 0 fail. Root `pnpm build` and `pnpm test`: 21/21 turbo tasks pass.

Proved by reverting the one-line source change with the test kept. Exactly one test fails, on its assertion rather than on compilation:

```
✖ lists the whole workspace for `.` and `/`, as the real runners do (#998)
ℹ tests 306  ℹ pass 305  ℹ fail 1
```

No existing test depended on the old behaviour: a repo-wide grep for `list('.')`, `list(".")` and `list('/')` returns zero hits, and every existing `list` assertion uses `list('src')` or `list()`.