### PR TITLE
feat(framework): context fragment points the knowledge base at a knowledge-base/ folder (#683)

### DIFF
--- a/.changeset/context-fragment-knowledge-base.md
+++ b/.changeset/context-fragment-knowledge-base.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/framework': minor
+---
+
+feat(framework): context fragment points the knowledge base at a `knowledge-base/` folder (#683)
+
+Splits the flat `KNOWLEDGE-BASE.md` into `knowledge-base/FACTS.md` and `knowledge-base/INSIGHTS.md`, and moves `DECISIONS.md` and `MARKET_RESEARCH.md` under `knowledge-base/`, with a `knowledge-base/**.md` catch-all. The on-before-mergeable prompt and the Market research preset name the same paths.

--- a/packages/framework/prompts/on_before_mergeable_prompt.md
+++ b/packages/framework/prompts/on_before_mergeable_prompt.md
@@ -12,7 +12,8 @@ If the changes introduced by ${{ tf.session_name }} can potentially lead to secu
 ## Business knowledge
 
 If you didn't already, consider updating the following based on the changes and discussions of ${{ tf.session_name }} (you can create the files if they're missing):
-- `DECISIONS.md` (decisions taken, and why)
-- `KNOWLEDGE-BASE.md` (knowledge and insights related to the project)
+- `knowledge-base/DECISIONS.md` (decisions taken, and why)
+- `knowledge-base/FACTS.md` (non-obvious facts relevant to the project)
+- `knowledge-base/INSIGHTS.md` (insights relevant to the project)
 
 Only write what a future agent would need and cannot get from the code itself.

--- a/packages/framework/prompts/presets/market_research.md
+++ b/packages/framework/prompts/presets/market_research.md
@@ -1,5 +1,5 @@
 - Make a thorough market research
-- Write it to `MARKET_RESEARCH.md`
+- Write it to `knowledge-base/MARKET_RESEARCH.md`
 - Add TODO_AGENTS.md entry: "Read <SESSION_NAME> then suggest new tickets"
 
 SESSION_NAME: the name of the session

--- a/packages/framework/src/system-prompt.test.ts
+++ b/packages/framework/src/system-prompt.test.ts
@@ -22,10 +22,12 @@ const KNOWLEDGE_CONTEXT = `Context:\n${KNOWLEDGE_LINES}`
 test('CONTEXT_DOCS is the #683 fragment: business knowledge plus the roadmap/queue pointers', () => {
   const paths = CONTEXT_DOCS.map(d => d.path)
   assert.deepEqual(paths, [
-    'DECISIONS.md',
+    'knowledge-base/DECISIONS.md',
     'GOAL.md',
-    'KNOWLEDGE-BASE.md',
-    'MARKET_RESEARCH.md',
+    'knowledge-base/FACTS.md',
+    'knowledge-base/INSIGHTS.md',
+    'knowledge-base/MARKET_RESEARCH.md',
+    'knowledge-base/**.md',
     'tickets/**.md',
     'TODO_AGENTS.md',
   ])
@@ -34,7 +36,7 @@ test('CONTEXT_DOCS is the #683 fragment: business knowledge plus the roadmap/que
   // GOAL / market research / tickets / TODO_AGENTS are read-only context, so they are not in the
   // merge-update set.
   const businessPaths = BUSINESS_KNOWLEDGE_DOCS.map(d => d.path)
-  for (const p of ['GOAL.md', 'MARKET_RESEARCH.md', 'tickets/**.md', 'TODO_AGENTS.md']) {
+  for (const p of ['GOAL.md', 'knowledge-base/MARKET_RESEARCH.md', 'knowledge-base/**.md', 'tickets/**.md', 'TODO_AGENTS.md']) {
     assert.ok(!businessPaths.includes(p))
   }
   // The ticket-format pointer is inlined here (this module stays node-free), so pin it to the

--- a/packages/framework/src/system-prompt.ts
+++ b/packages/framework/src/system-prompt.ts
@@ -94,11 +94,11 @@ export interface ContextDoc {
   comment: string
 }
 
-const DECISIONS_DOC: ContextDoc = { path: 'DECISIONS.md', comment: 'decisions taken, and why' }
-const KNOWLEDGE_BASE_DOC: ContextDoc = {
-  path: 'KNOWLEDGE-BASE.md',
-  comment: 'observed facts, non-obvious knowledge, and insights relevant to the project',
-}
+// The knowledge base lives under `knowledge-base/` (#683): one file per kind rather than a
+// single flat doc, so the agent folds each learning back into the right file.
+const DECISIONS_DOC: ContextDoc = { path: 'knowledge-base/DECISIONS.md', comment: 'decisions taken, and why' }
+const FACTS_DOC: ContextDoc = { path: 'knowledge-base/FACTS.md', comment: 'non-obvious facts relevant to the project' }
+const INSIGHTS_DOC: ContextDoc = { path: 'knowledge-base/INSIGHTS.md', comment: 'insights relevant to the project' }
 
 /**
  * The business-knowledge docs (#537): what the repo has learned about itself, which the
@@ -107,7 +107,7 @@ const KNOWLEDGE_BASE_DOC: ContextDoc = {
  * agent is never told to read one set of files and update another (pinned by a test). A
  * subset of {@link CONTEXT_DOCS}.
  */
-export const BUSINESS_KNOWLEDGE_DOCS: readonly ContextDoc[] = [DECISIONS_DOC, KNOWLEDGE_BASE_DOC]
+export const BUSINESS_KNOWLEDGE_DOCS: readonly ContextDoc[] = [DECISIONS_DOC, FACTS_DOC, INSIGHTS_DOC]
 
 /**
  * Everything the agent keeps in context at the start of a run (#683), which
@@ -124,11 +124,14 @@ export const BUSINESS_KNOWLEDGE_DOCS: readonly ContextDoc[] = [DECISIONS_DOC, KN
 export const CONTEXT_DOCS: readonly ContextDoc[] = [
   DECISIONS_DOC,
   { path: 'GOAL.md', comment: 'the goal of the project (long-term direction, scope, non-scope, ...)' },
-  KNOWLEDGE_BASE_DOC,
+  FACTS_DOC,
+  INSIGHTS_DOC,
   // What the market looks like (#694): written by the [Market research] preset and read by the
   // follow-up that turns it into tickets. A pointer the agent reads, not a doc it folds knowledge
   // back into, so it stays out of BUSINESS_KNOWLEDGE_DOCS.
-  { path: 'MARKET_RESEARCH.md', comment: 'the market the project competes in' },
+  { path: 'knowledge-base/MARKET_RESEARCH.md', comment: 'the market the project competes in' },
+  // The catch-all (#683): any other file the agent parks under knowledge-base/.
+  { path: 'knowledge-base/**.md', comment: 'more files holding knowledge related to the project' },
   { path: 'tickets/**.md', comment: 'things to potentially work on; format: node_modules/@gemstack/framework/prompts/ticketing_format.md' },
   { path: 'TODO_AGENTS.md', comment: 'the AI task queue; format: node_modules/@gemstack/framework/prompts/todo_format.md' },
 ]

--- a/packages/framework/src/tickets.ts
+++ b/packages/framework/src/tickets.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 /**
  * The root `tickets/` directory (#629): a plain repo convention where The Framework
  * keeps its human-facing roadmap files, rather than hiding them in a proprietary
- * `.the-framework/` dir. It sits beside conventions like a root `DECISIONS.md`. Since
+ * `.the-framework/` dir. It sits beside conventions like the `knowledge-base/` docs. Since
  * #682 moved the backlog out to a root `TODO_AGENTS.md`, this directory holds only
  * ticket files (`<DATE>_<SLUG>.md`).
  */


### PR DESCRIPTION
Closes #683.

Rom re-spec'd the context prompt fragment (updated the #683 OP) to keep the knowledge base under a `knowledge-base/` folder, one file per kind.

## Changes to `CONTEXT_DOCS` (the `Context:` bullets each run gets)
- `DECISIONS.md` -> `knowledge-base/DECISIONS.md`
- `KNOWLEDGE-BASE.md` (one flat doc) -> split into `knowledge-base/FACTS.md` + `knowledge-base/INSIGHTS.md`
- `MARKET_RESEARCH.md` -> `knowledge-base/MARKET_RESEARCH.md`
- add `knowledge-base/**.md` catch-all
- `GOAL.md`, `tickets/**.md`, `TODO_AGENTS.md` stay at root

## Kept in sync (avoids the read-one-set-write-another drift)
- on-before-mergeable prompt `## Business knowledge` names the three writeback files
- Market research preset writes to `knowledge-base/MARKET_RESEARCH.md`
- pinned tests updated (`system-prompt.test.ts`)

Clean switch, no legacy `KNOWLEDGE-BASE.md` fallback (brand-new layout, nothing relies on the old path yet).

61 affected framework tests pass. The `daemon.test.js` failures in a bare worktree are the pre-existing dashboard-bundle env issue, untouched here.