### PR TITLE
feat(dashboard): status colour tokens, a real Checkbox, and a stable Sessions rail

### DIFF
--- a/.changeset/tidy-jars-shout.md
+++ b/.changeset/tidy-jars-shout.md
@@ -1,0 +1,19 @@
+---
+'@gemstack/framework': minor
+---
+
+Dashboard: semantic status colours, a real Checkbox, a stable Sessions rail, and no emoji glyphs.
+
+The status colours are now four tokens (`--success`, `--warning`, `--danger`, `--info`) tuned per
+theme, replacing every raw palette value. Before this, "good" was six different greens, `amber-500`
+meant both "stopped" and "building, fine", and the flat `-500` tones sat near 2:1 contrast on the
+light canvas.
+
+Checkboxes are a shadcn-style primitive on Base UI instead of bare `<input type="checkbox">`, so
+they follow the theme and carry the same focus ring as everything else.
+
+The Sessions rail no longer collapses to a strip when the right rail opens the Browser or Views
+tab; its width is now constant.
+
+The ✅/❌/⚠️ glyphs in the Enhanced System Prompt disclosure are replaced by a status dot and plain
+text, matching how every other state in the app is drawn.

--- a/packages/framework-dashboard/components/AddProjectPanel.tsx
+++ b/packages/framework-dashboard/components/AddProjectPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, type FormEvent, type KeyboardEvent } from 
 import { sendAddProject } from '../server/projects.telefunc.js'
 import { useAction } from '../lib/use-action.js'
 import { Button } from './ui/button.js'
+import { Checkbox } from './ui/checkbox.js'
 
 // Add project(s) (#396/#433): install a single repo, or every git repo directly under a
 // directory, and register each so it joins the list. The daemon does the work; this posts
