### PR TITLE
fix(dashboard): bind the telefunc shims locally so `pnpm dev` can serve them

### DIFF
--- a/packages/framework-dashboard/server/control.telefunc.ts
+++ b/packages/framework-dashboard/server/control.telefunc.ts
@@ -1,4 +1,9 @@
 // Re-export shim (#405): the steering telefunctions live in @gemstack/framework so the
 // daemon serves them in-process. The file path keeps the baked RPC key
 // `/server/control.telefunc.ts`. See framework's dashboard-rpc/register.ts.
-export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendPushBranch, sendOpenPullRequest, sendQueueTicket } from '@gemstack/framework/dashboard-rpc'
+// Imported then exported, not re-exported (#1014): telefunc's dev transform appends
+// `__decorateTelefunction(<name>, ...)` per export, which needs a local binding. An
+// `export ... from` creates none, so `pnpm dev` died with `<name> is not defined`.
+import { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendPushBranch, sendOpenPullRequest, sendQueueTicket } from '@gemstack/framework/dashboard-rpc'
+
+export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendPushBranch, sendOpenPullRequest, sendQueueTicket }

--- a/packages/framework-dashboard/server/events.telefunc.ts
+++ b/packages/framework-dashboard/server/events.telefunc.ts
@@ -1,4 +1,9 @@
 // Re-export shim (#405): the live-event Channel telefunction lives in @gemstack/framework
 // so the daemon serves it in-process. The file path keeps the baked RPC key
 // `/server/events.telefunc.ts`. See framework's dashboard-rpc/register.ts.
-export { onEvents } from '@gemstack/framework/dashboard-rpc'
+// Imported then exported, not re-exported (#1014): telefunc's dev transform appends
+// `__decorateTelefunction(<name>, ...)` per export, which needs a local binding. An
+// `export ... from` creates none, so `pnpm dev` died with `<name> is not defined`.
+import { onEvents } from '@gemstack/framework/dashboard-rpc'
+
+export { onEvents }

--- a/packages/framework-dashboard/server/preferences.telefunc.ts
+++ b/packages/framework-dashboard/server/preferences.telefunc.ts
@@ -4,7 +4,10 @@
 // `/server/preferences.telefunc.ts` — the exact key the daemon registers the impls under (see
 // framework's dashboard-rpc/register.ts). The telefunc Vite transform turns these named
 // re-exports into client RPC stubs.
-export {
+// Imported then exported, not re-exported (#1014): telefunc's dev transform appends
+// `__decorateTelefunction(<name>, ...)` per export, which needs a local binding. An
+// `export ... from` creates none, so `pnpm dev` died with `<name> is not defined`.
+import {
   onPreferences,
   savePreferences,
   onProjectPreferences,
@@ -12,4 +15,13 @@ export {
   onEditors,
   onNotifyChannels,
 } from '@gemstack/framework/dashboard-rpc'
+
+export {
+  onPreferences,
+  savePreferences,
+  onProjectPreferences,
+  saveProjectPreferences,
+  onEditors,
+  onNotifyChannels,
+}
 export type { EditorInfo, NotifyChannels } from '@gemstack/framework/dashboard-rpc'

--- a/packages/framework-dashboard/server/projects.telefunc.ts
+++ b/packages/framework-dashboard/server/projects.telefunc.ts
@@ -1,4 +1,9 @@
 // Re-export shim (#405): the Projects telefunction lives in @gemstack/framework so the
 // daemon serves it in-process. The file path keeps the baked RPC key
 // `/server/projects.telefunc.ts`. See framework's dashboard-rpc/register.ts.
-export { onProjects, sendAddProject } from '@gemstack/framework/dashboard-rpc'
+// Imported then exported, not re-exported (#1014): telefunc's dev transform appends
+// `__decorateTelefunction(<name>, ...)` per export, which needs a local binding. An
+// `export ... from` creates none, so `pnpm dev` died with `<name> is not defined`.
+import { onProjects, sendAddProject } from '@gemstack/framework/dashboard-rpc'
+
+export { onProjects, sendAddProject }

--- a/packages/framework-dashboard/server/quota.telefunc.ts
+++ b/packages/framework-dashboard/server/quota.telefunc.ts
@@ -2,4 +2,9 @@
 // daemon serves it in-process, off the poller it owns for its whole life. Keeping this file
 // at `server/quota.telefunc.ts` means the client bakes the RPC key `/server/quota.telefunc.ts`
 // — the exact key the daemon registers the impl under (see framework's dashboard-rpc/register.ts).
-export { onQuota } from '@gemstack/framework/dashboard-rpc'
+// Imported then exported, not re-exported (#1014): telefunc's dev transform appends
+// `__decorateTelefunction(<name>, ...)` per export, which needs a local binding. An
+// `export ... from` creates none, so `pnpm dev` died with `<name> is not defined`.
+import { onQuota } from '@gemstack/framework/dashboard-rpc'
+
+export { onQuota }

--- a/packages/framework-dashboard/server/reads.telefunc.ts
+++ b/packages/framework-dashboard/server/reads.telefunc.ts
@@ -1,6 +1,10 @@
 // Re-export shim (#405): the read-model telefunctions live in @gemstack/framework so the
 // daemon serves them in-process. Keeping this file at `server/reads.telefunc.ts` means
 // the client bakes the RPC key `/server/reads.telefunc.ts` — the exact key the daemon
-// registers the impls under (see framework's dashboard-rpc/register.ts). The telefunc
-// Vite transform turns these named re-exports into client RPC stubs.
-export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent, onTickets, onRetainedWorktrees, onRunWorktree, onRunHandoff, onSystemPromptUser } from '@gemstack/framework/dashboard-rpc'
+// registers the impls under (see framework's dashboard-rpc/register.ts).
+// Imported then exported, not re-exported (#1014): telefunc's dev transform appends
+// `__decorateTelefunction(<name>, ...)` per export, which needs a local binding. An
+// `export ... from` creates none, so `pnpm dev` died with `<name> is not defined`.
+import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent, onTickets, onRetainedWorktrees, onRunWorktree, onRunHandoff, onSystemPromptUser } from '@gemstack/framework/dashboard-rpc'
+
+export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent, onTickets, onRetainedWorktrees, onRunWorktree, onRunHandoff, onSystemPromptUser }

