### PR TITLE
feat(dashboard): design gallery, and bind dark: to the theme class

### DIFF
--- a/.changeset/quiet-pugs-shave.md
+++ b/.changeset/quiet-pugs-shave.md
@@ -1,0 +1,12 @@
+---
+'@gemstack/framework': patch
+---
+
+Dashboard: make the `dark:` utilities follow the theme toggle instead of the OS.
+
+Tailwind v4 compiles `dark:` to `@media (prefers-color-scheme: dark)` unless a custom variant
+says otherwise, but the dashboard's tokens live on the `.dark` class that LayoutDefault toggles.
+The two disagreed: picking Dark on a light OS applied the dark tokens while leaving every
+`dark:text-*` rule unapplied, so diff counts, the stream-lost banner and the daemon-health banner
+kept their light-mode colours on a dark canvas (and the reverse on a dark OS set to Light).
+Declaring `@custom-variant dark` binds both to the same signal.

--- a/packages/framework-dashboard/design/.gitignore
+++ b/packages/framework-dashboard/design/.gitignore
@@ -1,0 +1,2 @@
+out/
+.css-build/

--- a/packages/framework-dashboard/design/build.mts
+++ b/packages/framework-dashboard/design/build.mts
@@ -1,0 +1,97 @@
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { build } from 'vite'
+import { PREVIEWS, type Preview } from './previews.js'
+
+// Builds the design gallery: one self-contained HTML file per card, each carrying the shipped
+// stylesheet inline and rendering its component in both themes. `pnpm design:build`, then
+// DesignSync uploads design/out/**. Cards are static — no client JS — so hover/open states are
+// shown as separate rendered instances rather than something to click.
+
+const here = dirname(fileURLToPath(import.meta.url))
+const outDir = join(here, 'out')
+const cssBuildDir = join(here, '.css-build')
+
+/** Runs the CSS-only Vite build and returns the compiled stylesheet. */
+async function compileCss(): Promise<string> {
+  await build({ configFile: join(here, 'vite.config.css.ts') })
+  const files: string[] = []
+  const walk = async (dir: string) => {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name)
+      if (entry.isDirectory()) await walk(full)
+      else if (entry.name.endsWith('.css')) files.push(full)
+    }
+  }
+  await walk(cssBuildDir)
+  const css = (await Promise.all(files.map(f => readFile(f, 'utf8')))).join('\n')
+  if (css.trim().length === 0) throw new Error('gallery CSS build produced nothing')
+  return css
+}
+
+/** Gallery chrome. Deliberately its own namespace so it cannot be mistaken for app styling. */
+const CHROME = `
+  .ds-page { padding: 24px; font-family: ui-sans-serif, system-ui, sans-serif; }
+  .ds-head { margin-bottom: 16px; }
+  .ds-title { font-size: 15px; font-weight: 600; }
+  .ds-sub { font-size: 12px; opacity: 0.65; margin-top: 2px; }
+  .ds-flag { display: inline-block; margin-top: 8px; padding: 2px 8px; border-radius: 999px;
+    font-size: 11px; background: rgba(245,158,11,0.16); color: #b45309; }
+  .ds-themes { display: grid; gap: 16px; grid-template-columns: 1fr; }
+  @media (min-width: 900px) { .ds-themes { grid-template-columns: 1fr 1fr; } }
+  .ds-pane { border-radius: 12px; overflow: hidden; border: 1px solid rgba(128,128,128,0.28); }
+  .ds-pane-label { font-size: 11px; letter-spacing: 0.04em; text-transform: uppercase;
+    padding: 6px 12px; opacity: 0.6; border-bottom: 1px solid rgba(128,128,128,0.22); }
+  .ds-pane-body { padding: 20px; }
+`
+
+function page(preview: Preview, css: string): string {
+  const body = renderToStaticMarkup(preview.node as never)
+  const pane = (label: string, dark: boolean) => `
+      <div class="ds-pane${dark ? ' dark' : ''}">
+        <div class="ds-pane-body bg-background text-foreground" style="padding:0">
+          <div class="ds-pane-label">${label}</div>
+          <div class="ds-pane-body">${body}</div>
+        </div>
+      </div>`
+
+  return `<!-- @dsCard group="${preview.group}" -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>${preview.name}</title>
+<style>${css}</style>
+<style>${CHROME}</style>
+</head>
+<body>
+<div class="ds-page">
+  <div class="ds-head">
+    <div class="ds-title">${preview.name}</div>
+    <div class="ds-sub">${preview.subtitle}</div>
+    ${preview.replica ? '<div class="ds-flag">Replica: portalled at runtime, markup hand-copied from source</div>' : ''}
+  </div>
+  <div class="ds-themes">
+${pane('Light', false)}
+${pane('Dark', true)}
+  </div>
+</div>
+</body>
+</html>
+`
+}
+
+const css = await compileCss()
+await rm(outDir, { recursive: true, force: true })
+
+for (const preview of PREVIEWS) {
+  const target = join(outDir, preview.path)
+  await mkdir(dirname(target), { recursive: true })
+  await writeFile(target, page(preview, css), 'utf8')
+}
+
+await rm(cssBuildDir, { recursive: true, force: true })
+console.log(`design gallery: ${PREVIEWS.length} cards -> ${outDir} (${Math.round(css.length / 1024)} KB css inlined)`)

