### PR TITLE
feat(dashboard): lead the session toolbar with the session name, not the branch

### DIFF
--- a/.changeset/warm-taxis-grin.md
+++ b/.changeset/warm-taxis-grin.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Dashboard: the session toolbar leads with the session's name — the same label the rail shows (your prompt) — instead of the branch. The agent renames its branch near the end of a run, and with the branch as the headline that mutation read as the whole view changing; as muted git context beside a stable name, it no longer does. The shared `the-framework/` prefix is dropped from the branch for legibility (the full name stays in the tooltip and copy). The branch summary also stops blanking for a beat when a run stops: it holds the last file counts until the handoff has loaded, so it swaps once instead of flashing empty. One line still, with the label truncating last and the branch, size and summary dropping out as the pane narrows.

--- a/packages/framework-dashboard/components/GitStatusBar.tsx
+++ b/packages/framework-dashboard/components/GitStatusBar.tsx
@@ -25,6 +25,7 @@ export function GitStatusBar({
   projectId,
   runId,
   inline = false,
+  label,
   summary,
   expanded = false,
   onToggle,
@@ -33,6 +34,9 @@ export function GitStatusBar({
   /** The session whose worktree to report; absent reports the project's checkout. */
   runId?: string | null | undefined
   inline?: boolean
+  /** The session's name (#1030). Given, it leads as the bold identity and the branch drops to
+   * muted git context beside it; absent (the project home), the branch stays the identity. */
+  label?: string | undefined
   /** What the branch holds, in a phrase — rendered beside the branch's own status. */
   summary?: ReactNode
   expanded?: boolean
@@ -61,21 +65,45 @@ export function GitStatusBar({
   // project's own checkout it is the user's. Same dot, honest wording.
   const dirtyLabel = worktree?.own ? 'Uncommitted changes in this session' : 'Uncommitted changes'
 
+  const branchTitle = worktree ? `${branch ?? 'no branch'}\n${worktree.path}` : `branch ${branch}`
+  // Beside a session label the `the-framework/` prefix is 14 characters of noise every session
+  // branch shares (#1030); the short name reads, and the tooltip and copy keep the real thing.
+  const branchText = label && branch ? branch.replace(/^the-framework\//, '') : (branch ?? 'no branch')
+
+  // One flat row so exactly one element gives up width: the label (or, with no label, the branch).
+  // Everything else is shrink-0 and drops out at a container width instead of squeezing to mush.
   const facts = (
     <>
-      <span className="flex min-w-0 items-center gap-1.5 overflow-hidden text-muted-foreground">
-        {/* The chevron only appears where there is something to open, so a bar without a
-            disclosure doesn't advertise one. */}
-        {onToggle && (
-          <ChevronRight className={cn('h-3.5 w-3.5 shrink-0 transition-transform', expanded && 'rotate-90')} />
+      {/* The chevron only appears where there is something to open, so a bar without a
+          disclosure doesn't advertise one. */}
+      {onToggle && (
+        <ChevronRight className={cn('h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform', expanded && 'rotate-90')} />
+      )}
+      {/* The session's name leads (#1030): it is what the rail calls this run and it does not
+          change under you, unlike the branch, which the agent renames near the end (#736). It is
+          the one element that shrinks, so it truncates last and the identity never disappears. */}
+      {label && (
+        <span className="min-w-0 truncate font-medium text-foreground" title={label}>
+          {label}
+        </span>
+      )}
+      {/* The branch: the identity when there is no session label (the project home), otherwise
+          muted git context. Beside a label it yields width first — a high shrink factor means it
+          truncates to make room for the name long before the name has to give any up (#1030). */}
+      <span
+        className={cn(
+          'flex items-center gap-1.5 overflow-hidden',
+          label
+            ? 'hidden min-w-0 shrink-[999] text-muted-foreground @2xl:flex'
+            : 'min-w-0 shrink-0 text-muted-foreground',
         )}
+      >
         <GitBranch className="h-3.5 w-3.5 shrink-0" />
         <span
-          // Never squeezed to nothing: below this it stops being a branch name (#1026).
-          className="min-w-[5rem] max-w-[14rem] truncate font-medium text-foreground"
-          title={worktree ? `${branch ?? 'no branch'}\n${worktree.path}` : `branch ${branch}`}
+          className={cn('truncate', label ? 'max-w-[14rem]' : 'min-w-[5rem] max-w-[16rem] font-medium text-foreground')}
+          title={branchTitle}
         >
-          {branch ?? 'no branch'}
+          {branchText}
         </span>
       </span>
       <span className="flex shrink-0 items-center gap-1.5">
@@ -91,14 +119,14 @@ export function GitStatusBar({
       </span>
       {/* Only a worktree has a size worth showing, and only once nothing is writing to it (#798). */}
       {size && (
-        <span className="hidden shrink-0 text-muted-foreground @2xl:inline" title="This session's worktree on disk">
+        <span className="hidden shrink-0 text-muted-foreground @4xl:inline" title="This session's worktree on disk">
           {size}
         </span>
       )}
       {/* The branch is the only part that gives up width (#1026): it truncates with an ellipsis
           and still reads, where a half-cut "0 files · me" does not. The facts furthest from the
           branch drop out first as the bar narrows, so it stays one line without colliding. */}
-      <span className="hidden shrink-0 @3xl:inline">{summary}</span>
+      <span className="hidden shrink-0 @5xl:inline">{summary}</span>
     </>
   )
 

--- a/packages/framework-dashboard/components/RunActionBar.tsx
+++ b/packages/framework-dashboard/components/RunActionBar.tsx
@@ -25,6 +25,7 @@ export function RunActionBar({
   events,
   retainedWorktree = false,
   onWorktreeRemoved,
+  label,
   summary,
   expanded = false,
   onToggle,
@@ -34,6 +35,8 @@ export function RunActionBar({
   /** Which run Stop addresses (#749); absent falls back to the project's own control log. */
   runId?: string | null | undefined
   events: FrameworkEvent[]
+  /** The session's name — leads the bar, so the branch is git context, not the identity (#1030). */
+  label?: string | undefined
   /** True when this finished run still has a worktree on disk, so it can be removed (#737). */
   retainedWorktree?: boolean
   /** Told after that worktree is removed, so the button goes. */
@@ -69,12 +72,14 @@ export function RunActionBar({
         {/* Where this session is working (#798/#809): the same status the project home shows,
             read from this session's own worktree — its branch, whether it is holding uncommitted
             work, its size on disk, and the PR its branch has. */}
-        <GitStatusBar projectId={projectId} runId={runId} inline summary={summary} expanded={expanded} onToggle={onToggle} />
-        {error && <span className="truncate text-xs text-danger">{error}</span>}
+        <GitStatusBar projectId={projectId} runId={runId} inline label={label} summary={summary} expanded={expanded} onToggle={onToggle} />
+        {error && <span className="shrink-0 truncate text-xs text-danger">{error}</span>}
         {/* What the session IS sits at the start of the bar; what you can DO to it sits at the end,
             so the buttons keep one home as the row's contents come and go (Stop only while it runs,
-            Remove only on a retained worktree, Open session only once one is reported). */}
-        <div className="min-w-0 flex-1" />
+            Remove only on a retained worktree, Open session only once one is reported). The spacer
+            grows to fill but never shrinks (#1030), so a tight row takes its width from the label
+            (which truncates) rather than from the spacer collapsing and the label surviving whole. */}
+        <div className="grow shrink-0" />
         <div className="flex shrink-0 items-center gap-2">
         {/* The handoff's next step sits before the workspace icons: it is the one thing here that
             moves the session forward rather than just opening it somewhere. */}

--- a/packages/framework-dashboard/components/RunView.tsx
+++ b/packages/framework-dashboard/components/RunView.tsx
@@ -28,6 +28,7 @@ export function RunView({
   runId,
   events,
   live,
+  label,
   files,
   addContext,
   removeContext,
@@ -41,6 +42,10 @@ export function RunView({
   events: FrameworkEvent[]
   /** Whether the run is still running. */
   live: boolean
+  /** The session's own name — the same label the rail shows (#1030). It leads the action bar as
+   * the stable identity, so the branch renaming itself near the end of a run (#736) reads as a
+   * detail changing rather than the whole view changing. */
+  label?: string | undefined
   files: string[]
   addContext: (path: string) => void
   removeContext?: ((path: string) => void) | undefined
@@ -78,7 +83,11 @@ export function RunView({
   const shown = live ? events : (archived ?? events)
   const session = sessionInfo(shown)
   const progress = runProgress(shown)
-  const canExpand = live ? changes.count > 0 : handoffExpandable(handoff.handoff)
+  // Until the handoff has actually loaded, a just-stopped run keeps showing the file counts it
+  // ended with (#1030): the summary swaps once, from the live counts to the handoff, instead of
+  // blanking for the beat the handoff read takes. Same for the chevron, so it does not blink out.
+  const showHandoff = !live && handoff.loaded
+  const canExpand = showHandoff ? handoffExpandable(handoff.handoff) : changes.count > 0
 
   return (
     <>
@@ -86,16 +95,17 @@ export function RunView({
         projectId={projectId}
         runId={runId}
         events={shown}
+        label={label ?? progress.sessionName}
         retainedWorktree={hasWorktree}
         onWorktreeRemoved={onWorktreeRemoved}
         summary={
-          live ? (
-            <ChangesSummary {...changes} />
-          ) : (
+          showHandoff ? (
             <>
               <HandoffSummary handoff={handoff.handoff} />
               {handoff.error && <span className="text-danger">{handoff.error}</span>}
             </>
+          ) : (
+            <ChangesSummary {...changes} />
           )
         }
         expanded={open}

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -11,6 +11,7 @@ import { RunHistory } from '../../components/RunHistory.js'
 import { ProjectHome } from '../../components/ProjectHome.js'
 import { DashboardPage } from '../../components/DashboardPage.js'
 import { RunView } from '../../components/RunView.js'
+import { runLabel } from '../../lib/run-label.js'
 import { RightRail } from '../../components/RightRail.js'
 import { RelayView } from '../../components/RelayView.js'
 import { NotFound } from '../../components/NotFound.js'
@@ -222,7 +223,7 @@ export default function Page() {
     if (runId === null) {
       // Just pressed Start on a project with no worktree: follow the live output until the poll
       // surfaces the run and the effect above adopts its id.
-      if (adopting) return <RunView projectId={projectId} runId={null} events={events} live files={files} addContext={addContext} removeContext={removeContext} lost={lost} onRunStarted={onRunStarted} />
+      if (adopting) return <RunView projectId={projectId} runId={null} events={events} live label={runStart.intent || undefined} files={files} addContext={addContext} removeContext={removeContext} lost={lost} onRunStarted={onRunStarted} />
       return (
         <ProjectHome
           projectId={projectId}
@@ -241,7 +242,7 @@ export default function Page() {
       // list we have not read yet. Both are live views; only a session that is genuinely absent
       // from a list we did read is gone.
       if (runId === runStart.id || !runsLoaded)
-        return <RunView projectId={projectId} runId={runId} events={events} live files={files} addContext={addContext} removeContext={removeContext} lost={lost} onRunStarted={onRunStarted} />
+        return <RunView projectId={projectId} runId={runId} events={events} live label={runStart.intent || undefined} files={files} addContext={addContext} removeContext={removeContext} lost={lost} onRunStarted={onRunStarted} />
       return (
         <NotFound
           title="This session is gone"
@@ -259,6 +260,7 @@ export default function Page() {
         runId={runId}
         events={events}
         live={selectedRun.status === 'running'}
+        label={runLabel(selectedRun)}
         files={files}
         addContext={addContext}
         removeContext={removeContext}


### PR DESCRIPTION
Closes #1030

The session toolbar led with the branch name in bold. Near the end of a run the agent names the session and renames its branch from `the-framework/run-<id>` to `the-framework/say-hello-static-html` (#736), so the loudest thing in the toolbar changed as the run finished — it read as the whole view changing, not a detail updating.

## What changed

- **Lead with the session's name**, the same `runLabel()` the rail shows (your prompt, then session name, branch, date). The branch drops to muted git context beside it, with the shared `the-framework/` prefix stripped for legibility — the full name stays in the tooltip and the copy button. The branch renaming is now a detail, not the identity.
- **The summary stops blanking at the stop.** It held the live file counts until the handoff loaded, so it swaps once (`1 file +1` → `2 commits · 0 files · merged`) instead of flashing empty for the beat the handoff read takes. The chevron holds too, so it doesn't blink out.
- **Still one line at any width.** The label is the only element that gives up width and it truncates last; the branch yields first (high shrink factor), then the size and summary drop out by container width, and the buttons never wrap.

## Verified

- 306 dashboard tests / 47 files, typecheck clean, root build green.
- Driven in a real browser at 1990 / 1600 / 1400 / 1250px: the label is readable at every width, the branch/size/summary drop cleanly, the bar stays 45px (one line).
- Scripted a running → stopped transition sampling the toolbar every 60ms across it: **150 samples — label missing 0, summary word missing 0, composer missing 0, height constant** at 2000px (where the summary is shown). The label stays put and the summary never blanks.