### PR TITLE
fix(framework): per-operation git timeouts, and a distinguishable timeout

### DIFF
--- a/.changeset/fix-997-per-operation-git-timeouts.md
+++ b/.changeset/fix-997-per-operation-git-timeouts.md
@@ -1,0 +1,30 @@
+---
+'@gemstack/framework': minor
+---
+
+Git operations get a timeout budget chosen by subcommand, and a timeout is now distinguishable
+from a command git rejected.
+
+One flat 10s budget covered every git invocation in the package, the repo's ~20 call sites, which
+meant the two slowest ran under what is really a read's budget. `git worktree add` writes a whole
+checkout and `git push` uploads a packfile; on a large repo both routinely pass 10s, at which
+point `execFile` SIGTERMs them. A killed `worktree add` drops a run into the user's main checkout
+instead of its own worktree, and a killed `push` may have half-landed on the remote.
+
+`nodeGitRunner()` now picks the budget from the args: 10s for reads (`status`, `rev-parse`,
+`ls-files`, `log`, `diff`, `show`, `remote`, `rev-list`, `symbolic-ref`, `branch --list`,
+`worktree list`), 30s for local mutations (`add`, `commit`, `init`, `checkout`,
+`worktree remove`, `worktree prune`), and 120s for the network and for a full checkout (`push`,
+`fetch`, `pull`, `clone`, `worktree add`). Reads deliberately keep the old budget: widening
+everything to cover a slow op would let a hung read hold the daemon six times longer. This
+mirrors the read/write split `gh` already had.
+
+A CLI killed for outrunning its budget now rejects with a `CliTimeoutError` reading
+`git push --set-upstream origin <branch> timed out after 120000ms`, rather than the bare
+`Command failed: git push ...` that a SIGTERM with empty stderr used to produce. `isCliTimeout()`
+tells the two apart programmatically.
+
+`nodeGitRunner()`'s signature is unchanged; the budget is derived from the args, so every existing
+call site gets the right one with no change. New exports: `gitTimeoutMs`, `GIT_READ_TIMEOUT_MS`,
+`GIT_WRITE_TIMEOUT_MS`, `GIT_SLOW_TIMEOUT_MS`, `CliTimeoutError`, `isCliTimeout` and the
+`CliTimeout` type. `CliRunnerOptions.timeoutMs` accepts a function of the args as well as a number.

--- a/packages/framework/src/cli-exec.test.ts
+++ b/packages/framework/src/cli-exec.test.ts
@@ -1,0 +1,63 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { tmpdir } from 'node:os'
+import { cliRunner, isCliTimeout, CliTimeoutError } from './cli-exec.js'
+
+const CWD = tmpdir()
+
+/** Node itself is the stand-in binary: every platform running these tests has one. */
+const NODE = process.execPath
+
+/** A script that writes `mark` after 400ms, so a short budget kills it and a long one does not. */
+const slowScript = (mark: string) => ['-e', `setTimeout(() => process.stdout.write('${mark}'), 400)`]
+
+/** The rejection of `promise`, or `undefined` when it resolved. */
+async function rejection(promise: Promise<unknown>): Promise<unknown> {
+  return promise.then(
+    () => undefined,
+    (err: unknown) => err,
+  )
+}
+
+test('a killed process rejects as a timeout, not as a generic failure (#997)', async () => {
+  const run = cliRunner({ bin: NODE, timeoutMs: 50 })
+  const err = await rejection(run(['-e', 'setTimeout(() => {}, 5000)'], CWD))
+  assert.equal(isCliTimeout(err), true)
+  assert.ok(err instanceof CliTimeoutError)
+  assert.match((err as Error).message, /timed out after 50ms/)
+})
+
+test('a non-zero exit is not reported as a timeout (#997)', async () => {
+  const run = cliRunner({ bin: NODE, timeoutMs: 10_000 })
+  const err = await rejection(run(['-e', 'process.exit(3)'], CWD))
+  assert.ok(err instanceof Error)
+  assert.equal(isCliTimeout(err), false)
+})
+
+test('a timeout names the operation and the budget it outran (#997)', () => {
+  const err = new CliTimeoutError('git', ['push', '--set-upstream', 'origin', 'branch'], 120_000)
+  assert.equal(err.message, 'git push --set-upstream origin branch timed out after 120000ms')
+  assert.equal(isCliTimeout(err), true)
+})
+
+test('isCliTimeout is false for a plain error and for a non-error (#997)', () => {
+  assert.equal(isCliTimeout(new Error('fatal: no upstream')), false)
+  assert.equal(isCliTimeout('nope'), false)
+  assert.equal(isCliTimeout(undefined), false)
+})
+
+test('a per-args timeout gives the slow op room the short one does not (#997)', async () => {
+  const seen: string[][] = []
+  // The same 400ms of work under two budgets, chosen from the args the way git's is.
+  const run = cliRunner({
+    bin: NODE,
+    timeoutMs: args => {
+      seen.push(args)
+      return args.includes('slow') ? 10_000 : 50
+    },
+  })
+
+  assert.equal((await run([...slowScript('slow-done'), 'slow'], CWD)).trim(), 'slow-done')
+  assert.equal(isCliTimeout(await rejection(run(slowScript('quick-done'), CWD))), true)
+  assert.equal(seen.length, 2)
+})