--- a/packages/framework-dashboard/design/gallery.css
+++ b/packages/framework-dashboard/design/gallery.css
@@ -1,0 +1,6 @@
+/* The gallery's stylesheet is the shipped one, unchanged, so a card cannot drift from the app.
+   The extra @source lines keep Tailwind scanning the preview files themselves. */
+@import '../layouts/tailwind.css';
+
+@source '../components';
+@source './previews.tsx';

--- a/packages/framework-dashboard/design/previews.tsx
+++ b/packages/framework-dashboard/design/previews.tsx
@@ -1,0 +1,439 @@
+import type { ReactNode } from 'react'
+import { Button } from '../components/ui/button.js'
+import { Badge } from '../components/ui/badge.js'
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.js'
+import { OptionLabel } from '../components/ui/option-label.js'
+import { DisclosureToggle } from '../components/DisclosureToggle.js'
+import { ActivityChart } from '../components/ActivityChart.js'
+import { RunOutcomes } from '../components/RunOutcomes.js'
+
+// The gallery's card registry (#DESIGN). Every entry renders the REAL component wherever the
+// component can stand alone, so a card cannot quietly drift from what ships. The few that cannot
+// (portalled tooltips, anything behind a Telefunc read) are marked `replica` and say so on the
+// card, because a silent hand-copy is exactly the drift this gallery exists to catch.
+
+export interface Preview {
+  path: string
+  group: string
+  name: string
+  subtitle: string
+  width: number
+  height?: number
+  /** True when the markup is a hand-copy rather than the shipped component. */
+  replica?: boolean
+  node: ReactNode
+}
+
+/** A labelled row inside a card. */
+function Row({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</span>
+      <div className="flex flex-wrap items-center gap-3">{children}</div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------- foundations
+
+const TOKENS = [
+  ['--background', 'Page canvas'],
+  ['--foreground', 'Body text'],
+  ['--card', 'Raised surface'],
+  ['--card-foreground', 'Text on card'],
+  ['--muted', 'Recessed fill'],
+  ['--muted-foreground', 'Secondary text'],
+  ['--border', 'Hairlines'],
+  ['--primary', 'Brand / action'],
+  ['--primary-foreground', 'Text on primary'],
+  ['--accent', 'Hover fill'],
+  ['--accent-foreground', 'Text on accent'],
+] as const
+
+function ColorTokens() {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+      {TOKENS.map(([token, use]) => (
+        <div key={token} className="flex items-center gap-3">
+          <div
+            className="h-10 w-10 shrink-0 rounded-md border border-border"
+            style={{ background: `var(${token})` }}
+          />
+          <div className="min-w-0">
+            <div className="truncate font-mono text-xs">{token}</div>
+            <div className="truncate text-xs text-muted-foreground">{use}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// The status hues are raw palette values today (no token backs them), which is why they are
+// shown apart from the token grid: this card is the evidence for that gap, not a blessing of it.
+const STATUS = [
+  ['Done / passing', 'bg-emerald-500', 'emerald-500'],
+  ['Failed / destructive', 'bg-red-500', 'red-500'],
+  ['Stopped / warning', 'bg-amber-500', 'amber-500'],
+  ['Running / live', 'bg-primary', '--primary'],
+] as const
+
+function StatusPalette() {
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {STATUS.map(([label, fill, value]) => (
+          <div key={label} className="flex items-center gap-2.5">
+            <span className={`h-8 w-8 shrink-0 rounded-md ${fill}`} />
+            <div className="min-w-0">
+              <div className="truncate text-xs font-medium">{label}</div>
+              <div className="truncate font-mono text-xs text-muted-foreground">{value}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Three of the four are raw Tailwind palette values with no semantic token behind them, so a
+        theme change cannot reach them and nothing stops a fifth green appearing.
+      </p>
+    </div>
+  )
+}
+
+const TYPE = [
+  ['text-2xl font-semibold tabular-nums', 'KPI value', '24px / 600'],
+  ['text-xl font-semibold', 'Page title', '20px / 600'],
+  ['text-sm font-semibold', 'Card title', '14px / 600'],
+  ['text-sm', 'Body', '14px / 400'],
+  ['text-xs text-muted-foreground', 'Meta, captions', '12px / 400'],
+  ['text-xs font-medium uppercase tracking-wide text-muted-foreground', 'Tile label', '12px / 500 caps'],
+] as const
+
+function TypeScale() {
+  return (
+    <div className="space-y-3">
+      {TYPE.map(([cls, label, spec]) => (
+        <div key={label} className="flex items-baseline justify-between gap-4 border-b border-border pb-2 last:border-0">
+          <span className={cls}>{label}</span>
+          <span className="shrink-0 font-mono text-xs text-muted-foreground">{spec}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function RadiusScale() {
+  const radii = [
+    ['rounded-sm', 'Chart bars'],
+    ['rounded', 'Icon buttons'],
+    ['rounded-md', 'Buttons, inputs'],
+    ['rounded-lg', 'Cards'],
+    ['rounded-full', 'Pills, dots'],
+  ] as const
+  return (
+    <div className="flex flex-wrap gap-4">
+      {radii.map(([cls, use]) => (
+        <div key={cls} className="flex flex-col items-center gap-1.5">
+          <div className={`h-12 w-12 border border-border bg-muted ${cls}`} />
+          <span className="font-mono text-xs">{cls}</span>
+          <span className="text-xs text-muted-foreground">{use}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------- components
+
+function Buttons() {
+  return (
+    <div className="space-y-5">
+      <Row label="Variants">
+        <Button>Start session</Button>
+        <Button variant="outline">Outline</Button>
+        <Button variant="ghost">Ghost</Button>
+      </Row>
+      <Row label="Sizes">
+        <Button size="default">Default</Button>
+        <Button size="sm">Small</Button>
+        <Button size="xs">Extra small</Button>
+        <Button size="icon" aria-label="Icon">
+          <span className="text-xs">IC</span>
+        </Button>
+        <Button size="icon-sm" aria-label="Icon small">
+          <span className="text-[10px]">S</span>
+        </Button>
+      </Row>
+      <Row label="States">
+        <Button disabled>Disabled</Button>
+        <Button variant="outline" disabled>
+          Disabled outline
+        </Button>
+      </Row>
+      <p className="text-xs text-muted-foreground">
+        There is no destructive variant, so every irreversible action in the app (remove worktree,
+        delete preset, stop a run) is styled ad hoc at the call site.
+      </p>
+    </div>
+  )
+}
+
+function Badges() {
+  return (
+    <div className="space-y-5">
+      <Row label="Event kinds">
+        <Badge>driver</Badge>
+        <Badge>tool</Badge>
+        <Badge>gate</Badge>
+        <Badge>end</Badge>
+      </Row>
+      <Row label="Status (as used today)">
+        <Badge className="border-transparent bg-emerald-500/15 text-emerald-600">DONE</Badge>
+        <Badge className="border-transparent bg-red-500/15 text-red-600">FAILED</Badge>
+        <Badge className="border-transparent bg-amber-500/15 text-amber-600">STOPPED</Badge>
+        <Badge className="border-transparent bg-primary/15 text-primary">RUNNING</Badge>
+      </Row>
+      <p className="text-xs text-muted-foreground">
+        The Badge primitive carries no variant prop, so status colouring is applied by hand at each
+        call site — the reason the same status reads differently in different rails.
+      </p>
+    </div>
+  )
+}
+
+function Cards() {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Session activity</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">Header plus content, the dashboard default.</p>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent className="flex flex-col gap-1">
+          <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Active sessions
+          </div>
+          <div className="text-2xl font-semibold tabular-nums text-primary">3</div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function StatTiles() {
+  const tiles = [
+    ['Projects', 12, false],
+    ['Active sessions', 3, true],
+    ['Open TODOs', 47, false],
+    ['Total sessions', 218, false],
+  ] as const
+  return (
+    <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+      {tiles.map(([label, value, accent]) => (
+        <Card key={label}>
+          <CardContent className="flex flex-col gap-1">
+            <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {label}
+            </div>
+            <div className={`text-2xl font-semibold tabular-nums${accent ? ' text-primary' : ''}`}>{value}</div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}
+
+function Disclosures() {
+  return (
+    <div className="space-y-3">
+      <DisclosureToggle open={false} onToggle={() => {}}>
+        See actual prompt sent
+      </DisclosureToggle>
+      <DisclosureToggle open onToggle={() => {}}>
+        Context (open)
+      </DisclosureToggle>
+      <div className="pt-2">
+        <OptionLabel label="Worktree" description="Run each session in its own git worktree" />
+      </div>
+    </div>
+  )
+}
+
+// Tooltip and dropdown popups are portalled, so they render to nothing server-side. These use the
+// popup's exact class string from ui/tooltip.tsx — a replica, flagged as one on the card.
+function Overlays() {
+  return (
+    <div className="flex flex-wrap items-start gap-6">
+      <div className="rounded-md border border-border bg-card px-2 py-1 text-xs text-card-foreground shadow-md">
+        Copy branch name
+      </div>
+      <div className="min-w-48 rounded-md border border-border bg-card p-1 text-card-foreground shadow-md">
+        <div className="rounded-sm px-2 py-1.5 text-sm">
+          <OptionLabel label="Autopilot" description="Accept safe edits without asking" />
+        </div>
+        <div className="rounded-sm bg-accent px-2 py-1.5 text-sm text-accent-foreground">
+          <OptionLabel label="Eco" description="Prefer the cheaper model" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------- data display
+
+const ACTIVITY = [
+  1, 0, 3, 2, 0, 5, 4, 2, 7, 3, 0, 1, 6, 4,
+].map((count, i) => ({ date: `2026-07-${String(i + 8).padStart(2, '0')}`, count }))
+
+function Charts() {
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Session activity</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ActivityChart data={ACTIVITY} />
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Session outcomes</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <RunOutcomes counts={{ done: 14, failed: 3, stopped: 5, running: 0 }} />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function EmptyStates() {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      <Card>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">No finished sessions yet.</p>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent className="flex flex-col items-start gap-3">
+          <p className="text-sm text-muted-foreground">Nothing in the backlog.</p>
+          <Button size="sm" variant="outline">
+            Add a TODO
+          </Button>
+        </CardContent>
+      </Card>
+      <p className="text-xs text-muted-foreground sm:col-span-2">
+        Empty states are bare sentences today: no icon, no explanation of what would fill the space,
+        and only sometimes a next action.
+      </p>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------- registry
+
+export const PREVIEWS: Preview[] = [
+  {
+    path: 'foundations/color-tokens.html',
+    group: 'Foundations',
+    name: 'Color tokens',
+    subtitle: '11 semantic tokens, light + dark',
+    width: 900,
+    node: <ColorTokens />,
+  },
+  {
+    path: 'foundations/status-palette.html',
+    group: 'Foundations',
+    name: 'Status palette',
+    subtitle: 'Done / failed / stopped / running — 3 of 4 untokenised',
+    width: 900,
+    node: <StatusPalette />,
+  },
+  {
+    path: 'foundations/typography.html',
+    group: 'Foundations',
+    name: 'Type scale',
+    subtitle: '6 roles from KPI value to caption',
+    width: 900,
+    node: <TypeScale />,
+  },
+  {
+    path: 'foundations/radius.html',
+    group: 'Foundations',
+    name: 'Radius scale',
+    subtitle: '5 steps, sm through full',
+    width: 900,
+    node: <RadiusScale />,
+  },
+  {
+    path: 'components/button.html',
+    group: 'Components',
+    name: 'Button',
+    subtitle: '3 variants, 5 sizes, disabled',
+    width: 900,
+    node: <Buttons />,
+  },
+  {
+    path: 'components/badge.html',
+    group: 'Components',
+    name: 'Badge',
+    subtitle: 'Event kinds and status pills',
+    width: 900,
+    node: <Badges />,
+  },
+  {
+    path: 'components/card.html',
+    group: 'Components',
+    name: 'Card',
+    subtitle: 'Header + content, and the bare tile form',
+    width: 900,
+    node: <Cards />,
+  },
+  {
+    path: 'components/stat-tile.html',
+    group: 'Components',
+    name: 'Stat tile',
+    subtitle: 'The Overview KPI row, accent on active',
+    width: 900,
+    node: <StatTiles />,
+  },
+  {
+    path: 'components/disclosure.html',
+    group: 'Components',
+    name: 'Disclosure + option label',
+    subtitle: 'Collapsible toggles and menu labels',
+    width: 900,
+    node: <Disclosures />,
+  },
+  {
+    path: 'components/overlays.html',
+    group: 'Components',
+    name: 'Tooltip + menu popup',
+    subtitle: 'Portalled surfaces (replica)',
+    width: 900,
+    replica: true,
+    node: <Overlays />,
+  },
+  {
+    path: 'data/charts.html',
+    group: 'Data display',
+    name: 'Activity + outcomes',
+    subtitle: 'The two Overview charts, real components',
+    width: 900,
+    node: <Charts />,
+  },
+  {
+    path: 'patterns/empty-states.html',
+    group: 'Patterns',
+    name: 'Empty states',
+    subtitle: 'What the rails show with no data',
+    width: 900,
+    node: <EmptyStates />,
+  },
+]

--- a/packages/framework-dashboard/design/vite.config.css.ts
+++ b/packages/framework-dashboard/design/vite.config.css.ts
@@ -1,0 +1,18 @@
+import { fileURLToPath } from 'node:url'
+import tailwindcss from '@tailwindcss/vite'
+import { defineConfig } from 'vite'
+
+// Compiles the gallery's Tailwind entry to one plain .css file, which build.mts inlines into
+// every card. Separate from the app's vite.config.ts on purpose: no Vike, no Telefunc, no React
+// plugin — this build exists only to produce CSS.
+export default defineConfig({
+  plugins: [tailwindcss()],
+  logLevel: 'warn',
+  build: {
+    outDir: fileURLToPath(new URL('./.css-build', import.meta.url)),
+    emptyOutDir: true,
+    rollupOptions: {
+      input: fileURLToPath(new URL('./gallery.css', import.meta.url)),
+    },
+  },
+})

--- a/packages/framework-dashboard/layouts/tailwind.css
+++ b/packages/framework-dashboard/layouts/tailwind.css
@@ -1,5 +1,11 @@
 @import 'tailwindcss';
 
+/* The theme is the `.dark` class LayoutDefault toggles, not the OS preference. Without this,
+   Tailwind v4 compiles `dark:` to `@media (prefers-color-scheme: dark)`, so the `dark:` utilities
+   disagreed with the tokens: picking Dark on a light OS applied the dark tokens but left
+   `dark:text-*-400` unapplied, and picking Light on a dark OS applied them when it should not. */
+@custom-variant dark (&:where(.dark, .dark *));
+
 /* shadcn-style design tokens (neutral slate), light + dark. The Framework's MVP page
    is dark-first; mirror that so the spike reads as the same product. */
 @theme {

--- a/packages/framework-dashboard/package.json
+++ b/packages/framework-dashboard/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "design:build": "tsx design/build.mts",
     "preview": "vite preview",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
@@ -46,6 +47,7 @@
     "@vitejs/plugin-react": "^6.0.3",
     "jsdom": "^29.1.1",
     "tailwindcss": "^4.0.0",
+    "tsx": "^4.22.4",
     "typescript": "^5.4.0",
     "vite": "^8.0.0",
     "vitest": "^4.1.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,6 +356,9 @@ importers:
       tailwindcss:
         specifier: ^4.0.0
         version: 4.3.2
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^5.4.0
         version: 5.9.3


### PR DESCRIPTION
Two things, one small and one that turned out to be a real bug.

## 1. A design gallery for the dashboard

`pnpm design:build` renders 12 cards to `design/out` as self-contained HTML, then they upload to a Claude Design project. Each card renders the **real component** with the **shipped stylesheet inlined**, in both themes side by side, so a card cannot drift from what ships and theme gaps are visible at a glance.

Covered: colour tokens, status palette, type scale, radius scale, Button, Badge, Card, stat tile, disclosure + option label, tooltip/menu popups, the two Overview charts, empty states.

Two cards are honest about their limits: portalled surfaces (tooltip, menu) cannot render server side, so they are hand-copied from source and the card is stamped "replica".

## 2. `dark:` did not follow the theme toggle

Tailwind v4 compiles `dark:` to `@media (prefers-color-scheme: dark)` unless a custom variant says otherwise. The dashboard's tokens live on the `.dark` class that `LayoutDefault` toggles. The two keyed off different signals.

So picking **Dark** while the OS is **light** applied the dark tokens but left every `dark:text-*` rule unapplied: diff counts, the stream-lost banner and the daemon-health banner kept their light-mode colours on a dark canvas. The reverse happened on a dark OS set to Light.

Affects 7 sites: `DiffView` (4), `RunFeed`, `RunOverview`, and the daemon-health banner in `+Page`.

Fix is one line, `@custom-variant dark (&:where(.dark, .dark *));`.

Verified by measuring computed colour on identical markup under both OS settings:

| | OS light | OS dark |
|---|---|---|
| before | `oklch(0.627 …)` | `oklch(0.792 …)` |
| after | `oklch(0.792 …)` | `oklch(0.792 …)` |

Compiled CSS went from 1 `prefers-color-scheme` rule and 0 `.dark`-keyed rules to 0 and 5.

## Verification

- 288 tests pass (47 files), typecheck clean, full `pnpm build` green
- Gallery driven in a real browser, not just asserted on markup
- Dashboard run from this branch against the real registry and screenshotted

## Not in this PR

The gallery was built to find drift, and it found plenty. Written up separately rather than bundled here: no semantic status tokens (which forces 60+ raw palette usages), 19 focusable elements with no visible focus ring, two interchangeable syntaxes for the same token, and four hand-rolled versions of the same count pill.