### PR TITLE
refactor(ai-sdk): finish the provider and run-store dedup (#972)

### DIFF
--- a/.changeset/refactor-972-provider-dedup.md
+++ b/.changeset/refactor-972-provider-dedup.md
@@ -1,0 +1,9 @@
+---
+'@gemstack/ai-sdk': patch
+---
+
+Internal: the provider layer no longer carries four copies of the same code. Every adapter builds its SDK client through one shared `lazyClient()` helper, the five pure OpenAI-compatible providers (`xai`, `groq`, `deepseek`, `ollama`, `azure`) come from one factory, and the Anthropic stream-event mapping is shared with Bedrock instead of being inlined twice.
+
+Two side effects worth naming. A first client build is now memoised as a promise, so two concurrent calls share one client rather than racing to construct two, and a failed dynamic import no longer caches. And `XaiProvider.name` and friends are typed `string` rather than the literal `'xai'`, matching the `ProviderFactory` contract they are consumed through.
+
+All public exports keep their names, constructor signatures, and default base URLs.

--- a/packages/ai-sdk/src/bedrock-openrouter.test.ts
+++ b/packages/ai-sdk/src/bedrock-openrouter.test.ts
@@ -2,7 +2,8 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { AiRegistry } from './registry.js'
 import { OpenRouterProvider } from './providers/openrouter.js'
-import { BedrockProvider, isAnthropicOnBedrock, mapBedrockAnthropicEvent, type BedrockStreamState } from './providers/bedrock.js'
+import { BedrockProvider, isAnthropicOnBedrock } from './providers/bedrock.js'
+import { mapAnthropicStreamEvent, type AnthropicStreamState } from './providers/anthropic-stream.js'
 import { OpenAIAdapter } from './providers/openai.js'
 
 // ─── OpenRouter ───────────────────────────────────────────
@@ -118,13 +119,13 @@ describe('isAnthropicOnBedrock', () => {
   })
 })
 
-// ─── mapBedrockAnthropicEvent ─────────────────────────────
+// ─── mapAnthropicStreamEvent ─────────────────────────────
 
