### PR TITLE
fix(ai-sdk): emit tool results and correct the Vercel data-stream prefixes

### DIFF
--- a/.changeset/rotten-bugs-repeat.md
+++ b/.changeset/rotten-bugs-repeat.md
@@ -1,0 +1,7 @@
+---
+"@gemstack/ai-sdk": patch
+---
+
+Fix `toVercelDataStream` so the wire matches the AI SDK v4 Data Stream Protocol it advertises. Tool results were never emitted at all, and the prefixes it did emit were mismapped: tool call streaming start went out on `9:` instead of `b:`, and argument deltas went out on `a:` instead of `c:`. Because `a:` is the Tool Result part, `useChat()` read every argument delta as a tool result with `result: undefined` and resolved the tool-call chip before the model had finished writing its arguments.
+
+Tool results now go out on `a:`, streaming start on `b:`, argument deltas on `c:`, and a complete `9:` tool call with its `args` is emitted. Argument deltas now carry the correlated `toolCallId` on adapters that ship args as a bare text delta, and the Finish Message part carries `usage` alongside the Finish Step part.

--- a/docs/packages/ai-sdk/streaming.md
+++ b/docs/packages/ai-sdk/streaming.md
@@ -50,6 +50,19 @@ return toVercelResponse(stream)   // text/plain Response, X-Vercel-AI-Data-Strea
 
 `toVercelResponse(stream)` wraps a `Response`; `toVercelDataStream(stream)` returns the raw `ReadableStream<Uint8Array>` if you need to frame the response yourself. Both take the `stream` iterator (`AgentStreamResponse.stream`), not the whole `{ stream, response }` object.
 
+The wire is the **AI SDK v4** Data Stream Protocol (the version `X-Vercel-AI-Data-Stream: v1` selects), not the v5 SSE protocol. Chunks map onto parts like this:
+
+| chunk | part | prefix |
+|---|---|---|
+| `text-delta` | Text | `0:` |
+| `tool-call-delta` (carrying `toolCall.name`) | Tool Call Streaming Start | `b:` |
+| `tool-call-delta` (carrying `text`) | Tool Call Delta | `c:` |
+| `tool-call` | Tool Call | `9:` |
+| `tool-result` | Tool Result | `a:` |
+| `finish` | Finish Step, then Finish Message | `e:`, then `d:` |
+
+`tool-update`, `pending-client-tools`, `pending-approval` and `handoff` have no v4 part and are dropped. Use the SSE protocol below when a UI needs them.
+
 ## Server-Sent Events (named-event protocol)
 
 When you want a plain `text/event-stream` with self-describing event names (rather than the Vercel numeric-prefix wire), `@gemstack/ai-sdk` ships a matched server/browser pair so the wire vocabulary can never drift between the two ends. Both live in the engine and use only web globals (`ReadableStream`, `Response`, `TextEncoder`), so they run server-side (Node or edge) and in the browser alike.

