### PR TITLE
fix(framework): git timeout option parsing, and a visible conversation-commit failure

### DIFF
--- a/.changeset/fix-git-timeout-parsing-and-commit-logging.md
+++ b/.changeset/fix-git-timeout-parsing-and-commit-logging.md
@@ -1,0 +1,22 @@
+---
+'@gemstack/framework': patch
+---
+
+`gitTimeoutMs()` no longer mistakes the value of a global git option for the subcommand, and a
+conversation commit that keeps failing now says why.
+
+`gitTimeoutMs()` picked the subcommand by dropping every word that starts with `-`, which drops
+the flags but keeps the values of the global options that take one. `git -C /repo push` therefore
+read as the subcommand `/repo`, and the push silently got the 30s local-mutation budget instead of
+its intended 120s network budget. The same held for `-c key=val`, `--git-dir`, `--work-tree`,
+`--namespace` and `--exec-path`. The leading global options are now skipped properly, value and
+all, so the real subcommand is what picks the budget. No call site in the package passes `-C`
+today, so no timeout that was already correct changes; this closes the trap before a future call
+site falls into it. `gitTimeoutMs()`'s signature is unchanged.
+
+The conversation committer logged only its successes. `commitConversations()` returns a reason
+when it declines or fails, and the poller dropped it, so a project whose commit failed every tick
+re-queued itself forever while printing nothing at all. The reason is now logged, but on change
+only: the first failure prints one line, and repeats of the same reason stay quiet until the
+reason changes or the commit lands, so a stuck project cannot flood the daemon log one line per
+poll window. The ordinary "no conversation changes" outcome is never reported as a failure.

--- a/packages/framework/src/conversation-commit.test.ts
+++ b/packages/framework/src/conversation-commit.test.ts
@@ -255,6 +255,100 @@ test('a busy repo keeps its place, so the next window retries it (#912)', async 
   }
 })
 
