### PR TITLE
fix(dashboard): divider colour and empty card stretch on Overview

### DIFF
--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,15 @@
+---
+'@gemstack/framework': patch
+---
+
+Dashboard: fix the Usage card's dividers rendering at full text brightness, and stop the
+Overview cards stretching into empty space.
+
+Tailwind v4 defaults an uncoloured `border-t` to `currentColor`, so the three dividers in the
+Usage card painted at `oklch(0.95 0 0)`, the body text colour, against hairlines that are
+`oklch(0.3 0.01 264)` everywhere else in the app. They now use the border token.
+
+The two Overview card rows also stretched each card to its neighbour's height, so on a quiet
+board half of "Session outcomes" and most of "Working now" were empty card. They are now two
+column stacks that size to their content, which pairs the tall chart against the tall list and
+brings the Projects table a full screen higher.

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -52,42 +52,47 @@ export function DashboardPage({
               <StatTile icon={<History className="h-4 w-4" />} label="Total sessions" value={data.totals.totalRuns} />
             </div>
 
-            <div className="grid gap-4 lg:grid-cols-2">
-              <Card>
-                <CardHeader>
-                  <CardTitle>Session activity</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <ActivityChart data={data.activity} />
-                </CardContent>
-              </Card>
-              <Card>
-                <CardHeader>
-                  <CardTitle>Session outcomes</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <RunOutcomes counts={data.runsByStatus} />
-                </CardContent>
-              </Card>
-            </div>
-
-            <div className="grid gap-4 lg:grid-cols-2">
-              <Card>
-                <CardHeader>
-                  <CardTitle>Working now</CardTitle>
-                </CardHeader>
-                <CardContent className="pt-0">
-                  <WorkingNow active={data.active} onSelectProject={onSelectProject} />
-                </CardContent>
-              </Card>
-              <Card>
-                <CardHeader>
-                  <CardTitle>Backlog</CardTitle>
-                </CardHeader>
-                <CardContent className="pt-0">
-                  <Backlog queue={data.queue} onSelectProject={onSelectProject} />
-                </CardContent>
-              </Card>
+            {/* Two column stacks rather than two rows of two. As rows, each card was stretched to
+                its neighbour's height, so a quiet board left half of "Session outcomes" and most of
+                "Working now" as empty card. Stacking lets every card size to its content and pairs
+                the tall chart against the tall list, so the columns come out level. */}
+            <div className="grid items-start gap-4 lg:grid-cols-2">
+              <div className="flex flex-col gap-4">
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Session activity</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <ActivityChart data={data.activity} />
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Working now</CardTitle>
+                  </CardHeader>
+                  <CardContent className="pt-0">
+                    <WorkingNow active={data.active} onSelectProject={onSelectProject} />
+                  </CardContent>
+                </Card>
+              </div>
+              <div className="flex flex-col gap-4">
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Session outcomes</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <RunOutcomes counts={data.runsByStatus} />
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Backlog</CardTitle>
+                  </CardHeader>
+                  <CardContent className="pt-0">
+                    <Backlog queue={data.queue} onSelectProject={onSelectProject} />
+                  </CardContent>
+                </Card>
+              </div>
             </div>
 
             <Card>

--- a/packages/framework-dashboard/components/Quota.tsx
+++ b/packages/framework-dashboard/components/Quota.tsx
@@ -214,15 +214,16 @@ export function Quota() {
           <OtherWindow window={week} />
         ) : null}
 
-        {others.length ? <div className="space-y-1 border-t pt-3">{others.map(w => <OtherWindow key={w.label} window={w} />)}</div> : null}
+        {others.length ? <div className="space-y-1 border-t border-border pt-3">{others.map(w => <OtherWindow key={w.label} window={w} />)}</div> : null}
 
         {note ? <p className="text-sm text-muted-foreground">{note}</p> : null}
 
         {view ? (
-          <div className="space-y-1 border-t pt-3">
+          <div className="space-y-1 border-t border-border pt-3">
             <label className="flex cursor-pointer items-center gap-1.5 text-sm">
               <input
                 type="checkbox"
+                className="accent-[var(--color-primary)]"
                 checked={preferences.autoPm ?? false}
                 onChange={e => updatePreferences({ autoPm: e.target.checked })}
               />
@@ -238,7 +239,7 @@ export function Quota() {
         {/* Only where there is a boundary to offset from: without one there is no line to move,
             and a slider over nothing would imply a limit that is not being applied. */}
         {view?.boundary ? (
-          <div className="border-t pt-3">
+          <div className="border-t border-border pt-3">
             <SpendLimit offset={offset} boundaryPercent={view.boundary.boundary.percent} onChange={setOffset} />
           </div>
         ) : null}


### PR DESCRIPTION
Two things visible on any quiet board, both spotted by putting the Overview side by side in the design gallery. Part of #1010.

## 1. The Usage dividers were painting at text brightness

The three dividers in the Usage card were bare `border-t`. Tailwind v4 defaults an uncoloured border to `currentColor`, so they rendered at the body text colour instead of the border token.

Measured in the browser rather than inferred:

| | colour |
|---|---|
| every other hairline in the app | `oklch(0.3 0.01 264)` |
| these three dividers | `oklch(0.95 0 0)` |
| body text | `oklch(0.95 0 0)` |

Byte-identical to the text colour. That is the harsh banding across the Usage card. Now `border-border`, so they match every other rule in the UI.

These were the only three uncoloured border utilities in the codebase, so this is not a wider sweep.

## 2. Cards stretched into empty space

The two Overview card rows were each `grid lg:grid-cols-2`, so every card stretched to its neighbour's height. With nothing running that left roughly half of "Session outcomes" and most of "Working now" as empty card, and pushed the Projects table below the fold.

They are now two column stacks that size to their content, pairing the tall chart against the tall backlog:

- left: Session activity, Working now
- right: Session outcomes, Backlog

The columns come out level, the interior voids are gone, and Projects moves a full screen higher.

## 3. Minor

The Usage checkbox now carries the same `accent-[var(--color-primary)]` its sibling slider already had, so the two controls in that card stop disagreeing.

## Verification

- 288 tests pass (47 files), typecheck clean, `pnpm build` green
- Driven in a real browser against the live daemon, before and after, with the divider colour read from `getComputedStyle` rather than eyeballed