### PR TITLE
feat(dashboard): delete a stopped session, records and all

### DIFF
--- a/.changeset/tame-parrots-help.md
+++ b/.changeset/tame-parrots-help.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Dashboard: a stopped session can be deleted. The sessions rail only ever grew — remove-worktree reclaimed a checkout on disk but kept the row, and nothing removed the record. Delete (a trash button beside Remove, which is now a folder-x icon so the two read apart) takes the session out of the dashboard: its run record and event log, and its worktree if one remains. It confirms first, because unlike remove-worktree the replayable history can't be recovered. It deliberately leaves the git branch and its commits, the committed `LOGS.md` line and the conversation record — deleting a branch that may carry merged work or an open PR is not something a trash icon should do silently. It refuses while a run is still going.

--- a/packages/framework-dashboard/components/DeleteSessionButton.test.tsx
+++ b/packages/framework-dashboard/components/DeleteSessionButton.test.tsx
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+const sendDeleteSession = vi.hoisted(() => vi.fn())
+vi.mock('../server/control.telefunc.js', () => ({ sendDeleteSession }))
+
+const { DeleteSessionButton } = await import('./DeleteSessionButton.js')
+
+function renderButton(over: Partial<Parameters<typeof DeleteSessionButton>[0]> = {}) {
+  const onDeleted = vi.fn()
+  render(<DeleteSessionButton projectId="p1" runId="run-1" label="update index.html" onDeleted={onDeleted} {...over} />)
+  return { onDeleted }
+}
+
+beforeEach(() => sendDeleteSession.mockReset())
+afterEach(cleanup)
+
+describe('DeleteSessionButton (#1032)', () => {
+  test('the trigger alone does not delete — it opens a confirm first', () => {
+    renderButton()
+    fireEvent.click(screen.getByLabelText('Delete this session'))
+    // The confirm names the session and is honest about what survives.
+    expect(screen.getByText('Delete this session?')).toBeTruthy()
+    expect(screen.getByText(/update index\.html/)).toBeTruthy()
+    expect(screen.getByText(/branch and any pull request stay/i)).toBeTruthy()
+    // Nothing has been deleted by merely opening it.
+    expect(sendDeleteSession).not.toHaveBeenCalled()
+  })
+
+  test('confirming deletes the session and then leaves it', async () => {
+    sendDeleteSession.mockResolvedValue({ ok: true })
+    const { onDeleted } = renderButton()
+    fireEvent.click(screen.getByLabelText('Delete this session'))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(sendDeleteSession).toHaveBeenCalledWith('p1', 'run-1'))
+    await waitFor(() => expect(onDeleted).toHaveBeenCalledTimes(1))
+  })
+
+  test('cancelling deletes nothing', () => {
+    renderButton()
+    fireEvent.click(screen.getByLabelText('Delete this session'))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(sendDeleteSession).not.toHaveBeenCalled()
+  })
+
+  test('a failed delete surfaces the reason and does not leave the session', async () => {
+    sendDeleteSession.mockResolvedValue({ ok: false, error: 'that session is still going; stop it before deleting it' })
+    const { onDeleted } = renderButton()
+    fireEvent.click(screen.getByLabelText('Delete this session'))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(screen.getByText(/still going; stop it/)).toBeTruthy())
+    expect(onDeleted).not.toHaveBeenCalled()
+  })
+})