+test('a failing commit logs its reason once, not once per poll', async () => {
+  const { git } = fakeGit({
+    'rev-parse': '/repo/.git\n',
+    status: '?? .the-framework/conversations/a.md',
+    commit: () => {
+      throw new Error('nothing added to commit')
+    },
+  })
+  const logs: string[] = []
+  const committer = startConversationCommitter({
+    projects: async () => [project('/repo')],
+    git,
+    exists: noLocks,
+    intervalMs: 1_000_000,
+    log: message => logs.push(message),
+  })
+  try {
+    await settle() // the baseline poll only opens the idle window
+    assert.deepEqual(logs, [], 'nothing has been attempted yet')
+
+    await committer.poll() // settled, so the commit is attempted and fails
+    assert.equal(logs.length, 1, `the first failure is announced, got ${JSON.stringify(logs)}`)
+    assert.match(logs[0] ?? '', /nothing added to commit/, 'the reason is in the message')
+    assert.match(logs[0] ?? '', /\/repo/, 'the project is named')
+
+    await committer.poll()
+    await committer.poll()
+    assert.equal(logs.length, 1, `an unchanged reason stays quiet, got ${JSON.stringify(logs)}`)
+  } finally {
+    committer.stop()
+  }
+})
+
+test('a changed failure reason is announced again', async () => {
+  let reason = 'first failure'
+  const { git } = fakeGit({
+    'rev-parse': '/repo/.git\n',
+    status: '?? .the-framework/conversations/a.md',
+    commit: () => {
+      throw new Error(reason)
+    },
+  })
+  const logs: string[] = []
+  const committer = startConversationCommitter({
+    projects: async () => [project('/repo')],
+    git,
+    exists: noLocks,
+    intervalMs: 1_000_000,
+    log: message => logs.push(message),
+  })
+  try {
+    await settle()
+    await committer.poll()
+    await committer.poll()
+    assert.equal(logs.length, 1, `one reason, one line, got ${JSON.stringify(logs)}`)
+
+    reason = 'second failure'
+    await committer.poll()
+    assert.equal(logs.length, 2, `a new reason is diagnosable, got ${JSON.stringify(logs)}`)
+    assert.match(logs[1] ?? '', /second failure/)
+  } finally {
+    committer.stop()
+  }
+})
+
+test('the ordinary idle case is not announced as a failure', async () => {
+  // The poll sees a pending file, but the commit's own re-read finds it already gone: an
+  // everyday race, not something to log.
+  const file = '?? .the-framework/conversations/a.md'
+  let reads = 0
+  const { git, commits } = fakeGit({
+    'rev-parse': '/repo/.git\n',
+    // Calls 1 and 2 are the poller's own reads; every later odd call is the commit's re-read.
+    status: () => (++reads <= 2 ? file : reads % 2 === 1 ? '' : file),
+  })
+  const logs: string[] = []
+  const committer = startConversationCommitter({
+    projects: async () => [project('/repo')],
+    git,
+    exists: noLocks,
+    intervalMs: 1_000_000,
+    log: message => logs.push(message),
+  })
+  try {
+    await settle()
+    await committer.poll()
+    await committer.poll()
+    assert.equal(commits(), 0, 'there was nothing to commit')
+    assert.deepEqual(logs, [], 'an empty batch is not a failure')
+  } finally {
+    committer.stop()
+  }
+})
+
 test('a project scan that throws costs one window rather than the committer (#912)', async () => {
   const { git } = fakeGit({ 'rev-parse': '/repo/.git\n', status: '?? .the-framework/conversations/a.md' })
   const committer = startConversationCommitter({

--- a/packages/framework/src/conversation-commit.ts
+++ b/packages/framework/src/conversation-commit.ts
@@ -142,6 +142,9 @@ export async function gitBusy(
   return undefined
 }
 
+/** The everyday no-op outcome. Named so the poller can tell it apart from a real failure. */
+const NOTHING_PENDING = 'no conversation changes'
+
 /**
  * Stage and commit the pending conversations under `cwd`, scoped to {@link CONVERSATIONS_PATHSPEC}.
  *
@@ -160,7 +163,7 @@ export async function commitConversations(
   if (busy) return { committed: false, reason: busy }
 
   const files = await pendingConversations(cwd, git)
-  if (files.length === 0) return { committed: false, reason: 'no conversation changes' }
+  if (files.length === 0) return { committed: false, reason: NOTHING_PENDING }
 
   try {
     await git(['add', '--', CONVERSATIONS_PATHSPEC], cwd)
@@ -211,6 +214,8 @@ export interface ConversationCommitterOptions {
 interface Pending {
   fingerprint: string
   since: number
+  /** The last failure already announced, so a stuck project logs on change rather than per poll. */
+  loggedReason: string | undefined
 }
 
 /**
@@ -254,8 +259,9 @@ export function startConversationCommitter(opts: ConversationCommitterOptions): 
         // Settled (nothing changed since the last poll), or dirty long enough that waiting for
         // quiet is no longer worth it.
         const settled = previous?.fingerprint === fingerprint || now() - since >= maxWaitMs
+        const loggedReason = previous?.loggedReason
         if (!settled) {
-          pending.set(project.path, { fingerprint, since })
+          pending.set(project.path, { fingerprint, since, loggedReason })
           continue
         }
         const outcome = await commitConversations(project.path, git, exists)
@@ -265,7 +271,13 @@ export function startConversationCommitter(opts: ConversationCommitterOptions): 
         } else {
           // A busy repo or a rejected commit keeps its place, so the next window retries it
           // rather than starting the idle count over.
-          pending.set(project.path, { fingerprint, since })
+          const reason = outcome.reason === NOTHING_PENDING ? undefined : outcome.reason
+          // Announced on change only: this is a poll, so logging every failure would repeat the
+          // same line forever while a project stays stuck.
+          if (reason !== undefined && reason !== loggedReason) {
+            opts.log?.(`[framework] conversation commit failed in ${project.name}: ${reason}`)
+          }
+          pending.set(project.path, { fingerprint, since, loggedReason: reason })
         }
       }
       // Drop state for projects that went away, so the map cannot grow without bound.

--- a/packages/framework/src/project.test.ts
+++ b/packages/framework/src/project.test.ts
@@ -134,3 +134,24 @@ test('gitTimeoutMs: leading flags do not hide the subcommand (#997)', () => {
   assert.equal(gitTimeoutMs(['--no-pager', 'status', '--porcelain']), GIT_READ_TIMEOUT_MS)
   assert.equal(gitTimeoutMs(['--no-pager', 'push', 'origin', 'b']), GIT_SLOW_TIMEOUT_MS)
 })
+
+test('gitTimeoutMs: the value of a global option is not mistaken for the subcommand', () => {
+  assert.equal(gitTimeoutMs(['-C', '/repo', 'push', 'origin', 'b']), GIT_SLOW_TIMEOUT_MS)
+  assert.equal(gitTimeoutMs(['-C', '/repo', 'status', '--porcelain']), GIT_READ_TIMEOUT_MS)
+  assert.equal(gitTimeoutMs(['-C', '/repo', 'commit', '-m', 'msg']), GIT_WRITE_TIMEOUT_MS)
+  assert.equal(gitTimeoutMs(['-c', 'user.name=x', 'fetch', 'origin']), GIT_SLOW_TIMEOUT_MS)
+  assert.equal(gitTimeoutMs(['--git-dir', '/repo/.git', 'clone', 'url', '/dest']), GIT_SLOW_TIMEOUT_MS)
+  assert.equal(gitTimeoutMs(['--work-tree', '/repo', 'pull']), GIT_SLOW_TIMEOUT_MS)
+  assert.equal(gitTimeoutMs(['--namespace', 'ns', 'log']), GIT_READ_TIMEOUT_MS)
+  assert.equal(gitTimeoutMs(['--exec-path', '/libexec', 'push']), GIT_SLOW_TIMEOUT_MS)
+})
+
+test('gitTimeoutMs: a global option before `worktree` does not hide `add`', () => {
+  assert.equal(gitTimeoutMs(['-C', '/repo', 'worktree', 'add', '-b', 'b', '/wt']), GIT_SLOW_TIMEOUT_MS)
+  assert.equal(gitTimeoutMs(['-C', '/repo', 'worktree', 'list', '--porcelain']), GIT_READ_TIMEOUT_MS)
+})
+
+test('gitTimeoutMs: an inline `--opt=value` global option carries its own value', () => {
+  assert.equal(gitTimeoutMs(['--git-dir=/repo/.git', 'push', 'origin', 'b']), GIT_SLOW_TIMEOUT_MS)
+  assert.equal(gitTimeoutMs(['--git-dir=/repo/.git', 'status']), GIT_READ_TIMEOUT_MS)
+})

--- a/packages/framework/src/project.ts
+++ b/packages/framework/src/project.ts
@@ -93,6 +93,24 @@ const GIT_READ_OPS = new Set([
 /** Subcommands bounded by the network rather than by this machine. */
 const GIT_SLOW_OPS = new Set(['clone', 'fetch', 'pull', 'push'])
 
+/** Global options whose value is the next word, so that word is not the subcommand. */
+const GIT_GLOBAL_VALUE_OPTIONS = new Set(['-C', '-c', '--git-dir', '--work-tree', '--namespace', '--exec-path'])
+
+/**
+ * The subcommand and its own words, with the leading global options dropped. A bare flag filter
+ * would read `git -C /repo push` as the subcommand `/repo`, costing `push` its slow budget.
+ */
+function gitWords(args: string[]): string[] {
+  let i = 0
+  while (i < args.length) {
+    const arg = args[i] ?? ''
+    if (!arg.startsWith('-')) break
+    // The `--opt=value` form carries its value inline; the separate form eats the next word.
+    i += GIT_GLOBAL_VALUE_OPTIONS.has(arg) ? 2 : 1
+  }
+  return args.slice(i).filter(arg => !arg.startsWith('-'))
+}
+
 /**
  * The timeout for one git invocation, chosen by subcommand (#997). One flat 10s budget covered
  * the repo's ~20 call sites, so the slowest two ran under what is really a read's budget: a
@@ -100,7 +118,7 @@ const GIT_SLOW_OPS = new Set(['clone', 'fetch', 'pull', 'push'])
  * have half-landed. Mirrors the read/write split `gh` already has (dashboard/gh.ts).
  */
 export function gitTimeoutMs(args: string[]): number {
-  const words = args.filter(arg => !arg.startsWith('-'))
+  const words = gitWords(args)
   const op = words[0] ?? ''
   if (GIT_SLOW_OPS.has(op)) return GIT_SLOW_TIMEOUT_MS
   if (op === 'worktree') {


### PR DESCRIPTION
Two small unfiled defects in `@gemstack/framework`, one commit each.

## 1. `gitTimeoutMs()` mis-parsed the global git options

`packages/framework/src/project.ts` picked the subcommand with
`args.filter(arg => !arg.startsWith('-'))`. That drops the flags but keeps the *values* of the
global options that take one, so `git -C /repo push` read as the subcommand `/repo`, missed
`GIT_SLOW_OPS`, and the push got the 30s local-mutation budget instead of its intended 120s
network budget. Same for `-c key=val`, `--git-dir <p>`, `--work-tree <p>`, `--namespace <n>` and
`--exec-path <p>`.

**Currently latent.** No call site in `packages/framework/src` passes `-C` to git today (the only
`-C` hits invoke the `codex` binary, not git), so this is a trap for a future call site rather
than a live bug. The fix deliberately changes no timeout that is correct today.

A small `gitWords()` helper now skips the leading global options, value and all, before the flag
filter, so `op` is the real subcommand. It is not a general git argument parser: it walks the
leading `-` words only, and knows the six that take a separate value. The `--opt=value` form
already worked and has a guard test. `gitTimeoutMs()` is exported from `src/index.ts`, so its
signature is untouched; only its behavior changes.

## 2. A failing conversation commit was invisible forever

`commitConversations()` returns `{committed: false, reason}`, but the poller in
`packages/framework/src/conversation-commit.ts` logged only on success and dropped the reason. A
project whose commit failed or timed out every tick re-pended forever while logging nothing, so
the failure could not be diagnosed from the daemon log.

The reason is now surfaced, but **on change only**. Because this runs on a polling tick, logging
every failure would print the same line once per window for as long as the project stayed stuck,
turning a diagnostic into a spam source. Instead `Pending` carries `loggedReason`: the first
failure prints one line, and repeats of the same reason stay quiet until the reason changes or the
commit lands (a success deletes the entry, so a later recurrence announces itself again). The
everyday `'no conversation changes'` outcome is extracted to a named constant and never reported
as a failure.

Message format: `[framework] conversation commit failed in <project>: <reason>`.

## Proof

Both regression tests were written first and confirmed to fail as assertions against the
unmodified source, on this base commit.

Defect 1, `packages/framework/src/project.test.ts`:

```
✖ gitTimeoutMs: the value of a global option is not mistaken for the subcommand
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  30000 !== 120000
      at project.test.js:107:12

✖ gitTimeoutMs: a global option before `worktree` does not hide `add`
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  30000 !== 120000
      at project.test.js:117:12
```

Defect 2, `packages/framework/src/conversation-commit.test.ts` (fake git runner + injectable
`log`, following the existing idiom in that file):

```
✖ a failing commit logs its reason once, not once per poll
  AssertionError [ERR_ASSERTION]: the first failure is announced, got []
  0 !== 1
      at conversation-commit.test.js:233:16

✖ a changed failure reason is announced again
  AssertionError [ERR_ASSERTION]: one reason, one line, got []
  0 !== 1
      at conversation-commit.test.js:265:16
```

Pre-fix run: `tests 1103, pass 1098, fail 4, skipped 1` (baseline before the new tests was 1097).
Post-fix run: `tests 1103, pass 1102, fail 0, skipped 1`. Root `pnpm typecheck` is green, 21 tasks
successful.

Patch changeset added for `@gemstack/framework` covering both.
