### PR TITLE
Read the session log as a conversation (YOU/AGENT, Markdown, collapse)

### DIFF
--- a/.changeset/conversation-view.md
+++ b/.changeset/conversation-view.md
@@ -1,0 +1,9 @@
+---
+'@gemstack/framework': minor
+---
+
+Dashboard: the session log reads like a conversation. Your prompt is its own `YOU` row and the agent's turn is `AGENT`, so a message is no longer echoed twice — the redundant `You: …` log line is gone and the first prompt and every follow-up now read the same way.
+
+Both your prompts and the agent's replies render as Markdown (headings, bold, lists, code, links), at the log's own density. A short message renders inline; a long one collapses to its first line with a chevron and expands in place on click, so the log stays scannable without hiding the text.
+
+Also: the sessions rail's home row is now "New session" (a launcher) instead of "Live", and a session's id is always offered for copy in the toolbar (the exact string `--resume` takes), beside the existing copy-branch action.

--- a/packages/framework-dashboard/components/EventList.test.tsx
+++ b/packages/framework-dashboard/components/EventList.test.tsx
@@ -1,0 +1,42 @@
+import type { FrameworkEvent } from '@gemstack/framework'
+import { afterEach, describe, expect, test } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { EventList } from './EventList.js'
+
+afterEach(cleanup)
+
+// The conversation view: the user's prompt is its own YOU row, the agent's reply is AGENT and
+// renders as Markdown, and a long message collapses to its first line (#1035 follow-up).
+describe('EventList conversation rows', () => {
+  test('a prompt reads YOU and a reply reads AGENT', () => {
+    const events: FrameworkEvent[] = [
+      { kind: 'driver', event: { type: 'start', prompt: 'what is your name?' } },
+      { kind: 'driver', event: { type: 'text', text: 'I am **Claude**.' } },
+    ]
+    render(<EventList events={events} stick={false} />)
+    expect(screen.getByText('you')).toBeTruthy()
+    expect(screen.getByText('agent')).toBeTruthy()
+  })
+
+  test('a prompt renders its text inline', () => {
+    render(<EventList events={[{ kind: 'driver', event: { type: 'start', prompt: 'what is your name?' } }]} stick={false} />)
+    expect(screen.getByText('what is your name?')).toBeTruthy()
+  })
+
+  test('a reply renders Markdown (bold, not raw asterisks)', () => {
+    render(<EventList events={[{ kind: 'driver', event: { type: 'text', text: 'I am **Claude**.' } }]} stick={false} />)
+    const strong = document.querySelector('strong')
+    expect(strong?.textContent).toBe('Claude')
+  })
+
+  test('a long message collapses to its first line and offers to expand', () => {
+    render(<EventList events={[{ kind: 'driver', event: { type: 'text', text: 'word '.repeat(40) } }]} stick={false} />)
+    expect(screen.getByLabelText('Expand message')).toBeTruthy()
+  })
+
+  test('a short message renders inline without a collapse control', () => {
+    render(<EventList events={[{ kind: 'driver', event: { type: 'text', text: 'all done' } }]} stick={false} />)
+    expect(screen.queryByLabelText('Expand message')).toBeNull()
+    expect(screen.getByText('all done')).toBeTruthy()
+  })
+})

--- a/packages/framework-dashboard/components/EventList.tsx
+++ b/packages/framework-dashboard/components/EventList.tsx
@@ -1,7 +1,9 @@
 import type { FrameworkEvent } from '@gemstack/framework'
 import { formatFrameworkEvent } from '@gemstack/framework/client'
+import { useState } from 'react'
 import { eventKindLabel } from '../lib/event-labels.js'
 import { receivedAt } from '../lib/event-times.js'
