### PR TITLE
feat(framework): non-loopback daemon bind guarded by a shared token (#1051)

### DIFF
--- a/.changeset/daemon-non-loopback-bind-token.md
+++ b/.changeset/daemon-non-loopback-bind-token.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/framework': minor
+---
+
+feat(framework): remote-daemon lane, non-loopback bind guarded by a shared token (#1051)
+
+`framework --daemon --host <addr>` binds the dashboard daemon to a non-loopback address so a device you own can reach it. Because a daemon that spawns processes is code execution for anyone who finds the port, a non-loopback bind generates and persists a shared token (`crypto.randomBytes(32)`, a top-level `Registry.daemonToken`, never a preference and never shipped to the browser bundle), and one guard fronts every route (static bundle, `/_telefunc`, `/browser`): a request needs a valid `fw_daemon` cookie or a matching `?token=`, else 401, compared with `crypto.timingSafeEqual`. A valid `?token=` sets an `HttpOnly; SameSite=Strict` cookie and 302s to the clean path, so one cookie rides the RPC, the live-events Channel, and the MJPEG screencast alike. A loopback bind generates nothing and the guard is a no-op, so the local zero-config path is byte-identical. The CLI prints a loud warning and the token URL on any non-loopback bind. Composes with (does not replace) the existing CSRF origin check.

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -51,11 +51,11 @@ import type { RecordMessage } from './await-gate.js'
 import { preflight } from './preflight.js'
 import { RunStore, currentBranch, nodeStoreFs, renameRunBranch, runBranchName, type StoreFs } from './store/index.js'
 import { materializePresets } from './presets.js'
-import { daemonStatus, ensureDaemon, registerHomeProject, runDaemon, stopDaemon, DEFAULT_DAEMON_PORT } from './daemon.js'
+import { daemonStatus, ensureDaemon, isLoopbackHost, registerHomeProject, runDaemon, stopDaemon, DEFAULT_DAEMON_HOST, DEFAULT_DAEMON_PORT } from './daemon.js'
 import { resetControl, watchControl, type ControlWatcher } from './control.js'
 import { RunMessageQueue } from './run-messages.js'
 import { nodeGitRunner } from './project.js'
-import { listProjects, readPreferences } from './registry.js'
+import { ensureDaemonToken, listProjects, readDaemonToken, readPreferences } from './registry.js'
 import { startConsumptionGuard } from './consumption-guard.js'
 import {
   planMaintenanceSweep,
@@ -228,6 +228,10 @@ Options:
   --dokploy-url <url>    Dokploy instance URL (required for --deploy dokploy).
   --dokploy-app <id>     Dokploy application id (required for --deploy dokploy).
   --port <n>             Dashboard port (default: 4200); with the relay, the relay port (4488).
+  --host <addr>          Daemon bind address (default: 127.0.0.1, localhost only). A non-loopback
+                         address (e.g. 0.0.0.0) exposes the daemon to your network and generates a
+                         shared token; the printed URL carries it, and any request without it gets
+                         401. Exposing a process spawner to the network is a security decision (#806).
   --no-dashboard         Do not start the localhost dashboard.
   --share <relay-url>    Publish this session to a relay (from "framework relay") so
                          teammates can watch it live; prints the shareable URL.
@@ -316,6 +320,9 @@ export interface CliOptions {
   servePath?: string | undefined
   sandbox?: 'local' | 'docker' | undefined
   port?: number
+  /** `--host <addr>` (#1051): the daemon's bind address. Default loopback; a non-loopback address
+   * exposes the daemon to the network and gates it behind the generated shared token. */
+  host?: string | undefined
   dashboard: boolean
   relayServe: boolean
   share?: string | undefined
@@ -585,6 +592,9 @@ export function parseArgs(argv: string[]): CliOptions {
         if (n !== undefined) opts.port = n
         break
       }
+      case '--host':
+        opts.host = argv[++i]
+        break
       default:
         if (arg.startsWith('-')) opts.error = `unknown option: ${arg}`
         else words.push(arg)
@@ -1155,7 +1165,10 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // `--daemon-serve` is the detached child's own entry: it *is* the persistent dashboard,
   // serving until signalled. Internal — the background `--daemon` path spawns it (#456).
   if (opts.daemonServe) {
-    await runDaemon(opts.cwd ?? process.cwd(), opts.port !== undefined ? { port: opts.port } : {})
+    await runDaemon(opts.cwd ?? process.cwd(), {
+      ...(opts.port !== undefined ? { port: opts.port } : {}),
+      ...(opts.host !== undefined ? { host: opts.host } : {}),
+    })
     return 0
   }
 
@@ -1666,17 +1679,25 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
 async function runForegroundDaemonCmd(opts: CliOptions, io: CliIO): Promise<number> {
   const cwd = opts.cwd ?? process.cwd()
   const port = opts.port ?? DEFAULT_DAEMON_PORT
+  const host = opts.host
   const existing = await daemonStatus()
   if (existing) {
     io.out(`◆ dashboard already running in the background: ${existing.url}`)
     io.out('  Stop it with `framework stop`, or open the URL above.')
     return 0
   }
+  // #1051: pre-generate the shared token for a non-loopback bind so onListening (sync) can print
+  // the reachable URL; runDaemon reuses the same persisted token.
+  const token = host !== undefined && !isLoopbackHost(host) ? await ensureDaemonToken() : undefined
   try {
     await runDaemon(cwd, {
       port,
+      ...(host !== undefined ? { host } : {}),
       onListening: state => {
         io.out(`◆ dashboard running: ${state.url}`)
+        if (!isLoopbackHost(state.host ?? DEFAULT_DAEMON_HOST)) {
+          printNonLoopbackAccess(io, state.host ?? DEFAULT_DAEMON_HOST, state.url, token)
+        }
         io.out('  Ctrl+C to stop. Server logs stream below.')
       },
     })
@@ -1685,6 +1706,20 @@ async function runForegroundDaemonCmd(opts: CliOptions, io: CliIO): Promise<numb
     return 1
   }
   return 0
+}
+
+/**
+ * The loud one-line warning and the token-bearing URL printed on any non-loopback daemon bind
+ * (#1051). A daemon that spawns processes is code execution for anyone who reaches the port, and
+ * the shared token is the only guard, so this says so before the daemon is left running. The bound
+ * host is a bind-all like `0.0.0.0`, so the user swaps it for the machine's actual reachable
+ * address (a Tailscale/LAN hostname); the token rides the URL for the first hop, then the cookie.
+ */
+function printNonLoopbackAccess(io: CliIO, host: string, url: string, token: string | undefined): void {
+  io.err(`⚠ SECURITY: bound to ${host} (non-loopback). This exposes code execution to your network; the shared token is the only guard (#1051).`)
+  if (!token) return
+  io.out(`  Open with the token (swap ${host} for this machine's reachable address, e.g. a Tailscale hostname):`)
+  io.out(`    ${url}/?token=${token}`)
 }
 
 /**
@@ -1698,7 +1733,7 @@ async function ensureDaemonCmd(opts: CliOptions, io: CliIO): Promise<number> {
   const port = opts.port ?? DEFAULT_DAEMON_PORT
   let result
   try {
-    result = await ensureDaemon(cwd, { port })
+    result = await ensureDaemon(cwd, { port, ...(opts.host !== undefined ? { host: opts.host } : {}) })
   } catch (err) {
     io.err(`could not start the dashboard daemon (${errorMessage(err)}).`)
     return 1
@@ -1710,6 +1745,10 @@ async function ensureDaemonCmd(opts: CliOptions, io: CliIO): Promise<number> {
 
   const { state, alreadyRunning } = result
   io.out(`◆ dashboard ${alreadyRunning ? 'already running' : 'started'}: ${state.url}`)
+  // #1051: warn + print the token URL when the daemon is actually bound non-loopback. Keyed off the
+  // host that is bound, not the flag, so re-reporting an already-running loopback daemon stays quiet.
+  const boundHost = state.host ?? DEFAULT_DAEMON_HOST
+  if (!isLoopbackHost(boundHost)) printNonLoopbackAccess(io, boundHost, state.url, await readDaemonToken())
   io.out('')
   io.out('Type a prompt on the dashboard to start a session, or use:')
   io.out('  framework "<what to build>"   Build (streams to the dashboard)')

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -9,7 +9,7 @@ import { defaultQuotaSource } from './dashboard/quota.js'
 import { startBackgroundServices, resumeSuspendedRuns } from './daemon-services.js'
 import { resolveDashboardBundle } from './dashboard/bundle.js'
 import { isActivated } from './project.js'
-import { addProject, listProjects } from './registry.js'
+import { addProject, ensureDaemonToken, listProjects } from './registry.js'
 import { JsonlTailer } from './jsonl-tail.js'
 
 /**
@@ -38,6 +38,17 @@ export const DAEMON_STATE_FILE = 'the-framework-daemon.json'
 /** The default dashboard port the daemon binds. Matches the per-run dashboard. */
 export const DEFAULT_DAEMON_PORT = 4200
 
+/** The default bind host (#1051): localhost only, so the daemon is unreachable off the machine. */
+export const DEFAULT_DAEMON_HOST = '127.0.0.1'
+
+/**
+ * True when `host` is a loopback address the browser reaches without leaving the machine (#1051).
+ * A bind-all (`0.0.0.0`, `::`) or a routable address is not, and gates behind the shared token.
+ */
+export function isLoopbackHost(host: string): boolean {
+  return host === 'localhost' || host === '::1' || host === '[::1]' || host.startsWith('127.')
+}
+
 /** What a running daemon writes so a later `framework` invocation can find it. */
 export interface DaemonState {
   /** The daemon process id. */
@@ -48,6 +59,8 @@ export interface DaemonState {
   url: string
   /** ISO timestamp the daemon started. */
   startedAt: string
+  /** The host the dashboard is bound to (#1051); absent in state files written before this shipped. */
+  host?: string
 }
 
 /** The `.the-framework/` directory for a workspace. */
@@ -94,7 +107,14 @@ export async function readDaemonState(env: NodeJS.ProcessEnv = process.env): Pro
     const raw = await readFile(daemonStatePath(env), 'utf8')
     const data = JSON.parse(raw) as Partial<DaemonState>
     if (typeof data.pid === 'number' && typeof data.port === 'number' && typeof data.url === 'string') {
-      return { pid: data.pid, port: data.port, url: data.url, startedAt: data.startedAt ?? '' }
+      return {
+        pid: data.pid,
+        port: data.port,
+        url: data.url,
+        startedAt: data.startedAt ?? '',
+        // #1051: only present once an upgraded daemon wrote it; an older file reads as no host.
+        ...(typeof data.host === 'string' ? { host: data.host } : {}),
+      }
     }
   } catch {
     // absent / unreadable / malformed -> treat as no daemon
@@ -196,6 +216,9 @@ export interface EnsureResult {
 export interface EnsureDaemonOptions {
   /** Port to bind when spawning. Default {@link DEFAULT_DAEMON_PORT}. */
   port?: number
+  /** Host to bind when spawning (#1051). Default {@link DEFAULT_DAEMON_HOST}; a non-loopback address
+   * generates and requires the shared token. */
+  host?: string
   /** How long to wait for a freshly spawned daemon to report itself, ms. Default 5000. */
   timeoutMs?: number
   /** The CLI entry script to re-invoke for the child. Default `process.argv[1]`. */
@@ -216,7 +239,10 @@ export async function ensureDaemon(cwd: string, opts: EnsureDaemonOptions = {}):
   if (existing) return { state: existing, alreadyRunning: true }
 
   const port = opts.port ?? DEFAULT_DAEMON_PORT
-  spawnDetached(resolveSpawnBin(opts.binPath), ['--daemon-serve', '--cwd', cwd, '--port', String(port)])
+  const args = ['--daemon-serve', '--cwd', cwd, '--port', String(port)]
+  // #1051: forward a non-loopback bind to the detached child, which generates the token there.
+  if (opts.host !== undefined) args.push('--host', opts.host)
+  spawnDetached(resolveSpawnBin(opts.binPath), args)
 
   const state = await waitForDaemon(opts.env, opts.timeoutMs ?? 5000)
   if (!state) throw new Error('the daemon did not come up in time')
@@ -270,6 +296,9 @@ export class EventTailer extends JsonlTailer<FrameworkEvent> {}
 export interface RunDaemonOptions {
   /** Port to bind. Default {@link DEFAULT_DAEMON_PORT}; pass `0` for an ephemeral port. */
   port?: number
+  /** Host to bind (#1051). Default {@link DEFAULT_DAEMON_HOST}; a non-loopback address generates and
+   * requires the shared token, and every route is then gated behind it. */
+  host?: string
   /** Shut the daemon down when this aborts (in addition to SIGINT/SIGTERM). For tests. */
   signal?: AbortSignal
   /** The CLI entry script to re-invoke for a dashboard-started run (#345). Default `process.argv[1]`. */
@@ -292,7 +321,12 @@ export interface RunDaemonOptions {
  */
 export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promise<void> {
   const port = opts.port ?? DEFAULT_DAEMON_PORT
+  const host = opts.host ?? DEFAULT_DAEMON_HOST
   const env = opts.env ?? process.env
+  // #1051: a non-loopback bind reaches the network, where a daemon that spawns processes is RCE for
+  // anyone who finds the port, so generate + persist the shared token the request guard requires. A
+  // loopback bind needs none, so the local zero-config path stays byte-identical.
+  const token = isLoopbackHost(host) ? undefined : await ensureDaemonToken(undefined, env)
   // Steering (#344): the daemon owns no run, so its Stop button and choice picks
   // append to `.the-framework/control.jsonl`; the live run tails that file. Appends
   // are best-effort — a full disk must not take the dashboard down with it.
@@ -326,11 +360,13 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
   // long-lived meter the usage panel draws, and a second poller would double a rate-limited read.
   const quota = defaultQuotaSource()
   const dashboard: Dashboard = await startDashboard({
+    host,
     port,
     quota,
     onStart: runtime.onStart,
     onAddProject: runtime.onAddProject,
     preview: runtime.preview,
+    ...(token ? { token } : {}),
     ...(clientBundleDir ? { clientBundleDir } : {}),
   })
 
@@ -339,7 +375,7 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
   let selfHeal: DaemonStateHeartbeat | undefined
   try {
     const actualPort = Number(new URL(dashboard.url).port) || port
-    const state: DaemonState = { pid: process.pid, port: actualPort, url: dashboard.url, startedAt: new Date().toISOString() }
+    const state: DaemonState = { pid: process.pid, port: actualPort, host, url: dashboard.url, startedAt: new Date().toISOString() }
     await writeDaemonState(state, env)
     opts.onListening?.(state)
     selfHeal = startDaemonStateHeartbeat(state, env, opts.heartbeatMs ?? DAEMON_STATE_HEARTBEAT_MS)

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -21,6 +21,27 @@ function fetchText(url: string): Promise<{ status: number; body: string; type: s
   })
 }
 
+// Like fetchText, but with an optional Cookie header and the response's Set-Cookie / Location back.
+function fetchAuth(
+  url: string,
+  cookie?: string,
+): Promise<{ status: number; body: string; setCookie?: string | undefined; location?: string | undefined }> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    get(url, { headers: cookie ? { cookie } : {} }, res => {
+      let body = ''
+      res.on('data', c => (body += c))
+      res.on('end', () =>
+        resolvePromise({
+          status: res.statusCode ?? 0,
+          body,
+          setCookie: res.headers['set-cookie']?.[0],
+          location: res.headers.location,
+        }),
+      )
+    }).on('error', rejectPromise)
+  })
+}
+
 /** Send a raw request line over a socket — for request targets `http.get` refuses to send. */
 function rawRequest(url: string, requestLine: string): Promise<string> {
   const port = Number(new URL(url).port)
@@ -151,6 +172,96 @@ test('the Telefunc mount rejects a cross-origin POST (CSRF guard)', async () => 
     const { status, body } = await postCrossOrigin(dash.url + '/_telefunc')
     assert.equal(status, 403)
     assert.match(body, /cross-origin/)
+  } finally {
+    await dash.close()
+    await rm(bundle, { recursive: true, force: true })
+  }
+})
+
+// The shared token (#1051): a real base64url token, matching what the registry generates.
+const TOKEN = 'zX2p8Q0hqk3m9tR7vN1cW4bY6sJ5aL0dFgHiKlMnOp'
+
+// The guard triggers on the token being configured, not on the bind host (a non-loopback bind is
+// exactly what configures one). Binding loopback with the token set exercises every guard path
+// without an external bind that could trip the OS firewall in an automated run; the true two-daemon
+// non-loopback drive is noted as a follow-up in the PR.
+async function guardedDashboard(): Promise<{ base: string; close: () => Promise<void> }> {
+  const bundle = await fakeBundle()
+  const dash = await startDashboard({ port: 0, clientBundleDir: bundle, token: TOKEN })
+  return {
+    base: dash.url,
+    close: async () => {
+      await dash.close()
+      await rm(bundle, { recursive: true, force: true })
+    },
+  }
+}
+
+test('with a token set, every route is 401 without a cookie or ?token= (#1051)', async () => {
+  const { base, close } = await guardedDashboard()
+  try {
+    // The static bundle, the RPC mount, and the browser proxy are all fronted uniformly.
+    for (const path of ['/', '/assets/app.js', '/_telefunc', '/browser/p/x/stream']) {
+      const res = await fetchAuth(base + path)
+      assert.equal(res.status, 401, `${path} should be 401`)
+      assert.match(res.body, /unauthorized/)
+    }
+  } finally {
+    await close()
+  }
+})
+
+test('a valid ?token= sets the HttpOnly fw_daemon cookie and 302s to the clean path (#1051)', async () => {
+  const { base, close } = await guardedDashboard()
+  try {
+    const res = await fetchAuth(`${base}/?token=${TOKEN}`)
+    assert.equal(res.status, 302)
+    assert.equal(res.location, '/') // the token is stripped from the redirect target
+    assert.match(res.setCookie ?? '', /^fw_daemon=/)
+    assert.match(res.setCookie ?? '', /HttpOnly/)
+    assert.match(res.setCookie ?? '', /SameSite=Strict/)
+    assert.match(res.setCookie ?? '', /Path=\//)
+  } finally {
+    await close()
+  }
+})
+
+test('a wrong ?token= is 401, not admitted (timing-safe compare) (#1051)', async () => {
+  const { base, close } = await guardedDashboard()
+  try {
+    const sameLength = await fetchAuth(`${base}/?token=${'a'.repeat(TOKEN.length)}`)
+    assert.equal(sameLength.status, 401)
+    const shorter = await fetchAuth(`${base}/?token=nope`)
+    assert.equal(shorter.status, 401)
+  } finally {
+    await close()
+  }
+})
+
+test('the fw_daemon cookie admits the bundle, /_telefunc, and /browser (#1051)', async () => {
+  const { base, close } = await guardedDashboard()
+  try {
+    const cookie = `fw_daemon=${TOKEN}`
+    const root = await fetchAuth(`${base}/`, cookie)
+    assert.equal(root.status, 200)
+    assert.match(root.body, /<div id="root">/)
+    // Not 401 is the guard passing; the mount / proxy then answer on their own terms.
+    const rpc = await fetchAuth(`${base}/_telefunc`, cookie)
+    assert.notEqual(rpc.status, 401)
+    const browser = await fetchAuth(`${base}/browser/p/x/stream`, cookie)
+    assert.notEqual(browser.status, 401)
+  } finally {
+    await close()
+  }
+})
+
+test('a loopback bind sets no token, so the gate is a no-op (byte-identical) (#1051)', async () => {
+  const bundle = await fakeBundle()
+  const dash = await startDashboard({ port: 0, clientBundleDir: bundle }) // no token
+  try {
+    const res = await fetchAuth(dash.url + '/') // no cookie, no ?token=
+    assert.equal(res.status, 200)
+    assert.match(res.body, /<div id="root">/)
   } finally {
     await dash.close()
     await rm(bundle, { recursive: true, force: true })

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -1,4 +1,5 @@
-import { createServer, type Server } from 'node:http'
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'node:http'
+import { timingSafeEqual } from 'node:crypto'
 import type { AddressInfo } from 'node:net'
 import type { ProjectsProvider } from './projects.js'
 import { registryPreferencesStore, type PreferencesStore } from '../registry.js'
@@ -72,6 +73,13 @@ export interface DashboardOptions {
    * no built bundle, where the server reports the bundle is missing.
    */
   clientBundleDir?: string
+  /**
+   * The shared token that guards a non-loopback bind (#1051): with it set, every route (static
+   * bundle, `/_telefunc`, `/browser`) needs a valid `fw_daemon` cookie or a matching `?token=`,
+   * else 401. Omit for a loopback bind, where the guard is a no-op and local UX is byte-identical.
+   * A separate concern from the CSRF origin check in telefunc-serve.ts, which it composes with.
+   */
+  token?: string
 }
 
 /** A running localhost dashboard: the prerendered SPA + its Telefunc mount. */
@@ -122,12 +130,15 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
     quota,
   })
 
+  const token = opts.token
   const server = createServer((req, res) => {
     const pathname = requestPathname(req)
     if (pathname === undefined) {
       res.writeHead(400, { 'content-type': 'text/plain' }).end('bad request')
       return
     }
+    // #1051: one guard fronting every route on a non-loopback bind; a no-op when no token is set.
+    if (token !== undefined && !authorizeDaemonRequest(req, res, token)) return
     if (pathname === '/_telefunc' || pathname.startsWith('/_telefunc/')) {
       void telefuncMount(req, res)
       return
@@ -168,4 +179,53 @@ function listenDashboard(server: Server, host: string, port: number, close: () =
 
 function closeServer(server: Server): Promise<void> {
   return new Promise(resolvePromise => server.close(() => resolvePromise()))
+}
+
+/** The cookie a bootstrapped browser carries on every same-origin request (#1051). */
+const DAEMON_COOKIE = 'fw_daemon'
+
+/**
+ * The non-loopback bind guard (#1051): a request needs a valid `fw_daemon` cookie or a matching
+ * `?token=`, else 401. A valid `?token=` sets the cookie and 302s to the clean path so the token
+ * leaves the URL bar, history, and Referer after one hop; the cookie then rides RPC, the events
+ * Channel, and the MJPEG `<img>` screencast alike (all same-origin), which a bearer header cannot
+ * reach. Returns true to admit the request, false once it has answered (401 or the redirect).
+ */
+export function authorizeDaemonRequest(req: IncomingMessage, res: ServerResponse, token: string): boolean {
+  // Safe to re-parse: requestPathname already parsed this same url without throwing (#938).
+  const url = new URL(req.url ?? '/', 'http://localhost')
+  const queryToken = url.searchParams.get('token')
+  if (queryToken !== null && tokensMatch(queryToken, token)) {
+    url.searchParams.delete('token')
+    const query = url.searchParams.toString()
+    res.writeHead(302, {
+      'set-cookie': `${DAEMON_COOKIE}=${token}; HttpOnly; SameSite=Strict; Path=/`,
+      location: url.pathname + (query ? `?${query}` : ''),
+    })
+    res.end()
+    return false
+  }
+  const cookieToken = readCookie(req.headers.cookie, DAEMON_COOKIE)
+  if (cookieToken !== undefined && tokensMatch(cookieToken, token)) return true
+  res.writeHead(401, { 'content-type': 'text/plain' })
+  res.end('unauthorized')
+  return false
+}
+
+/** Constant-time token compare (#1051). The length check first, since `timingSafeEqual` throws on
+ * unequal-length buffers and a length mismatch cannot be a match anyway. */
+function tokensMatch(a: string, b: string): boolean {
+  const ab = Buffer.from(a)
+  const bb = Buffer.from(b)
+  return ab.length === bb.length && timingSafeEqual(ab, bb)
+}
+
+/** One cookie's value out of a `Cookie` header, or `undefined`. */
+function readCookie(header: string | undefined, name: string): string | undefined {
+  if (!header) return undefined
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=')
+    if (eq !== -1 && part.slice(0, eq).trim() === name) return part.slice(eq + 1).trim()
+  }
+  return undefined
 }

--- a/packages/framework/src/registry.test.ts
+++ b/packages/framework/src/registry.test.ts
@@ -3,8 +3,10 @@ import { test } from 'node:test'
 import { join } from 'node:path'
 import {
   addProject,
+  ensureDaemonToken,
   listProjects,
   projectId,
+  readDaemonToken,
   readPreferences,
   readProjectPreferences,
   readRegistry,
@@ -489,3 +491,46 @@ test('a rejected mutation does not wedge the queue for the next caller (#991)', 
   assert.deepEqual(await listProjects(healthy, ENV), [APP_B])
 })
 
+
+test('ensureDaemonToken generates a base64url token, persists it, and reuses it (#1051)', async () => {
+  const fs = memFs()
+  const first = await ensureDaemonToken(fs, ENV)
+  assert.match(first, /^[A-Za-z0-9_-]+$/) // base64url: URL-safe, so it drops into ?token= unencoded
+  assert.ok(first.length >= 43) // 32 random bytes as base64url
+  // Persisted as a top-level field, never under preferences (never shipped to the browser bundle).
+  const stored = JSON.parse(fs.files.get(FILE)!)
+  assert.equal(stored.daemonToken, first)
+  assert.equal(stored.preferences.daemonToken, undefined)
+  // A second call reuses the persisted one rather than rotating it.
+  assert.equal(await ensureDaemonToken(fs, ENV), first)
+})
+
+test('readDaemonToken returns undefined until one is generated, then the persisted token (#1051)', async () => {
+  const fs = memFs()
+  assert.equal(await readDaemonToken(fs, ENV), undefined)
+  const token = await ensureDaemonToken(fs, ENV)
+  assert.equal(await readDaemonToken(fs, ENV), token)
+})
+
+test('a non-string / empty daemonToken in a hand-edited file is dropped (#1051)', async () => {
+  for (const bad of [42, '', null, {}]) {
+    const fs = memFs({ [FILE]: JSON.stringify({ projects: [], preferences: {}, daemonToken: bad }) })
+    assert.equal(await readDaemonToken(fs, ENV), undefined)
+  }
+})
+
+test('the daemon token survives the other registry mutators (#1051)', async () => {
+  const fs = memFs()
+  const token = await ensureDaemonToken(fs, ENV)
+  await addProject('/repos/app-a', APP_A.addedAt, fs, ENV)
+  await writePreferences({ vanilla: true }, fs, ENV)
+  await writeProjectPreferences(APP_A.id, { model: 'opus' }, fs, ENV)
+  await removeProject(APP_A.id, fs, ENV)
+  assert.equal(await readDaemonToken(fs, ENV), token)
+})
+
+test('two concurrent first-binds settle on one shared token, not two (#1051)', async () => {
+  const fs = memFs({ [FILE]: JSON.stringify({ projects: [], preferences: {} }) }, { slow: true })
+  const [a, b] = await Promise.all([ensureDaemonToken(fs, ENV), ensureDaemonToken(fs, ENV)])
+  assert.equal(a, b)
+})

--- a/packages/framework/src/registry.ts
+++ b/packages/framework/src/registry.ts
@@ -1,4 +1,5 @@
 import { basename, dirname, join, resolve } from 'node:path'
+import { randomBytes } from 'node:crypto'
 import { isAgentName } from './agent-names.js'
 import { nodeFs } from './node-fs.js'
 import { PROJECT_PREFERENCE_KEYS, MAX_SPEND_OFFSET, type ProjectPreferences } from './preference-defaults.js'
@@ -147,6 +148,12 @@ export interface Registry {
   preferences: Preferences
   /** Per-project overrides (#840), keyed by {@link ProjectRecord.id}. Absent keys fall through. */
   projectPreferences: Record<string, ProjectPreferences>
+  /**
+   * The shared daemon token (#1051): generated on the first non-loopback bind and reused after.
+   * A top-level field, deliberately not a {@link Preferences} one, so it is never shipped to the
+   * browser bundle or the per-project override map. Absent on a loopback-only machine.
+   */
+  daemonToken?: string
 }
 
 /** A read/write handle for the user preferences, threaded through the dashboard's Telefunc
@@ -385,6 +392,8 @@ export async function readRegistry(
     projects,
     preferences: sanitizePreferences(obj.preferences),
     projectPreferences: sanitizeProjectPreferenceMap(obj.projectPreferences),
+    // #1051: kept only as a non-empty string, so a hand-edited registry can't smuggle a junk token.
+    ...(typeof obj.daemonToken === 'string' && obj.daemonToken ? { daemonToken: obj.daemonToken } : {}),
   }
 }
 
@@ -402,10 +411,13 @@ export async function readRegistry(
  */
 async function writeRegistry(registry: Registry, fs: RegistryFs, env: NodeJS.ProcessEnv): Promise<void> {
   const file = registryPath(env)
-  const { projects, preferences, projectPreferences } = registry
-  const contents = Object.keys(projectPreferences).length
-    ? { projects, preferences, projectPreferences }
-    : { projects, preferences }
+  const { projects, preferences, projectPreferences, daemonToken } = registry
+  const contents = {
+    projects,
+    preferences,
+    ...(Object.keys(projectPreferences).length ? { projectPreferences } : {}),
+    ...(daemonToken ? { daemonToken } : {}),
+  }
   const json = JSON.stringify(contents, null, 2)
   await fs.mkdir(dirname(file))
   if (!fs.rename) return fs.write(file, json)
@@ -485,7 +497,7 @@ export async function removeProject(
     const remaining = registry.projects.filter(project => project.id !== id)
     if (remaining.length === registry.projects.length) return false
     const { [id]: _dropped, ...projectPreferences } = registry.projectPreferences
-    await writeRegistry({ projects: remaining, preferences: registry.preferences, projectPreferences }, fs, env)
+    await writeRegistry({ ...registry, projects: remaining, projectPreferences }, fs, env)
     return true
   })
 }
@@ -537,6 +549,34 @@ export async function writeProjectPreferences(
     const projectPreferences = Object.keys(sanitized).length ? { ...rest, [projectId]: sanitized } : rest
     await writeRegistry({ ...registry, projectPreferences }, fs, env)
   })
+}
+
+/**
+ * The shared daemon token (#1051): read the persisted one, or generate + persist it now. Called
+ * only on a non-loopback bind, so a loopback-only machine never grows one. Serialized with the
+ * other mutators so two concurrent binds can't each write a different token. `base64url` of 32
+ * random bytes: URL-safe, so it drops straight into a `?token=` without encoding.
+ */
+export async function ensureDaemonToken(
+  fs: RegistryFs = nodeRegistryFs(),
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string> {
+  return serialize(async () => {
+    const registry = await readRegistry(fs, env)
+    if (registry.daemonToken) return registry.daemonToken
+    const daemonToken = randomBytes(32).toString('base64url')
+    await writeRegistry({ ...registry, daemonToken }, fs, env)
+    return daemonToken
+  })
+}
+
+/** The persisted daemon token (#1051), or `undefined` when none exists. A pure read, so a process
+ * that only prints the reachable URL never generates one. */
+export async function readDaemonToken(
+  fs: RegistryFs = nodeRegistryFs(),
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string | undefined> {
+  return (await readRegistry(fs, env)).daemonToken
 }
 
 /** A {@link PreferencesStore} bound to the real registry file, wired by the daemon so the


### PR DESCRIPTION
Part of #1049, the security-critical slice of the "a device I have" lane (#806 Phase 1). The non-loopback bind and the shared token ship in one atomic commit: a non-loopback daemon that spawns processes is RCE for anyone who finds the port, and the daemon has no auth today (the loopback bind is the only guard; `isSameOriginRequest` in telefunc-serve.ts is a CSRF guard, not auth).

## What changed

- **registry.ts** adds a top-level `Registry.daemonToken`, generated with `crypto.randomBytes(32).toString('base64url')` on the first non-loopback bind, then persisted and reused. It is sanitized as a non-empty string and is deliberately not a `Preferences` field, so it is never shipped to the browser bundle or the per-project override map. A loopback-only machine never grows one. New reads: `ensureDaemonToken()` (read-or-generate, serialized with the other mutators) and `readDaemonToken()` (pure read).
- **dashboard/server.ts** adds one guard at the top of the request handler, fronting the static bundle, `/_telefunc`, and `/browser` uniformly. With a token configured, a request needs a valid `fw_daemon` cookie or a matching `?token=`, else 401, compared with `crypto.timingSafeEqual`. A valid `?token=` sets `Set-Cookie: fw_daemon=<token>; HttpOnly; SameSite=Strict; Path=/` then 302s to the clean path, so one cookie rides RPC, the live-events Channel, and the MJPEG `<img>` screencast (a bearer header cannot reach the `<img>` src). A loopback bind passes no token, so the guard is a no-op and local UX is byte-identical. It composes with, and does not replace, the CSRF origin check.
- **daemon.ts** threads `host` from `RunDaemonOptions` into `startDashboard`, forwards `--host` to the detached child in `ensureDaemon`, generates the token on a non-loopback bind, and records the bound host in `DaemonState` (optional, so older state files still read).
- **cli.ts** parses `--host` (mirroring `--port`), wires it through `framework --daemon`, `--daemon-serve`, and the bare-`framework` foreground path, and prints a loud one-line warning plus the reachable `?token=` URL on any non-loopback bind.

## Verification

Ran in the worktree after `pnpm install` + root `pnpm build`:

- `pnpm --filter @gemstack/framework typecheck` -> clean.
- Full framework suite (`dist-test` removed first): 1132 pass, 0 fail, 1 pre-existing skip.
  - `dashboard/server.test.ts` (new, 5 cases): 401 on every route without a cookie/token; valid `?token=` sets the HttpOnly SameSite=Strict cookie and 302s to the clean path; a wrong same-length `?token=` is 401 (timing-safe); the cookie admits the bundle, `/_telefunc`, and `/browser`; a loopback bind (no token) is an unguarded no-op.
  - `registry.test.ts` (new, 5 cases): `ensureDaemonToken` generates a base64url token, persists it top-level (not under preferences), and reuses it; `readDaemonToken` lifecycle; a non-string/empty token in a hand-edited file is dropped; the token survives the other mutators; two concurrent first-binds settle on one token.

**Live drive follow-up:** the guard is host-independent by design (it triggers on a token being configured), so the automated test sets the token on a loopback bind to exercise every path without an external bind that could trip the OS firewall in CI. The full two-daemon round-trip over a real non-loopback interface is left as an explicit follow-up rather than claimed here.

## Note on the sibling

This touches regions of `registry.ts` and `cli.ts` disjoint from #1050 (which adds `Preferences.target` and `--run-on`). Whichever merges second needs `git merge origin/main`.

Closes #1051