### PR TITLE
Widen the session-log badge column so SYSTEM PROMPT fits one line

### DIFF
--- a/.changeset/wider-log-badge-column.md
+++ b/.changeset/wider-log-badge-column.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Dashboard: widen the session-log badge column so "SYSTEM PROMPT" fits on one line. The badge column was narrow enough that the one two-word label wrapped to two lines; the column now fits it (measured at 106px, column is 112px).

--- a/packages/framework-dashboard/components/EventList.tsx
+++ b/packages/framework-dashboard/components/EventList.tsx
@@ -63,8 +63,8 @@ export function EventList({
               const at = receivedAt(e)
               return (
                 <MessageScrollerItem key={i} messageId={String(i)} scrollAnchor={isTurnBoundary(e)} className="flex items-start gap-2">
-                  {/* Fixed-width badge column so the text lines up whether or not this row repeats the kind. */}
-                  <span className="w-20 shrink-0">
+                  {/* Fixed-width badge column so the text lines up whether or not this row repeats the kind. Wide enough for the longest common label ("system prompt") to sit on one line. */}
+                  <span className="w-28 shrink-0">
                     {chunkHead && <Badge className="mt-0.5 text-[10px] uppercase text-muted-foreground">{eventKindLabel(e.kind)}</Badge>}
                   </span>
                   {disclosable ? (


### PR DESCRIPTION
Follow-up to #1038 (plain-language log labels).

The one two-word label, `SYSTEM PROMPT`, wrapped to two lines because the fixed badge column was 80px. Measured its rendered width at 106px, so the column is now 112px (`w-20` -> `w-28`) and it sits on one line. Every other label already fit; the rare long lifecycle labels (`ready for merge`, etc.) still wrap, which is fine.

Verified live: the `SYSTEM PROMPT` badge is 19px tall (one line) at the new width.
