### PR TITLE
refactor(ai-sdk): build each provider's SDK client in one place

### DIFF
--- a/packages/ai-sdk/src/providers/client-construction.test.ts
+++ b/packages/ai-sdk/src/providers/client-construction.test.ts
@@ -1,0 +1,95 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { OpenAIAdapter } from './openai/chat.js'
+import { OpenAIFileAdapter } from './openai/files.js'
+import { OpenAIImageAdapter } from './openai/images.js'
+import { OpenAISttAdapter } from './openai/stt.js'
+import { OpenAITtsAdapter } from './openai/tts.js'
+import { OpenAIVectorStoreAdapter } from './openai/vector-store.js'
+import type { OpenAIConfig } from './openai/config.js'
+
+import { GoogleAdapter } from './google/chat.js'
+import { GoogleEmbeddingAdapter } from './google/embeddings.js'
+import { GoogleFileAdapter } from './google/files.js'
+import { GoogleVectorStoreAdapter } from './google/vector-store.js'
+import type { GoogleConfig } from './google/config.js'
+
+/**
+ * The client-construction path is otherwise untested: every other suite
+ * pre-sets `client` so `getClient()` short-circuits. These drive the real
+ * lazy import so a shared helper cannot silently drop a config field.
+ */
+
+/** `getClient()` is private; the tests are the only callers that need it. */
+function getClient(adapter: unknown): Promise<any> {
+  return (adapter as { getClient(): Promise<any> }).getClient()
+}
+
+const openAiAdapters: ReadonlyArray<[string, (c: OpenAIConfig) => unknown]> = [
+  ['OpenAIAdapter', c => new OpenAIAdapter(c, 'gpt-4o')],
+  ['OpenAIFileAdapter', c => new OpenAIFileAdapter(c)],
+  ['OpenAIImageAdapter', c => new OpenAIImageAdapter(c, 'gpt-image-1')],
+  ['OpenAISttAdapter', c => new OpenAISttAdapter(c, 'whisper-1')],
+  ['OpenAITtsAdapter', c => new OpenAITtsAdapter(c, 'tts-1')],
+  ['OpenAIVectorStoreAdapter', c => new OpenAIVectorStoreAdapter(c)],
+]
+
+const googleAdapters: ReadonlyArray<[string, (c: GoogleConfig) => unknown]> = [
+  ['GoogleAdapter', c => new GoogleAdapter(c, 'gemini-2.0-flash')],
+  ['GoogleEmbeddingAdapter', c => new GoogleEmbeddingAdapter(c, 'text-embedding-004')],
+  ['GoogleFileAdapter', c => new GoogleFileAdapter(c)],
+  ['GoogleVectorStoreAdapter', c => new GoogleVectorStoreAdapter(c)],
+]
+
+describe('OpenAI adapters — client construction', () => {
+  for (const [name, make] of openAiAdapters) {
+    it(`${name} forwards every configured field to the SDK`, async () => {
+      const client = await getClient(
+        make({
+          apiKey: 'sk-test',
+          baseUrl: 'https://proxy.example/v1',
+          organization: 'org-test',
+          defaultHeaders: { 'X-Trace': 'on' },
+        }),
+      )
+
+      assert.equal(client.apiKey, 'sk-test')
+      assert.equal(client.baseURL, 'https://proxy.example/v1')
+      assert.equal(client.organization, 'org-test')
+      assert.deepEqual(client._options.defaultHeaders, { 'X-Trace': 'on' })
+    })
+
+    it(`${name} leaves the SDK defaults alone when only apiKey is set`, async () => {
+      const client = await getClient(make({ apiKey: 'sk-test' }))
+
+      assert.equal(client.apiKey, 'sk-test')
+      assert.equal(client.baseURL, 'https://api.openai.com/v1')
+      assert.equal(client.organization, null)
+      assert.equal(client._options.defaultHeaders, undefined)
+    })
+
+    it(`${name} builds the client once and memoises it`, async () => {
+      const adapter = make({ apiKey: 'sk-test' })
+
+      assert.equal(await getClient(adapter), await getClient(adapter))
+    })
+  }
+})
+
+describe('Google adapters — client construction', () => {
+  for (const [name, make] of googleAdapters) {
+    it(`${name} forwards the api key to the SDK`, async () => {
+      const client = await getClient(make({ apiKey: 'gk-test' }))
+
+      assert.equal(client.apiKey, 'gk-test')
+      assert.equal(client.vertexai, false)
+    })
+
+    it(`${name} builds the client once and memoises it`, async () => {
+      const adapter = make({ apiKey: 'gk-test' })
+
+      assert.equal(await getClient(adapter), await getClient(adapter))
+    })
+  }
+})