--- a/packages/ai-sdk/src/vercel-protocol.test.ts
+++ b/packages/ai-sdk/src/vercel-protocol.test.ts
@@ -1,0 +1,224 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { toVercelDataStream, toVercelResponse } from './vercel-protocol.js'
+import type { StreamChunk } from './types.js'
+
+function streamOf(chunks: StreamChunk[]): AsyncIterable<StreamChunk> {
+  return (async function* () {
+    for (const c of chunks) yield c
+  })()
+}
+
+/** Drain the data stream into its raw wire text. */
+async function drain(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let out = ''
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    out += decoder.decode(value, { stream: true })
+  }
+  return out
+}
+
+const wire = (chunks: StreamChunk[]) => drain(toVercelDataStream(streamOf(chunks)))
+
+describe('toVercelDataStream — text', () => {
+  it('emits each text delta as a 0: part holding a JSON string', async () => {
+    assert.equal(
+      await wire([
+        { type: 'text-delta', text: 'Hi ' },
+        { type: 'text-delta', text: 'there' },
+      ]),
+      '0:"Hi "\n0:"there"\n',
+    )
+  })
+
+  it('JSON-escapes newlines and quotes inside a text delta', async () => {
+    assert.equal(
+      await wire([{ type: 'text-delta', text: 'a "b"\nc' }]),
+      '0:"a \\"b\\"\\nc"\n',
+    )
+  })
+})
+
+describe('toVercelDataStream — tool call streaming', () => {
+  it('emits the start on b: and argument deltas on c:', async () => {
+    assert.equal(
+      await wire([
+        { type: 'tool-call-delta', toolCall: { id: 'call-1', name: 'lookup' } },
+        { type: 'tool-call-delta', text: '{"q":' },
+        { type: 'tool-call-delta', text: '"x"}' },
+      ]),
+      'b:{"toolCallId":"call-1","toolName":"lookup"}\n'
+      + 'c:{"toolCallId":"call-1","argsTextDelta":"{\\"q\\":"}\n'
+      + 'c:{"toolCallId":"call-1","argsTextDelta":"\\"x\\"}"}\n',
+    )
+  })
+
+  it('never emits an argument delta on a: (that prefix is Tool Result)', async () => {
+    const raw = await wire([
+      { type: 'tool-call-delta', toolCall: { id: 'call-1', name: 'lookup' } },
+      { type: 'tool-call-delta', text: '{}' },
+    ])
+    assert.equal(raw.includes('a:'), false)
+    assert.equal(raw.includes('9:'), false)
+  })
+
+  it('routes parallel argument deltas by toolCallIndex', async () => {
+    assert.equal(
+      await wire([
+        { type: 'tool-call-delta', toolCall: { id: 'call-a', name: 'one' }, toolCallIndex: 0 },
+        { type: 'tool-call-delta', toolCall: { id: 'call-b', name: 'two' }, toolCallIndex: 1 },
+        { type: 'tool-call-delta', text: 'A', toolCallIndex: 0 },
+        { type: 'tool-call-delta', text: 'B', toolCallIndex: 1 },
+      ]),
+      'b:{"toolCallId":"call-a","toolName":"one"}\n'
+      + 'b:{"toolCallId":"call-b","toolName":"two"}\n'
+      + 'c:{"toolCallId":"call-a","argsTextDelta":"A"}\n'
+      + 'c:{"toolCallId":"call-b","argsTextDelta":"B"}\n',
+    )
+  })
+
+  it('emits start and delta in one frame when a chunk carries both', async () => {
+    assert.equal(
+      await wire([{ type: 'tool-call-delta', toolCall: { id: 'call-1', name: 'lookup' }, text: '{}' }]),
+      'b:{"toolCallId":"call-1","toolName":"lookup"}\n'
+      + 'c:{"toolCallId":"call-1","argsTextDelta":"{}"}\n',
+    )
+  })
+
+  it('leaves toolCallId empty when no start was ever seen', async () => {
+    assert.equal(
+      await wire([{ type: 'tool-call-delta', text: '{}' }]),
+      'c:{"toolCallId":"","argsTextDelta":"{}"}\n',
+    )
+  })
+})
+
+describe('toVercelDataStream — complete tool call', () => {
+  it('emits 9: with toolCallId, toolName and args', async () => {
+    assert.equal(
+      await wire([{ type: 'tool-call', toolCall: { id: 'call-1', name: 'lookup', arguments: { q: 'x' } } }]),
+      '9:{"toolCallId":"call-1","toolName":"lookup","args":{"q":"x"}}\n',
+    )
+  })
+
+  it('defaults missing tool call fields rather than dropping keys', async () => {
+    assert.equal(
+      await wire([{ type: 'tool-call', toolCall: { id: 'call-1' } }]),
+      '9:{"toolCallId":"call-1","toolName":"","args":{}}\n',
+    )
+  })
+
+  it('emits nothing for a tool-call chunk with no toolCall', async () => {
+    assert.equal(await wire([{ type: 'tool-call' }]), '')
+  })
+})
+
+describe('toVercelDataStream — tool results', () => {
+  it('emits a: with toolCallId and the result (#999)', async () => {
+    assert.equal(
+      await wire([{ type: 'tool-result', toolCall: { id: 'call-1', name: 'lookup' }, result: { hits: 2 } }]),
+      'a:{"toolCallId":"call-1","result":{"hits":2}}\n',
+    )
+  })
+
+  it('passes a string result through as a JSON string, not double-encoded', async () => {
+    assert.equal(
+      await wire([{ type: 'tool-result', toolCall: { id: 'call-1' }, result: 'plain string' }]),
+      'a:{"toolCallId":"call-1","result":"plain string"}\n',
+    )
+  })
+
+  it('null-fills an undefined result so the key survives JSON.stringify', async () => {
+    assert.equal(
+      await wire([{ type: 'tool-result', toolCall: { id: 'call-1' } }]),
+      'a:{"toolCallId":"call-1","result":null}\n',
+    )
+  })
+
+  it('emits the whole call/result sequence in protocol order', async () => {
+    assert.equal(
+      await wire([
+        { type: 'tool-call-delta', toolCall: { id: 'call-1', name: 'lookup' } },
+        { type: 'tool-call-delta', text: '{"q":"x"}' },
+        { type: 'tool-call', toolCall: { id: 'call-1', name: 'lookup', arguments: { q: 'x' } } },
+        { type: 'tool-result', toolCall: { id: 'call-1', name: 'lookup' }, result: { hits: 2 } },
+        { type: 'text-delta', text: 'Found 2.' },
+      ]),
+      'b:{"toolCallId":"call-1","toolName":"lookup"}\n'
+      + 'c:{"toolCallId":"call-1","argsTextDelta":"{\\"q\\":\\"x\\"}"}\n'
+      + '9:{"toolCallId":"call-1","toolName":"lookup","args":{"q":"x"}}\n'
+      + 'a:{"toolCallId":"call-1","result":{"hits":2}}\n'
+      + '0:"Found 2."\n',
+    )
+  })
+})
+
+describe('toVercelDataStream — finish', () => {
+  it('emits e: then d:, both carrying finishReason and usage', async () => {
+    assert.equal(
+      await wire([{
+        type: 'finish',
+        finishReason: 'stop',
+        usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      }]),
+      'e:{"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":5}}\n'
+      + 'd:{"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":5}}\n',
+    )
+  })
+
+  it('renames the tool_calls finish reason to the protocol tool-calls', async () => {
+    assert.equal(
+      await wire([{ type: 'finish', finishReason: 'tool_calls' }]),
+      'e:{"finishReason":"tool-calls"}\nd:{"finishReason":"tool-calls"}\n',
+    )
+  })
+
+  it('omits usage when the finish chunk has none', async () => {
+    assert.equal(
+      await wire([{ type: 'finish', finishReason: 'length' }]),
+      'e:{"finishReason":"length"}\nd:{"finishReason":"length"}\n',
+    )
+  })
+})
+
+describe('toVercelDataStream — chunks with no v4 part', () => {
+  it('drops usage, tool-update, pending and handoff chunks silently', async () => {
+    assert.equal(
+      await wire([
+        { type: 'usage', usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 } },
+        { type: 'tool-update', toolCall: { id: 'call-1' }, update: { pct: 50 } },
+        { type: 'pending-client-tools', toolCalls: [{ id: 'c', name: 'geo', arguments: {} }] },
+        { type: 'pending-approval', toolCall: { id: 'call-1' }, isClientTool: false },
+        { type: 'handoff', handoff: { from: 'A', to: 'B' } },
+      ]),
+      '',
+    )
+  })
+})
+
+describe('toVercelDataStream — errors', () => {
+  it('surfaces a throwing source stream to the reader', async () => {
+    const stream = toVercelDataStream((async function* (): AsyncGenerator<StreamChunk> {
+      yield { type: 'text-delta', text: 'hi' }
+      throw new Error('upstream exploded')
+    })())
+    const reader = stream.getReader()
+    assert.deepEqual(await reader.read(), { done: false, value: new TextEncoder().encode('0:"hi"\n') })
+    await assert.rejects(() => reader.read(), /upstream exploded/)
+  })
+})
+
+describe('toVercelResponse', () => {
+  it('sets the text/plain content type and the v1 data-stream header', async () => {
+    const res = toVercelResponse(streamOf([{ type: 'text-delta', text: 'hi' }]))
+    assert.equal(res.status, 200)
+    assert.equal(res.headers.get('content-type'), 'text/plain; charset=utf-8')
+    assert.equal(res.headers.get('x-vercel-ai-data-stream'), 'v1')
+    assert.equal(await res.text(), '0:"hi"\n')
+  })
+})

