### PR TITLE
perf(dashboard): stop the session bar waiting on a PR lookup

### DIFF
--- a/.changeset/tidy-eels-repeat.md
+++ b/.changeset/tidy-eels-repeat.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Dashboard: the session's branch row fills in about three times faster. It was waiting on a `gh pr view` (≈574ms, against ~10ms for every git read beside it) that ran twice per session, on every navigation and every poll. That lookup is now read through a single-flight, stale-while-revalidate cache, and it no longer blocks the branch, dirty flag, size, commits or files — they render at git speed while the PR arrives behind them. Opening a PR invalidates the cached answer, and a lookup still in flight is reported as pending rather than as "no PR", so the Open PR button holds off instead of offering to open a second one.

--- a/packages/framework-dashboard/components/GitStatusBar.tsx
+++ b/packages/framework-dashboard/components/GitStatusBar.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import type { GitStatus, RunWorktree } from '@gemstack/framework'
 import { ChevronRight, GitBranch } from 'lucide-react'
 import { onGitStatus, onRunWorktree } from '../server/reads.telefunc.js'
@@ -41,12 +41,16 @@ export function GitStatusBar({
 }) {
   // Two reads, one shape: both carry branch/dirty/PR, because the server resolves them from
   // whichever checkout it was asked about, and the session read adds what only a worktree has.
+  // Resting cadence is ten seconds, but a PR lookup still in flight (#1028) is an answer that
+  // lands in under a second — worth asking again for rather than showing a gap for ten.
+  const [everyMs, setEveryMs] = useState(10_000)
   const { value: status } = usePolled<GitStatus | RunWorktree | null>(
     () => (runId ? onRunWorktree(projectId, runId) : onGitStatus(projectId)),
     null,
-    10_000,
-    [projectId, runId],
+    everyMs,
+    [projectId, runId, everyMs],
   )
+  useEffect(() => setEveryMs(status?.prPending ? 1_000 : 10_000), [status?.prPending])
 
   if (!status) return null
 

--- a/packages/framework-dashboard/components/RunHandoff.tsx
+++ b/packages/framework-dashboard/components/RunHandoff.tsx
@@ -68,6 +68,9 @@ export function HandoffActions({
 }) {
   const { handoff, busy, pending, act } = state
   if (!handoff || !handoff.exists || handoff.empty || handoff.pr) return null
+  // While the PR lookup is still out (#1028), offering "Open PR" could mean offering to open a
+  // second one. Say nothing for the moment it takes rather than offer the wrong thing.
+  if (handoff.prPending) return null
   // No remote means neither action can work, and a disabled button with no reason is worse than
   // a sentence saying why.
   if (!handoff.hasRemote) return <span className="text-xs text-muted-foreground">No remote to push to.</span>

--- a/packages/framework-dashboard/lib/use-run-handoff.ts
+++ b/packages/framework-dashboard/lib/use-run-handoff.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { RunHandoff } from '@gemstack/framework'
 import { onRunHandoff } from '../server/reads.telefunc.js'
 import { usePolled } from './use-async.js'
@@ -23,12 +23,16 @@ export function useRunHandoff(projectId: string, runId: string | null | undefine
   // Polled rather than read once: a push or a PR opened from here (or from a terminal) changes
   // what to offer, and `reload` makes the bar's own actions land immediately. Not read while the
   // run is live (#1026): a branch still being written to has nothing to hand off yet.
+  // Same as the bar above it (#1028): fifteen seconds at rest, but a PR lookup still in flight
+  // holds the Push / Open PR offer back, so that one is worth asking again for straight away.
+  const [everyMs, setEveryMs] = useState(15_000)
   const { value: handoff, reload, loaded } = usePolled<RunHandoff | null>(
     enabled && runId ? () => onRunHandoff(projectId, runId) : null,
     null,
-    15_000,
-    [projectId, runId, enabled],
+    everyMs,
+    [projectId, runId, enabled, everyMs],
   )
+  useEffect(() => setEveryMs(handoff?.prPending ? 1_000 : 15_000), [handoff?.prPending])
   const { busy, error, run } = useAction()
   const [pending, setPending] = useState<'push' | 'pr' | null>(null)
 

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -108,6 +108,8 @@ export async function onRunWorktree(projectId: string, runId: string): Promise<R
     // The same read already looked the PR up (#809): a session's branch is exactly the thing
     // that has one, so the session's bar can show it like the project's does.
     ...(status?.pr ? { pr: status.pr } : {}),
+    // Still being looked up rather than absent (#1028), so the bar can ask again shortly.
+    ...(status?.prPending ? { prPending: true } : {}),
   }
 }
 

--- a/packages/framework/src/dashboard/cache.test.ts
+++ b/packages/framework/src/dashboard/cache.test.ts
@@ -1,0 +1,88 @@
+import { test, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { cachedRead, clearCache, invalidate } from './cache.js'
+
+// A promise you resolve by hand, so a "slow" read is slow on purpose rather than by sleeping.
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (error: Error) => void } {
+  let resolve!: (value: T) => void
+  let reject!: (error: Error) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+const settle = (): Promise<void> => new Promise(resolve => setImmediate(resolve))
+
+beforeEach(() => clearCache())
+
+test('concurrent asks for the same key share one call (#1028)', async () => {
+  let calls = 0
+  const gate = deferred<string>()
+  const load = async (): Promise<string> => {
+    calls++
+    return gate.promise
+  }
+  const both = Promise.all([cachedRead('k', load, { budgetMs: 50 }), cachedRead('k', load, { budgetMs: 50 })])
+  gate.resolve('pr-1')
+  const [a, b] = await both
+  assert.equal(calls, 1) // two panels and a poll tick must not become three subprocesses
+  assert.deepEqual([a.value, b.value], ['pr-1', 'pr-1'])
+})
+
+test('a known value answers without calling again, until it is stale', async () => {
+  let calls = 0
+  const load = async (): Promise<number> => ++calls
+  let now = 1000
+  const opts = { ttlMs: 100, budgetMs: 50, now: () => now }
+
+  assert.deepEqual(await cachedRead('k', load, opts), { value: 1, pending: false })
+  assert.deepEqual(await cachedRead('k', load, opts), { value: 1, pending: false })
+  assert.equal(calls, 1)
+
+  // Past the TTL the caller still gets the old value at once; the refresh happens behind it.
+  now += 200
+  assert.deepEqual(await cachedRead('k', load, opts), { value: 1, pending: false })
+  await settle()
+  assert.equal(calls, 2)
+  assert.deepEqual(await cachedRead('k', load, opts), { value: 2, pending: false })
+})
+
+test('a first ask slower than the budget reports pending, and the answer lands for the next one', async () => {
+  const gate = deferred<string>()
+  const load = (): Promise<string> => gate.promise
+  const first = await cachedRead('k', load, { budgetMs: 5 })
+  // Not "there is no PR" — "not known yet", which is what a caller needs to tell them apart.
+  assert.deepEqual(first, { value: undefined, pending: true })
+
+  gate.resolve('pr-9')
+  await settle()
+  assert.deepEqual(await cachedRead('k', load, { budgetMs: 5 }), { value: 'pr-9', pending: false })
+})
+
+test('a failed read keeps the last good value rather than dropping it', async () => {
+  let attempt = 0
+  const load = async (): Promise<string> => {
+    attempt++
+    if (attempt === 2) throw new Error('gh exploded')
+    return `v${attempt}`
+  }
+  let now = 0
+  const opts = { ttlMs: 10, budgetMs: 50, now: () => now }
+  assert.equal((await cachedRead('k', load, opts)).value, 'v1')
+
+  now += 100 // stale: the background refresh runs and fails
+  assert.equal((await cachedRead('k', load, opts)).value, 'v1')
+  await settle()
+  // The panel keeps showing the PR it knew about instead of losing it to one bad call.
+  assert.equal((await cachedRead('k', load, opts)).value, 'v1')
+})
+
+test('invalidate forces the next read to go again', async () => {
+  let calls = 0
+  const load = async (): Promise<number> => ++calls
+  assert.equal((await cachedRead('k', load, { budgetMs: 50 })).value, 1)
+  invalidate('k')
+  assert.equal((await cachedRead('k', load, { budgetMs: 50 })).value, 2)
+})

--- a/packages/framework/src/dashboard/cache.ts
+++ b/packages/framework/src/dashboard/cache.ts
@@ -1,0 +1,117 @@
+/**
+ * A read-through cache for the dashboard's slow reads (#1028).
+ *
+ * The dashboard polls. Every session view asks for its branch's PR, twice (the worktree bar and
+ * the handoff summary), on every navigation and again every ten seconds — and `gh pr view` costs
+ * about 600ms against a local git read's ten. So the same answer was being bought over and over,
+ * and the panel waited for it each time.
+ *
+ * Three behaviours, and each one is load-bearing:
+ *   - **single flight** — concurrent asks for the same key share one call, so two panels and a
+ *     poll tick do not become three subprocesses
+ *   - **stale while revalidate** — once a value exists it is returned immediately, and refreshed
+ *     in the background when it is older than `ttlMs`; nobody waits twice for the same answer
+ *   - **a budget on the cold ask** — the first ask waits only `budgetMs` for the answer before
+ *     reporting `pending`, so a slow lookup delays one panel's extra detail rather than the page
+ *
+ * `pending` is not "failed": it means the answer is on its way and the next read will have it.
+ * A caller that must not act on a half-answer (offering to open a PR that may already exist)
+ * uses it to hold off.
+ */
+
+interface Entry<T> {
+  /** Set only once a read has succeeded; `has` tells an unset value from a cached `undefined`. */
+  value?: T | undefined
+  has: boolean
+  /** When `value` was read, for the staleness check. */
+  at: number
+  /** The in-flight refresh, if one is running. */
+  inflight?: Promise<T> | undefined
+}
+
+const entries = new Map<string, Entry<unknown>>()
+
+/** What a cached read answers with: the value, and whether it is still being fetched. */
+export interface Cached<T> {
+  value: T | undefined
+  /** True when no value is known yet and a read is still running. */
+  pending: boolean
+}
+
+/** Clock seam, so the tests do not sleep. */
+export type Now = () => number
+
+export interface CacheOptions {
+  /** How old a value may be before a background refresh is started. */
+  ttlMs?: number
+  /** How long a first, uncached ask waits before reporting `pending`. */
+  budgetMs?: number
+  now?: Now
+}
+
+/**
+ * Read `key` through the cache, calling `load` when it is missing or stale.
+ *
+ * A failed load is not cached: it leaves whatever was there (a panel keeps showing the last PR it
+ * knew about rather than dropping it because gh hiccuped) and the next read tries again.
+ */
+export async function cachedRead<T>(key: string, load: () => Promise<T>, options: CacheOptions = {}): Promise<Cached<T>> {
+  const { ttlMs = 60_000, budgetMs = 150, now = Date.now } = options
+  const entry = entries.get(key) as Entry<T> | undefined
+
+  // A known value answers straight away. Refresh it in the background when it has aged out, so
+  // the cost of being current is never paid by the caller that happens to ask.
+  if (entry?.has) {
+    if (now() - entry.at >= ttlMs && !entry.inflight) void refresh(key, load, now)
+    return { value: entry.value, pending: false }
+  }
+
+  // Nothing known yet: join the running read, or start one, and wait a moment for it.
+  const inflight = entry?.inflight ?? refresh(key, load, now)
+  const settled = await withBudget(inflight, budgetMs)
+  if (settled.done) return { value: settled.value, pending: false }
+  return { value: undefined, pending: true }
+}
+
+/** Drop what is cached under `key`, so the next read is a fresh one. */
+export function invalidate(key: string): void {
+  entries.delete(key)
+}
+
+/** Test seam: forget everything. */
+export function clearCache(): void {
+  entries.clear()
+}
+
+function refresh<T>(key: string, load: () => Promise<T>, now: Now): Promise<T> {
+  const inflight = load()
+    .then(value => {
+      entries.set(key, { value, has: true, at: now() })
+      return value
+    })
+    .catch(error => {
+      // Keep the last good value; only the in-flight marker goes.
+      const current = entries.get(key) as Entry<T> | undefined
+      if (current?.has) entries.set(key, { value: current.value, has: true, at: current.at })
+      else entries.delete(key)
+      throw error
+    })
+  const current = entries.get(key) as Entry<T> | undefined
+  entries.set(key, { ...(current ?? { has: false, at: 0 }), inflight })
+  // The rejection is reported to whoever awaited it; nothing else must see an unhandled one.
+  inflight.catch(() => {})
+  return inflight
+}
+
+/** Resolve as soon as `promise` does, or give up waiting after `ms`. */
+async function withBudget<T>(promise: Promise<T>, ms: number): Promise<{ done: true; value: T } | { done: false }> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<{ done: false }>(resolve => {
+    timer = setTimeout(() => resolve({ done: false }), ms)
+  })
+  try {
+    return await Promise.race([promise.then(value => ({ done: true as const, value })).catch(() => ({ done: false as const })), timeout])
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/packages/framework/src/dashboard/gh.ts
+++ b/packages/framework/src/dashboard/gh.ts
@@ -1,4 +1,5 @@
 import { cliRunner, type CliRunner } from '../cli-exec.js'
+import { cachedRead, invalidate, type Cached } from './cache.js'
 
 /**
  * The `gh` CLI, in one place: the two JSON reads the dashboard makes and the runner its write
@@ -72,6 +73,28 @@ export async function ghPrView(cwd: string, branch?: string): Promise<LinkedPr |
   const args = ['pr', 'view', ...(branch ? [branch] : []), '--json', PR_VIEW_FIELDS]
   const pr = await ghJson<LinkedPr | undefined>(args, cwd, undefined)
   return pr ? { number: pr.number, url: pr.url, state: pr.state, title: pr.title } : undefined
+}
+
+/**
+ * The cached form of {@link ghPrView} (#1028), and what the dashboard's panels use.
+ *
+ * A PR lookup costs about 600ms where the git reads beside it cost ten, and the answer changes
+ * about as often as someone opens a PR. Cached per checkout and branch, shared between the
+ * worktree bar and the handoff summary, and refreshed behind whoever asks. `pending` says the
+ * answer is not known yet rather than that there is no PR — the difference matters to a caller
+ * deciding whether to offer "Open PR".
+ */
+export async function cachedPrView(cwd: string, branch?: string): Promise<Cached<LinkedPr | undefined>> {
+  return cachedRead(prCacheKey(cwd, branch), () => ghPrView(cwd, branch))
+}
+
+/** Forget a branch's PR, after an action that changes whether it has one. */
+export function forgetPr(cwd: string, branch?: string): void {
+  invalidate(prCacheKey(cwd, branch))
+}
+
+function prCacheKey(cwd: string, branch?: string): string {
+  return `pr\u0000${cwd}\u0000${branch ?? ''}`
 }
 
 /** An open PR on the interventions queue (#632). */

--- a/packages/framework/src/dashboard/git-status.ts
+++ b/packages/framework/src/dashboard/git-status.ts
@@ -1,5 +1,5 @@
 import { nodeGitRunner, type GitRunner } from '../project.js'
-import { ghPrView, type LinkedPr, type PrLookup } from './gh.js'
+import { cachedPrView, type LinkedPr, type PrLookup } from './gh.js'
 
 // The project panel's git status (#491, part of #488): the active branch, whether the tree is
 // dirty, and the linked PR. Branch + dirty are a local git read; the PR is a best-effort gh
@@ -12,6 +12,8 @@ export interface GitStatus {
   /** Uncommitted changes present. */
   dirty: boolean
   pr?: LinkedPr
+  /** The PR is not known yet, rather than absent (#1028): the lookup is still running. */
+  prPending?: boolean
 }
 
 /** Injectable seams so {@link readGitStatus} is unit-testable off disk. */
@@ -34,6 +36,11 @@ export async function readGitStatus(cwd: string, deps: GitStatusDeps = {}): Prom
     return undefined // not a git repo (or git failed)
   }
   const dirty = (await git(['status', '--porcelain'], cwd).catch(() => '')).trim().length > 0
-  const pr = await (deps.pr ?? ghPrView)(cwd).catch(() => undefined)
-  return { branch, dirty, ...(pr ? { pr } : {}) }
+  // The branch and the dirty flag are what this row is for, and they are ten milliseconds of git.
+  // The PR is a `gh` call an order of magnitude slower, so it is read through the cache and is
+  // allowed to arrive late (#1028) rather than holding the whole row back on every poll.
+  const pr = deps.pr
+    ? { value: await deps.pr(cwd).catch(() => undefined), pending: false }
+    : await cachedPrView(cwd).catch(() => ({ value: undefined, pending: false }))
+  return { branch, dirty, ...(pr.value ? { pr: pr.value } : {}), ...(pr.pending ? { prPending: true } : {}) }
 }

--- a/packages/framework/src/dashboard/run-handoff.ts
+++ b/packages/framework/src/dashboard/run-handoff.ts
@@ -1,5 +1,5 @@
 import { nodeGitRunner, type GitRunner } from '../project.js'
-import { ghPrView, nodeGhRunner, type GhRunner, type LinkedPr, type BranchPrLookup } from './gh.js'
+import { cachedPrView, forgetPr, nodeGhRunner, type GhRunner, type LinkedPr, type BranchPrLookup } from './gh.js'
 import { parseNumstat } from './file-diff.js'
 import { errorMessage } from '../error-message.js'
 
@@ -60,6 +60,8 @@ export interface RunHandoff {
   merged: boolean
   /** The PR opened for this branch, when there is one. */
   pr?: LinkedPr
+  /** The PR is not known yet, rather than absent (#1028): the lookup is still running. */
+  prPending?: boolean
 }
 
 /** Injectable seams so the reader is unit-testable off disk. */
@@ -152,7 +154,11 @@ export async function readRunHandoff(
 
   const commits = parseCommits(commitsOut)
   const files = parseHandoffFiles(numstatOut)
-  const pr = await (deps.pr ?? ghPrView)(cwd, branch).catch(() => undefined)
+  // Read through the cache and allowed to arrive late (#1028): the commits, the files and
+  // whether the branch is pushed are all local git, and none of them should wait on `gh`.
+  const pr = deps.pr
+    ? { value: await deps.pr(cwd, branch).catch(() => undefined), pending: false }
+    : await cachedPrView(cwd, branch).catch(() => ({ value: undefined, pending: false }))
 
   return {
     branch,
@@ -168,7 +174,8 @@ export async function readRunHandoff(
     hasRemote,
     pushed: remoteTip.trim() === tip,
     merged: mergedOut.trim().length > 0,
-    ...(pr ? { pr } : {}),
+    ...(pr.value ? { pr: pr.value } : {}),
+    ...(pr.pending ? { prPending: true } : {}),
   }
 }
 
@@ -238,6 +245,9 @@ export async function openRunPullRequest(
     const args = ['pr', 'create', '--head', branch, '--title', draft.title, '--body', draft.body]
     if (draft.base) args.push('--base', draft.base)
     const out = (await gh(args, cwd)).trim()
+    // The branch has a PR now, so the cached "no PR" must go or the bar would keep offering to
+    // open one for the next minute (#1028).
+    forgetPr(cwd, branch)
     // gh prints the new PR's URL as its last line.
     const url = out.split('\n').filter(Boolean).at(-1)
     return url ? { ok: true, url } : { ok: true }

--- a/packages/framework/src/dashboard/types.ts
+++ b/packages/framework/src/dashboard/types.ts
@@ -113,4 +113,6 @@ export interface RunWorktree {
   sizeBytes?: number
   /** The PR opened for this checkout's branch (#809), when there is one. */
   pr?: LinkedPr
+  /** The PR is not known yet, rather than absent (#1028): the lookup is still running. */
+  prPending?: boolean
 }


### PR DESCRIPTION
Closes #1028

Opening a session left the branch row empty for about two thirds of a second, and navigating between sessions paid it again every time.

## What was slow

| read | before | after |
|---|---|---|
| `onRunWorktree` | 611ms | 84ms |
| `onRunHandoff` | 526ms | 135ms |

The whole cost was one subprocess:

| command | time |
|---|---|
| `git rev-parse --abbrev-ref HEAD` | 11ms |
| `git status --porcelain` | 11ms |
| `du -sk .` | 3ms |
| **`gh pr view --json …`** | **574ms** |

It ran twice per session view — the worktree bar and the handoff summary each ask — on every navigation, and again on each 10s / 15s poll.

## What changed

- **`dashboard/cache.ts`**: a read-through cache. Single-flight (two panels and a poll tick are one subprocess, not three), stale-while-revalidate (once an answer exists nobody waits for it again; it refreshes behind the caller), and a 150ms budget on the first, uncached ask.
- **The PR stops blocking the row.** Branch, dirty, size, commits and files are ~10ms of git and now render at that speed.
- **`prPending`** distinguishes "not known yet" from "there is no PR". The Open PR button holds off while it is pending rather than offering to open a second one, and both panels poll every second until it lands.
- **Opening a PR invalidates** the cached answer, so the bar doesn't keep offering to open one for the next minute.
- Injected `pr` deps still resolve inline, so the existing unit tests stay deterministic.

## Verified

- 1110 framework tests + 306 dashboard tests, both typechecks, root build green. New `cache.test.ts` covers single-flight, TTL + background refresh, the pending budget, keeping the last good value through a failed read, and invalidation.
- Measured in a real browser against a real daemon, three navigations each: **cold load 757ms -> 330ms, session-to-session 681ms -> 263ms, back to a session 619ms -> 202ms**, and the PR-dependent actions land with the summary.