--- a/packages/framework-dashboard/components/DeleteSessionButton.tsx
+++ b/packages/framework-dashboard/components/DeleteSessionButton.tsx
@@ -1,0 +1,52 @@
+import { Trash2 } from 'lucide-react'
+import { sendDeleteSession } from '../server/control.telefunc.js'
+import { ConfirmDialog } from './ui/confirm-dialog.js'
+import { Button } from './ui/button.js'
+
+// Delete a finished session (#1032): take it out of the dashboard, records and all — the sibling
+// of Remove worktree, which keeps the session and only reclaims its checkout. This removes the run
+// meta and its event log too, so the row is gone for good; that is why it confirms, where remove
+// does not. It leaves the branch and any PR alone, because those are git history the dashboard has
+// no business rewriting from a trash icon.
+//
+// Only for a finished run (the caller renders it when the run is not live), and the confirm refuses
+// server-side while a run is still going regardless. It sits in the action bar beside Remove, one
+// click from the session you are looking at.
+export function DeleteSessionButton({
+  projectId,
+  runId,
+  label,
+  onDeleted,
+}: {
+  projectId: string
+  runId: string
+  /** The session's own name, so the dialog says which one is going, not a bare id. */
+  label?: string | undefined
+  /** Told after a successful delete, so the caller can leave the now-gone session. */
+  onDeleted: () => void
+}) {
+  const name = label?.trim() || runId
+  return (
+    <ConfirmDialog
+      title="Delete this session?"
+      body={
+        <>
+          Deleting <span className="font-medium text-foreground">{name}</span> removes it from the dashboard for good
+          — its history can&rsquo;t be recovered. Its branch and any pull request stay in git.
+        </>
+      }
+      confirmLabel="Delete"
+      confirmBusyLabel="Deleting…"
+      fallbackError="Could not delete the session."
+      onConfirm={() => sendDeleteSession(projectId, runId).then(result => (result.ok ? result : Promise.reject(new Error(result.error))))}
+      onSuccess={onDeleted}
+      trigger={
+        // A plain titled button, not a Tooltip: the dialog's own trigger owns this element, and two
+        // Base UI triggers cannot share one. The confirm dialog is the real explanation anyway.
+        <Button variant="outline" size="icon-sm" aria-label="Delete this session" title="Delete this session">
+          <Trash2 className="h-3.5 w-3.5" />
+        </Button>
+      }
+    />
+  )
+}

--- a/packages/framework-dashboard/components/RemoveWorktreeButton.tsx
+++ b/packages/framework-dashboard/components/RemoveWorktreeButton.tsx
@@ -1,4 +1,4 @@
-import { Trash2 } from 'lucide-react'
+import { FolderX } from 'lucide-react'
 import { sendRemoveWorktree } from '../server/control.telefunc.js'
 import { useAction } from '../lib/use-action.js'
 import { Button } from './ui/button.js'
