### PR TITLE
fix(framework): guard runPrompt's onEvent listener against throwing

### DIFF
--- a/.changeset/fix-prompt-run-emit-guard.md
+++ b/.changeset/fix-prompt-run-emit-guard.md
@@ -1,0 +1,11 @@
+---
+'@gemstack/framework': patch
+---
+
+Stop a throwing onEvent listener from escaping a prompt run (runPrompt).
+
+runFramework wraps each `opts.onEvent(event)` call in a try/catch and logs-and-ignores a listener
+that throws, but runPrompt's emit did not. Because emit is called both inside and outside the run's
+try block (the session-start and system-prompt events fire before it), an onEvent listener that threw
+could escape runPrompt uncaught, or skip the run's `end` event. runPrompt now guards the listener the
+same way, so a bad listener can no longer take the run down.

--- a/packages/framework/src/prompt-run.test.ts
+++ b/packages/framework/src/prompt-run.test.ts
@@ -36,6 +36,26 @@ test('runPrompt runs a gateless prompt straight through and emits session + end'
   assert.equal(events.some(e => e.kind === 'choice'), false)
 })
 
+test('runPrompt swallows a throwing onEvent listener and still finishes', async () => {
+  // A listener that throws on every event, including the session/system-prompt events emitted
+  // before the run's try block. Without the guard the first throw escapes runPrompt uncaught; with
+  // it, the run completes and its `end` still fires. Events are recorded before the throw.
+  const seen: FrameworkEvent[] = []
+  const driver = new FakeDriver({ turns: [{ text: 'all done' }] })
+  const { text } = await runPrompt({
+    prompt: 'do the thing',
+    driver,
+    cwd: '/ws',
+    onEvent: e => {
+      seen.push(e)
+      throw new Error('listener boom')
+    },
+  })
+  assert.equal(text, 'all done')
+  assert.equal(seen[0]!.kind, 'session') // the pre-try session event was delivered, its throw swallowed
+  assert.deepEqual(seen.at(-1), { kind: 'end', ok: true })
+})
+
 test('runPrompt seeds the driver and resumes the opening prompt for a finished-run session (#720)', async () => {
   let startOpts: DriverStartOptions | undefined
   let openingResume: boolean | undefined

--- a/packages/framework/src/prompt-run.ts
+++ b/packages/framework/src/prompt-run.ts
@@ -97,7 +97,16 @@ export async function runPrompt(opts: RunPromptOptions): Promise<RunPromptResult
   const events: FrameworkEvent[] = []
   const emit = (event: FrameworkEvent): void => {
     events.push(event)
-    opts.onEvent?.(event)
+    // Swallow a listener that throws, as runFramework does: emit runs both inside and outside the
+    // try below (the session-start and system-prompt events fire first), so an unguarded throw would
+    // escape the run uncaught or skip its `end` event.
+    if (opts.onEvent) {
+      try {
+        opts.onEvent(event)
+      } catch (err) {
+        console.error('[framework] onEvent threw; ignoring:', err)
+      }
+    }
   }
 
   // The built-in #326 prompt + any user SYSTEM.md frame the session (#301). The


### PR DESCRIPTION
runFramework wraps each `opts.onEvent(event)` call in a try/catch and logs-and-ignores a listener that throws. runPrompt's emit did not.

Because emit is called both inside and outside the run's try block (the session-start and system-prompt events fire before it), an onEvent listener that threw could escape runPrompt uncaught, or skip the run's `end` event. In practice the listeners are the dashboard stream, the terminal renderer, and the store writer, so a bug in any of them could take a prompt run down where the same bug is survivable on a build run.

## Fix

runPrompt now guards the listener exactly as runFramework does: a throw is caught, logged as `[framework] onEvent threw; ignoring`, and the run carries on.

## Test

Adds a regression test: a listener that throws on every event (including the pre-try session event) no longer rejects the run, and the run's `end` still fires. Proven to fail without the guard (reverting the guard turns the new test red, restoring it green).

Surfaced as a flagged finding during the framework quality pass (#1034).