-describe('mapBedrockAnthropicEvent', () => {
-  const newState = (): BedrockStreamState => ({ lastPromptTokens: 0 })
+describe('mapAnthropicStreamEvent', () => {
+  const newState = (): AnthropicStreamState => ({ lastPromptTokens: 0 })
 
   it('maps text-delta events', () => {
-    const chunks = [...mapBedrockAnthropicEvent({
+    const chunks = [...mapAnthropicStreamEvent({
       type: 'content_block_delta',
       delta: { type: 'text_delta', text: 'Hello' },
     }, newState())]
@@ -132,7 +133,7 @@ describe('mapBedrockAnthropicEvent', () => {
   })
 
   it('maps tool_use start to tool-call-delta', () => {
-    const chunks = [...mapBedrockAnthropicEvent({
+    const chunks = [...mapAnthropicStreamEvent({
       type: 'content_block_start',
       content_block: { type: 'tool_use', id: 'tu_123', name: 'getWeather' },
     }, newState())]
@@ -143,7 +144,7 @@ describe('mapBedrockAnthropicEvent', () => {
   })
 
   it('maps input_json_delta to tool-call-delta with text', () => {
-    const chunks = [...mapBedrockAnthropicEvent({
+    const chunks = [...mapAnthropicStreamEvent({
       type: 'content_block_delta',
       delta: { type: 'input_json_delta', partial_json: '{"city":"' },
     }, newState())]
@@ -151,7 +152,7 @@ describe('mapBedrockAnthropicEvent', () => {
   })
 
   it('maps message_delta with tool_use stop reason', () => {
-    const chunks = [...mapBedrockAnthropicEvent({
+    const chunks = [...mapAnthropicStreamEvent({
       type: 'message_delta',
       delta: { stop_reason: 'tool_use' },
       usage: { output_tokens: 12 },
@@ -162,7 +163,7 @@ describe('mapBedrockAnthropicEvent', () => {
   })
 
   it('maps message_delta with end_turn stop reason', () => {
-    const chunks = [...mapBedrockAnthropicEvent({
+    const chunks = [...mapAnthropicStreamEvent({
       type: 'message_delta',
       delta: { stop_reason: 'end_turn' },
       usage: { output_tokens: 5 },
@@ -171,7 +172,7 @@ describe('mapBedrockAnthropicEvent', () => {
   })
 
   it('maps message_start to a usage chunk', () => {
-    const chunks = [...mapBedrockAnthropicEvent({
+    const chunks = [...mapAnthropicStreamEvent({
       type: 'message_start',
       message: { usage: { input_tokens: 100, output_tokens: 0 } },
     }, newState())]
@@ -181,7 +182,7 @@ describe('mapBedrockAnthropicEvent', () => {
   })
 
   it('emits nothing for unknown event types', () => {
-    const chunks = [...mapBedrockAnthropicEvent({ type: 'ping' }, newState())]
+    const chunks = [...mapAnthropicStreamEvent({ type: 'ping' }, newState())]
     assert.equal(chunks.length, 0)
   })
 
@@ -196,11 +197,11 @@ describe('mapBedrockAnthropicEvent', () => {
 
   it('threads promptTokens from message_start into the finish chunk', () => {
     const state = newState()
-    const startChunks = [...mapBedrockAnthropicEvent({
+    const startChunks = [...mapAnthropicStreamEvent({
       type: 'message_start',
       message: { usage: { input_tokens: 100, output_tokens: 0 } },
     }, state)]
-    const deltaChunks = [...mapBedrockAnthropicEvent({
+    const deltaChunks = [...mapAnthropicStreamEvent({
       type: 'message_delta',
       delta: { stop_reason: 'end_turn' },
       usage: { output_tokens: 42 },

--- a/packages/ai-sdk/src/google-cache.test.ts
+++ b/packages/ai-sdk/src/google-cache.test.ts
@@ -284,7 +284,7 @@ describe('GoogleAdapter cache wiring', () => {
     const { client, counters } = createFakeClient()
     const reg = new GoogleCacheRegistry()
     const adapter = new GoogleAdapter({ apiKey: 'k' }, 'gemini-2.5-flash', reg)
-    ;(adapter as unknown as { client: unknown }).client = client  // bypass the dynamic SDK import
+    ;(adapter as unknown as { getClient: { set(c: unknown): void } }).getClient.set(client)  // bypass the dynamic SDK import
 
     await adapter.generate({
       model: 'gemini-2.5-flash',
@@ -314,7 +314,7 @@ describe('GoogleAdapter cache wiring', () => {
     })
     const reg = new GoogleCacheRegistry()
     const adapter = new GoogleAdapter({ apiKey: 'k' }, 'gemini-2.5-flash', reg)
-    ;(adapter as unknown as { client: unknown }).client = client
+    ;(adapter as unknown as { getClient: { set(c: unknown): void } }).getClient.set(client)
 
     await adapter.generate({
       model: 'gemini-2.5-flash',
@@ -350,7 +350,7 @@ describe('GoogleAdapter cache wiring', () => {
     })
     const reg = new GoogleCacheRegistry()
     const adapter = new GoogleAdapter({ apiKey: 'k' }, 'gemini-2.5-flash', reg)
-    ;(adapter as unknown as { client: unknown }).client = client
+    ;(adapter as unknown as { getClient: { set(c: unknown): void } }).getClient.set(client)
 
     const response = await adapter.generate({
       model: 'gemini-2.5-flash',
@@ -370,7 +370,7 @@ describe('GoogleAdapter cache wiring', () => {
     const { client, counters } = createFakeClient()
     const reg = new GoogleCacheRegistry()
     const adapter = new GoogleAdapter({ apiKey: 'k' }, 'gemini-2.5-flash', reg)
-    ;(adapter as unknown as { client: unknown }).client = client
+    ;(adapter as unknown as { getClient: { set(c: unknown): void } }).getClient.set(client)
 
     await adapter.generate({
       model: 'gemini-2.5-flash',

--- a/packages/ai-sdk/src/google-vector-stores.test.ts
+++ b/packages/ai-sdk/src/google-vector-stores.test.ts
@@ -54,7 +54,7 @@ async function emitToolBlock(schema: ToolDefinitionSchema): Promise<unknown[]> {
       },
     },
   }
-  ;(adapter as unknown as { client: unknown }).client = fakeClient
+  ;(adapter as unknown as { getClient: { set(c: unknown): void } }).getClient.set(fakeClient)
 
   await adapter.generate({
     model:    'gemini-2.5-flash',
@@ -450,7 +450,7 @@ function makeFakeGoogleClient(overrides: {
 function adapterWith(client: any): VectorStoreAdapter {
   const provider = new GoogleProvider({ apiKey: 'k' })
   const adapter  = provider.createVectorStores()
-  ;(adapter as unknown as { client: unknown }).client = client
+  ;(adapter as unknown as { getClient: { set(c: unknown): void } }).getClient.set(client)
   return adapter
 }
 

--- a/packages/ai-sdk/src/openai-compatible.test.ts
+++ b/packages/ai-sdk/src/openai-compatible.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { XaiProvider } from './providers/xai.js'
+import { GroqProvider } from './providers/groq.js'
+import { DeepSeekProvider } from './providers/deepseek.js'
+import { OllamaProvider } from './providers/ollama.js'
+import { AzureOpenAIProvider } from './providers/azure.js'
+import type { ProviderAdapter } from './types.js'
+import type { OpenAIConfig } from './providers/openai/config.js'
+
+/** The adapter keeps its resolved config privately; read it to assert wiring. */
+function resolved(adapter: ProviderAdapter): OpenAIConfig {
+  return (adapter as unknown as { config: OpenAIConfig }).config
+}
+
+describe('OpenAI-compatible providers', () => {
+  const cases = [
+    { name: 'xai', make: () => new XaiProvider({ apiKey: 'k' }), baseUrl: 'https://api.x.ai/v1' },
+    { name: 'groq', make: () => new GroqProvider({ apiKey: 'k' }), baseUrl: 'https://api.groq.com/openai/v1' },
+    { name: 'deepseek', make: () => new DeepSeekProvider({ apiKey: 'k' }), baseUrl: 'https://api.deepseek.com/v1' },
+    { name: 'ollama', make: () => new OllamaProvider(), baseUrl: 'http://localhost:11434/v1' },
+  ]
+
+  for (const c of cases) {
+    it(`${c.name} reports its name and defaults its base URL`, () => {
+      const provider = c.make()
+      assert.equal(provider.name, c.name)
+      assert.equal(resolved(provider.create('some-model')).baseUrl, c.baseUrl)
+    })
+  }
+
+  it('an explicit baseUrl wins over the default', () => {
+    const adapter = new GroqProvider({ apiKey: 'k', baseUrl: 'http://proxy.local/v1' }).create('m')
+    assert.equal(resolved(adapter).baseUrl, 'http://proxy.local/v1')
+  })
+
+  it('forwards the api key', () => {
+    assert.equal(resolved(new XaiProvider({ apiKey: 'sk-xai' }).create('m')).apiKey, 'sk-xai')
+  })
+
+  it('ollama substitutes a placeholder key the SDK will accept', () => {
+    assert.equal(resolved(new OllamaProvider().create('llama3')).apiKey, 'ollama')
+  })
+
+  it('azure uses the caller endpoint verbatim, with no default', () => {
+    const endpoint = 'https://my-resource.openai.azure.com/openai/deployments/my-deployment'
+    const adapter = new AzureOpenAIProvider({ apiKey: 'k', baseUrl: endpoint }).create('gpt-4o')
+    assert.equal(resolved(adapter).baseUrl, endpoint)
+  })
+})

--- a/packages/ai-sdk/src/provider-protocol-fixes.test.ts
+++ b/packages/ai-sdk/src/provider-protocol-fixes.test.ts
@@ -38,7 +38,7 @@ describe('google prompt cache — only the regions actually cached are dropped',
   it('still sends the system instruction when the markers did not cache it', async () => {
     const { client, payloads } = fakeGoogleClient()
     const adapter = new GoogleAdapter({ apiKey: 'k' }, 'gemini-2.5-flash', new GoogleCacheRegistry())
-    ;(adapter as unknown as { client: unknown }).client = client
+    ;(adapter as unknown as { getClient: { set(c: unknown): void } }).getClient.set(client)
 
     await adapter.generate({
       model: 'gemini-2.5-flash',
@@ -71,7 +71,7 @@ describe('google streaming finish reason', () => {
       { candidates: [{ content: { parts: [] }, finishReason: 'STOP' }] },
     ])
     const adapter = new GoogleAdapter({ apiKey: 'k' }, 'gemini-2.5-flash')
-    ;(adapter as unknown as { client: unknown }).client = client
+    ;(adapter as unknown as { getClient: { set(c: unknown): void } }).getClient.set(client)
 
     const chunks = await collect(adapter.stream({ model: 'gemini-2.5-flash', messages: [{ role: 'user', content: 'hi' }] }))
     const finish = chunks.find(c => c.type === 'finish') as { finishReason: string } | undefined
@@ -84,7 +84,7 @@ describe('google streaming finish reason', () => {
       { candidates: [{ content: { parts: [{ text: 'partial' }] }, finishReason: 'SAFETY' }] },
     ])
     const adapter = new GoogleAdapter({ apiKey: 'k' }, 'gemini-2.5-flash')
-    ;(adapter as unknown as { client: unknown }).client = client
+    ;(adapter as unknown as { getClient: { set(c: unknown): void } }).getClient.set(client)
 
     const chunks = await collect(adapter.stream({ model: 'gemini-2.5-flash', messages: [{ role: 'user', content: 'hi' }] }))
     const finish = chunks.find(c => c.type === 'finish') as { finishReason: string } | undefined

--- a/packages/ai-sdk/src/provider-tools.test.ts
+++ b/packages/ai-sdk/src/provider-tools.test.ts
@@ -135,19 +135,18 @@ describe('toAnthropicTools — web_search hint', () => {
 // ─── Gemini native block emission ─────────────────────────
 
 describe('GoogleAdapter — google_search hint via tools array', () => {
-  // Stub the Gemini SDK client by overriding the lazy client property.
-  // The adapter's getClient() short-circuits on a non-null `this.client`.
+  // Stub the Gemini SDK client so no dynamic SDK import (or network call) runs.
   function adapter(): { adapter: GoogleAdapter; captured: () => Record<string, unknown> | undefined } {
     const a = new GoogleAdapter({ apiKey: 'sk-test' }, 'gemini-2.5-pro')
     let captured: Record<string, unknown> | undefined
-    ;(a as unknown as { client: unknown }).client = {
+    ;(a as unknown as { getClient: { set(c: unknown): void } }).getClient.set({
       models: {
         generateContent: async (payload: Record<string, unknown>) => {
           captured = payload
           return { candidates: [{ content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' }] }
         },
       },
-    }
+    })
     return { adapter: a, captured: () => captured }
   }
 

--- a/packages/ai-sdk/src/providers/anthropic-stream.ts
+++ b/packages/ai-sdk/src/providers/anthropic-stream.ts
@@ -1,0 +1,69 @@
+import type { StreamChunk } from '../types.js'
+
+/**
+ * Cross-event state for Anthropic streaming. The protocol splits prompt and
+ * completion token counts across two distinct events; we track the prompt
+ * count from `message_start` so the later `message_delta` → `finish` chunk can
+ * emit a complete usage object.
+ */
+export interface AnthropicStreamState {
+  lastPromptTokens: number
+}
+
+export function newAnthropicStreamState(): AnthropicStreamState {
+  return { lastPromptTokens: 0 }
+}
+
+/**
+ * Map a single decoded Anthropic stream event to zero-or-more `StreamChunk`s.
+ * Shared by the native Anthropic adapter and Bedrock, which wraps Anthropic's
+ * events 1:1 in `chunk.bytes`.
+ *
+ * `state` is mutated across calls: `message_start` captures `lastPromptTokens`,
+ * the subsequent `message_delta` reads it back. Without this, the `finish`
+ * chunk reports `promptTokens: 0`, the agent loop's last-wins aggregation
+ * overwrites the correct earlier value, and consumers (billing, withBudget)
+ * silently undercharge for streamed calls.
+ */
+export function* mapAnthropicStreamEvent(
+  event: Record<string, any>,
+  state: AnthropicStreamState,
+): Generator<StreamChunk> {
+  if (event['type'] === 'content_block_delta') {
+    const delta = event['delta']
+    if (delta?.type === 'text_delta') {
+      yield { type: 'text-delta', text: delta.text }
+    } else if (delta?.type === 'input_json_delta') {
+      yield { type: 'tool-call-delta', text: delta.partial_json }
+    }
+  } else if (event['type'] === 'content_block_start' && event['content_block']?.type === 'tool_use') {
+    yield {
+      type: 'tool-call-delta',
+      toolCall: { id: event['content_block'].id, name: event['content_block'].name },
+    }
+  } else if (event['type'] === 'message_delta') {
+    const completionTokens = event['usage']?.output_tokens ?? 0
+    yield {
+      type: 'finish',
+      finishReason: event['delta']?.stop_reason === 'tool_use' ? 'tool_calls' : 'stop',
+      usage: {
+        promptTokens: state.lastPromptTokens,
+        completionTokens,
+        totalTokens: state.lastPromptTokens + completionTokens,
+      },
+    }
+  } else if (event['type'] === 'message_start' && event['message']?.usage) {
+    state.lastPromptTokens = event['message'].usage.input_tokens ?? 0
+    // output_tokens at message_start is the SDK's initial counter (~0/1), not
+    // the final completion total — don't claim a totalTokens here. The
+    // `finish` chunk above carries the authoritative final usage.
+    yield {
+      type: 'usage',
+      usage: {
+        promptTokens: state.lastPromptTokens,
+        completionTokens: 0,
+        totalTokens: state.lastPromptTokens,
+      },
+    }
+  }
+}

--- a/packages/ai-sdk/src/providers/anthropic.ts
+++ b/packages/ai-sdk/src/providers/anthropic.ts
@@ -16,10 +16,25 @@ import type {
 } from '../types.js'
 import { base64ToUtf8 } from '../base64.js'
 import { contentToString } from '../util/content.js'
+import { mapAnthropicStreamEvent, newAnthropicStreamState } from './anthropic-stream.js'
+import { lazyClient } from './lazy-client.js'
 
 export interface AnthropicConfig {
   apiKey: string
   baseUrl?: string | undefined
+}
+
+/**
+ * Builds the `@anthropic-ai/sdk` client. The import is dynamic so the SDK stays
+ * an optional dependency that is only resolved once an Anthropic adapter is used.
+ */
+async function createAnthropicClient(config: AnthropicConfig): Promise<any> {
+  const sdk = await import(/* @vite-ignore */ '@anthropic-ai/sdk')
+  const Anthropic = sdk.default ?? sdk.Anthropic
+  return new Anthropic({
+    apiKey: config.apiKey,
+    ...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
+  })
 }
 
 export class AnthropicProvider implements ProviderFactory {
@@ -42,23 +57,12 @@ export class AnthropicProvider implements ProviderFactory {
 // ─── Adapter ──────────────────────────────────────────────
 
 class AnthropicAdapter implements ProviderAdapter {
-  private client: any = null
-
   constructor(
     private readonly config: AnthropicConfig,
     private readonly model: string,
   ) {}
 
-  private async getClient(): Promise<any> {
-    if (this.client) return this.client
-    const sdk = await import(/* @vite-ignore */ '@anthropic-ai/sdk')
-    const Anthropic = sdk.default ?? sdk.Anthropic
-    this.client = new Anthropic({
-      apiKey: this.config.apiKey,
-      ...(this.config.baseUrl ? { baseURL: this.config.baseUrl } : {}),
-    })
-    return this.client
-  }
+  private readonly getClient = lazyClient(() => createAnthropicClient(this.config))
 
   async generate(options: ProviderRequestOptions): Promise<ProviderResponse> {
     const client = await this.getClient()
@@ -107,53 +111,9 @@ class AnthropicAdapter implements ProviderAdapter {
 
     const stream = await client.messages.stream(params, options.signal ? { signal: options.signal } : undefined)
 
-    // Anthropic's stream protocol splits usage across two events:
-    //   - `message_start.message.usage.input_tokens` carries the prompt count
-    //   - `message_delta.usage.output_tokens` carries the completion count
-    // Track the prompt count from message_start so we can emit a complete
-    // `finish` usage object — without this the finish chunk reports
-    // `promptTokens: 0`, the agent loop's last-wins aggregation overwrites
-    // the correct earlier value, and consumers (billing, withBudget) silently
-    // undercharge for streamed calls.
-    let lastPromptTokens = 0
-
+    const state = newAnthropicStreamState()
     for await (const event of stream) {
-      if (event.type === 'content_block_delta') {
-        if (event.delta.type === 'text_delta') {
-          yield { type: 'text-delta', text: event.delta.text }
-        } else if (event.delta.type === 'input_json_delta') {
-          yield { type: 'tool-call-delta', text: event.delta.partial_json }
-        }
-      } else if (event.type === 'content_block_start' && event.content_block.type === 'tool_use') {
-        yield {
-          type: 'tool-call-delta',
-          toolCall: { id: event.content_block.id, name: event.content_block.name },
-        }
-      } else if (event.type === 'message_delta') {
-        const completionTokens = event.usage?.output_tokens ?? 0
-        yield {
-          type: 'finish',
-          finishReason: event.delta.stop_reason === 'tool_use' ? 'tool_calls' : 'stop',
-          usage: {
-            promptTokens: lastPromptTokens,
-            completionTokens,
-            totalTokens: lastPromptTokens + completionTokens,
-          },
-        }
-      } else if (event.type === 'message_start' && event.message?.usage) {
-        lastPromptTokens = event.message.usage.input_tokens ?? 0
-        // output_tokens at message_start is the SDK's initial counter (~0/1),
-        // not the final completion total — don't claim a totalTokens here.
-        // The `finish` chunk above carries the authoritative final usage.
-        yield {
-          type: 'usage',
-          usage: {
-            promptTokens: lastPromptTokens,
-            completionTokens: 0,
-            totalTokens: lastPromptTokens,
-          },
-        }
-      }
+      yield* mapAnthropicStreamEvent(event, state)
     }
   }
 }
@@ -362,20 +322,9 @@ export function fromAnthropicResponse(response: any): ProviderResponse {
 // ─── Files ──────────────────────────────────────────────
 
 class AnthropicFileAdapter implements FileAdapter {
-  private client: any = null
-
   constructor(private readonly config: AnthropicConfig) {}
 
-  private async getClient(): Promise<any> {
-    if (this.client) return this.client
-    const sdk = await import(/* @vite-ignore */ '@anthropic-ai/sdk')
-    const Anthropic = sdk.default ?? sdk.Anthropic
-    this.client = new Anthropic({
-      apiKey: this.config.apiKey,
-      ...(this.config.baseUrl ? { baseURL: this.config.baseUrl } : {}),
-    })
-    return this.client
-  }
+  private readonly getClient = lazyClient(() => createAnthropicClient(this.config))
 
   async upload(options: FileUploadOptions): Promise<FileUploadResult> {
     const client = await this.getClient()

--- a/packages/ai-sdk/src/providers/azure.ts
+++ b/packages/ai-sdk/src/providers/azure.ts
@@ -1,5 +1,4 @@
-import { OpenAIAdapter } from './openai.js'
-import type { ProviderFactory, ProviderAdapter } from '../types.js'
+import { defineOpenAiCompatible } from './openai-compatible.js'
 
 export interface AzureOpenAIConfig {
   apiKey: string
@@ -7,21 +6,8 @@ export interface AzureOpenAIConfig {
   baseUrl: string
 }
 
-export class AzureOpenAIProvider implements ProviderFactory {
-  readonly name = 'azure'
-  private readonly config: AzureOpenAIConfig
-
-  constructor(config: AzureOpenAIConfig) {
-    this.config = config
-  }
-
-  create(model: string): ProviderAdapter {
-    return new OpenAIAdapter(
-      {
-        apiKey: this.config.apiKey,
-        baseUrl: this.config.baseUrl,
-      },
-      model,
-    )
-  }
-}
+// No default base URL: the endpoint carries the resource and deployment names,
+// so it can only come from the caller.
+export class AzureOpenAIProvider extends defineOpenAiCompatible<AzureOpenAIConfig>({
+  name: 'azure',
+}) {}

--- a/packages/ai-sdk/src/providers/bedrock.ts
+++ b/packages/ai-sdk/src/providers/bedrock.ts
@@ -15,6 +15,8 @@ import {
   applyCacheToTools,
   applyCacheToMessages,
 } from './anthropic.js'
+import { mapAnthropicStreamEvent, newAnthropicStreamState } from './anthropic-stream.js'
+import { lazyClient } from './lazy-client.js'
 
 /**
  * AWS Bedrock — managed access to foundation models on AWS infrastructure.
@@ -56,6 +58,24 @@ export interface BedrockConfig {
   }
 }
 
+/**
+ * Builds the Bedrock runtime client. The import is dynamic so the AWS SDK stays
+ * an optional dependency that is only resolved once a Bedrock adapter is used.
+ */
+async function createBedrockClient(config: BedrockConfig): Promise<any> {
+  const sdk = await import(/* @vite-ignore */ '@aws-sdk/client-bedrock-runtime')
+  const clientConfig: Record<string, unknown> = { region: config.region }
+  if (config.credentials) {
+    const c = config.credentials
+    clientConfig['credentials'] = {
+      accessKeyId: c.accessKeyId,
+      secretAccessKey: c.secretAccessKey,
+      ...(c.sessionToken ? { sessionToken: c.sessionToken } : {}),
+    }
+  }
+  return new sdk.BedrockRuntimeClient(clientConfig)
+}
+
 export class BedrockProvider implements ProviderFactory {
   readonly name = 'bedrock'
   private readonly config: BedrockConfig
@@ -72,8 +92,6 @@ export class BedrockProvider implements ProviderFactory {
 // ─── Adapter ──────────────────────────────────────────────
 
 class BedrockAdapter implements ProviderAdapter {
-  private client: any = null
-
   constructor(
     private readonly config: BedrockConfig,
     private readonly model: string,
@@ -86,22 +104,7 @@ class BedrockAdapter implements ProviderAdapter {
     }
   }
 
-  private async getClient(): Promise<any> {
-    if (this.client) return this.client
-    const sdk = await import(/* @vite-ignore */ '@aws-sdk/client-bedrock-runtime')
-    const BedrockRuntimeClient = sdk.BedrockRuntimeClient
-    const clientConfig: Record<string, unknown> = { region: this.config.region }
-    if (this.config.credentials) {
-      const c = this.config.credentials
-      clientConfig['credentials'] = {
-        accessKeyId: c.accessKeyId,
-        secretAccessKey: c.secretAccessKey,
-        ...(c.sessionToken ? { sessionToken: c.sessionToken } : {}),
-      }
-    }
-    this.client = new BedrockRuntimeClient(clientConfig)
-    return this.client
-  }
+  private readonly getClient = lazyClient(() => createBedrockClient(this.config))
 
   async generate(options: ProviderRequestOptions): Promise<ProviderResponse> {
     const client = await this.getClient()
@@ -140,13 +143,11 @@ class BedrockAdapter implements ProviderAdapter {
     if (!response.body) return
 
     const decoder = new TextDecoder()
-    // See anthropic.ts for the same shape — Bedrock-Anthropic uses the
-    // identical event protocol, so the prompt-token tracking is identical too.
-    const state: BedrockStreamState = { lastPromptTokens: 0 }
+    const state = newAnthropicStreamState()
     for await (const event of response.body) {
       if (!event.chunk?.bytes) continue
       const decoded = JSON.parse(decoder.decode(event.chunk.bytes)) as Record<string, any>
-      yield* mapBedrockAnthropicEvent(decoded, state)
+      yield* mapAnthropicStreamEvent(decoded, state)
     }
   }
 
@@ -191,67 +192,3 @@ export function isAnthropicOnBedrock(model: string): boolean {
   return model.startsWith('anthropic.') || model.startsWith('us.anthropic.') || model.startsWith('eu.anthropic.') || model.startsWith('apac.anthropic.')
 }
 
-/**
- * Cross-event state for Bedrock-Anthropic streaming. The Anthropic stream
- * protocol splits prompt + completion token counts across two distinct
- * events; we track the prompt count from `message_start` so the later
- * `message_delta` → `finish` chunk can emit a complete usage object.
- */
-export interface BedrockStreamState {
-  lastPromptTokens: number
-}
-
-/**
- * Map a single decoded Bedrock-Anthropic stream event to zero-or-more
- * `StreamChunk`s. Bedrock wraps Anthropic's native streaming events 1:1 in
- * `chunk.bytes`, so the body shape matches `anthropic.ts`'s loop — but we
- * keep the mapping here so a future model family can be added cleanly.
- *
- * `state` is mutated across calls: `message_start` captures `lastPromptTokens`,
- * the subsequent `message_delta` reads it back. Without this, the `finish`
- * chunk reports `promptTokens: 0`, the agent loop's last-wins aggregation
- * overwrites the correct earlier value, and consumers (billing, withBudget)
- * silently undercharge for streamed calls.
- */
-export function* mapBedrockAnthropicEvent(
-  event: Record<string, any>,
-  state: BedrockStreamState,
-): Generator<StreamChunk> {
-  if (event['type'] === 'content_block_delta') {
-    const delta = event['delta']
-    if (delta?.type === 'text_delta') {
-      yield { type: 'text-delta', text: delta.text }
-    } else if (delta?.type === 'input_json_delta') {
-      yield { type: 'tool-call-delta', text: delta.partial_json }
-    }
-  } else if (event['type'] === 'content_block_start' && event['content_block']?.type === 'tool_use') {
-    yield {
-      type: 'tool-call-delta',
-      toolCall: { id: event['content_block'].id, name: event['content_block'].name },
-    }
-  } else if (event['type'] === 'message_delta') {
-    const completionTokens = event['usage']?.output_tokens ?? 0
-    yield {
-      type: 'finish',
-      finishReason: event['delta']?.stop_reason === 'tool_use' ? 'tool_calls' : 'stop',
-      usage: {
-        promptTokens: state.lastPromptTokens,
-        completionTokens,
-        totalTokens: state.lastPromptTokens + completionTokens,
-      },
-    }
-  } else if (event['type'] === 'message_start' && event['message']?.usage) {
-    state.lastPromptTokens = event['message'].usage.input_tokens ?? 0
-    // output_tokens at message_start is the SDK's initial counter (~0/1), not
-    // the final completion total — don't claim a totalTokens here. The
-    // `finish` chunk above carries the authoritative final usage.
-    yield {
-      type: 'usage',
-      usage: {
-        promptTokens: state.lastPromptTokens,
-        completionTokens: 0,
-        totalTokens: state.lastPromptTokens,
-      },
-    }
-  }
-}

--- a/packages/ai-sdk/src/providers/cohere.ts
+++ b/packages/ai-sdk/src/providers/cohere.ts
@@ -10,9 +10,20 @@ import type {
   RerankingOptions,
   RerankingResult,
 } from '../types.js'
+import { lazyClient } from './lazy-client.js'
 
 export interface CohereConfig {
   apiKey: string
+}
+
+/**
+ * Builds the `cohere-ai` SDK client. The import is dynamic so the SDK stays an
+ * optional dependency that is only resolved once a Cohere adapter is used.
+ */
+async function createCohereClient(config: CohereConfig): Promise<any> {
+  const sdk: any = await import(/* @vite-ignore */ 'cohere-ai' as string)
+  const CohereClientV2 = sdk.CohereClientV2 ?? sdk.default?.CohereClientV2
+  return new CohereClientV2({ token: config.apiKey })
 }
 
 export class CohereProvider implements ProviderFactory {
@@ -39,20 +50,12 @@ export class CohereProvider implements ProviderFactory {
 // ─── Reranking ───────────────────────────────────────────
 
 class CohereRerankingAdapter implements RerankingAdapter {
-  private client: any = null
-
   constructor(
     private readonly config: CohereConfig,
     private readonly model: string,
   ) {}
 
-  private async getClient(): Promise<any> {
-    if (this.client) return this.client
-    const sdk: any = await import(/* @vite-ignore */ 'cohere-ai' as string)
-    const CohereClientV2 = sdk.CohereClientV2 ?? sdk.default?.CohereClientV2
-    this.client = new CohereClientV2({ token: this.config.apiKey })
-    return this.client
-  }
+  private readonly getClient = lazyClient(() => createCohereClient(this.config))
 
   async rerank(options: RerankingOptions): Promise<RerankingResult> {
     const client = await this.getClient()
@@ -77,20 +80,12 @@ class CohereRerankingAdapter implements RerankingAdapter {
 // ─── Embeddings ──────────────────────────────────────────
 
 class CohereEmbeddingAdapter implements EmbeddingAdapter {
-  private client: any = null
-
   constructor(
     private readonly config: CohereConfig,
     private readonly model: string,
   ) {}
 
-  private async getClient(): Promise<any> {
-    if (this.client) return this.client
-    const sdk: any = await import(/* @vite-ignore */ 'cohere-ai' as string)
-    const CohereClientV2 = sdk.CohereClientV2 ?? sdk.default?.CohereClientV2
-    this.client = new CohereClientV2({ token: this.config.apiKey })
-    return this.client
-  }
+  private readonly getClient = lazyClient(() => createCohereClient(this.config))
 
   async embed(input: string | string[], _model: string): Promise<EmbeddingResult> {
     const client = await this.getClient()

--- a/packages/ai-sdk/src/providers/deepseek.ts
+++ b/packages/ai-sdk/src/providers/deepseek.ts
@@ -1,26 +1,11 @@
-import { OpenAIAdapter } from './openai.js'
-import type { ProviderFactory, ProviderAdapter } from '../types.js'
+import { defineOpenAiCompatible } from './openai-compatible.js'
 
 export interface DeepSeekConfig {
   apiKey: string
   baseUrl?: string | undefined
 }
 
-export class DeepSeekProvider implements ProviderFactory {
-  readonly name = 'deepseek'
-  private readonly config: DeepSeekConfig
-
-  constructor(config: DeepSeekConfig) {
-    this.config = config
-  }
-
-  create(model: string): ProviderAdapter {
-    return new OpenAIAdapter(
-      {
-        apiKey: this.config.apiKey,
-        baseUrl: this.config.baseUrl ?? 'https://api.deepseek.com/v1',
-      },
-      model,
-    )
-  }
-}
+export class DeepSeekProvider extends defineOpenAiCompatible<DeepSeekConfig>({
+  name: 'deepseek',
+  defaultBaseUrl: 'https://api.deepseek.com/v1',
+}) {}

--- a/packages/ai-sdk/src/providers/google/chat.ts
+++ b/packages/ai-sdk/src/providers/google/chat.ts
@@ -21,24 +21,19 @@ import {
 import { contentToString } from '../../util/content.js'
 import type { GoogleConfig } from './config.js'
 import { createGoogleClient } from './client.js'
+import { lazyClient } from '../lazy-client.js'
 import { filterToGeminiString } from './filters.js'
 
 // ─── Adapter ──────────────────────────────────────────────
 
 export class GoogleAdapter implements ProviderAdapter {
-  private client: any = null
-
   constructor(
     private readonly config: GoogleConfig,
     private readonly model: string,
     private readonly cacheRegistry?: GoogleCacheRegistry | undefined,
   ) {}
 
-  private async getClient(): Promise<any> {
-    if (this.client) return this.client
-    this.client = await createGoogleClient(this.config)
-    return this.client
-  }
+  private readonly getClient = lazyClient(() => createGoogleClient(this.config))
 
   /**
    * Build the request payload, consulting the cache registry if `options.cache`

--- a/packages/ai-sdk/src/providers/google/embeddings.ts
+++ b/packages/ai-sdk/src/providers/google/embeddings.ts
@@ -1,22 +1,17 @@
 import type { EmbeddingAdapter, EmbeddingResult } from '../../types.js'
 import type { GoogleConfig } from './config.js'
 import { createGoogleClient } from './client.js'
+import { lazyClient } from '../lazy-client.js'
 
 // ─── Embedding Adapter ──────────────────────────────────
 
 export class GoogleEmbeddingAdapter implements EmbeddingAdapter {
-  private client: any = null
-
   constructor(
     private readonly config: GoogleConfig,
     private readonly model: string,
   ) {}
 
-  private async getClient(): Promise<any> {
-    if (this.client) return this.client
-    this.client = await createGoogleClient(this.config)
-    return this.client
-  }
+  private readonly getClient = lazyClient(() => createGoogleClient(this.config))
 
   async embed(input: string | string[]): Promise<EmbeddingResult> {
     const client = await this.getClient()

--- a/packages/ai-sdk/src/providers/google/files.ts
+++ b/packages/ai-sdk/src/providers/google/files.ts
@@ -6,19 +6,14 @@ import type {
 } from '../../types.js'
 import type { GoogleConfig } from './config.js'
 import { createGoogleClient } from './client.js'
+import { lazyClient } from '../lazy-client.js'
 
 // ─── Files ──────────────────────────────────────────────
 
 export class GoogleFileAdapter implements FileAdapter {
-  private client: any = null
-
   constructor(private readonly config: GoogleConfig) {}
 
-  private async getClient(): Promise<any> {
-    if (this.client) return this.client
-    this.client = await createGoogleClient(this.config)
-    return this.client
-  }
+  private readonly getClient = lazyClient(() => createGoogleClient(this.config))
 
   async upload(options: FileUploadOptions): Promise<FileUploadResult> {
     const client = await this.getClient()

--- a/packages/ai-sdk/src/providers/google/vector-store.ts
+++ b/packages/ai-sdk/src/providers/google/vector-store.ts
@@ -11,6 +11,7 @@ import type {
 import { sleep } from '../../util/sleep.js'
 import type { GoogleConfig } from './config.js'
 import { createGoogleClient } from './client.js'
+import { lazyClient } from '../lazy-client.js'
 
 // ─── Vector Stores (Gemini FileSearchStores, #B8.5) ──────
 //
@@ -44,15 +45,9 @@ import { createGoogleClient } from './client.js'
 //   array shape; booleans coerce to `stringValue: 'true' | 'false'`.
 
 export class GoogleVectorStoreAdapter implements VectorStoreAdapter {
-  private client: any = null
-
   constructor(private readonly config: GoogleConfig) {}
 
-  private async getClient(): Promise<any> {
-    if (this.client) return this.client
-    this.client = await createGoogleClient(this.config)
-    return this.client
-  }
+  private readonly getClient = lazyClient(() => createGoogleClient(this.config))
 
   async create(opts: VectorStoreCreateOptions): Promise<VectorStoreInfo> {
     if (opts.metadata) {

--- a/packages/ai-sdk/src/providers/groq.ts
+++ b/packages/ai-sdk/src/providers/groq.ts
@@ -1,26 +1,11 @@
-import { OpenAIAdapter } from './openai.js'
-import type { ProviderFactory, ProviderAdapter } from '../types.js'
+import { defineOpenAiCompatible } from './openai-compatible.js'
 
 export interface GroqConfig {
   apiKey: string
   baseUrl?: string | undefined
 }
 
-export class GroqProvider implements ProviderFactory {
-  readonly name = 'groq'
-  private readonly config: GroqConfig
-
-  constructor(config: GroqConfig) {
-    this.config = config
-  }
-
-  create(model: string): ProviderAdapter {
-    return new OpenAIAdapter(
-      {
-        apiKey: this.config.apiKey,
-        baseUrl: this.config.baseUrl ?? 'https://api.groq.com/openai/v1',
-      },
-      model,
-    )
-  }
-}
+export class GroqProvider extends defineOpenAiCompatible<GroqConfig>({
+  name: 'groq',
+  defaultBaseUrl: 'https://api.groq.com/openai/v1',
+}) {}

--- a/packages/ai-sdk/src/providers/lazy-client.ts
+++ b/packages/ai-sdk/src/providers/lazy-client.ts
@@ -1,0 +1,29 @@
+export interface LazyClient<T> {
+  (): Promise<T>
+  /** Test seam: inject a client so the dynamic SDK import is never made. */
+  set(client: T): void
+}
+
+/**
+ * Memoise a lazily-built SDK client.
+ *
+ * Every adapter resolves its SDK through a dynamic import so the dependency
+ * stays optional and is only paid for once the provider is actually used.
+ * The in-flight promise is cached too, so two concurrent first calls share one
+ * client instead of racing to construct two.
+ */
+export function lazyClient<T>(build: () => Promise<T>): LazyClient<T> {
+  let pending: Promise<T> | undefined
+  const get = (() => {
+    // A failed import must not poison later calls, so drop the cache on reject.
+    pending ??= build().catch(err => {
+      pending = undefined
+      throw err
+    })
+    return pending
+  }) as LazyClient<T>
+  get.set = client => {
+    pending = Promise.resolve(client)
+  }
+  return get
+}

--- a/packages/ai-sdk/src/providers/ollama.ts
+++ b/packages/ai-sdk/src/providers/ollama.ts
@@ -1,25 +1,16 @@
-import { OpenAIAdapter } from './openai.js'
-import type { ProviderFactory, ProviderAdapter } from '../types.js'
+import { defineOpenAiCompatible } from './openai-compatible.js'
 
 export interface OllamaConfig {
   baseUrl?: string | undefined
 }
 
-export class OllamaProvider implements ProviderFactory {
-  readonly name = 'ollama'
-  private readonly config: OllamaConfig
-
+export class OllamaProvider extends defineOpenAiCompatible<OllamaConfig>({
+  name: 'ollama',
+  defaultBaseUrl: 'http://localhost:11434/v1',
+  // Ollama ignores the key, but the OpenAI SDK refuses to build without one.
+  defaultApiKey: 'ollama',
+}) {
   constructor(config: OllamaConfig = {}) {
-    this.config = config
-  }
-
-  create(model: string): ProviderAdapter {
-    return new OpenAIAdapter(
-      {
-        apiKey: 'ollama',
-        baseUrl: this.config.baseUrl ?? 'http://localhost:11434/v1',
-      },
-      model,
-    )
+    super(config)
   }
 }

--- a/packages/ai-sdk/src/providers/openai-compatible.ts
+++ b/packages/ai-sdk/src/providers/openai-compatible.ts
@@ -1,0 +1,48 @@
+import { OpenAIAdapter } from './openai.js'
+import type { ProviderFactory, ProviderAdapter } from '../types.js'
+
+/** The config subset every OpenAI-compatible provider accepts. */
+export interface OpenAiCompatibleConfig {
+  apiKey?: string | undefined
+  baseUrl?: string | undefined
+}
+
+export interface OpenAiCompatibleOptions {
+  /** Reported as `ProviderFactory.name`. */
+  name: string
+  /** Used when the caller passes no `baseUrl`. Omit to require one. */
+  defaultBaseUrl?: string
+  /** For services that ignore the key but whose SDK still demands one. */
+  defaultApiKey?: string
+}
+
+/**
+ * Build a `ProviderFactory` for a service that speaks the OpenAI wire protocol.
+ * These differ only in a name and a base URL, so they share `OpenAIAdapter`
+ * instead of each re-wrapping it.
+ *
+ * Providers that add real behaviour (OpenRouter's analytics headers, Mistral's
+ * embeddings) stay hand-written.
+ */
+export function defineOpenAiCompatible<C extends OpenAiCompatibleConfig>(
+  options: OpenAiCompatibleOptions,
+): new (config: C) => ProviderFactory {
+  return class implements ProviderFactory {
+    readonly name = options.name
+    protected readonly config: C
+
+    constructor(config: C) {
+      this.config = config
+    }
+
+    create(model: string): ProviderAdapter {
+      return new OpenAIAdapter(
+        {
+          apiKey: this.config.apiKey ?? options.defaultApiKey ?? '',
+          baseUrl: this.config.baseUrl ?? options.defaultBaseUrl,
+        },
+        model,
+      )
+    }
+  }
+}

--- a/packages/ai-sdk/src/providers/openai/chat.ts
+++ b/packages/ai-sdk/src/providers/openai/chat.ts
@@ -14,23 +14,18 @@ import { base64ToUtf8 } from '../../base64.js'
 import { contentToString } from '../../util/content.js'
 import type { OpenAIConfig } from './config.js'
 import { createOpenAIClient } from './client.js'
+import { lazyClient } from '../lazy-client.js'
 import { buildPromptCacheKey } from './prompt-cache.js'
 
 // ─── Adapter (also reused by Ollama) ─────────────────────
 
 export class OpenAIAdapter implements ProviderAdapter {
-  private client: any = null
-
   constructor(
     private readonly config: OpenAIConfig,
     private readonly model: string,
   ) {}
 
-  private async getClient(): Promise<any> {
-    if (this.client) return this.client
-    this.client = await createOpenAIClient(this.config)
-    return this.client
-  }
+  private readonly getClient = lazyClient(() => createOpenAIClient(this.config))
 
   async generate(options: ProviderRequestOptions): Promise<ProviderResponse> {
     const client = await this.getClient()

--- a/packages/ai-sdk/src/providers/openai/files.ts
+++ b/packages/ai-sdk/src/providers/openai/files.ts
@@ -7,19 +7,14 @@ import type {
 } from '../../types.js'
 import type { OpenAIConfig } from './config.js'
 import { createOpenAIClient } from './client.js'
+import { lazyClient } from '../lazy-client.js'
 
 // ─── Files ──────────────────────────────────────────────
 
 export class OpenAIFileAdapter implements FileAdapter {
-  private client: any = null
-
   constructor(private readonly config: OpenAIConfig) {}
 
-  private async getClient(): Promise<any> {
-    if (this.client) return this.client
-    this.client = await createOpenAIClient(this.config)
-    return this.client
-  }
+  private readonly getClient = lazyClient(() => createOpenAIClient(this.config))
 
   async upload(options: FileUploadOptions): Promise<FileUploadResult> {
     const client = await this.getClient()

--- a/packages/ai-sdk/src/providers/openai/images.ts
+++ b/packages/ai-sdk/src/providers/openai/images.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../types.js'
 import type { OpenAIConfig } from './config.js'
 import { createOpenAIClient } from './client.js'
+import { lazyClient } from '../lazy-client.js'
 
 // ─── Image Generation Adapter ────────────────────────────
 
@@ -15,18 +16,12 @@ const IMAGE_SIZE_MAP: Record<string, string> = {
 }
 
 export class OpenAIImageAdapter implements ImageGenerationAdapter {
-  private client: any = null
-
   constructor(
     private readonly config: OpenAIConfig,
     private readonly model: string,
   ) {}
 
-  private async getClient(): Promise<any> {
-    if (this.client) return this.client
-    this.client = await createOpenAIClient(this.config)
-    return this.client
-  }
+  private readonly getClient = lazyClient(() => createOpenAIClient(this.config))
 
   async generate(options: ImageGenerationOptions): Promise<ImageGenerationResult> {
     const client = await this.getClient()

--- a/packages/ai-sdk/src/providers/openai/stt.ts
+++ b/packages/ai-sdk/src/providers/openai/stt.ts
@@ -5,19 +5,14 @@ import type {
 } from '../../types.js'
 import type { OpenAIConfig } from './config.js'
 import { createOpenAIClient } from './client.js'
+import { lazyClient } from '../lazy-client.js'
 
 // ─── STT Adapter ─────────────────────────────────────────
 
 export class OpenAISttAdapter implements SpeechToTextAdapter {
-  private client: any = null
-
   constructor(private readonly config: OpenAIConfig, private readonly model: string) {}
 
-  private async getClient(): Promise<any> {
-    if (this.client) return this.client
-    this.client = await createOpenAIClient(this.config)
-    return this.client
-  }
+  private readonly getClient = lazyClient(() => createOpenAIClient(this.config))
 
   async transcribe(options: SpeechToTextOptions): Promise<SpeechToTextResult> {
     const client = await this.getClient()

--- a/packages/ai-sdk/src/providers/openai/tts.ts
+++ b/packages/ai-sdk/src/providers/openai/tts.ts
@@ -5,19 +5,14 @@ import type {
 } from '../../types.js'
 import type { OpenAIConfig } from './config.js'
 import { createOpenAIClient } from './client.js'
+import { lazyClient } from '../lazy-client.js'
 
 // ─── TTS Adapter ─────────────────────────────────────────
 
 export class OpenAITtsAdapter implements TextToSpeechAdapter {
-  private client: any = null
-
   constructor(private readonly config: OpenAIConfig, private readonly model: string) {}
 
-  private async getClient(): Promise<any> {
-    if (this.client) return this.client
-    this.client = await createOpenAIClient(this.config)
-    return this.client
-  }
+  private readonly getClient = lazyClient(() => createOpenAIClient(this.config))
 
   async generate(options: TextToSpeechOptions): Promise<TextToSpeechResult> {
     const client = await this.getClient()

--- a/packages/ai-sdk/src/providers/openai/vector-store.ts
+++ b/packages/ai-sdk/src/providers/openai/vector-store.ts
@@ -11,6 +11,7 @@ import type {
 import { sleep } from '../../util/sleep.js'
 import type { OpenAIConfig } from './config.js'
 import { createOpenAIClient } from './client.js'
+import { lazyClient } from '../lazy-client.js'
 
 // ─── OpenAI Vector Stores (#B8 Phase 1) ──────────────────
 
@@ -28,15 +29,9 @@ import { createOpenAIClient } from './client.js'
  * a file id pass `{ fileId }` directly.
  */
 export class OpenAIVectorStoreAdapter implements VectorStoreAdapter {
-  private client: any = null
-
   constructor(private readonly config: OpenAIConfig) {}
 
-  private async getClient(): Promise<any> {
-    if (this.client) return this.client
-    this.client = await createOpenAIClient(this.config)
-    return this.client
-  }
+  private readonly getClient = lazyClient(() => createOpenAIClient(this.config))
 
   async create(opts: VectorStoreCreateOptions): Promise<VectorStoreInfo> {
     const client = await this.getClient()

--- a/packages/ai-sdk/src/providers/xai.ts
+++ b/packages/ai-sdk/src/providers/xai.ts
@@ -1,26 +1,11 @@
-import { OpenAIAdapter } from './openai.js'
-import type { ProviderFactory, ProviderAdapter } from '../types.js'
+import { defineOpenAiCompatible } from './openai-compatible.js'
 
 export interface XaiConfig {
   apiKey: string
   baseUrl?: string | undefined
 }
 
-export class XaiProvider implements ProviderFactory {
-  readonly name = 'xai'
-  private readonly config: XaiConfig
-
-  constructor(config: XaiConfig) {
-    this.config = config
-  }
-
-  create(model: string): ProviderAdapter {
-    return new OpenAIAdapter(
-      {
-        apiKey: this.config.apiKey,
-        baseUrl: this.config.baseUrl ?? 'https://api.x.ai/v1',
-      },
-      model,
-    )
-  }
-}
+export class XaiProvider extends defineOpenAiCompatible<XaiConfig>({
+  name: 'xai',
+  defaultBaseUrl: 'https://api.x.ai/v1',
+}) {}


### PR DESCRIPTION
Closes #972.

The run-store half of #972 landed in #1013, and #1016/#1018 centralised the OpenAI and Google client builders. This finishes the remaining three items in one pass, since they all touch the same provider files.

**1. `getClient()` copy-paste.** Every adapter hand-rolled the same memoise-a-dynamic-import block. They now share `lazyClient()`. The OpenAI and Google adapters already delegated the actual client construction to a builder; Anthropic (x2), Cohere (x2) and Bedrock still inlined theirs, so those got builders too.

`lazyClient()` also caches the in-flight promise, so two concurrent first calls share one client instead of racing to build two, and it drops the cache when the import fails so one bad attempt does not poison later calls.

**2. Seven OpenAI-compatible providers.** The five that differed only in a name and a default base URL (`xai`, `groq`, `deepseek`, `ollama`, `azure`) now come from `defineOpenAiCompatible()`. `openrouter` (analytics headers) and `mistral` (embeddings) add real behaviour and stay hand-written, as the issue suggested.

**3. Inlined Anthropic stream mapping.** `mapBedrockAnthropicEvent` had exactly one caller and an identical twin inlined in `anthropic.ts`. Hoisted to `providers/anthropic-stream.ts` as `mapAnthropicStreamEvent`; both providers now call it. It was not exported from the package index, so this is not a public rename.

Net 130 insertions, 367 deletions.

## Notes for review

- Provider classes now inherit `readonly name: string` rather than declaring the literal `'xai'`. They are consumed through `ProviderFactory`, which declares `string`, so this is only a loss of an incidental literal type. Called out in the changeset.
- The tests stubbed adapters by assigning the private `client` field. Removing that field turned four test files into live API calls that failed against the real Google endpoint. `lazyClient` now exposes an explicit `.set()` test seam and those tests use it.
- Nothing covered the default base URLs, so the refactor that rewires all five of them ships with a test that pins each one.

## Verification

- `pnpm typecheck` passes (exit 0).
- `pnpm test` on this branch fails exactly the same 2 tests as `origin/main` does from a clean `dist-test` (`main entry has no Node-only imports`, `/node subpath exists`), both pre-existing and unrelated. Baselined against a detached worktree at `origin/main` rather than assumed.