+import { Markdown } from './Markdown.js'
 import { Badge } from './ui/badge.js'
 import {
   MessageScroller,
@@ -12,24 +14,51 @@ import {
   MessageScrollerViewport,
 } from './ui/message-scroller.js'
 
-// Presentational event log, shared by the live stream and past-run replay. Each
-// FrameworkEvent renders as its human-readable line (the same formatter the terminal
-// uses, so a `driver` turn reads "· Read" / "‹ turn complete" rather than raw JSON),
-// with the kind badge shown once per run of same-kind lines — a 200-line driver turn
-// used to be 200 identical "DRIVER" badges (#948). Live rows carry their arrival time
-// at each kind boundary; replayed events were never live, so they show none.
-// Scrolling rides shadcn's Base UI message-scroller (#712): live follows the edge
-// (`autoScroll`) but yields the moment the reader scrolls up, replay renders static from the
-// top, and the "Jump to latest" chip is the scroller's own inert-when-not-scrollable button —
-// replacing the hand-rolled U19 stick/jump logic.
-// The prompt-disclosure surface (#476/#520): the full text rides on the event, but the
-// one-line formatter reduces it to a char count (a driver `start`'s prompt) or drops it (a
-// system prompt). So the "see every prompt without a script" block renders it here; every
-// other event renders as its formatted line. Returns null for the non-disclosable events.
+// Presentational event log, shared by the live stream and past-run replay. Most events render as
+// their human-readable line (the same formatter the terminal uses, so a `driver` turn reads
+// "· Read" / "‹ turn complete" rather than raw JSON). Two things get special rows:
+//   - The message text: the user's prompt (`driver` `start`) and the agent's reply (`driver` `text`)
+//     render their raw text inline, truncated to one line when long and expanding in place on click
+//     (#476/#520). The prompt carries its own YOU badge so the log reads like a conversation.
+//   - The system prompt keeps a char-count summary with the full text behind a click.
+// The kind badge shows once per run of same-group rows — a 200-line driver turn used to be 200
+// identical badges (#948). A driver `start` breaks out of the AGENT group so the user's turn gets
+// its own YOU badge. Live rows carry their arrival time at each group boundary; replayed events were
+// never live, so they show none. Scrolling rides shadcn's Base UI message-scroller (#712): live
+// follows the edge (`autoScroll`) but yields the moment the reader scrolls up, replay renders static
+// from the top, and the "Jump to latest" chip is the scroller's own inert-when-not-scrollable button.
+
+/** The system prompt: a char-count summary with the full text behind a click. */
 function disclosableText(e: FrameworkEvent): { text: string; label: string } | null {
   if (e.kind === 'system-prompt') return { text: e.text, label: 'system prompt sent' }
-  if (e.kind === 'driver' && e.event.type === 'start') return { text: e.event.prompt, label: '› prompt sent' }
   return null
+}
+
+// The conversation text — the user's prompt (YOU) and the agent's reply (AGENT). Both are rendered
+// as Markdown: the agent writes in Markdown, and a prompt may too.
+function messageText(e: FrameworkEvent): string | null {
+  if (e.kind !== 'driver') return null
+  if (e.event.type === 'start') return e.event.prompt
+  if (e.event.type === 'text') return e.event.text
+  return null
+}
+
+// Long enough that an inline row truncates to one line and offers to expand. Mirrors terminal.ts's
+// `truncate`: collapse whitespace, trim, compare to 100.
+function isLong(text: string): boolean {
+  return text.replace(/\s+/g, ' ').trim().length > 100
+}
+
+/** Grouping key for the once-per-run badge: the user's prompt stands apart from the agent's work. */
+function rowGroup(e: FrameworkEvent): string {
+  if (e.kind === 'driver') return e.event.type === 'start' ? 'you' : 'agent'
+  return e.kind
+}
+
+/** The badge word for a row: the user's prompt reads YOU, everything else its kind label. */
+function rowLabel(e: FrameworkEvent): string {
+  if (e.kind === 'driver' && e.event.type === 'start') return 'you'
+  return eventKindLabel(e.kind)
 }
 
 // A driver `start` opens a fresh prompt turn — the natural anchor the scroller keeps in view.
@@ -40,6 +69,40 @@ function isTurnBoundary(e: FrameworkEvent): boolean {
 /** HH:MM:SS in the reader's locale, for the arrival-time column. */
 function formatTime(ms: number): string {
   return new Date(ms).toLocaleTimeString()
+}
+
+// A conversation message (a prompt or a reply), rendered as compact Markdown. A short one renders
+// as-is. A long one clamps to its first line with a chevron beside it and expands in place on click —
+// the chevron stays on that first line (never a lone chevron on its own row), and the same rendered
+// Markdown just unclamps, so the opening is never shown twice.
+function Message({ text }: { text: string }) {
+  const [open, setOpen] = useState(false)
+  if (!isLong(text)) {
+    return (
+      <div className="min-w-0 flex-1">
+        <Markdown text={text} compact />
+      </div>
+    )
+  }
+  return (
+    <div className="flex min-w-0 flex-1 items-start gap-1.5">
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        aria-expanded={open}
+        aria-label={open ? 'Collapse message' : 'Expand message'}
+        className={`shrink-0 select-none text-muted-foreground transition-transform ${open ? 'rotate-90' : ''}`}
+      >
+        ›
+      </button>
+      <div
+        className={open ? 'min-w-0 flex-1' : 'max-h-[1.35rem] min-w-0 flex-1 cursor-pointer overflow-hidden'}
+        onClick={open ? undefined : () => setOpen(true)}
+      >
+        <Markdown text={text} compact />
+      </div>
+    </div>
+  )
 }
 
 export function EventList({
@@ -59,21 +122,26 @@ export function EventList({
           <MessageScrollerContent className="gap-1 p-4 font-mono text-xs">
             {events.map((e, i) => {
               const disclosable = disclosableText(e)
-              const chunkHead = i === 0 || events[i - 1]?.kind !== e.kind
+              const message = messageText(e)
+              const prev = i > 0 ? events[i - 1] : undefined
+              const chunkHead = !prev || rowGroup(prev) !== rowGroup(e)
               const at = receivedAt(e)
               return (
                 <MessageScrollerItem key={i} messageId={String(i)} scrollAnchor={isTurnBoundary(e)} className="flex items-start gap-2">
-                  {/* Fixed-width badge column so the text lines up whether or not this row repeats the kind. Wide enough for the longest common label ("system prompt") to sit on one line. */}
+                  {/* Fixed-width badge column so the text lines up whether or not this row repeats the badge. Wide enough for the longest common label ("system prompt") to sit on one line. */}
                   <span className="w-28 shrink-0">
-                    {chunkHead && <Badge className="mt-0.5 text-[10px] uppercase text-muted-foreground">{eventKindLabel(e.kind)}</Badge>}
+                    {chunkHead && <Badge className="mt-0.5 text-[10px] uppercase text-muted-foreground">{rowLabel(e)}</Badge>}
                   </span>
                   {disclosable ? (
                     <details className="min-w-0 flex-1">
                       <summary className="cursor-pointer text-foreground marker:text-muted-foreground">
-                        {disclosable.label} ({disclosable.text.length.toLocaleString()} chars) — click to expand
+                        {disclosable.label} ({disclosable.text.length.toLocaleString()} chars)
                       </summary>
                       <pre className="mt-1 max-h-96 overflow-auto whitespace-pre-wrap break-words rounded bg-muted p-2 text-foreground">{disclosable.text}</pre>
                     </details>
+                  ) : message !== null ? (
+                    // A prompt (YOU) or a reply (AGENT): compact Markdown, collapsed to its first line when long.
+                    <Message text={message} />
                   ) : (
                     <span className="min-w-0 flex-1 whitespace-pre-wrap break-words text-foreground">{(formatFrameworkEvent(e) ?? '').trim()}</span>
                   )}

--- a/packages/framework-dashboard/components/Markdown.test.tsx
+++ b/packages/framework-dashboard/components/Markdown.test.tsx
@@ -50,3 +50,19 @@ describe('Markdown links (#948)', () => {
     expect(screen.getByText('curl https://example.com')).toBeTruthy()
   })
 })
+
+// `compact` shrinks the renderer a notch so a reply reads at the density of the event log.
+describe('Markdown compact', () => {
+  test('the body renders at text-xs', () => {
+    const { container } = render(<Markdown text="hello" compact />)
+    expect(container.querySelector('.text-xs')).toBeTruthy()
+  })
+
+  test('a heading is smaller than its full-size counterpart', () => {
+    const { unmount } = render(<Markdown text={'# Section'} compact />)
+    expect(screen.getByText('Section').className).toContain('text-sm')
+    unmount()
+    render(<Markdown text={'# Section'} />)
+    expect(screen.getByText('Section').className).toContain('text-lg')
+  })
+})

--- a/packages/framework-dashboard/components/Markdown.tsx
+++ b/packages/framework-dashboard/components/Markdown.tsx
@@ -7,8 +7,14 @@ import { Fragment, type ReactNode } from 'react'
 // the reader wants to click; http(s) only, so no javascript: smuggling), and pipe tables
 // (#869 — an agent comparing options or listing files reaches for one, and it rendered as
 // raw pipes). Anything else falls through as a paragraph.
-export function Markdown({ text }: { text: string }) {
-  return <div className="space-y-2 text-sm leading-relaxed">{renderBlocks(text)}</div>
+// `compact` shrinks everything a notch (text-xs, smaller headings) so a reply reads at the density
+// of the surrounding event log rather than a full document.
+export function Markdown({ text, compact = false }: { text: string; compact?: boolean }) {
+  return (
+    <div className={compact ? 'space-y-1.5 text-xs leading-relaxed' : 'space-y-2 text-sm leading-relaxed'}>
+      {renderBlocks(text, compact)}
+    </div>
+  )
 }
 
 // A fenced-code block, rendered both when its closing fence arrives and when the doc ends
@@ -34,7 +40,7 @@ function isTableSeparator(row: string): boolean {
   return tableCells(row).length > 0 && tableCells(row).every(c => /^:?-{3,}:?$/.test(c))
 }
 
-function renderBlocks(text: string): ReactNode[] {
+function renderBlocks(text: string, compact = false): ReactNode[] {
   const lines = text.replace(/\r\n/g, '\n').split('\n')
   const blocks: ReactNode[] = []
   let list: ReactNode[] = []
@@ -121,7 +127,9 @@ function renderBlocks(text: string): ReactNode[] {
     if (heading) {
       flushList()
       const level = heading[1]!.length
-      const sizes = ['text-lg', 'text-base', 'text-sm', 'text-sm', 'text-sm', 'text-sm']
+      const sizes = compact
+        ? ['text-sm', 'text-sm', 'text-xs', 'text-xs', 'text-xs', 'text-xs']
+        : ['text-lg', 'text-base', 'text-sm', 'text-sm', 'text-sm', 'text-sm']
       blocks.push(
         <p key={key++} className={`font-semibold ${sizes[level - 1]}`}>
           {inline(heading[2]!)}

--- a/packages/framework-dashboard/components/RunActionBar.tsx
+++ b/packages/framework-dashboard/components/RunActionBar.tsx
@@ -123,7 +123,9 @@ export function RunActionBar({
         {onDeleted && !active && runId && (
           <DeleteSessionButton projectId={projectId} runId={runId} label={label} onDeleted={onDeleted} />
         )}
-        {!session && info?.sessionId && (
+        {/* The session id is the exact string a `--resume` takes (#948), useful even when the deep
+            link below is also shown, so it is always offered for copy when a session has one. */}
+        {info?.sessionId && (
           <CopyButton text={info.sessionId} label={`Copy session id (${info.sessionId})`} className="p-1.5" />
         )}
         {session && (

--- a/packages/framework-dashboard/components/RunHistory.test.tsx
+++ b/packages/framework-dashboard/components/RunHistory.test.tsx
@@ -37,7 +37,7 @@ describe('RunHistory (#785)', () => {
 
   test('a session selected before its row lands highlights the starting row (#784)', () => {
     // Start navigates to the run's id right away; its run.json, and so its row, arrives a beat
-    // later. The highlight belongs on the optimistic row standing in for it, not on Live.
+    // later. The highlight belongs on the optimistic row standing in for it, not on the home row.
     const { container, rerender } = render(
       <RunHistory projectId="p1" runs={[]} selectedRunId={null} onSelect={() => {}} startTick={0} startIntent="" />,
     )
@@ -45,10 +45,10 @@ describe('RunHistory (#785)', () => {
       <RunHistory projectId="p1" runs={[]} selectedRunId="run-2" onSelect={() => {}} startTick={1} startIntent="add dark mode" />,
     )
     const rows = [...container.querySelectorAll('button')]
-    const live = rows.find(row => row.textContent?.includes('Live'))
+    const home = rows.find(row => row.textContent?.includes('New session'))
     const starting = rows.find(row => row.textContent?.includes('starting…'))
     expect(starting?.className).toContain('bg-accent')
-    expect(live?.className).not.toContain('bg-accent')
+    expect(home?.className).not.toContain('bg-accent')
   })
 
   test('a finished run is finished, never waiting', () => {

--- a/packages/framework-dashboard/components/RunHistory.tsx
+++ b/packages/framework-dashboard/components/RunHistory.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Plus } from 'lucide-react'
 import type { RunMeta, RunStatus } from '@gemstack/framework'
 import { AGENT_LABELS, agentForDriver } from '@gemstack/framework/client'
 import { Button } from './ui/button.js'
@@ -13,7 +14,7 @@ import { ScrollArea } from './ui/scroll-area.js'
 /** A label hidden in the collapsed strip, revealed by hover/focus on the rail (#862). */
 const FADED_LABEL = 'opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100'
 
-// The Runs rail (#314 second sidebar). "Live" is the permanent home/launcher — selecting it
+// The Runs rail (#314 second sidebar). "New session" is the permanent home/launcher — selecting it
 // shows the Start form + cards (ProjectHome), and it is never consumed by a run. Every run
 // (live + archived, from `onRuns`) is its own row below it; selecting a run shows that run's
 // own view (its live output while running, a replay once finished). `runs` is owned by the
@@ -103,15 +104,15 @@ export function RunHistory({
       </div>
       <ScrollArea className="min-h-0 flex-1">
         <div className="px-2">
-        {/* Permanent home / launcher — always present, never a run. */}
+        {/* Permanent home / launcher — always present, never a run: starting a new session. */}
         <Button
           variant="ghost"
           className={cn('mb-1 w-full justify-start', collapsed && 'justify-center px-0', atHome && 'bg-accent text-accent-foreground')}
           onClick={() => onSelect(null)}
-          title={collapsed ? 'Live' : undefined}
+          title={collapsed ? 'New session' : undefined}
         >
-          <span className={cn('inline-block h-2 w-2 shrink-0 rounded-full bg-primary', !collapsed && 'mr-2')} />
-          <span className={cn('whitespace-nowrap', label)}>Live</span>
+          <Plus className={cn('h-4 w-4 shrink-0', !collapsed && 'mr-2')} />
+          <span className={cn('whitespace-nowrap', label)}>New session</span>
         </Button>
 
         {/* A just-started run, before its run.json exists — highlighted while following it. */}

--- a/packages/framework/src/await-gate.ts
+++ b/packages/framework/src/await-gate.ts
@@ -221,7 +221,8 @@ export async function runChatPhase(session: DriverSession, messages: RunMessages
     deps.emit({ kind: 'settled' })
     const message = await messages.next(deps.signal)
     if (message === undefined) return { turn, exhausted } // Stop / budget cap: end the conversation.
-    deps.emit({ kind: 'log', message: `You: ${message.text}` })
+    // The message shows in the feed as the driver's own `start` event (the YOU row), so it is not
+    // echoed as a separate log line — that only duplicated it.
     deps.recordMessage?.('user', message.text, message.via)
     turn = await session.prompt(message.text, { ...signalOpt, resume: true })
     deps.emitTurnSignals(turn.text)

--- a/packages/framework/src/prompt-run.test.ts
+++ b/packages/framework/src/prompt-run.test.ts
@@ -107,12 +107,11 @@ test('runPrompt stays open for a live-chat message and delivers it as a turn (#7
   })
   // The final turn is the chat reply, not the opening turn.
   assert.equal(text, 'added dark mode')
-  // The message rode a driver `start` event (so it shows in the feed) and was echoed as a log.
+  // The message rode a driver `start` event, which is how it shows in the feed (the YOU row).
   assert.ok(
     events.some(e => e.kind === 'driver' && e.event.type === 'start' && e.event.prompt === 'also add dark mode'),
     'the chat message was delivered as a driver turn',
   )
-  assert.ok(events.some(e => e.kind === 'log' && e.message === 'You: also add dark mode'))
   assert.deepEqual(events.at(-1), { kind: 'end', ok: true })
 })
 

--- a/packages/framework/src/run.test.ts
+++ b/packages/framework/src/run.test.ts
@@ -893,7 +893,8 @@ test('runAwaitRounds gives up after MAX_AWAIT_ROUNDS and reports it exhausted', 
 test('the run says it is parked each time it waits for the user (#785)', async () => {
   // The build settles, chat opens: that is the moment the agent stops working and the run is
   // waiting on you. Before #785 nothing said so, and the dashboard kept animating "running".
-  const driver = new FakeDriver({ respond: () => 'built it' })
+  const prompts: string[] = []
+  const driver = new FakeDriver({ respond: prompt => (prompts.push(prompt), 'built it') })
   const session = await driver.start({ cwd: '/tmp/ws' })
   const messages = new RunMessageQueue()
   const events: FrameworkEvent[] = []
@@ -915,7 +916,7 @@ test('the run says it is parked each time it waits for the user (#785)', async (
   // dashboard can stop animating the moment the agent stops. (The matching "working again"
   // edge is the driver's own `start` event, which applyEventToMeta clears the flag on.)
   assert.equal(events.filter(e => e.kind === 'settled').length, 2)
-  assert.ok(events.some(e => e.kind === 'log' && e.message === 'You: now add dark mode'), 'the chat turn ran between the two parks')
+  assert.ok(prompts.includes('now add dark mode'), 'the chat turn ran between the two parks')
 })
 
 test('runAwaitRounds does not report exhausted when a chat phase follows the opening cap (#742)', async () => {


### PR DESCRIPTION
Follow-up to the session-log label work (#1035/#1038). Makes the session log read like a conversation, driven by live feedback.

### What changed
- **YOU / AGENT rows.** Your prompt (`driver start`) is its own `YOU` row; the agent's turn is `AGENT`. A message shows once — the redundant `You: …` log echo is removed (`await-gate.ts`), so the first prompt and every follow-up read the same way (before, follow-ups showed twice).
- **Markdown.** Both your prompts and the agent's replies render as Markdown — headings, bold, lists, code, links. A new `compact` variant on `Markdown` renders at the log's density (`text-xs`, smaller headings); its other uses (plans, pushed views) are unchanged.
- **Collapse long messages.** A short message renders inline; a long one clamps to its first (formatted) line with a `›` chevron beside it and expands in place on click — the preview is never shown twice and the chevron never lands on its own row.
- **Sessions rail.** The home/launcher row is now **New session** (`＋`) instead of `Live`.
- **Toolbar.** A session's id is always offered for copy (the exact string `--resume` takes), beside the existing copy-branch/workspace action — it was previously hidden whenever a claude.ai deep link was present.

### Verify
- New `EventList.test.tsx` (YOU/AGENT grouping, Markdown reply, long-message collapse) + `Markdown` compact tests + `RunHistory` test updated.
- Framework `await-gate` change: the two tests that keyed on the `You:` echo now key on the actual chat-turn signal (driver `start` / the driver prompt).
- 320 dashboard tests, 1115 framework tests (1 skipped) pass; both typechecks; build green.
- Driven end-to-end in a real browser at each step (collapsed/expanded, short/long, prompt+reply, rail, toolbar).
