### PR TITLE
fix(ai-sdk): share one gate chain between the serial and parallel tool phases

### DIFF
--- a/.changeset/refactor-971-one-tool-phase.md
+++ b/.changeset/refactor-971-one-tool-phase.md
@@ -1,0 +1,24 @@
+---
+'@gemstack/ai-sdk': patch
+---
+
+Tool calls alongside a handoff now dispatch in parallel like every other batch (#971)
+
+`tool-execution.ts` implemented the tool phase twice, once serial and once parallel, with
+every gate written in both copies: unknown-tool, client-tool stop and placeholder, approval
+rejected and pending, `onBeforeToolCall` skip/abort/transformArgs, and argument validation.
+The `executeMaybeStreaming` pause-detection loop was duplicated near byte-for-byte,
+differing only in `yield` versus a push into a buffer.
+
+The copies had already drifted. The handoff branch existed only in the serial path, so
+`executeToolPhase` force-downgraded the whole step to serial whenever any call in it was a
+handoff. The gate chain is now one function, `decideToolCall()`, that returns a decision
+both paths consume, and one shared generator drives execution for both. The parallel path
+gained the handoff branch from that, so the downgrade is gone.
+
+The only user-visible change: in a step that mixes ordinary tool calls with a handoff, the
+ordinary calls decided before the handoff now run concurrently instead of one after another.
+Everything downstream is unchanged. The first handoff in a step still wins, later calls are
+still skipped with the same synthetic result rather than executed, and the tool messages are
+still emitted in tool-call order with identical content. Apps that need the old ordering can
+already opt out with `parallelTools: false`.

--- a/packages/ai-sdk/src/handoff.test.ts
+++ b/packages/ai-sdk/src/handoff.test.ts
@@ -381,6 +381,139 @@ describe('handoff loop integration', () => {
     assert.equal(sideEffectRan, false, 'sibling tool was skipped, not executed')
   })
 
+  // #971 removed the force-downgrade to serial dispatch when a handoff tool
+  // was present, so the two tests below exercise a handoff inside a
+  // multi-call step under BOTH dispatch modes and assert they agree.
+
+  it('parallel dispatch: a sibling after a handoff is skipped and the carried log stays paired', async () => {
+    const parent = scriptedAdapter('parent', [
+      {
+        kind: 'toolCalls',
+        calls: [
+          { id: 'p1', name: 'handoffToChild', arguments: { message: 'go' } },
+          { id: 'p2', name: 'sideEffect',     arguments: {} },
+        ],
+      },
+    ])
+    const childMsgs: AiMessage[][] = []
+    const child = scriptedAdapter('child', [{ kind: 'text', text: 'done' }], { lastMessages: childMsgs })
+
+    AiRegistry.register(parent.factory)
+    AiRegistry.register(child.factory)
+    AiRegistry.setDefault('parent/m')
+
+    let sideEffectRan = false
+    class Child extends Agent {
+      instructions() { return 'c' }
+      override model() { return 'child/m' }
+    }
+    class Parent extends Agent {
+      instructions() { return 'p' }
+      override model() { return 'parent/m' }
+      tools() {
+        return [
+          handoff(Child),
+          {
+            definition: { name: 'sideEffect', description: 'side effect', inputSchema: z.object({}) },
+            execute: async () => { sideEffectRan = true; return 'should not run' },
+            toSchema() {
+              return { name: 'sideEffect', description: 'side effect', parameters: { type: 'object', properties: {}, required: [], additionalProperties: false } }
+            },
+          } as never,
+        ]
+      }
+    }
+
+    const r = await new Parent().prompt('go', { parallelTools: true })
+    assert.equal(r.text, 'done')
+    assert.equal(sideEffectRan, false, 'sibling must not be dispatched once the handoff has been decided')
+
+    // Both tool calls still get a tool message, so the carried log replays.
+    const seen = childMsgs[0]!
+    assert.ok(seen.some(m => m.role === 'tool' && m.toolCallId === 'p1' && String(m.content).includes('Handed off to Child')))
+    assert.ok(seen.some(m => m.role === 'tool' && m.toolCallId === 'p2' && String(m.content).includes('Skipped: parent agent handed off')))
+  })
+
+  it('tools decided before a handoff still dispatch concurrently, and the log matches serial', async () => {
+    const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms))
+
+    const run = async (parallelTools: boolean) => {
+      AiRegistry.reset()
+      const parent = scriptedAdapter('parent', [
+        {
+          kind: 'toolCalls',
+          calls: [
+            { id: 'b1', name: 'slow_a',         arguments: {} },
+            { id: 'b2', name: 'fast_b',         arguments: {} },
+            { id: 'b3', name: 'handoffToChild', arguments: { message: 'go' } },
+          ],
+        },
+      ])
+      const childMsgs: AiMessage[][] = []
+      const child = scriptedAdapter('child', [{ kind: 'text', text: 'done' }], { lastMessages: childMsgs })
+
+      AiRegistry.register(parent.factory)
+      AiRegistry.register(child.factory)
+      AiRegistry.setDefault('parent/m')
+
+      const events: string[] = []
+      const sleeper = (name: string, ms: number) => ({
+        definition: { name, description: name, inputSchema: z.object({}) },
+        execute: async () => {
+          events.push(`${name}-enter`)
+          await sleep(ms)
+          events.push(`${name}-exit`)
+          return `${name}-done`
+        },
+        toSchema() {
+          return { name, description: name, parameters: { type: 'object', properties: {}, required: [], additionalProperties: false } }
+        },
+      }) as never
+
+      class Child extends Agent {
+        instructions() { return 'c' }
+        override model() { return 'child/m' }
+      }
+      class Parent extends Agent {
+        instructions() { return 'p' }
+        override model() { return 'parent/m' }
+        tools() { return [sleeper('slow_a', 40), sleeper('fast_b', 5), handoff(Child)] }
+      }
+
+      const r = await new Parent().prompt('go', { parallelTools })
+      return {
+        text:        r.text,
+        handoffPath: r.handoffPath,
+        events,
+        toolMsgs:    childMsgs[0]!.filter(m => m.role === 'tool'),
+      }
+    }
+
+    const parallel = await run(true)
+    const serial   = await run(false)
+
+    // The handoff no longer forces serial dispatch (#971): both non-handoff
+    // calls enter before either exits.
+    const enters = [parallel.events.indexOf('slow_a-enter'), parallel.events.indexOf('fast_b-enter')]
+    const exits  = [parallel.events.indexOf('slow_a-exit'),  parallel.events.indexOf('fast_b-exit')]
+    assert.ok(enters.every(i => i >= 0) && exits.every(i => i >= 0), `all lifecycle events fire — got ${parallel.events.join(' → ')}`)
+    assert.ok(Math.max(...enters) < Math.min(...exits), `concurrent: both enters precede both exits — got ${parallel.events.join(' → ')}`)
+    // Serial still interleaves, which is what the downgrade used to force.
+    assert.deepEqual(serial.events, ['slow_a-enter', 'slow_a-exit', 'fast_b-enter', 'fast_b-exit'])
+
+    // Everything observable downstream is identical between the two modes.
+    for (const [mode, got] of [['parallel', parallel], ['serial', serial]] as const) {
+      assert.equal(got.text, 'done', `${mode}: child still produces the final text`)
+      assert.deepEqual(got.toolMsgs.map(m => m.toolCallId), ['b1', 'b2', 'b3'], `${mode}: tool messages stay in tool-call order`)
+      assert.ok(String(got.toolMsgs[2]!.content).includes('Handed off to Child'), `${mode}: handoff result recorded`)
+    }
+    assert.deepEqual(parallel.handoffPath, serial.handoffPath)
+    assert.deepEqual(
+      parallel.toolMsgs.map(m => m.content),
+      serial.toolMsgs.map(m => m.content),
+    )
+  })
+
   it('handoffPath is absent when no handoff occurred', async () => {
     const adapter = scriptedAdapter('plain', [{ kind: 'text', text: 'hi' }])
     AiRegistry.register(adapter.factory)

--- a/packages/ai-sdk/src/tool-execution.ts
+++ b/packages/ai-sdk/src/tool-execution.ts
@@ -44,15 +44,7 @@ export async function* executeToolPhase(
   // agent-level override which defaults to `true`. Single-tool batches
   // route through the serial path either way (no parallelism to gain, and
   // serial preserves live `tool-update` streaming for that one tool).
-  //
-  // Handoffs always force serial dispatch — the parent loop has to halt
-  // immediately on the first handoff and synthesize "skipped" results for
-  // any sibling calls. Handling that across the parallel classify/replay
-  // phases is doable but adds complexity for negligible benefit (the model
-  // rarely emits parallel siblings alongside a handoff, and even then,
-  // running them while the agent is being torn down is wasted work).
-  const hasHandoff = toolCalls.some(tc => isHandoffTool(loopCtx.toolMap.get(tc.name)))
-  const parallel = (options?.parallelTools ?? loopCtx.agent.parallelTools()) && toolCalls.length > 1 && !hasHandoff
+  const parallel = (options?.parallelTools ?? loopCtx.agent.parallelTools()) && toolCalls.length > 1
 
   if (parallel) {
     yield* runToolPhaseParallel(loopCtx, toolCalls, toolResults)
@@ -67,147 +59,25 @@ export async function* executeToolPhase(
 }
 
 /**
- * Serial tool execution — the original behavior. Runs each tool call's
- * prelude (approval, before-middleware, validation) and `execute()`
- * one-after-another, streaming `tool-update` chunks live as the tool
- * emits them.
+ * Serial tool execution — the original behavior. Decides each tool call's
+ * fate and runs its `execute()` one-after-another, streaming `tool-update`
+ * chunks live as the tool emits them.
  */
 async function* runToolPhaseSerial(
   loopCtx:     LoopContext,
   toolCalls:   ToolCall[],
   toolResults: ToolResult[],
 ): AsyncGenerator<StreamChunk, void, void> {
-  const { messages, middlewares, toolMap, options, ctx } = loopCtx
+  const { messages, middlewares, ctx } = loopCtx
 
   for (const tc of toolCalls) {
-    const tool = toolMap.get(tc.name)
-    if (!tool) {
-      const unknownResult = `Error: Unknown tool "${tc.name}"`
-      toolResults.push({ toolCallId: tc.id, result: unknownResult })
-      messages.push({ role: 'tool', content: unknownResult, toolCallId: tc.id })
-      yield { type: 'tool-result' as const, toolCall: tc, result: unknownResult }
+    const decision = await decideToolCall(loopCtx, tc)
+
+    if (decision.kind !== 'ready') {
+      yield* emitDecision(loopCtx, decision, toolResults)
+      if (haltsToolPhase(decision)) break
       continue
     }
-
-    // Handoff — detected before the no-execute (client tool) branch because
-    // a handoff tool also has no `execute`, but it has wholly different
-    // semantics: pivot control to a new agent instead of pausing for the
-    // browser. The first handoff in a step wins; any subsequent tool calls
-    // in the same step are skipped with a synthetic "skipped: handed off"
-    // tool result so the message log stays well-formed for replay.
-    if (loopCtx.stopForHandoff) {
-      const skippedResult = 'Skipped: parent agent handed off to another agent.'
-      toolResults.push({ toolCallId: tc.id, result: skippedResult })
-      messages.push({ role: 'tool', content: skippedResult, toolCallId: tc.id })
-      yield { type: 'tool-call' as const, toolCall: tc }
-      yield { type: 'tool-result' as const, toolCall: tc, result: skippedResult }
-      continue
-    }
-    if (isHandoffTool(tool)) {
-      const spec = tool.__handoffSpec
-      const validation = validateToolArgs(tool, tc.arguments)
-      // Handoff payload defaults to `{ message: string }`; custom schemas
-      // are accepted but the loop only uses `args.message` (string) as the
-      // transition prompt. Anything else surfaces in the conversation as
-      // the args of the synthetic tool-call.
-      const args = validation.ok ? (validation.value as Record<string, unknown>) : (tc.arguments as Record<string, unknown>)
-      const transitionMessage = typeof args['message'] === 'string' ? (args['message'] as string) : ''
-      const handoffResult = `Handed off to ${spec.AgentClass.name}.`
-
-      toolResults.push({ toolCallId: tc.id, result: handoffResult })
-      messages.push({ role: 'tool', content: handoffResult, toolCallId: tc.id })
-      yield { type: 'tool-call' as const, toolCall: tc }
-      yield { type: 'tool-result' as const, toolCall: tc, result: handoffResult }
-      yield {
-        type: 'handoff' as const,
-        handoff: {
-          from: loopCtx.agent.constructor.name,
-          to:   spec.AgentClass.name,
-          ...(transitionMessage ? { message: transitionMessage } : {}),
-        },
-      }
-
-      loopCtx.pendingHandoff = { spec, transitionMessage, parentToolCallId: tc.id }
-      loopCtx.stopForHandoff = true
-      // Do NOT break — keep iterating so any sibling tool calls in this
-      // step get their synthetic "skipped" tool results before the loop
-      // exits. This preserves message-log invariants for downstream
-      // persistence.
-      continue
-    }
-
-    if (!tool.execute) {
-      // Client tool — no server-side handler.
-      if (options?.toolCallStreamingMode === 'stop-on-client-tool') {
-        loopCtx.pendingClientToolCalls.push(tc)
-        loopCtx.loopFinishReason = 'client_tool_calls'
-        loopCtx.stopForClientTools = true
-        yield { type: 'tool-call' as const, toolCall: tc }
-        continue
-      }
-      const placeholder = '[client tool — execute on client]'
-      toolResults.push({ toolCallId: tc.id, result: placeholder })
-      messages.push({ role: 'tool', content: placeholder, toolCallId: tc.id })
-      yield { type: 'tool-call' as const, toolCall: tc }
-      yield { type: 'tool-result' as const, toolCall: tc, result: placeholder }
-      continue
-    }
-
-    // needsApproval enforcement
-    const approvalDecision = await evaluateApproval(tool, tc, options)
-    if (approvalDecision === 'rejected') {
-      const rejectionResult = { rejected: true, reason: 'User rejected this tool call' }
-      toolResults.push({ toolCallId: tc.id, result: rejectionResult })
-      messages.push({ role: 'tool', content: JSON.stringify(rejectionResult), toolCallId: tc.id })
-      yield { type: 'tool-result' as const, toolCall: tc, result: rejectionResult }
-      continue
-    }
-    if (approvalDecision === 'pending') {
-      loopCtx.pendingApprovalToolCall = { toolCall: tc, isClientTool: false }
-      loopCtx.loopFinishReason = 'tool_approval_required'
-      loopCtx.stopForApproval = true
-      yield { type: 'tool-call' as const, toolCall: tc }
-      break
-    }
-
-    // onBeforeToolCall
-    let toolArgs = tc.arguments
-    if (middlewares.length > 0) {
-      const beforeResult = await runOnBeforeToolCall(middlewares, ctx, tc.name, toolArgs)
-      if (beforeResult) {
-        if (beforeResult.type === 'skip') {
-          const resultStr = typeof beforeResult.result === 'string' ? beforeResult.result : JSON.stringify(beforeResult.result)
-          toolResults.push({ toolCallId: tc.id, result: beforeResult.result })
-          messages.push({ role: 'tool', content: resultStr, toolCallId: tc.id })
-          yield { type: 'tool-result' as const, toolCall: tc, result: beforeResult.result }
-          await runOnAfterToolCall(middlewares, ctx, tc.name, toolArgs, beforeResult.result)
-          continue
-        }
-        if (beforeResult.type === 'abort') {
-          await runOnAbort(middlewares, ctx, beforeResult.reason)
-          break
-        }
-        if (beforeResult.type === 'transformArgs') {
-          toolArgs = beforeResult.args
-        }
-      }
-    }
-
-    // Validate args against the tool's inputSchema. Runs after middleware
-    // transforms so transforms can reshape malformed model output before
-    // it is judged. The tool-call chunk is emitted even on validation
-    // failure so streaming UIs see a paired tool-call → tool-result(error)
-    // sequence; non-streaming callers discard the chunk.
-    const validation = validateToolArgs(tool, toolArgs)
-    if (!validation.ok) {
-      yield { type: 'tool-call' as const, toolCall: tc }
-      toolResults.push({ toolCallId: tc.id, result: validation.error })
-      messages.push({ role: 'tool', content: JSON.stringify(validation.error), toolCallId: tc.id })
-      yield { type: 'tool-result' as const, toolCall: tc, result: validation.error }
-      if (middlewares.length > 0) await runOnAfterToolCall(middlewares, ctx, tc.name, toolArgs, validation.error)
-      continue
-    }
-    const validatedArgs = validation.value
 
     const toolStart = performance.now()
     try {
@@ -215,67 +85,15 @@ async function* runToolPhaseSerial(
       // tool-call → tool-update* → tool-result in order. Async-generator
       // executes stream their yields as tool-update chunks live; plain
       // executes yield nothing here.
-      //
-      // Pause detection: a yielded `pause_for_client_tools` control chunk
-      // halts iteration, propagates the nested calls to the parent's
-      // pending list, and SKIPS the tool_result emission — the yielding
-      // tool's own call stays orphaned in the parent message history
-      // until the caller resolves it on resume.
       yield { type: 'tool-call' as const, toolCall: tc }
-      const execGen = executeMaybeStreaming(tool, validatedArgs, { toolCallId: tc.id })
-      let result: unknown
-      let paused = false
-      while (true) {
-        const step = await execGen.next()
-        if (step.done) {
-          result = step.value
-          break
-        }
-        if (isPauseForClientToolsChunk(step.value)) {
-          for (const pending of step.value.toolCalls) {
-            loopCtx.pendingClientToolCalls.push(pending)
-          }
-          loopCtx.loopFinishReason = 'client_tool_calls'
-          loopCtx.stopForClientTools = true
-          paused = true
-          break
-        }
-        if (isPauseForApprovalChunk(step.value)) {
-          loopCtx.pendingApprovalToolCall = {
-            toolCall:     step.value.toolCall,
-            isClientTool: step.value.isClientTool,
-          }
-          loopCtx.loopFinishReason = 'tool_approval_required'
-          loopCtx.stopForApproval = true
-          paused = true
-          break
-        }
-        const updateChunk: StreamChunk = { type: 'tool-update', toolCall: tc, update: step.value }
-        if (middlewares.length > 0) {
-          const transformed = runOnChunk(middlewares, ctx, updateChunk)
-          if (transformed) yield transformed
-        } else {
-          yield updateChunk
-        }
-      }
-      if (paused) continue   // skip tool_result emission + message push for this tc
-      const duration = performance.now() - toolStart
-      // toolResults preserves the ORIGINAL value; only the message content
-      // pushed onto `messages` (next-step model input) is narrowed by
-      // toModelOutput. The streamed `tool-result` chunk also carries the
-      // ORIGINAL value.
-      toolResults.push({ toolCallId: tc.id, result, duration })
-      const resultStr = await applyToModelOutput(
-        tool,
-        result,
-        middlewares.length > 0 ? (e) => runOnError(middlewares, ctx, e) : undefined,
-      )
-      messages.push({ role: 'tool', content: resultStr, toolCallId: tc.id })
-      yield { type: 'tool-result' as const, toolCall: tc, result }
-
-      // onAfterToolCall
-      if (middlewares.length > 0) await runOnAfterToolCall(middlewares, ctx, tc.name, toolArgs, result)
+      const exec = yield* runToolExecution(loopCtx, decision)
+      yield* emitExecutionResult(loopCtx, decision, exec, toolResults)
     } catch (err: unknown) {
+      // `runToolExecution` already funnels `execute()` throws into an
+      // `error` outcome, so only the post-execution hooks (a rejecting
+      // `onAfterToolCall`/`onError`) can land here. Serial has always
+      // reported those as the tool's result; the parallel replay lets them
+      // propagate. See #971 — the two are deliberately left as they were.
       const duration = performance.now() - toolStart
       const msg = err instanceof Error ? err.message : String(err)
       const errResult = `Error: ${msg}`
@@ -284,7 +102,7 @@ async function* runToolPhaseSerial(
       yield { type: 'tool-result' as const, toolCall: tc, result: errResult }
 
       // onAfterToolCall (error case)
-      if (middlewares.length > 0) await runOnAfterToolCall(middlewares, ctx, tc.name, toolArgs, errResult)
+      if (middlewares.length > 0) await runOnAfterToolCall(middlewares, ctx, tc.name, decision.toolArgs, errResult)
     }
   }
 }
@@ -292,18 +110,20 @@ async function* runToolPhaseSerial(
 /**
  * Parallel tool execution — three phases:
  *
- * 1. **Prelude (serial, in tool-call order):** classify each call. Approval
- *    decisions, `onBeforeToolCall` middleware, and arg validation all
- *    resolve here; the next phase only sees calls that cleared every
- *    gate. `pending-approval` and `mw-abort` short-circuit the prelude
- *    exactly as they do in serial mode — later calls are never dispatched.
+ * 1. **Prelude (serial, in tool-call order):** run {@link decideToolCall}
+ *    for each call. Approval decisions, `onBeforeToolCall` middleware, and
+ *    arg validation all resolve here; the next phase only sees calls that
+ *    cleared every gate. `pending-approval` and `mw-abort` short-circuit the
+ *    prelude exactly as they do in serial mode — later calls are never
+ *    dispatched. A handoff does the same by flipping `loopCtx.stopForHandoff`,
+ *    which turns every later call into `handoff-skipped`.
  *
- * 2. **Execution (parallel):** for every `ready` outcome, drive
+ * 2. **Execution (parallel):** for every `ready` decision, drive
  *    `executeMaybeStreaming` to completion concurrently. `tool-update`
  *    chunks (and any pause-for-client-tools mutations to `loopCtx`) are
  *    captured per-call into a buffer.
  *
- * 3. **Replay (serial, in tool-call order):** for each outcome, emit its
+ * 3. **Replay (serial, in tool-call order):** for each decision, emit its
  *    chunks (including buffered `tool-update`s for ready calls), push
  *    tool messages, and run `onAfterToolCall`. This is the only phase
  *    that yields chunks to consumers, so streamed output stays
@@ -314,102 +134,41 @@ async function* runToolPhaseParallel(
   toolCalls:   ToolCall[],
   toolResults: ToolResult[],
 ): AsyncGenerator<StreamChunk, void, void> {
-  const { messages, middlewares, ctx } = loopCtx
-
   // ─── Phase 1: prelude ──────────────────────────────────
-  const outcomes = await classifyToolCalls(loopCtx, toolCalls)
+  const decisions: ToolCallDecision[] = []
+  for (const tc of toolCalls) {
+    const decision = await decideToolCall(loopCtx, tc)
+    // Halting decisions are kept in the list so Phase 3 emits everything
+    // up to and including them, exactly as serial does before it breaks.
+    decisions.push(decision)
+    if (haltsToolPhase(decision)) break
+  }
 
   // ─── Phase 2: dispatch ready executions concurrently ──
-  const ready = outcomes.filter((o): o is ReadyOutcome => o.kind === 'ready')
-  const executions = await Promise.all(ready.map(o => runToolExecution(loopCtx, o)))
-  const executionByCallId = new Map<string, ToolExecutionResult>()
+  const ready = decisions.filter((d): d is ReadyDecision => d.kind === 'ready')
+  const executions = await Promise.all(ready.map(d => bufferToolExecution(loopCtx, d)))
+  const executionByCallId = new Map<string, BufferedExecution>()
   for (let i = 0; i < ready.length; i++) {
     executionByCallId.set(ready[i]!.tc.id, executions[i]!)
   }
 
   // ─── Phase 3: replay chunks + side-effects in order ───
-  for (const outcome of outcomes) {
-    if (outcome.kind === 'unknown-tool') {
-      toolResults.push({ toolCallId: outcome.tc.id, result: outcome.result })
-      messages.push({ role: 'tool', content: outcome.result, toolCallId: outcome.tc.id })
-      yield { type: 'tool-result' as const, toolCall: outcome.tc, result: outcome.result }
+  for (const decision of decisions) {
+    if (decision.kind !== 'ready') {
+      yield* emitDecision(loopCtx, decision, toolResults)
+      if (haltsToolPhase(decision)) break
       continue
     }
-    if (outcome.kind === 'client-tool-stop') {
-      // loopCtx mutations already applied during the prelude.
-      yield { type: 'tool-call' as const, toolCall: outcome.tc }
-      continue
-    }
-    if (outcome.kind === 'client-tool-placeholder') {
-      toolResults.push({ toolCallId: outcome.tc.id, result: outcome.result })
-      messages.push({ role: 'tool', content: outcome.result, toolCallId: outcome.tc.id })
-      yield { type: 'tool-call' as const, toolCall: outcome.tc }
-      yield { type: 'tool-result' as const, toolCall: outcome.tc, result: outcome.result }
-      continue
-    }
-    if (outcome.kind === 'rejected') {
-      toolResults.push({ toolCallId: outcome.tc.id, result: outcome.result })
-      messages.push({ role: 'tool', content: JSON.stringify(outcome.result), toolCallId: outcome.tc.id })
-      yield { type: 'tool-result' as const, toolCall: outcome.tc, result: outcome.result }
-      continue
-    }
-    if (outcome.kind === 'pending-approval') {
-      // loopCtx mutations already applied during the prelude.
-      yield { type: 'tool-call' as const, toolCall: outcome.tc }
-      // Phase 1 stops classifying after pending-approval, so this is the
-      // last outcome — but `break` keeps the intent explicit.
-      break
-    }
-    if (outcome.kind === 'mw-skip') {
-      const resultStr = typeof outcome.result === 'string' ? outcome.result : JSON.stringify(outcome.result)
-      toolResults.push({ toolCallId: outcome.tc.id, result: outcome.result })
-      messages.push({ role: 'tool', content: resultStr, toolCallId: outcome.tc.id })
-      yield { type: 'tool-result' as const, toolCall: outcome.tc, result: outcome.result }
-      if (middlewares.length > 0) await runOnAfterToolCall(middlewares, ctx, outcome.tc.name, outcome.toolArgs, outcome.result)
-      continue
-    }
-    if (outcome.kind === 'validation-error') {
-      yield { type: 'tool-call' as const, toolCall: outcome.tc }
-      toolResults.push({ toolCallId: outcome.tc.id, result: outcome.error })
-      messages.push({ role: 'tool', content: JSON.stringify(outcome.error), toolCallId: outcome.tc.id })
-      yield { type: 'tool-result' as const, toolCall: outcome.tc, result: outcome.error }
-      if (middlewares.length > 0) await runOnAfterToolCall(middlewares, ctx, outcome.tc.name, outcome.toolArgs, outcome.error)
-      continue
-    }
-    // outcome.kind === 'ready'
-    const exec = executionByCallId.get(outcome.tc.id)!
-    yield { type: 'tool-call' as const, toolCall: outcome.tc }
-    for (const chunk of exec.updates) yield chunk
-    if (exec.kind === 'paused') {
-      // Pause-for-client-tools propagated its calls onto `loopCtx` during
-      // execution. Skip tool_result emission + message push — the call
-      // stays orphaned until resume.
-      continue
-    }
-    if (exec.kind === 'error') {
-      const errResult = `Error: ${exec.error.message}`
-      toolResults.push({ toolCallId: outcome.tc.id, result: errResult, duration: exec.duration })
-      messages.push({ role: 'tool', content: errResult, toolCallId: outcome.tc.id })
-      yield { type: 'tool-result' as const, toolCall: outcome.tc, result: errResult }
-      if (middlewares.length > 0) await runOnAfterToolCall(middlewares, ctx, outcome.tc.name, outcome.toolArgs, errResult)
-      continue
-    }
-    // exec.kind === 'ok'
-    toolResults.push({ toolCallId: outcome.tc.id, result: exec.result, duration: exec.duration })
-    const resultStr = await applyToModelOutput(
-      outcome.tool,
-      exec.result,
-      middlewares.length > 0 ? (e) => runOnError(middlewares, ctx, e) : undefined,
-    )
-    messages.push({ role: 'tool', content: resultStr, toolCallId: outcome.tc.id })
-    yield { type: 'tool-result' as const, toolCall: outcome.tc, result: exec.result }
-    if (middlewares.length > 0) await runOnAfterToolCall(middlewares, ctx, outcome.tc.name, outcome.toolArgs, exec.result)
+    const buffered = executionByCallId.get(decision.tc.id)!
+    yield { type: 'tool-call' as const, toolCall: decision.tc }
+    for (const chunk of buffered.updates) yield chunk
+    yield* emitExecutionResult(loopCtx, decision, buffered.exec, toolResults)
   }
 }
 
-// ─── Parallel-mode helpers ───────────────────────────────
+// ─── The shared gate chain ───────────────────────────────
 
-type ReadyOutcome = {
+type ReadyDecision = {
   kind:          'ready'
   tc:            ToolCall
   tool:          AnyTool
@@ -417,113 +176,249 @@ type ReadyOutcome = {
   validatedArgs: Record<string, unknown>
 }
 
-type PreludeOutcome =
+type NonReadyDecision =
   | { kind: 'unknown-tool';             tc: ToolCall; result: string }
+  | { kind: 'handoff-skipped';          tc: ToolCall; result: string }
+  | { kind: 'handoff';                  tc: ToolCall; result: string; chunk: StreamChunk }
   | { kind: 'client-tool-placeholder';  tc: ToolCall; result: string }
   | { kind: 'client-tool-stop';         tc: ToolCall }
   | { kind: 'rejected';                 tc: ToolCall; result: { rejected: true; reason: string } }
   | { kind: 'pending-approval';         tc: ToolCall }
   | { kind: 'mw-skip';                  tc: ToolCall; toolArgs: Record<string, unknown>; result: unknown }
+  | { kind: 'mw-abort';                 tc: ToolCall }
   | { kind: 'validation-error';         tc: ToolCall; toolArgs: Record<string, unknown>; error: InvalidToolArgumentsError }
-  | ReadyOutcome
 
-/**
- * Walk `toolCalls` in order and decide each call's fate. Mutations to
- * `loopCtx` for client-tool-stop, pending-approval, and middleware-abort
- * happen here so the rest of the parallel flow sees the same state the
- * serial path would. `pending-approval` and `mw-abort` stop the walk —
- * later calls are not classified and are silently dropped.
- */
-async function classifyToolCalls(loopCtx: LoopContext, toolCalls: ToolCall[]): Promise<PreludeOutcome[]> {
-  const { middlewares, toolMap, options, ctx } = loopCtx
-  const outcomes: PreludeOutcome[] = []
+type ToolCallDecision = NonReadyDecision | ReadyDecision
 
-  for (const tc of toolCalls) {
-    const tool = toolMap.get(tc.name)
-    if (!tool) {
-      outcomes.push({ kind: 'unknown-tool', tc, result: `Error: Unknown tool "${tc.name}"` })
-      continue
-    }
-    if (!tool.execute) {
-      if (options?.toolCallStreamingMode === 'stop-on-client-tool') {
-        loopCtx.pendingClientToolCalls.push(tc)
-        loopCtx.loopFinishReason = 'client_tool_calls'
-        loopCtx.stopForClientTools = true
-        outcomes.push({ kind: 'client-tool-stop', tc })
-        continue
-      }
-      outcomes.push({ kind: 'client-tool-placeholder', tc, result: '[client tool — execute on client]' })
-      continue
-    }
-
-    const approvalDecision = await evaluateApproval(tool, tc, options)
-    if (approvalDecision === 'rejected') {
-      outcomes.push({ kind: 'rejected', tc, result: { rejected: true, reason: 'User rejected this tool call' } })
-      continue
-    }
-    if (approvalDecision === 'pending') {
-      loopCtx.pendingApprovalToolCall = { toolCall: tc, isClientTool: false }
-      loopCtx.loopFinishReason = 'tool_approval_required'
-      loopCtx.stopForApproval = true
-      outcomes.push({ kind: 'pending-approval', tc })
-      break
-    }
-
-    let toolArgs = tc.arguments
-    if (middlewares.length > 0) {
-      const beforeResult = await runOnBeforeToolCall(middlewares, ctx, tc.name, toolArgs)
-      if (beforeResult) {
-        if (beforeResult.type === 'skip') {
-          outcomes.push({ kind: 'mw-skip', tc, toolArgs, result: beforeResult.result })
-          continue
-        }
-        if (beforeResult.type === 'abort') {
-          await runOnAbort(middlewares, ctx, beforeResult.reason)
-          // Drop any prior outcomes too? No — serial mode emits prior
-          // outcomes' chunks before hitting abort, so we keep them in the
-          // outcomes list and Phase 3 emits them up to (but not including)
-          // this call. Stop classifying further.
-          break
-        }
-        if (beforeResult.type === 'transformArgs') {
-          toolArgs = beforeResult.args
-        }
-      }
-    }
-
-    const validation = validateToolArgs(tool, toolArgs)
-    if (!validation.ok) {
-      outcomes.push({ kind: 'validation-error', tc, toolArgs, error: validation.error })
-      continue
-    }
-
-    outcomes.push({ kind: 'ready', tc, tool, toolArgs, validatedArgs: validation.value })
-  }
-
-  return outcomes
+/** Decisions after which no further tool call in the step is dispatched. */
+function haltsToolPhase(decision: ToolCallDecision): boolean {
+  return decision.kind === 'pending-approval' || decision.kind === 'mw-abort'
 }
 
-type ToolExecutionResult =
-  | { kind: 'ok';     result: unknown; updates: StreamChunk[]; duration: number }
-  | { kind: 'paused';                   updates: StreamChunk[]; duration: number }
-  | { kind: 'error';  error: Error;     updates: StreamChunk[]; duration: number }
+/**
+ * Decide a single tool call's fate. This is the one place every gate lives
+ * (#971) — unknown tool, handoff, client tool, approval, `onBeforeToolCall`
+ * middleware, argument validation — so both the serial and the parallel
+ * path see identical semantics and a new gate is written once.
+ *
+ * Side effects that the rest of the loop depends on (the pending-state
+ * mutations on `loopCtx`, `onAbort` middleware) are applied here, before the
+ * decision is returned. Nothing between a mutation and its emitted chunks
+ * observes `loopCtx`, so applying them up front in the parallel prelude is
+ * indistinguishable from applying them mid-stream in serial mode.
+ */
+async function decideToolCall(loopCtx: LoopContext, tc: ToolCall): Promise<ToolCallDecision> {
+  const { middlewares, toolMap, options, ctx } = loopCtx
+
+  const tool = toolMap.get(tc.name)
+  if (!tool) {
+    return { kind: 'unknown-tool', tc, result: `Error: Unknown tool "${tc.name}"` }
+  }
+
+  // Handoff — detected before the no-execute (client tool) branch because
+  // a handoff tool also has no `execute`, but it has wholly different
+  // semantics: pivot control to a new agent instead of pausing for the
+  // browser. The first handoff in a step wins; any subsequent tool calls
+  // in the same step are skipped with a synthetic "skipped: handed off"
+  // tool result so the message log stays well-formed for replay.
+  if (loopCtx.stopForHandoff) {
+    return { kind: 'handoff-skipped', tc, result: 'Skipped: parent agent handed off to another agent.' }
+  }
+  if (isHandoffTool(tool)) {
+    const spec = tool.__handoffSpec
+    const validation = validateToolArgs(tool, tc.arguments)
+    // Handoff payload defaults to `{ message: string }`; custom schemas
+    // are accepted but the loop only uses `args.message` (string) as the
+    // transition prompt. Anything else surfaces in the conversation as
+    // the args of the synthetic tool-call.
+    const args = validation.ok ? (validation.value as Record<string, unknown>) : (tc.arguments as Record<string, unknown>)
+    const transitionMessage = typeof args['message'] === 'string' ? (args['message'] as string) : ''
+
+    loopCtx.pendingHandoff = { spec, transitionMessage, parentToolCallId: tc.id }
+    // Set before the sibling calls are decided so they resolve to
+    // `handoff-skipped` — in the parallel prelude that is what stops a
+    // sibling from ever being dispatched.
+    loopCtx.stopForHandoff = true
+
+    return {
+      kind:   'handoff',
+      tc,
+      result: `Handed off to ${spec.AgentClass.name}.`,
+      chunk:  {
+        type:    'handoff' as const,
+        handoff: {
+          from: loopCtx.agent.constructor.name,
+          to:   spec.AgentClass.name,
+          ...(transitionMessage ? { message: transitionMessage } : {}),
+        },
+      },
+    }
+  }
+
+  if (!tool.execute) {
+    // Client tool — no server-side handler.
+    if (options?.toolCallStreamingMode === 'stop-on-client-tool') {
+      loopCtx.pendingClientToolCalls.push(tc)
+      loopCtx.loopFinishReason = 'client_tool_calls'
+      loopCtx.stopForClientTools = true
+      return { kind: 'client-tool-stop', tc }
+    }
+    return { kind: 'client-tool-placeholder', tc, result: '[client tool — execute on client]' }
+  }
+
+  // needsApproval enforcement
+  const approvalDecision = await evaluateApproval(tool, tc, options)
+  if (approvalDecision === 'rejected') {
+    return { kind: 'rejected', tc, result: { rejected: true, reason: 'User rejected this tool call' } }
+  }
+  if (approvalDecision === 'pending') {
+    loopCtx.pendingApprovalToolCall = { toolCall: tc, isClientTool: false }
+    loopCtx.loopFinishReason = 'tool_approval_required'
+    loopCtx.stopForApproval = true
+    return { kind: 'pending-approval', tc }
+  }
+
+  // onBeforeToolCall
+  let toolArgs = tc.arguments
+  if (middlewares.length > 0) {
+    const beforeResult = await runOnBeforeToolCall(middlewares, ctx, tc.name, toolArgs)
+    if (beforeResult) {
+      if (beforeResult.type === 'skip') {
+        return { kind: 'mw-skip', tc, toolArgs, result: beforeResult.result }
+      }
+      if (beforeResult.type === 'abort') {
+        await runOnAbort(middlewares, ctx, beforeResult.reason)
+        return { kind: 'mw-abort', tc }
+      }
+      if (beforeResult.type === 'transformArgs') {
+        toolArgs = beforeResult.args
+      }
+    }
+  }
+
+  // Validate args against the tool's inputSchema. Runs after middleware
+  // transforms so transforms can reshape malformed model output before
+  // it is judged. The tool-call chunk is emitted even on validation
+  // failure so streaming UIs see a paired tool-call → tool-result(error)
+  // sequence; non-streaming callers discard the chunk.
+  const validation = validateToolArgs(tool, toolArgs)
+  if (!validation.ok) {
+    return { kind: 'validation-error', tc, toolArgs, error: validation.error }
+  }
+
+  return { kind: 'ready', tc, tool, toolArgs, validatedArgs: validation.value }
+}
 
 /**
- * Drive a single tool's `executeMaybeStreaming` to completion. Buffers
- * `tool-update` chunks for replay in tool-call order; pause-for-client-tools
- * mutations to `loopCtx` apply immediately and the call returns `paused`.
- *
- * `ctx` is shared across concurrent invocations. Middleware that writes
- * through `ctx` during `runOnChunk` (uncommon — most use it read-only for
- * telemetry) may observe interleaved updates from sibling tool calls;
- * apps with such middleware should opt out via `parallelTools: false`.
+ * Emit the chunks, message pushes, and `onAfterToolCall` hook for every
+ * decision that does not reach `execute()`. Shared by both paths so the
+ * observable sequence for a gated call is identical in serial and parallel
+ * mode. Ready decisions are handled by {@link emitExecutionResult} instead.
  */
-async function runToolExecution(loopCtx: LoopContext, outcome: ReadyOutcome): Promise<ToolExecutionResult> {
+async function* emitDecision(
+  loopCtx:     LoopContext,
+  decision:    NonReadyDecision,
+  toolResults: ToolResult[],
+): AsyncGenerator<StreamChunk, void, void> {
+  const { messages, middlewares, ctx } = loopCtx
+  const tc = decision.tc
+
+  switch (decision.kind) {
+    case 'unknown-tool': {
+      toolResults.push({ toolCallId: tc.id, result: decision.result })
+      messages.push({ role: 'tool', content: decision.result, toolCallId: tc.id })
+      yield { type: 'tool-result' as const, toolCall: tc, result: decision.result }
+      return
+    }
+    case 'handoff-skipped': {
+      toolResults.push({ toolCallId: tc.id, result: decision.result })
+      messages.push({ role: 'tool', content: decision.result, toolCallId: tc.id })
+      yield { type: 'tool-call' as const, toolCall: tc }
+      yield { type: 'tool-result' as const, toolCall: tc, result: decision.result }
+      return
+    }
+    case 'handoff': {
+      toolResults.push({ toolCallId: tc.id, result: decision.result })
+      messages.push({ role: 'tool', content: decision.result, toolCallId: tc.id })
+      yield { type: 'tool-call' as const, toolCall: tc }
+      yield { type: 'tool-result' as const, toolCall: tc, result: decision.result }
+      yield decision.chunk
+      return
+    }
+    case 'client-tool-stop': {
+      // loopCtx mutations already applied by decideToolCall.
+      yield { type: 'tool-call' as const, toolCall: tc }
+      return
+    }
+    case 'client-tool-placeholder': {
+      toolResults.push({ toolCallId: tc.id, result: decision.result })
+      messages.push({ role: 'tool', content: decision.result, toolCallId: tc.id })
+      yield { type: 'tool-call' as const, toolCall: tc }
+      yield { type: 'tool-result' as const, toolCall: tc, result: decision.result }
+      return
+    }
+    case 'rejected': {
+      toolResults.push({ toolCallId: tc.id, result: decision.result })
+      messages.push({ role: 'tool', content: JSON.stringify(decision.result), toolCallId: tc.id })
+      yield { type: 'tool-result' as const, toolCall: tc, result: decision.result }
+      return
+    }
+    case 'pending-approval': {
+      // loopCtx mutations already applied by decideToolCall.
+      yield { type: 'tool-call' as const, toolCall: tc }
+      return
+    }
+    case 'mw-skip': {
+      const resultStr = typeof decision.result === 'string' ? decision.result : JSON.stringify(decision.result)
+      toolResults.push({ toolCallId: tc.id, result: decision.result })
+      messages.push({ role: 'tool', content: resultStr, toolCallId: tc.id })
+      yield { type: 'tool-result' as const, toolCall: tc, result: decision.result }
+      if (middlewares.length > 0) await runOnAfterToolCall(middlewares, ctx, tc.name, decision.toolArgs, decision.result)
+      return
+    }
+    case 'mw-abort': {
+      // `onAbort` already ran in decideToolCall; the aborted call emits
+      // nothing and the caller halts the phase.
+      return
+    }
+    case 'validation-error': {
+      yield { type: 'tool-call' as const, toolCall: tc }
+      toolResults.push({ toolCallId: tc.id, result: decision.error })
+      messages.push({ role: 'tool', content: JSON.stringify(decision.error), toolCallId: tc.id })
+      yield { type: 'tool-result' as const, toolCall: tc, result: decision.error }
+      if (middlewares.length > 0) await runOnAfterToolCall(middlewares, ctx, tc.name, decision.toolArgs, decision.error)
+      return
+    }
+  }
+}
+
+// ─── Shared execution ────────────────────────────────────
+
+type ToolExecutionResult =
+  | { kind: 'ok';     result: unknown; duration: number }
+  | { kind: 'paused';                  duration: number }
+  | { kind: 'error';  error: Error;    duration: number }
+
+/**
+ * Drive a single tool's `executeMaybeStreaming` to completion, yielding each
+ * `tool-update` chunk and returning the outcome. Serial delegates with
+ * `yield*` so updates stream live; parallel drains it through
+ * {@link bufferToolExecution} so they replay in tool-call order.
+ *
+ * Pause detection: a yielded `pause_for_client_tools` control chunk halts
+ * iteration, propagates the nested calls to the parent's pending list, and
+ * returns `paused` so the caller SKIPS the tool_result emission — the
+ * yielding tool's own call stays orphaned in the parent message history
+ * until the caller resolves it on resume.
+ */
+async function* runToolExecution(
+  loopCtx:  LoopContext,
+  decision: ReadyDecision,
+): AsyncGenerator<StreamChunk, ToolExecutionResult, void> {
   const { middlewares, ctx } = loopCtx
-  const updates: StreamChunk[] = []
   const toolStart = performance.now()
   try {
-    const execGen = executeMaybeStreaming(outcome.tool, outcome.validatedArgs, { toolCallId: outcome.tc.id })
+    const execGen = executeMaybeStreaming(decision.tool, decision.validatedArgs, { toolCallId: decision.tc.id })
     let result: unknown
     let paused = false
     while (true) {
@@ -551,19 +446,88 @@ async function runToolExecution(loopCtx: LoopContext, outcome: ReadyOutcome): Pr
         paused = true
         break
       }
-      const updateChunk: StreamChunk = { type: 'tool-update', toolCall: outcome.tc, update: step.value }
+      const updateChunk: StreamChunk = { type: 'tool-update', toolCall: decision.tc, update: step.value }
       if (middlewares.length > 0) {
         const transformed = runOnChunk(middlewares, ctx, updateChunk)
-        if (transformed) updates.push(transformed)
+        if (transformed) yield transformed
       } else {
-        updates.push(updateChunk)
+        yield updateChunk
       }
     }
     const duration = performance.now() - toolStart
-    if (paused) return { kind: 'paused', updates, duration }
-    return { kind: 'ok', result, updates, duration }
+    if (paused) return { kind: 'paused', duration }
+    return { kind: 'ok', result, duration }
   } catch (err) {
     const duration = performance.now() - toolStart
-    return { kind: 'error', error: err instanceof Error ? err : new Error(String(err)), updates, duration }
+    return { kind: 'error', error: err instanceof Error ? err : new Error(String(err)), duration }
   }
+}
+
+type BufferedExecution = { exec: ToolExecutionResult; updates: StreamChunk[] }
+
+/**
+ * Run {@link runToolExecution} to completion, buffering its `tool-update`
+ * chunks instead of streaming them. Concurrent invocations share `ctx`:
+ * middleware that writes through `ctx` during `runOnChunk` (uncommon — most
+ * use it read-only for telemetry) may observe interleaved updates from
+ * sibling tool calls; apps with such middleware should opt out via
+ * `parallelTools: false`.
+ */
+async function bufferToolExecution(loopCtx: LoopContext, decision: ReadyDecision): Promise<BufferedExecution> {
+  const gen = runToolExecution(loopCtx, decision)
+  const updates: StreamChunk[] = []
+  while (true) {
+    const step = await gen.next()
+    if (step.done) return { exec: step.value, updates }
+    updates.push(step.value)
+  }
+}
+
+/**
+ * Emit the tool_result, message push, and `onAfterToolCall` hook for a call
+ * that reached `execute()`. Shared by both paths; the caller has already
+ * emitted the `tool-call` chunk and the tool's updates.
+ */
+async function* emitExecutionResult(
+  loopCtx:     LoopContext,
+  decision:    ReadyDecision,
+  exec:        ToolExecutionResult,
+  toolResults: ToolResult[],
+): AsyncGenerator<StreamChunk, void, void> {
+  const { messages, middlewares, ctx } = loopCtx
+  const tc = decision.tc
+
+  if (exec.kind === 'paused') {
+    // Pause-for-client-tools propagated its calls onto `loopCtx` during
+    // execution. Skip tool_result emission + message push — the call
+    // stays orphaned until resume.
+    return
+  }
+
+  if (exec.kind === 'error') {
+    const errResult = `Error: ${exec.error.message}`
+    toolResults.push({ toolCallId: tc.id, result: errResult, duration: exec.duration })
+    messages.push({ role: 'tool', content: errResult, toolCallId: tc.id })
+    yield { type: 'tool-result' as const, toolCall: tc, result: errResult }
+
+    // onAfterToolCall (error case)
+    if (middlewares.length > 0) await runOnAfterToolCall(middlewares, ctx, tc.name, decision.toolArgs, errResult)
+    return
+  }
+
+  // toolResults preserves the ORIGINAL value; only the message content
+  // pushed onto `messages` (next-step model input) is narrowed by
+  // toModelOutput. The streamed `tool-result` chunk also carries the
+  // ORIGINAL value.
+  toolResults.push({ toolCallId: tc.id, result: exec.result, duration: exec.duration })
+  const resultStr = await applyToModelOutput(
+    decision.tool,
+    exec.result,
+    middlewares.length > 0 ? (e) => runOnError(middlewares, ctx, e) : undefined,
+  )
+  messages.push({ role: 'tool', content: resultStr, toolCallId: tc.id })
+  yield { type: 'tool-result' as const, toolCall: tc, result: exec.result }
+
+  // onAfterToolCall
+  if (middlewares.length > 0) await runOnAfterToolCall(middlewares, ctx, tc.name, decision.toolArgs, exec.result)
 }


### PR DESCRIPTION
Closes #971

## What

`tool-execution.ts` implemented the tool phase twice. The per-call gate chain is now **one function** that returns a decision, and both paths consume it.

```ts
type ToolCallDecision = NonReadyDecision | ReadyDecision

type ReadyDecision = {
  kind: 'ready'; tc: ToolCall; tool: AnyTool
  toolArgs: Record<string, unknown>; validatedArgs: Record<string, unknown>
}

type NonReadyDecision =
  | { kind: 'unknown-tool';            tc; result: string }
  | { kind: 'handoff-skipped';         tc; result: string }
  | { kind: 'handoff';                 tc; result: string; chunk: StreamChunk }
  | { kind: 'client-tool-placeholder'; tc; result: string }
  | { kind: 'client-tool-stop';        tc }
  | { kind: 'rejected';                tc; result: { rejected: true; reason: string } }
  | { kind: 'pending-approval';        tc }
  | { kind: 'mw-skip';                 tc; toolArgs; result: unknown }
  | { kind: 'mw-abort';                tc }
  | { kind: 'validation-error';        tc; toolArgs; error: InvalidToolArgumentsError }

async function decideToolCall(loopCtx: LoopContext, tc: ToolCall): Promise<ToolCallDecision>
```

`decideToolCall()` owns every gate and every pending-state mutation on `loopCtx`. Four more shared pieces hang off it:

- `haltsToolPhase(decision)` - the one place that knows `pending-approval` and `mw-abort` stop the step.
- `emitDecision()` - an async generator replaying the chunks, message pushes and `onAfterToolCall` for every non-ready decision. Used verbatim by both paths.
- `runToolExecution()` - the pause-detection loop, now an `AsyncGenerator<StreamChunk, ToolExecutionResult>`. Serial delegates with `yield*` so `tool-update` chunks still stream **live**; parallel drains it through `bufferToolExecution()` so they replay in tool-call order. The loop existed twice before, differing only in `yield` versus `updates.push`.
- `emitExecutionResult()` - the ok / paused / error tail, shared.

Both phase functions are now short: decide, dispatch, emit. A future gate is written once.

## The handoff downgrade: removed

The drift the issue identified was real. `isHandoffTool` / `stopForHandoff` lived only in the serial path, so `executeToolPhase` did:

```ts
const hasHandoff = toolCalls.some(tc => isHandoffTool(loopCtx.toolMap.get(tc.name)))
const parallel = (...) && toolCalls.length > 1 && !hasHandoff
```

The shared chain gives the parallel path the handoff branch for free, and the mechanism carries over cleanly: the prelude is serial and in tool-call order, so a handoff decision flips `loopCtx.stopForHandoff` before its siblings are decided, and every later call resolves to `handoff-skipped`. A skipped sibling is never `ready`, so it is never dispatched in phase 2. The downgrade is gone.

## What behaviour changed

**One thing.** In a step that mixes ordinary tool calls with a handoff, the ordinary calls decided *before* the handoff now run concurrently instead of one after another. That is the whole delta, and it is what the downgrade was suppressing.

**What did not change:**

- The first handoff in a step still wins; later calls are still skipped with the same synthetic result, never executed.
- Tool messages are still pushed in tool-call order with identical content, so the carried message log replays the same.
- `handoffPath` and the final response are identical between the two dispatch modes.
- Gate semantics, chunk sequences and `loopCtx` mutations are unchanged for every other path.
- Serial still streams `tool-update` chunks live; parallel still buffers and replays deterministically.
- The pre-existing serial-only `try`/`catch` around the post-execution hooks is preserved rather than unified. Serial has always reported a rejecting `onAfterToolCall`/`onError` as the tool's result while the parallel replay lets it propagate. Unifying it would have changed one path or the other, so it stays as it was, now in one visible place with a comment rather than baked into a duplicate.

## Tests

**885 before, 887 after, 0 fail.** Root `pnpm build`, `pnpm typecheck` (21/21) and `pnpm test` (21/21) all green.

**No existing test was edited.** No test asserted the downgrade, so removing it required no changes. The existing `a regular tool call alongside a handoff in the same step is skipped with a synthetic result` case now runs through the parallel path instead of the serial one and still passes unmodified.

Two tests added for what the refactor newly makes reachable:

- `parallel dispatch: a sibling after a handoff is skipped and the carried log stays paired` - pins the skip under explicit `parallelTools: true` and asserts both tool calls still get a paired tool message.
- `tools decided before a handoff still dispatch concurrently, and the log matches serial` - two sleeping tools plus a handoff, asserting both enter before either exits under parallel, that serial still interleaves, and that the tool messages, `handoffPath` and final text are identical between the modes.

The concurrency test was verified to fail against the old code: restoring the `hasHandoff` downgrade turns it red (886 pass / 1 fail) and nothing else.

## Changeset

Included, `patch`. No public signature changed, but the handoff dispatch behaviour did, so it is worth a released note rather than nothing.