### PR TITLE
fix(framework): fail a run whose worktree could not be created

### DIFF
--- a/.changeset/fix-997-no-silent-worktree-downgrade.md
+++ b/.changeset/fix-997-no-silent-worktree-downgrade.md
@@ -1,0 +1,22 @@
+---
+'@gemstack/framework': patch
+---
+
+Never silently downgrade a run into your own checkout when its worktree could not be created (#997).
+
+Every run gets its own git worktree (#736) so the agent never edits the working tree you are sitting
+in. When `git worktree add` failed, the daemon logged a line and ran the agent in the project's main
+checkout instead, mixing its edits into your uncommitted work. That is reachable in normal use: on a
+large repo `worktree add` writes a whole checkout and can outrun its budget and be killed.
+
+A project that is not a git repo still falls back to the main checkout, which is the supported
+pre-#736 behavior. A project that *is* a repo and whose `worktree add` failed now fails the Start
+instead, and the dashboard shows why. A failed Start is recoverable by starting it again; a checkout
+with agent edits mixed into it is not.
+
+A `worktree add` killed mid-write leaves the partial checkout it had already written behind (git
+drops its own administrative entry on the way out, so `git worktree prune` finds nothing to do), so
+that directory is now removed on the timeout path.
+
+The fallback's log line also says which case it is: "is not a git repository, so it gets no
+worktree" rather than a generic "no worktree" that read the same either way.

--- a/packages/framework/src/daemon-runtime.ts
+++ b/packages/framework/src/daemon-runtime.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { basename, resolve } from 'node:path'
-import { stat } from 'node:fs/promises'
+import { rm, stat } from 'node:fs/promises'
 import {
   runIdFromStartedAt,
   addWorktree,
@@ -28,6 +28,8 @@ import { isSafeVia } from './conversations.js'
 import { startPreview, detectServeTargets, type PreviewHandle, type ServeTarget } from './preview.js'
 import { addProject, listProjects, projectId } from './registry.js'
 import { installProject, enumerateGitRepos } from './install.js'
+import { isGitRepo } from './project.js'
+import { isCliTimeout } from './cli-exec.js'
 import { errorMessage } from './error-message.js'
 
 /**
@@ -69,6 +71,19 @@ export function resolveSpawnBin(explicitBinPath: string | undefined): string {
     throw new Error('refusing to spawn a framework process from a test entry; pass an explicit binPath')
   }
   return binPath
+}
+
+/**
+ * Clean up after a `git worktree add` that was SIGTERMed mid-write (#997). Observed behavior: git
+ * removes its own administrative entry on the way out but leaves the partial checkout it had
+ * already written, so `git worktree prune` finds nothing to do and the directory stays.
+ *
+ * Only a timeout kill is cleaned up. Any other rejection may be git refusing a path that was
+ * already on disk before this run asked for it, and that is not ours to delete.
+ */
+export async function cleanupTimedOutWorktree(repo: string, runId: string, err: unknown): Promise<void> {
+  if (!isCliTimeout(err)) return
+  await rm(worktreePath(repo, runId), { recursive: true, force: true }).catch(() => {})
 }
 
 /** Spawn a detached, unref'd framework child (`node <binPath> <args...>`) that outlives us. */
@@ -242,21 +257,35 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
    * repo never fight over the working tree — and the user's own checkout, uncommitted work
    * included, is left untouched.
    *
-   * A project that cannot provide one (not a git repo, or any git failure) falls back to the main
-   * checkout, which is exactly the pre-#736 behavior — and keeps its pre-#736 limit of one run at a
-   * time, since those runs *would* collide. Signalled by the absent `runId`.
+   * A project that *structurally* cannot provide one — it is not a git repo — falls back to the
+   * main checkout, which is exactly the pre-#736 behavior, and keeps its pre-#736 limit of one run
+   * at a time, since those runs *would* collide. Signalled by the absent `runId`.
+   *
+   * A project that *is* a repo and whose `worktree add` failed does not fall back (#997): that
+   * downgrade silently pointed the agent at the user's own working tree, uncommitted work
+   * included, which is the one thing #736 exists to prevent. A `worktree add` on a large repo can
+   * outrun its budget and be SIGTERMed, so this is reachable in normal use, not just on a broken
+   * repo. The run fails instead, because a failed run is recoverable by starting it again and a
+   * checkout with agent edits mixed into it is not.
    */
-  const allocateWorkspace = async (projectCwd: string, runId: string): Promise<{ cwd: string; runId?: string }> => {
+  const allocateWorkspace = async (
+    projectCwd: string,
+    runId: string,
+  ): Promise<{ ok: true; workspace: { cwd: string; runId?: string } } | { ok: false; error: string }> => {
     try {
       const worktree = await addWorktree(projectCwd, { runId, branch: runBranchName(runId) })
       // `node_modules` is gitignored, so a fresh worktree has none: link the parent's in, and
       // make git ignore the links (a `node_modules/` rule does not match a symlink, #738).
       await linkDependencies(projectCwd, worktree.path).catch(() => [])
       await excludeDependencyLinks(projectCwd).catch(() => {})
-      return { cwd: worktree.path, runId }
+      return { ok: true, workspace: { cwd: worktree.path, runId } }
     } catch (err) {
-      console.log(`[framework] no worktree for ${basename(projectCwd)} (${errorMessage(err)}); running in the main checkout`)
-      return { cwd: projectCwd }
+      if (await isGitRepo(projectCwd)) {
+        await cleanupTimedOutWorktree(projectCwd, runId, err)
+        return { ok: false, error: `could not create a worktree for this run: ${errorMessage(err)}` }
+      }
+      console.log(`[framework] ${basename(projectCwd)} is not a git repository, so it gets no worktree; running in the main checkout`)
+      return { ok: true, workspace: { cwd: projectCwd } }
     }
   }
 
@@ -326,7 +355,13 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
 
     // Continuing an existing run (#762) reuses its id, checkout and log; anything else is new.
     const continued = options.continueRunId ? await continueWorkspace(projectCwd, options.continueRunId) : undefined
-    const workspace = continued ?? (await allocateWorkspace(projectCwd, runIdFromStartedAt(new Date().toISOString())))
+    // A repo that could not be given a worktree fails the Start rather than borrowing the user's
+    // own checkout (#997); the dashboard shows the reason, and starting again is the retry.
+    const allocated = continued
+      ? ({ ok: true, workspace: continued } as const)
+      : await allocateWorkspace(projectCwd, runIdFromStartedAt(new Date().toISOString()))
+    if (!allocated.ok) return { ok: false, error: allocated.error }
+    const workspace = allocated.workspace
     // A run in its own worktree is keyed by that worktree, so it never collides with a
     // sibling; a fallback run is keyed by the project, restoring the one-at-a-time guard.
     const key = scopedKey(projectKey, workspace.runId)

--- a/packages/framework/src/daemon-workspace.test.ts
+++ b/packages/framework/src/daemon-workspace.test.ts
@@ -1,0 +1,126 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, writeFile, readFile, rm, stat, realpath } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { createProjectRuntime, cleanupTimedOutWorktree } from './daemon-runtime.js'
+import { CliTimeoutError } from './cli-exec.js'
+import { FRAMEWORK_DIR, WORKTREES_DIR, worktreePath } from './store/index.js'
+import { nodeGitRunner } from './project.js'
+
+/**
+ * Where a run is allowed to land (#997). A run gets its own worktree (#736); the pre-#736
+ * fallback into the project's own checkout survives only for a project that cannot host one at
+ * all. A repo whose `worktree add` failed used to take that same fallback, which pointed the
+ * agent at the user's working tree and its uncommitted work.
+ */
+
+/** A stub CLI that records the argv it was spawned with, so a start is observable. */
+async function writeStub(dir: string, log: string): Promise<string> {
+  const stub = join(dir, 'stub-cli.cjs')
+  await writeFile(
+    stub,
+    `require('node:fs').appendFileSync(${JSON.stringify(log)}, JSON.stringify(process.argv.slice(2)) + '\\n')\n`,
+  )
+  return stub
+}
+
+/** The stub's recorded starts, waited for (a start spawns detached). */
+async function startedArgs(log: string, expected: number): Promise<string[][]> {
+  let lines: string[] = []
+  for (let i = 0; i < 100 && lines.length < expected; i++) {
+    await new Promise(r => setTimeout(r, 20))
+    lines = await readFile(log, 'utf8').then(s => s.split('\n').filter(Boolean), () => [])
+  }
+  return lines.map(line => JSON.parse(line) as string[])
+}
+
+/** Capture `console.log` for the duration of `body`. */
+async function withCapturedLog(body: () => Promise<void>): Promise<string> {
+  const original = console.log
+  const lines: string[] = []
+  console.log = (...args: unknown[]) => void lines.push(args.map(String).join(' '))
+  try {
+    await body()
+  } finally {
+    console.log = original
+  }
+  return lines.join('\n')
+}
+
+test('a repo whose worktree could not be created fails the run instead of borrowing the checkout (#997)', async () => {
+  // realpath: on macOS tmpdir sits under the /var -> /private/var symlink and git reports the
+  // resolved path (the same gotcha the worktree round-trip test documents).
+  const cwd = await realpath(await mkdtemp(join(tmpdir(), 'framework-alloc-fail-')))
+  try {
+    const git = nodeGitRunner()
+    await git(['init'], cwd)
+    await git(['config', 'user.email', 't@t'], cwd)
+    await git(['config', 'user.name', 't'], cwd)
+    await writeFile(join(cwd, 'README.md'), '# t\n')
+    await git(['add', '-A'], cwd)
+    await git(['commit', '-m', 'init'], cwd)
+
+    // A *file* where the worktrees directory belongs: git cannot create the leading directories,
+    // so `worktree add` rejects. Stands in for the SIGTERM this exists for, which needs a repo big
+    // enough to outrun a 120s budget; both arrive here as one rejection from a working git.
+    await mkdir(join(cwd, FRAMEWORK_DIR), { recursive: true })
+    await writeFile(join(cwd, FRAMEWORK_DIR, WORKTREES_DIR), '')
+
+    const log = join(cwd, 'started.log')
+    const runtime = createProjectRuntime({ cwd, env: {}, binPath: await writeStub(cwd, log) })
+    const result = await runtime.onStart('build a thing', 'build')
+
+    assert.equal(result.ok, false, 'the Start is refused rather than downgraded into the main checkout')
+    assert.match(result.ok ? '' : result.error, /could not create a worktree for this run/)
+    // The real damage the fallback did: an agent editing the user's own working tree.
+    assert.deepEqual(await startedArgs(log, 1), [], 'no run was spawned at all')
+    await runtime.dispose()
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('a project that is not a git repo still falls back to the main checkout, and says why (#997)', async () => {
+  const cwd = await realpath(await mkdtemp(join(tmpdir(), 'framework-alloc-nogit-')))
+  try {
+    const log = join(cwd, 'started.log')
+    const runtime = createProjectRuntime({ cwd, env: {}, binPath: await writeStub(cwd, log) })
+    let result: { ok: boolean; runId?: string } | undefined
+    const logged = await withCapturedLog(async () => {
+      result = (await runtime.onStart('build a thing', 'build')) as { ok: boolean; runId?: string }
+    })
+
+    assert.equal(result?.ok, true, 'the pre-#736 fallback is intact for a project with no repo')
+    assert.equal(result?.runId, undefined, 'and is still signalled by the absent runId')
+    const args = await startedArgs(log, 1)
+    assert.equal(args.length, 1, 'the run spawned')
+    assert.equal(args[0]![args[0]!.indexOf('--cwd') + 1], cwd, 'in the main checkout')
+    assert.equal(args[0]!.includes('--run-id'), false)
+    // The message has to name the reason: "no worktree (<git error>)" read the same whether git
+    // was absent or git had failed, which is exactly the distinction that went missing.
+    assert.match(logged, /is not a git repository, so it gets no worktree/)
+    await runtime.dispose()
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('a SIGTERMed worktree add has its partial checkout removed, other failures do not (#997)', async () => {
+  // Observed against real git: a SIGTERM mid-add leaves the directory it had written and git
+  // drops its own administrative entry, so `worktree prune` has nothing to clean.
+  const repo = await realpath(await mkdtemp(join(tmpdir(), 'framework-alloc-partial-')))
+  try {
+    const partial = worktreePath(repo, 'run1')
+    const exists = async (): Promise<boolean> => stat(partial).then(() => true, () => false)
+
+    await mkdir(join(partial, 'src'), { recursive: true })
+    await cleanupTimedOutWorktree(repo, 'run1', new Error('fatal: invalid reference: HEAD'))
+    assert.equal(await exists(), true, 'a plain git rejection leaves the path alone')
+
+    await cleanupTimedOutWorktree(repo, 'run1', new CliTimeoutError('git', ['worktree', 'add'], 120_000))
+    assert.equal(await exists(), false, 'a timeout kill takes its half-written checkout with it')
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -193,6 +193,7 @@ export {
   isActivated,
   nodeProjectFs,
   crawlRepoFiles,
+  isGitRepo,
   nodeGitRunner,
   gitTimeoutMs,
   GIT_READ_TIMEOUT_MS,

--- a/packages/framework/src/project.ts
+++ b/packages/framework/src/project.ts
@@ -123,6 +123,20 @@ export function nodeGitRunner(): GitRunner {
 }
 
 /**
+ * Whether `cwd` sits inside a git working tree (#997). Lets a caller tell "this project cannot
+ * host a worktree at all" from "git was there and the operation failed", which are the same
+ * rejection out of `git worktree add` but call for opposite handling.
+ *
+ * Forgiving in one direction only: an unreadable / missing git reads as "no repo", which is the
+ * conservative answer for the caller that treats a repo's failure as fatal.
+ */
+export async function isGitRepo(cwd: string, run: GitRunner = nodeGitRunner()): Promise<boolean> {
+  return run(['rev-parse', '--is-inside-work-tree'], cwd)
+    .then(out => out.trim() === 'true')
+    .catch(() => false)
+}
+
+/**
  * List every file git sees in the repo at `cwd`: tracked + untracked, honoring
  * .gitignore. Uses `git ls-files -z --cached --others --exclude-standard` (the
  * same approach Vike uses). Returns repo-relative paths, deduped and sorted.


### PR DESCRIPTION
The second half of #997. The first half (#1004) gave `worktree add` its own 120s budget and a distinguishable `CliTimeoutError`; this half stops the failure from being swallowed.

## What was wrong

`allocateWorkspace` (`packages/framework/src/daemon-runtime.ts:249`) caught every `addWorktree` rejection and returned the project's main checkout:

```ts
} catch (err) {
  console.log(`[framework] no worktree for ${basename(projectCwd)} (${errorMessage(err)}); running in the main checkout`)
  return { cwd: projectCwd }
}
```

`addWorktree`'s own doc comment (`src/store/worktree.ts:56`) says it "rejects on any git failure (a caller that wants a run needs its checkout, so failure must surface, not be swallowed)". Its one caller did the opposite.

Two very different situations were conflated:

- the project is not a git repo, so it structurally cannot host a worktree. Falling back is correct and is the supported pre-#736 behavior.
- the project is a git repo and `worktree add` failed. Falling back points the agent at the user's own working tree, uncommitted work included, which is the one thing #736 exists to prevent.

The second is reachable in normal use: `worktree add` writes a whole checkout, and on a large repo it can outrun its budget and be SIGTERMed. `src/project.ts:99` already said so in prose.

## What changed

- `allocateWorkspace` now returns `{ ok: true, workspace } | { ok: false, error }`. A repo whose `worktree add` failed produces `{ ok: false }`, which `onStart` returns as the `StartRunResult` `{ ok: false, error }` the dashboard already renders. No new mechanism; that union already existed for `busy` and `unknown project`. A failed Start is recoverable by starting it again, a checkout with agent edits mixed into it is not.
- A non-repo project still falls back, still signalled by the absent `runId`, and its log line now says which case it is instead of `no worktree for X (<git error>)`, which read the same either way. The daemon has no run-level event bus at that call site (the run narrates through its own `events.jsonl`, which does not exist yet at allocation time), so this stays a `console.log`, just a distinguishable one.
- New `isGitRepo()` in `src/project.ts`, the `rev-parse --is-inside-work-tree` idiom `install.ts:43` already used inline. Forgiving in one direction only: an unreadable git reads as "no repo", the conservative answer for the caller that treats a repo's failure as fatal.
- New `cleanupTimedOutWorktree()` removes the partial checkout a SIGTERMed `worktree add` leaves behind. Timeout kills only: any other rejection may be git refusing a path that was already on disk, which is not ours to delete.

## On `git worktree prune`

Not warranted, and this is measured, not assumed. Killing a real `git worktree add` with SIGTERM at seven points during a 0.78s add on a 6000-file repo, every time:

- the target directory survives with a partial checkout and a `.git` file pointing at `.git/worktrees/<name>`
- `.git/worktrees/` is **empty**: git removes its own administrative entry on the way out
- `git worktree list` shows only the main checkout, and `git worktree prune -n -v` prints nothing

So prune has nothing to clean; the leftover is the directory. Hence the `rm`, not a prune.

One remnant is deliberately left alone: the `the-framework/run-<id>` branch git created before it died. Deleting a branch on a failure path is destructive in the case where `worktree add` failed *because* the branch already existed, and it costs one ref.

## How it was proven

Both behavior changes have a regression test that was run against the unmodified source first. Stashing only `daemon-runtime.ts` and `project.ts` and re-running `pnpm test`, the new tests fail as assertions:

```
✖ a repo whose worktree could not be created fails the run instead of borrowing the checkout (#997)
  AssertionError [ERR_ASSERTION]: the Start is refused rather than downgraded into the main checkout

  true !== false

✖ a project that is not a git repo still falls back to the main checkout, and says why (#997)
  AssertionError [ERR_ASSERTION]: The input did not match the regular expression
  /is not a git repository, so it gets no worktree/. Input:

  '[framework] no worktree for framework-alloc-nogit-VKnzup (Command failed: git worktree add -b ...
  fatal: not a git repository (or any of the parent directories): .git
  ); running in the main checkout'

ℹ tests 1099  ℹ pass 1096  ℹ fail 2  ℹ skipped 1
```

The first test drives the real `createProjectRuntime` against a real git repo with a file where `.the-framework/worktrees/` belongs, so git rejects with "could not create leading directories". It asserts the Start is refused **and** that no child was spawned at all, which is the damage the old fallback did.

The third test (`cleanupTimedOutWorktree`) is a direct contract test rather than red-then-green: the function is new, so against the old source it would only fail to compile, which proves nothing. Its evidence is the SIGTERM probe above.

With the fix: `tests 1100, pass 1099, fail 0, skipped 1` (baseline 1097 plus the three new tests). `pnpm typecheck` green at the repo root, 21/21 tasks.

## Callers checked

`addWorktree` is called from exactly one place outside tests, `daemon-runtime.ts:251`, and its signature is unchanged. `allocateWorkspace` is a closure inside `createProjectRuntime` with the one call site at `onStart`. Swept across all packages, examples and docs.

Closes #997