--- a/packages/ai-sdk/src/providers/google/chat.ts
+++ b/packages/ai-sdk/src/providers/google/chat.ts
@@ -20,6 +20,7 @@ import {
 } from '../google-cache-registry.js'
 import { contentToString } from '../../util/content.js'
 import type { GoogleConfig } from './config.js'
+import { createGoogleClient } from './client.js'
 import { filterToGeminiString } from './filters.js'
 
 // ─── Adapter ──────────────────────────────────────────────
@@ -35,9 +36,7 @@ export class GoogleAdapter implements ProviderAdapter {
 
   private async getClient(): Promise<any> {
     if (this.client) return this.client
-    const sdk: any = await import(/* @vite-ignore */ '@google/genai')
-    const GoogleGenAI = sdk.GoogleGenAI ?? sdk.default
-    this.client = new GoogleGenAI({ apiKey: this.config.apiKey })
+    this.client = await createGoogleClient(this.config)
     return this.client
   }
 

--- a/packages/ai-sdk/src/providers/google/client.ts
+++ b/packages/ai-sdk/src/providers/google/client.ts
@@ -1,0 +1,12 @@
+import type { GoogleConfig } from './config.js'
+
+/**
+ * Builds the `@google/genai` SDK client. The import is dynamic so the SDK
+ * stays an optional dependency that is only resolved once a Google adapter
+ * is used.
+ */
+export async function createGoogleClient(config: GoogleConfig): Promise<any> {
+  const sdk: any = await import(/* @vite-ignore */ '@google/genai')
+  const GoogleGenAI = sdk.GoogleGenAI ?? sdk.default
+  return new GoogleGenAI({ apiKey: config.apiKey })
+}

--- a/packages/ai-sdk/src/providers/google/embeddings.ts
+++ b/packages/ai-sdk/src/providers/google/embeddings.ts
@@ -1,5 +1,6 @@
 import type { EmbeddingAdapter, EmbeddingResult } from '../../types.js'
 import type { GoogleConfig } from './config.js'
+import { createGoogleClient } from './client.js'
 
 // ─── Embedding Adapter ──────────────────────────────────
 
@@ -13,9 +14,7 @@ export class GoogleEmbeddingAdapter implements EmbeddingAdapter {
 
   private async getClient(): Promise<any> {
     if (this.client) return this.client
-    const sdk: any = await import(/* @vite-ignore */ '@google/genai')
-    const GoogleGenAI = sdk.GoogleGenAI ?? sdk.default
-    this.client = new GoogleGenAI({ apiKey: this.config.apiKey })
+    this.client = await createGoogleClient(this.config)
     return this.client
   }
 

--- a/packages/ai-sdk/src/providers/google/files.ts
+++ b/packages/ai-sdk/src/providers/google/files.ts
@@ -5,6 +5,7 @@ import type {
   FileListResult,
 } from '../../types.js'
 import type { GoogleConfig } from './config.js'
+import { createGoogleClient } from './client.js'
 
 // ─── Files ──────────────────────────────────────────────
 
@@ -15,9 +16,7 @@ export class GoogleFileAdapter implements FileAdapter {
 
   private async getClient(): Promise<any> {
     if (this.client) return this.client
-    const sdk: any = await import(/* @vite-ignore */ '@google/genai')
-    const GoogleGenAI = sdk.GoogleGenAI ?? sdk.default
-    this.client = new GoogleGenAI({ apiKey: this.config.apiKey })
+    this.client = await createGoogleClient(this.config)
     return this.client
   }
 

--- a/packages/ai-sdk/src/providers/google/vector-store.ts
+++ b/packages/ai-sdk/src/providers/google/vector-store.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../types.js'
 import { sleep } from '../../util/sleep.js'
 import type { GoogleConfig } from './config.js'
+import { createGoogleClient } from './client.js'
 
 // ─── Vector Stores (Gemini FileSearchStores, #B8.5) ──────
 //
@@ -49,9 +50,7 @@ export class GoogleVectorStoreAdapter implements VectorStoreAdapter {
 
   private async getClient(): Promise<any> {
     if (this.client) return this.client
-    const sdk: any = await import(/* @vite-ignore */ '@google/genai')
-    const GoogleGenAI = sdk.GoogleGenAI ?? sdk.default
-    this.client = new GoogleGenAI({ apiKey: this.config.apiKey })
+    this.client = await createGoogleClient(this.config)
     return this.client
   }
 

--- a/packages/ai-sdk/src/providers/openai/chat.ts
+++ b/packages/ai-sdk/src/providers/openai/chat.ts
@@ -13,6 +13,7 @@ import type {
 import { base64ToUtf8 } from '../../base64.js'
 import { contentToString } from '../../util/content.js'
 import type { OpenAIConfig } from './config.js'
+import { createOpenAIClient } from './client.js'
 import { buildPromptCacheKey } from './prompt-cache.js'
 
 // ─── Adapter (also reused by Ollama) ─────────────────────
@@ -27,14 +28,7 @@ export class OpenAIAdapter implements ProviderAdapter {
 
   private async getClient(): Promise<any> {
     if (this.client) return this.client
-    const sdk = await import(/* @vite-ignore */ 'openai')
-    const OpenAI = sdk.default ?? sdk.OpenAI
-    this.client = new OpenAI({
-      apiKey: this.config.apiKey,
-      ...(this.config.baseUrl ? { baseURL: this.config.baseUrl } : {}),
-      ...(this.config.organization ? { organization: this.config.organization } : {}),
-      ...(this.config.defaultHeaders ? { defaultHeaders: this.config.defaultHeaders } : {}),
-    })
+    this.client = await createOpenAIClient(this.config)
     return this.client
   }
 

--- a/packages/ai-sdk/src/providers/openai/client.ts
+++ b/packages/ai-sdk/src/providers/openai/client.ts
@@ -1,0 +1,16 @@
+import type { OpenAIConfig } from './config.js'
+
+/**
+ * Builds the `openai` SDK client. The import is dynamic so the SDK stays an
+ * optional dependency that is only resolved once an OpenAI adapter is used.
+ */
+export async function createOpenAIClient(config: OpenAIConfig): Promise<any> {
+  const sdk = await import(/* @vite-ignore */ 'openai')
+  const OpenAI = sdk.default ?? sdk.OpenAI
+  return new OpenAI({
+    apiKey: config.apiKey,
+    ...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
+    ...(config.organization ? { organization: config.organization } : {}),
+    ...(config.defaultHeaders ? { defaultHeaders: config.defaultHeaders } : {}),
+  })
+}

--- a/packages/ai-sdk/src/providers/openai/files.ts
+++ b/packages/ai-sdk/src/providers/openai/files.ts
@@ -6,6 +6,7 @@ import type {
   FileContent,
 } from '../../types.js'
 import type { OpenAIConfig } from './config.js'
+import { createOpenAIClient } from './client.js'
 
 // ─── Files ──────────────────────────────────────────────
 
@@ -16,14 +17,7 @@ export class OpenAIFileAdapter implements FileAdapter {
 
   private async getClient(): Promise<any> {
     if (this.client) return this.client
-    const sdk = await import(/* @vite-ignore */ 'openai')
-    const OpenAI = sdk.default ?? sdk.OpenAI
-    this.client = new OpenAI({
-      apiKey: this.config.apiKey,
-      ...(this.config.baseUrl ? { baseURL: this.config.baseUrl } : {}),
-      ...(this.config.organization ? { organization: this.config.organization } : {}),
-      ...(this.config.defaultHeaders ? { defaultHeaders: this.config.defaultHeaders } : {}),
-    })
+    this.client = await createOpenAIClient(this.config)
     return this.client
   }
 

--- a/packages/ai-sdk/src/providers/openai/images.ts
+++ b/packages/ai-sdk/src/providers/openai/images.ts
@@ -4,6 +4,7 @@ import type {
   ImageGenerationResult,
 } from '../../types.js'
 import type { OpenAIConfig } from './config.js'
+import { createOpenAIClient } from './client.js'
 
 // ─── Image Generation Adapter ────────────────────────────
 
@@ -23,14 +24,7 @@ export class OpenAIImageAdapter implements ImageGenerationAdapter {
 
   private async getClient(): Promise<any> {
     if (this.client) return this.client
-    const sdk = await import(/* @vite-ignore */ 'openai')
-    const OpenAI = sdk.default ?? sdk.OpenAI
-    this.client = new OpenAI({
-      apiKey: this.config.apiKey,
-      ...(this.config.baseUrl ? { baseURL: this.config.baseUrl } : {}),
-      ...(this.config.organization ? { organization: this.config.organization } : {}),
-      ...(this.config.defaultHeaders ? { defaultHeaders: this.config.defaultHeaders } : {}),
-    })
+    this.client = await createOpenAIClient(this.config)
     return this.client
   }
 

--- a/packages/ai-sdk/src/providers/openai/stt.ts
+++ b/packages/ai-sdk/src/providers/openai/stt.ts
@@ -4,6 +4,7 @@ import type {
   SpeechToTextResult,
 } from '../../types.js'
 import type { OpenAIConfig } from './config.js'
+import { createOpenAIClient } from './client.js'
 
 // ─── STT Adapter ─────────────────────────────────────────
 
@@ -14,14 +15,7 @@ export class OpenAISttAdapter implements SpeechToTextAdapter {
 
   private async getClient(): Promise<any> {
     if (this.client) return this.client
-    const sdk = await import(/* @vite-ignore */ 'openai')
-    const OpenAI = sdk.default ?? sdk.OpenAI
-    this.client = new OpenAI({
-      apiKey: this.config.apiKey,
-      ...(this.config.baseUrl ? { baseURL: this.config.baseUrl } : {}),
-      ...(this.config.organization ? { organization: this.config.organization } : {}),
-      ...(this.config.defaultHeaders ? { defaultHeaders: this.config.defaultHeaders } : {}),
-    })
+    this.client = await createOpenAIClient(this.config)
     return this.client
   }
 

--- a/packages/ai-sdk/src/providers/openai/tts.ts
+++ b/packages/ai-sdk/src/providers/openai/tts.ts
@@ -4,6 +4,7 @@ import type {
   TextToSpeechResult,
 } from '../../types.js'
 import type { OpenAIConfig } from './config.js'
+import { createOpenAIClient } from './client.js'
 
 // ─── TTS Adapter ─────────────────────────────────────────
 
@@ -14,14 +15,7 @@ export class OpenAITtsAdapter implements TextToSpeechAdapter {
 
   private async getClient(): Promise<any> {
     if (this.client) return this.client
-    const sdk = await import(/* @vite-ignore */ 'openai')
-    const OpenAI = sdk.default ?? sdk.OpenAI
-    this.client = new OpenAI({
-      apiKey: this.config.apiKey,
-      ...(this.config.baseUrl ? { baseURL: this.config.baseUrl } : {}),
-      ...(this.config.organization ? { organization: this.config.organization } : {}),
-      ...(this.config.defaultHeaders ? { defaultHeaders: this.config.defaultHeaders } : {}),
-    })
+    this.client = await createOpenAIClient(this.config)
     return this.client
   }
 

--- a/packages/ai-sdk/src/providers/openai/vector-store.ts
+++ b/packages/ai-sdk/src/providers/openai/vector-store.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../types.js'
 import { sleep } from '../../util/sleep.js'
 import type { OpenAIConfig } from './config.js'
+import { createOpenAIClient } from './client.js'
 
 // ─── OpenAI Vector Stores (#B8 Phase 1) ──────────────────
 
@@ -33,14 +34,7 @@ export class OpenAIVectorStoreAdapter implements VectorStoreAdapter {
 
   private async getClient(): Promise<any> {
     if (this.client) return this.client
-    const sdk = await import(/* @vite-ignore */ 'openai')
-    const OpenAI = sdk.default ?? sdk.OpenAI
-    this.client = new OpenAI({
-      apiKey: this.config.apiKey,
-      ...(this.config.baseUrl ? { baseURL: this.config.baseUrl } : {}),
-      ...(this.config.organization ? { organization: this.config.organization } : {}),
-      ...(this.config.defaultHeaders ? { defaultHeaders: this.config.defaultHeaders } : {}),
-    })
+    this.client = await createOpenAIClient(this.config)
     return this.client
   }
 


### PR DESCRIPTION
Part of #972 (item 1 of 4), and the last of its items that was unblocked.

## What

`private async getClient()` was copy-pasted across every OpenAI and Google adapter: 6 byte-identical copies under `providers/openai/` and 4 under `providers/google/`. The directory split in #1016 spread them across ten separate files, so the knowledge of how each SDK gets constructed (the `default ?? Named` export dance, and which config field maps to which SDK option) now had ten places to drift.

Construction moves into `createOpenAIClient()` and `createGoogleClient()`. Each adapter keeps its own memoised `client` field, so the laziness and the per-instance caching are unchanged.

## The gap this closed

The construction path had **no test coverage at all**. Every existing suite pre-sets `client` so `getClient()` short-circuits before the body ever runs (`provider-tools.test.ts:139` says so explicitly). Deduping ten copies into one under those conditions would have been unguarded, so this adds characterisation tests first: they drive the real lazy import for all ten adapters and assert the constructed client carries `apiKey`, `baseUrl`, `organization` and `defaultHeaders`, plus that it is built once and memoised.

Those tests were proven to have teeth before the refactor landed: dropping the `organization` passthrough from one adapter and hardcoding a wrong `apiKey` in another failed exactly those two adapters and nothing else.

## Verification

- ai-sdk: 947 tests, 947 pass, 0 fail (baseline 921 + 26 new); identical before and after the dedup
- repo typecheck: 21/21
- Built `.d.ts` surface diffed against `main`: **zero** content differences across all shared declarations, the only additions being the two new helper files. That is the real proof a pure movement stayed pure.
- Barrels untouched; no importer outside `providers/` references the new modules

## No changeset

Pure movement, no behavior change and no public surface change, matching #1016. (#1013 carried one because it also changed behavior.)

## Still open on #972

Items 2 and 3 are deliberately not touched here, both need a human:

- **Item 2** (five OpenAI-compatible clones): azure, xai, groq, deepseek and mistral have zero tests, so a factory would be unguarded. Characterisation tests have to come first. Also azure has a required base URL and ollama has no `apiKey` and a defaulted constructor, so neither actually fits a `defineOpenAiCompatible({name, baseUrl})` factory.
- **Item 3** (import Bedrock's `mapBedrockAnthropicEvent` into `anthropic.ts`): a true dedup, the two mappings are verified not drifted, but adopting Bedrock's version trades `anthropic.ts`'s typed SDK events for `Record<string, any>`. That is a judgement call, not an agent's.

Also worth noting: #972's own text is stale in two places. It claims a sub-store key prefix `gemstack:ai:p-run:` that exists nowhere (the real one is `gemstack:ai:sub-agent-run:`), and item 4 (the run-store twins) is already done, shipped in #1013.