### PR TITLE
feat(framework): wire the GitHub Actions run target into the Run on gear (#1050)

### DIFF
--- a/.changeset/run-on-actions-target.md
+++ b/.changeset/run-on-actions-target.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": minor
+---
+
+Run target: wire GitHub Actions into the "Run on" gear (#1050). The options gear gains a single-select "Run on" submenu (Current device, the default; GitHub Actions; Claude web as a disabled placeholder), and picking GitHub Actions runs the turn on a fresh Actions runner via the already-merged ActionsDriver instead of on this device. The choice sticks per project like the agent and model. A new `--run-on <local|actions>` flag drives it from the CLI; `actions` reads the repo owner/repo from the origin remote and a user token from `GH_TOKEN` (repo + workflow scopes). `local` is unchanged.

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -19,7 +19,7 @@ import { PromptEditor, type PromptEditorHandle } from './PromptEditor.js'
 import { PresetCreatePanel } from './PresetCreatePanel.js'
 import { PresetsMenu } from './PresetsMenu.js'
 import { AgentModelMenu, type AgentOption } from './AgentModelMenu.js'
-import { OptionsMenu, type OptionRow } from './OptionsMenu.js'
+import { OptionsMenu, type OptionRow, type RunTarget } from './OptionsMenu.js'
 import { ResolvedOptions } from './ResolvedOptions.js'
 import { ClaudeLogo, CodexLogo } from './agent-logos.js'
 import { Button } from './ui/button.js'
@@ -154,6 +154,7 @@ export const Composer = forwardRef<ComposerHandle, {
   const browser = preferences.browser ?? false
   const model = preferences.model ?? '' // #628: empty = the driver's default model
   const agent = preferences.agent ?? 'claude' // #650: which coding agent drives the run
+  const target = preferences.target ?? 'local' // #1050: where the run executes (this device / GitHub Actions)
   // The stored agent as a display name; an unknown stored value falls back to Claude Code.
   const agentLabel = AGENT_LABELS[AGENTS.includes(agent as AgentName) ? (agent as AgentName) : 'claude']
   const customPresets = preferences.customPresets ?? [] // #626: the user's own saved prompts
@@ -300,6 +301,9 @@ export const Composer = forwardRef<ComposerHandle, {
       showEco={!inSession && eco && !ecoDisabled}
       busy={busy}
       {...(inSession ? { label: 'Preferences' } : {})}
+      // The "Run on" driver axis (#1050) is baked in at spawn, so it is offered only at the launcher —
+      // same reasoning as the agent select being hidden in-session.
+      {...(inSession ? {} : { runTarget: { value: target, onChange: (t: RunTarget) => updatePreferences({ target: t }) } })}
     />
   )
 

--- a/packages/framework-dashboard/components/OptionsMenu.test.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.test.tsx
@@ -75,4 +75,27 @@ describe('OptionsMenu (#654)', () => {
     expect(updatePreferences).not.toHaveBeenCalled()
   })
 
+  test('the Run on submenu picks a target and calls back (#1050)', () => {
+    const onChange = vi.fn()
+    render(
+      <OptionsMenu
+        options={mainOptions()}
+        ecoOptions={ecoOptions()}
+        showEco={false}
+        busy={false}
+        runTarget={{ value: 'local', onChange }}
+      />,
+    )
+    open()
+    fireEvent.click(screen.getByText('Run on'))
+    fireEvent.click(screen.getByText('GitHub Actions'))
+    expect(onChange).toHaveBeenCalledWith('actions')
+  })
+
+  test('the Run on submenu is absent when no target control is passed (in-session) (#1050)', () => {
+    render(<OptionsMenu options={[]} ecoOptions={[]} showEco={false} busy={false} />)
+    open()
+    expect(screen.queryByText('Run on')).toBeNull()
+  })
+
 })

--- a/packages/framework-dashboard/components/OptionsMenu.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.tsx
@@ -1,5 +1,5 @@
 import type { Preferences } from '@gemstack/framework'
-import { Settings } from 'lucide-react'
+import { Settings, Check } from 'lucide-react'
 import { updatePreferences } from '../lib/preferences.js'
 import { cn } from '../lib/utils.js'
 import { buttonVariants } from './ui/button.js'
@@ -8,7 +8,11 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuCheckboxItem,
+  DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
 } from './ui/dropdown-menu.js'
 
 // The Global options (#314) as one "Options" checkbox dropdown (#654), replacing the row of
