### PR TITLE
fix(dashboard): let Telefunc's dev middleware see its own requests

### DIFF
--- a/packages/framework-dashboard/vite.config.ts
+++ b/packages/framework-dashboard/vite.config.ts
@@ -3,7 +3,33 @@ import react from '@vitejs/plugin-react'
 import vike from 'vike/plugin'
 import { telefunc } from 'telefunc/vite'
 import tailwindcss from '@tailwindcss/vite'
-import { defineConfig, type UserConfig } from 'vite'
+import { defineConfig, type Plugin, type UserConfig } from 'vite'
+
+// `pnpm dev` only. Telefunc's client marks every request URL with its kind
+// (`/_telefunc?_telefunc=txt`, `sse` for a Channel) and may append an advisory `session`, but its
+// dev middleware matches with `url !== '/_telefunc'`, so it declines its own requests. Vike's
+// catch-all route (#784) then answers them with the SPA shell, and since Vike's dev middleware
+// never calls next() on a 404, every read failed on `Unexpected token '<'` and the UI sat behind
+// the daemon-down banner. Dropping the query restores the exact match: the request kind and the
+// session both ride headers too, and Telefunc's own docs call the URL param advisory. Registered
+// from configureServer directly so it lands ahead of the middlewares Vike and Telefunc add from
+// their returned post-hooks. The daemon is unaffected: it matches on the parsed pathname.
+function telefuncDevUrlFix(): Plugin {
+  return {
+    name: 'framework:telefunc-dev-url-fix',
+    apply: 'serve',
+    configureServer(server) {
+      server.middlewares.use((req, _res, next) => {
+        const url = req.originalUrl ?? req.url
+        if (url?.startsWith('/_telefunc?')) {
+          req.url = '/_telefunc'
+          req.originalUrl = '/_telefunc'
+        }
+        next()
+      })
+    },
+  }
+}
 
 // Dashboard (#405): Vike (SPA / client-only, see pages/+config.ts) + React + Tailwind
 // v4 + shadcn, with Telefunc for everything over the wire — the read-model RPCs plus
@@ -11,7 +37,7 @@ import { defineConfig, type UserConfig } from 'vite'
 // a custom endpoint anymore. Side-by-side with the MVP page.ts dashboard; nothing
 // there is touched. Production serving (daemon serves the built bundle) is next (#405).
 export default defineConfig({
-  plugins: [react(), vike(), telefunc(), tailwindcss()],
+  plugins: [telefuncDevUrlFix(), react(), vike(), telefunc(), tailwindcss()],
   // `@/*` -> package root, matching tsconfig `paths` (used by the copied-in animate-ui components).
   resolve: {
     alias: { '@': fileURLToPath(new URL('.', import.meta.url)) },


### PR DESCRIPTION
Answers "why does localhost:4300 say the daemon is not answering". Part of #1014.

Follow-up to #1005, which merged before this landed, so it is a separate PR off main.

## What was wrong

Telefunc's client marks every request URL with its kind via `getMarkedRequestUrl()`: `/_telefunc?_telefunc=txt` for an RPC, `sse` for a Channel, plus an advisory `?session=` once a session token exists.

Its dev middleware matches with:

```js
if (url !== '/_telefunc') return next()
```

An exact comparison against a URL its own client guarantees will carry a query, so Telefunc declined every one of its own requests. Vike's catch-all route (#784) then claimed them, and `addSsrMiddleware` never calls `next()` on a 404 in dev, so the RPC got answered with the SPA shell. The client threw `Unexpected token '<'` and `use-daemon-health` reported the daemon as down.

Telefunc's own `getRequestKind()` compares `url.pathname`, and our daemon matches on the parsed pathname too. Only the dev middleware does a raw string compare, so this looks like an upstream bug worth reporting.

## The fix

A dev-only Vite plugin that drops the query before those middlewares run. Registered from `configureServer` directly rather than a returned hook, so it lands ahead of the middlewares Vike and Telefunc both add from returned post-hooks. It rewrites `req.originalUrl` as well as `req.url`, since Telefunc reads `originalUrl || url`.

Nothing is lost by dropping the query: the request kind falls back to the `x-telefunc-request` header, and Telefunc's own comment calls the URL session param advisory because it also rides `TELEFUNC_SESSION_HEADER`.

`apply: 'serve'`, so the built bundle is untouched and the daemon path is unchanged. No changeset for that reason: the published artifact does not change.

## This unblocks one of two layers

`pnpm dev` still does not work after this. The next failure is:

```
ReferenceError: onProjects is not defined
    at server/projects.telefunc.ts:13:50
```

The `server/*.telefunc.ts` files are pure re-export shims and Telefunc's dev transform assumes locally declared telefunctions. That needs the RPC shims restructured, which touches the shipping path, so it is left to #1014 rather than bundled here.

## Verification

- 288 tests pass (47 files), typecheck clean, `vite build` clean
- Before: `curl -X POST 'localhost:4300/_telefunc?_telefunc=txt'` returns Vike's HTML. After: it reaches Telefunc