### PR TITLE
fix(framework): absorb a failed pull and a watcher error in followFile (#996)

### DIFF
--- a/.changeset/gentle-jars-tickle.md
+++ b/.changeset/gentle-jars-tickle.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Stop a failed log tail from killing the daemon. `followFile`'s pump had no `catch` and every caller discarded its promise, so a rejected read (EIO on a network mount, EISDIR, a log grown past `kMaxLength`) surfaced as an unhandled rejection and exited the process, taking every connected dashboard stream with it. The same function installed no `'error'` listener on its `FSWatcher`, where an error event with no listener throws out of the emitter. Both are now absorbed, and the poll backstop carries the tail on its own once a watcher is lost.

--- a/packages/framework/src/jsonl-tail.test.ts
+++ b/packages/framework/src/jsonl-tail.test.ts
@@ -1,0 +1,112 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { watch, type FSWatcher } from 'node:fs'
+import { appendFile, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { JsonlTailer, followFile } from './jsonl-tail.js'
+
+const line = (message: string): string => JSON.stringify({ message }) + '\n'
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+
+async function tmpWorkspace(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'framework-jsonl-tail-'))
+}
+
+/**
+ * `followFile` keeps its watcher private, so hook the FSWatcher prototype across the one call
+ * that creates it. `fs.watch(dir, listener)` registers the listener on the instance, which hands
+ * us the instance an 'error' has to be emitted on to reproduce #996 (no real filesystem event is
+ * portable enough to raise one on demand).
+ */
+function captureWatcher(create: () => () => void): { watcher: FSWatcher; stop: () => void } {
+  const probe = watch(tmpdir(), () => {})
+  const proto = Object.getPrototypeOf(probe) as FSWatcher
+  probe.close()
+  const seen = new Set<FSWatcher>()
+  const original = proto.addListener
+  const record = function (this: FSWatcher, ...args: Parameters<FSWatcher['addListener']>): FSWatcher {
+    seen.add(this)
+    return original.apply(this, args)
+  }
+  Object.assign(proto, { on: record, addListener: record })
+  let stop: () => void
+  try {
+    stop = create()
+  } finally {
+    delete (proto as Partial<FSWatcher>).on
+    delete (proto as Partial<FSWatcher>).addListener
+  }
+  const [watcher] = [...seen]
+  assert.ok(watcher, 'expected followFile to create an FSWatcher')
+  return { watcher, stop }
+}
+
+test('JsonlTailer.pull rejects when the read fails, which is what pump has to absorb (#996)', async () => {
+  const cwd = await tmpWorkspace()
+  try {
+    // A directory opens and stats fine, then rejects on read (EISDIR) — the same shape as an
+    // EIO on a network mount, and the surface `pull`'s own try/catch does not cover.
+    const tailer = new JsonlTailer(cwd, () => {})
+    await assert.rejects(() => tailer.pull(), /EISDIR/)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('followFile survives a pull that rejects, and keeps pulling (#996)', async () => {
+  const cwd = await tmpWorkspace()
+  let calls = 0
+  // Rejects on the seeding pull and the first polls, then recovers, the way a transient read
+  // error does. Without the catch in `pump` the very first one is an unhandled rejection.
+  const stop = followFile(
+    cwd,
+    async () => {
+      calls += 1
+      if (calls <= 3) throw new Error('EIO: simulated read failure')
+    },
+    { pollMs: 20 },
+  )
+  try {
+    await sleep(300)
+    assert.ok(calls > 4, `expected polling to continue past the failures, saw ${calls} pulls`)
+  } finally {
+    stop()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('followFile survives a rejecting pull through the real tailer, over a directory (#996)', async () => {
+  const cwd = await tmpWorkspace()
+  const tailer = new JsonlTailer(cwd, () => {})
+  const stop = followFile(cwd, () => tailer.pull(), { pollMs: 20 })
+  try {
+    await sleep(200) // several failing polls; the process must still be here to assert
+    assert.ok(true)
+  } finally {
+    stop()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('a watcher error does not throw, and the poll keeps the tail alive (#996)', async () => {
+  const cwd = await tmpWorkspace()
+  const path = join(cwd, 'events.jsonl')
+  await writeFile(path, line('before'))
+  const seen: string[] = []
+  const tailer = new JsonlTailer<{ message: string }>(path, e => void seen.push(e.message))
+  const { watcher, stop } = captureWatcher(() => followFile(cwd, () => tailer.pull(), { pollMs: 20 }))
+  try {
+    await sleep(150)
+    assert.deepEqual(seen, ['before'])
+    // Exactly what node does when the watch handle fails: it closes the handle, then emits.
+    // With no listener that throws straight out of `emit` and takes the process with it.
+    assert.doesNotThrow(() => void watcher.emit('error', new Error('EPERM: simulated watch failure')))
+    await appendFile(path, line('after'))
+    await sleep(300) // the watcher is gone; only the poll backstop can deliver this
+    assert.deepEqual(seen, ['before', 'after'])
+  } finally {
+    stop()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})

--- a/packages/framework/src/jsonl-tail.ts
+++ b/packages/framework/src/jsonl-tail.ts
@@ -74,6 +74,9 @@ export interface FollowFileOptions {
  * pull already in flight swallows the next trigger) and stop for good once the returned
  * function is called. Shared by the run's control tail and the dashboard's event tail, which
  * hand-rolled this separately and drifted apart.
+ *
+ * Nothing here may throw at the process: a failed pull and a watcher error are both survivable,
+ * and the poll alone is a complete tail (#996).
  */
 export function followFile(dir: string, pull: () => Promise<void>, opts: FollowFileOptions): () => void {
   let pulling = false
@@ -83,6 +86,11 @@ export function followFile(dir: string, pull: () => Promise<void>, opts: FollowF
     pulling = true
     try {
       await pull()
+    } catch {
+      // #996: every caller discards this promise, so a rejected read (EIO on a network mount,
+      // EISDIR, a log grown past kMaxLength) would be an unhandled rejection and kill the
+      // process. Swallowed rather than logged: the next tick retries, and a fault that persists
+      // would otherwise print once per poll forever.
     } finally {
       pulling = false
     }
@@ -91,6 +99,13 @@ export function followFile(dir: string, pull: () => Promise<void>, opts: FollowF
   let watcher: FSWatcher | undefined
   try {
     watcher = watch(dir, () => void pump())
+    // #996: an 'error' with no listener throws out of the emitter, which is the same process
+    // death. The watcher is spent once it errors (node closes the handle first), so drop it and
+    // let the poll below carry the tail on its own.
+    watcher.on('error', () => {
+      watcher?.close()
+      watcher = undefined
+    })
   } catch {
     // dir may not be watchable everywhere; the poll backstop still covers it
   }


### PR DESCRIPTION
Closes #996

`followFile`'s `pump()` had a `try/finally` and no `catch`, and all three call sites are `void pump()`. A rejected `pull()` was therefore an unhandled rejection, and on Node >= 22.12 (`packages/framework/package.json:28`) with no process-level handler anywhere in the repo, that exits the process: the daemon dies and takes every connected browser's event stream with it, or a run dies. The `FSWatcher` next to it had no `'error'` listener, and an `'error'` event on an emitter with no listener throws synchronously, which is the same death.

## What was actually exposed

`pull()` already guards `open()` (`:25-29`) and the `onLine` callback (`:51-55`), so those are untouched. What was uncovered is the read path: `fd.stat()` (`:31`), `fd.read()` (`:43`), `Buffer.alloc(size - this.offset)` (`:42`, a `RangeError` once a log passes `buffer.kMaxLength`) and `fd.close()` in the `finally` (`:58`).

## The fix

- `catch` in `pump`, swallowed rather than logged. That matches the sibling pump `forwardStream` (`dashboard-rpc/stream-channel.ts:41-43`) and `pull()`'s own two catches, none of which log. The next tick retries anyway, and logging here would print once per poll tick for as long as a broken mount lasts.
- `watcher.on('error')` closes the watcher and drops the reference.

**Does polling alone still suffice after a watcher error? Yes.** The watcher is only a latency optimisation; the doc comment on `followFile` already calls the poll a backstop "because `fs.watch` is unreliable across platforms", and `pull()` re-opens the log by path every tick, so nothing about the tail depends on the watcher. The watcher is spent in any case: node closes the handle *before* it emits `'error'` (`lib/internal/fs/watchers.js`, the `onchange` status < 0 branch), so keeping the reference would buy nothing. The last test asserts exactly this by appending a line after the error and requiring it to arrive.

`followFile` and `JsonlTailer` are not exported from `packages/framework/src/index.ts` (only `watchControl`, `:305`), so no public signature changed.

## Tests

New `packages/framework/src/jsonl-tail.test.ts`; there was none, coverage was indirect via `control.test.ts` and `dashboard-rpc/events-tail.test.ts`.

| | tests | pass | fail | skip |
|---|---|---|---|---|
| before | 1049 | 1048 | 0 | 1 |
| after | 1053 | 1052 | 0 | 1 |

Root `pnpm build` (11/11), `pnpm typecheck` (21/21) and `pnpm test` (21/21) all pass.

Two notes on how these are driven, since asserting a `catch` block exists by inspection proves nothing:

- The end-to-end rejection is real, not stubbed: a `JsonlTailer` pointed at a **directory** opens and stats fine, then rejects `EISDIR` on `fd.read` - the same shape as an EIO on a network mount, and precisely the surface `pull()` does not guard.
- The watcher case needs the `FSWatcher` instance, which `followFile` keeps private. No filesystem event raises an `'error'` portably (see the correction below), so the test hooks the `FSWatcher` prototype across the single call that creates the watcher (`fs.watch(dir, listener)` registers the listener on the instance) and emits `'error'` on it directly, which is exactly what node itself does on a watch failure.

## Proof by revert

Reverting only `src/jsonl-tail.ts` and keeping the tests, 3 of the 4 fail. Node's test runner attributes the unhandled rejection to the enclosing test rather than crashing the worker, so these are clean failures:

```
test at jsonl-tail.test.js:54:1
✖ followFile survives a pull that rejects, and keeps pulling (#996)
  Error: EIO: simulated read failure
      at pump (dist-test/jsonl-tail.js:81:19)
      at followFile (dist-test/jsonl-tail.js:97:10)

test at jsonl-tail.test.js:73:1
✖ followFile survives a rejecting pull through the real tailer, over a directory (#996)
  Error: EISDIR: illegal operation on a directory, read
      at async JsonlTailer.pull (dist-test/jsonl-tail.js:44:13)
      at async pump (dist-test/jsonl-tail.js:81:13) {
    errno: -21, code: 'EISDIR', syscall: 'read' }

test at jsonl-tail.test.js:86:1
✖ a watcher error does not throw, and the poll keeps the tail alive (#996)
  AssertionError [ERR_ASSERTION]: Got unwanted exception.
  Actual message: "EPERM: simulated watch failure"
```

The fourth (`JsonlTailer.pull rejects when the read fails`) passes either way on purpose: it pins the uncovered surface, it is not a guard test.

## One correction to the issue

The issue names `tearDownWorktree` (`daemon-runtime.ts:294`) deleting a watched `.the-framework/` as the trigger for the watcher `'error'`, flagged there as medium confidence. It does not reproduce: on darwin, deleting a watched directory emits a `'change'` event, not an `'error'`. The missing listener is still a real hazard (inotify queue exhaustion on Linux, EPERM on Windows), which is why the test synthesises the event rather than provoking it, but that specific path is not it.