@@ -39,6 +43,47 @@ function setOption(key: keyof Preferences, checked: boolean) {
 import { OptionLabel } from './ui/option-label.js'
 export { OptionLabel }
 
+/** Where a run executes (#1050). `local` runs on this device; `actions` on a GitHub Actions runner. */
+export type RunTarget = 'local' | 'actions'
+
+/** The single-select "Run on" control (#1050): the driver axis, at the top of the gear. */
+export type RunTargetControl = {
+  value: RunTarget
+  onChange: (value: RunTarget) => void
+}
+
+// The run targets the gear offers (#1050). A single-select modeled on the agent tree (Check-marked
+// rows), not the boolean OptionRow. "Claude web" is a disabled placeholder for the sibling axis in
+// #1049 that has not shipped yet, so the menu shows where this is going without promising it.
+const RUN_TARGET_ROWS: { value: RunTarget; label: string; description: string }[] = [
+  { value: 'local', label: 'Current device', description: 'Run on this machine, as today.' },
+  { value: 'actions', label: 'GitHub Actions', description: 'Run on a fresh GitHub Actions runner.' },
+]
+
+function RunTargetSub({ control, busy }: { control: RunTargetControl; busy: boolean }) {
+  const current = RUN_TARGET_ROWS.find(r => r.value === control.value) ?? RUN_TARGET_ROWS[0]!
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger disabled={busy}>
+        <span className="flex-1">Run on</span>
+        <span className="text-muted-foreground">{current.label}</span>
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent>
+        {RUN_TARGET_ROWS.map(row => (
+          <DropdownMenuItem key={row.value} className="items-start" onClick={() => control.onChange(row.value)}>
+            <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', row.value === control.value ? 'opacity-100' : 'opacity-0')} />
+            <OptionLabel label={row.label} description={row.description} />
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuItem disabled className="items-start">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 opacity-0" />
+          <OptionLabel label="Claude web" description="Coming soon." />
+        </DropdownMenuItem>
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  )
+}
+
 /** One preference checkbox row. The disabled reason rides the description (the `title`
  * tooltip is suppressed on disabled dropdown items), so a greyed row isn't a mystery. */
 function OptionCheckboxRow({ row, busy, indent = false }: { row: OptionRow; busy: boolean; indent?: boolean }) {
@@ -64,6 +109,7 @@ export function OptionsMenu({
   showEco,
   busy,
   label = 'Session options',
+  runTarget,
 }: {
   options: OptionRow[]
   ecoOptions: OptionRow[]
@@ -73,6 +119,9 @@ export function OptionsMenu({
   /** The trigger's name. In-session composers pass no run options (#833), so theirs says
    *  "Preferences" rather than promising session control it does not have. */
   label?: string
+  /** The "Run on" driver axis (#1050), at the top of the gear. Omitted in-session, where the
+   *  target is baked in at spawn — same as the agent select. */
+  runTarget?: RunTargetControl | undefined
 }) {
   const activeCount = options.filter(o => o.checked && !o.disabled).length
   return (
@@ -92,6 +141,12 @@ export function OptionsMenu({
         )}
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-[19rem] max-w-[22rem]">
+        {runTarget && (
+          <>
+            <RunTargetSub control={runTarget} busy={busy} />
+            {options.length > 0 && <DropdownMenuSeparator />}
+          </>
+        )}
         {options.map(o => (
           <OptionCheckboxRow key={o.key} row={o} busy={busy} />
         ))}

--- a/packages/framework/src/cli.test.ts
+++ b/packages/framework/src/cli.test.ts
@@ -381,12 +381,20 @@ test('parseArgs flags unknown options and bad values', () => {
   assert.match(parseArgs(['--permission-mode', 'wat']).error!, /permission-mode/)
   assert.match(parseArgs(['--agent', 'gemini']).error!, /invalid --agent/)
   assert.match(parseArgs(['--agent']).error!, /invalid --agent/)
+  assert.match(parseArgs(['--run-on', 'cloud']).error!, /invalid --run-on/)
+  assert.match(parseArgs(['--run-on']).error!, /invalid --run-on/)
 })
 
 test('parseArgs reads --agent, defaulting to claude (#542)', () => {
   assert.equal(parseArgs(['x']).agent, 'claude')
   assert.equal(parseArgs(['--agent', 'claude', 'x']).agent, 'claude')
   assert.equal(parseArgs(['--agent', 'codex', 'x']).agent, 'codex')
+})
+
+test('parseArgs reads --run-on, absent by default (#1050)', () => {
+  assert.equal(parseArgs(['x']).target, undefined)
+  assert.equal(parseArgs(['--run-on', 'local', 'x']).target, 'local')
+  assert.equal(parseArgs(['--run-on', 'actions', 'x']).target, 'actions')
 })
 
 test('createDriver builds the agent --agent picked (#542)', () => {

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -13,7 +13,10 @@ import {
   type FrameworkSignals,
 } from '@gemstack/ai-autopilot'
 import { type ClaudeCodeDriverOptions, type Driver, type DriverSession, type PermissionMode } from './driver/index.js'
-import { AGENTS, AGENT_SPECS, createDriver, isAgentName, type AgentName } from './agent.js'
+import { AGENTS, AGENT_SPECS, isAgentName, type AgentName } from './agent.js'
+import { createRunDriver } from './run-driver.js'
+import { githubSlugFor } from './dashboard/github.js'
+import type { ActionsDriverOptions } from './driver/index.js'
 import { launchSharedBrowser, withBrowser, type SharedBrowser } from './browser.js'
 import { connectCdp, startBrowserStream, type BrowserStream } from './browser-stream.js'
 import { hostExecutor } from './host-exec.js'
@@ -159,6 +162,10 @@ Options:
                          (default: claude). Codex reports no price and no quota,
                          so --max-cost and the consumption limits cannot gate it;
                          the session says so at startup rather than imply a guard.
+  --run-on <local|actions>   Where the run executes (default: local, this device).
+                         actions drives it on a fresh GitHub Actions runner; needs a
+                         GitHub origin remote and a user token in GH_TOKEN (repo +
+                         workflow scopes).
   --cwd <dir>            Workspace the agent builds in (default: current directory).
   --model <id>           Model to pass through to the wrapped agent.
   --via <surface>        Surface this run was started from (e.g. discord); recorded
@@ -258,6 +265,9 @@ export interface CliOptions {
   intent: string
   /** `--agent <claude|codex>`: which agent CLI drives the run (#542). Default `claude`. */
   agent: AgentName
+  /** `--run-on <local|actions>` (#1050): where the run executes. `actions` drives it on a GitHub
+   * Actions runner via ActionsDriver (#934); absent / `local` runs on this device as before. */
+  target?: 'local' | 'actions' | undefined
   cwd?: string | undefined
   /**
    * `--run-id <id>` (#736): the id the daemon allocated for this run before spawning it. Its
@@ -483,6 +493,12 @@ export function parseArgs(argv: string[]): CliOptions {
         const value = argv[++i]
         if (!isAgentName(value)) opts.error = `invalid --agent: ${value ?? '(missing)'}. Expected: ${AGENTS.join(' | ')}`
         else opts.agent = value
+        break
+      }
+      case '--run-on': {
+        const value = argv[++i]
+        if (value !== 'local' && value !== 'actions') opts.error = `invalid --run-on: ${value ?? '(missing)'}. Expected: local | actions`
+        else opts.target = value
         break
       }
       case '--cwd':
@@ -1485,9 +1501,34 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
     io.err('note: no Chrome found, so --browser falls back to its own browser (no preview).')
   }
 
+  // Run on GitHub Actions (#1050): owner/repo come from the project's origin remote, the token from
+  // GH_TOKEN. The token is read from the environment, never the committed the-framework.yml, since a
+  // repo file is public and this must be a user PAT. Resolved before the driver so a missing remote
+  // or token fails the run with a clear reason rather than deep inside ActionsDriver.
+  let actionsConfig: ActionsDriverOptions | undefined
+  if (opts.target === 'actions' && !fake) {
+    const slug = await githubSlugFor(cwd)
+    const token = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN
+    if (!slug) {
+      io.err('--run-on actions needs a GitHub origin remote on this repo.')
+      return 2
+    }
+    if (!token) {
+      io.err('--run-on actions needs a GitHub user token in GH_TOKEN (repo + workflow scopes).')
+      return 2
+    }
+    actionsConfig = { owner: slug.owner, repo: slug.repo, token }
+    io.out(`◆ run on: GitHub Actions (${slug.owner}/${slug.repo})`)
+  }
+
   const driver: Driver = fake
     ? fakeDriver()
-    : createDriver({ agent: opts.agent, claudeOpts: withBrowser(claudeOpts, opts.browser, sharedBrowser?.browserUrl) })
+    : createRunDriver({
+        agent: opts.agent,
+        claudeOpts: withBrowser(claudeOpts, opts.browser, sharedBrowser?.browserUrl),
+        ...(opts.target ? { target: opts.target } : {}),
+        ...(actionsConfig ? { actionsConfig } : {}),
+      })
 
   // Whether the agent actually ends up with browser tools, which is narrower than the flag: they
   // ride Claude Code's MCP config, so `--browser` on another agent wires nothing (see

--- a/packages/framework/src/daemon-runtime.ts
+++ b/packages/framework/src/daemon-runtime.ts
@@ -107,6 +107,8 @@ export function startOptionFlags(options: StartRunOptions): string[] {
   if (typeof options.agent === 'string' && options.agent.trim() && options.agent !== 'claude') {
     flags.push('--agent', options.agent.trim())
   }
+  // Run target (#1050): only `actions` needs a flag; `local` is the default and emits nothing.
+  if (options.target === 'actions') flags.push('--run-on', 'actions')
   // Unattended (#846): nobody is at the keyboard, so gates take the recommended option
   // rather than park for an answer that is not coming.
   if (options.unattended) flags.push('--unattended')

--- a/packages/framework/src/daemon.test.ts
+++ b/packages/framework/src/daemon.test.ts
@@ -85,6 +85,9 @@ test('startOptionFlags spells an explicit off as the --no-* form (#842)', () => 
   assert.deepEqual(startOptionFlags({ agent: 'codex' }), ['--agent', 'codex'])
   assert.deepEqual(startOptionFlags({ agent: 'claude' }), [])
   assert.deepEqual(startOptionFlags({ agent: '   ' }), [])
+  // Run target (#1050): only `actions` emits --run-on; `local` is the default -> no flag.
+  assert.deepEqual(startOptionFlags({ target: 'actions' }), ['--run-on', 'actions'])
+  assert.deepEqual(startOptionFlags({ target: 'local' }), [])
   // Unattended (#846): auto PM's own runs, whose gates must not park for an absent human.
   assert.deepEqual(startOptionFlags({ unattended: true }), ['--unattended'])
   assert.deepEqual(startOptionFlags({ unattended: false }), [])

--- a/packages/framework/src/dashboard/github.test.ts
+++ b/packages/framework/src/dashboard/github.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { githubUrlFromRemote, githubUrlFor } from './github.js'
+import { githubUrlFromRemote, githubUrlFor, githubSlugFromRemote, githubSlugFor } from './github.js'
 
 test('githubUrlFromRemote normalizes the common remote forms', () => {
   const expected = 'https://github.com/gemstack-land/gemstack'
@@ -18,6 +18,25 @@ test('githubUrlFromRemote returns undefined for non-GitHub or junk remotes', () 
   assert.equal(githubUrlFromRemote('https://github.com/'), undefined)
   assert.equal(githubUrlFromRemote('https://github.com/only-owner'), undefined)
   assert.equal(githubUrlFromRemote(''), undefined)
+})
+
+test('githubSlugFromRemote splits owner and repo, or undefined for a non-GitHub remote (#1050)', () => {
+  assert.deepEqual(githubSlugFromRemote('git@github.com:gemstack-land/gemstack.git'), { owner: 'gemstack-land', repo: 'gemstack' })
+  assert.equal(githubSlugFromRemote('git@gitlab.com:o/r.git'), undefined)
+  assert.equal(githubSlugFromRemote('https://github.com/only-owner'), undefined)
+})
+
+test('githubSlugFor reads origin and returns undefined when git fails (#1050)', async () => {
+  assert.deepEqual(
+    await githubSlugFor('/x', async () => 'https://github.com/gemstack-land/gemstack.git\n'),
+    { owner: 'gemstack-land', repo: 'gemstack' },
+  )
+  assert.equal(
+    await githubSlugFor('/x', async () => {
+      throw new Error('no origin')
+    }),
+    undefined,
+  )
 })
 
 test('githubUrlFor reads origin and returns undefined when git fails', async () => {

--- a/packages/framework/src/dashboard/github.ts
+++ b/packages/framework/src/dashboard/github.ts
@@ -31,3 +31,20 @@ export async function githubUrlFor(cwd: string, git: GitRunner = nodeGitRunner()
     return undefined
   }
 }
+
+/** The `{ owner, repo }` a GitHub remote names, or undefined when it is not a GitHub remote (#1050). */
+export function githubSlugFromRemote(remote: string): { owner: string; repo: string } | undefined {
+  const url = githubUrlFromRemote(remote)
+  if (!url) return undefined
+  const [owner, repo] = url.slice('https://github.com/'.length).split('/')
+  return owner && repo ? { owner, repo } : undefined
+}
+
+/** The repo's `{ owner, repo }` from its `origin` remote, or undefined (no remote / not GitHub) (#1050). */
+export async function githubSlugFor(cwd: string, git: GitRunner = nodeGitRunner()): Promise<{ owner: string; repo: string } | undefined> {
+  try {
+    return githubSlugFromRemote(await git(['remote', 'get-url', 'origin'], cwd))
+  } catch {
+    return undefined
+  }
+}

--- a/packages/framework/src/dashboard/types.ts
+++ b/packages/framework/src/dashboard/types.ts
@@ -43,6 +43,8 @@ export interface StartRunOptions {
   model?: string
   /** Which coding agent drives the run (#650): `claude` or `codex`; maps to `--agent`. Absent = the default (`claude`). */
   agent?: string
+  /** Where this run executes (#1050): `local` (this device, the default) or `actions` (a fresh GitHub Actions runner via ActionsDriver); maps to `--run-on`. Absent = local, i.e. today's behavior. */
+  target?: 'local' | 'actions'
   /**
    * Nobody is watching this run (#846): its choice gates take the recommended option instead of
    * parking for an answer, which is the fallback a fully headless run already uses and the one

--- a/packages/framework/src/preference-defaults.ts
+++ b/packages/framework/src/preference-defaults.ts
@@ -37,6 +37,7 @@ export const PROJECT_PREFERENCE_KEYS = [
   'transparent',
   'model',
   'agent',
+  'target',
 ] as const
 
 /** What one project overrides: a subset of {@link Preferences}, storing only the keys it sets. */

--- a/packages/framework/src/registry.test.ts
+++ b/packages/framework/src/registry.test.ts
@@ -225,6 +225,23 @@ test('every boolean preference survives a save; the sanitizer cannot silently dr
   assert.deepEqual(await readPreferences(fs, ENV), allOn)
 })
 
+test('sanitizePreferences keeps a valid run target and drops junk (#1050)', async () => {
+  // The PREFERENCE_KEYS loop is boolean-only, so a string preference needs its own branch or the
+  // save silently eats it. A valid target round-trips; an unknown one is dropped to the default.
+  const fs = memFs()
+  await writePreferences({ target: 'actions' }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { target: 'actions' })
+  await writePreferences({ target: 'moon' } as never, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), {})
+})
+
+test('a project may override the run target (#1050)', async () => {
+  // `target` is a project-scoped key (like agent/model), so "run this repo on Actions" sticks.
+  const fs = memFs()
+  await writeProjectPreferences('app-1', { target: 'actions' }, fs, ENV)
+  assert.deepEqual(await readProjectPreferences('app-1', fs, ENV), { target: 'actions' })
+})
+
 // Per-project run options (#840): a project overrides only what it sets, the rest falls through.
 
 test('resolvePreferences lets a project override only the keys it stores', async () => {

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -88,6 +88,8 @@ export interface Preferences {
   editor?: string
   /** Dashboard color theme (#725): `system` (follow the OS, the default), `light`, or `dark`. Absent = system. */
   theme?: 'system' | 'light' | 'dark'
+  /** Where a run executes (#1050): `local` (this device, the default) or `actions` (a fresh GitHub Actions runner); maps to `--run-on`. Absent = local. */
+  target?: 'local' | 'actions'
   /**
    * Post a Discord message when a new item lands on the "needs you" queue (#627). Absent = off:
    * unlike the in-browser toggle, Discord reaches you when no dashboard is open, so it is opt-in.
@@ -268,6 +270,8 @@ const PREFERENCE_KEYS = Object.keys(BOOLEAN_PREFERENCES) as BooleanPreferenceKey
  * object never lands junk (or the wrong type) in the user's home file. */
 /** The color themes the dashboard offers (#725); anything else means the default `system`. */
 const KNOWN_THEMES = ['system', 'light', 'dark'] as const
+/** The run targets the dashboard offers (#1050); anything else means the default `local`. */
+const KNOWN_RUN_TARGETS = ['local', 'actions'] as const
 
 function sanitizePreferences(value: unknown): Preferences {
   if (typeof value !== 'object' || value === null) return {}
@@ -290,6 +294,10 @@ function sanitizePreferences(value: unknown): Preferences {
   // `system`, so it is simply dropped rather than persisted.
   if (typeof input['theme'] === 'string' && (KNOWN_THEMES as readonly string[]).includes(input['theme']))
     preferences.theme = input['theme'] as (typeof KNOWN_THEMES)[number]
+  // `target` (#1050) is a string, so the boolean-only PREFERENCE_KEYS loop would silently eat it;
+  // it gets its own branch like `theme`, constrained to the known set (anything else = default `local`).
+  if (typeof input['target'] === 'string' && (KNOWN_RUN_TARGETS as readonly string[]).includes(input['target']))
+    preferences.target = input['target'] as (typeof KNOWN_RUN_TARGETS)[number]
   // `autoSpendOffset` (#960) is the one numeric preference: a slider position in percentage
   // points, clamped so a hand-edited file cannot push the limit somewhere the slider could not.
   const offset = input['autoSpendOffset']

--- a/packages/framework/src/run-driver.test.ts
+++ b/packages/framework/src/run-driver.test.ts
@@ -1,0 +1,24 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { createRunDriver } from './run-driver.js'
+import { ActionsDriver, ClaudeCodeDriver, CodexDriver } from './driver/index.js'
+
+// The run-target wrapper (#1050): `--run-on actions` becomes an ActionsDriver (#934); anything else
+// falls through to the local agent driver, byte-identical to before.
+
+const ACTIONS = { owner: 'gemstack-land', repo: 'gemstack', token: 't' }
+
+test('createRunDriver returns an ActionsDriver for target "actions"', () => {
+  const driver = createRunDriver({ agent: 'claude', target: 'actions', actionsConfig: ACTIONS })
+  assert.ok(driver instanceof ActionsDriver)
+})
+
+test('createRunDriver falls through to the local agent driver otherwise', () => {
+  assert.ok(createRunDriver({ agent: 'claude' }) instanceof ClaudeCodeDriver)
+  assert.ok(createRunDriver({ agent: 'claude', target: 'local' }) instanceof ClaudeCodeDriver)
+  assert.ok(createRunDriver({ agent: 'codex', target: 'local' }) instanceof CodexDriver)
+})
+
+test('createRunDriver requires the Actions config when target is "actions"', () => {
+  assert.throws(() => createRunDriver({ agent: 'claude', target: 'actions' }), /needs the repo owner/)
+})

--- a/packages/framework/src/run-driver.ts
+++ b/packages/framework/src/run-driver.ts
@@ -1,0 +1,29 @@
+import { createDriver, type CreateDriverOptions } from './agent.js'
+import { ActionsDriver, type ActionsDriverOptions, type Driver } from './driver/index.js'
+
+/**
+ * Build the {@link Driver} for a run's *target* (#1050): where the turn runs, on top of the agent
+ * axis {@link createDriver} owns. `actions` returns an {@link ActionsDriver} (#934) built from the
+ * resolved owner/repo/token; anything else falls through to the local agent driver — byte-identical
+ * to today.
+ *
+ * Kept off {@link createDriver} on purpose: ActionsDriver's owner/repo/token do not fit
+ * {@link CreateDriverOptions}, and folding them in would push GitHub config onto every local run.
+ */
+export interface CreateRunDriverOptions extends CreateDriverOptions {
+  /** Where the run executes (#1050): `local` (this device, the default) or `actions` (a GitHub Actions runner). */
+  target?: 'local' | 'actions'
+  /** The Actions runner config, required when {@link target} is `actions`. */
+  actionsConfig?: ActionsDriverOptions
+}
+
+/** The one place a run path turns `--run-on` into a real driver. */
+export function createRunDriver(opts: CreateRunDriverOptions): Driver {
+  if (opts.target === 'actions') {
+    if (!opts.actionsConfig) {
+      throw new Error('run target "actions" needs the repo owner/repo and a GitHub token; set a GitHub origin remote and GH_TOKEN')
+    }
+    return new ActionsDriver(opts.actionsConfig)
+  }
+  return createDriver(opts)
+}

--- a/packages/framework/src/run-options.test.ts
+++ b/packages/framework/src/run-options.test.ts
@@ -64,6 +64,12 @@ test('the model passes through, and an empty one does not (#858)', () => {
   assert.equal(runOptionsFromPreferences({ model: '' }).model, undefined)
 })
 
+test('the run target is sent only when it is not the default local (#1050)', () => {
+  assert.equal(runOptionsFromPreferences({}).target, undefined)
+  assert.equal(runOptionsFromPreferences({ target: 'local' }).target, undefined)
+  assert.equal(runOptionsFromPreferences({ target: 'actions' }).target, 'actions')
+})
+
 test('browser is dropped for an agent that cannot use it (#801)', () => {
   assert.equal(runOptionsFromPreferences({ browser: true }).browser, true)
   assert.equal(runOptionsFromPreferences({ browser: true, agent: 'codex' }).browser, undefined)

--- a/packages/framework/src/run-options.ts
+++ b/packages/framework/src/run-options.ts
@@ -56,6 +56,7 @@ export function runOptionsFromPreferences(preferences: Preferences, context: str
   const browser = preferences.browser ?? false
   const model = preferences.model ?? ''
   const agent = preferences.agent ?? 'claude'
+  const target = preferences.target ?? 'local'
   const ecoDrops = {
     ...(preferences.ecoPlanning ? { autoPlanning: true } : {}),
     ...(preferences.ecoResearch ? { autoResearch: true } : {}),
@@ -77,6 +78,8 @@ export function runOptionsFromPreferences(preferences: Preferences, context: str
     ...(browser && agent === 'claude' ? { browser: true } : {}),
     ...(model ? { model } : {}),
     ...(agent !== 'claude' ? { agent } : {}),
+    // Run target (#1050): only `actions` travels; `local` is the default the CLI already assumes.
+    ...(target === 'actions' ? { target } : {}),
     ...(context.length ? { context } : {}),
   }
 }


### PR DESCRIPTION
## What

The **driver axis** of the "Run on" selector (part of #1049). Zero security surface, so it ships first. Wires the already-merged `ActionsDriver` (#934) into the run path: nothing was constructing it before.

Picking **GitHub Actions** in the options gear runs the turn on a fresh Actions runner; **Current device** (the default) is unchanged.

## Changes

- `dashboard/types.ts`: `StartRunOptions.target?: 'local' | 'actions'` (browser-safe leaf).
- `registry.ts`: `Preferences.target` with a **dedicated string sanitizer branch** (the `PREFERENCE_KEYS` loop is boolean-only and would silently drop it), mirroring `theme`. Added to `PROJECT_PREFERENCE_KEYS` so "run this repo on Actions" sticks per project like `agent`/`model`.
- `run-options.ts`: maps `preferences.target` into the run options (only `actions` travels).
- `daemon-runtime.ts`: `startOptionFlags` emits `--run-on actions` only for `target === 'actions'`; `local` emits nothing (byte-identical default).
- `cli.ts`: parses `--run-on <local|actions>`; a `createRunDriver({ agent, target, actionsConfig })` wrapper (`run-driver.ts`) returns an `ActionsDriver` for `actions`, else the normal agent driver. `createDriver` is left untouched, since `ActionsDriver`'s owner/repo/token do not fit `CreateDriverOptions`.
- Actions config resolved at the call site: owner/repo from the `origin` remote (`githubSlugFor`), the user PAT from `GH_TOKEN` (or `GITHUB_TOKEN`).
- `OptionsMenu.tsx` + `Composer.tsx`: a single-select `DropdownMenuSub` "Run on" at the top of the gear, modeled on `AgentModelMenu` (Check-marked rows). Rows: Current device, GitHub Actions, Claude web (disabled placeholder). Hidden in-session (baked at spawn, same as the agent select).

## Deviation from the issue

The issue lists the token source as "env `GH_TOKEN` or `the-framework.yml`". Only the env is wired: `the-framework.yml` is committed to the repo, and this must be a **user PAT**, so a config-file token would be a secret in version control. Env-only is the safer posture; noted here rather than silently.

## Verify

- `pnpm --filter @gemstack/framework typecheck` — clean
- `pnpm --filter @gemstack/framework-dashboard typecheck` — clean
- `pnpm --filter @gemstack/framework test` — 1131 pass, 1 skipped, 0 fail (adds: `startOptionFlags` run-on flag, `sanitizePreferences` keeps/drops target + boolean loop no longer eats it, project override of target, `createRunDriver` returns `ActionsDriver`, `--run-on` parsing, `githubSlug*` helpers, run-options mapping)
- `pnpm --filter @gemstack/framework-dashboard test` — 332 pass (adds: Run on submenu picks a target + is absent in-session)

## Sibling

Touches `registry.ts` and `cli.ts` in regions **disjoint** from #1051 (which adds `daemonToken` and `--host`). Whichever merges second just needs `git merge origin/main`.

Closes #1050