--- a/packages/framework/src/cli-exec.ts
+++ b/packages/framework/src/cli-exec.ts
@@ -10,11 +10,45 @@
 /** Runs a CLI binary in `cwd`, resolving its stdout. Rejects on a non-zero exit. */
 export type CliRunner = (args: string[], cwd: string) => Promise<string>
 
+/**
+ * How long one invocation may run: a flat budget, or one derived from the args (#997).
+ *
+ * One binary is not one operation. `git push` talks to a remote and `git worktree add` writes a
+ * whole checkout, while `git rev-parse` reads a file; a single number has to be either too short
+ * for the first two or too long for the third.
+ */
+export type CliTimeout = number | ((args: string[]) => number)
+
+/**
+ * A CLI killed for outrunning its timeout, as opposed to one the tool itself rejected (#997).
+ *
+ * `execFile` SIGTERMs on timeout, and a killed `git push` usually writes nothing to stderr, so
+ * without this the failure surfaces as a bare "Command failed: git push ..." that reads like a
+ * rejected push.
+ */
+export class CliTimeoutError extends Error {
+  /** Brand, so a value that crossed a module boundary is still recognisable. */
+  readonly timedOut = true
+  constructor(
+    readonly bin: string,
+    readonly args: string[],
+    readonly timeoutMs: number,
+  ) {
+    super(`${bin} ${args.join(' ')} timed out after ${timeoutMs}ms`)
+    this.name = 'CliTimeoutError'
+  }
+}
+
+/** True when a {@link CliRunner} rejection is a timeout kill rather than a non-zero exit (#997). */
+export function isCliTimeout(err: unknown): err is CliTimeoutError {
+  return err instanceof Error && (err as { timedOut?: unknown }).timedOut === true
+}
+
 /** How to invoke one binary. */
 export interface CliRunnerOptions {
   bin: string
   /** Kill the process after this long, so a hung CLI cannot hang the caller. */
-  timeoutMs: number
+  timeoutMs: CliTimeout
   /** Raise the stdout cap for a command whose output can be large (a repo crawl). */
   maxBuffer?: number
   /**
@@ -29,13 +63,19 @@ export interface CliRunnerOptions {
 export function cliRunner(opts: CliRunnerOptions): CliRunner {
   return async (args, cwd) => {
     const { execFile } = await import('node:child_process')
+    const timeoutMs = typeof opts.timeoutMs === 'function' ? opts.timeoutMs(args) : opts.timeoutMs
     return new Promise<string>((resolvePromise, rejectPromise) => {
       execFile(
         opts.bin,
         args,
-        { cwd, timeout: opts.timeoutMs, ...(opts.maxBuffer !== undefined ? { maxBuffer: opts.maxBuffer } : {}) },
+        { cwd, timeout: timeoutMs, ...(opts.maxBuffer !== undefined ? { maxBuffer: opts.maxBuffer } : {}) },
         (err, stdout, stderr) => {
           if (!err) return resolvePromise(String(stdout))
+          // execFile kills on both timeout and a maxBuffer overrun; only the latter carries ENOBUFS.
+          const killed = (err as { killed?: boolean }).killed === true
+          if (killed && (err as { code?: unknown }).code !== 'ENOBUFS') {
+            return rejectPromise(new CliTimeoutError(opts.bin, args, timeoutMs))
+          }
           rejectPromise(opts.preferStderr ? new Error(String(stderr).trim() || err.message) : err)
         },
       )

--- a/packages/framework/src/dashboard/run-handoff.test.ts
+++ b/packages/framework/src/dashboard/run-handoff.test.ts
@@ -6,7 +6,8 @@ import { join } from 'node:path'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import { readRunHandoff, runBranchFor, pushRunBranch, openRunPullRequest, gitReason } from './run-handoff.js'
-import { nodeGitRunner, type GitRunner } from '../project.js'
+import { nodeGitRunner, GIT_SLOW_TIMEOUT_MS, type GitRunner } from '../project.js'
+import { CliTimeoutError, isCliTimeout } from '../cli-exec.js'
 
 const exec = promisify(execFile)
 const SEP = String.fromCharCode(31)
@@ -144,6 +145,23 @@ test('a failed push comes back as an error rather than throwing', async () => {
   }
   const result = await pushRunBranch('/repo', 'b', git)
   assert.deepEqual(result, { ok: false, error: 'no upstream configured' })
+})
+
+test('a timed-out push says so instead of reading like a rejected push (#997)', async () => {
+  const git: GitRunner = async args => {
+    throw new CliTimeoutError('git', args, GIT_SLOW_TIMEOUT_MS)
+  }
+  const result = await pushRunBranch('/repo', 'b', git)
+  assert.equal(result.ok, false)
+  const error = result.ok === false ? result.error : ''
+  // A SIGTERM'd push has empty stderr, so this used to surface as a bare 'Command failed: git push'.
+  assert.match(error, /timed out after 120000ms/)
+  assert.match(error, /push --set-upstream origin b/)
+})
+
+test('a timeout is distinguishable from a git rejection (#997)', () => {
+  assert.equal(isCliTimeout(new CliTimeoutError('git', ['push'], 120_000)), true)
+  assert.equal(isCliTimeout(new Error("fatal: 'origin' does not appear to be a git repository")), false)
 })
 
 test("a push failure shows git's reason, not the command echoed back", () => {

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -194,10 +194,15 @@ export {
   nodeProjectFs,
   crawlRepoFiles,
   nodeGitRunner,
+  gitTimeoutMs,
+  GIT_READ_TIMEOUT_MS,
+  GIT_WRITE_TIMEOUT_MS,
+  GIT_SLOW_TIMEOUT_MS,
   readProjectSignals,
   type ProjectFs,
   type GitRunner,
 } from './project.js'
+export { CliTimeoutError, isCliTimeout, type CliTimeout } from './cli-exec.js'
 export {
   projectId,
   registryPath,

--- a/packages/framework/src/project.test.ts
+++ b/packages/framework/src/project.test.ts
@@ -4,8 +4,12 @@ import { join } from 'node:path'
 import { THE_FRAMEWORK_DIR } from './logs.js'
 import {
   crawlRepoFiles,
+  gitTimeoutMs,
   isActivated,
   theFrameworkDir,
+  GIT_READ_TIMEOUT_MS,
+  GIT_SLOW_TIMEOUT_MS,
+  GIT_WRITE_TIMEOUT_MS,
   type GitRunner,
   type ProjectFs,
 } from './project.js'
@@ -62,4 +66,71 @@ test('crawlRepoFiles yields [] when git fails', async () => {
     throw new Error('not a git repository')
   })
   assert.deepEqual(files, [])
+})
+
+/**
+ * Every git invocation in the package, taken from the call sites listed in #997, against the
+ * budget it should get. The point of the split is that these are not all the same number.
+ */
+const BUDGETS: { args: string[]; ms: number }[] = [
+  // The network and a whole checkout: the two the flat 10s budget was killing.
+  { args: ['push', '--set-upstream', 'origin', 'the-framework/run-1'], ms: GIT_SLOW_TIMEOUT_MS },
+  { args: ['worktree', 'add', '-b', 'the-framework/run-1', '/wt', 'main'], ms: GIT_SLOW_TIMEOUT_MS },
+  { args: ['worktree', 'add', '/wt', 'the-framework/run-1'], ms: GIT_SLOW_TIMEOUT_MS },
+  { args: ['clone', 'https://example.com/repo.git', '/dest'], ms: GIT_SLOW_TIMEOUT_MS },
+  { args: ['fetch', 'origin'], ms: GIT_SLOW_TIMEOUT_MS },
+  // Local mutations.
+  { args: ['add', '-A'], ms: GIT_WRITE_TIMEOUT_MS },
+  { args: ['commit', '-m', 'msg', '--', 'path'], ms: GIT_WRITE_TIMEOUT_MS },
+  { args: ['init'], ms: GIT_WRITE_TIMEOUT_MS },
+  { args: ['checkout', 'branch', '--', 'TODO.md'], ms: GIT_WRITE_TIMEOUT_MS },
+  { args: ['worktree', 'remove', '--force', '/wt'], ms: GIT_WRITE_TIMEOUT_MS },
+  { args: ['worktree', 'prune'], ms: GIT_WRITE_TIMEOUT_MS },
+  // Reads, which must stay short so a hung one does not hold the daemon for minutes.
+  { args: ['ls-files', '-z', '--cached', '--others', '--exclude-standard'], ms: GIT_READ_TIMEOUT_MS },
+  { args: ['status', '--porcelain'], ms: GIT_READ_TIMEOUT_MS },
+  { args: ['rev-parse', '--abbrev-ref', 'HEAD'], ms: GIT_READ_TIMEOUT_MS },
+  { args: ['rev-parse', '--git-common-dir'], ms: GIT_READ_TIMEOUT_MS },
+  { args: ['rev-list', '--count', 'a..b'], ms: GIT_READ_TIMEOUT_MS },
+  { args: ['log', '--format=%H%x1f%s', 'a..b'], ms: GIT_READ_TIMEOUT_MS },
+  { args: ['diff', '--numstat', 'HEAD'], ms: GIT_READ_TIMEOUT_MS },
+  { args: ['show', 'HEAD:TODO.md'], ms: GIT_READ_TIMEOUT_MS },
+  { args: ['remote', 'get-url', 'origin'], ms: GIT_READ_TIMEOUT_MS },
+  { args: ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], ms: GIT_READ_TIMEOUT_MS },
+  { args: ['branch', '--list', '--merged', 'main', 'topic'], ms: GIT_READ_TIMEOUT_MS },
+  { args: ['worktree', 'list', '--porcelain'], ms: GIT_READ_TIMEOUT_MS },
+]
+
+for (const { args, ms } of BUDGETS) {
+  test(`gitTimeoutMs: \`git ${args.join(' ')}\` gets ${ms}ms (#997)`, () => {
+    assert.equal(gitTimeoutMs(args), ms)
+  })
+}
+
+test('the git budgets stay split rather than collapsing to one number (#997)', () => {
+  // Pinned on purpose: widening reads to "fix" a slow op would let a hung read hold the daemon.
+  assert.equal(GIT_READ_TIMEOUT_MS, 10_000)
+  assert.equal(GIT_WRITE_TIMEOUT_MS, 30_000)
+  assert.equal(GIT_SLOW_TIMEOUT_MS, 120_000)
+})
+
+test('gitTimeoutMs: a slow op gets far longer than a read (#997)', () => {
+  assert.ok(
+    gitTimeoutMs(['push', '--set-upstream', 'origin', 'b']) > gitTimeoutMs(['rev-parse', 'HEAD']) * 2,
+    'push must not run under a read budget',
+  )
+  assert.ok(
+    gitTimeoutMs(['worktree', 'add', '-b', 'b', '/wt']) > gitTimeoutMs(['worktree', 'list']) * 2,
+    'worktree add must not run under the budget its read sibling gets',
+  )
+})
+
+test('gitTimeoutMs: an unknown subcommand is treated as a mutation, not as slow (#997)', () => {
+  assert.equal(gitTimeoutMs(['bisect', 'start']), GIT_WRITE_TIMEOUT_MS)
+  assert.equal(gitTimeoutMs([]), GIT_WRITE_TIMEOUT_MS)
+})
+
+test('gitTimeoutMs: leading flags do not hide the subcommand (#997)', () => {
+  assert.equal(gitTimeoutMs(['--no-pager', 'status', '--porcelain']), GIT_READ_TIMEOUT_MS)
+  assert.equal(gitTimeoutMs(['--no-pager', 'push', 'origin', 'b']), GIT_SLOW_TIMEOUT_MS)
 })

