### PR TITLE
feat(framework): project-scoped custom presets, shared via the repo (#1025)

### DIFF
--- a/.changeset/project-custom-presets.md
+++ b/.changeset/project-custom-presets.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': minor
+---
+
+Custom presets can now be saved to a project, not just to you. When you create a preset with a project open, a "Save to" choice lets you keep it private (as before) or commit it into the repo's `.the-framework/custom-presets.json`, so everyone who clones the project gets it. Shared presets show up in their own "Project presets" group in the Presets menu and under `/` in the editor, and delete from there. Personal presets still live in your home config and follow you across every project.

--- a/packages/framework-dashboard/components/Composer.test.tsx
+++ b/packages/framework-dashboard/components/Composer.test.tsx
@@ -13,6 +13,10 @@ vi.mock('../lib/preferences.js', () => ({
   // #842: the launcher strip reads the resolved layers; nothing here sets a repo tier.
   usePreferenceSources: () => ({}),
   useProjectFileConfig: () => ({}),
+  // #1025: project presets; nothing here opens a project, so no shared presets and no project scope.
+  useProjectPresets: () => [],
+  saveProjectPresetList: vi.fn(),
+  useActiveProjectId: () => null,
 }))
 // The editor picker (#727) detects installed editors over Telefunc; stub it to none in the test.
 vi.mock('../lib/editors.js', () => ({ useDetectedEditors: () => [] }))

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -8,6 +8,9 @@ import {
   themePreference,
   usePreferenceSources,
   useProjectFileConfig,
+  useProjectPresets,
+  saveProjectPresetList,
+  useActiveProjectId,
 } from '../lib/preferences.js'
 import { useDetectedEditors } from '../lib/editors.js'
 import { useLoaded } from '../lib/use-async.js'
@@ -148,6 +151,8 @@ export const Composer = forwardRef<ComposerHandle, {
   // The stored agent as a display name; an unknown stored value falls back to Claude Code.
   const agentLabel = AGENT_LABELS[AGENTS.includes(agent as AgentName) ? (agent as AgentName) : 'claude']
   const customPresets = preferences.customPresets ?? [] // #626: the user's own saved prompts
+  const projectPresets = useProjectPresets() // #1025: presets committed in the open project's repo
+  const activeProjectId = useActiveProjectId() // #1025: a project to commit a shared preset into
   const editor = preferences.editor // #727: preferred editor; undefined = $FRAMEWORK_EDITOR / code
   const detectedEditors = useDetectedEditors() // #727: editors installed on the daemon's machine
   const theme = themePreference(preferences) // #725: system (default) / light / dark
@@ -243,6 +248,7 @@ export const Composer = forwardRef<ComposerHandle, {
       files={files}
       presets={presets}
       customPresets={customPresets}
+      projectPresets={projectPresets}
       // The `/` menu offers "New preset…" only in the full composer, where the create panel renders;
       // the compact navbar launch has no panel, so it gets no callback (and no item).
       {...(compact ? {} : { onNewPreset: () => setAddingPreset(true) })}
@@ -273,10 +279,12 @@ export const Composer = forwardRef<ComposerHandle, {
         <PresetsMenu
           presets={presets}
           customPresets={customPresets}
+          projectPresets={projectPresets}
           busy={busy}
           onLoad={loadPresetFromMenu}
           onNew={() => setAddingPreset(true)}
           onDelete={id => updatePreferences({ customPresets: customPresets.filter(p => p.id !== id) })}
+          onDeleteProject={id => saveProjectPresetList(projectPresets.filter(p => p.id !== id))}
         />
       )}
       <OptionsMenu
@@ -355,12 +363,14 @@ export const Composer = forwardRef<ComposerHandle, {
         <PresetCreatePanel
           currentPrompt={prompt}
           busy={busy}
+          canSaveToProject={activeProjectId !== null}
           onCancel={() => {
             setAddingPreset(false)
             editorRef.current?.focus()
           }}
-          onSave={preset => {
-            updatePreferences({ customPresets: [...customPresets, preset] })
+          onSave={(preset, scope) => {
+            if (scope === 'project') saveProjectPresetList([...projectPresets, preset])
+            else updatePreferences({ customPresets: [...customPresets, preset] })
             setAddingPreset(false)
             editorRef.current?.focus()
           }}

--- a/packages/framework-dashboard/components/PresetCreatePanel.test.tsx
+++ b/packages/framework-dashboard/components/PresetCreatePanel.test.tsx
@@ -8,23 +8,39 @@ afterEach(cleanup)
 describe('PresetCreatePanel (#649)', () => {
   test('prefills the prompt from the editor and saves a well-formed preset', () => {
     const onSave = vi.fn()
-    render(<PresetCreatePanel currentPrompt="my crafted prompt" busy={false} onSave={onSave} onCancel={() => {}} />)
+    render(<PresetCreatePanel currentPrompt="my crafted prompt" busy={false} canSaveToProject={false} onSave={onSave} onCancel={() => {}} />)
     expect((screen.getByPlaceholderText(/prompt this preset runs/i) as HTMLTextAreaElement).value).toBe('my crafted prompt')
     fireEvent.change(screen.getByPlaceholderText('Preset name'), { target: { value: 'My preset' } })
     fireEvent.click(screen.getByRole('button', { name: 'Save preset' }))
-    const saved = onSave.mock.calls[0]![0] as CustomPreset
+    const [saved, scope] = onSave.mock.calls[0]! as [CustomPreset, string]
     expect({ label: saved.label, prompt: saved.prompt }).toEqual({ label: 'My preset', prompt: 'my crafted prompt' })
     expect(saved.id).toBeTruthy()
+    expect(scope).toBe('user') // no project open -> always the user tier (#1025)
   })
 
   test('cannot save without both a name and a prompt', () => {
-    render(<PresetCreatePanel currentPrompt="" busy={false} onSave={() => {}} onCancel={() => {}} />)
+    render(<PresetCreatePanel currentPrompt="" busy={false} canSaveToProject={false} onSave={() => {}} onCancel={() => {}} />)
     expect((screen.getByRole('button', { name: 'Save preset' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  test('with a project open, saving "This project" reports the project scope (#1025)', () => {
+    const onSave = vi.fn()
+    render(<PresetCreatePanel currentPrompt="shared prompt" busy={false} canSaveToProject onSave={onSave} onCancel={() => {}} />)
+    fireEvent.change(screen.getByPlaceholderText('Preset name'), { target: { value: 'Team preset' } })
+    fireEvent.click(screen.getByRole('button', { name: 'This project' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save preset' }))
+    const [, scope] = onSave.mock.calls[0]! as [CustomPreset, string]
+    expect(scope).toBe('project')
+  })
+
+  test('no scope choice when there is no project to share into (#1025)', () => {
+    render(<PresetCreatePanel currentPrompt="" busy={false} canSaveToProject={false} onSave={() => {}} onCancel={() => {}} />)
+    expect(screen.queryByRole('button', { name: 'This project' })).toBeNull()
   })
 
   test('Cancel backs out', () => {
     const onCancel = vi.fn()
-    render(<PresetCreatePanel currentPrompt="" busy={false} onSave={() => {}} onCancel={onCancel} />)
+    render(<PresetCreatePanel currentPrompt="" busy={false} canSaveToProject={false} onSave={() => {}} onCancel={onCancel} />)
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
     expect(onCancel).toHaveBeenCalledTimes(1)
   })

--- a/packages/framework-dashboard/components/PresetCreatePanel.tsx
+++ b/packages/framework-dashboard/components/PresetCreatePanel.tsx
@@ -8,6 +8,9 @@ import { Button } from './ui/button.js'
 
 const LABEL_MAX = 80
 
+/** Where a saved preset lives (#1025): private to the user, or committed into the project's repo. */
+export type PresetScope = 'user' | 'project'
+
 /** A fresh id for a saved preset. `crypto.randomUUID` is present in the browser + prerender runtime. */
 function newId(): string {
   return typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `p-${Date.now()}`
@@ -16,23 +19,27 @@ function newId(): string {
 export function PresetCreatePanel({
   currentPrompt,
   busy,
+  canSaveToProject,
   onSave,
   onCancel,
 }: {
   /** The editor's current text, prefilled so you can save what you just wrote. */
   currentPrompt: string
   busy: boolean
-  onSave: (preset: CustomPreset) => void
+  /** Whether a project is open to commit a shared preset into (#1025); hides the scope choice otherwise. */
+  canSaveToProject: boolean
+  onSave: (preset: CustomPreset, scope: PresetScope) => void
   onCancel: () => void
 }) {
   const [label, setLabel] = useState('')
   const [prompt, setPrompt] = useState(currentPrompt)
+  const [scope, setScope] = useState<PresetScope>('user')
 
   const save = () => {
     const trimmedLabel = label.trim()
     const trimmedPrompt = prompt.trim()
     if (!trimmedLabel || !trimmedPrompt) return
-    onSave({ id: newId(), label: trimmedLabel, prompt: trimmedPrompt })
+    onSave({ id: newId(), label: trimmedLabel, prompt: trimmedPrompt }, canSaveToProject ? scope : 'user')
   }
 
   // Keyboard parity with the composer (#948): Esc cancels, ⌘/Ctrl+Enter saves.
@@ -67,6 +74,32 @@ export function PresetCreatePanel({
         onChange={e => setPrompt(e.target.value)}
         className="w-full resize-y rounded-md border border-border bg-background px-2 py-1 font-mono text-xs text-foreground"
       />
+      {canSaveToProject && (
+        <div className="flex items-center gap-2 text-xs text-[var(--color-muted-foreground)]">
+          <span>Save to</span>
+          <div className="inline-flex overflow-hidden rounded-md border border-border">
+            {(['user', 'project'] as const).map(value => (
+              <button
+                key={value}
+                type="button"
+                disabled={busy}
+                onClick={() => setScope(value)}
+                aria-pressed={scope === value}
+                className={
+                  scope === value
+                    ? 'bg-foreground px-2 py-0.5 text-background'
+                    : 'px-2 py-0.5 text-foreground hover:bg-[var(--color-muted)]'
+                }
+              >
+                {value === 'user' ? 'Just me' : 'This project'}
+              </button>
+            ))}
+          </div>
+          <span className="truncate">
+            {scope === 'project' ? 'Committed to the repo, shared with your team' : 'Private to you, on every project'}
+          </span>
+        </div>
+      )}
       <div className="flex items-center justify-end gap-2">
         <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
           Cancel

--- a/packages/framework-dashboard/components/PresetsMenu.test.tsx
+++ b/packages/framework-dashboard/components/PresetsMenu.test.tsx
@@ -9,16 +9,28 @@ const presets = [
   { id: 'maintenance', label: '[Maintenance]', render: () => 'MAINTENANCE PROMPT' },
 ]
 const custom = [{ id: 'c1', label: 'My sweep', prompt: 'sweep it' }]
+const project = [{ id: 'p1', label: 'Team sweep', prompt: 'team it' }]
 
 function mount(over: Partial<Parameters<typeof PresetsMenu>[0]> = {}) {
   const onLoad = vi.fn()
   const onNew = vi.fn()
   const onDelete = vi.fn()
+  const onDeleteProject = vi.fn()
   render(
-    <PresetsMenu presets={presets} customPresets={custom} busy={false} onLoad={onLoad} onNew={onNew} onDelete={onDelete} {...over} />,
+    <PresetsMenu
+      presets={presets}
+      customPresets={custom}
+      projectPresets={project}
+      busy={false}
+      onLoad={onLoad}
+      onNew={onNew}
+      onDelete={onDelete}
+      onDeleteProject={onDeleteProject}
+      {...over}
+    />,
   )
   fireEvent.click(screen.getByRole('button', { name: /presets/i }))
-  return { onLoad, onNew, onDelete }
+  return { onLoad, onNew, onDelete, onDeleteProject }
 }
 
 // #948: presets used to load only behind typing `/`, and delete lived in the options gear.
@@ -40,6 +52,24 @@ describe('PresetsMenu', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete preset My sweep' }))
     expect(onDelete).toHaveBeenCalledWith('c1')
     expect(onLoad).not.toHaveBeenCalled()
+  })
+
+  test('a shared project preset loads verbatim (#1025)', () => {
+    const { onLoad } = mount()
+    fireEvent.click(screen.getByText('Team sweep'))
+    expect(onLoad).toHaveBeenCalledWith('team it', 'Team sweep')
+  })
+
+  test('a project preset deletes via its own handler (#1025)', () => {
+    const { onDeleteProject, onDelete } = mount()
+    fireEvent.click(screen.getByRole('button', { name: 'Delete preset Team sweep' }))
+    expect(onDeleteProject).toHaveBeenCalledWith('p1')
+    expect(onDelete).not.toHaveBeenCalled()
+  })
+
+  test('the Project presets group is hidden when there are none (#1025)', () => {
+    mount({ projectPresets: [] })
+    expect(screen.queryByText('Project presets')).toBeNull()
   })
 
   test('"New preset…" opens the create panel', () => {

--- a/packages/framework-dashboard/components/PresetsMenu.tsx
+++ b/packages/framework-dashboard/components/PresetsMenu.tsx
@@ -28,24 +28,63 @@ export interface PresetEntry {
 // no sign that 13 launcher presets exist — and deleting lived in the options gear, a different
 // menu. This button is the one surface that loads, creates, and deletes; the `/` menu stays as
 // the fast path for those who know it.
+/** One saved (user or project) preset row: click loads it, the X deletes it. */
+function SavedPresetRow({
+  preset,
+  busy,
+  onLoad,
+  onDelete,
+}: {
+  preset: CustomPreset
+  busy: boolean
+  onLoad: (text: string, label: string) => void
+  onDelete: (id: string) => void
+}) {
+  return (
+    <DropdownMenuItem disabled={busy} onClick={() => onLoad(preset.prompt, preset.label)} className="items-center gap-2">
+      <span className="flex-1 truncate">{preset.label}</span>
+      <button
+        type="button"
+        disabled={busy}
+        onClick={e => {
+          // Delete, not load — keep the row's own click out of it.
+          e.stopPropagation()
+          onDelete(preset.id)
+        }}
+        title={`Delete "${preset.label}"`}
+        aria-label={`Delete preset ${preset.label}`}
+        className="rounded p-0.5 text-[var(--color-muted-foreground)] hover:text-danger"
+      >
+        <X className="h-3.5 w-3.5" aria-hidden />
+      </button>
+    </DropdownMenuItem>
+  )
+}
+
 export function PresetsMenu({
   presets,
   customPresets,
+  projectPresets,
   busy,
   onLoad,
   onNew,
   onDelete,
+  onDeleteProject,
 }: {
   presets: PresetEntry[]
   customPresets: CustomPreset[]
+  /** The open project's shared presets, committed in its `.the-framework/` (#1025). */
+  projectPresets: CustomPreset[]
   busy: boolean
   /** Load a preset's prompt into the editor. `newSession` marks the ones that never append to
    *  the open session (#959); a saved preset is always a plain load. */
   onLoad: (text: string, label: string, newSession?: boolean) => void
   /** Open the create panel; absent where no panel renders. */
   onNew?: (() => void) | undefined
-  /** Delete a saved preset by id. */
+  /** Delete a saved user preset by id. */
   onDelete: (id: string) => void
+  /** Delete a shared project preset by id. */
+  onDeleteProject: (id: string) => void
 }) {
   return (
     <DropdownMenu>
@@ -78,23 +117,16 @@ export function PresetsMenu({
             <DropdownMenuSeparator />
             <DropdownMenuLabel>Your presets</DropdownMenuLabel>
             {customPresets.map(p => (
-              <DropdownMenuItem key={p.id} disabled={busy} onClick={() => onLoad(p.prompt, p.label)} className="items-center gap-2">
-                <span className="flex-1 truncate">{p.label}</span>
-                <button
-                  type="button"
-                  disabled={busy}
-                  onClick={e => {
-                    // Delete, not load — keep the row's own click out of it.
-                    e.stopPropagation()
-                    onDelete(p.id)
-                  }}
-                  title={`Delete "${p.label}"`}
-                  aria-label={`Delete preset ${p.label}`}
-                  className="rounded p-0.5 text-[var(--color-muted-foreground)] hover:text-danger"
-                >
-                  <X className="h-3.5 w-3.5" aria-hidden />
-                </button>
-              </DropdownMenuItem>
+              <SavedPresetRow key={p.id} preset={p} busy={busy} onLoad={onLoad} onDelete={onDelete} />
+            ))}
+          </DropdownMenuGroup>
+        )}
+        {projectPresets.length > 0 && (
+          <DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel>Project presets</DropdownMenuLabel>
+            {projectPresets.map(p => (
+              <SavedPresetRow key={p.id} preset={p} busy={busy} onLoad={onLoad} onDelete={onDeleteProject} />
             ))}
           </DropdownMenuGroup>
         )}

--- a/packages/framework-dashboard/components/PromptEditor.tsx
+++ b/packages/framework-dashboard/components/PromptEditor.tsx
@@ -47,6 +47,8 @@ interface PromptEditorProps {
   presets: PresetEntry[]
   /** The user's saved presets (#626), loaded verbatim from the `/` menu (#722). */
   customPresets?: CustomPreset[]
+  /** The open project's shared presets (#1025), committed in its repo; loaded verbatim like the user's. */
+  projectPresets?: CustomPreset[]
   /** Open the create panel from the `/` menu's "New preset…" (#722). Omit where there is no panel
    *  (the compact navbar launch), which also drops the item. */
   onNewPreset?: () => void
@@ -78,7 +80,7 @@ function applyTemplate(editor: Editor, text: string): void {
 }
 
 export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(function PromptEditor(
-  { onChange, onSubmit, onPreset, onMentionProject, onMentionFile, onMentionRemoved, projects, files = [], presets, customPresets = [], onNewPreset, disabled = false, placeholder = 'Describe what to build…  ( / commands · < tags · @ projects · # files )', compact = false },
+  { onChange, onSubmit, onPreset, onMentionProject, onMentionFile, onMentionRemoved, projects, files = [], presets, customPresets = [], projectPresets = [], onNewPreset, disabled = false, placeholder = 'Describe what to build…  ( / commands · < tags · @ projects · # files )', compact = false },
   ref,
 ) {
   const [isEmpty, setIsEmpty] = useState(true)
@@ -88,6 +90,7 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
   const filesRef = useRef(files)
   const presetsRef = useRef(presets)
   const customPresetsRef = useRef(customPresets)
+  const projectPresetsRef = useRef(projectPresets)
   const onNewPresetRef = useRef(onNewPreset)
   const onPresetRef = useRef(onPreset)
   const onMentionRef = useRef(onMentionProject)
@@ -100,6 +103,7 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
     filesRef.current = files
     presetsRef.current = presets
     customPresetsRef.current = customPresets
+    projectPresetsRef.current = projectPresets
     onNewPresetRef.current = onNewPreset
     onPresetRef.current = onPreset
     onMentionRef.current = onMentionProject
@@ -174,6 +178,11 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
           const customItems: SuggestionItem[] = customPresetsRef.current
             .filter(p => p.label.toLowerCase().includes(q))
             .map(p => ({ id: `custom-preset:${p.id}`, label: p.label, hint: 'saved preset', group: 'Presets' }))
+          // The open project's shared presets (#1025): same verbatim load, tagged so the hint tells
+          // them apart from your own.
+          const projectItems: SuggestionItem[] = projectPresetsRef.current
+            .filter(p => p.label.toLowerCase().includes(q))
+            .map(p => ({ id: `project-preset:${p.id}`, label: p.label, hint: 'project preset', group: 'Presets' }))
           // "New preset…" to capture the current prompt (#722), only where the create panel exists
           // (the full composer, not the compact navbar launch, which passes no onNewPreset).
           const newPresetItem: SuggestionItem[] =
@@ -186,7 +195,7 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
             hint: a.hint,
             group: 'Actions',
           }))
-          return [...presetItems, ...customItems, ...newPresetItem, ...actionItems]
+          return [...presetItems, ...customItems, ...projectItems, ...newPresetItem, ...actionItems]
         },
         onSelect: (item, { editor: ed, range }) => {
           if (item.id.startsWith('preset:')) {
@@ -201,6 +210,15 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
           }
           if (item.id.startsWith('custom-preset:')) {
             const preset = customPresetsRef.current.find(p => `custom-preset:${p.id}` === item.id)
+            if (preset) {
+              ed.chain().focus().deleteRange(range).run()
+              const replaced = loadTemplateInto(ed, preset.prompt)
+              onPresetRef.current?.(preset.label, replaced)
+            }
+            return
+          }
+          if (item.id.startsWith('project-preset:')) {
+            const preset = projectPresetsRef.current.find(p => `project-preset:${p.id}` === item.id)
             if (preset) {
               ed.chain().focus().deleteRange(range).run()
               const replaced = loadTemplateInto(ed, preset.prompt)

--- a/packages/framework-dashboard/lib/preferences.test.ts
+++ b/packages/framework-dashboard/lib/preferences.test.ts
@@ -5,11 +5,15 @@ const onPreferences = vi.hoisted(() => vi.fn())
 const savePreferences = vi.hoisted(() => vi.fn())
 const onProjectPreferences = vi.hoisted(() => vi.fn())
 const saveProjectPreferences = vi.hoisted(() => vi.fn())
+const onProjectPresets = vi.hoisted(() => vi.fn())
+const saveProjectPresets = vi.hoisted(() => vi.fn())
 vi.mock('../server/preferences.telefunc.js', () => ({
   onPreferences,
   savePreferences,
   onProjectPreferences,
   saveProjectPreferences,
+  onProjectPresets,
+  saveProjectPresets,
 }))
 // The repo tier (#842) rides on the project payload, so the store reads the projects RPC too.
 const onProjects = vi.hoisted(() => vi.fn())
@@ -32,6 +36,8 @@ describe('preferences', () => {
     savePreferences.mockReset().mockResolvedValue({ ok: true })
     onProjectPreferences.mockReset().mockResolvedValue({})
     saveProjectPreferences.mockReset().mockResolvedValue({ ok: true })
+    onProjectPresets.mockReset().mockResolvedValue([])
+    saveProjectPresets.mockReset().mockResolvedValue({ ok: true })
     onProjects.mockReset().mockResolvedValue([])
     openProject(null)
   })

--- a/packages/framework-dashboard/lib/preferences.ts
+++ b/packages/framework-dashboard/lib/preferences.ts
@@ -1,11 +1,13 @@
 import { useEffect, useSyncExternalStore } from 'react'
-import type { FrameworkFileConfig, Preferences, ProjectPreferences, ProjectSummary } from '@gemstack/framework'
+import type { CustomPreset, FrameworkFileConfig, Preferences, ProjectPreferences, ProjectSummary } from '@gemstack/framework'
 import { preferencesFromFileConfig, notificationEnabled, PROJECT_PREFERENCE_KEYS } from '@gemstack/framework/client'
 import {
   onPreferences,
   savePreferences,
   onProjectPreferences,
   saveProjectPreferences,
+  onProjectPresets,
+  saveProjectPresets,
 } from '../server/preferences.telefunc.js'
 import { onProjects } from '../server/projects.telefunc.js'
 import { parseRoute } from './route.js'
@@ -36,6 +38,10 @@ const projectLoads = new Set<string>()
 const files = new Map<string, FrameworkFileConfig>()
 let filesLoading: Promise<void> | null = null
 let filesLoaded = false
+/** Each project's shared custom presets, committed in its `.the-framework/custom-presets.json` (#1025). */
+const projectPresets = new Map<string, CustomPreset[]>()
+const projectPresetLoads = new Set<string>()
+const EMPTY_PRESETS: CustomPreset[] = []
 /** Resolved snapshots, one per project, cleared on every notify. `useSyncExternalStore` compares
  * snapshots by identity, so resolving fresh on each read would re-render forever. */
 let resolved = new Map<string, Preferences>()
@@ -115,6 +121,7 @@ function ensureLoaded(projectId: string | null): void {
       })
   }
   if (!filesLoaded) loadFileConfigs()
+  ensureProjectPresetsLoaded(projectId)
   if (!projectId || projects.has(projectId) || projectLoads.has(projectId)) return
   projectLoads.add(projectId)
   void onProjectPreferences(projectId)
@@ -161,6 +168,53 @@ export function refreshFileConfigs(): void {
 
 if (typeof window !== 'undefined') window.addEventListener('focus', refreshFileConfigs)
 
+/** Load a project's shared custom presets (#1025) once, from its committed `.the-framework/`. */
+function ensureProjectPresetsLoaded(projectId: string | null): void {
+  if (!projectId || projectPresets.has(projectId) || projectPresetLoads.has(projectId)) return
+  projectPresetLoads.add(projectId)
+  void onProjectPresets(projectId)
+    .then(presets => {
+      // `??=` reasoning as elsewhere: a save during the load already wrote this entry.
+      if (!projectPresets.has(projectId)) projectPresets.set(projectId, presets)
+    })
+    .catch(() => {
+      if (!projectPresets.has(projectId)) projectPresets.set(projectId, [])
+    })
+    .finally(() => {
+      projectPresetLoads.delete(projectId)
+      notify()
+    })
+}
+
+/**
+ * The open project's shared custom presets (#1025): the ones committed into its `.the-framework/`,
+ * so everyone who clones the repo sees them. Empty with no project open, since there is no repo to
+ * read them from.
+ */
+export function useProjectPresets(): CustomPreset[] {
+  const projectId = typeof window === 'undefined' ? null : parseRoute(window.location.pathname).projectId
+  const value = useSyncExternalStore(
+    subscribe,
+    () => (projectId ? (projectPresets.get(projectId) ?? EMPTY_PRESETS) : EMPTY_PRESETS),
+    () => EMPTY_PRESETS,
+  )
+  useEffect(() => ensureProjectPresetsLoaded(projectId), [projectId])
+  return value
+}
+
+/**
+ * Replace the open project's shared presets, write-through then persist into its `.the-framework/`
+ * (#1025). Best-effort like {@link updatePreferences}: a failed save is not worth surfacing over a
+ * preset edit. A no-op when no project is open — there is no repo to commit them to.
+ */
+export function saveProjectPresetList(next: CustomPreset[]): void {
+  const projectId = activeProjectId()
+  if (!projectId) return
+  projectPresets.set(projectId, next)
+  void saveProjectPresets(projectId, next).catch(() => {})
+  notify()
+}
+
 /**
  * The project a write belongs to, read straight off the URL (#784 makes it the selection).
  * `updatePreferences` runs in an event handler rather than a render, so it reads the location
@@ -196,6 +250,11 @@ export function updatePreferences(patch: Partial<Preferences>): void {
     void saveProjectPreferences(projectId, next).catch(() => {})
   }
   notify()
+}
+
+/** The open project's id, or null on a view with none — for deciding a preset can be shared (#1025). */
+export function useActiveProjectId(): string | null {
+  return typeof window === 'undefined' ? null : parseRoute(window.location.pathname).projectId
 }
 
 /**

--- a/packages/framework-dashboard/server/preferences.telefunc.ts
+++ b/packages/framework-dashboard/server/preferences.telefunc.ts
@@ -12,6 +12,8 @@ import {
   savePreferences,
   onProjectPreferences,
   saveProjectPreferences,
+  onProjectPresets,
+  saveProjectPresets,
   onEditors,
   onNotifyChannels,
 } from '@gemstack/framework/dashboard-rpc'
@@ -21,6 +23,8 @@ export {
   savePreferences,
   onProjectPreferences,
   saveProjectPreferences,
+  onProjectPresets,
+  saveProjectPresets,
   onEditors,
   onNotifyChannels,
 }

--- a/packages/framework/src/dashboard-rpc/index.ts
+++ b/packages/framework/src/dashboard-rpc/index.ts
@@ -11,6 +11,8 @@ export {
   savePreferences,
   onProjectPreferences,
   saveProjectPreferences,
+  onProjectPresets,
+  saveProjectPresets,
   onEditors,
   onNotifyChannels,
   type SavePreferencesResult,

--- a/packages/framework/src/dashboard-rpc/preferences.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/preferences.telefunc.ts
@@ -1,6 +1,7 @@
-import { contextPreferences } from './context.js'
+import { contextPreferences, resolveProjectPath } from './context.js'
 import { detectEditors, type EditorInfo } from '../dashboard/open-in-app.js'
-import type { Preferences, ProjectPreferences } from '../registry.js'
+import { readProjectPresets, writeProjectPresets } from '../project-presets.js'
+import type { CustomPreset, Preferences, ProjectPreferences } from '../registry.js'
 
 // The user-preferences surface behind the new dashboard (#410): the Global options (Autopilot,
 // Technical, Vanilla, Eco + its section drops) the Start form and choice gate share. Persisted
@@ -56,6 +57,35 @@ export async function saveProjectPreferences(
     return { ok: true }
   } catch {
     return { ok: false, error: 'failed to save preferences' }
+  }
+}
+
+/**
+ * A project's shared custom presets (#1025), committed into its `.the-framework/` so they travel
+ * with the repo — the team-shared counterpart to the user-tier {@link onPreferences} presets. Read
+ * from the project's own checkout, so this resolves the project id to its workspace path rather than
+ * touching the home registry. `[]` on a public host (no local checkout) or an unknown project.
+ */
+export async function onProjectPresets(projectId: string): Promise<CustomPreset[]> {
+  if (!contextPreferences()) return []
+  const cwd = await resolveProjectPath(projectId)
+  if (!cwd) return []
+  return readProjectPresets(cwd).catch(() => [])
+}
+
+/** Persist a project's shared custom presets into its `.the-framework/` (#1025). No-op-safe on a public host. */
+export async function saveProjectPresets(
+  projectId: string,
+  presets: CustomPreset[],
+): Promise<SavePreferencesResult> {
+  if (!contextPreferences()) return { ok: false, error: 'preferences are not enabled on this server' }
+  const cwd = await resolveProjectPath(projectId)
+  if (!cwd) return { ok: false, error: 'unknown project' }
+  try {
+    await writeProjectPresets(cwd, presets)
+    return { ok: true }
+  } catch {
+    return { ok: false, error: 'failed to save presets' }
   }
 }
 

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -220,6 +220,7 @@ export {
   writeProjectPreferences,
   resolvePreferences,
   registryPreferencesStore,
+  sanitizeCustomPresets,
   REGISTRY_FILE,
   PROJECT_PREFERENCE_KEYS,
   type ProjectRecord,
@@ -230,6 +231,11 @@ export {
   type CustomPreset,
   type RegistryFs,
 } from './registry.js'
+export {
+  readProjectPresets,
+  writeProjectPresets,
+  PROJECT_PRESETS_FILE,
+} from './project-presets.js'
 export {
   installProject,
   enumerateGitRepos,

--- a/packages/framework/src/project-presets.test.ts
+++ b/packages/framework/src/project-presets.test.ts
@@ -1,0 +1,85 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { join } from 'node:path'
+import {
+  readProjectPresets,
+  writeProjectPresets,
+  PROJECT_PRESETS_FILE,
+} from './project-presets.js'
+import type { StoreFs } from './store/index.js'
+
+/** A minimal in-memory {@link StoreFs}: `read` throws on a missing path, like the node one. */
+function memFs(seed: Record<string, string> = {}): StoreFs & { files: Map<string, string> } {
+  const files = new Map<string, string>(Object.entries(seed))
+  return {
+    files,
+    async read(path) {
+      const v = files.get(path)
+      if (v === undefined) throw new Error(`ENOENT: ${path}`)
+      return v
+    },
+    async write(path, contents) { files.set(path, contents) },
+    async append(path, contents) { files.set(path, (files.get(path) ?? '') + contents) },
+    async exists(path) { return files.has(path) },
+    async mkdir() {},
+    async readdir() { return [] },
+  }
+}
+
+const GITIGNORE = join('/repo', '.the-framework', '.gitignore')
+const PRESETS = join('/repo', PROJECT_PRESETS_FILE)
+
+test('readProjectPresets is empty for a missing file (never throws)', async () => {
+  assert.deepEqual(await readProjectPresets('/repo', memFs()), [])
+})
+
+test('readProjectPresets is empty for malformed JSON', async () => {
+  const fs = memFs({ [PRESETS]: '{ not json' })
+  assert.deepEqual(await readProjectPresets('/repo', fs), [])
+})
+
+test('writeProjectPresets round-trips through readProjectPresets', async () => {
+  const fs = memFs()
+  const presets = [{ id: 'a', label: 'Ship it', prompt: 'do the thing' }]
+  await writeProjectPresets('/repo', presets, fs)
+  assert.deepEqual(await readProjectPresets('/repo', fs), presets)
+})
+
+test('writeProjectPresets sanitizes: drops malformed entries and trims', async () => {
+  const fs = memFs()
+  await writeProjectPresets(
+    '/repo',
+    [
+      { id: 'a', label: '  Keep  ', prompt: '  body  ' },
+      { id: '', label: 'no id', prompt: 'x' } as never,
+      { id: 'a', label: 'dup id', prompt: 'x' }, // duplicate id dropped
+      { id: 'b', label: 'no prompt', prompt: '' } as never,
+    ],
+    fs,
+  )
+  assert.deepEqual(await readProjectPresets('/repo', fs), [{ id: 'a', label: 'Keep', prompt: 'body' }])
+})
+
+test('writeProjectPresets un-ignores the file in .the-framework/.gitignore', async () => {
+  const fs = memFs({ [GITIGNORE]: '*\n!.gitignore\n!LOGS.md\n' })
+  await writeProjectPresets('/repo', [{ id: 'a', label: 'l', prompt: 'p' }], fs)
+  const gitignore = fs.files.get(GITIGNORE) ?? ''
+  assert.ok(gitignore.split('\n').includes('!custom-presets.json'), 'adds the negation')
+})
+
+test('writeProjectPresets does not duplicate the negation on a second save', async () => {
+  const fs = memFs({ [GITIGNORE]: '*\n!.gitignore\n!LOGS.md\n' })
+  await writeProjectPresets('/repo', [{ id: 'a', label: 'l', prompt: 'p' }], fs)
+  await writeProjectPresets('/repo', [{ id: 'a', label: 'l2', prompt: 'p2' }], fs)
+  const count = (fs.files.get(GITIGNORE) ?? '')
+    .split('\n')
+    .filter(line => line.trim() === '!custom-presets.json').length
+  assert.equal(count, 1)
+})
+
+test('writing an empty list keeps the file and the negation', async () => {
+  const fs = memFs({ [GITIGNORE]: '*\n!.gitignore\n!LOGS.md\n' })
+  await writeProjectPresets('/repo', [], fs)
+  assert.equal(fs.files.get(PRESETS), '[]\n')
+  assert.ok((fs.files.get(GITIGNORE) ?? '').includes('!custom-presets.json'))
+})

--- a/packages/framework/src/project-presets.ts
+++ b/packages/framework/src/project-presets.ts
@@ -1,0 +1,83 @@
+import { join } from 'node:path'
+import { THE_FRAMEWORK_DIR } from './framework-dir.js'
+import { sanitizeCustomPresets, type CustomPreset } from './registry.js'
+import { nodeStoreFs, type StoreFs } from './store/index.js'
+
+/**
+ * Project-scoped custom presets (#1025).
+ *
+ * The user tier (#626) saves a custom preset to the user's home file, so it follows the person
+ * across every project and stays private. The project tier saves it into the repo instead, so it
+ * travels with the code and everyone who clones the repo gets it — the "share your presets" half
+ * of the issue.
+ *
+ * The store is a plain JSON array of {@link CustomPreset}, the exact shape the user tier uses, so
+ * the dashboard renders both from one type and the same sanitizer guards both files.
+ */
+
+/** The committed file holding a project's shared custom presets, under `.the-framework/`. */
+export const PROJECT_PRESETS_FILE = `${THE_FRAMEWORK_DIR}/custom-presets.json`
+
+/** The `.the-framework/.gitignore` line that un-ignores the presets file so git tracks it. */
+const GITIGNORE_NEGATION = '!custom-presets.json'
+
+function gitignorePath(cwd: string): string {
+  return join(cwd, THE_FRAMEWORK_DIR, '.gitignore')
+}
+
+/**
+ * Read a project's shared custom presets. Forgiving like every other read here: a missing,
+ * unreadable or malformed file yields `[]`, never throws, and the same sanitizer that guards
+ * the home file drops any hand-edited or hostile entry.
+ */
+export async function readProjectPresets(
+  cwd: string,
+  fs: StoreFs = nodeStoreFs(),
+): Promise<CustomPreset[]> {
+  let raw: string
+  try {
+    raw = await fs.read(join(cwd, PROJECT_PRESETS_FILE))
+  } catch {
+    return []
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  return sanitizeCustomPresets(parsed)
+}
+
+/**
+ * Write a project's shared custom presets, sanitizing first so the committed file is always
+ * well-formed. Also ensures `.the-framework/.gitignore` un-ignores the file: the dir's ignore is
+ * `*` + a short allowlist (only `LOGS.md` is committed by default), so without a negation git would
+ * never see the presets and they could not be shared. Removing every preset writes an empty array
+ * rather than deleting the file, so the negation stays in place for the next save.
+ */
+export async function writeProjectPresets(
+  cwd: string,
+  presets: CustomPreset[],
+  fs: StoreFs = nodeStoreFs(),
+): Promise<void> {
+  await fs.mkdir(join(cwd, THE_FRAMEWORK_DIR))
+  await ensureGitignoreNegation(cwd, fs)
+  const sanitized = sanitizeCustomPresets(presets)
+  await fs.write(join(cwd, PROJECT_PRESETS_FILE), `${JSON.stringify(sanitized, null, 2)}\n`)
+}
+
+/** Append the un-ignore line to `.the-framework/.gitignore` unless it is already there. */
+async function ensureGitignoreNegation(cwd: string, fs: StoreFs): Promise<void> {
+  const path = gitignorePath(cwd)
+  let current = ''
+  try {
+    current = await fs.read(path)
+  } catch {
+    // No .gitignore yet (a pre-install dir): the negation only bites once the `*` ignore exists,
+    // so writing a bare negation is harmless and self-heals when install adds the rest.
+  }
+  if (current.split('\n').some(line => line.trim() === GITIGNORE_NEGATION)) return
+  const prefix = current && !current.endsWith('\n') ? `${current}\n` : current
+  await fs.write(path, `${prefix}${GITIGNORE_NEGATION}\n`)
+}

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -339,7 +339,7 @@ export function resolvePreferences(global: Preferences, project: ProjectPreferen
  * label/prompt are trimmed and length-capped, the list capped at {@link CUSTOM_PRESET_LIMITS.count},
  * and duplicate ids dropped. A malformed entry is skipped, not thrown — a bad registry never breaks the read.
  */
-function sanitizeCustomPresets(value: unknown): CustomPreset[] {
+export function sanitizeCustomPresets(value: unknown): CustomPreset[] {
   if (!Array.isArray(value)) return []
   const out: CustomPreset[] = []
   const seen = new Set<string>()


### PR DESCRIPTION
Closes #1025.

## What

Custom presets were user-global only (#626): saved to your home config, private, following you everywhere. This adds the **project tier** the issue asks for, so a preset can be **committed into the repo and shared with your team**.

When you create a preset with a project open, a **"Save to"** choice appears:
- **Just me** (default) - the existing user-home store, private, on every project.
- **This project** - committed into `.the-framework/custom-presets.json`, so anyone who clones the repo gets it.

Shared presets show under a **"Project presets"** group in the Presets menu and the `/` editor menu, and delete from there. No project open = no scope choice (nothing to share into).

## How

- **`project-presets.ts`** - `readProjectPresets`/`writeProjectPresets` over a committed JSON file, reusing the `CustomPreset` shape + `sanitizeCustomPresets` (now exported). Write self-heals `.the-framework/.gitignore` with a `!custom-presets.json` negation, since that dir ignores everything but `LOGS.md` by default.
- **Two telefuncs** `onProjectPresets`/`saveProjectPresets`, folded into `preferences.telefunc.ts` (so they auto-register and the #866 register test auto-covers them). They resolve the project's own checkout via `resolveProjectPath` and are gated on `contextPreferences()` like the other preference RPCs, so a public relay host reads nothing and writes nothing.
- **Client tier** in `lib/preferences.ts`: a per-project presets cache, `useProjectPresets()`, and `saveProjectPresetList()`, mirroring the existing project-preferences tier.
- **UI**: scope selector in `PresetCreatePanel`, a "Project presets" group in `PresetsMenu` (shared `SavedPresetRow` extracted to avoid duplicating the user group), `project-preset:` items in the `/` menu.

## Notes for review

- **Committed, not auto-committed.** The gitignore negation makes git *track* the file; it lands in the repo on the next framework commit or a manual `git add`, like any source file. I did not add a dedicated commit step. Say the word if you want the write to commit itself.
- Location follows the issue literally (`.the-framework/`). Open to `the-framework.yml` instead if you'd rather it sit with the other committed run config.

## Tests

- Framework: **1122 pass / 0 fail** (new `project-presets.test.ts`: missing/malformed reads, round-trip, sanitize, gitignore negation idempotence). Register auto-check confirms both telefuncs registered.
- Dashboard: **325 pass / 0 fail** (new coverage in `PresetsMenu.test.tsx` + `PresetCreatePanel.test.tsx`).
- Both typechecks clean; dashboard build + daemon serve tests green.