--- a/packages/ai-sdk/src/vercel-protocol.ts
+++ b/packages/ai-sdk/src/vercel-protocol.ts
@@ -1,23 +1,31 @@
 import type { StreamChunk } from './types.js'
 
 /**
- * Convert an ai-sdk agent stream to Vercel AI SDK Data Stream Protocol format.
+ * Convert an ai-sdk agent stream to Vercel AI SDK Data Stream Protocol format
+ * (the v4 wire that `X-Vercel-AI-Data-Stream: v1` selects and `useChat()` reads).
  *
  * Protocol prefixes:
  * - `0:` text delta (JSON string)
- * - `9:` tool call begin (JSON: toolCallId + toolName)
- * - `a:` tool call delta (JSON: toolCallId + argsTextDelta)
- * - `b:` tool call result (JSON: toolCallId + result)
- * - `e:` finish (JSON: finishReason + usage)
- * - `d:` done (JSON: finishReason)
+ * - `9:` tool call, complete (JSON: toolCallId + toolName + args)
+ * - `a:` tool result (JSON: toolCallId + result)
+ * - `b:` tool call streaming start (JSON: toolCallId + toolName)
+ * - `c:` tool call delta (JSON: toolCallId + argsTextDelta)
+ * - `e:` finish step (JSON: finishReason + usage)
+ * - `d:` finish message (JSON: finishReason + usage)
  *
- * @see https://sdk.vercel.ai/docs/ai-sdk-ui/stream-protocol#data-stream-protocol
+ * @see https://ai-sdk.dev/v4/docs/ai-sdk-ui/stream-protocol
  */
 export function toVercelDataStream(stream: AsyncIterable<StreamChunk>): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder()
 
   return new ReadableStream({
     async start(controller) {
+      // Arg-delta chunks carry no tool call id on adapters that ship args as a
+      // bare text delta (Anthropic, Bedrock), but `c:` parts must be addressed.
+      // Same index-then-most-recent routing the agent loop uses. See #999.
+      const startedByIndex = new Map<number, string>()
+      let lastStartedId = ''
+
       try {
         for await (const chunk of stream) {
           let line: string | undefined
@@ -27,17 +35,42 @@ export function toVercelDataStream(stream: AsyncIterable<StreamChunk>): Readable
               line = `0:${JSON.stringify(chunk.text)}\n`
               break
 
-            case 'tool-call-delta':
+            case 'tool-call-delta': {
+              if (chunk.toolCall?.id) {
+                lastStartedId = chunk.toolCall.id
+                if (typeof chunk.toolCallIndex === 'number') {
+                  startedByIndex.set(chunk.toolCallIndex, chunk.toolCall.id)
+                }
+              }
               if (chunk.toolCall?.name) {
-                line = `9:${JSON.stringify({ toolCallId: chunk.toolCall.id ?? '', toolName: chunk.toolCall.name })}\n`
+                line = `b:${JSON.stringify({ toolCallId: chunk.toolCall.id ?? '', toolName: chunk.toolCall.name })}\n`
               }
               if (chunk.text) {
-                line = (line ?? '') + `a:${JSON.stringify({ toolCallId: chunk.toolCall?.id ?? '', argsTextDelta: chunk.text })}\n`
+                const toolCallId = chunk.toolCall?.id
+                  ?? (typeof chunk.toolCallIndex === 'number' ? startedByIndex.get(chunk.toolCallIndex) : undefined)
+                  ?? lastStartedId
+                line = (line ?? '') + `c:${JSON.stringify({ toolCallId, argsTextDelta: chunk.text })}\n`
+              }
+              break
+            }
+
+            case 'tool-call':
+              if (chunk.toolCall) {
+                line = `9:${JSON.stringify({
+                  toolCallId: chunk.toolCall.id ?? '',
+                  toolName: chunk.toolCall.name ?? '',
+                  args: chunk.toolCall.arguments ?? {},
+                })}\n`
               }
               break
 
-            case 'tool-call':
-              // Tool call complete — result will be emitted separately if available
+            case 'tool-result':
+              line = `a:${JSON.stringify({
+                toolCallId: chunk.toolCall?.id ?? '',
+                // `undefined` would drop the key and read back as an unresolved
+                // result on the client, so null-fill it.
+                result: chunk.result === undefined ? null : chunk.result,
+              })}\n`
               break
 
             case 'usage':
@@ -46,16 +79,20 @@ export function toVercelDataStream(stream: AsyncIterable<StreamChunk>): Readable
 
             case 'finish': {
               const finishReason = chunk.finishReason === 'tool_calls' ? 'tool-calls' : chunk.finishReason
-              line = `e:${JSON.stringify({
-                finishReason,
-                usage: chunk.usage ? {
-                  promptTokens: chunk.usage.promptTokens,
-                  completionTokens: chunk.usage.completionTokens,
-                } : undefined,
-              })}\n`
-              line += `d:${JSON.stringify({ finishReason })}\n`
+              const usage = chunk.usage ? {
+                promptTokens: chunk.usage.promptTokens,
+                completionTokens: chunk.usage.completionTokens,
+              } : undefined
+              line = `e:${JSON.stringify({ finishReason, usage })}\n`
+              line += `d:${JSON.stringify({ finishReason, usage })}\n`
               break
             }
+
+            default:
+              // 'tool-update' | 'pending-client-tools' | 'pending-approval' |
+              // 'handoff' have no v4 data-stream part. Use the SSE protocol
+              // (toAgentSseResponse) when a UI needs them.
+              break
           }
 
           if (line) {


### PR DESCRIPTION
Closes #999

`toVercelDataStream` advertises `X-Vercel-AI-Data-Stream: v1` but does not implement that protocol. There was no `case 'tool-result'` and no `default`, so tool-result chunks fell through with `line === undefined` and nothing was enqueued. The prefixes it did emit were mismapped, and `a:` is the Tool Result part, so `useChat()` read every argument delta as a tool result with `result: undefined` and resolved the tool-call chip before the model had finished writing its arguments.

### Protocol, verified

Checked against the v4 spec at https://ai-sdk.dev/v4/docs/ai-sdk-ui/stream-protocol, cross-checked against the current (v5) protocol page and a third-party implementation of the same wire. The table in the issue is correct in every row.

| part | spec prefix | before | after |
|---|---|---|---|
| Text | `0:` `"text"` | `0:` | `0:` unchanged |
| Tool Call Streaming Start | `b:` `{toolCallId, toolName}` | emitted as `9:` | `b:` |
| Tool Call Delta | `c:` `{toolCallId, argsTextDelta}` | emitted as `a:` | `c:` |
| Tool Call | `9:` `{toolCallId, toolName, args}` | never emitted | `9:` with `args` |
| Tool Result | `a:` `{toolCallId, result}` | never emitted | `a:` |
| Finish Step | `e:` `{finishReason, usage}` | `e:` | `e:` unchanged |
| Finish Message | `d:` `{finishReason, usage}` | `d:` without `usage` | `d:` with `usage` |

Two things beyond the issue's fix shape, both needed for the wire to actually work:

- **Argument deltas had no `toolCallId`.** Anthropic and Bedrock ship args as a bare `{type:'tool-call-delta', text}` with no `toolCall`, so the old code sent `toolCallId: ''` and a `c:` part would be unaddressable. The stream now remembers the started call and resolves by `toolCallIndex` first, then most-recent, the same routing `agent.ts:1937-1955` uses for parallel calls.
- **`result: undefined` dropped the key.** `JSON.stringify` omits undefined-valued keys, so an `undefined` tool result would have gone out as `a:{"toolCallId":"x"}` and read back as unresolved on the client. Null-filled.

`tool-update`, `pending-client-tools`, `pending-approval` and `handoff` have no v4 part; they are dropped under an explicit `default` with a comment pointing at `toAgentSseResponse`, rather than falling through silently.

### v1 or v5?

**Keep `v1`, and make it correct.** Moving to v5 is a different wire entirely, not a relabel: SSE framing (`data: {"type":...}`) instead of prefixed lines, a different header (`x-vercel-ai-ui-message-stream: v1`), and a different tool vocabulary (`tool-input-start` / `tool-input-delta` / `tool-input-available` / `tool-output-available`). That is a new function and a real breaking change for anyone on the current one, and it should not ride along with a bug fix. Worth filing separately once there is demand; today this package has zero internal consumers of either.

### Changeset: patch

No TypeScript signature moves; `toVercelDataStream` and `toVercelResponse` keep their types. The wire format changes, but every prefix it changes was previously wrong against the protocol the header names, so no correct consumer can be relying on it, and there are zero internal consumers and zero tests. Patch, as a bug fix.

### Tests

`vercel-protocol.ts` had no tests at all. Adds `vercel-protocol.test.ts` with 20 tests asserting exact wire bytes prefix by prefix, since the whole defect was a wrong prefix no type could catch: text deltas and their JSON escaping, `b:` start, `c:` deltas including parallel routing by `toolCallIndex`, the complete `9:` call, `a:` results including string and undefined results, the full call/result sequence in order, `e:`/`d:` finish with and without usage, dropped chunk types, error propagation to the reader, and the response headers.

- ai-sdk baseline: 885 pass / 0 fail
- ai-sdk after: **905 pass / 0 fail**
- root `pnpm build` 11/11, `pnpm typecheck` 21/21, `pnpm test` 21/21

### Proof by revert

Reverted only `vercel-protocol.ts`, kept the tests, rebuilt. It compiles clean, so the tests fail at runtime on their assertions rather than on the type checker:

```
ℹ tests 905
ℹ pass 893
ℹ fail 12

✖ toVercelDataStream — tool call streaming
✖ toVercelDataStream — complete tool call
✖ toVercelDataStream — tool results
✖ toVercelDataStream — finish

✖ emits a: with toolCallId and the result (#999)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  actual expected

  'a:{"toolCallId":"call-1","result":{"hits":2}}\n'
```

`actual` is the empty string: nothing at all reached the wire for a tool result. Restored, back to 905/0.

### Docs

`docs/packages/ai-sdk/streaming.md` said nothing wrong (it never listed prefixes), but it also never said which chunks survive the conversion. Adds the chunk-to-part table and a note that this is the v4 wire, not v5, and that the four unmapped chunk types need the SSE protocol.
