### PR TITLE
fix(ai-sdk): refuse a resume-by-id when the store's list() hides threads

### DIFF
--- a/.changeset/fix-conversation-owner-hidden-listing.md
+++ b/.changeset/fix-conversation-owner-hidden-listing.md
@@ -1,0 +1,13 @@
+---
+'@gemstack/ai-sdk': patch
+---
+
+fix(ai-sdk): a store whose unscoped `list()` hides other users' threads no longer fails open on resume-by-id
+
+The #984 owner check settles ownership from `ConversationStoreListEntry.userId`, falling back to an unscoped `store.list()` when the caller's scoped listing does not hold the thread. A thread missing from that unscoped listing was read as "no owner recorded" and allowed, which is right for a pre-#984 ownerless row but wrong for a store whose `list()` with no user id returns nothing. Such a store implements `list(userId)` correctly and is fully owner-aware, and a cross-user resume was still allowed.
+
+The unscoped listing reporting nothing at all, while the store demonstrably holds rows (the caller has threads of their own, or the target thread has messages), now proves the listing is not enumerating the backend, and the resume is refused with `ConversationOwnershipError`.
+
+Deliberately unchanged: a listing that reports rows but not this one stays permissive, since an absent thread and a partial listing are indistinguishable there. Ownerless legacy threads on a store that enumerates normally stay resumable, with or without a user on the run, and a store that omits `userId` from its entries keeps its old permissive behavior.
+
+`ConversationStore` gains no members. The listing contract the check depends on is now documented on the interface itself, where an implementer sees it, rather than only on the entry type's `userId` field.

--- a/packages/ai-sdk/src/auto-persist.test.ts
+++ b/packages/ai-sdk/src/auto-persist.test.ts
@@ -447,4 +447,63 @@ describe('Resume-by-id owner check', () => {
     const r = await new ChatAgent().forUser('alice').continue(bobs).prompt('hi')
     assert.equal(r.conversationId, bobs)
   })
+
+  it('an ownerless thread stays resumable by a user-scoped run too', async () => {
+    const store = new MemoryConversationStore()
+    setConversationStore(store)
+    fake.respondWith('still open')
+    const orphan = await seed(store)  // pre-#984 row: created without meta
+
+    const r = await new ChatAgent().forUser('alice').continue(orphan).prompt('resume me')
+    assert.equal(r.conversationId, orphan)
+  })
+
+  /** A store that only answers scoped listings; `list()` reports nothing. */
+  function scopedOnly(store: MemoryConversationStore): ConversationStore {
+    return {
+      create:   (t, m) => store.create(t, m),
+      load:     id => store.load(id),
+      append:   (id, m) => store.append(id, m),
+      setTitle: (id, t) => store.setTitle(id, t),
+      list:     async userId => (userId ? store.list(userId) : []),
+    }
+  }
+
+  it('a store whose list() hides other users threads refuses instead of failing open', async () => {
+    const store = new MemoryConversationStore()
+    const bobs = await seed(store, 'bob')
+    setConversationStore(scopedOnly(store))
+    fake.respondWith('leaked?')
+
+    await assert.rejects(
+      () => new ChatAgent().forUser('alice').continue(bobs).prompt('what did bob say?'),
+      /is owned by a different user/,
+    )
+    assert.equal(fake.getCalls().length, 0, 'the provider never saw bob history')
+    assert.deepStrictEqual((await store.load(bobs)).map(m => m.content), ['bob-secret'])
+  })
+
+  it('a store whose list() hides threads refuses even when the target thread is empty', async () => {
+    const store = new MemoryConversationStore()
+    const bobs = await store.create(undefined, { userId: 'bob', agent: 'ChatAgent' })
+    await seed(store, 'alice')  // the caller has a thread of their own
+    setConversationStore(scopedOnly(store))
+    fake.respondWith('leaked?')
+
+    await assert.rejects(
+      () => new ChatAgent().forUser('alice').continue(bobs).prompt('hi'),
+      /is owned by a different user/,
+    )
+    assert.equal(fake.getCalls().length, 0)
+  })
+
+  it('the owner still resumes their own thread on a store whose list() hides threads', async () => {
+    const store = new MemoryConversationStore()
+    const bobs = await seed(store, 'bob')
+    setConversationStore(scopedOnly(store))
+    fake.respondWith('welcome back')
+
+    const r = await new ChatAgent().forUser('bob').continue(bobs).prompt('me again')
+    assert.equal(r.conversationId, bobs)
+  })
 })

