### PR TITLE
feat(dashboard): launcher composer and rail UX pass

### DIFF
--- a/.changeset/launcher-composer-uiux.md
+++ b/.changeset/launcher-composer-uiux.md
@@ -1,0 +1,14 @@
+---
+"@gemstack/framework": minor
+---
+
+Dashboard launcher and rail UX pass:
+
+- The prompt editor and its run controls are grouped into one rounded "composer box"; the editor loses its own border and focus ring, and the placeholder and typed text get roomier padding.
+- The submit button is a single arrow icon that stays hidden until the prompt has text, then fades in and slides into place, pushing the model select over smoothly (a spinner shows while starting or sending).
+- The agent/model select sits just left of the submit button, borderless, with the model shown as selected (the default reads "Default", no separator dot).
+- Presets is a borderless slash icon, the options gear is borderless with a smaller count badge, and all controls share one height.
+- "Open in editor" moved out of the options gear onto the workspace editor button, which now opens the checkout and picks the preferred editor.
+- The right rail holds one fixed width for every tab (no expand on Views/Browser).
+- The sessions rail: "New session" is now "New", the "Sessions" heading is replaced by a "Recents" label over the list, the agent logo is smaller, and rows clear the scrollbar.
+- The session toolbar drops the copy-branch and copy-session-id buttons, and the branch dirty/clean indicator sits closer to the branch name.

--- a/packages/framework-dashboard/components/AgentModelMenu.tsx
+++ b/packages/framework-dashboard/components/AgentModelMenu.tsx
@@ -63,14 +63,13 @@ export function AgentModelMenu({
         type="button"
         disabled={busy}
         title={`Agent: ${current?.label ?? ''} · Model: ${currentModelLabel}`}
-        className={cn(buttonVariants({ variant: 'outline', size: 'xs' }), 'gap-1.5 font-normal')}
+        className={cn(buttonVariants({ variant: 'ghost', size: 'sm' }), 'gap-1.5 font-normal')}
       >
         {current?.icon ? (
           <span className="flex h-4 w-4 items-center justify-center">{current.icon}</span>
         ) : (
           current?.label
         )}
-        <span className="text-[var(--color-muted-foreground)]">·</span>
         {currentModelLabel}
         <ChevronDown className="h-3.5 w-3.5 opacity-70" />
       </DropdownMenuTrigger>

--- a/packages/framework-dashboard/components/Composer.test.tsx
+++ b/packages/framework-dashboard/components/Composer.test.tsx
@@ -77,6 +77,8 @@ describe('Composer (#721)', () => {
     expect(screen.getByRole('button', { name: /Presets/ })).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Session options' })).toBeTruthy()
     expect(screen.getByTitle(/Agent: Claude Code/)).toBeTruthy() // the agent/model trigger
+    // The submit button appears only once the prompt has text (#721).
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'x' } })
     expect(screen.getByRole('button', { name: /Start session/ })).toBeTruthy()
   })
 
@@ -132,11 +134,12 @@ describe('Composer (#721)', () => {
     expect(screen.getByText(/only applies while Post-merge cleanup is on/)).toBeTruthy()
   })
 
