### PR TITLE
refactor(ai-sdk): share one implementation between the two run stores

### DIFF
--- a/.changeset/refactor-972-run-store-dedup.md
+++ b/.changeset/refactor-972-run-store-dedup.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/ai-sdk': patch
+---
+
+`CachedSubAgentRunStore.load()` now returns `null` (not `undefined`) when a `CacheAdapter` resolves `undefined` on a miss, matching `CachedAgentRunStore.load()`. The `CacheAdapter` contract already declares `Promise<T | null>`, so adapters that honour it are unaffected; adapters that resolve `undefined` now get the documented `null`.
+
+Internal: both run-store families now share one storage implementation. All public exports (`InMemoryAgentRunStore`, `CachedAgentRunStore`, `newAgentRunId`, `InMemorySubAgentRunStore`, `CachedSubAgentRunStore` and their types) keep the same shape.

--- a/packages/ai-sdk/src/agent-run-store.test.ts
+++ b/packages/ai-sdk/src/agent-run-store.test.ts
@@ -7,6 +7,7 @@ import {
   newAgentRunId,
   type AgentRunState,
 } from './agent-run-store.js'
+import type { CacheAdapter } from './cache-adapter.js'
 
 function clientToolState(over: Partial<AgentRunState> = {}): AgentRunState {
   return {
@@ -184,6 +185,17 @@ describe('CachedAgentRunStore', () => {
     const store = new CachedAgentRunStore({ cache: fakeCache() })
     assert.equal(await store.load('missing'), null)
     assert.equal(await store.consume('missing'), null)
+  })
+
+  it('normalises an undefined cache miss to null', async () => {
+    // some CacheAdapter impls resolve `undefined` rather than `null` on a miss
+    const cache = {
+      async get() { return undefined },
+      async set() {},
+      async forget() {},
+    } as unknown as CacheAdapter
+    const store = new CachedAgentRunStore({ cache })
+    assert.equal(await store.load('missing'), null)
   })
 
   it('throws when constructed without a cache adapter', () => {

--- a/packages/ai-sdk/src/agent-run-store.ts
+++ b/packages/ai-sdk/src/agent-run-store.ts
@@ -1,5 +1,6 @@
 import type { AiMessage, ToolCall } from './types.js'
 import type { CacheAdapter } from './cache-adapter.js'
+import { CachedRunStoreBase, InMemoryRunStoreBase } from './run-store-base.js'
 
 /**
  * Discriminator for the kind of pause a standalone run is parked on.
@@ -116,29 +117,7 @@ export function newAgentRunId(): string {
  * deployment, use {@link CachedAgentRunStore} with a shared cache, or a custom
  * backend.
  */
-export class InMemoryAgentRunStore implements AgentRunStore {
-  private readonly states = new Map<string, AgentRunState>()
-
-  async store(runId: string, state: AgentRunState): Promise<void> {
-    this.states.set(runId, state)
-  }
-
-  async load(runId: string): Promise<AgentRunState | null> {
-    return this.states.get(runId) ?? null
-  }
-
-  async consume(runId: string): Promise<AgentRunState | null> {
-    const state = this.states.get(runId)
-    if (!state) return null
-    this.states.delete(runId)
-    return state
-  }
-
-  /** Test helper — clears all snapshots without consuming. */
-  clear(): void {
-    this.states.clear()
-  }
-}
+export class InMemoryAgentRunStore extends InMemoryRunStoreBase<AgentRunState> implements AgentRunStore {}
 
 // ─── Cache-backed store (bring your own CacheAdapter) ───────
 
@@ -164,33 +143,8 @@ export interface CachedAgentRunStoreOptions {
  * client tool calls or an approval decision, short enough that abandoned runs
  * garbage-collect promptly and the storage bill stays bounded.
  */
-export class CachedAgentRunStore implements AgentRunStore {
-  private readonly cache:      CacheAdapter
-  private readonly keyPrefix:  string
-  private readonly ttlSeconds: number
-
+export class CachedAgentRunStore extends CachedRunStoreBase<AgentRunState> implements AgentRunStore {
   constructor(opts: CachedAgentRunStoreOptions) {
-    if (!opts?.cache) {
-      throw new Error('[ai-sdk] CachedAgentRunStore requires a cache adapter: new CachedAgentRunStore({ cache }).')
-    }
-    this.cache      = opts.cache
-    this.keyPrefix  = opts.keyPrefix  ?? 'gemstack:ai:agent-run:'
-    this.ttlSeconds = opts.ttlSeconds ?? 5 * 60
-  }
-
-  async store(runId: string, state: AgentRunState): Promise<void> {
-    await this.cache.set(this.keyPrefix + runId, state, this.ttlSeconds)
-  }
-
-  async load(runId: string): Promise<AgentRunState | null> {
-    return (await this.cache.get<AgentRunState>(this.keyPrefix + runId)) ?? null
-  }
-
-  async consume(runId: string): Promise<AgentRunState | null> {
-    const key = this.keyPrefix + runId
-    const state = await this.cache.get<AgentRunState>(key)
-    if (!state) return null
-    await this.cache.forget(key)
-    return state
+    super(opts, { keyPrefix: 'gemstack:ai:agent-run:', storeName: 'CachedAgentRunStore' })
   }
 }

--- a/packages/ai-sdk/src/run-store-base.ts
+++ b/packages/ai-sdk/src/run-store-base.ts
@@ -1,0 +1,88 @@
+import type { CacheAdapter } from './cache-adapter.js'
+
+/**
+ * Shared machinery behind the two public run-store families
+ * ({@link AgentRunStore} for top-level `stream()` pauses,
+ * {@link SubAgentRunStore} for `Agent.asTool` sub-run pauses).
+ *
+ * Nothing here is exported from the package entrypoint: the public surface is
+ * the concrete subclasses in `agent-run-store.ts` / `sub-agent-run-store.ts`,
+ * which pin the snapshot type, the default key prefix and the docs. Both
+ * families store the same shape of thing under a different id, so the storage
+ * mechanics live once.
+ */
+
+// ─── In-memory ─────────────────────────────────────────────
+
+/** `Map`-backed store body. Single-process only; lossy across restarts. */
+export class InMemoryRunStoreBase<S> {
+  private readonly snapshots = new Map<string, S>()
+
+  async store(id: string, snapshot: S): Promise<void> {
+    this.snapshots.set(id, snapshot)
+  }
+
+  async load(id: string): Promise<S | null> {
+    return this.snapshots.get(id) ?? null
+  }
+
+  async consume(id: string): Promise<S | null> {
+    const snapshot = this.snapshots.get(id)
+    if (!snapshot) return null
+    this.snapshots.delete(id)
+    return snapshot
+  }
+
+  /** Test helper — clears all snapshots without consuming. */
+  clear(): void {
+    this.snapshots.clear()
+  }
+}
+
+// ─── Cache-backed store (bring your own CacheAdapter) ───────
+
+/** Options shared by both cache-backed stores; each subclass re-declares its own public alias. */
+export interface CachedRunStoreBaseOptions {
+  cache:       CacheAdapter
+  keyPrefix?:  string
+  ttlSeconds?: number
+}
+
+/** Per-subclass constants: the default key namespace and the name used in the constructor error. */
+export interface CachedRunStoreDefaults {
+  keyPrefix: string
+  storeName: string
+}
+
+/** `CacheAdapter`-backed store body. Default TTL is 5 minutes. */
+export class CachedRunStoreBase<S> {
+  private readonly cache:      CacheAdapter
+  private readonly keyPrefix:  string
+  private readonly ttlSeconds: number
+
+  constructor(opts: CachedRunStoreBaseOptions, defaults: CachedRunStoreDefaults) {
+    if (!opts?.cache) {
+      throw new Error(`[ai-sdk] ${defaults.storeName} requires a cache adapter: new ${defaults.storeName}({ cache }).`)
+    }
+    this.cache      = opts.cache
+    this.keyPrefix  = opts.keyPrefix  ?? defaults.keyPrefix
+    this.ttlSeconds = opts.ttlSeconds ?? 5 * 60
+  }
+
+  async store(id: string, snapshot: S): Promise<void> {
+    await this.cache.set(this.keyPrefix + id, snapshot, this.ttlSeconds)
+  }
+
+  async load(id: string): Promise<S | null> {
+    // `?? null` because an off-contract adapter may resolve `undefined` on a miss
+    return (await this.cache.get<S>(this.keyPrefix + id)) ?? null
+  }
+
+  async consume(id: string): Promise<S | null> {
+    const key = this.keyPrefix + id
+    const snapshot = await this.cache.get<S>(key)
+    if (!snapshot) return null
+    await this.cache.forget(key)
+    return snapshot
+  }
+}

--- a/packages/ai-sdk/src/sub-agent-run-store.test.ts
+++ b/packages/ai-sdk/src/sub-agent-run-store.test.ts
@@ -6,6 +6,7 @@ import {
   CachedSubAgentRunStore,
   type SubAgentRunSnapshot,
 } from './sub-agent-run-store.js'
+import type { CacheAdapter } from './cache-adapter.js'
 
 function clientToolSnapshot(over: Partial<SubAgentRunSnapshot> = {}): SubAgentRunSnapshot {
   return {
@@ -101,6 +102,17 @@ describe('CachedSubAgentRunStore.load', () => {
 
   it('returns null for an unknown id', async () => {
     const cache = fakeCache()
+    const store = new CachedSubAgentRunStore({ cache })
+    assert.equal(await store.load('missing'), null)
+  })
+
+  it('normalises an undefined cache miss to null', async () => {
+    // some CacheAdapter impls resolve `undefined` rather than `null` on a miss
+    const cache = {
+      async get() { return undefined },
+      async set() {},
+      async forget() {},
+    } as unknown as CacheAdapter
     const store = new CachedSubAgentRunStore({ cache })
     assert.equal(await store.load('missing'), null)
   })

--- a/packages/ai-sdk/src/sub-agent-run-store.ts
+++ b/packages/ai-sdk/src/sub-agent-run-store.ts
@@ -1,5 +1,6 @@
 import type { AiMessage, ToolCall } from './types.js'
 import type { CacheAdapter } from './cache-adapter.js'
+import { CachedRunStoreBase, InMemoryRunStoreBase } from './run-store-base.js'
 
 /**
  * Discriminator for the kind of pause a snapshot represents. Determines
@@ -107,29 +108,7 @@ export interface SubAgentRunStore {
  * Loses state across restarts and worker processes — for any multi-worker
  * deployment, use {@link CachedSubAgentRunStore} or a custom backend.
  */
-export class InMemorySubAgentRunStore implements SubAgentRunStore {
-  private readonly snapshots = new Map<string, SubAgentRunSnapshot>()
-
-  async store(subRunId: string, snapshot: SubAgentRunSnapshot): Promise<void> {
-    this.snapshots.set(subRunId, snapshot)
-  }
-
-  async consume(subRunId: string): Promise<SubAgentRunSnapshot | null> {
-    const snapshot = this.snapshots.get(subRunId)
-    if (!snapshot) return null
-    this.snapshots.delete(subRunId)
-    return snapshot
-  }
-
-  async load(subRunId: string): Promise<SubAgentRunSnapshot | null> {
-    return this.snapshots.get(subRunId) ?? null
-  }
-
-  /** Test helper — clears all snapshots without consuming. */
-  clear(): void {
-    this.snapshots.clear()
-  }
-}
+export class InMemorySubAgentRunStore extends InMemoryRunStoreBase<SubAgentRunSnapshot> implements SubAgentRunStore {}
 
 // ─── Cache-backed store (bring your own CacheAdapter) ───────
 
@@ -155,33 +134,8 @@ export interface CachedSubAgentRunStoreOptions {
  * few client tool calls, short enough that abandoned runs garbage-collect
  * promptly and the storage bill stays bounded.
  */
-export class CachedSubAgentRunStore implements SubAgentRunStore {
-  private readonly cache:      CacheAdapter
-  private readonly keyPrefix:  string
-  private readonly ttlSeconds: number
-
+export class CachedSubAgentRunStore extends CachedRunStoreBase<SubAgentRunSnapshot> implements SubAgentRunStore {
   constructor(opts: CachedSubAgentRunStoreOptions) {
-    if (!opts?.cache) {
-      throw new Error('[ai-sdk] CachedSubAgentRunStore requires a cache adapter: new CachedSubAgentRunStore({ cache }).')
-    }
-    this.cache      = opts.cache
-    this.keyPrefix  = opts.keyPrefix  ?? 'gemstack:ai:sub-agent-run:'
-    this.ttlSeconds = opts.ttlSeconds ?? 5 * 60
-  }
-
-  async store(subRunId: string, snapshot: SubAgentRunSnapshot): Promise<void> {
-    await this.cache.set(this.keyPrefix + subRunId, snapshot, this.ttlSeconds)
-  }
-
-  async consume(subRunId: string): Promise<SubAgentRunSnapshot | null> {
-    const key = this.keyPrefix + subRunId
-    const snapshot = await this.cache.get<SubAgentRunSnapshot>(key)
-    if (!snapshot) return null
-    await this.cache.forget(key)
-    return snapshot
-  }
-
-  async load(subRunId: string): Promise<SubAgentRunSnapshot | null> {
-    return this.cache.get<SubAgentRunSnapshot>(this.keyPrefix + subRunId)
+    super(opts, { keyPrefix: 'gemstack:ai:sub-agent-run:', storeName: 'CachedSubAgentRunStore' })
   }
 }


### PR DESCRIPTION
Item 4 of 4 from #972: the run-store twins. The three provider-duplication items in that issue are out of scope and untouched.

## What changed

`agent-run-store.ts` and `sub-agent-run-store.ts` carried line-for-line identical `InMemory*` and `Cached*` bodies under different identifier names (`AgentRunState`/`SubAgentRunSnapshot`, `runId`/`subRunId`, `state`/`snapshot`). New internal `src/run-store-base.ts` holds one `InMemoryRunStoreBase<S>` and one `CachedRunStoreBase<S>`; each public class extends it and pins its own default cache-key prefix and constructor-error name.

## The one deliberate behavior change

`CachedSubAgentRunStore.load()` was `return this.cache.get<T>(key)` with no normalisation, while `CachedAgentRunStore.load()` was `return (await this.cache.get<T>(key)) ?? null`. If a `CacheAdapter` resolves `undefined` on a miss, the two disagreed. Both now normalise to `null`.

The `CacheAdapter` contract already declares `get<T>(key): Promise<T | null>`, so any adapter honouring it is unaffected. Adapters that resolve `undefined` now get the documented `null` instead. Patch changeset added.

Pinned by a new test in each suite. Against the unmodified `sub-agent-run-store.ts` it fails as an assertion, not a compile error:

```
✖ normalises an undefined cache miss to null
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  + actual - expected
  + undefined
  - null
```

## Deliberately not harmonised

- `AgentRunStore.load` is required, `SubAgentRunStore.load?` is optional. Both interfaces are left exactly as they are, so a caller doing a truthiness check on `store.load` keeps working. Both concrete classes still have `load` (now inherited, so still on the prototype chain).
- `newAgentRunId()` stays exported from `agent-run-store.ts`.
- Cache-key prefixes are unchanged: `gemstack:ai:agent-run:` and `gemstack:ai:sub-agent-run:`. Note that #972 describes the sub- prefix as `gemstack:ai:p-run:`; that string does not exist in the tree, the issue body is wrong.

## Line counts

| file | before | after |
|---|---|---|
| `agent-run-store.ts` | 196 | 150 |
| `sub-agent-run-store.ts` | 187 | 141 |
| `run-store-base.ts` | 0 | 88 |
| total | 383 | 379 |

The total barely moves because both files are mostly JSDoc documenting two distinct public types, and that has to stay. The win is ~100 lines of duplicated storage logic collapsing into one ~50-line implementation.

## Verification

- `rm -rf dist-test && pnpm test` in `packages/ai-sdk`: **tests 917, pass 917, fail 0** (baseline was 915, plus the 2 new tests).
- Root `pnpm typecheck` and `pnpm build`: green.
- Runtime smoke check against the built `dist/index.js`: both `InMemory*` expose `store`/`load`/`consume`/`clear`, both `Cached*` write the unchanged key prefixes, both constructor errors keep their exact message, `instanceof` and `newAgentRunId()` unchanged.