--- a/packages/framework-dashboard/server/shims.test.ts
+++ b/packages/framework-dashboard/server/shims.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * #1014: telefunc's dev transform appends `__decorateTelefunction(<name>, ...)` for every
+ * export in a `.telefunc.ts` file, which only resolves if the name is a local binding.
+ * `export { x } from '...'` creates no local binding, so `pnpm dev` answered every RPC with
+ * `ReferenceError: x is not defined`. Production never noticed, because the daemon registers
+ * the telefunctions in-process and these files exist only to pin the baked RPC keys.
+ *
+ * Guarded here rather than in a running dev server: the failure needs vite plus telefunc plus
+ * a real request, and the shape that causes it is visible in the source.
+ */
+
+const serverDir = dirname(fileURLToPath(import.meta.url))
+const shims = readdirSync(serverDir).filter(f => f.endsWith('.telefunc.ts'))
+
+/** `export { a, b } from 'x'` — the form that produces no local binding. */
+const VALUE_REEXPORT = /export\s*\{[^}]*\}\s*from\s*['"]/g
+
+function namesIn(block: string): string[] {
+  return block
+    .split(',')
+    .map(n => n.trim().split(/\s+as\s+/).pop()!.trim())
+    .filter(Boolean)
+}
+
+describe('telefunc shims (#1014)', () => {
+  it('finds the shim files', () => {
+    expect(shims.length).toBeGreaterThan(0)
+  })
+
+  for (const file of shims) {
+    const src = readFileSync(join(serverDir, file), 'utf8')
+
+    it(`${file} does not re-export values with \`export ... from\``, () => {
+      // `export type { ... } from` is fine: types are erased before the transform runs.
+      const withoutTypeExports = src.replace(/export\s+type\s*\{[^}]*\}\s*from\s*['"][^'"]*['"]/g, '')
+
+      expect(withoutTypeExports.match(VALUE_REEXPORT)).toBeNull()
+    })
+
+    it(`${file} exports exactly the names it imports`, () => {
+      const imported = [...src.matchAll(/import\s*\{([^}]*)\}\s*from\s*['"][^'"]*['"]/g)]
+        .flatMap(m => namesIn(m[1]!))
+      const exported = [...src.matchAll(/export\s*\{([^}]*)\}(?!\s*from)/g)]
+        .flatMap(m => namesIn(m[1]!))
+
+      expect(exported.length).toBeGreaterThan(0)
+      expect([...exported].sort()).toEqual([...imported].sort())
+    })
+  }
+})


### PR DESCRIPTION
Closes #1014.

Layer 1 (#1015) got RPCs as far as Telefunc. This is the wall right behind it: every request then died with `ReferenceError: onProjects is not defined`, so dashboard development still required a full build plus the daemon, with no HMR.

## Cause

Telefunc's server-side transform (`transformTelefuncFileServerSide.js`) appends one line per export:

```js
__decorateTelefunction(<localName || exportName>, "<exportName>", "<filePath>", "<appRootDir>")
```

That only resolves if the name is a **local binding**. All six shims were pure `export { ... } from '@gemstack/framework/dashboard-rpc'`, and `export ... from` binds nothing locally, so the generated line referenced a name that did not exist in the module.

## Fix

The issue suggested wrapping each telefunction in a delegating function (option 1). That would have meant 45 hand-written wrappers to keep in sync with the RPC surface, plus care around shields and context. Reading the transform showed a local binding is the *only* requirement, so the re-exports simply become an import plus a local export:

```ts
import { onProjects, sendAddProject } from '@gemstack/framework/dashboard-rpc'

export { onProjects, sendAddProject }
```

Same export names, same function identities, no wrapper indirection, nothing to maintain as telefunctions are added. `decorateTelefunction` only does `Object.assign(fn, {_key, _appRootDir})` and registers under the file-path key, so identity is all it needs. `export type { ... } from` is left alone, since types are erased before the transform runs.

## Verification

Against a dev server I positively identified as this branch's vite (checked pid, cwd and listening port, because an unrelated daemon was occupying a nearby port):

- All six shims answer **200 with real data**: `onProjects`, `onRuns`, `onQuota`, `onPreferences`, `onDashboard`
- **Red then green**: reverting `projects.telefunc.ts` to `export ... from` reproduces the issue's exact `ReferenceError: onProjects is not defined` with HTTP 500; restoring it returns 200
- The dashboard **loads in a real browser** under `pnpm dev`: no daemon-down banner, real project data rendered, zero console errors
- Dashboard suite 301 passed (288 baseline + 13 new); repo typecheck 21/21

## Regression guard

`server/shims.test.ts` asserts no shim uses a value `export ... from`, and that each exports exactly the names it imports. Guarded in source rather than against a live server because reproducing it needs vite plus telefunc plus a real request. Proven to have teeth: reverting one shim fails exactly its two cases.

## No changeset

`@gemstack/framework-dashboard` is `private: true` and unpublished, and the change is dev-only. Confirmed rather than assumed: the built `dist/dashboard-client` bundle hashes **identically** to main. Matches #1015, which also took none.

## Note for #1010

Item 8 of #1010 ("`vite dev` telefunc is broken") is the same defect and can be struck once this lands.