-  test('the submit button is disabled until the editor has text, then fires onSubmit', () => {
+  test('the submit button is hidden until the editor has text, then appears and fires onSubmit', () => {
     const { onSubmit } = renderComposer()
-    const submit = screen.getByRole('button', { name: 'Send' })
-    expect(submit.hasAttribute('disabled')).toBe(true)
+    // Empty prompt: nothing to send, so the button is not in the DOM (#721).
+    expect(screen.queryByRole('button', { name: 'Send' })).toBeNull()
     fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'ship it' } })
+    const submit = screen.getByRole('button', { name: 'Send' })
     expect(submit.hasAttribute('disabled')).toBe(false)
     fireEvent.click(submit)
     expect(onSubmit).toHaveBeenCalledWith('ship it', 'build', { newSession: false })

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, useImperativeHandle, useMemo, useRef, useState, type FormEvent } from 'react'
+import { ArrowUp, Loader2 } from 'lucide-react'
 import type { ProjectSummary } from '@gemstack/framework'
 import { AGENTS, AGENT_LABELS, LAUNCHER_PRESETS, type AgentName } from '@gemstack/framework/client'
 import {
@@ -9,7 +10,6 @@ import {
   usePreferenceSources,
   useProjectFileConfig,
 } from '../lib/preferences.js'
-import { useDetectedEditors } from '../lib/editors.js'
 import { useLoaded } from '../lib/use-async.js'
 import { onProjects } from '../server/projects.telefunc.js'
 import { PromptEditor, type PromptEditorHandle } from './PromptEditor.js'
@@ -20,6 +20,7 @@ import { OptionsMenu, type OptionRow } from './OptionsMenu.js'
 import { ResolvedOptions } from './ResolvedOptions.js'
 import { ClaudeLogo, CodexLogo } from './agent-logos.js'
 import { Button } from './ui/button.js'
+import { cn } from '../lib/utils.js'
 
 // The presets (#353/#433): each PREFILLS the editor with a rendered prompt and runs it verbatim
 // (`kind: 'prompt'`). Emptying the box falls back to a normal `build` run. The list, its order and
@@ -35,7 +36,7 @@ const AGENT_UI: Record<AgentName, { icon: AgentOption['icon']; models: AgentOpti
   claude: {
     icon: <ClaudeLogo className="h-4 w-4" />,
     models: [
-      { value: '', label: 'Default model' },
+      { value: '', label: 'Default' },
       { value: 'opus', label: 'Opus' },
       { value: 'sonnet', label: 'Sonnet' },
       { value: 'haiku', label: 'Haiku' },
@@ -44,7 +45,7 @@ const AGENT_UI: Record<AgentName, { icon: AgentOption['icon']; models: AgentOpti
   codex: {
     icon: <CodexLogo className="h-4 w-4" />,
     models: [
-      { value: '', label: 'Default model' },
+      { value: '', label: 'Default' },
       { value: 'gpt-5-codex', label: 'GPT-5 Codex' },
       { value: 'gpt-5', label: 'GPT-5' },
       { value: 'o3', label: 'o3' },
@@ -85,8 +86,6 @@ export const Composer = forwardRef<ComposerHandle, {
   submitLabel: string
   submitBusyLabel: string
   placeholder?: string | undefined
-  /** Show the ⌘↵ hint on the submit button (the launcher's Start). */
-  showShortcutHint?: boolean | undefined
   /** Compact single-row form for the navbar quick-launch (#723): editor + submit, no control row
    *  or preset panel. The `/` `<` `@` `#` triggers still work; agent/model + options come from the
    *  shared prefs the launcher sets. */
@@ -103,7 +102,7 @@ export const Composer = forwardRef<ComposerHandle, {
    *  session exists yet. */
   sessionName?: string | undefined
 }>(function Composer(
-  { files, addContext, removeContext, onSubmit, onPromptChange, onPreset, busy, submitLabel, submitBusyLabel, placeholder, showShortcutHint = false, compact = false, showAgentModel = true, inSession = false, sessionName },
+  { files, addContext, removeContext, onSubmit, onPromptChange, onPreset, busy, submitLabel, submitBusyLabel, placeholder, compact = false, showAgentModel = true, inSession = false, sessionName },
   ref,
 ) {
   const [prompt, setPrompt] = useState('')
@@ -148,8 +147,6 @@ export const Composer = forwardRef<ComposerHandle, {
   // The stored agent as a display name; an unknown stored value falls back to Claude Code.
   const agentLabel = AGENT_LABELS[AGENTS.includes(agent as AgentName) ? (agent as AgentName) : 'claude']
   const customPresets = preferences.customPresets ?? [] // #626: the user's own saved prompts
-  const editor = preferences.editor // #727: preferred editor; undefined = $FRAMEWORK_EDITOR / code
-  const detectedEditors = useDetectedEditors() // #727: editors installed on the daemon's machine
   const theme = themePreference(preferences) // #725: system (default) / light / dark
 
   // Vanilla removes the system prompt (nothing left for Eco to trim); Transparent turns off the
@@ -255,17 +252,17 @@ export const Composer = forwardRef<ComposerHandle, {
   // one real omission: a run started from the navbar used the stored agent, model and options with
   // nothing on screen saying which. Every value is preferences-backed and global, so the same
   // controls in either place read and write the same state.
-  const controls = (
+  const agentModelEl = showAgentModel && (
+    <AgentModelMenu
+      agents={AGENT_OPTIONS}
+      agent={agent}
+      model={model}
+      onChange={(a, m) => updatePreferences({ agent: a, model: m })}
+      busy={busy}
+    />
+  )
+  const secondaryControls = (
     <>
-      {showAgentModel && (
-        <AgentModelMenu
-          agents={AGENT_OPTIONS}
-          agent={agent}
-          model={model}
-          onChange={(a, m) => updatePreferences({ agent: a, model: m })}
-          busy={busy}
-        />
-      )}
       {/* Presets get a visible surface (#948): load, create and delete in one menu, instead of
           loading only behind typing `/` and deleting off in the options gear. Not in the compact
           row, which has no room and no create panel. */}
@@ -286,12 +283,39 @@ export const Composer = forwardRef<ComposerHandle, {
         ecoOptions={inSession ? [] : ecoOptions}
         showEco={!inSession && eco && !ecoDisabled}
         busy={busy}
-        editor={editor}
-        editors={detectedEditors}
-        onEditorChange={e => updatePreferences({ editor: e ?? '' })}
         {...(inSession ? { label: 'Preferences' } : {})}
       />
     </>
+  )
+
+  // The submit is a single icon button that only shows once the prompt has text (#721): an empty
+  // launcher has nothing to send, and the arrow reads as "send" in either place (Start session /
+  // Send). It is always full size (never appears to grow): it fades in and slides into place, and
+  // its layout footprint is animated with a negative margin (0 <- -w) rather than its width, so the
+  // control to its left (the agent/model select) is pushed over smoothly. `aria-hidden` while empty
+  // keeps it out of the a11y tree and role queries.
+  const hasPrompt = !!prompt.trim()
+  const submitButton = (
+    <Button
+      type="submit"
+      size="icon-sm"
+      onClick={submit}
+      disabled={busy || !hasPrompt}
+      aria-hidden={!hasPrompt}
+      tabIndex={hasPrompt ? undefined : -1}
+      aria-label={submitLabel}
+      title={busy ? submitBusyLabel : `${submitLabel}  (⌘↵ / Ctrl+Enter)`}
+      className={cn(
+        // `disabled:opacity-*` overrides the base (the button is disabled while empty/busy), so the
+        // hidden state must force it to 0 and the shown state back to full for the busy spinner.
+        'h-8 w-8 shrink-0 transition-[margin,opacity,transform] duration-150 ease-out',
+        hasPrompt
+          ? 'ml-0 translate-x-0 opacity-100 disabled:opacity-100'
+          : 'pointer-events-none -ml-8 translate-x-2 opacity-0 disabled:opacity-0',
+      )}
+    >
+      {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowUp className="h-4 w-4" />}
+    </Button>
   )
 
   // Compact (#723): a single row for the navbar — editor, then the same controls and submit. It
@@ -300,50 +324,29 @@ export const Composer = forwardRef<ComposerHandle, {
     return (
       <div className="flex items-start gap-1.5">
         <div className="min-w-0 flex-1">{editorEl}</div>
-        {controls}
-        <Button
-          type="submit"
-          size="sm"
-          onClick={submit}
-          disabled={busy || !prompt.trim()}
-          title={!prompt.trim() ? 'Type a prompt first' : `${submitLabel}  (⌘↵ / Ctrl+Enter)`}
-        >
-          {busy ? submitBusyLabel : submitLabel}
-        </Button>
+        {agentModelEl}
+        {secondaryControls}
+        {submitButton}
       </div>
     )
   }
 
   return (
     <>
-      {editorEl}
-
-      {/* Run controls, directly under the editor (#649/#650/#654/#668): agent+model at the start,
-          then presets and the options gear, then submit at the end. */}
-      <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
-        {controls}
-        <Button
-          type="submit"
-          size="sm"
-          onClick={submit}
-          className="ml-auto"
-          disabled={busy || !prompt.trim()}
-          title={!prompt.trim() ? 'Type a prompt first' : `${submitLabel}  (⌘↵ / Ctrl+Enter)`}
-        >
-          {busy ? (
-            submitBusyLabel
-          ) : (
-            <>
-              {submitLabel}
-              {showShortcutHint && (
-                // The editor submits on ⌘/Ctrl+Enter (#695/U13): surface the otherwise-hidden shortcut.
-                <kbd className="ml-1.5 hidden rounded border border-primary-foreground/30 px-1 text-[10px] font-medium text-primary-foreground/70 sm:inline">
-                  ⌘↵
-                </kbd>
-              )}
-            </>
-          )}
-        </Button>
+      {/* The composer box (#721): the editor and its run controls under one rounded border, so the
+          prompt and the buttons that act on it read as a single input surface. The editor is
+          borderless here (its border moved out to this box); controls sit tucked below it. */}
+      <div className="rounded-lg border border-border bg-transparent focus-within:border-muted-foreground/40">
+        {editorEl}
+        {/* Run controls (#649/#650/#654/#668): presets and the options gear at the start, then the
+            agent+model select paired with submit at the end. */}
+        <div className="flex flex-wrap items-center gap-1.5 px-2 pb-2">
+          {secondaryControls}
+          <div className="ml-auto flex items-center gap-1.5">
+            {agentModelEl}
+            {submitButton}
+          </div>
+        </div>
       </div>
 
       {/* What the session resolves to, without opening the gear (#842). Off in the compact row

--- a/packages/framework-dashboard/components/GitStatusBar.tsx
+++ b/packages/framework-dashboard/components/GitStatusBar.tsx
@@ -5,7 +5,6 @@ import { onGitStatus, onRunWorktree } from '../server/reads.telefunc.js'
 import { usePolled } from '../lib/use-async.js'
 import { formatBytes } from '@gemstack/framework/client'
 import { cn } from '../lib/utils.js'
-import { CopyButton } from './ui/copy-button.js'
 
 // The checkout in play (#491, part of #488): active branch, a clean/dirty dot, the linked PR.
 // Polled, so it tracks a run committing or branching. Hidden when there is no git repo (or on
@@ -100,7 +99,7 @@ export function GitStatusBar({
       >
         <GitBranch className="h-3.5 w-3.5 shrink-0" />
         <span
-          className={cn('truncate', label ? 'max-w-[14rem]' : 'min-w-[5rem] max-w-[16rem] font-medium text-foreground')}
+          className={cn('truncate', label ? 'max-w-[14rem]' : 'max-w-[16rem] font-medium text-foreground')}
           title={branchTitle}
         >
           {branchText}
@@ -146,7 +145,6 @@ export function GitStatusBar({
       ) : (
         facts
       )}
-      {branch && <CopyButton text={branch} label="Copy branch name" />}
       {status.pr && (
         <a
           href={status.pr.url}

--- a/packages/framework-dashboard/components/OptionsMenu.test.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.test.tsx
@@ -18,35 +18,32 @@ const mainOptions = (): OptionRow[] => [
 ]
 const ecoOptions = (): OptionRow[] => [{ key: 'ecoPlanning', label: 'Auto planning', title: 't', checked: false }]
 
-// The editor props (#727) are required; default them so the existing cases stay focused.
-const editorProps = { editor: undefined as string | undefined, editors: [], onEditorChange: () => {} }
-
 function open() {
   fireEvent.click(screen.getByRole('button', { name: /session options/i }))
 }
 
 describe('OptionsMenu (#654)', () => {
   test('the trigger badges how many options are on', () => {
-    render(<OptionsMenu options={mainOptions()} ecoOptions={ecoOptions()} showEco={false} busy={false} {...editorProps} />)
+    render(<OptionsMenu options={mainOptions()} ecoOptions={ecoOptions()} showEco={false} busy={false} />)
     // Only Eco is checked -> the gear trigger shows a corner badge "1".
     expect(screen.getByRole('button', { name: /session options/i }).textContent).toContain('1')
   })
 
   test('toggling an item writes the new value through', () => {
-    render(<OptionsMenu options={mainOptions()} ecoOptions={ecoOptions()} showEco={false} busy={false} {...editorProps} />)
+    render(<OptionsMenu options={mainOptions()} ecoOptions={ecoOptions()} showEco={false} busy={false} />)
     open()
     fireEvent.click(screen.getByText('Autopilot'))
     expect(updatePreferences).toHaveBeenCalledWith({ autopilot: true })
   })
 
   test('hides the Eco sub-drops when Eco does not apply', () => {
-    render(<OptionsMenu options={mainOptions()} ecoOptions={ecoOptions()} showEco={false} busy={false} {...editorProps} />)
+    render(<OptionsMenu options={mainOptions()} ecoOptions={ecoOptions()} showEco={false} busy={false} />)
     open()
     expect(screen.queryByText('Auto planning')).toBeNull()
   })
 
   test('shows the Eco sub-drops when Eco applies', () => {
-    render(<OptionsMenu options={mainOptions()} ecoOptions={ecoOptions()} showEco={true} busy={false} {...editorProps} />)
+    render(<OptionsMenu options={mainOptions()} ecoOptions={ecoOptions()} showEco={true} busy={false} />)
     open()
     expect(screen.getByText('Auto planning')).toBeTruthy()
   })
@@ -55,7 +52,7 @@ describe('OptionsMenu (#654)', () => {
     const options: OptionRow[] = [
       { key: 'browser', label: 'Browser', title: 't', description: 'Gives the agent a real browser.', checked: false, disabled: true, disabledReason: 'only on Claude Code' },
     ]
-    render(<OptionsMenu options={options} ecoOptions={ecoOptions()} showEco={false} busy={false} {...editorProps} />)
+    render(<OptionsMenu options={options} ecoOptions={ecoOptions()} showEco={false} busy={false} />)
     open()
     expect(screen.getByText(/only on Claude Code/)).toBeTruthy()
     fireEvent.click(screen.getByText('Browser'))
@@ -68,71 +65,11 @@ describe('OptionsMenu (#654)', () => {
     const eco: OptionRow[] = [
       { key: 'ecoMaintenance', label: 'Auto maintenance', title: 't', checked: false, disabled: true, disabledReason: 'only applies while Post-merge cleanup is on' },
     ]
-    render(<OptionsMenu options={mainOptions()} ecoOptions={eco} showEco={true} busy={false} {...editorProps} />)
+    render(<OptionsMenu options={mainOptions()} ecoOptions={eco} showEco={true} busy={false} />)
     open()
     expect(screen.getByText(/only applies while Post-merge cleanup is on/)).toBeTruthy()
     fireEvent.click(screen.getByText('Auto maintenance'))
     expect(updatePreferences).not.toHaveBeenCalled()
   })
 
-})
-
-describe('OptionsMenu editor picker (#727)', () => {
-  const editors = [
-    { bin: 'code', label: 'VS Code' },
-    { bin: 'cursor', label: 'Cursor' },
-  ]
-
-  test('picking a detected editor sends its CLI bin', () => {
-    const onEditorChange = vi.fn()
-    render(
-      <OptionsMenu
-        options={mainOptions()}
-        ecoOptions={ecoOptions()}
-        showEco={false}
-        busy={false}
-        editor={undefined}
-        editors={editors}
-        onEditorChange={onEditorChange}
-      />,
-    )
-    open()
-    fireEvent.click(screen.getByText('Cursor'))
-    expect(onEditorChange).toHaveBeenCalledWith('cursor')
-  })
-
-  test('picking Default clears the editor (undefined)', () => {
-    const onEditorChange = vi.fn()
-    render(
-      <OptionsMenu
-        options={mainOptions()}
-        ecoOptions={ecoOptions()}
-        showEco={false}
-        busy={false}
-        editor="cursor"
-        editors={editors}
-        onEditorChange={onEditorChange}
-      />,
-    )
-    open()
-    fireEvent.click(screen.getByText('Default'))
-    expect(onEditorChange).toHaveBeenCalledWith(undefined)
-  })
-
-  test('shows a stored editor that was not auto-detected as a custom row', () => {
-    render(
-      <OptionsMenu
-        options={mainOptions()}
-        ecoOptions={ecoOptions()}
-        showEco={false}
-        busy={false}
-        editor="mate"
-        editors={editors}
-        onEditorChange={() => {}}
-      />,
-    )
-    open()
-    // The custom bin appears (as both its own label and description), selectable like the rest.
-    expect(screen.getAllByText('mate').length).toBeGreaterThan(0)
-  })
 })

--- a/packages/framework-dashboard/components/OptionsMenu.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.tsx
@@ -1,7 +1,6 @@
 import type { Preferences } from '@gemstack/framework'
-import { Settings, Check } from 'lucide-react'
+import { Settings } from 'lucide-react'
 import { updatePreferences } from '../lib/preferences.js'
-import type { EditorInfo } from '../server/preferences.telefunc.js'
 import { cn } from '../lib/utils.js'
 import { buttonVariants } from './ui/button.js'
 import {
@@ -9,9 +8,6 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuCheckboxItem,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
 } from './ui/dropdown-menu.js'
 
@@ -67,9 +63,6 @@ export function OptionsMenu({
   ecoOptions,
   showEco,
   busy,
-  editor,
-  editors,
-  onEditorChange,
   label = 'Session options',
 }: {
   options: OptionRow[]
@@ -80,18 +73,8 @@ export function OptionsMenu({
   /** The trigger's name. In-session composers pass no run options (#833), so theirs says
    *  "Preferences" rather than promising session control it does not have. */
   label?: string
-  /** The current preferred-editor CLI (#727), or undefined for the default. */
-  editor: string | undefined
-  /** The editors detected on the daemon's machine; empty on a public host. */
-  editors: EditorInfo[]
-  /** Pick an editor CLI, or `undefined` to fall back to `$FRAMEWORK_EDITOR` / `code`. */
-  onEditorChange: (editor: string | undefined) => void
 }) {
   const activeCount = options.filter(o => o.checked && !o.disabled).length
-  // Detected editors, plus the stored one as a "custom" row when it isn't auto-detected (e.g. a
-  // hand-set $FRAMEWORK_EDITOR), so the current choice always shows even if we couldn't find it.
-  const editorRows: EditorInfo[] =
-    editor && !editors.some(e => e.bin === editor) ? [...editors, { bin: editor, label: editor }] : editors
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
@@ -99,11 +82,11 @@ export function OptionsMenu({
         disabled={busy}
         title={activeCount > 0 ? `${label} — ${activeCount} on` : label}
         aria-label={label}
-        className={cn(buttonVariants({ variant: 'outline', size: 'icon-sm' }), 'relative')}
+        className={cn(buttonVariants({ variant: 'ghost', size: 'icon-sm' }), 'relative h-8 w-8')}
       >
         <Settings className="h-4 w-4" />
         {activeCount > 0 && (
-          <span className="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-[var(--color-primary)] px-1 text-[10px] font-medium leading-none text-[var(--color-primary-foreground)]">
+          <span className="absolute -right-1 -top-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-[var(--color-primary)] px-0.5 text-[9px] font-medium leading-none text-[var(--color-primary-foreground)]">
             {activeCount}
           </span>
         )}
@@ -120,33 +103,6 @@ export function OptionsMenu({
             ))}
           </>
         )}
-        <DropdownMenuSeparator />
-        <DropdownMenuGroup>
-          <DropdownMenuLabel>Open in editor</DropdownMenuLabel>
-          <DropdownMenuItem
-            disabled={busy}
-            closeOnClick={false}
-            onClick={() => onEditorChange(undefined)}
-            title="Use $FRAMEWORK_EDITOR, or VS Code"
-            className="items-start"
-          >
-            <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', editor ? 'opacity-0' : 'opacity-100')} />
-            <OptionLabel label="Default" description="$FRAMEWORK_EDITOR, or code" />
-          </DropdownMenuItem>
-          {editorRows.map(e => (
-            <DropdownMenuItem
-              key={e.bin}
-              disabled={busy}
-              closeOnClick={false}
-              onClick={() => onEditorChange(e.bin)}
-              title={`Open projects in ${e.label} (${e.bin})`}
-              className="items-start"
-            >
-              <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', editor === e.bin ? 'opacity-100' : 'opacity-0')} />
-              <OptionLabel label={e.label} description={e.bin} />
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/packages/framework-dashboard/components/PresetsMenu.tsx
+++ b/packages/framework-dashboard/components/PresetsMenu.tsx
@@ -1,5 +1,5 @@
 import type { CustomPreset } from '@gemstack/framework'
-import { BookMarked, Plus, X } from 'lucide-react'
+import { SquareSlash, Plus, X } from 'lucide-react'
 import { cn } from '../lib/utils.js'
 import { buttonVariants } from './ui/button.js'
 import { OptionLabel } from './ui/option-label.js'
@@ -52,11 +52,11 @@ export function PresetsMenu({
       <DropdownMenuTrigger
         type="button"
         disabled={busy}
+        aria-label="Presets"
         title="Load a preset prompt — also available by typing / in the editor"
-        className={cn(buttonVariants({ variant: 'outline', size: 'sm' }))}
+        className={cn(buttonVariants({ variant: 'ghost', size: 'icon-sm' }), 'h-8 w-8')}
       >
-        <BookMarked className="h-4 w-4" aria-hidden />
-        Presets
+        <SquareSlash className="h-4 w-4" aria-hidden />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="min-w-[16rem] max-w-[20rem]">
         <DropdownMenuGroup>

--- a/packages/framework-dashboard/components/PromptEditor.tsx
+++ b/packages/framework-dashboard/components/PromptEditor.tsx
@@ -313,18 +313,29 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
     editor?.setEditable(!disabled)
   }, [editor, disabled])
 
+  // The placeholder is absolutely positioned, so it must share the editor's padding to sit exactly
+  // where the first typed character will (#721). The full composer breathes with more room; the
+  // compact navbar row stays tight.
+  const pad = compact ? 'px-2 py-1.5' : 'px-4 pt-4 pb-3'
+  const placeholderInset = compact ? 'left-2 top-1.5' : 'left-4 top-4'
   return (
     <div className="relative">
       <EditorContent
         editor={editor}
-        className={`w-full overflow-y-auto rounded-md border border-border bg-transparent px-2 py-1.5 text-sm focus-within:ring-2 focus-within:ring-[var(--color-primary)] ${
+        className={`w-full overflow-y-auto bg-transparent text-sm ${pad} ${
           // The resting height is deliberately short (#756): the editor grows with its content up
           // to max-h, so the tall empty box was reserving room for text nobody had typed yet.
-          compact ? 'max-h-32 min-h-8' : 'max-h-64 min-h-[2.75rem]'
+          // Compact (navbar) keeps its own border+ring; the full composer's border lives on the
+          // surrounding composer box (#721) so the editor and its controls read as one surface.
+          compact
+            ? 'max-h-32 min-h-8 rounded-md border border-border focus-within:ring-2 focus-within:ring-[var(--color-primary)]'
+            : 'max-h-64 min-h-[2.75rem]'
         }`}
       />
       {isEmpty && (
-        <span className="pointer-events-none absolute left-2 top-1.5 text-sm text-muted-foreground">{placeholder}</span>
+        <span className={`pointer-events-none absolute text-sm text-muted-foreground ${placeholderInset}`}>
+          {placeholder}
+        </span>
       )}
     </div>
   )

--- a/packages/framework-dashboard/components/RightRail.test.tsx
+++ b/packages/framework-dashboard/components/RightRail.test.tsx
@@ -26,39 +26,30 @@ const baseProps = {
   toggleContext: () => {},
 }
 
-// #862: the rail asks for the room when it is showing something worth reading wide, and the
-// shell hands it over by collapsing the sessions rail. Reported up, since only the rail knows
-// which tab is open.
-describe('RightRail wide mode (#862)', () => {
+// The rail holds one fixed width for every tab: switching to a pushed view no longer widens it
+// (the per-tab wide mode from #862 was dropped so the tabs read as one stable column).
+describe('RightRail width', () => {
   const rail = (container: HTMLElement) => container.querySelector('aside')!
 
-  test('a list-shaped tab stays narrow and asks for nothing', () => {
-    const onWideChange = vi.fn()
-    const { container } = render(<RightRail {...baseProps} onWideChange={onWideChange} />)
-    expect(rail(container).className).toContain('w-80')
-    expect(onWideChange).toHaveBeenLastCalledWith(false)
+  test('a list-shaped tab holds the fixed width', () => {
+    const { container } = render(<RightRail {...baseProps} />)
+    expect(rail(container).className).toContain('w-[27rem]')
   })
 
-  test('a pushed view takes the wide form and says so', () => {
-    const onWideChange = vi.fn()
-    const { container } = render(<RightRail {...baseProps} views={[view]} onWideChange={onWideChange} />)
-    // The first view pulls the rail to the Views tab on its own.
-    expect(rail(container).className).toContain('w-[32rem]')
-    expect(onWideChange).toHaveBeenLastCalledWith(true)
+  test('a pushed view keeps the same width — no expand', () => {
+    const { container } = render(<RightRail {...baseProps} views={[view]} />)
+    // The first view pulls the rail to the Views tab on its own, but the width does not change.
+    expect(rail(container).className).toContain('w-[27rem]')
   })
 
-  test('leaving the view gives the room back', () => {
-    const onWideChange = vi.fn()
-    const { container } = render(<RightRail {...baseProps} views={[view]} onWideChange={onWideChange} />)
+  test('the width is unchanged after switching away from a view', () => {
+    const { container } = render(<RightRail {...baseProps} views={[view]} />)
     fireEvent.click(screen.getByRole('tab', { name: /docs/i }))
-    expect(rail(container).className).toContain('w-80')
-    expect(onWideChange).toHaveBeenLastCalledWith(false)
+    expect(rail(container).className).toContain('w-[27rem]')
   })
 
-  test('no project means no rail and no claim on the room', () => {
-    const onWideChange = vi.fn()
-    const { container } = render(<RightRail {...baseProps} projectId={null} onWideChange={onWideChange} />)
+  test('no project means no rail', () => {
+    const { container } = render(<RightRail {...baseProps} projectId={null} />)
     expect(container.querySelector('aside')).toBeNull()
-    expect(onWideChange).toHaveBeenLastCalledWith(false)
   })
 })

--- a/packages/framework-dashboard/components/RightRail.tsx
+++ b/packages/framework-dashboard/components/RightRail.tsx
@@ -28,7 +28,6 @@ export function RightRail({
   context,
   toggleContext,
   hasBrowser = false,
-  onWideChange,
   onRunStarted,
 }: {
   projectId: string | null
@@ -44,8 +43,6 @@ export function RightRail({
   toggleContext: (path: string) => void
   /** Whether the selected run is serving a browser preview (#813), i.e. it was started with Browser on. */
   hasBrowser?: boolean
-  /** Told when the rail takes its wide form (#862), so the shell can free the room for it. */
-  onWideChange?: (wide: boolean) => void
   /** Told when a panel starts a session (the tickets import, #948), so the shell shows it. */
   onRunStarted?: ((intent: string, runId?: string) => void) | undefined
 }) {
@@ -76,16 +73,6 @@ export function RightRail({
     else if (firstView) setTab('views')
     else if (!touched.current && !hasChoices && !hasViews) setTab(hasFiles ? 'files' : 'docs')
   }, [choices, hasChoices, hasViews, hasFiles])
-
-  // The rail's own content decides when it needs the room (#862): a pushed view, the agent's
-  // browser, and a choice gate are the surfaces worth reading wide. Files/docs/log are lists and
-  // read fine narrow. Reported up rather than decided there, since only the rail knows its tab.
-  const wide = projectId !== null && (tab === 'views' || tab === 'browser' || tab === 'choices')
-  useEffect(() => {
-    onWideChange?.(wide)
-    // `onWideChange` is a fresh closure each render; the state it reports is the trigger.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [wide])
 
   if (!projectId) return null
 
@@ -122,8 +109,7 @@ export function RightRail({
   return (
     <aside
       className={cn(
-        'flex shrink-0 flex-col border-l border-border transition-[width] duration-150',
-        wide ? 'w-[32rem]' : 'w-80',
+        'flex w-[27rem] shrink-0 flex-col border-l border-border',
       )}
     >
       {/* flex-wrap: up to 7 tabs share a w-80 rail, and without it the tail clipped (#948).

--- a/packages/framework-dashboard/components/RunActionBar.tsx
+++ b/packages/framework-dashboard/components/RunActionBar.tsx
@@ -11,7 +11,6 @@ import { DeleteSessionButton } from './DeleteSessionButton.js'
 import { WorkspaceActions } from './WorkspaceActions.js'
 import { GitStatusBar } from './GitStatusBar.js'
 import { Button, buttonVariants } from './ui/button.js'
-import { CopyButton } from './ui/copy-button.js'
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './ui/tooltip.js'
 
 // One run's action bar: Serve, Stop, and Open session as a single row of icon buttons with
@@ -122,11 +121,6 @@ export function RunActionBar({
             Remove, the more destructive of the pair. */}
         {onDeleted && !active && runId && (
           <DeleteSessionButton projectId={projectId} runId={runId} label={label} onDeleted={onDeleted} />
-        )}
-        {/* The session id is the exact string a `--resume` takes (#948), useful even when the deep
-            link below is also shown, so it is always offered for copy when a session has one. */}
-        {info?.sessionId && (
-          <CopyButton text={info.sessionId} label={`Copy session id (${info.sessionId})`} className="p-1.5" />
         )}
         {session && (
           <Tooltip>

--- a/packages/framework-dashboard/components/RunHistory.test.tsx
+++ b/packages/framework-dashboard/components/RunHistory.test.tsx
@@ -45,7 +45,7 @@ describe('RunHistory (#785)', () => {
       <RunHistory projectId="p1" runs={[]} selectedRunId="run-2" onSelect={() => {}} startTick={1} startIntent="add dark mode" />,
     )
     const rows = [...container.querySelectorAll('button')]
-    const home = rows.find(row => row.textContent?.includes('New session'))
+    const home = rows.find(row => row.textContent?.trim() === 'New')
     const starting = rows.find(row => row.textContent?.includes('starting…'))
     expect(starting?.className).toContain('bg-accent')
     expect(home?.className).not.toContain('bg-accent')

--- a/packages/framework-dashboard/components/RunHistory.tsx
+++ b/packages/framework-dashboard/components/RunHistory.tsx
@@ -99,21 +99,26 @@ export function RunHistory({
             : 'w-full',
         )}
       >
-      <div className={cn('whitespace-nowrap px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground', label)}>
-        Sessions
-      </div>
       <ScrollArea className="min-h-0 flex-1">
-        <div className="px-2">
+        {/* Extra right padding clears the overlay scrollbar (w-2.5) so a row's hover fill doesn't
+            run under the bar. */}
+        <div className="pl-2 pr-3.5 pt-3">
         {/* Permanent home / launcher — always present, never a run: starting a new session. */}
         <Button
           variant="ghost"
-          className={cn('mb-1 w-full justify-start', collapsed && 'justify-center px-0', atHome && 'bg-accent text-accent-foreground')}
+          className={cn('mb-1 w-full justify-start gap-2', collapsed && 'justify-center px-0', atHome && 'bg-accent text-accent-foreground')}
           onClick={() => onSelect(null)}
           title={collapsed ? 'New session' : undefined}
         >
-          <Plus className={cn('h-4 w-4 shrink-0', !collapsed && 'mr-2')} />
-          <span className={cn('whitespace-nowrap', label)}>New session</span>
+          <Plus className="h-4 w-4 shrink-0" />
+          <span className={cn('whitespace-nowrap', label)}>New</span>
         </Button>
+        {/* Recents label sits under the launcher, over the run list (not a page-wide header). */}
+        {(runs.length > 0 || optimistic !== null) && (
+          <div className={cn('whitespace-nowrap px-2 pb-1 pt-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground', label)}>
+            Recents
+          </div>
+        )}
 
         {/* A just-started run, before its run.json exists — highlighted while following it. */}
         {optimistic !== null && !hasRunning && (
@@ -211,7 +216,7 @@ function RunRow({
           <AgentLogo
             agent={agent}
             title={AGENT_LABELS[agent]}
-            className={cn('ml-auto h-3.5 w-3.5 shrink-0 text-muted-foreground', label)}
+            className={cn('ml-auto h-3 w-3 shrink-0 text-muted-foreground', label)}
           />
         )}
       </span>

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -117,7 +117,6 @@ export function StartRunForm({
         busy={busy}
         submitLabel="Start session"
         submitBusyLabel="Starting…"
-        showShortcutHint
       />
 
       {/* Feedback right where the action is (#948): the error used to render below the (possibly

--- a/packages/framework-dashboard/components/WorkspaceActions.test.tsx
+++ b/packages/framework-dashboard/components/WorkspaceActions.test.tsx
@@ -17,6 +17,14 @@ vi.mock('../server/control.telefunc.js', () => ({
   sendStopPreview,
 }))
 
+// The editor picker (#727) lives on the editor button now; stub the preference store and the
+// detected-editors read so the tests drive a fixed set.
+const updatePreferences = vi.hoisted(() => vi.fn())
+let prefs: { editor?: string } = {}
+let detectedEditors: { bin: string; label: string }[] = []
+vi.mock('../lib/preferences.js', () => ({ usePreferences: () => prefs, updatePreferences }))
+vi.mock('../lib/editors.js', () => ({ useDetectedEditors: () => detectedEditors }))
+
 const { WorkspaceActions } = await import('./WorkspaceActions.js')
 const { TooltipProvider } = await import('./ui/tooltip.js')
 
@@ -34,8 +42,14 @@ const buttons = () => screen.getAllByRole('button')
 beforeEach(() => {
   sendOpenInApp.mockClear()
   onGithubUrl.mockClear()
+  updatePreferences.mockClear()
+  prefs = {}
+  detectedEditors = []
 })
 afterEach(cleanup)
+
+// The editor button is a dropdown now (#727): open it, then click the "open" item.
+const openEditorMenu = () => fireEvent.click(screen.getByRole('button', { name: /open in editor/i }))
 
 describe('WorkspaceActions (#809)', () => {
   test("a session's folder and editor open that session's worktree", async () => {
@@ -45,7 +59,8 @@ describe('WorkspaceActions (#809)', () => {
     await waitFor(() => expect(buttons().length).toBeGreaterThan(1))
     fireEvent.click(buttons()[0]!)
     await waitFor(() => expect(sendOpenInApp).toHaveBeenCalledWith('p1', 'files', 'run-1'))
-    fireEvent.click(buttons()[1]!)
+    openEditorMenu()
+    fireEvent.click(screen.getByText("Open this session's checkout"))
     await waitFor(() => expect(sendOpenInApp).toHaveBeenCalledWith('p1', 'editor', 'run-1'))
   })
 
@@ -67,5 +82,36 @@ describe('WorkspaceActions (#809)', () => {
     renderActions('run-1')
     await waitFor(() => expect(screen.getByRole('link')).toBeTruthy())
     expect(buttons().length).toBe(projectCount)
+  })
+})
+
+describe('WorkspaceActions editor picker (#727)', () => {
+  test('picking a detected editor stores its CLI bin', () => {
+    detectedEditors = [
+      { bin: 'code', label: 'VS Code' },
+      { bin: 'cursor', label: 'Cursor' },
+    ]
+    renderActions('run-1')
+    openEditorMenu()
+    fireEvent.click(screen.getByText('Cursor'))
+    expect(updatePreferences).toHaveBeenCalledWith({ editor: 'cursor' })
+  })
+
+  test('picking Default clears the editor', () => {
+    prefs = { editor: 'cursor' }
+    detectedEditors = [{ bin: 'cursor', label: 'Cursor' }]
+    renderActions('run-1')
+    openEditorMenu()
+    fireEvent.click(screen.getByText('Default'))
+    expect(updatePreferences).toHaveBeenCalledWith({ editor: '' })
+  })
+
+  test('shows a stored editor that was not auto-detected as a custom row', () => {
+    prefs = { editor: 'mate' }
+    detectedEditors = [{ bin: 'code', label: 'VS Code' }]
+    renderActions('run-1')
+    openEditorMenu()
+    // The custom bin appears (as both its own label and description), selectable like the rest.
+    expect(screen.getAllByText('mate').length).toBeGreaterThan(0)
   })
 })

--- a/packages/framework-dashboard/components/WorkspaceActions.tsx
+++ b/packages/framework-dashboard/components/WorkspaceActions.tsx
@@ -1,12 +1,26 @@
 import { useEffect } from 'react'
-import { Github, FolderOpen, Code } from 'lucide-react'
+import { Github, FolderOpen, Code, Check } from 'lucide-react'
 import { onGithubUrl } from '../server/reads.telefunc.js'
 import { sendOpenInApp } from '../server/control.telefunc.js'
+import type { EditorInfo } from '../server/preferences.telefunc.js'
 import { useLoaded } from '../lib/use-async.js'
 import { useAction } from '../lib/use-action.js'
+import { usePreferences, updatePreferences } from '../lib/preferences.js'
+import { useDetectedEditors } from '../lib/editors.js'
+import { cn } from '../lib/utils.js'
 import { PreviewBar } from './PreviewBar.js'
 import { Button, buttonVariants } from './ui/button.js'
+import { OptionLabel } from './ui/option-label.js'
 import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip.js'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from './ui/dropdown-menu.js'
 
 // What you can do to a checkout: open it on GitHub (#489), in the file manager or an editor
 // (#490), and serve it (#475). One component for both pages (#809) — the project home passes no
@@ -27,6 +41,15 @@ export function WorkspaceActions({
   // branch may not be pushed anywhere yet. Its PR, when there is one, shows in the git status.
   const githubUrl = useLoaded<string | null>(() => onGithubUrl(projectId), null, [projectId])
   const { busy, error, reset, run } = useAction()
+  // The preferred editor lives with the action that opens it now (#727), not off in the options
+  // gear: click to open, or pick which editor to remember. The stored one shows as a "custom" row
+  // when it isn't auto-detected (a hand-set $FRAMEWORK_EDITOR), so the choice always appears.
+  const editor = usePreferences().editor
+  const detectedEditors = useDetectedEditors()
+  const editorRows: EditorInfo[] =
+    editor && !detectedEditors.some(e => e.bin === editor)
+      ? [...detectedEditors, { bin: editor, label: editor }]
+      : detectedEditors
 
   // `error` belongs to open(), not to the read, so clearing it on a switch is its own effect:
   // otherwise the last checkout's failure stays on screen next to the new one's actions.
@@ -62,17 +85,50 @@ export function WorkspaceActions({
         </TooltipTrigger>
         <TooltipContent>{runId ? "Open this session's folder" : 'Open folder'} (Finder / Explorer)</TooltipContent>
       </Tooltip>
-      <Tooltip>
-        <TooltipTrigger
-          render={<Button variant="outline" size="icon-sm" disabled={busy} onClick={() => void open('editor')} />}
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          type="button"
+          disabled={busy}
+          title="Open in editor"
+          aria-label="Open in editor"
+          className={buttonVariants({ variant: 'outline', size: 'icon-sm' })}
         >
           <Code className="h-3.5 w-3.5" />
-        </TooltipTrigger>
-        <TooltipContent>
-          {runId ? "Open this session's checkout in your editor" : 'Open in your preferred editor'} (set it in Options;
-          falls back to $FRAMEWORK_EDITOR / code)
-        </TooltipContent>
-      </Tooltip>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="min-w-[15rem]">
+          <DropdownMenuItem disabled={busy} onClick={() => void open('editor')}>
+            <Code className="h-3.5 w-3.5 shrink-0" />
+            {runId ? "Open this session's checkout" : 'Open in your editor'}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Preferred editor</DropdownMenuLabel>
+            <DropdownMenuItem
+              disabled={busy}
+              closeOnClick={false}
+              onClick={() => updatePreferences({ editor: '' })}
+              title="Use $FRAMEWORK_EDITOR, or VS Code"
+              className="items-start"
+            >
+              <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', editor ? 'opacity-0' : 'opacity-100')} />
+              <OptionLabel label="Default" description="$FRAMEWORK_EDITOR, or code" />
+            </DropdownMenuItem>
+            {editorRows.map(e => (
+              <DropdownMenuItem
+                key={e.bin}
+                disabled={busy}
+                closeOnClick={false}
+                onClick={() => updatePreferences({ editor: e.bin })}
+                title={`Open in ${e.label} (${e.bin})`}
+                className="items-start"
+              >
+                <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', editor === e.bin ? 'opacity-100' : 'opacity-0')} />
+                <OptionLabel label={e.label} description={e.bin} />
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
       {/* Serve (#475) the checkout this bar is about: the project's, or the session's own (#797). */}
       <PreviewBar projectId={projectId} runId={runId} inline />
       {error && <span className="text-xs text-danger">{error}</span>}


### PR DESCRIPTION
A live UI/UX pairing pass over the dashboard launcher and rails.

## Composer box
- The prompt editor and its run controls now sit in one rounded, bordered "composer box". The editor loses its own border and focus ring; the box owns them (subtle focus-within border, no ring).
- Placeholder and typed text share roomier padding (pt-4 pb-3, px-4), kept aligned.

## Submit button
- One arrow icon, hidden until the prompt has text. It fades in from opacity 0 and slides into place while pushing the model select over smoothly (animated via margin, not width, so it never looks like it grows). A spinner shows while starting or sending.

## Controls row
- Agent/model select moved to sit just left of submit, borderless. The model shows as selected; the default option reads "Default" (was "Default model"), and the separator dot is gone.
- Presets is a borderless slash icon (no label). The options gear is borderless with a smaller, lower count badge. All controls share one height.
- "Open in editor" moved out of the gear onto the workspace editor button, which now opens the checkout and lets you pick the preferred editor.

## Rails
- Right rail: one fixed width for every tab (Views/Browser no longer expand it). The per-tab wide mode (`onWideChange`) was dropped since nothing consumed it.
- Sessions rail: "New session" is now "New" with the + tucked close; the "Sessions" heading is replaced by a "Recents" label over the list; the agent logo is a touch smaller; rows clear the overlay scrollbar.
- Session toolbar: dropped the copy-branch and copy-session-id buttons; the branch dirty/clean indicator sits closer to the branch name.

## Tests
- 320 dashboard tests, 1115 framework tests, typecheck and root build all green. Editor-picker tests moved from OptionsMenu to WorkspaceActions; RightRail width tests updated for the fixed width.