@@ -125,7 +126,7 @@ export function AddProjectPanel({ onAdded, onClose }: { onAdded: () => void; onC
               Adding it lets the agent read its files. Hidden instructions in an untrusted repo can hijack the agent
               (prompt injection), so only add repos you trust.
             </p>
-            {error && <p className="mb-2 text-xs text-red-500">{error}</p>}
+            {error && <p className="mb-2 text-xs text-danger">{error}</p>}
             <div className="flex justify-end gap-2">
               <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={() => setConfirming(false)}>
                 Back
@@ -148,10 +149,10 @@ export function AddProjectPanel({ onAdded, onClose }: { onAdded: () => void; onC
               className="mb-2 w-full rounded-md border border-border bg-transparent px-2 py-1 text-sm outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
             />
             <label className="mb-2 flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
-              <input type="checkbox" checked={directory} onChange={e => setDirectory(e.target.checked)} disabled={busy} />{' '}
+              <Checkbox checked={directory} onCheckedChange={setDirectory} disabled={busy} />
               It&apos;s a folder of repos
             </label>
-            {error && <p className="mb-2 text-xs text-red-500">{error}</p>}
+            {error && <p className="mb-2 text-xs text-danger">{error}</p>}
             <div className="flex justify-end gap-2">
               <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={onClose}>
                 Cancel

--- a/packages/framework-dashboard/components/ChoicePanel.tsx
+++ b/packages/framework-dashboard/components/ChoicePanel.tsx
@@ -4,6 +4,7 @@ import { sendChoice } from '../server/control.telefunc.js'
 import { useAction } from '../lib/use-action.js'
 import { usePreferences, updatePreferences, autopilotEnabled } from '../lib/preferences.js'
 import { Button } from './ui/button.js'
+import { Checkbox } from './ui/checkbox.js'
 import { cn } from '../lib/utils.js'
 
 // "Your call" — the interactive gate the run parks on (#304/#332), rendered from the
@@ -122,7 +123,9 @@ export function ChoicePanel({
       {choice.confirm ? (
         <div className="flex gap-2">
           <Button
-            className="bg-emerald-600 text-white hover:bg-emerald-600 hover:opacity-90"
+            /* `text-background`, not white: the success token is dark on the light canvas and light
+               on the dark one, so the label has to invert with it to stay legible on both. */
+            className="bg-success text-background hover:bg-success hover:opacity-90"
             disabled={parked || !approveId}
             onClick={() => approveId && post(approveId)}
           >
@@ -130,7 +133,7 @@ export function ChoicePanel({
           </Button>
           <Button
             variant="outline"
-            className="border-red-500/50 text-red-500 hover:bg-red-500/10 hover:text-red-500"
+            className="border-danger/50 text-danger hover:bg-danger/10 hover:text-danger"
             disabled={parked || !declineId}
             onClick={() => declineId && post(declineId)}
           >
@@ -143,7 +146,7 @@ export function ChoicePanel({
             {choice.options.map(o => (
               <li key={o.id}>
                 <label className="flex cursor-pointer items-start gap-2 text-sm">
-                  <input type="checkbox" className="mt-1" checked={checked.has(o.id)} onChange={() => toggle(o.id)} disabled={parked} />
+                  <Checkbox className="mt-0.5" checked={checked.has(o.id)} onCheckedChange={() => toggle(o.id)} disabled={parked} />
                   <span>
                     {o.label}
                     {o.detail && <span className="block text-xs text-muted-foreground">{o.detail}</span>}
@@ -177,7 +180,7 @@ export function ChoicePanel({
         </div>
       )}
 
-      {error && <p className="mt-2 text-xs text-red-500">{error}</p>}
+      {error && <p className="mt-2 text-xs text-danger">{error}</p>}
 
       <div className="mt-3 flex items-center gap-3 text-xs text-muted-foreground">
         {parked ? (
@@ -185,7 +188,7 @@ export function ChoicePanel({
         ) : (
           <>
             <label className="flex cursor-pointer items-center gap-1.5">
-              <input type="checkbox" checked={autopilot} onChange={e => toggleAutopilot(e.target.checked)} /> Autopilot
+              <Checkbox checked={autopilot} onCheckedChange={toggleAutopilot} /> Autopilot
             </label>
             {autopilot && (
               <span className={cn(secondsLeft !== null && !cancelled && 'font-medium text-foreground')}>

--- a/packages/framework-dashboard/components/ContextFiles.tsx
+++ b/packages/framework-dashboard/components/ContextFiles.tsx
@@ -26,7 +26,7 @@ export function ContextFiles({
             onClick={() => onRemove(file)}
             title={`Remove ${file}`}
             aria-label={`Remove ${file} from context`}
-            className="flex h-3.5 w-3.5 items-center justify-center rounded text-muted-foreground hover:text-red-500 disabled:opacity-50"
+            className="flex h-3.5 w-3.5 items-center justify-center rounded text-muted-foreground hover:text-danger disabled:opacity-50"
           >
             <X className="h-3.5 w-3.5" />
           </button>

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -145,8 +145,8 @@ function NeedsYou({ items, onSelectProject }: { items: Intervention[]; onSelectP
                     className="flex w-full items-center gap-2 py-2 text-left hover:opacity-80"
                     title="Open the session to answer"
                   >
-                    <MessageCircleQuestion className="h-4 w-4 shrink-0 text-amber-500" />
-                    <span className="shrink-0 text-xs font-medium text-amber-500">Awaiting</span>
+                    <MessageCircleQuestion className="h-4 w-4 shrink-0 text-warning" />
+                    <span className="shrink-0 text-xs font-medium text-warning">Awaiting</span>
                     <span className="truncate font-medium">{item.title}</span>
                     <span className="ml-auto shrink-0 text-xs text-muted-foreground">{item.projectName}</span>
                   </button>
@@ -157,8 +157,8 @@ function NeedsYou({ items, onSelectProject }: { items: Intervention[]; onSelectP
                     className="flex w-full items-center gap-2 py-2 text-left hover:opacity-80"
                     title={`Open the session: work on ${item.branch ?? ''} was never pushed`}
                   >
-                    <GitBranch className="h-4 w-4 shrink-0 text-sky-500" />
-                    <span className="shrink-0 text-xs font-medium text-sky-500">Unpushed</span>
+                    <GitBranch className="h-4 w-4 shrink-0 text-info" />
+                    <span className="shrink-0 text-xs font-medium text-info">Unpushed</span>
                     <span className="truncate font-medium">{item.title}</span>
                     {/* An unknown count says nothing rather than the contradictory "0 commits". */}
                     {item.commits !== undefined && item.commits > 0 && (
@@ -176,7 +176,7 @@ function NeedsYou({ items, onSelectProject }: { items: Intervention[]; onSelectP
                     className="flex items-center gap-2 py-2 hover:opacity-80"
                     title={`Open PR #${item.number} on GitHub`}
                   >
-                    <GitPullRequest className="h-4 w-4 shrink-0 text-emerald-500" />
+                    <GitPullRequest className="h-4 w-4 shrink-0 text-success" />
                     <span className="shrink-0 text-xs font-medium tabular-nums text-muted-foreground">#{item.number}</span>
                     <span className="truncate font-medium">{item.title}</span>
                     <span className="ml-auto shrink-0 text-xs text-muted-foreground">{item.projectName}</span>
@@ -233,7 +233,7 @@ function WorkingNow({ active, onSelectProject }: { active: ActiveRun[]; onSelect
               {/* Decorative dot + sr-only status (#695/U33): color alone reaches no screen reader. */}
               <span
                 aria-hidden
-                className={cn('h-2 w-2 shrink-0 rounded-full', run.readyForMerge ? 'bg-emerald-500' : 'animate-pulse bg-amber-500')}
+                className={cn('h-2 w-2 shrink-0 rounded-full', run.readyForMerge ? 'bg-success' : 'animate-pulse bg-warning')}
                 title={run.readyForMerge ? 'Ready for merge' : 'Building'}
               />
               <span className="sr-only">{run.readyForMerge ? 'Ready for merge' : 'Building'}: </span>
@@ -322,7 +322,7 @@ function ProjectsTable({ projects, onSelectProject }: { projects: ProjectStat[];
                     aria-hidden
                     className={cn(
                       'h-2 w-2 shrink-0 rounded-full',
-                      p.running ? 'animate-pulse bg-primary' : p.activated ? 'bg-emerald-500' : 'bg-muted-foreground',
+                      p.running ? 'animate-pulse bg-primary' : p.activated ? 'bg-success' : 'bg-muted-foreground',
                     )}
                     title={p.running ? 'Running' : p.activated ? 'Activated' : 'Not activated'}
                   />

--- a/packages/framework-dashboard/components/DiffView.tsx
+++ b/packages/framework-dashboard/components/DiffView.tsx
@@ -23,9 +23,9 @@ function Binary() {
 export function DiffStat({ added, removed, className }: { added: number; removed: number; className?: string }) {
   return (
     <span className={cn('shrink-0 font-mono text-[10px] tabular-nums', className)}>
-      {added > 0 && <span className="text-green-600 dark:text-green-400">+{added}</span>}
+      {added > 0 && <span className="text-success">+{added}</span>}
       {added > 0 && removed > 0 && ' '}
-      {removed > 0 && <span className="text-red-600 dark:text-red-400">−{removed}</span>}
+      {removed > 0 && <span className="text-danger">−{removed}</span>}
     </span>
   )
 }
@@ -34,8 +34,8 @@ function lineClass(line: string): string {
   if (line.startsWith('+++') || line.startsWith('---')) return 'text-muted-foreground'
   if (line.startsWith('@@')) return 'text-primary'
   // Both themes: the 300s wash out on a light background, the 700s on a dark one.
-  if (line.startsWith('+')) return 'bg-green-400/10 text-green-700 dark:text-green-300'
-  if (line.startsWith('-')) return 'bg-red-400/10 text-red-700 dark:text-red-300'
+  if (line.startsWith('+')) return 'bg-success/10 text-success'
+  if (line.startsWith('-')) return 'bg-danger/10 text-danger'
   return 'text-muted-foreground'
 }
 

--- a/packages/framework-dashboard/components/GitStatusBar.tsx
+++ b/packages/framework-dashboard/components/GitStatusBar.tsx
@@ -56,7 +56,7 @@ export function GitStatusBar({
       </span>
       <span className="flex items-center gap-1.5">
         <span
-          className={cn('h-2 w-2 rounded-full', status.dirty ? 'bg-amber-500' : 'bg-emerald-500')}
+          className={cn('h-2 w-2 rounded-full', status.dirty ? 'bg-warning' : 'bg-success')}
           title={status.dirty ? dirtyLabel : 'Clean'}
         />
         <span className="text-muted-foreground">{status.dirty ? 'dirty' : 'clean'}</span>

--- a/packages/framework-dashboard/components/PresetsMenu.tsx
+++ b/packages/framework-dashboard/components/PresetsMenu.tsx
@@ -90,7 +90,7 @@ export function PresetsMenu({
                   }}
                   title={`Delete "${p.label}"`}
                   aria-label={`Delete preset ${p.label}`}
-                  className="rounded p-0.5 text-[var(--color-muted-foreground)] hover:text-red-500"
+                  className="rounded p-0.5 text-[var(--color-muted-foreground)] hover:text-danger"
                 >
                   <X className="h-3.5 w-3.5" aria-hidden />
                 </button>

--- a/packages/framework-dashboard/components/PreviewBar.tsx
+++ b/packages/framework-dashboard/components/PreviewBar.tsx
@@ -168,7 +168,7 @@ export function PreviewBar({
     return (
       <>
         {controls}
-        {error && <p className="w-full text-xs text-red-500">{error}</p>}
+        {error && <p className="w-full text-xs text-danger">{error}</p>}
       </>
     )
   }
@@ -178,7 +178,7 @@ export function PreviewBar({
       <span className="font-semibold uppercase tracking-wide text-muted-foreground">Serve</span>
       {!url && <span className="text-muted-foreground">Serve this project's built result</span>}
       <span className="ml-auto flex items-center gap-2">{controls}</span>
-      {error && <p className="w-full text-red-500">{error}</p>}
+      {error && <p className="w-full text-danger">{error}</p>}
     </div>
   )
 }

--- a/packages/framework-dashboard/components/Quota.tsx
+++ b/packages/framework-dashboard/components/Quota.tsx
@@ -5,6 +5,7 @@ import { useQuota } from '../lib/quota.js'
 import { usePreferences, updatePreferences } from '../lib/preferences.js'
 import { weekTicks, quotaTone, limitPercent, TONE_NOTE, type QuotaTone } from '../lib/quota-bar.js'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card.js'
+import { Checkbox } from './ui/checkbox.js'
 import { cn } from '../lib/utils.js'
 
 // The usage bar (#960): one week-long track, so "am I ahead or behind?" is a glance rather than a
@@ -18,10 +19,10 @@ import { cn } from '../lib/utils.js'
 
 /** The bar's colour per tone. Fill and marker share a scale so the comparison reads at a glance. */
 const TONE_FILL: Record<QuotaTone, string> = {
-  under: 'bg-emerald-500',
-  near: 'bg-blue-500',
-  over: 'bg-orange-500',
-  full: 'bg-red-500',
+  under: 'bg-success',
+  near: 'bg-info',
+  over: 'bg-warning',
+  full: 'bg-danger',
 }
 
 /** The account's own week: the window the bar is about. */
@@ -221,11 +222,9 @@ export function Quota() {
         {view ? (
           <div className="space-y-1 border-t border-border pt-3">
             <label className="flex cursor-pointer items-center gap-1.5 text-sm">
-              <input
-                type="checkbox"
-                className="accent-[var(--color-primary)]"
+              <Checkbox
                 checked={preferences.autoPm ?? false}
-                onChange={e => updatePreferences({ autoPm: e.target.checked })}
+                onCheckedChange={checked => updatePreferences({ autoPm: checked })}
               />
               <span className="font-medium text-foreground">Spend what's left on the roadmap</span>
             </label>

--- a/packages/framework-dashboard/components/RunActionBar.tsx
+++ b/packages/framework-dashboard/components/RunActionBar.tsx
@@ -57,7 +57,7 @@ export function RunActionBar({
             read from this session's own worktree — its branch, whether it is holding uncommitted
             work, its size on disk, and the PR its branch has. */}
         <GitStatusBar projectId={projectId} runId={runId} inline />
-        {error && <span className="text-xs text-red-500">{error}</span>}
+        {error && <span className="text-xs text-danger">{error}</span>}
         {/* What the session IS sits at the start of the bar; what you can DO to it sits at the end,
             so the buttons keep one home as the row's contents come and go (Stop only while it runs,
             Remove only on a retained worktree, Open session only once one is reported). */}

--- a/packages/framework-dashboard/components/RunChanges.tsx
+++ b/packages/framework-dashboard/components/RunChanges.tsx
@@ -28,9 +28,9 @@ const LABEL: Record<FileChange['status'], string> = {
 }
 
 const TONE: Record<FileChange['status'], string> = {
-  untracked: 'text-green-400',
-  modified: 'text-amber-400',
-  deleted: 'text-red-400',
+  untracked: 'text-success',
+  modified: 'text-warning',
+  deleted: 'text-danger',
 }
 
 function ChangeRow({ projectId, runId, change }: { projectId: string; runId: string; change: FileChange }) {

--- a/packages/framework-dashboard/components/RunChat.tsx
+++ b/packages/framework-dashboard/components/RunChat.tsx
@@ -75,7 +75,7 @@ export function RunChat({
           Queued — the session reads it between turns: &ldquo;{queued}&rdquo;
         </p>
       )}
-      {(error ?? startError) && <p role="alert" className="mb-1 px-2 text-xs text-red-500">{error ?? startError}</p>}
+      {(error ?? startError) && <p role="alert" className="mb-1 px-2 text-xs text-danger">{error ?? startError}</p>}
       <Composer
         ref={composerRef}
         files={files}

--- a/packages/framework-dashboard/components/RunFeed.tsx
+++ b/packages/framework-dashboard/components/RunFeed.tsx
@@ -19,7 +19,7 @@ export function RunFeed({
   lost?: boolean
 }) {
   const lostBanner = lost && (
-    <div role="status" className="flex items-center gap-2 border-b border-border bg-amber-500/10 px-4 py-2 text-xs text-amber-600 dark:text-amber-400">
+    <div role="status" className="flex items-center gap-2 border-b border-border bg-warning/10 px-4 py-2 text-xs text-warning">
       <TriangleAlert className="h-3.5 w-3.5 shrink-0" aria-hidden />
       Live stream lost — reconnecting. The session keeps running; this view may be behind.
     </div>

--- a/packages/framework-dashboard/components/RunHandoffPanel.tsx
+++ b/packages/framework-dashboard/components/RunHandoffPanel.tsx
@@ -56,7 +56,7 @@ export function RunHandoffPanel({ projectId, runId }: { projectId: string; runId
         </span>
         <Summary handoff={handoff} />
         <div className="min-w-0 flex-1" />
-        {error && <span className="text-red-500">{error}</span>}
+        {error && <span className="text-danger">{error}</span>}
         <Actions handoff={handoff} busy={busy} pending={pending} act={act} projectId={projectId} runId={runId} />
       </div>
       {!handoff.empty && handoff.exists && (

--- a/packages/framework-dashboard/components/RunOutcomes.tsx
+++ b/packages/framework-dashboard/components/RunOutcomes.tsx
@@ -4,9 +4,9 @@ import type { RunStatus } from '@gemstack/framework'
 // critical), so every segment ships with a written label and count — identity is never
 // carried by colour alone. Zero-count outcomes are dropped from the bar but still listed.
 const OUTCOMES: { key: Exclude<RunStatus, 'running'>; label: string; fill: string; dot: string }[] = [
-  { key: 'done', label: 'Done', fill: 'bg-emerald-500', dot: 'bg-emerald-500' },
-  { key: 'failed', label: 'Failed', fill: 'bg-red-500', dot: 'bg-red-500' },
-  { key: 'stopped', label: 'Stopped', fill: 'bg-amber-500', dot: 'bg-amber-500' },
+  { key: 'done', label: 'Done', fill: 'bg-success', dot: 'bg-success' },
+  { key: 'failed', label: 'Failed', fill: 'bg-danger', dot: 'bg-danger' },
+  { key: 'stopped', label: 'Stopped', fill: 'bg-warning', dot: 'bg-warning' },
 ]
 
 export function RunOutcomes({ counts }: { counts: Record<RunStatus, number> }) {

--- a/packages/framework-dashboard/components/RunOverview.tsx
+++ b/packages/framework-dashboard/components/RunOverview.tsx
@@ -25,13 +25,13 @@ export function RunOverview({ events, showSessionLink = true }: { events: Framew
   const stopped = outcome?.stopped === true
   const hasProgress = Boolean(progress.sessionName) || progress.readyForMerge || failed || stopped
   const status = failed
-    ? { dot: 'bg-red-500', label: outcome?.detail ? `failed — ${outcome.detail}` : 'failed', tone: 'text-red-500' }
+    ? { dot: 'bg-danger', label: outcome?.detail ? `failed — ${outcome.detail}` : 'failed', tone: 'text-danger' }
     : stopped
-      ? { dot: 'bg-amber-500', label: 'stopped', tone: 'text-amber-600 dark:text-amber-400' }
+      ? { dot: 'bg-warning', label: 'stopped', tone: 'text-warning' }
       : progress.readyForMerge
-        ? { dot: 'bg-green-500', label: 'ready for merge', tone: 'text-muted-foreground' }
+        ? { dot: 'bg-success', label: 'ready for merge', tone: 'text-muted-foreground' }
         : active
-          ? { dot: 'animate-pulse bg-amber-500', label: 'building…', tone: 'text-muted-foreground' }
+          ? { dot: 'animate-pulse bg-warning', label: 'building…', tone: 'text-muted-foreground' }
           : { dot: 'bg-muted-foreground', label: 'finished', tone: 'text-muted-foreground' }
 
   // The "Open session" link, labeled honestly: a headless Claude Code run has no per-session
@@ -65,7 +65,8 @@ export function RunOverview({ events, showSessionLink = true }: { events: Framew
             <ul className="space-y-0.5 text-xs">
               {loop.blockers.map((b, i) => (
                 <li key={i} className="text-foreground">
-                  <span className="text-muted-foreground">☐</span> {b}
+                  <span className="mr-1.5 inline-block h-1 w-1 shrink-0 rounded-full bg-muted-foreground align-middle" aria-hidden />
+                  {b}
                 </li>
               ))}
             </ul>

--- a/packages/framework-dashboard/components/RunResumeChat.tsx
+++ b/packages/framework-dashboard/components/RunResumeChat.tsx
@@ -102,7 +102,7 @@ export function RunResumeChat({
         sessionName={sessionName}
         placeholder="Message the session to continue it…  ( / commands · < tags · @ projects · # files )"
       />
-      {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
+      {error && <p className="mt-1 text-xs text-danger">{error}</p>}
     </div>
   )
 }

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -10,6 +10,7 @@ import { Composer, type ComposerHandle } from './Composer.js'
 import { ContextFiles } from './ContextFiles.js'
 import { DisclosureToggle } from './DisclosureToggle.js'
 import { SystemPromptDisclosure } from './SystemPromptDisclosure.js'
+import { Checkbox } from './ui/checkbox.js'
 
 // Start a run in the selected project (#405): the one write that goes through the daemon's own
 // `startRun` (with its one-run-per-project busy guard), posted over Telefunc. The editor + control
@@ -121,7 +122,7 @@ export function StartRunForm({
 
       {/* Feedback right where the action is (#948): the error used to render below the (possibly
           expanded, tall) Context disclosure, past the fold from the Start button that caused it. */}
-      {error && <p role="alert" className="mt-2 text-xs text-red-500">{error}</p>}
+      {error && <p role="alert" className="mt-2 text-xs text-danger">{error}</p>}
       {note && !error && <p role="status" className="mt-2 text-xs text-muted-foreground">{note}</p>}
 
       <SystemPromptDisclosure
@@ -159,7 +160,7 @@ export function StartRunForm({
                   <div className="flex flex-col gap-1">
                     {otherProjects.map(p => (
                       <label key={p.id} className="flex cursor-pointer items-center gap-1.5" title={p.path}>
-                        <input type="checkbox" checked={context.has(p.path)} onChange={() => toggleContext(p.path)} disabled={busy} />
+                        <Checkbox checked={context.has(p.path)} onCheckedChange={() => toggleContext(p.path)} disabled={busy} />
                         <span className="truncate">{p.name}</span>
                       </label>
                     ))}

--- a/packages/framework-dashboard/components/SystemPromptDisclosure.test.tsx
+++ b/packages/framework-dashboard/components/SystemPromptDisclosure.test.tsx
@@ -9,7 +9,7 @@ function openDisclosure() {
   fireEvent.click(screen.getByText(/Enhanced System Prompt/))
 }
 
-/** The summary line, which carries the ✅/❌ state (#863). */
+/** The summary line, whose dot + screen-reader text carry the state (#863). */
 function summary(): string {
   return screen.getAllByRole('button')[0]?.textContent ?? ''
 }
@@ -41,25 +41,26 @@ describe('SystemPromptDisclosure transparent mode (#625)', () => {
 })
 
 describe('Enhanced System Prompt summary (#863)', () => {
-  test('✅ only when every axis is on', () => {
+  test('reads as fully enabled only when every axis is on', () => {
     render(<SystemPromptDisclosure {...baseProps} disabled={false} />)
-    expect(summary()).toContain('✅')
+    expect(summary()).toContain('fully enabled')
+    expect(summary()).not.toContain('not fully enabled')
   })
 
-  test('❌ when the built-in block is off, even though the protocols still ship', () => {
+  test('not fully enabled when the built-in block is off, even though the protocols still ship', () => {
     render(<SystemPromptDisclosure {...baseProps} disabled />)
-    expect(summary()).toContain('❌')
+    expect(summary()).toContain('not fully enabled')
     openDisclosure()
     // Not "completely enabled", but the channel is not empty either.
     expect(screen.queryByText(/No extra system prompt/)).toBeNull()
   })
 
-  test('❌ when the framework integration is off', () => {
+  test('not fully enabled when the framework integration is off', () => {
     render(<SystemPromptDisclosure {...baseProps} disabled={false} transparent />)
-    expect(summary()).toContain('❌')
+    expect(summary()).toContain('not fully enabled')
   })
 
-  test('the state is not carried by the glyph alone', () => {
+  test('the state is not carried by the dot alone', () => {
     render(<SystemPromptDisclosure {...baseProps} disabled={false} />)
     expect(summary()).toContain('fully enabled')
   })

--- a/packages/framework-dashboard/components/SystemPromptDisclosure.tsx
+++ b/packages/framework-dashboard/components/SystemPromptDisclosure.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react'
 import { composeRunSystem, type EcoOptions } from '@gemstack/framework/client'
 import { DisclosureToggle } from './DisclosureToggle.js'
+import { Checkbox } from './ui/checkbox.js'
+import { cn } from '../lib/utils.js'
 
 /**
  * "Enhanced System Prompt" (#863, was "See actual prompt sent" #520): the built-in system
@@ -67,14 +69,20 @@ export function SystemPromptDisclosure({
   // `vanilla` says — the row has to read the way the run will actually behave.
   const antiLazyOn = !disabled && !transparent
   const integrationOn = !transparent
-  // ✅ only when *completely* enabled (#863): either axis off is a ❌, even though a run with
-  // only the built-in block off still sends the emit protocols.
+  // Lit only when *completely* enabled (#863): either axis off dims the dot, even though a run
+  // with only the built-in block off still sends the emit protocols.
   const fullyOn = antiLazyOn && integrationOn
 
   return (
     <div className="mt-3 text-xs">
       <DisclosureToggle open={open} onToggle={() => setOpen(o => !o)}>
-        <span aria-hidden>{fullyOn ? '✅' : '❌'}</span> Enhanced System Prompt
+        {/* A status dot, like every other state in the app. This was a ✅/❌ pair, which sat at
+            emoji size and colour next to 12px text and matched nothing else on the page. */}
+        <span
+          className={cn('h-1.5 w-1.5 shrink-0 rounded-full', fullyOn ? 'bg-success' : 'bg-muted-foreground')}
+          aria-hidden
+        />
+        Enhanced System Prompt
         <span className="sr-only">{fullyOn ? ' (fully enabled)' : ' (not fully enabled)'}</span>
       </DisclosureToggle>
 
@@ -85,25 +93,24 @@ export function SystemPromptDisclosure({
             your prompt) in order to enable long-running autonomous agents.
           </p>
 
-          <label className="flex w-fit cursor-pointer items-center gap-1.5">
-            <input
-              type="checkbox"
+          <label className="flex w-fit cursor-pointer items-center gap-2">
+            <Checkbox
               checked={antiLazyOn}
-              onChange={e => onDisabledChange(!e.target.checked)}
+              onCheckedChange={checked => onDisabledChange(!checked)}
               disabled={busy || transparent}
-              title={transparent ? 'Off while the framework integration is off' : undefined}
-            />{' '}
+              {...(transparent ? { title: 'Off while the framework integration is off' } : {})}
+            />
             Anti-laziness and improved large-scope planning
           </label>
 
-          <label className="flex w-fit cursor-pointer items-center gap-1.5">
-            <input
-              type="checkbox"
+          <label className="flex w-fit cursor-pointer items-center gap-2">
+            <Checkbox
               checked={integrationOn}
-              onChange={e => onTransparentChange?.(!e.target.checked)}
+              onCheckedChange={checked => onTransparentChange?.(!checked)}
               disabled={busy || !onTransparentChange}
-            />{' '}
-            Integration with The Framework (⚠️ Some functionalities won&apos;t work)
+            />
+            Integration with The Framework
+            <span className="text-muted-foreground/80">(some functionality stops working)</span>
           </label>
 
           {text ? (

--- a/packages/framework-dashboard/components/TicketsPanel.tsx
+++ b/packages/framework-dashboard/components/TicketsPanel.tsx
@@ -20,8 +20,8 @@ const IMPORT_PROMPT =
 
 /** How a priority reads, for the ones the format names. */
 const PRIORITY_TONE: Record<string, string> = {
-  urgent: 'text-red-500',
-  high: 'text-amber-500',
+  urgent: 'text-danger',
+  high: 'text-warning',
   medium: 'text-muted-foreground',
   low: 'text-muted-foreground',
 }
@@ -72,7 +72,7 @@ export function TicketsPanel({
           No tickets yet. Tickets live in <code className="rounded bg-muted px-1">tickets/</code> and are what the agent
           plans from.
         </p>
-        {error && <p className="text-xs text-red-500">{error}</p>}
+        {error && <p className="text-xs text-danger">{error}</p>}
         <Button size="sm" variant="outline" disabled={busy} onClick={() => void importFromGithub()}>
           {busy ? 'Starting…' : 'Import tickets from GitHub'}
         </Button>
@@ -82,7 +82,7 @@ export function TicketsPanel({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {error && <p className="border-b border-border p-2 text-xs text-red-500">{error}</p>}
+      {error && <p className="border-b border-border p-2 text-xs text-danger">{error}</p>}
       <ScrollArea className="min-h-0 flex-1">
         <div className="p-2">
         {tickets.map(ticket => (

--- a/packages/framework-dashboard/components/WorkspaceActions.tsx
+++ b/packages/framework-dashboard/components/WorkspaceActions.tsx
@@ -75,7 +75,7 @@ export function WorkspaceActions({
       </Tooltip>
       {/* Serve (#475) the checkout this bar is about: the project's, or the session's own (#797). */}
       <PreviewBar projectId={projectId} runId={runId} inline />
-      {error && <span className="text-xs text-red-500">{error}</span>}
+      {error && <span className="text-xs text-danger">{error}</span>}
     </>
   )
 }

--- a/packages/framework-dashboard/components/animate-ui/components/base/files/index.tsx
+++ b/packages/framework-dashboard/components/animate-ui/components/base/files/index.tsx
@@ -68,9 +68,9 @@ function FolderTrigger({
             <div
               className={cn(
                 'flex items-center gap-2',
-                gitStatus === 'untracked' && 'text-green-400',
-                gitStatus === 'modified' && 'text-amber-400',
-                gitStatus === 'deleted' && 'text-red-400',
+                gitStatus === 'untracked' && 'text-success',
+                gitStatus === 'modified' && 'text-warning',
+                gitStatus === 'deleted' && 'text-danger',
               )}
             >
               <FolderIconPrimitive
@@ -89,9 +89,9 @@ function FolderTrigger({
               <span
                 className={cn(
                   'rounded-full size-2',
-                  gitStatus === 'untracked' && 'bg-green-400',
-                  gitStatus === 'modified' && 'bg-amber-400',
-                  gitStatus === 'deleted' && 'bg-red-400',
+                  gitStatus === 'untracked' && 'bg-success',
+                  gitStatus === 'modified' && 'bg-warning',
+                  gitStatus === 'deleted' && 'bg-danger',
                 )}
               />
             )}
@@ -129,9 +129,9 @@ function FileItem({
       <FilePrimitive
         className={cn(
           'flex items-center justify-between gap-2 p-2 pointer-events-none',
-          gitStatus === 'untracked' && 'text-green-400',
-          gitStatus === 'modified' && 'text-amber-400',
-          gitStatus === 'deleted' && 'text-red-400',
+          gitStatus === 'untracked' && 'text-success',
+          gitStatus === 'modified' && 'text-warning',
+          gitStatus === 'deleted' && 'text-danger',
         )}
       >
         <div className="flex items-center gap-2">

--- a/packages/framework-dashboard/components/ui/checkbox.tsx
+++ b/packages/framework-dashboard/components/ui/checkbox.tsx
@@ -1,0 +1,36 @@
+'use client'
+import type { ComponentProps } from 'react'
+import { Checkbox as CheckboxPrimitive } from '@base-ui-components/react/checkbox'
+import { Check } from 'lucide-react'
+import { cn } from '../../lib/utils.js'
+
+// A shadcn-style Checkbox on Base UI, matching the Tooltip and DropdownMenu already here (no Radix
+// pulled in). Replaces the bare `<input type="checkbox">` every panel used to hand-roll: those got
+// their look from the browser, so they ignored the theme tokens, skipped the focus ring the rest of
+// the app uses, and drew a light box on the dark canvas.
+// `disabled` is widened to accept undefined: under `exactOptionalPropertyTypes` the primitive's
+// `disabled?: boolean` rejects it, and callers pass expressions like `busy || transparent` that are
+// naturally `boolean | undefined`. Normalising here beats a `!!` at every call site.
+type CheckboxProps = Omit<ComponentProps<typeof CheckboxPrimitive.Root>, 'disabled'> & {
+  disabled?: boolean | undefined
+}
+
+export function Checkbox({ className, disabled = false, ...props }: CheckboxProps) {
+  return (
+    <CheckboxPrimitive.Root
+      disabled={disabled}
+      className={cn(
+        'inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-[4px] border border-border bg-transparent',
+        'transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]',
+        'data-[checked]:border-primary data-[checked]:bg-primary data-[checked]:text-primary-foreground',
+        'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
+        <Check className="h-3 w-3" strokeWidth={3} aria-hidden />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}

--- a/packages/framework-dashboard/components/ui/copy-button.tsx
+++ b/packages/framework-dashboard/components/ui/copy-button.tsx
@@ -26,7 +26,7 @@ export function CopyButton({ text, label, className }: { text: string; label: st
       title={label}
       className={cn(
         'inline-flex shrink-0 items-center rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground',
-        copied && 'text-emerald-600',
+        copied && 'text-success',
         className,
       )}
     >

--- a/packages/framework-dashboard/design/previews.tsx
+++ b/packages/framework-dashboard/design/previews.tsx
@@ -48,6 +48,10 @@ const TOKENS = [
   ['--primary-foreground', 'Text on primary'],
   ['--accent', 'Hover fill'],
   ['--accent-foreground', 'Text on accent'],
+  ['--success', 'Done, passing'],
+  ['--warning', 'Stopped, dirty'],
+  ['--danger', 'Failed, destructive'],
+  ['--info', 'Unpushed, neutral note'],
 ] as const
 
 function ColorTokens() {
@@ -69,19 +73,20 @@ function ColorTokens() {
   )
 }
 
-// The status hues are raw palette values today (no token backs them), which is why they are
-// shown apart from the token grid: this card is the evidence for that gap, not a blessing of it.
+// The status vocabulary, now tokenised. Each is tuned per theme against that theme's canvas
+// rather than picked once from the middle of a palette ramp.
 const STATUS = [
-  ['Done / passing', 'bg-emerald-500', 'emerald-500'],
-  ['Failed / destructive', 'bg-red-500', 'red-500'],
-  ['Stopped / warning', 'bg-amber-500', 'amber-500'],
+  ['Done / passing', 'bg-success', '--success'],
+  ['Failed / destructive', 'bg-danger', '--danger'],
+  ['Stopped / warning', 'bg-warning', '--warning'],
+  ['Unpushed / informational', 'bg-info', '--info'],
   ['Running / live', 'bg-primary', '--primary'],
 ] as const
 
 function StatusPalette() {
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
         {STATUS.map(([label, fill, value]) => (
           <div key={label} className="flex items-center gap-2.5">
             <span className={`h-8 w-8 shrink-0 rounded-md ${fill}`} />
@@ -93,8 +98,8 @@ function StatusPalette() {
         ))}
       </div>
       <p className="text-xs text-muted-foreground">
-        Three of the four are raw Tailwind palette values with no semantic token behind them, so a
-        theme change cannot reach them and nothing stops a fifth green appearing.
+        One token per meaning. Before these existed &quot;good&quot; was six different greens and
+        <code> amber-500</code> meant both &quot;stopped&quot; and &quot;building, fine&quot;.
       </p>
     </div>
   )
@@ -188,9 +193,9 @@ function Badges() {
         <Badge>end</Badge>
       </Row>
       <Row label="Status (as used today)">
-        <Badge className="border-transparent bg-emerald-500/15 text-emerald-600">DONE</Badge>
-        <Badge className="border-transparent bg-red-500/15 text-red-600">FAILED</Badge>
-        <Badge className="border-transparent bg-amber-500/15 text-amber-600">STOPPED</Badge>
+        <Badge className="border-transparent bg-success/15 text-success">DONE</Badge>
+        <Badge className="border-transparent bg-danger/15 text-danger">FAILED</Badge>
+        <Badge className="border-transparent bg-warning/15 text-warning">STOPPED</Badge>
         <Badge className="border-transparent bg-primary/15 text-primary">RUNNING</Badge>
       </Row>
       <p className="text-xs text-muted-foreground">
@@ -343,7 +348,7 @@ export const PREVIEWS: Preview[] = [
     path: 'foundations/color-tokens.html',
     group: 'Foundations',
     name: 'Color tokens',
-    subtitle: '11 semantic tokens, light + dark',
+    subtitle: '15 semantic tokens, light + dark',
     width: 900,
     node: <ColorTokens />,
   },
@@ -351,7 +356,7 @@ export const PREVIEWS: Preview[] = [
     path: 'foundations/status-palette.html',
     group: 'Foundations',
     name: 'Status palette',
-    subtitle: 'Done / failed / stopped / running — 3 of 4 untokenised',
+    subtitle: 'One token per meaning, tuned per theme',
     width: 900,
     node: <StatusPalette />,
   },

--- a/packages/framework-dashboard/layouts/tailwind.css
+++ b/packages/framework-dashboard/layouts/tailwind.css
@@ -28,6 +28,15 @@
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
 
+  /* Status. Every status colour used to be a raw palette value, so "good" was six different
+     greens and `amber-500` meant both "stopped" and "building, fine". These four are the whole
+     vocabulary. They are tuned per theme against that theme's canvas rather than picked once
+     from the middle of a ramp: the old flat `-500` tones sat at ~2:1 on white. */
+  --success: oklch(0.52 0.13 155);
+  --warning: oklch(0.52 0.12 70);
+  --danger: oklch(0.52 0.2 27);
+  --info: oklch(0.53 0.15 245);
+
   /* The brand mark's six strands (#757), darkest first, exactly as the brand ships them.
      Kept as variables so the mark can be re-ramped for a dark canvas without touching the SVG. */
   --logo-1: #0a0a0a;
@@ -52,6 +61,12 @@
   --accent: oklch(0.27 0.01 264);
   --accent-foreground: oklch(0.95 0 0);
 
+  /* Same four meanings, lifted for the dark canvas. */
+  --success: oklch(0.78 0.16 155);
+  --warning: oklch(0.8 0.14 75);
+  --danger: oklch(0.71 0.18 25);
+  --info: oklch(0.75 0.13 240);
+
   /* The ramp inverted for a dark canvas: the shipped one starts at near-black, which would sink
      the leading strands into the background. Same order (leading strand lightest against dark),
      so the knot's depth reads the same way round. */
@@ -75,6 +90,10 @@
   --color-primary-foreground: var(--primary-foreground);
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+  --color-danger: var(--danger);
+  --color-info: var(--info);
 }
 
 body {

--- a/packages/framework-dashboard/lib/status-tone.ts
+++ b/packages/framework-dashboard/lib/status-tone.ts
@@ -2,7 +2,7 @@
 // (the Runs rail, the project log) so the same status can never read as two colors.
 export const STATUS_TONE: Record<string, string> = {
   running: 'text-primary',
-  done: 'text-emerald-500',
-  stopped: 'text-amber-500',
-  failed: 'text-red-500',
+  done: 'text-success',
+  stopped: 'text-warning',
+  failed: 'text-danger',
 }

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -71,10 +71,6 @@ export default function Page() {
   // be known.
   const [adopting, setAdopting] = useState(false)
 
-  // The right rail is showing something worth reading wide (#862), so the sessions rail gives up
-  // its column for it. Owned here because it is the two rails' shared layout, not either's state.
-  const [wideRail, setWideRail] = useState(false)
-
   const { runs, reload, loaded: runsLoaded } = useRuns(projectId)
 
   // The run Context set lives in the shell (#492/#504) so the two surfaces that feed it share
@@ -289,7 +285,7 @@ export default function Page() {
         </div>
       </header>
       {!healthy && (
-        <div role="alert" className="flex items-center gap-2 border-b border-border bg-amber-500/10 px-4 py-2 text-xs text-amber-600 dark:text-amber-400">
+        <div role="alert" className="flex items-center gap-2 border-b border-border bg-warning/10 px-4 py-2 text-xs text-warning">
           <TriangleAlert className="h-3.5 w-3.5 shrink-0" aria-hidden />
           The daemon is not answering — retrying. Everything on this page is frozen until it returns.
         </div>
@@ -310,7 +306,6 @@ export default function Page() {
           startTick={runStart.tick}
           startIntent={runStart.intent}
           followLive={adopting}
-          collapsed={wideRail}
         />
         <main className="flex min-w-0 flex-1 flex-col">{renderMain()}</main>
         <RightRail
@@ -322,7 +317,6 @@ export default function Page() {
           context={context}
           toggleContext={toggleContext}
           hasBrowser={selectedRun?.status === 'running' && selectedRun.browserStreamPort !== undefined}
-          onWideChange={setWideRail}
           onRunStarted={onRunStarted}
         />
       </div>


### PR DESCRIPTION
Four things off the session page. Closes most of #1010's colour section.

## 1. The Sessions rail no longer shrinks

It collapsed to a 12px strip whenever the right rail widened for the Browser or Views tab (`collapsed={wideRail}`), so opening a preview reflowed the column you were reading. Now a constant 15rem; the main pane absorbs the width change instead.

`RunHistory` keeps its collapsed rendering, nothing triggers it, so re-enabling it later is one prop.

## 2. Status colour is now four tokens

`--success`, `--warning`, `--danger`, `--info`, each tuned per theme against that theme's canvas rather than picked once from the middle of a palette ramp. They replace **every** raw palette value in the app; a grep for `(text|bg|border|ring|fill)-(emerald|green|amber|orange|red|sky|blue)-\d+` now returns nothing outside tests.

What this fixes, all from #1010:

- "good" was six different greens (`emerald-500`, `emerald-600`, `green-500`, `green-400`, `green-600/400`, `green-700/300`)
- `bg-amber-500` meant both "stopped" and "building, everything fine"
- "ready for merge" was emerald in `DashboardPage` and green in `RunOverview`, one click apart
- git status used the `-400` ramp while run status used `-500`, two parallel vocabularies
- `Quota` had its own `emerald -> blue -> orange -> red` scale, where `orange-500` read as the `amber-500` warning
- the flat `-500` tones measured near 2:1 contrast on the light canvas; `text-amber-500` for "Awaiting" and priority "high" was the worst

The five `text-*-600 dark:text-*-400` pairs collapse into one token that already knows the theme.

One call site needed thought: the Approve button is `bg-success`, which is dark on the light canvas and light on the dark one, so its label is `text-background` rather than `text-white`. That inverts with the fill and stays legible on both.

## 3. Checkboxes are a real primitive

New `ui/checkbox.tsx`, shadcn-style on Base UI, matching the Tooltip and DropdownMenu already here (no Radix pulled in). Replaces the bare `<input type="checkbox">` in SystemPromptDisclosure, Quota, AddProjectPanel, StartRunForm and ChoicePanel: those took their look from the browser, so they ignored the tokens, drew a light box on the dark canvas, and skipped the focus ring the rest of the app uses.

`disabled` is widened to accept `undefined` in the wrapper, since under `exactOptionalPropertyTypes` callers pass `busy || transparent`.

## 4. No emoji glyphs

The ✅/❌ pair and the ⚠️ in the Enhanced System Prompt disclosure are gone. It is a status dot and plain text now, drawn like every other state in the app. The screen-reader text is unchanged; the three tests that asserted on the glyphs now assert on that text, which is the better assertion anyway.

## Verification

- 288 tests pass (47 files), typecheck clean, `pnpm build` green
- Driven in a real browser against the live daemon, light and dark, with the dark tokens exercised by forcing `.dark` rather than assumed
- Design gallery regenerated; the colour and status cards now show the token set instead of documenting its absence