@@ -41,7 +41,7 @@ export function RemoveWorktreeButton({
           />
         }
       >
-        <Trash2 className="h-3.5 w-3.5" />
+        <FolderX className="h-3.5 w-3.5" />
       </TooltipTrigger>
       <TooltipContent>
         {error ?? (busy ? 'Removing…' : "Remove this session's worktree (its history is already saved)")}

--- a/packages/framework-dashboard/components/RunActionBar.tsx
+++ b/packages/framework-dashboard/components/RunActionBar.tsx
@@ -7,6 +7,7 @@ import { useAction } from '../lib/use-action.js'
 import { isRunActive } from '../lib/live-state.js'
 import { describeSessionLink } from '../lib/session-link.js'
 import { RemoveWorktreeButton } from './RemoveWorktreeButton.js'
+import { DeleteSessionButton } from './DeleteSessionButton.js'
 import { WorkspaceActions } from './WorkspaceActions.js'
 import { GitStatusBar } from './GitStatusBar.js'
 import { Button, buttonVariants } from './ui/button.js'
@@ -25,6 +26,7 @@ export function RunActionBar({
   events,
   retainedWorktree = false,
   onWorktreeRemoved,
+  onDeleted,
   label,
   summary,
   expanded = false,
@@ -41,6 +43,9 @@ export function RunActionBar({
   retainedWorktree?: boolean
   /** Told after that worktree is removed, so the button goes. */
   onWorktreeRemoved?: () => void
+  /** Told after this session is deleted, so the caller can leave it (#1032). Given only for a
+   * finished run: absent, no delete is offered. */
+  onDeleted?: (() => void) | undefined
   /** What the session's branch holds, said beside the branch itself (#1023). */
   summary?: ReactNode
   expanded?: boolean
@@ -111,6 +116,12 @@ export function RunActionBar({
         {/* A retained worktree only exists for a finished run, so this never sits beside Stop. */}
         {retainedWorktree && !active && runId && (
           <RemoveWorktreeButton projectId={projectId} runId={runId} onRemoved={() => onWorktreeRemoved?.()} />
+        )}
+        {/* Delete the whole session, records and all (#1032). Finished runs only, and it needs no
+            worktree — a clean run that kept none can still be cleared from the list. Sits after
+            Remove, the more destructive of the pair. */}
+        {onDeleted && !active && runId && (
+          <DeleteSessionButton projectId={projectId} runId={runId} label={label} onDeleted={onDeleted} />
         )}
         {!session && info?.sessionId && (
           <CopyButton text={info.sessionId} label={`Copy session id (${info.sessionId})`} className="p-1.5" />

--- a/packages/framework-dashboard/components/RunView.tsx
+++ b/packages/framework-dashboard/components/RunView.tsx
@@ -34,6 +34,7 @@ export function RunView({
   removeContext,
   lost = false,
   onRunStarted,
+  onDeleted,
 }: {
   projectId: string
   /** Which run this is (#749); absent right after Start, before the poll adopts its id. */
@@ -53,6 +54,8 @@ export function RunView({
   lost?: boolean
   /** Jump to the run a preset or a continuation started (#959). */
   onRunStarted?: ((intent: string, runId?: string) => void) | undefined
+  /** Leave this session after it is deleted (#1032) — back to the project home. */
+  onDeleted?: (() => void) | undefined
 }) {
   // The archived log, read only once the run has ended: while it runs, the channel is the truth.
   const archived = useLoaded<FrameworkEvent[] | null>(
@@ -98,6 +101,7 @@ export function RunView({
         label={label ?? progress.sessionName}
         retainedWorktree={hasWorktree}
         onWorktreeRemoved={onWorktreeRemoved}
+        onDeleted={onDeleted}
         summary={
           showHandoff ? (
             <>

--- a/packages/framework-dashboard/components/ui/button.tsx
+++ b/packages/framework-dashboard/components/ui/button.tsx
@@ -12,6 +12,9 @@ const buttonVariants = cva(
         outline:
           'border border-[var(--color-border)] bg-transparent hover:bg-[var(--color-accent)] hover:text-[var(--color-accent-foreground)]',
         ghost: 'hover:bg-[var(--color-accent)] hover:text-[var(--color-accent-foreground)]',
+        // A confirmed destructive action (#1032): --danger is a fill, so its label inverts the
+        // opposite way (text-background), the same rule ChoicePanel's Approve button follows.
+        destructive: 'bg-[var(--color-danger)] text-[var(--color-background)] hover:opacity-90',
       },
       size: {
         default: 'h-9 px-4 py-2',

--- a/packages/framework-dashboard/components/ui/confirm-dialog.tsx
+++ b/packages/framework-dashboard/components/ui/confirm-dialog.tsx
@@ -1,0 +1,94 @@
+'use client'
+import { useState, type ReactNode } from 'react'
+import { AlertDialog } from '@base-ui-components/react/alert-dialog'
+import { useAction } from '../../lib/use-action.js'
+import { Button } from './button.js'
+import { cn } from '../../lib/utils.js'
+
+// A confirm-before-you-act dialog on Base UI's AlertDialog (#1032): for the one action that cannot
+// be taken back. The trigger is whatever the caller renders; confirming runs `onConfirm` through
+// useAction, so it disables + shows a busy label and surfaces a failure in place instead of
+// closing on a silent error. The dialog stays open until the action succeeds.
+//
+// AlertDialog rather than Dialog on purpose: it traps focus and has no light-dismiss, so a
+// destructive confirm is a deliberate choice, not something a stray click past the edge triggers.
+export function ConfirmDialog({
+  trigger,
+  title,
+  body,
+  confirmLabel,
+  confirmBusyLabel = 'Working…',
+  onConfirm,
+  onSuccess,
+  fallbackError = 'Something went wrong.',
+  destructive = true,
+}: {
+  /** The control that opens the dialog (an icon button, a menu item). */
+  trigger: ReactNode
+  title: ReactNode
+  /** The consequence, said plainly — this is where the caveats live. */
+  body: ReactNode
+  confirmLabel: string
+  confirmBusyLabel?: string
+  /** Runs on confirm; returning a falsy/thrown result keeps the dialog open with the error. */
+  onConfirm: () => Promise<unknown>
+  /** Fires once, after the dialog has closed on a successful confirm — safe to navigate away in. */
+  onSuccess?: () => void
+  fallbackError?: string
+  destructive?: boolean
+}) {
+  const [open, setOpen] = useState(false)
+  const { busy, error, run, reset } = useAction()
+
+  const confirm = (): void => {
+    void run(onConfirm, fallbackError).then(result => {
+      if (result === undefined) return
+      setOpen(false)
+      // After the close, so a caller that unmounts this (navigating off the deleted session) does
+      // not tear the dialog down mid-transition.
+      queueMicrotask(() => onSuccess?.())
+    })
+  }
+
+  return (
+    <AlertDialog.Root
+      open={open}
+      onOpenChange={next => {
+        // Never close while the action is in flight, and clear a prior error on reopen.
+        if (busy) return
+        setOpen(next)
+        if (next) reset()
+      }}
+    >
+      <AlertDialog.Trigger render={trigger as never} />
+      <AlertDialog.Portal>
+        <AlertDialog.Backdrop className="fixed inset-0 z-50 bg-black/40 backdrop-blur-[1px]" />
+        <AlertDialog.Popup className="fixed left-1/2 top-1/2 z-50 w-[min(26rem,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-card p-5 text-card-foreground shadow-lg">
+          <AlertDialog.Title className="text-sm font-semibold">{title}</AlertDialog.Title>
+          <AlertDialog.Description className="mt-2 text-xs leading-relaxed text-muted-foreground">
+            {body}
+          </AlertDialog.Description>
+          {error && <p className="mt-2 text-xs text-danger">{error}</p>}
+          <div className="mt-4 flex justify-end gap-2">
+            <AlertDialog.Close
+              render={
+                <Button variant="outline" size="sm" disabled={busy}>
+                  Cancel
+                </Button>
+              }
+            />
+            <Button
+              variant={destructive ? 'destructive' : 'default'}
+              size="sm"
+              disabled={busy}
+              onClick={confirm}
+              className={cn(busy && 'cursor-progress')}
+            >
+              {busy ? confirmBusyLabel : confirmLabel}
+            </Button>
+          </div>
+        </AlertDialog.Popup>
+      </AlertDialog.Portal>
+    </AlertDialog.Root>
+  )
+}

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -266,6 +266,12 @@ export default function Page() {
         removeContext={removeContext}
         lost={lost}
         onRunStarted={onRunStarted}
+        onDeleted={() => {
+          // Its view is about to point at a session that no longer exists; go home and refresh
+          // the rail so the row is gone (#1032).
+          selectRun(null)
+          reload()
+        }}
       />
     )
   }

--- a/packages/framework-dashboard/server/control.telefunc.ts
+++ b/packages/framework-dashboard/server/control.telefunc.ts
@@ -4,6 +4,6 @@
 // Imported then exported, not re-exported (#1014): telefunc's dev transform appends
 // `__decorateTelefunction(<name>, ...)` per export, which needs a local binding. An
 // `export ... from` creates none, so `pnpm dev` died with `<name> is not defined`.
-import { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendPushBranch, sendOpenPullRequest, sendQueueTicket } from '@gemstack/framework/dashboard-rpc'
+import { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendDeleteSession, sendPushBranch, sendOpenPullRequest, sendQueueTicket } from '@gemstack/framework/dashboard-rpc'
 
-export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendPushBranch, sendOpenPullRequest, sendQueueTicket }
+export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendDeleteSession, sendPushBranch, sendOpenPullRequest, sendQueueTicket }

--- a/packages/framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/control.telefunc.ts
@@ -5,7 +5,7 @@ import { openInApp, type OpenTarget, type OpenResult } from '../dashboard/open-i
 import { resolveProjectPath, resolveRunPath, contextPreferences, contextPreview } from './context.js'
 import { appendFlatTodoEntry } from '../todo-loop.js'
 import { findRun, isSafeRunId, type RunMeta } from '../store/index.js'
-import { removeProjectWorktree } from '../worktrees.js'
+import { removeProjectWorktree, deleteProjectRun } from '../worktrees.js'
 import {
   openRunPullRequest,
   pushRunBranch,
@@ -15,6 +15,7 @@ import {
 } from '../dashboard/run-handoff.js'
 import type { ChoiceBy } from '../events.js'
 import type {
+  DeleteSessionResult,
   PreviewResult,
   PreviewStatus,
   RemoveWorktreeResult,
@@ -102,6 +103,24 @@ export async function sendRemoveWorktree(projectId: string, runId: string): Prom
   const cwd = await resolveProjectPath(projectId)
   if (!cwd) return { ok: false, error: 'this project has no local path on this server' }
   return removeProjectWorktree(cwd, runId, {
+    beforeRemove: async id => {
+      await preview?.stop(projectId, id)
+    },
+  })
+}
+
+/**
+ * Delete a session (#1032): remove it from the dashboard, records and all — the sibling of
+ * {@link sendRemoveWorktree}, and the one destructive-of-history action, so its surface confirms
+ * first. The checks, the worktree removal and what it leaves behind (the branch, the committed
+ * `LOGS.md` line, the conversation record) are all {@link deleteProjectRun}'s; this adds only the
+ * daemon step of stopping a preview that may be serving the worktree before it comes off disk.
+ */
+export async function sendDeleteSession(projectId: string, runId: string): Promise<DeleteSessionResult> {
+  const preview = contextPreview()
+  const cwd = await resolveProjectPath(projectId)
+  if (!cwd) return { ok: false, error: 'this project has no local path on this server' }
+  return deleteProjectRun(cwd, runId, {
     beforeRemove: async id => {
       await preview?.stop(projectId, id)
     },

--- a/packages/framework/src/dashboard-rpc/index.ts
+++ b/packages/framework/src/dashboard-rpc/index.ts
@@ -3,7 +3,7 @@
 // wiring) can reach the daemon's `startRun`; the framework-dashboard client imports
 // these through thin re-export shims so the baked RPC keys stay `/server/*.telefunc.ts`.
 export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent, onTickets, onRetainedWorktrees, onRunWorktree, onRunHandoff, onSystemPromptUser } from './reads.telefunc.js'
-export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendPushBranch, sendOpenPullRequest, sendQueueTicket, type QueueTicketResult } from './control.telefunc.js'
+export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendDeleteSession, sendPushBranch, sendOpenPullRequest, sendQueueTicket, type QueueTicketResult } from './control.telefunc.js'
 export { onEvents } from './events.telefunc.js'
 export { onProjects, sendAddProject } from './projects.telefunc.js'
 export {

--- a/packages/framework/src/dashboard-rpc/register.ts
+++ b/packages/framework/src/dashboard-rpc/register.ts
@@ -1,6 +1,6 @@
 import { __decorateTelefunction } from 'telefunc'
 import { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent, onTickets, onRetainedWorktrees, onRunWorktree, onRunHandoff, onSystemPromptUser } from './reads.telefunc.js'
-import { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendPushBranch, sendOpenPullRequest, sendQueueTicket } from './control.telefunc.js'
+import { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendDeleteSession, sendPushBranch, sendOpenPullRequest, sendQueueTicket } from './control.telefunc.js'
 import { onEvents } from './events.telefunc.js'
 import { onProjects, sendAddProject } from './projects.telefunc.js'
 import { onPreferences, savePreferences, onProjectPreferences, saveProjectPreferences, onEditors, onNotifyChannels } from './preferences.telefunc.js'
@@ -79,6 +79,7 @@ export function registerDashboardTelefunctions(appRootDir: string = process.cwd(
   reg(onPreviewStatus, 'onPreviewStatus', control)
   reg(sendOpenInApp, 'sendOpenInApp', control)
   reg(sendRemoveWorktree, 'sendRemoveWorktree', control)
+  reg(sendDeleteSession, 'sendDeleteSession', control)
   reg(sendPushBranch, 'sendPushBranch', control)
   reg(sendOpenPullRequest, 'sendOpenPullRequest', control)
   reg(sendQueueTicket, 'sendQueueTicket', control)

--- a/packages/framework/src/dashboard/types.ts
+++ b/packages/framework/src/dashboard/types.ts
@@ -8,6 +8,9 @@ import type { EcoOptions } from '../system-prompt.js'
 /** The outcome of removing a retained worktree (#737). */
 export type RemoveWorktreeResult = { ok: true } | { ok: false; error: string }
 
+/** The outcome of deleting a session — its records and worktree (#1032). */
+export type DeleteSessionResult = { ok: true } | { ok: false; error: string }
+
 /** The outcome of an add-project attempt (#396). */
 export type AddProjectResult =
   | { ok: true; added: number; alreadyActivated: number }

--- a/packages/framework/src/worktrees.test.ts
+++ b/packages/framework/src/worktrees.test.ts
@@ -3,8 +3,8 @@ import { test } from 'node:test'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises'
-import { formatWorktreeList, removeProjectWorktree, type WorktreeRow } from './worktrees.js'
-import { addWorktree, runBranchName } from './store/index.js'
+import { deleteProjectRun, formatWorktreeList, removeProjectWorktree, type WorktreeRow } from './worktrees.js'
+import { addWorktree, listRuns, runBranchName } from './store/index.js'
 import { nodeGitRunner } from './project.js'
 
 const row = (over: Partial<WorktreeRow> & { runId: string }): WorktreeRow => ({ live: false, ...over })
@@ -96,4 +96,72 @@ test('an unknown session is refused before any git runs (#982)', async () => {
   } finally {
     await rm(repo, { recursive: true, force: true })
   }
+})
+
+// #1032: delete removes the session from the dashboard, records and all — where remove-worktree
+// keeps it. Against real git, because "did the branch survive" is the whole distinction.
+
+/** Write an archived run's meta + log, the two files that put its row in the rail. */
+async function archiveRun(repo: string, id: string): Promise<{ meta: string; log: string }> {
+  const runs = join(repo, '.the-framework', 'runs')
+  await mkdir(runs, { recursive: true })
+  const meta = join(runs, `${id}.json`)
+  const log = join(runs, `${id}.jsonl`)
+  await writeFile(meta, JSON.stringify({ version: 1, status: 'stopped', id, startedAt: '2026-01-01T00:00:00.000Z' }))
+  await writeFile(log, '{"kind":"end"}\n')
+  return { meta, log }
+}
+
+test('deleting a session removes its records and worktree but keeps the branch (#1032)', async () => {
+  const { repo, path, branch } = await repoWithDirtyWorktree()
+  try {
+    const { meta, log } = await archiveRun(repo, RUN_ID)
+    assert.equal((await listRuns(repo)).some(r => r.id === RUN_ID), true, 'the row is listed to begin with')
+
+    assert.deepEqual(await deleteProjectRun(repo, RUN_ID), { ok: true })
+
+    await assert.rejects(() => stat(path), 'the worktree is gone')
+    await assert.rejects(() => stat(meta), 'the run meta is gone')
+    await assert.rejects(() => stat(log), 'the event log is gone')
+    assert.equal((await listRuns(repo)).some(r => r.id === RUN_ID), false, 'the row has left the list')
+    // The branch and its commits are git history, deliberately left behind.
+    const shown = await nodeGitRunner()(['rev-parse', '--verify', branch], repo)
+    assert.match(shown, /^[0-9a-f]{40}/, 'the branch still exists')
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})
+
+test('deleting discards uncommitted worktree work rather than committing it (#1032)', async () => {
+  const { repo, path, branch } = await repoWithDirtyWorktree()
+  try {
+    await archiveRun(repo, RUN_ID)
+    // The worktree holds an uncommitted "Welcome!" edit. remove-worktree would commit it to the
+    // branch; delete throws the session away, so the branch keeps only what it had committed.
+    assert.deepEqual(await deleteProjectRun(repo, RUN_ID), { ok: true })
+    await assert.rejects(() => stat(path))
+    const shown = await nodeGitRunner()(['show', `${branch}:index.html`], repo)
+    assert.match(shown, /Hello, world!/, 'the branch keeps its committed content, not the discarded edit')
+    assert.doesNotMatch(shown, /Welcome!/)
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})
+
+test('deleting a record-only session (its worktree already gone) still clears the row (#1032)', async () => {
+  const repo = await realpath(await mkdtemp(join(tmpdir(), 'framework-del-')))
+  try {
+    const { meta } = await archiveRun(repo, 'run-x')
+    // No worktree on disk — a clean finished run, or one already removed. Delete must not need one.
+    assert.deepEqual(await deleteProjectRun(repo, 'run-x'), { ok: true })
+    await assert.rejects(() => stat(meta), 'the record is gone')
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})
+
+test('an invalid session id is refused before anything is touched (#1032)', async () => {
+  const result = await deleteProjectRun('/nowhere', '../etc/passwd')
+  assert.equal(result.ok, false)
+  assert.match(result.ok === false ? result.error : '', /invalid session id/)
 })

--- a/packages/framework/src/worktrees.ts
+++ b/packages/framework/src/worktrees.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path'
 import { formatBytes } from './format-bytes.js'
 import { errorMessage } from './error-message.js'
 import {
@@ -10,6 +11,8 @@ import {
   worktreePath,
   worktreeSize,
   isSafeRunId,
+  FRAMEWORK_DIR,
+  RUNS_DIR,
   type RunStatus,
 } from './store/index.js'
 
@@ -126,6 +129,69 @@ export async function removeProjectWorktree(
     await opts.beforeRemove?.(runId)
     await removeWorktree(cwd, path)
     await pruneWorktrees(cwd)
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: errorMessage(err) }
+  }
+}
+
+/** The outcome of {@link deleteProjectRun}. */
+export type DeleteRunResult = { ok: true } | { ok: false; error: string }
+
+/** Surface-specific work {@link deleteProjectRun} does, and the file-removal seam for tests. */
+export interface DeleteRunOptions {
+  /** Run before the worktree comes off disk (stop a preview serving it, as removal does). */
+  beforeRemove?: (runId: string) => Promise<void>
+  /** Remove one file, tolerant of an absent one. Defaults to `rm(path, { force: true })`. */
+  removeFile?: (path: string) => Promise<void>
+}
+
+async function rmFile(path: string): Promise<void> {
+  const { rm } = await import('node:fs/promises')
+  await rm(path, { force: true })
+}
+
+/**
+ * Delete a session (#1032): take it out of the dashboard, records and all.
+ *
+ * This is the sibling of {@link removeProjectWorktree}, and the difference is the whole point.
+ * Remove-worktree reclaims the checkout on disk and keeps the session — its row, its replayable
+ * log — because the history was already archived. Delete removes that archive too: the run meta
+ * (`runs/<id>.json`, what the rail lists) and its event log (`runs/<id>.jsonl`, what replays), so
+ * the row is gone for good. It is the one destructive-of-history action, which is why the surfaces
+ * that call it confirm first.
+ *
+ * What it deliberately leaves is git's, not the dashboard's: the branch `the-framework/run-<id>`
+ * (or the name the agent gave it) and its commits, the committed `LOGS.md` line, and the
+ * conversation record. Deleting a branch that may carry merged work or an open PR is not a thing a
+ * dashboard action should do silently, so the branch stays and delete means "remove from the
+ * dashboard", not "erase every trace".
+ *
+ * Refuses while the run is still going — Stop is how a run ends. Any uncommitted work in the
+ * worktree is discarded with it, which is the intent here (the session is being thrown away),
+ * unlike remove-worktree, which commits that work to the kept branch first.
+ */
+export async function deleteProjectRun(cwd: string, runId: string, opts: DeleteRunOptions = {}): Promise<DeleteRunResult> {
+  if (!isSafeRunId(runId)) return { ok: false, error: `invalid session id: ${runId}` }
+  const live = await readLiveMetas(cwd).catch(() => [])
+  if (live.some(run => run.id === runId && run.status === 'running')) {
+    return { ok: false, error: 'that session is still going; stop it before deleting it' }
+  }
+  const removeFile = opts.removeFile ?? rmFile
+  try {
+    // The worktree first, if one is on disk: force-removed (its uncommitted work goes with the
+    // session), where remove-worktree would have committed it to the kept branch.
+    const names = await listWorktreeDirs(cwd).catch((): string[] => [])
+    if (names.includes(runId)) {
+      await opts.beforeRemove?.(runId)
+      await removeWorktree(cwd, worktreePath(cwd, runId))
+      await pruneWorktrees(cwd)
+    }
+    // Then the records that put the row in the list. Tolerant of an absent file, so a half-deleted
+    // session (its worktree already gone) still finishes cleanly.
+    const runsDir = join(cwd, FRAMEWORK_DIR, RUNS_DIR)
+    await removeFile(join(runsDir, `${runId}.json`))
+    await removeFile(join(runsDir, `${runId}.jsonl`))
     return { ok: true }
   } catch (err) {
     return { ok: false, error: errorMessage(err) }


### PR DESCRIPTION
Closes #1032

The sessions rail only ever grew. Remove-worktree reclaims a session's checkout but keeps its row; nothing removed the record. So a project accumulates every session it ever ran, with no way to clear one out.

## What changed

**Delete session**, a sibling of Remove worktree:
- **`deleteProjectRun(cwd, runId)`** (store) removes `runs/<id>.json` (the rail row) and `runs/<id>.jsonl` (the replay log), plus the worktree if one is on disk. Refuses while the run is running; discards uncommitted worktree work (the session is being thrown away) where remove-worktree commits it to the kept branch.
- **`sendDeleteSession`** (daemon RPC) wires it up, stopping a preview serving the worktree first, exactly as remove does.
- **Leaves git alone**: the branch and its commits, the committed `LOGS.md` line, and the conversation record all stay. "Delete" means remove from the dashboard, not erase every trace.

**UI:**
- A trash button in the action bar beside Remove, for a finished run. Confirms via a new **`ConfirmDialog`** (Base UI AlertDialog: focus-trapped, no light-dismiss) and a new **destructive** Button variant. Copy: "Delete this session? Removes it from the dashboard for good — its history can't be recovered. Its branch and any pull request stay in git."
- **Remove-worktree moves to a folder-x icon** so the two actions no longer read as the same trash can.

## Verified

- 1114 framework tests (4 new for `deleteProjectRun`: keeps the branch, discards uncommitted work, record-only session, invalid id — against real git) + 310 dashboard tests (4 new for the button: confirm-first, deletes-then-leaves, cancel, error), both typechecks, root build green.
- Driven in a real browser end to end: opened a disposable stopped session, deleted it, and confirmed on disk — **`runs/<id>.json` gone, `.jsonl` gone, worktree gone, branch still present**, and the row left the rail (project count 6 → 5). Confirmed the two icons read apart on a run that has both.