--- a/packages/ai-sdk/src/conversation-persistence.ts
+++ b/packages/ai-sdk/src/conversation-persistence.ts
@@ -68,24 +68,46 @@ export class ConversationOwnershipError extends Error {
 }
 
 /**
- * Owner recorded on a thread, or `undefined` when the store reports none.
- * `undefined` is deliberately permissive: threads written before #984, and
- * stores that don't mirror `meta.userId` into their listings, carry no owner
- * and must stay readable by whoever holds the id.
+ * What the store could tell us about a thread's owner.
+ *
+ * `owner: undefined` is deliberately permissive: threads written before #984,
+ * and stores that don't mirror `meta.userId` into their listings, carry no
+ * owner and must stay readable by whoever holds the id.
+ *
+ * `hidden` is the one case that is not permissive: the store demonstrably
+ * holds rows its unscoped `list()` did not report, so "absent from the
+ * listing" is no evidence of being ownerless.
  */
+interface OwnerLookup {
+  owner:  string | undefined
+  hidden: boolean
+}
+
 async function storedOwner(
   store:  ConversationStore,
   convId: string,
   user:   string | undefined,
-): Promise<string | undefined> {
+): Promise<OwnerLookup> {
   // Scoped listing first — the indexed read every store already supports, and
   // a hit settles ownership without enumerating every thread in the backend.
   if (user) {
     const mine = await store.list(user)
-    if (mine.some(t => t.id === convId)) return user
+    if (mine.some(t => t.id === convId)) return { owner: user, hidden: false }
+
+    const all   = await store.list()
+    const entry = all.find(t => t.id === convId)
+    if (entry) return { owner: entry.userId || undefined, hidden: false }
+    // Rows listed but not this one: absent thread or partial listing, and we
+    // can't tell which, so stay permissive.
+    if (all.length > 0) return { owner: undefined, hidden: false }
+    // Nothing listed while the store demonstrably holds rows: list() is not
+    // enumerating the backend, so it never had a chance to report an owner.
+    const hidden = mine.length > 0 || (await store.load(convId)).length > 0
+    return { owner: undefined, hidden }
   }
+
   const entry = (await store.list()).find(t => t.id === convId)
-  return entry?.userId || undefined
+  return { owner: entry?.userId || undefined, hidden: false }
 }
 
 /**
@@ -98,7 +120,8 @@ async function assertOwnership(
   convId: string,
   user:   string | undefined,
 ): Promise<void> {
-  const owner = await storedOwner(store, convId, user)
+  const { owner, hidden } = await storedOwner(store, convId, user)
+  if (hidden) throw new ConversationOwnershipError(convId, user)
   if (owner === undefined) return
   if (owner !== (user || undefined)) throw new ConversationOwnershipError(convId, user)
 }

--- a/packages/ai-sdk/src/types.ts
+++ b/packages/ai-sdk/src/types.ts
@@ -952,11 +952,30 @@ export interface ConversationStoreListEntry {
   userId?: string
 }
 
+/**
+ * Backend for persisted conversation threads.
+ *
+ * Implementing `list` correctly is what makes the resume-by-id owner check
+ * (#984) enforceable, so it carries a contract beyond its signature:
+ *
+ * - `list(userId)` must return only that user's threads.
+ * - `list()` with no argument must return every thread in the store, and each
+ *   entry must mirror the row's `meta.userId` into
+ *   {@link ConversationStoreListEntry.userId}. That field is the only
+ *   owner-aware read in the contract.
+ * - Omitting `userId` from entries leaves the store as permissive as it was
+ *   before #984: whoever holds a thread id can resume it, because there is no
+ *   owner to compare the run's user against.
+ * - A `list()` that reports nothing while the store demonstrably holds rows
+ *   cannot be reasoned about at all, so a resume by id is refused with
+ *   `ConversationOwnershipError` rather than allowed.
+ */
 export interface ConversationStore {
   create(title?: string, meta?: ConversationStoreMeta): Promise<string>
   load(conversationId: string): Promise<AiMessage[]>
   append(conversationId: string, messages: AiMessage[]): Promise<void>
   setTitle(conversationId: string, title: string): Promise<void>
+  /** Threads for `userId`, or every thread in the store when omitted. See the interface docs. */
   list(userId?: string): Promise<ConversationStoreListEntry[]>
   delete?(conversationId: string): Promise<void>
 }


