### PR TITLE
feat(dashboard): launcher control-row + Context/system-prompt dropdowns (#1046)

### DIFF
--- a/.changeset/launcher-context-dropdown.md
+++ b/.changeset/launcher-context-dropdown.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework': patch
+---
+
+Dashboard launcher polish. The run Context picker is now a dropdown that sits in the composer control row next to the presets button, instead of an inline section that pushed the form down. The options gear moved next to the model selector, before Send, and shows a small presence dot rather than a count. "Enhanced System Prompt" is now a dropdown too, sharing the "In play" row. Every menu trigger stays highlighted while its menu is open, and menus open toward the side with room. The prompt editor and all dropdowns now scroll through the shared thin overlay scrollbar, which also removes the doubled border/track the native bar left inside popups.

--- a/packages/framework-dashboard/components/AgentModelMenu.tsx
+++ b/packages/framework-dashboard/components/AgentModelMenu.tsx
@@ -63,7 +63,7 @@ export function AgentModelMenu({
         type="button"
         disabled={busy}
         title={`Agent: ${current?.label ?? ''} · Model: ${currentModelLabel}`}
-        className={cn(buttonVariants({ variant: 'ghost', size: 'sm' }), 'gap-1.5 font-normal')}
+        className={cn(buttonVariants({ variant: 'ghost', size: 'sm' }), 'gap-1.5 px-2 font-normal')}
       >
         {current?.icon ? (
           <span className="flex h-4 w-4 items-center justify-center">{current.icon}</span>
@@ -73,7 +73,7 @@ export function AgentModelMenu({
         {currentModelLabel}
         <ChevronDown className="h-3.5 w-3.5 opacity-70" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start">
+      <DropdownMenuContent align="end">
         {agents.map(a => (
           <DropdownMenuSub key={a.value}>
             <DropdownMenuSubTrigger>

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useImperativeHandle, useMemo, useRef, useState, type FormEvent } from 'react'
+import { forwardRef, useImperativeHandle, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react'
 import { ArrowUp, Loader2 } from 'lucide-react'
 import type { ProjectSummary } from '@gemstack/framework'
 import { AGENTS, AGENT_LABELS, LAUNCHER_PRESETS, type AgentName } from '@gemstack/framework/client'
@@ -104,8 +104,15 @@ export const Composer = forwardRef<ComposerHandle, {
    *  that session by default, instead of the whole codebase. Absent at the launcher, where no
    *  session exists yet. */
   sessionName?: string | undefined
+  /** A control the launcher hangs in the composer control row (#1046): the Context picker. Only the
+   *  launcher passes one; in-session there is no launcher row. */
+  contextControl?: ReactNode
+  /** What the launcher puts at the start of the "In play" row (#1046): the Enhanced System Prompt
+   *  disclosure, so it shares that row with the resolved-options strip. Its own expandable panel
+   *  drops full-width below. Only the launcher passes one. */
+  resolvedRowStart?: ReactNode
 }>(function Composer(
-  { files, addContext, removeContext, onSubmit, onPromptChange, onPreset, busy, submitLabel, submitBusyLabel, placeholder, compact = false, showAgentModel = true, inSession = false, sessionName },
+  { files, addContext, removeContext, onSubmit, onPromptChange, onPreset, busy, submitLabel, submitBusyLabel, placeholder, compact = false, showAgentModel = true, inSession = false, sessionName, contextControl, resolvedRowStart },
   ref,
 ) {
   const [prompt, setPrompt] = useState('')
@@ -267,33 +274,33 @@ export const Composer = forwardRef<ComposerHandle, {
       busy={busy}
     />
   )
-  const secondaryControls = (
-    <>
-      {/* Presets get a visible surface (#948): load, create and delete in one menu, instead of
-          loading only behind typing `/` and deleting off in the options gear. Not in the compact
-          row, which has no room and no create panel. */}
-      {!compact && (
-        <PresetsMenu
-          presets={presets}
-          customPresets={customPresets}
-          projectPresets={projectPresets}
-          busy={busy}
-          onLoad={loadPresetFromMenu}
-          onNew={() => setAddingPreset(true)}
-          onDelete={id => updatePreferences({ customPresets: customPresets.filter(p => p.id !== id) })}
-          onDeleteProject={id => saveProjectPresetList(projectPresets.filter(p => p.id !== id))}
-        />
-      )}
-      <OptionsMenu
-        // In-session (#833): the run options were baked into the session at spawn, so offering
-        // them here only rewrote the next session's defaults while reading as session state.
-        options={inSession ? [] : mainOptions}
-        ecoOptions={inSession ? [] : ecoOptions}
-        showEco={!inSession && eco && !ecoDisabled}
-        busy={busy}
-        {...(inSession ? { label: 'Preferences' } : {})}
-      />
-    </>
+  {/* Presets get a visible surface (#948): load, create and delete in one menu, instead of
+      loading only behind typing `/` and deleting off in the options gear. Not in the compact
+      row, which has no room and no create panel. */}
+  const presetsEl = !compact && (
+    <PresetsMenu
+      presets={presets}
+      customPresets={customPresets}
+      projectPresets={projectPresets}
+      busy={busy}
+      onLoad={loadPresetFromMenu}
+      onNew={() => setAddingPreset(true)}
+      onDelete={id => updatePreferences({ customPresets: customPresets.filter(p => p.id !== id) })}
+      onDeleteProject={id => saveProjectPresetList(projectPresets.filter(p => p.id !== id))}
+    />
+  )
+  // The options gear sits with the agent/model select and submit at the end of the row (#1046), so
+  // the three run controls read as one cluster.
+  const optionsGearEl = (
+    <OptionsMenu
+      // In-session (#833): the run options were baked into the session at spawn, so offering
+      // them here only rewrote the next session's defaults while reading as session state.
+      options={inSession ? [] : mainOptions}
+      ecoOptions={inSession ? [] : ecoOptions}
+      showEco={!inSession && eco && !ecoDisabled}
+      busy={busy}
+      {...(inSession ? { label: 'Preferences' } : {})}
+    />
   )
 
   // The submit is a single icon button that only shows once the prompt has text (#721): an empty
@@ -319,7 +326,9 @@ export const Composer = forwardRef<ComposerHandle, {
         'h-8 w-8 shrink-0 transition-[margin,opacity,transform] duration-150 ease-out',
         hasPrompt
           ? 'ml-0 translate-x-0 opacity-100 disabled:opacity-100'
-          : 'pointer-events-none -ml-8 translate-x-2 opacity-0 disabled:opacity-0',
+          // -2.375rem = the button's own w-8 (2rem) plus the row's gap-1.5 (0.375rem), so a hidden
+          // submit leaves the gear flush to the box edge — bottom and right padding stay equal.
+          : 'pointer-events-none -ml-[2.375rem] translate-x-2 opacity-0 disabled:opacity-0',
       )}
     >
       {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowUp className="h-4 w-4" />}
@@ -333,7 +342,7 @@ export const Composer = forwardRef<ComposerHandle, {
       <div className="flex items-start gap-1.5">
         <div className="min-w-0 flex-1">{editorEl}</div>
         {agentModelEl}
-        {secondaryControls}
+        {optionsGearEl}
         {submitButton}
       </div>
     )
@@ -346,21 +355,28 @@ export const Composer = forwardRef<ComposerHandle, {
           borderless here (its border moved out to this box); controls sit tucked below it. */}
       <div className="rounded-lg border border-border bg-transparent focus-within:border-muted-foreground/40">
         {editorEl}
-        {/* Run controls (#649/#650/#654/#668): presets and the options gear at the start, then the
-            agent+model select paired with submit at the end. */}
+        {/* Run controls (#649/#650/#654/#668): presets then the Context picker at the start (#1046),
+            the agent+model select, the options gear and submit clustered at the end. */}
         <div className="flex flex-wrap items-center gap-1.5 px-2 pb-2">
-          {secondaryControls}
+          {presetsEl}
+          {contextControl}
           <div className="ml-auto flex items-center gap-1.5">
             {agentModelEl}
+            {optionsGearEl}
             {submitButton}
           </div>
         </div>
       </div>
 
-      {/* What the session resolves to, without opening the gear (#842). Off in the compact row
-          above, which is one line on purpose, and in-session (#833), where it described the
-          *global* options rather than the ones this session actually runs with. */}
-      {!inSession && <ResolvedOptions options={mainOptions} sources={sources} fileConfig={fileConfig} />}
+      {/* The "In play" row (#842/#1046): the Enhanced System Prompt dropdown at the start, the
+          resolved-options strip at the end. Off in the compact row (one line) and in-session
+          (#833), where the strip described the *global* options rather than this session's. */}
+      {!inSession && (
+        <div className="mt-2 flex items-center justify-between gap-3">
+          {resolvedRowStart}
+          <ResolvedOptions options={mainOptions} sources={sources} fileConfig={fileConfig} />
+        </div>
+      )}
 
       {addingPreset && (
         <PresetCreatePanel

--- a/packages/framework-dashboard/components/ContextMenu.test.tsx
+++ b/packages/framework-dashboard/components/ContextMenu.test.tsx
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { ProjectSummary } from '@gemstack/framework'
+import { ContextMenu } from './ContextMenu.js'
+
+afterEach(cleanup)
+
+const proj = (id: string, name: string, path: string) => ({ id, name, path }) as ProjectSummary
+const others = [proj('a', 'api', '/w/api'), proj('b', 'ui', '/w/ui')]
+
+function open(over: Partial<Parameters<typeof ContextMenu>[0]> = {}) {
+  const onToggle = vi.fn()
+  render(
+    <ContextMenu
+      otherProjects={others}
+      context={new Set(['/w/api'])}
+      contextFiles={[]}
+      summary=""
+      busy={false}
+      onToggle={onToggle}
+      {...over}
+    />,
+  )
+  fireEvent.click(screen.getByRole('button', { name: /Context/ }))
+  return { onToggle }
+}
+
+// #1046: the Context picker moved from an inline disclosure to a dropdown on the "In play" row.
+describe('ContextMenu (#1046)', () => {
+  test('lists the other repos and reflects which are already in context', () => {
+    open()
+    const api = screen.getByRole('menuitemcheckbox', { name: 'api' })
+    const ui = screen.getByRole('menuitemcheckbox', { name: 'ui' })
+    expect(api.getAttribute('aria-checked')).toBe('true')
+    expect(ui.getAttribute('aria-checked')).toBe('false')
+  })
+
+  test('toggling a repo reports its path', () => {
+    const { onToggle } = open()
+    fireEvent.click(screen.getByRole('menuitemcheckbox', { name: 'ui' }))
+    expect(onToggle).toHaveBeenCalledWith('/w/ui')
+  })
+
+  test('the trigger carries the summary', () => {
+    render(
+      <ContextMenu otherProjects={others} context={new Set()} contextFiles={[]} summary="2 projects" busy={false} onToggle={() => {}} />,
+    )
+    const trigger = screen.getByRole('button', { name: /Context/ })
+    expect(trigger.textContent).toContain('2 projects')
+  })
+
+  test('shows picked files, removable, and the empty hint otherwise', () => {
+    const onToggle = vi.fn()
+    open({ contextFiles: ['DECISIONS.md'], onToggle })
+    expect(screen.getByText('DECISIONS.md')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: /Remove DECISIONS\.md/ }))
+    expect(onToggle).toHaveBeenCalledWith('DECISIONS.md')
+  })
+
+  test('empty Files hint when nothing is picked', () => {
+    open()
+    expect(screen.getByText(/None yet/)).toBeTruthy()
+  })
+})

--- a/packages/framework-dashboard/components/ContextMenu.tsx
+++ b/packages/framework-dashboard/components/ContextMenu.tsx
@@ -1,0 +1,90 @@
+import type { ProjectSummary } from '@gemstack/framework'
+import { Layers } from 'lucide-react'
+import { cn } from '../lib/utils.js'
+import { buttonVariants } from './ui/button.js'
+import { ContextFiles } from './ContextFiles.js'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuCheckboxItem,
+  DropdownMenuSeparator,
+} from './ui/dropdown-menu.js'
+
+// The run Context picker (#439/#314) as a dropdown on the launcher's "In play" row. It was an
+// inline disclosure that pushed the whole form down when opened; a dropdown keeps it folded away
+// until asked for. Ticking other repos narrows the agent's focus (it can still reach every repo);
+// the Files list shows what a `#` mention or the file tree added, each removable.
+export function ContextMenu({
+  otherProjects,
+  context,
+  contextFiles,
+  summary,
+  busy,
+  onToggle,
+}: {
+  /** The registered repos other than the current one — the focus targets (#665). */
+  otherProjects: ProjectSummary[]
+  /** The run Context set (repo paths + file paths), for the checked state. */
+  context: Set<string>
+  /** The individual files in the Context, added via `#` or the tree. */
+  contextFiles: string[]
+  /** "2 projects · 1 file", or empty when nothing is picked. */
+  summary: string
+  busy: boolean
+  /** Toggle a repo or drop a file from the Context. */
+  onToggle: (path: string) => void
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        type="button"
+        disabled={busy}
+        title="Narrow the run to specific repos and files"
+        className={cn(
+          buttonVariants({ variant: 'ghost', size: 'sm' }),
+          // h-8 to match the Presets `[/]` button beside it; the open-highlight is shared on the trigger.
+          'h-8 items-center gap-1.5 px-2 text-[11px] font-normal text-muted-foreground hover:text-foreground',
+        )}
+      >
+        <Layers className="h-3.5 w-3.5 shrink-0" aria-hidden />
+        Context{summary && <span className="text-primary"> · {summary}</span>}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-[18rem] max-w-[24rem]">
+        <DropdownMenuGroup>
+          <DropdownMenuLabel title="The agent can still reach every repo; ticking some just narrows its focus.">
+            Projects
+          </DropdownMenuLabel>
+          {otherProjects.length > 0 ? (
+            otherProjects.map(p => (
+              <DropdownMenuCheckboxItem
+                key={p.id}
+                checked={context.has(p.path)}
+                onCheckedChange={() => onToggle(p.path)}
+                disabled={busy}
+                title={p.path}
+              >
+                <span className="truncate">{p.name}</span>
+              </DropdownMenuCheckboxItem>
+            ))
+          ) : (
+            <p className="px-2 py-1 text-xs text-muted-foreground/60">No other repos to add.</p>
+          )}
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Files</DropdownMenuLabel>
+          {contextFiles.length > 0 ? (
+            <div className="px-2 py-1">
+              <ContextFiles files={contextFiles} onRemove={onToggle} busy={busy} />
+            </div>
+          ) : (
+            <p className="px-2 py-1 text-xs text-muted-foreground/60">None yet — add with # or the Files tab.</p>
+          )}
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/packages/framework-dashboard/components/OptionsMenu.test.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.test.tsx
@@ -23,10 +23,13 @@ function open() {
 }
 
 describe('OptionsMenu (#654)', () => {
-  test('the trigger badges how many options are on', () => {
+  test('the trigger marks that options are on with a dot (#1046)', () => {
     render(<OptionsMenu options={mainOptions()} ecoOptions={ecoOptions()} showEco={false} busy={false} />)
-    // Only Eco is checked -> the gear trigger shows a corner badge "1".
-    expect(screen.getByRole('button', { name: /session options/i }).textContent).toContain('1')
+    const trigger = screen.getByRole('button', { name: /session options/i })
+    // A presence dot now, not a number: the count lives in the title for a11y, the dot in the corner.
+    expect(trigger.getAttribute('title')).toMatch(/\bon$/)
+    expect(trigger.querySelector('span.rounded-full')).not.toBeNull()
+    expect(trigger.textContent).not.toContain('1') // no number in the badge anymore
   })
 
   test('toggling an item writes the new value through', () => {

--- a/packages/framework-dashboard/components/OptionsMenu.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.tsx
@@ -86,12 +86,12 @@ export function OptionsMenu({
       >
         <Settings className="h-4 w-4" />
         {activeCount > 0 && (
-          <span className="absolute -right-1 -top-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-[var(--color-primary)] px-0.5 text-[9px] font-medium leading-none text-[var(--color-primary-foreground)]">
-            {activeCount}
-          </span>
+          // A small presence dot (#1046): that some options are on is the signal; the exact count
+          // is one click away in the menu, so the number was noise.
+          <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-[var(--color-primary)]" />
         )}
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="min-w-[19rem] max-w-[22rem]">
+      <DropdownMenuContent align="end" className="min-w-[19rem] max-w-[22rem]">
         {options.map(o => (
           <OptionCheckboxRow key={o.key} row={o} busy={busy} />
         ))}

--- a/packages/framework-dashboard/components/PromptEditor.tsx
+++ b/packages/framework-dashboard/components/PromptEditor.tsx
@@ -7,6 +7,7 @@ import type { Editor, Range } from '@tiptap/core'
 import { Token, MACRO_TOKENS, ACTION_TOKENS, type TokenSpec } from './prompt-editor/tokens.js'
 import { makeTrigger } from './prompt-editor/suggestion.js'
 import { tokenizeEditorDoc } from './prompt-editor/tokenize.js'
+import { ScrollArea } from './ui/scroll-area.js'
 import type { SuggestionItem } from './prompt-editor/SuggestionList.js'
 // The same entry the Presets button renders: the `/` menu is the other face of that one list,
 // so it reads the shape rather than restating it structurally.
@@ -338,18 +339,19 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
   const placeholderInset = compact ? 'left-2 top-1.5' : 'left-4 top-4'
   return (
     <div className="relative">
-      <EditorContent
-        editor={editor}
-        className={`w-full overflow-y-auto bg-transparent text-sm ${pad} ${
-          // The resting height is deliberately short (#756): the editor grows with its content up
-          // to max-h, so the tall empty box was reserving room for text nobody had typed yet.
-          // Compact (navbar) keeps its own border+ring; the full composer's border lives on the
-          // surrounding composer box (#721) so the editor and its controls read as one surface.
-          compact
-            ? 'max-h-32 min-h-8 rounded-md border border-border focus-within:ring-2 focus-within:ring-[var(--color-primary)]'
-            : 'max-h-64 min-h-[2.75rem]'
-        }`}
-      />
+      {/* The scroll rides a ScrollArea (#1046) so a long prompt shows our thin overlay bar, not the
+          OS one. The resting height is deliberately short (#756): the editor grows with its content
+          up to max-h, so the tall empty box no longer reserves room for text nobody has typed.
+          Compact (navbar) keeps its own border+ring; the full composer's border lives on the
+          surrounding composer box (#721) so the editor and its controls read as one surface. */}
+      <ScrollArea
+        className={compact ? 'rounded-md border border-border focus-within:ring-2 focus-within:ring-[var(--color-primary)]' : ''}
+        // The height cap goes on the viewport (the scroller), not the Root — a Root max-h cannot be
+        // resolved by the viewport's height, so the editor would grow instead of scrolling.
+        viewportClassName={compact ? 'max-h-32 min-h-8' : 'max-h-64 min-h-[2.75rem]'}
+      >
+        <EditorContent editor={editor} className={`w-full bg-transparent text-sm ${pad}`} />
+      </ScrollArea>
       {isEmpty && (
         <span className={`pointer-events-none absolute text-sm text-muted-foreground ${placeholderInset}`}>
           {placeholder}

--- a/packages/framework-dashboard/components/ResolvedOptions.tsx
+++ b/packages/framework-dashboard/components/ResolvedOptions.tsx
@@ -29,7 +29,7 @@ export function ResolvedOptions({
   ]
   if (!chips.length) return null
   return (
-    <div className="mt-1.5 flex flex-wrap items-center gap-1 text-[11px] text-muted-foreground">
+    <div className="flex flex-wrap items-center gap-1 text-[11px] text-muted-foreground">
       <span className="mr-0.5">In play:</span>
       {chips.map(chip => (
         <span

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -7,10 +7,8 @@ import { usePreferences, updatePreferences, autopilotEnabled } from '../lib/pref
 import { useStartRun } from '../lib/use-start-run.js'
 import { useLoaded } from '../lib/use-async.js'
 import { Composer, type ComposerHandle } from './Composer.js'
-import { ContextFiles } from './ContextFiles.js'
-import { DisclosureToggle } from './DisclosureToggle.js'
+import { ContextMenu } from './ContextMenu.js'
 import { SystemPromptDisclosure } from './SystemPromptDisclosure.js'
-import { Checkbox } from './ui/checkbox.js'
 
 // Start a run in the selected project (#405): the one write that goes through the daemon's own
 // `startRun` (with its one-run-per-project busy guard), posted over Telefunc. The editor + control
@@ -53,7 +51,6 @@ export function StartRunForm({
   // Context selector (#439/#314): the agent can reach every registered repo, so ticking a subset
   // narrows its focus — the picked paths become one `Context:` line in the system prompt.
   const projects = useLoaded<ProjectSummary[]>(onProjects, [], [])
-  const [showContext, setShowContext] = useState(false)
   // The repo's own SYSTEM.md (#872): composition takes it as `user`, but reading it is
   // Node-bound, so without this read the "entire system prompt" preview under-reported.
   const userSystemPrompt = useLoaded<string | null>(() => onSystemPromptUser(projectId), null, [projectId])
@@ -91,8 +88,28 @@ export function StartRunForm({
     }
   }
 
+  // The Enhanced System Prompt dropdown (#863) rides the start of the "In play" row (#1046).
+  const systemPromptEl = (
+    <SystemPromptDisclosure
+      prompt={prompt}
+      disabled={vanilla}
+      onDisabledChange={value => updatePreferences({ vanilla: value })}
+      transparent={transparent}
+      onTransparentChange={value => updatePreferences({ transparent: value })}
+      // Read off the options this form will really send, so the preview cannot claim a
+      // smaller prompt than the run gets (#863 asks for the entire one). The browser
+      // section is Claude-only, and that rule lives in the mapping rather than here.
+      browser={options.browser ?? false}
+      autopilot={autopilot}
+      eco={options.eco}
+      context={[...context]}
+      user={userSystemPrompt}
+      busy={busy}
+    />
+  )
+
   return (
-    <form onSubmit={e => e.preventDefault()} className="border-b border-border p-3">
+    <form onSubmit={e => e.preventDefault()} className="p-3">
       <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Start a session</div>
       <Composer
         ref={composerRef}
@@ -117,69 +134,23 @@ export function StartRunForm({
         busy={busy}
         submitLabel="Start session"
         submitBusyLabel="Starting…"
+        contextControl={
+          <ContextMenu
+            otherProjects={otherProjects}
+            context={context}
+            contextFiles={contextFiles}
+            summary={contextSummary}
+            busy={busy}
+            onToggle={toggleContext}
+          />
+        }
+        resolvedRowStart={systemPromptEl}
       />
 
       {/* Feedback right where the action is (#948): the error used to render below the (possibly
           expanded, tall) Context disclosure, past the fold from the Start button that caused it. */}
       {error && <p role="alert" className="mt-2 text-xs text-danger">{error}</p>}
       {note && !error && <p role="status" className="mt-2 text-xs text-muted-foreground">{note}</p>}
-
-      <SystemPromptDisclosure
-        prompt={prompt}
-        disabled={vanilla}
-        onDisabledChange={value => updatePreferences({ vanilla: value })}
-        transparent={transparent}
-        onTransparentChange={value => updatePreferences({ transparent: value })}
-        // Read off the options this form will really send, so the preview cannot claim a
-        // smaller prompt than the run gets (#863 asks for the entire one). The browser
-        // section is Claude-only, and that rule lives in the mapping rather than here.
-        browser={options.browser ?? false}
-        autopilot={autopilot}
-        eco={options.eco}
-        context={[...context]}
-        user={userSystemPrompt}
-        busy={busy}
-      />
-
-      {/* Always rendered (#948): hiding the whole section for a single-project setup also hid
-          the only place that teaches the `#` / Files-tab focus flow. */}
-      <div className="mt-3 text-xs text-muted-foreground">
-          <DisclosureToggle open={showContext} onToggle={() => setShowContext(s => !s)}>
-            Context{contextSummary && <span className="text-primary"> · {contextSummary}</span>}
-          </DisclosureToggle>
-          {showContext && (
-            <div className="mt-2 grid grid-cols-1 gap-4 rounded border border-border p-3 sm:grid-cols-2">
-              {/* Projects: repo checkboxes. The agent can still reach every repo; ticking some just
-                  narrows its focus (kept in the heading's tooltip). */}
-              <div>
-                <p className="mb-1.5 text-muted-foreground/80" title="The agent can still reach every repo; ticking some just narrows its focus.">
-                  Projects
-                </p>
-                {otherProjects.length > 0 ? (
-                  <div className="flex flex-col gap-1">
-                    {otherProjects.map(p => (
-                      <label key={p.id} className="flex cursor-pointer items-center gap-1.5" title={p.path}>
-                        <Checkbox checked={context.has(p.path)} onCheckedChange={() => toggleContext(p.path)} disabled={busy} />
-                        <span className="truncate">{p.name}</span>
-                      </label>
-                    ))}
-                  </div>
-                ) : (
-                  <p className="text-muted-foreground/60">No other repos to add.</p>
-                )}
-              </div>
-              {/* Files picked via a `#` mention or the file tree (#661): removable with an X. */}
-              <div>
-                <p className="mb-1 text-muted-foreground/80">Files</p>
-                {contextFiles.length > 0 ? (
-                  <ContextFiles files={contextFiles} onRemove={toggleContext} busy={busy} />
-                ) : (
-                  <p className="text-muted-foreground/60">None yet — add with # or the Files tab.</p>
-                )}
-              </div>
-            </div>
-          )}
-      </div>
     </form>
   )
 }

--- a/packages/framework-dashboard/components/SystemPromptDisclosure.tsx
+++ b/packages/framework-dashboard/components/SystemPromptDisclosure.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react'
+import { ChevronDown } from 'lucide-react'
 import { composeRunSystem, type EcoOptions } from '@gemstack/framework/client'
-import { DisclosureToggle } from './DisclosureToggle.js'
+import { Popover, PopoverTrigger, PopoverContent } from './ui/popover.js'
 import { Checkbox } from './ui/checkbox.js'
 import { cn } from '../lib/utils.js'
 
@@ -54,8 +54,6 @@ export function SystemPromptDisclosure({
   user?: string | null | undefined
   busy: boolean
 }) {
-  const [open, setOpen] = useState(false)
-
   const text = composeRunSystem({
     antiLazyPill: !disabled,
     ...(transparent ? { transparent: true } : {}),
@@ -74,8 +72,14 @@ export function SystemPromptDisclosure({
   const fullyOn = antiLazyOn && integrationOn
 
   return (
-    <div className="mt-3 text-xs">
-      <DisclosureToggle open={open} onToggle={() => setOpen(o => !o)}>
+    // A dropdown, matching the Context / preset menus on this row (#1046). No top margin: the
+    // launcher's "In play" row owns the spacing.
+    <Popover>
+      <PopoverTrigger
+        className={cn(
+          'flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground outline-none hover:text-foreground',
+        )}
+      >
         {/* A status dot, like every other state in the app. This was a ✅/❌ pair, which sat at
             emoji size and colour next to 12px text and matched nothing else on the page. */}
         <span
@@ -84,10 +88,10 @@ export function SystemPromptDisclosure({
         />
         Enhanced System Prompt
         <span className="sr-only">{fullyOn ? ' (fully enabled)' : ' (not fully enabled)'}</span>
-      </DisclosureToggle>
-
-      {open && (
-        <div className="mt-2 space-y-2 rounded border border-border p-3 text-muted-foreground">
+        <ChevronDown className="h-3.5 w-3.5 opacity-70" aria-hidden />
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[min(42rem,calc(100vw-2rem))] text-xs text-muted-foreground">
+        <div className="space-y-2">
           <p>
             The Framework wraps your prompt with a so-called &quot;system prompt&quot; (it&apos;s just a prompt wrapping
             your prompt) in order to enable long-running autonomous agents.
@@ -129,7 +133,7 @@ export function SystemPromptDisclosure({
             </p>
           )}
         </div>
-      )}
-    </div>
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/packages/framework-dashboard/components/ui/dropdown-menu.tsx
+++ b/packages/framework-dashboard/components/ui/dropdown-menu.tsx
@@ -1,33 +1,62 @@
 import { Menu } from '@base-ui-components/react/menu'
 import { ChevronRight, Check } from 'lucide-react'
-import type { ComponentProps } from 'react'
+import type { ComponentProps, ReactNode } from 'react'
 import { cn } from '../../lib/utils.js'
+import { ScrollArea } from './scroll-area.js'
 
 // The shadcn "base" dropdown menu (built on Base UI, not Radix) — trimmed to what the Start
 // form's preset + agent/model menus need (#649/#650). Themed with the dashboard's CSS-var tokens
 // (there is no --color-popover, so the card surface stands in). Item highlight state is
 // `data-highlighted`; an open submenu trigger is `data-popup-open`.
 
+// Border + surface live on the Popup; the scroll (and its padding) move inside a ScrollArea so a
+// long menu shows our own thin overlay bar (#1046) instead of the OS one, whose grey track read as
+// a second layer beside the border. #710 stands: no native scrollbar comes back.
 const POPUP_CLASS =
-  'max-h-[var(--available-height)] min-w-[13rem] overflow-y-auto rounded-md border border-[var(--color-border)] bg-[var(--color-card)] p-1 text-[var(--color-card-foreground)] shadow-md outline-none'
+  'min-w-[13rem] rounded-md border border-[var(--color-border)] bg-[var(--color-card)] text-[var(--color-card-foreground)] shadow-md outline-none'
+
+/** The scrolled body every popup shares: caps at the space the positioner allows, pads the items. */
+function PopupBody({ children }: { children: ReactNode }) {
+  return (
+    <ScrollArea viewportClassName="max-h-[var(--available-height)]">
+      <div className="p-1">{children}</div>
+    </ScrollArea>
+  )
+}
 const ITEM_CLASS =
   'relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[highlighted]:bg-[var(--color-accent)] data-[highlighted]:text-[var(--color-accent-foreground)] data-[disabled]:pointer-events-none data-[disabled]:opacity-50'
 
 export const DropdownMenu = Menu.Root
-export const DropdownMenuTrigger = Menu.Trigger
 export const DropdownMenuGroup = Menu.Group
 export const DropdownMenuSub = Menu.SubmenuRoot
+
+// Keep a trigger lit while its menu is open (#1046), matching the hover state Base UI marks it with.
+// One place so every menu button (presets, agent/model, gear, Context, notifications) behaves the same.
+const TRIGGER_OPEN_HIGHLIGHT =
+  'data-[popup-open]:bg-[var(--color-accent)] data-[popup-open]:text-[var(--color-accent-foreground)]'
+
+export function DropdownMenuTrigger({ className, ...props }: ComponentProps<typeof Menu.Trigger>) {
+  return (
+    <Menu.Trigger
+      className={typeof className === 'function' ? className : cn(TRIGGER_OPEN_HIGHLIGHT, className)}
+      {...props}
+    />
+  )
+}
 
 export function DropdownMenuContent({
   className,
   sideOffset = 6,
   align = 'start',
+  children,
   ...props
 }: ComponentProps<typeof Menu.Popup> & { sideOffset?: number; align?: 'start' | 'center' | 'end' }) {
   return (
     <Menu.Portal>
       <Menu.Positioner sideOffset={sideOffset} align={align} className="z-50 outline-none">
-        <Menu.Popup className={cn(POPUP_CLASS, className)} {...props} />
+        <Menu.Popup className={cn(POPUP_CLASS, className)} {...props}>
+          <PopupBody>{children}</PopupBody>
+        </Menu.Popup>
       </Menu.Positioner>
     </Menu.Portal>
   )
@@ -68,11 +97,13 @@ export function DropdownMenuSubTrigger({ className, children, ...props }: Compon
   )
 }
 
-export function DropdownMenuSubContent({ className, ...props }: ComponentProps<typeof Menu.Popup>) {
+export function DropdownMenuSubContent({ className, children, ...props }: ComponentProps<typeof Menu.Popup>) {
   return (
     <Menu.Portal>
       <Menu.Positioner side="right" align="start" sideOffset={2} className="z-50 outline-none">
-        <Menu.Popup className={cn(POPUP_CLASS, className)} {...props} />
+        <Menu.Popup className={cn(POPUP_CLASS, className)} {...props}>
+          <PopupBody>{children}</PopupBody>
+        </Menu.Popup>
       </Menu.Positioner>
     </Menu.Portal>
   )

--- a/packages/framework-dashboard/components/ui/popover.tsx
+++ b/packages/framework-dashboard/components/ui/popover.tsx
@@ -1,0 +1,49 @@
+import { Popover as BasePopover } from '@base-ui-components/react/popover'
+import type { ComponentProps, ReactNode } from 'react'
+import { cn } from '../../lib/utils.js'
+import { ScrollArea } from './scroll-area.js'
+
+// The shadcn "base" popover (Base UI, not Radix) — the floating panel for rich content a menu can't
+// hold, like the Enhanced System Prompt's checkboxes + prompt preview (#1046). Same surface as the
+// dropdown menu (border + card + shadow on the Popup, the body scrolls through our ScrollArea), and
+// the trigger stays lit while open via `data-popup-open`, matching the menus.
+
+const TRIGGER_OPEN_HIGHLIGHT =
+  'data-[popup-open]:bg-[var(--color-accent)] data-[popup-open]:text-[var(--color-accent-foreground)]'
+
+export const Popover = BasePopover.Root
+
+export function PopoverTrigger({ className, ...props }: ComponentProps<typeof BasePopover.Trigger>) {
+  return (
+    <BasePopover.Trigger
+      className={typeof className === 'function' ? className : cn(TRIGGER_OPEN_HIGHLIGHT, className)}
+      {...props}
+    />
+  )
+}
+
+export function PopoverContent({
+  className,
+  sideOffset = 6,
+  align = 'start',
+  children,
+  ...props
+}: ComponentProps<typeof BasePopover.Popup> & { sideOffset?: number; align?: 'start' | 'center' | 'end' }) {
+  return (
+    <BasePopover.Portal>
+      <BasePopover.Positioner sideOffset={sideOffset} align={align} className="z-50 outline-none">
+        <BasePopover.Popup
+          className={cn(
+            'rounded-md border border-[var(--color-border)] bg-[var(--color-card)] text-[var(--color-card-foreground)] shadow-md outline-none',
+            className,
+          )}
+          {...props}
+        >
+          <ScrollArea viewportClassName="max-h-[var(--available-height)]">
+            <div className="p-3">{children as ReactNode}</div>
+          </ScrollArea>
+        </BasePopover.Popup>
+      </BasePopover.Positioner>
+    </BasePopover.Portal>
+  )
+}

--- a/packages/framework-dashboard/components/ui/scroll-area.tsx
+++ b/packages/framework-dashboard/components/ui/scroll-area.tsx
@@ -22,17 +22,27 @@ export function ScrollArea({
   className,
   children,
   viewportRef,
+  viewportClassName,
   ...props
 }: ScrollAreaPrimitive.Root.Props & {
   /** The scrolled element, for a rail that scrolls itself (ViewsRail, ChoicesRail). */
   viewportRef?: Ref<HTMLDivElement>
+  /** Extra classes on the viewport — where the height cap belongs when the Root has no definite
+   *  height. A `max-h-*` on the Root only caps the box; the viewport's `h-full` cannot resolve
+   *  against a parent's max-height, so the content grows instead of scrolling. Put the cap here. */
+  viewportClassName?: string
 }) {
   return (
     <ScrollAreaPrimitive.Root data-slot="scroll-area" className={cn('relative', className)} {...props}>
       <ScrollAreaPrimitive.Viewport
         ref={viewportRef}
         data-slot="scroll-area-viewport"
-        className="size-full rounded-[inherit] outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]"
+        className={cn(
+          'w-full rounded-[inherit] outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]',
+          // Default: fill a definite-height Root. A caller that caps the viewport (a dropdown, the
+          // editor) passes its own `max-h-*` here instead of relying on the Root.
+          viewportClassName ?? 'h-full',
+        )}
       >
         {children}
       </ScrollAreaPrimitive.Viewport>


### PR DESCRIPTION
Closes #1046. A pass over the Start-a-session controls (iterated live on the daemon dashboard).

## Changes
- **Context picker → dropdown** in the composer control row, next to the presets `[/]` button (new `ContextMenu`). Was an inline section that pushed the whole form down. Ticking repos narrows focus; files are listed + removable.
- **Options gear** moved next to the model selector, before Send; equal bottom/right spacing; a small **presence dot** instead of the count badge.
- **Enhanced System Prompt → dropdown** on the "In play" row (new `ui/popover.tsx` on Base UI, since it holds rich content a menu can't). Was an inline expander.
- **Open-highlight** on every menu trigger (shared once on `DropdownMenuTrigger`): presets, model, gear, Context, notifications all stay lit while open. Menus/popovers open toward the side with room (`align`).
- **ScrollArea everywhere**: the prompt editor and all dropdown popups now scroll through the shared thin overlay bar instead of the native one, which also removes the doubled border/track the OS bar left inside popups. The height cap moved onto the **viewport** (a Root `max-h` can't bound the viewport's `h-full`, so content grew instead of scrolling — that was the "not scrolling" bug).
- Model trigger padding `px-3`→`px-2`; dropped the form's bottom border.

## Notes
- `DisclosureToggle` is kept — still used by `design/previews.tsx`.
- `ScrollArea` gained an optional `viewportClassName` so a caller with no definite-height Root can cap the scroller.

## Tests
- Dashboard **330 pass / 0 fail** (new `ContextMenu` tests; menu item navigation re-verified through the ScrollArea wrapper; badge test updated for the dot). Typecheck clean; framework build + daemon serve tests green.
- Iterated and verified live on the daemon dashboard throughout.