### PR TITLE
Plain-language labels in the session log (#1035)

### DIFF
--- a/.changeset/self-explanatory-log-labels.md
+++ b/.changeset/self-explanatory-log-labels.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Dashboard: the session log labels each row with a plain word instead of its internal event name (#1035). The badge used to show the raw event kind, so a turn of the AI read `DRIVER`, the paused state read `SETTLED`, and the spend row read `USAGE`. These now read `AGENT`, `WAITING`, and `COST`, and the resume-link row reads `RESUME`. Kinds that were already clear are unchanged.

--- a/packages/framework-dashboard/components/EventList.tsx
+++ b/packages/framework-dashboard/components/EventList.tsx
@@ -1,5 +1,6 @@
 import type { FrameworkEvent } from '@gemstack/framework'
 import { formatFrameworkEvent } from '@gemstack/framework/client'
+import { eventKindLabel } from '../lib/event-labels.js'
 import { receivedAt } from '../lib/event-times.js'
 import { Badge } from './ui/badge.js'
 import {
@@ -64,7 +65,7 @@ export function EventList({
                 <MessageScrollerItem key={i} messageId={String(i)} scrollAnchor={isTurnBoundary(e)} className="flex items-start gap-2">
                   {/* Fixed-width badge column so the text lines up whether or not this row repeats the kind. */}
                   <span className="w-20 shrink-0">
-                    {chunkHead && <Badge className="mt-0.5 text-[10px] uppercase text-muted-foreground">{e.kind}</Badge>}
+                    {chunkHead && <Badge className="mt-0.5 text-[10px] uppercase text-muted-foreground">{eventKindLabel(e.kind)}</Badge>}
                   </span>
                   {disclosable ? (
                     <details className="min-w-0 flex-1">

--- a/packages/framework-dashboard/lib/event-labels.test.ts
+++ b/packages/framework-dashboard/lib/event-labels.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { eventKindLabel } from './event-labels.js'
+
+describe('eventKindLabel', () => {
+  it('renames the jargon kinds to plain words', () => {
+    expect(eventKindLabel('driver')).toBe('agent')
+    expect(eventKindLabel('settled')).toBe('waiting')
+    expect(eventKindLabel('usage')).toBe('cost')
+    expect(eventKindLabel('session-update')).toBe('resume')
+  })
+
+  it('de-hyphenates the kinds that are already clear', () => {
+    expect(eventKindLabel('system-prompt')).toBe('system prompt')
+    expect(eventKindLabel('ready-for-merge')).toBe('ready for merge')
+  })
+
+  it('leaves a plain single-word kind untouched', () => {
+    expect(eventKindLabel('session')).toBe('session')
+    expect(eventKindLabel('log')).toBe('log')
+  })
+})

--- a/packages/framework-dashboard/lib/event-labels.ts
+++ b/packages/framework-dashboard/lib/event-labels.ts
@@ -1,0 +1,19 @@
+import type { FrameworkEvent } from '@gemstack/framework'
+
+type EventKind = FrameworkEvent['kind']
+
+// The badge next to each session-log line should read plainly to someone seeing the UI for the
+// first time (#1035). Only the kinds whose raw name is internal jargon get a friendly word; every
+// other kind falls back to its name with hyphens turned to spaces (`system-prompt` -> "system
+// prompt"). The badge is CSS-uppercased, so the values here stay lowercase.
+const OVERRIDES: Partial<Record<EventKind, string>> = {
+  driver: 'agent', // the AI turn: prompt sent, reply, turn complete
+  settled: 'waiting', // done for now, waiting for your next message
+  usage: 'cost', // spend so far
+  'session-update': 'resume', // the resumable session id + link
+}
+
+/** The plain-language badge label for a session-log event kind. */
+export function eventKindLabel(kind: EventKind): string {
+  return OVERRIDES[kind] ?? kind.replace(/-/g, ' ')
+}


### PR DESCRIPTION
Closes #1035.

Every badge in the session log should read plainly to someone seeing the UI for the first time. The badge showed the raw internal event kind, so a turn of the AI read `DRIVER`, the paused state read `SETTLED`, and the spend row read `USAGE`.

### Change
New `lib/event-labels.ts` with `eventKindLabel()`. `EventList` renders it instead of the raw kind.

| kind | before | after |
|---|---|---|
| `driver` | DRIVER | **AGENT** |
| `settled` | SETTLED | **WAITING** |
| `usage` | USAGE | **COST** |
| `session-update` | SESSION-UPDATE | **RESUME** |
| `system-prompt` | SYSTEM-PROMPT | SYSTEM PROMPT |
| everything else | (raw) | de-hyphenated |

Only the jargon kinds are overridden; every other kind falls back to its name with hyphens turned to spaces. `log` stays `LOG` on purpose (it carries budget/quota/backlog notes as well as "You: …", so it isn't a "you" row).

Words are a one-line change in the map if any should read differently.

### Verify
- New `lib/event-labels.test.ts`.
- 313 dashboard tests pass, typecheck clean.