### PR DESCRIPTION
## The fail-open

`storedOwner` (`packages/ai-sdk/src/conversation-persistence.ts`) settles ownership from the caller's scoped `store.list(user)`, then falls back to an unscoped `store.list()` and reads `entry?.userId`. A thread that is absent from that unscoped listing yields `undefined`, and `assertOwnership` treats `undefined` as "no owner recorded" and allows the resume.

That is correct for a pre-#984 row that genuinely has no owner. It is a fail-open for a store whose `list()` with no user id returns nothing (or only the caller's threads): the `.find()` misses, no owner is found, and `forUser('alice').continue(bobsThread)` goes through. Such a store implements `list(userId)` correctly and is otherwise fully owner-aware, so it fails open despite doing everything the check needs.

## What is tightened

An unscoped listing that reports **nothing at all** while the store demonstrably holds rows proves the listing is not enumerating the backend, so absence from it is no evidence of being ownerless. "Demonstrably holds rows" is either the caller's own scoped listing being non-empty, or the target thread having messages. In that state the resume is refused with `ConversationOwnershipError` (the same 403-shaped error #984 introduced).

This cannot fire on a store that enumerates normally: if such a store returned rows for `list(user)`, or holds a thread with messages, its `list()` is non-empty and the earlier branches decide.

## What is deliberately NOT tightened

- **Listing returned rows but not this one.** Left permissive. There, a genuinely absent thread and a partial listing are indistinguishable, and refusing would break exactly the legacy compatibility #984 promises.
- **A thread that is listed with no `userId`.** Still allowed, as before.
- **A store that omits `userId` from its entries.** Unchanged, still permissive.
- **`continue(id)` with no user at all.** Untouched path.

`ConversationStore` is public API and gains no members. `storedOwner` / `assertOwnership` are file-private with no other callers in the repo; only their internal return shape changed.

## Docs

The listing contract the owner check depends on was documented only on `ConversationStoreListEntry.userId`. Someone writing a custom store implements `ConversationStore.list(userId?)` and need never read the entry type's field docs, so the contract now sits on the interface and its `list` member: what `list()` with no argument must return, that mirroring `userId` is what makes enforcement work, and what omitting it costs.

## Proof

Tests written first and run against unmodified source:

```
✖ a store whose list() hides other users threads refuses instead of failing open
  AssertionError [ERR_ASSERTION]: Missing expected rejection.
    expected: /is owned by a different user/,
    operator: 'rejects',

✖ a store whose list() hides threads refuses even when the target thread is empty
  AssertionError [ERR_ASSERTION]: Missing expected rejection.
    expected: /is owned by a different user/,
    operator: 'rejects',
```

After the fix, `pnpm test` in `packages/ai-sdk`:

```
ℹ tests 919
ℹ pass 919
ℹ fail 0
```

(915 was the pre-change baseline; the 4 added tests are the two refusals above, the owner still resuming on such a store, and an ownerless legacy thread still resumable by a user-scoped run, so the compatibility promise is pinned by a test rather than a comment.)

`pnpm typecheck` at the repo root: 21 successful, 21 total.