### PR TITLE
feat(dashboard): name every session row, show its agent, and settle what green means

### DIFF
--- a/.changeset/tidy-jars-shout.md
+++ b/.changeset/tidy-jars-shout.md
@@ -17,3 +17,14 @@ tab; its width is now constant.
 
 The ✅/❌/⚠️ glyphs in the Enhanced System Prompt disclosure are replaced by a status dot and plain
 text, matching how every other state in the app is drawn.
+
+Sessions rail rows now show which agent ran them, and lead with something that identifies the
+session: the agent's own session name or its branch when there is no typed prompt, and the start
+time when there is neither. They used to print a bold "(no prompt)" while the timestamp that
+actually told them apart sat beside it in small muted text.
+
+A clean git tree's dot is neutral rather than green. Green means "added / new / done" everywhere
+else, so a green dot for "nothing changed" sat one pane from the file tree's green dot for "this
+folder has changes".
+
+Claude's logo is its own starburst rather than the Anthropic wordmark.

--- a/packages/framework-dashboard/components/GitStatusBar.tsx
+++ b/packages/framework-dashboard/components/GitStatusBar.tsx
@@ -55,8 +55,12 @@ export function GitStatusBar({
         </span>
       </span>
       <span className="flex items-center gap-1.5">
+        {/* Clean is neutral, not green. Green means "added / new / done" everywhere else, so a
+            green dot for "nothing changed" sat one pane away from the file tree's green dot for
+            "this folder HAS changes": the same colour for opposite facts. A clean tree is the
+            unremarkable default and has nothing to announce. */}
         <span
-          className={cn('h-2 w-2 rounded-full', status.dirty ? 'bg-warning' : 'bg-success')}
+          className={cn('h-2 w-2 rounded-full', status.dirty ? 'bg-warning' : 'bg-muted-foreground')}
           title={status.dirty ? dirtyLabel : 'Clean'}
         />
         <span className="text-muted-foreground">{status.dirty ? 'dirty' : 'clean'}</span>

--- a/packages/framework-dashboard/components/RunHistory.tsx
+++ b/packages/framework-dashboard/components/RunHistory.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from 'react'
 import type { RunMeta, RunStatus } from '@gemstack/framework'
+import { AGENT_LABELS, agentForDriver } from '@gemstack/framework/client'
 import { Button } from './ui/button.js'
 import { Badge } from './ui/badge.js'
 import { cn } from '../lib/utils.js'
-import { formatDateTime } from '../lib/format-date.js'
+import { formatRelative } from '../lib/format-date.js'
 import { STATUS_TONE } from '../lib/status-tone.js'
+import { runLabel } from '../lib/run-label.js'
+import { AgentLogo } from './agent-logos.js'
 import { ScrollArea } from './ui/scroll-area.js'
 
 /** A label hidden in the collapsed strip, revealed by hover/focus on the rail (#862). */
@@ -123,8 +126,9 @@ export function RunHistory({
           <RunRow
             key={run.id}
             status={run.status}
-            intent={run.intent}
-            subtitle={formatDateTime(run.startedAt)}
+            intent={runLabel(run)}
+            driver={run.driver}
+            subtitle={formatRelative(run.startedAt)}
             // Following live highlights the newest running run, not every one of them (#738):
             // `runs` is newest-first, so that is the first with a running status.
             active={run.id === selectedRunId || (followLive && run.id === newestRunningId)}
@@ -148,6 +152,7 @@ function RunRow({
   subtitle,
   active,
   onClick,
+  driver,
   dim = false,
   waiting = false,
   collapsed = false,
@@ -155,6 +160,8 @@ function RunRow({
   status: RunStatus
   intent: string | undefined
   subtitle: string
+  /** The agent that ran it, so the row can show whose session it was. */
+  driver?: string | undefined
   active: boolean
   onClick: () => void
   dim?: boolean
@@ -166,6 +173,7 @@ function RunRow({
   // Only a live run can be waiting on you; a finished one is just finished.
   const parked = waiting && status === 'running'
   const label = collapsed ? FADED_LABEL : ''
+  const agent = agentForDriver(driver)
   return (
     <Button
       variant="ghost"
@@ -178,7 +186,7 @@ function RunRow({
       onClick={onClick}
       // Collapsed, the visible labels fade and the row is carried by a colour dot; keep the
       // whole story reachable by hover and assistive tech (#948).
-      {...(collapsed ? { title: `${parked ? 'waiting' : status}: ${intent || '(no prompt)'}`, 'aria-label': `${parked ? 'waiting' : status}: ${intent || '(no prompt)'}` } : {})}
+      {...(collapsed ? { title: `${parked ? 'waiting' : status}: ${intent || 'New session'}`, 'aria-label': `${parked ? 'waiting' : status}: ${intent || 'New session'}` } : {})}
     >
       <span className="flex w-full items-center gap-2">
         {/* The dot means "the agent is working", so a run parked on you gets a still one (#785):
@@ -196,8 +204,17 @@ function RunRow({
           {parked ? 'waiting' : status}
         </Badge>
         <span className={cn('truncate text-xs font-normal text-muted-foreground', label)}>{subtitle}</span>
+        {/* Which agent ran it. The logo is the only thing naming the agent on this row, so it
+            carries a title rather than being decorative. */}
+        {agent && (
+          <AgentLogo
+            agent={agent}
+            title={AGENT_LABELS[agent]}
+            className={cn('ml-auto h-3.5 w-3.5 shrink-0 text-muted-foreground', label)}
+          />
+        )}
       </span>
-      <span className={cn('w-full truncate text-sm font-medium', label)}>{intent || '(no prompt)'}</span>
+      <span className={cn('w-full truncate text-sm font-medium', label)}>{intent || 'New session'}</span>
     </Button>
   )
 }

--- a/packages/framework-dashboard/components/agent-logos.tsx
+++ b/packages/framework-dashboard/components/agent-logos.tsx
@@ -1,19 +1,43 @@
+import type { AgentName } from '@gemstack/framework/client'
+
 // Monochrome brand logomarks for the coding agents (#656), so the run picker can show a logo
 // instead of the agent's name. They inherit the text colour (`fill="currentColor"`) and take a
-// className for sizing. Decorative — the accessible name is carried by the option's label.
+// className for sizing. Decorative by default — the accessible name is carried by the option's
+// label; pass `title` where the logo is the only thing naming the agent (the Sessions rail).
 
-export function ClaudeLogo({ className }: { className?: string }) {
+export function ClaudeLogo({ className, title }: LogoProps) {
+  // Claude's own starburst, not the Anthropic `A\` wordmark this used to draw. Two different
+  // marks: the wordmark is the company, the burst is the product the agent actually is.
   return (
-    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
-      <path d="M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.541Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z" />
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} {...labelProps(title)}>
+      {title && <title>{title}</title>}
+      <path d="m4.714 15.956l4.718-2.648l.079-.23l-.08-.128h-.23l-.79-.048l-2.695-.073l-2.337-.097l-2.265-.122l-.57-.121l-.535-.704l.055-.353l.48-.321l.685.06l1.518.104l2.277.157l1.651.098l2.447.255h.389l.054-.158l-.133-.097l-.103-.098l-2.356-1.596l-2.55-1.688l-1.336-.972l-.722-.491L2 6.223l-.158-1.008l.656-.722l.88.06l.224.061l.893.686l1.906 1.476l2.49 1.833l.364.304l.146-.104l.018-.072l-.164-.274l-1.354-2.446l-1.445-2.49l-.644-1.032l-.17-.619a3 3 0 0 1-.103-.729L6.287.133L6.7 0l.995.134l.42.364l.619 1.415L9.735 4.14l1.555 3.03l.455.898l.243.832l.09.255h.159V9.01l.127-1.706l.237-2.095l.23-2.695l.08-.76l.376-.91l.747-.492l.583.28l.48.685l-.067.444l-.286 1.851l-.558 2.903l-.365 1.942h.213l.243-.242l.983-1.306l1.652-2.064l.728-.82l.85-.904l.547-.431h1.032l.759 1.129l-.34 1.166l-1.063 1.347l-.88 1.142l-1.263 1.7l-.79 1.36l.074.11l.188-.02l2.853-.606l1.542-.28l1.84-.315l.832.388l.09.395l-.327.807l-1.967.486l-2.307.462l-3.436.813l-.043.03l.049.061l1.548.146l.662.036h1.62l3.018.225l.79.522l.473.638l-.08.485l-1.213.62l-1.64-.389l-3.825-.91l-1.31-.329h-.183v.11l1.093 1.068l2.003 1.81l2.508 2.33l.127.578l-.321.455l-.34-.049l-2.204-1.657l-.85-.747l-1.925-1.62h-.127v.17l.443.649l2.343 3.521l.122 1.08l-.17.353l-.607.213l-.668-.122l-1.372-1.924l-1.415-2.168l-1.141-1.943l-.14.08l-.674 7.254l-.316.37l-.728.28l-.607-.461l-.322-.747l.322-1.476l.388-1.924l.316-1.53l.285-1.9l.17-.632l-.012-.042l-.14.018l-1.432 1.967l-2.18 2.945l-1.724 1.845l-.413.164l-.716-.37l.066-.662l.401-.589l2.386-3.036l1.439-1.882l.929-1.086l-.006-.158h-.055L4.138 18.56l-1.13.146l-.485-.456l.06-.746l.231-.243l1.907-1.312Z" />
     </svg>
   )
 }
 
-export function CodexLogo({ className }: { className?: string }) {
+export function CodexLogo({ className, title }: LogoProps) {
   return (
-    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} {...labelProps(title)}>
+      {title && <title>{title}</title>}
       <path d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.0201 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z" />
     </svg>
   )
+}
+
+interface LogoProps {
+  className?: string | undefined
+  /** Names the agent for assistive tech. Omit where a visible label already does. */
+  title?: string | undefined
+}
+
+/** Decorative unless it is the only thing naming the agent. */
+function labelProps(title: string | undefined) {
+  return title ? ({ role: 'img' } as const) : ({ 'aria-hidden': 'true' } as const)
+}
+
+/** The logo for an agent, so a caller with an `AgentName` does not repeat the mapping. */
+export function AgentLogo({ agent, className, title }: LogoProps & { agent: AgentName }) {
+  const Logo = agent === 'codex' ? CodexLogo : ClaudeLogo
+  return <Logo className={className} {...(title ? { title } : {})} />
 }

--- a/packages/framework-dashboard/lib/format-date.ts
+++ b/packages/framework-dashboard/lib/format-date.ts
@@ -17,6 +17,18 @@ export function formatDateTime(value: string | undefined, fallback = '—'): str
   return date ? date.toLocaleString() : fallback
 }
 
+/**
+ * A short local date + time, e.g. "Jul 18, 10:35 PM". For places where the timestamp is standing
+ * in as a name (an unnamed session in the rail), where seconds are noise on the line that has to
+ * identify the row.
+ */
+export function formatDateTimeShort(value: string | undefined, fallback = '—'): string {
+  const date = parse(value)
+  return date
+    ? date.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })
+    : fallback
+}
+
 /** A timestamp as a local date alone, for the denser table columns. */
 export function formatDate(value: string | undefined, fallback = '—'): string {
   const date = parse(value)

--- a/packages/framework-dashboard/lib/run-label.ts
+++ b/packages/framework-dashboard/lib/run-label.ts
@@ -1,0 +1,16 @@
+import type { RunMeta } from '@gemstack/framework'
+import { formatDateTimeShort } from './format-date.js'
+
+// What to call a session in a list.
+//
+// `intent` is what the user typed, and it is often absent: a session started from a preset or
+// resumed from the CLI never records one. The rail used to print a bold "(no prompt)" for those
+// and push the one fact that did identify them, the timestamp, into small muted text beside it.
+// So the loudest thing on most rows said nothing, and the rows were told apart by the quietest.
+//
+// The fallbacks in order: the agent's own name for the session (#326, also its branch), then the
+// branch its work landed on, then when nothing describes the run, the time it started. A date is
+// a poor name but a real one, and it belongs on the line that identifies the row.
+export function runLabel(run: Pick<RunMeta, 'intent' | 'sessionName' | 'branch' | 'startedAt'>): string {
+  return run.intent?.trim() || run.sessionName?.trim() || run.branch?.trim() || formatDateTimeShort(run.startedAt)
+}


### PR DESCRIPTION
Follow-up to #1019, which merged before these landed. Closes the colour contradiction left open there.

## 1. Every session row now says something

`intent` is only recorded for a session started from the composer, so on a real board **5 of 7 rows printed a bold "(no prompt)"**. The loudest thing on the row said nothing, and the rows were told apart by the timestamp beside it in small muted text.

I checked the actual run data before writing the fallback, which was worth doing: `sessionName` was never set and `branch` only once, so a name-only fallback would have renamed "(no prompt)" to "(unnamed session)" and fixed nothing. The row hierarchy was the real problem.

Now the identifying line falls through the agent's own session name (#326, also its branch), then the branch, then the start time; and the meta line carries freshness rather than a full locale timestamp:

```
before:  DONE  7/18/2026, 10:35:01 PM
         (no prompt)

after:   DONE  3d ago                    [logo]
         Jul 18, 10:35 PM
```

A date is a poor name but a real one, and it belongs on the line that identifies the row. New `formatDateTimeShort` for that, since seconds are noise on a title line.

## 2. Rows show which agent ran them

Off `RunMeta.driver`, through the existing `agentForDriver` (#831), so `claude-code` to `claude` stays in one place. New `AgentLogo` so callers with an `AgentName` do not repeat the mapping.

The logo is the only thing naming the agent on a row, so it renders `role="img"` with a `<title>` rather than `aria-hidden` like the decorative ones in the composer menu.

Note: the **model** is not shown, because `RunMeta` does not record one. Only the driver is persisted. Worth a follow-up if the model matters on the row.

## 3. Green meant two opposite things

One pane apart:

- `GitStatusBar`: green dot = clean, **nothing changed**
- `FileTree` / `RunChanges`: green = untracked, **this folder HAS changes**

Green keeps its diff meaning, since green-for-added is the universal convention and `RunChanges`/`DiffView` depend on it. The clean dot goes neutral: a clean tree is the unremarkable default and has nothing to announce. That leaves one vocabulary:

| colour | meaning |
|---|---|
| success | done, added, ready |
| warning | stopped, modified, dirty |
| danger | failed, deleted |
| neutral | clean, nothing to report |

## 4. Claude's logo is Claude's

It was drawing the Anthropic `A\` wordmark. Two different marks: the wordmark is the company, the burst is the product the agent actually is. Taken from `@iconify-json/simple-icons`, already a dependency, rather than hand-drawn.

## Verification

- 301 tests pass (48 files), typecheck clean, `pnpm build` green
- Driven in a real browser against the live daemon, light and dark; row text read back out of the DOM and the logos confirmed to expose accessible names