--- a/packages/framework/src/project.ts
+++ b/packages/framework/src/project.ts
@@ -60,13 +60,66 @@ export async function isActivated(cwd: string, fs: ProjectFs = nodeProjectFs()):
 export type GitRunner = CliRunner
 
 /**
- * A {@link GitRunner} backed by `execFile('git', ...)`. Rejects on any git error.
+ * A local read: the index, a ref, or objects already on disk. Kept at the budget that used to
+ * cover everything, so a hung read still fails fast instead of holding the daemon longer (#997).
+ */
+export const GIT_READ_TIMEOUT_MS = 10_000
+
+/** A local mutation. Bounded by disk, but an index write on a large repo outlives a read. */
+export const GIT_WRITE_TIMEOUT_MS = 30_000
+
+/**
+ * The network, or a whole checkout. `git worktree add` writes every tracked file and `git push`
+ * uploads a packfile; on a large repo both routinely pass 10s, which is what #997 is about. Well
+ * past the 60s `gh` allows its write actions (dashboard/gh.ts), because those are API calls.
+ */
+export const GIT_SLOW_TIMEOUT_MS = 120_000
+
+/** Subcommands that only read. Everything unlisted is treated as a mutation. */
+const GIT_READ_OPS = new Set([
+  'branch',
+  'cat-file',
+  'diff',
+  'log',
+  'ls-files',
+  'remote',
+  'rev-list',
+  'rev-parse',
+  'show',
+  'status',
+  'symbolic-ref',
+])
+
+/** Subcommands bounded by the network rather than by this machine. */
+const GIT_SLOW_OPS = new Set(['clone', 'fetch', 'pull', 'push'])
+
+/**
+ * The timeout for one git invocation, chosen by subcommand (#997). One flat 10s budget covered
+ * the repo's ~20 call sites, so the slowest two ran under what is really a read's budget: a
+ * SIGTERM'd `worktree add` drops a run into the user's main checkout, a SIGTERM'd `push` may
+ * have half-landed. Mirrors the read/write split `gh` already has (dashboard/gh.ts).
+ */
+export function gitTimeoutMs(args: string[]): number {
+  const words = args.filter(arg => !arg.startsWith('-'))
+  const op = words[0] ?? ''
+  if (GIT_SLOW_OPS.has(op)) return GIT_SLOW_TIMEOUT_MS
+  if (op === 'worktree') {
+    // Only `add` writes a checkout; `list` is a read, and remove/prune are ordinary mutations.
+    if (words[1] === 'add') return GIT_SLOW_TIMEOUT_MS
+    return words[1] === 'list' ? GIT_READ_TIMEOUT_MS : GIT_WRITE_TIMEOUT_MS
+  }
+  return GIT_READ_OPS.has(op) ? GIT_READ_TIMEOUT_MS : GIT_WRITE_TIMEOUT_MS
+}
+
+/**
+ * A {@link GitRunner} backed by `execFile('git', ...)`. Rejects on any git error, and with a
+ * `CliTimeoutError` when the operation outran its {@link gitTimeoutMs} budget.
  *
  * The buffer is raised well past the default because a repo crawl (`git ls-files`) prints a
  * line per file, and a large checkout overruns it.
  */
 export function nodeGitRunner(): GitRunner {
-  return cliRunner({ bin: 'git', timeoutMs: 10_000, maxBuffer: 16 * 1024 * 1024 })
+  return cliRunner({ bin: 'git', timeoutMs: gitTimeoutMs, maxBuffer: 16 * 1024 * 1024 })
 }
 
 /**


### PR DESCRIPTION
Part of #997. This is the first of the two problems that issue describes; the second is deliberately untouched, see "What is not fixed here".

## The problem

`packages/framework/src/project.ts:68-70` built the one git runner in the repo with a flat `timeoutMs: 10_000`, and it is the default parameter at the package's ~20 git call sites. That single budget covered network-bound `push` and disk-bound `worktree add`, which writes a whole checkout, alongside `rev-parse` and `status`.

`git worktree add` on a large repo routinely passes 10s. `execFile` SIGTERMs it, `addWorktree` rejects, and the run loses its isolated checkout. A SIGTERM'd `push` may have half-landed on the remote, and because a killed `push` usually writes nothing to stderr, `gitReason` (`dashboard/run-handoff.ts:205-209`) surfaced a bare `Command failed: git push --set-upstream origin ...` with no hint that time, not git, was the reason.

The codebase already splits budgets by operation for `gh`: `dashboard/gh.ts:21` uses 60s for writes, `:28` uses 8s for reads. This gives `git` the same shape.

## The budgets

`nodeGitRunner()` now derives the budget from the subcommand. Every git argv in the package was enumerated by grep, not sampled, and assigned deliberately:

| Budget | Ops | Why |
|---|---|---|
| **10s** `GIT_READ_TIMEOUT_MS` | `status`, `rev-parse`, `rev-list`, `ls-files`, `log`, `diff`, `show`, `remote`, `symbolic-ref`, `branch --list`, `cat-file`, `worktree list` | Local reads of the index, a ref or objects already on disk. Unchanged from today on purpose: a hung read must still fail fast rather than hold the daemon longer. |
| **30s** `GIT_WRITE_TIMEOUT_MS` | `add`, `commit`, `init`, `checkout`, `worktree remove`, `worktree prune`, and any unlisted subcommand | Local mutations. Bounded by disk rather than by the network, but an index write or a `commit` on a large repo outlives a read. |
| **120s** `GIT_SLOW_TIMEOUT_MS` | `push`, `fetch`, `pull`, `clone`, `worktree add` | The network, or a whole checkout. These are the two the flat budget was killing. Chosen above the 60s `gh` allows its write actions because those are API calls, whereas `worktree add` writes every tracked file to disk and `push` uploads a packfile. |

Two details worth naming. `worktree` is split by its subcommand rather than treated as one op: only `add` writes a checkout, `list` is a read, and `remove`/`prune` are ordinary mutations. And an unrecognised subcommand falls to the *write* budget, not the slow one, so nothing is silently granted two minutes.

## Distinguishing a timeout

`cliRunner` now detects the SIGTERM kill (`err.killed` without `ENOBUFS`, which is the maxBuffer overrun rather than a timeout) and rejects with a `CliTimeoutError`:

```
git push --set-upstream origin the-framework/x timed out after 120000ms
```

That flows through `gitReason` unchanged and reaches the dashboard as the reason, instead of the command echoed back. `isCliTimeout(err)` is exported for callers that need to branch on it programmatically, and the error carries a `timedOut` brand so it survives a module boundary. The `console.log` in `allocateWorkspace` also gets the better message for free, with no change to what it does.

## Public API

`nodeGitRunner()` is public API (`src/index.ts:196`) and **its signature is unchanged**. No optional parameter was needed: the budget is derived from the args the caller already passes, so all ~20 call sites get the right one without touching any of them.

Additive only, hence `minor` rather than `patch`: `gitTimeoutMs`, the three budget constants, `CliTimeoutError`, `isCliTimeout`, and the `CliTimeout` type. `CliRunnerOptions.timeoutMs` widens from `number` to `number | ((args: string[]) => number)`, which is backward compatible for callers.

## What is not fixed here

**`allocateWorkspace`'s fallback to the main checkout** (`daemon-runtime.ts:249-261`) is left exactly as it is. When `addWorktree` rejects it still logs and runs in the user's own checkout. Whether that should instead fail the run is an open policy question and a user-visible behaviour change, so it is not decided in a timeout PR. Raising the `worktree add` budget from 10s to 120s means that fallback fires far less often, which is most of why this half is worth landing on its own.

**The silent re-pend in `conversation-commit.ts`** (`:265-269`, where the poller's `else` branch re-pends without logging) is also untouched and still open.

## Tests

Baseline on `f6efb7d`: **1059 tests, 1058 pass, 0 fail, 1 skipped**. After: **1093 tests, 1092 pass, 0 fail, 1 skipped** (+34). Root `pnpm build` 11/11, `pnpm typecheck` 21/21, `pnpm test` 21/21.

New coverage: a real killed process rejects as a timeout while a non-zero exit does not; a per-args budget lets the same 400ms of work complete under the long budget and be killed under the short one; every git argv in the package against its expected budget; the three constants pinned so they cannot quietly collapse into one; and a timed-out `pushRunBranch` surfacing "timed out" rather than a generic failure.

### Proof by revert

The source fix was reverted behaviourally (`gitTimeoutMs` returning a flat `10_000`, and the timeout-detection branch removed from `cliRunner`) while keeping the new tests and the new symbols, so the failures are runtime assertion failures and not compile errors. 16 tests failed:

```
✖ a killed process rejects as a timeout, not as a generic failure (#997)
✖ a per-args timeout gives the slow op room the short one does not (#997)
✖ gitTimeoutMs: `git push --set-upstream origin the-framework/run-1` gets 120000ms (#997)
✖ gitTimeoutMs: `git worktree add -b the-framework/run-1 /wt main` gets 120000ms (#997)
✖ gitTimeoutMs: `git worktree add /wt the-framework/run-1` gets 120000ms (#997)
✖ gitTimeoutMs: `git clone https://example.com/repo.git /dest` gets 120000ms (#997)
✖ gitTimeoutMs: `git fetch origin` gets 120000ms (#997)
✖ gitTimeoutMs: `git add -A` gets 30000ms (#997)
✖ gitTimeoutMs: `git commit -m msg -- path` gets 30000ms (#997)
✖ gitTimeoutMs: `git init` gets 30000ms (#997)
✖ gitTimeoutMs: `git checkout branch -- TODO.md` gets 30000ms (#997)
✖ gitTimeoutMs: `git worktree remove --force /wt` gets 30000ms (#997)
✖ gitTimeoutMs: `git worktree prune` gets 30000ms (#997)
✖ gitTimeoutMs: a slow op gets far longer than a read (#997)
✖ gitTimeoutMs: an unknown subcommand is treated as a mutation, not as slow (#997)
✖ gitTimeoutMs: leading flags do not hide the subcommand (#997)

ℹ tests 1093
ℹ pass 1076
ℹ fail 16
```

One honest caveat: `a timed-out push says so instead of reading like a rejected push (#997)` does not fail under that revert, because it constructs a `CliTimeoutError` directly to lock the string the dashboard shows. The detection half of that path is what `a killed process rejects as a timeout` proves, and it does fail.