### PR TITLE
feat(framework): run-view polish for a GitHub Actions target (#1053)

### DIFF
--- a/.changeset/run-view-actions-target-polish.md
+++ b/.changeset/run-view-actions-target-polish.md
@@ -1,0 +1,6 @@
+---
+"@gemstack/framework": minor
+"@gemstack/framework-dashboard": minor
+---
+
+Run-view polish for a GitHub Actions target (#1053). A run started with `--run-on actions` now records its target on the run's meta, and the run view reads it: instead of an apparently-stalled live feed (the ActionsDriver replays its transcript in a burst at the end, on a fresh runner per turn), it shows a "running on GitHub Actions, updates arrive when the run finishes" affordance with a clickable link through to the live Actions run (from the `action`/`notice` events the driver emits, which carry the run's `html_url`). The right rail's Browser pane is gated off for an Actions run, since there is no browser on the runner to screencast. A local or remote-device run is unchanged.

--- a/packages/framework-dashboard/components/ActionsRunNotice.test.tsx
+++ b/packages/framework-dashboard/components/ActionsRunNotice.test.tsx
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import type { FrameworkEvent } from '@gemstack/framework'
+import { ActionsRunNotice } from './ActionsRunNotice.js'
+
+afterEach(cleanup)
+
+const runAction = (url: string): FrameworkEvent => ({ kind: 'driver', event: { type: 'action', label: `run ${url}` } })
+
+describe('ActionsRunNotice (#1053)', () => {
+  test('an Actions run explains the burst wait while it runs', () => {
+    render(<ActionsRunNotice target="actions" events={[]} live />)
+    expect(screen.getByRole('status').textContent).toMatch(/updates arrive when the run finishes/i)
+  })
+
+  test('links through to the live Actions run once the driver reports it', () => {
+    render(<ActionsRunNotice target="actions" events={[runAction('https://github.com/o/r/actions/runs/7')]} live />)
+    const link = screen.getByRole('link', { name: /Actions run/i })
+    expect(link.getAttribute('href')).toBe('https://github.com/o/r/actions/runs/7')
+  })
+
+  test('no link before the driver has found the run', () => {
+    render(<ActionsRunNotice target="actions" events={[]} live />)
+    expect(screen.queryByRole('link')).toBeNull()
+  })
+
+  test('a finished Actions run drops the "updates on completion" line but keeps the link', () => {
+    render(<ActionsRunNotice target="actions" events={[runAction('https://github.com/o/r/actions/runs/7')]} live={false} />)
+    expect(screen.getByRole('status').textContent).not.toMatch(/updates arrive/i)
+    expect(screen.getByRole('link', { name: /Actions run/i })).toBeTruthy()
+  })
+
+  test('renders nothing for a local run', () => {
+    const { container } = render(<ActionsRunNotice target="local" events={[]} live />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  test('renders nothing when the target is unset (a plain local run)', () => {
+    const { container } = render(<ActionsRunNotice events={[]} live />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/packages/framework-dashboard/components/ActionsRunNotice.tsx
+++ b/packages/framework-dashboard/components/ActionsRunNotice.tsx
@@ -1,0 +1,40 @@
+import { Github, ExternalLink } from 'lucide-react'
+import type { FrameworkEvent } from '@gemstack/framework'
+import { actionsRunUrl } from '../lib/live-state.js'
+
+// The run view's affordance for a GitHub Actions target (#1053). An Actions run replays its
+// transcript in a burst at the end (fresh runner per turn), so a live feed looks stalled with
+// nothing streaming. This says the wait is expected and links through to the live Actions run.
+// Renders nothing for a local/remote run, so the run view can mount it unconditionally.
+export function ActionsRunNotice({
+  target,
+  events,
+  live,
+}: {
+  target?: 'local' | 'actions' | undefined
+  events: readonly FrameworkEvent[]
+  /** Whether the run is still going: the "updates on completion" line only applies while it runs. */
+  live: boolean
+}) {
+  if (target !== 'actions') return null
+  const url = actionsRunUrl(events)
+  return (
+    <div role="status" className="flex items-center gap-2 border-b border-border bg-muted/40 px-4 py-2 text-xs text-muted-foreground">
+      <Github className="h-3.5 w-3.5 shrink-0" aria-hidden />
+      <span className="min-w-0 flex-1">
+        Running on GitHub Actions{live ? ' — updates arrive when the run finishes.' : '.'}
+      </span>
+      {url && (
+        <a
+          href={url}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex shrink-0 items-center gap-1 text-primary hover:underline"
+        >
+          View the Actions run
+          <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+        </a>
+      )}
+    </div>
+  )
+}

--- a/packages/framework-dashboard/components/RightRail.test.tsx
+++ b/packages/framework-dashboard/components/RightRail.test.tsx
@@ -53,3 +53,17 @@ describe('RightRail width', () => {
     expect(container.querySelector('aside')).toBeNull()
   })
 })
+
+// A GitHub Actions run has no browser on the runner (#1053), so the pane must not be offered even
+// when the browser flag is on; a local run keeps it.
+describe('RightRail browser tab (#1053)', () => {
+  test('a local run with a browser offers the Browser tab', () => {
+    render(<RightRail {...baseProps} hasBrowser />)
+    expect(screen.getByRole('tab', { name: /browser/i })).toBeTruthy()
+  })
+
+  test('an Actions run never offers the Browser tab, even with the flag on', () => {
+    render(<RightRail {...baseProps} hasBrowser target="actions" />)
+    expect(screen.queryByRole('tab', { name: /browser/i })).toBeNull()
+  })
+})

--- a/packages/framework-dashboard/components/RightRail.tsx
+++ b/packages/framework-dashboard/components/RightRail.tsx
@@ -28,6 +28,7 @@ export function RightRail({
   context,
   toggleContext,
   hasBrowser = false,
+  target,
   onRunStarted,
 }: {
   projectId: string | null
@@ -43,6 +44,8 @@ export function RightRail({
   toggleContext: (path: string) => void
   /** Whether the selected run is serving a browser preview (#813), i.e. it was started with Browser on. */
   hasBrowser?: boolean
+  /** Where the selected run executes (#1053): an `actions` run has no browser on the runner, so no pane. */
+  target?: 'local' | 'actions' | undefined
   /** Told when a panel starts a session (the tickets import, #948), so the shell shows it. */
   onRunStarted?: ((intent: string, runId?: string) => void) | undefined
 }) {
@@ -57,6 +60,8 @@ export function RightRail({
   const hasChoices = choices.length > 0
   const hasViews = views.length > 0
   const hasFiles = files.length > 0
+  // No browser on a GitHub Actions runner (#1053), so no screencast to proxy — never offer the tab.
+  const showBrowser = hasBrowser && target !== 'actions'
 
   // Only pull the rail for something genuinely new (#695/U22): a fresh choice gate (an id we
   // haven't shown) or the first view. A resolving gate, a second view, or a Files flip no longer
@@ -82,7 +87,7 @@ export function RightRail({
     ...(hasChoices ? ['choices' as const] : []),
     ...(hasViews ? ['views' as const] : []),
     // Only when the run actually has one (#813) — a dead tab teaches people the preview is broken.
-    ...(hasBrowser && runId ? ['browser' as const] : []),
+    ...(showBrowser && runId ? ['browser' as const] : []),
     'tickets',
     'docs',
     'log',
@@ -137,7 +142,7 @@ export function RightRail({
           <ChoicesRail projectId={projectId} runId={runId} choices={choices} />
         ) : tab === 'views' && hasViews ? (
           <ViewsRail views={views} />
-        ) : tab === 'browser' && hasBrowser && runId ? (
+        ) : tab === 'browser' && showBrowser && runId ? (
           <BrowserPanel projectId={projectId} runId={runId} />
         ) : tab === 'tickets' ? (
           <TicketsPanel projectId={projectId} onRunStarted={onRunStarted} />

--- a/packages/framework-dashboard/components/RunView.tsx
+++ b/packages/framework-dashboard/components/RunView.tsx
@@ -8,6 +8,7 @@ import { runOutcome } from '../lib/live-state.js'
 import { RunActionBar } from './RunActionBar.js'
 import { RunComposer } from './RunComposer.js'
 import { RunFeed } from './RunFeed.js'
+import { ActionsRunNotice } from './ActionsRunNotice.js'
 import { ChangesSummary, RunChanges } from './RunChanges.js'
 import { HandoffActions, HandoffSummary, RunHandoffDetails, handoffExpandable } from './RunHandoff.js'
 
@@ -29,6 +30,7 @@ export function RunView({
   events,
   live,
   label,
+  target,
   files,
   addContext,
   removeContext,
@@ -47,6 +49,8 @@ export function RunView({
    * the stable identity, so the branch renaming itself near the end of a run (#736) reads as a
    * detail changing rather than the whole view changing. */
   label?: string | undefined
+  /** Where the run executes (#1053): `actions` swaps the live feed for a burst-mode affordance. */
+  target?: 'local' | 'actions' | undefined
   files: string[]
   addContext: (path: string) => void
   removeContext?: ((path: string) => void) | undefined
@@ -122,6 +126,9 @@ export function RunView({
           files as the run's. */}
       {live && runId && <RunChanges projectId={projectId} runId={runId} open={open} onSummary={onChangesSummary} />}
       {!live && open && <RunHandoffDetails handoff={handoff.handoff} />}
+      {/* A GitHub Actions run replays in a burst at the end (#1053), so the live feed looks stalled:
+          say the wait is expected and link through to the live Actions run. */}
+      <ActionsRunNotice target={target} events={shown} live={live} />
       {/* Nothing to show yet is not the same thing in both states: a live run is waiting for its
           first event, a finished one is still reading its log. */}
       {!live && archived === null && shown.length === 0 ? (

--- a/packages/framework-dashboard/lib/live-state.test.ts
+++ b/packages/framework-dashboard/lib/live-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import type { FrameworkEvent } from '@gemstack/framework'
-import { agentViews, pendingChoices, isRunActive, currentRunEvents, runOutcome } from './live-state.js'
+import { agentViews, pendingChoices, isRunActive, currentRunEvents, runOutcome, actionsRunUrl } from './live-state.js'
 
 const view = (id: string, title: string, markdown: string): FrameworkEvent => ({ kind: 'view', id, title, markdown })
 const choice = (id: string, title: string): FrameworkEvent => ({
@@ -125,5 +125,29 @@ describe('runOutcome', () => {
 
   test('a user stop is a stop, not a failure', () => {
     expect(runOutcome([{ kind: 'end', ok: false, stopped: true }])).toEqual({ ok: false, stopped: true })
+  })
+})
+
+describe('actionsRunUrl', () => {
+  const action = (label: string): FrameworkEvent => ({ kind: 'driver', event: { type: 'action', label } })
+
+  test('extracts the html_url from the ActionsDriver run action', () => {
+    expect(actionsRunUrl([action('run https://github.com/o/r/actions/runs/42')])).toBe(
+      'https://github.com/o/r/actions/runs/42',
+    )
+  })
+
+  test('undefined before the run action has fired', () => {
+    expect(actionsRunUrl([{ kind: 'driver', event: { type: 'start', prompt: 'go' } }])).toBeUndefined()
+  })
+
+  test('a plain tool action is not mistaken for a run url', () => {
+    expect(actionsRunUrl([action('Edit')])).toBeUndefined()
+  })
+
+  test('the most recent run wins across turns', () => {
+    expect(
+      actionsRunUrl([action('run https://github.com/o/r/actions/runs/1'), action('run https://github.com/o/r/actions/runs/2')]),
+    ).toBe('https://github.com/o/r/actions/runs/2')
   })
 })

--- a/packages/framework-dashboard/lib/live-state.ts
+++ b/packages/framework-dashboard/lib/live-state.ts
@@ -83,6 +83,23 @@ export function runOutcome(events: readonly FrameworkEvent[]): RunOutcome | unde
 }
 
 /**
+ * The GitHub Actions run's live URL, from the `action` event the ActionsDriver emits once it
+ * finds its workflow run (#1053): its label is `run <html_url>`. Lets the run view link through
+ * to the live Actions run while the transcript is still burst-replaying at the end. The last
+ * match wins, so a multi-turn session points at its most recent run. Absent until the driver has
+ * found the run (and for any non-Actions target).
+ */
+export function actionsRunUrl(events: readonly FrameworkEvent[]): string | undefined {
+  let url: string | undefined
+  for (const event of events) {
+    if (event.kind !== 'driver' || event.event.type !== 'action') continue
+    const match = /^run (https?:\/\/\S+)$/.exec(event.event.label)
+    if (match) url = match[1]
+  }
+  return url
+}
+
+/**
  * The current run's slice of an accumulated live feed. The dashboard's live channel keeps
  * one long-lived subscription per project and appends every streamed event, but each run
  * truncates `events.jsonl` on disk and opens with exactly one `session` event

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -265,6 +265,7 @@ export default function Page() {
         addContext={addContext}
         removeContext={removeContext}
         lost={lost}
+        target={selectedRun.target}
         onRunStarted={onRunStarted}
         onDeleted={() => {
           // Its view is about to point at a session that no longer exists; go home and refresh
@@ -336,6 +337,7 @@ export default function Page() {
           context={context}
           toggleContext={toggleContext}
           hasBrowser={selectedRun?.status === 'running' && selectedRun.browserStreamPort !== undefined}
+          target={selectedRun?.target}
           onRunStarted={onRunStarted}
         />
       </div>

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -1355,6 +1355,8 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
         ...(opts.runId ? { id: opts.runId } : {}),
         // Continuing (#762): keep the existing log rather than starting this run's history over.
         ...(opts.continueRun ? { continueRun: true } : {}),
+        // Where the run executes (#1053): the run view reads it to switch to the Actions affordance.
+        ...(opts.target ? { target: opts.target } : {}),
       })
     } catch (err) {
       io.err(`could not persist session state (${errorMessage(err)}); continuing without it`)

--- a/packages/framework/src/store/run-store.test.ts
+++ b/packages/framework/src/store/run-store.test.ts
@@ -90,6 +90,18 @@ test('fresh open seeds the run intent into the snapshot (so prompt runs are not 
   assert.equal((await store.readMeta())?.intent, 'what is your name')
 })
 
+test('fresh open records an actions target so the run view can read it (#1053)', async () => {
+  const fs = memFs()
+  const store = await RunStore.open(CWD, { fs, fresh: true, now: AT, target: 'actions' })
+  assert.equal((await store.readMeta())?.target, 'actions')
+})
+
+test('a local target is left off the snapshot (default, #1053)', async () => {
+  const fs = memFs()
+  const store = await RunStore.open(CWD, { fs, fresh: true, now: AT, target: 'local' })
+  assert.equal('target' in (await store.readMeta())!, false)
+})
+
 test('a scope event still refines a seeded intent (build path)', async () => {
   const fs = memFs()
   const store = await RunStore.open(CWD, { fs, fresh: true, now: AT, intent: 'build a blog' })

--- a/packages/framework/src/store/run-store.ts
+++ b/packages/framework/src/store/run-store.ts
@@ -129,6 +129,12 @@ export interface RunMeta {
    * dashboard is a different process, so meta is the only place it can learn it.
    */
   browserStreamPort?: number
+  /**
+   * Where this run executes (#1050/#1053): `actions` for a GitHub Actions run, absent for a local
+   * run. Persisted so the run view can tell a burst-mode Actions run from a stalled live feed and
+   * gate the browser pane off (#1053).
+   */
+  target?: 'local' | 'actions'
 }
 
 /**
@@ -195,6 +201,8 @@ export interface OpenStoreOptions {
    * Falls back to a fresh run when there is nothing to reopen.
    */
   continueRun?: boolean
+  /** Where this run executes (#1053): recorded on the meta so the run view can read it. */
+  target?: 'local' | 'actions'
 }
 
 /**
@@ -268,7 +276,7 @@ export interface RunOwner {
 }
 
 /** The seed meta a run starts from, before any event is folded in. */
-function freshMeta(startedAt: string, intent?: string, owner?: RunOwner, id?: string): RunMeta {
+function freshMeta(startedAt: string, intent?: string, owner?: RunOwner, id?: string, target?: 'local' | 'actions'): RunMeta {
   return {
     version: RUN_META_VERSION,
     status: 'running',
@@ -278,6 +286,8 @@ function freshMeta(startedAt: string, intent?: string, owner?: RunOwner, id?: st
     passes: 0,
     ...(owner ? { pid: owner.pid, host: owner.host } : {}),
     ...(intent ? { intent } : {}),
+    // Only `actions` travels; `local` is the default every reader already assumes.
+    ...(target === 'actions' ? { target } : {}),
   }
 }
 
@@ -377,7 +387,7 @@ export class RunStore {
     await fs.mkdir(dir)
     const owner = opts.owner ?? { pid: process.pid, host: hostname() }
     const clock = opts.clock ?? (() => new Date().toISOString())
-    const store = new RunStore(fs, dir, clock, freshMeta(now, opts.intent, owner, opts.id))
+    const store = new RunStore(fs, dir, clock, freshMeta(now, opts.intent, owner, opts.id, opts.target))
     if (opts.continueRun) {
       // Reopen: the log stays, the row keeps its original intent, and this process takes ownership
       // so a liveness probe (#716) reads the run as alive rather than as an orphan.


### PR DESCRIPTION
Part of #1049 (Wave 2). Polishes the run view so a non-local target reads correctly instead of looking broken.

## What changed

A GitHub Actions run replays its transcript in a burst at the end (fresh runner per turn), so the live feed looks stalled with nothing streaming. This teaches the run view about the run's target:

- **Persist the target.** A run started with `--run-on actions` now records `target: 'actions'` on its `RunMeta` (`.the-framework/run.json`), threaded through `RunStore.open`. `local` is left off the meta, so every existing reader is byte-identical. This is the small "surface the target to the run view" piece the issue anticipated: the target reached run start via #1050 but was not persisted anywhere the run view could read.
- **Actions affordance.** `ActionsRunNotice` renders above the feed for `target === 'actions'`: "Running on GitHub Actions, updates arrive when the run finishes" while live, plus a clickable link through to the live Actions run. The URL comes from the `action` event the driver emits (`run <html_url>`), via a pure `actionsRunUrl(events)` helper.
- **Browser pane gated off.** The right rail never offers the Browser tab for an Actions run, since there is no browser on the runner to screencast. (Belt and suspenders: an Actions run never sets `browserStreamPort` either, but the gate is explicit and tested.)
- **Local / remote-device runs unchanged.** The notice renders nothing and the browser gate is a no-op when the target is `local` or unset.

## Where the code contradicted the issue

- The issue's html_url source is the `action` event (`run <url>`), not a `notice` event: the dispatch `notice` carries only the correlation id. The link reads the `action` event's label; noted in the helper.
- The two just-started RunView call sites (optimistic follow before the poll surfaces the run) render without a known target, so the affordance appears once `run.json` lands and the poll adopts the run. Acceptable: an Actions run's orchestrator process is local, so its meta is written promptly.

The "connected to <box>" remote-device cue is out of scope here; it belongs to sibling #1052 (the gear / connection profiles). This PR stays in the run-view / BrowserPanel area and does not touch the "Run on" gear. Whichever of #1052 / this PR merges second may need `git merge origin/main`.

## Verify

- `pnpm typecheck` (framework + framework-dashboard): clean.
- framework-dashboard: 344 tests pass (52 files), incl. new `ActionsRunNotice.test.tsx` (6), `actionsRunUrl` cases in `live-state.test.ts` (4), and browser-gating cases in `RightRail.test.tsx` (2).
- framework: 1143 pass / 1 skipped, incl. two new `run-store.test.ts` cases for target persistence.
- Root `pnpm build`: green.

Closes #1053