### PR TITLE
feat(dashboard): client connection profiles + "a device I have" in the gear (#1052)

### DIFF
--- a/.changeset/connection-profiles-device.md
+++ b/.changeset/connection-profiles-device.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework-dashboard": minor
+---
+
+Client connection profiles + "a device I have" in the gear (#1052). The "Run on" submenu gains an "A device I have" section: Local (this machine's own daemon), your saved daemons, and "Add a device". These rows diverge from the driver rows above them: a driver row writes a preference, a device row NAVIGATES the browser to that daemon's origin carrying its token, where the same-origin bootstrap re-authenticates from the cookie it sets. "Add a device" takes the full `http://host:port/?token=…` URL a box prints on its network bind (any reachable host: LAN IP, tailnet name, tunnel URL), parsing the origin and token out of one paste. Profiles live in per-browser localStorage, so the token never reaches the daemon's registry file. A "connected to <device>" indicator in the header shows which daemon the dashboard is talking to.

--- a/packages/framework-dashboard/components/AddDeviceDialog.test.tsx
+++ b/packages/framework-dashboard/components/AddDeviceDialog.test.tsx
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { AddDeviceDialog } from './AddDeviceDialog.js'
+import { listProfiles } from '../lib/profiles.js'
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+})
+
+describe('AddDeviceDialog (#1052)', () => {
+  test('pasting a ?token= URL saves a profile and closes', () => {
+    const onClose = vi.fn()
+    const onAdded = vi.fn()
+    render(<AddDeviceDialog onClose={onClose} onAdded={onAdded} />)
+    fireEvent.change(screen.getByPlaceholderText(/host:port/), { target: { value: 'http://192.168.1.5:4200/?token=abc123' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add device' }))
+    expect(listProfiles()).toEqual([
+      { id: 'http://192.168.1.5:4200', label: '192.168.1.5:4200', url: 'http://192.168.1.5:4200', token: 'abc123' },
+    ])
+    expect(onAdded).toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  test('a URL without a token cannot be saved', () => {
+    render(<AddDeviceDialog onClose={vi.fn()} onAdded={vi.fn()} />)
+    fireEvent.change(screen.getByPlaceholderText(/host:port/), { target: { value: 'http://192.168.1.5:4200' } })
+    expect((screen.getByRole('button', { name: 'Add device' }) as HTMLButtonElement).disabled).toBe(true)
+    expect(screen.getByText(/no token/i)).toBeTruthy()
+  })
+
+  test('an optional label overrides the host default', () => {
+    render(<AddDeviceDialog onClose={vi.fn()} onAdded={vi.fn()} />)
+    fireEvent.change(screen.getByPlaceholderText(/host:port/), { target: { value: 'http://box:4200/?token=xyz' } })
+    fireEvent.change(screen.getByPlaceholderText(/Name/), { target: { value: 'Workshop' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add device' }))
+    expect(listProfiles()[0]!.label).toBe('Workshop')
+  })
+})

--- a/packages/framework-dashboard/components/AddDeviceDialog.tsx
+++ b/packages/framework-dashboard/components/AddDeviceDialog.tsx
@@ -1,0 +1,70 @@
+import { useState, type KeyboardEvent } from 'react'
+import { addProfile, parseDeviceUrl } from '../lib/profiles.js'
+import { Button } from './ui/button.js'
+import { Dialog } from './ui/dialog.js'
+
+// The "Add a device" modal off the gear (#1052). A device is any reachable daemon — a LAN IP, a
+// tailnet name, a tunnel URL — so the input is not a LAN-IP model but the full `?token=` URL the
+// box prints on its non-loopback bind (cli.ts). We parse the origin and token out of one paste;
+// the token is a per-browser secret, so it lands in localStorage (profiles.ts), never a server file.
+
+export function AddDeviceDialog({ onClose, onAdded }: { onClose: () => void; onAdded: () => void }) {
+  const [url, setUrl] = useState('')
+  const [label, setLabel] = useState('')
+  const parsed = parseDeviceUrl(url)
+  // A pasted URL with no `?token=` cannot authenticate against a guarded box, so it is not savable.
+  const valid = parsed !== null && parsed.token !== ''
+
+  const save = () => {
+    if (!parsed || !valid) return
+    addProfile({ url: parsed.url, token: parsed.token, ...(label.trim() ? { label } : {}) })
+    onAdded()
+    onClose()
+  }
+
+  const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      e.preventDefault()
+      save()
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={next => { if (!next) onClose() }} title="Add a device">
+      <div className="flex w-full flex-col gap-2" onKeyDown={onKeyDown}>
+        <p className="text-xs text-muted-foreground">
+          Paste the URL the box printed on its network bind (it looks like <code>http://host:port/?token=…</code>).
+        </p>
+        <input
+          type="text"
+          value={url}
+          placeholder="http://host:port/?token=…"
+          autoFocus
+          onChange={e => setUrl(e.target.value)}
+          className="w-full rounded-md border border-border bg-background px-2 py-1 font-mono text-xs text-foreground"
+        />
+        <input
+          type="text"
+          value={label}
+          maxLength={60}
+          placeholder={parsed ? `Name (optional) — defaults to ${new URL(parsed.url).host}` : 'Name (optional)'}
+          onChange={e => setLabel(e.target.value)}
+          className="w-full rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground"
+        />
+        {url.trim() !== '' && !valid && (
+          <p className="text-xs text-warning">
+            {parsed === null ? 'That is not a valid URL.' : 'This URL has no token, so the box could not authenticate you.'}
+          </p>
+        )}
+        <div className="mt-1 flex items-center justify-end gap-2">
+          <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="button" size="sm" disabled={!valid} onClick={save}>
+            Add device
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  )
+}

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -20,6 +20,8 @@ import { PresetCreatePanel } from './PresetCreatePanel.js'
 import { PresetsMenu } from './PresetsMenu.js'
 import { AgentModelMenu, type AgentOption } from './AgentModelMenu.js'
 import { OptionsMenu, type OptionRow, type RunTarget } from './OptionsMenu.js'
+import { AddDeviceDialog } from './AddDeviceDialog.js'
+import { useConnectionProfiles, connectTo, connectLocal, isLoopbackHost } from '../lib/profiles.js'
 import { ResolvedOptions } from './ResolvedOptions.js'
 import { ClaudeLogo, CodexLogo } from './agent-logos.js'
 import { Button } from './ui/button.js'
@@ -120,7 +122,13 @@ export const Composer = forwardRef<ComposerHandle, {
   // Set by the loaded preset, not by the surface (#959). Cleared with the box, like `kind`.
   const [newSession, setNewSession] = useState(false)
   const [addingPreset, setAddingPreset] = useState(false)
+  const [addingDevice, setAddingDevice] = useState(false) // #1052: the "Add a device" modal
   const editorRef = useRef<PromptEditorHandle>(null)
+  // The saved daemons this browser can hop to (#1052). Which one we are on now comes from the URL,
+  // fixed for the page's life (a device switch reloads), so it is read once rather than as state.
+  const profiles = useConnectionProfiles()
+  const currentUrl = typeof window === 'undefined' ? null : window.location.origin
+  const isLocalConnection = typeof window === 'undefined' ? true : isLoopbackHost(window.location.hostname)
   // The registered projects for the `@` picker — the same list the launcher reads.
   const projects = useLoaded<ProjectSummary[]>(onProjects, [], [])
 
@@ -304,6 +312,20 @@ export const Composer = forwardRef<ComposerHandle, {
       // The "Run on" driver axis (#1050) is baked in at spawn, so it is offered only at the launcher —
       // same reasoning as the agent select being hidden in-session.
       {...(inSession ? {} : { runTarget: { value: target, onChange: (t: RunTarget) => updatePreferences({ target: t }) } })}
+      // The saved-devices connection section (#1052) rides the same "Run on" sub, so it too is
+      // launcher-only; the header indicator shows the current device everywhere.
+      {...(inSession
+        ? {}
+        : {
+            connection: {
+              profiles,
+              currentUrl,
+              isLocal: isLocalConnection,
+              onConnect: connectTo,
+              onConnectLocal: connectLocal,
+              onAddDevice: () => setAddingDevice(true),
+            },
+          })}
     />
   )
 
@@ -339,6 +361,10 @@ export const Composer = forwardRef<ComposerHandle, {
     </Button>
   )
 
+  // The "Add a device" modal (#1052), rendered by both forms since the gear is in both. A portal, so
+  // its place in the tree does not matter.
+  const deviceDialog = addingDevice && <AddDeviceDialog onClose={() => setAddingDevice(false)} onAdded={() => editorRef.current?.focus()} />
+
   // Compact (#723): a single row for the navbar — editor, then the same controls and submit. It
   // stays one row on purpose (#755): the header must not grow taller to gain them.
   if (compact) {
@@ -348,6 +374,7 @@ export const Composer = forwardRef<ComposerHandle, {
         {agentModelEl}
         {optionsGearEl}
         {submitButton}
+        {deviceDialog}
       </div>
     )
   }
@@ -399,6 +426,7 @@ export const Composer = forwardRef<ComposerHandle, {
           }}
         />
       )}
+      {deviceDialog}
     </>
   )
 })

--- a/packages/framework-dashboard/components/ConnectionIndicator.tsx
+++ b/packages/framework-dashboard/components/ConnectionIndicator.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react'
+import { Laptop, MonitorSmartphone } from 'lucide-react'
+import { useConnectionProfiles, currentConnection, rememberLocalOrigin } from '../lib/profiles.js'
+
+// The "connected to <label>" indicator (#1052): which daemon the dashboard is talking to. Every
+// transport is same-origin, so the browser's origin IS the connection — loopback is this machine's
+// own daemon ("Local"), any other origin is a device you hopped to. It reads accented off Local so
+// a remote box (where the agent runs on someone else's hardware) is never mistaken for your own.
+export function ConnectionIndicator() {
+  const profiles = useConnectionProfiles()
+  // Remember the loopback origin we launched from, so "Local" can return to the right port later.
+  useEffect(() => {
+    if (typeof window !== 'undefined') rememberLocalOrigin(window.location.origin, window.location.hostname)
+  }, [])
+  if (typeof window === 'undefined') return null
+  const { label, isLocal } = currentConnection(profiles, window.location.origin, window.location.hostname)
+  const Icon = isLocal ? Laptop : MonitorSmartphone
+  return (
+    <span
+      title={isLocal ? 'Connected to this machine' : `Connected to ${label} — the agent runs on that device`}
+      className={
+        isLocal
+          ? 'hidden items-center gap-1.5 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground sm:inline-flex'
+          : 'inline-flex items-center gap-1.5 rounded-md border border-[var(--color-primary)]/40 bg-[var(--color-primary)]/10 px-2 py-1 text-xs text-[var(--color-primary)]'
+      }
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+      <span className="max-w-[10rem] truncate">{label}</span>
+    </span>
+  )
+}

--- a/packages/framework-dashboard/components/OptionsMenu.test.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import type { OptionRow } from './OptionsMenu.js'
+import type { OptionRow, ConnectionControl } from './OptionsMenu.js'
+import type { ConnectionProfile } from '../lib/profiles.js'
 
 const updatePreferences = vi.hoisted(() => vi.fn())
 vi.mock('../lib/preferences.js', () => ({ updatePreferences }))
@@ -96,6 +97,73 @@ describe('OptionsMenu (#654)', () => {
     render(<OptionsMenu options={[]} ecoOptions={[]} showEco={false} busy={false} />)
     open()
     expect(screen.queryByText('Run on')).toBeNull()
+  })
+
+  const profiles = (): ConnectionProfile[] => [
+    { id: 'http://192.168.1.5:4200', label: 'Studio', url: 'http://192.168.1.5:4200', token: 'aaa' },
+  ]
+  const connectionControl = (over: Partial<ConnectionControl> = {}): ConnectionControl => ({
+    profiles: profiles(),
+    currentUrl: 'http://127.0.0.1:4200',
+    isLocal: true,
+    onConnect: vi.fn(),
+    onConnectLocal: vi.fn(),
+    onAddDevice: vi.fn(),
+    ...over,
+  })
+
+  test('the "A device I have" section lists saved profiles under Run on (#1052)', () => {
+    render(
+      <OptionsMenu options={[]} ecoOptions={[]} showEco={false} busy={false} runTarget={{ value: 'local', onChange: vi.fn() }} connection={connectionControl()} />,
+    )
+    open()
+    fireEvent.click(screen.getByText('Run on'))
+    expect(screen.getByText('A device I have')).toBeTruthy()
+    expect(screen.getByText('Local')).toBeTruthy()
+    expect(screen.getByText('Studio')).toBeTruthy()
+    expect(screen.getByText('Add a device…')).toBeTruthy()
+  })
+
+  test('selecting a device navigates (does not write a preference) (#1052)', () => {
+    const onConnect = vi.fn()
+    render(
+      <OptionsMenu options={[]} ecoOptions={[]} showEco={false} busy={false} runTarget={{ value: 'local', onChange: vi.fn() }} connection={connectionControl({ onConnect })} />,
+    )
+    open()
+    fireEvent.click(screen.getByText('Run on'))
+    fireEvent.click(screen.getByText('Studio'))
+    expect(onConnect).toHaveBeenCalledWith(profiles()[0])
+    // A device row is a connection hop, not a driver preference.
+    expect(updatePreferences).not.toHaveBeenCalled()
+  })
+
+  test('Local fires its connect handler (#1052)', () => {
+    const onConnectLocal = vi.fn()
+    render(
+      <OptionsMenu options={[]} ecoOptions={[]} showEco={false} busy={false} runTarget={{ value: 'local', onChange: vi.fn() }} connection={connectionControl({ onConnectLocal })} />,
+    )
+    open()
+    fireEvent.click(screen.getByText('Run on'))
+    fireEvent.click(screen.getByText('Local'))
+    expect(onConnectLocal).toHaveBeenCalled()
+  })
+
+  test('Add a device opens the add flow (#1052)', () => {
+    const onAddDevice = vi.fn()
+    render(
+      <OptionsMenu options={[]} ecoOptions={[]} showEco={false} busy={false} runTarget={{ value: 'local', onChange: vi.fn() }} connection={connectionControl({ onAddDevice })} />,
+    )
+    open()
+    fireEvent.click(screen.getByText('Run on'))
+    fireEvent.click(screen.getByText('Add a device…'))
+    expect(onAddDevice).toHaveBeenCalled()
+  })
+
+  test('the device section is absent without a connection control (#1052)', () => {
+    render(<OptionsMenu options={[]} ecoOptions={[]} showEco={false} busy={false} runTarget={{ value: 'local', onChange: vi.fn() }} />)
+    open()
+    fireEvent.click(screen.getByText('Run on'))
+    expect(screen.queryByText('A device I have')).toBeNull()
   })
 
 })

--- a/packages/framework-dashboard/components/OptionsMenu.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.tsx
@@ -1,6 +1,7 @@
 import type { Preferences } from '@gemstack/framework'
-import { Settings, Check } from 'lucide-react'
+import { Settings, Check, Laptop, MonitorSmartphone, Plus } from 'lucide-react'
 import { updatePreferences } from '../lib/preferences.js'
+import type { ConnectionProfile } from '../lib/profiles.js'
 import { cn } from '../lib/utils.js'
 import { buttonVariants } from './ui/button.js'
 import {
@@ -8,7 +9,9 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuCheckboxItem,
+  DropdownMenuGroup,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubTrigger,
@@ -52,6 +55,24 @@ export type RunTargetControl = {
   onChange: (value: RunTarget) => void
 }
 
+/**
+ * The "A device I have" section of the "Run on" sub (#1052). A device is a CONNECTION, not a driver:
+ * the driver rows above rewrite a preference, these NAVIGATE the browser to another daemon's origin.
+ * That is the divergence the gear holds in one list — driver rows call `updatePreferences` (per-run),
+ * device rows call `onConnect`/`onConnectLocal` (a page navigation carrying the token).
+ */
+export type ConnectionControl = {
+  /** The saved remote daemons this browser can hop to. */
+  profiles: ConnectionProfile[]
+  /** `window.location.origin`, to mark the daemon the dashboard is on now. */
+  currentUrl: string | null
+  /** Whether the current origin is loopback, so "Local" is the checked row. */
+  isLocal: boolean
+  onConnect: (profile: ConnectionProfile) => void
+  onConnectLocal: () => void
+  onAddDevice: () => void
+}
+
 // The run targets the gear offers (#1050). A single-select modeled on the agent tree (Check-marked
 // rows), not the boolean OptionRow. "Claude web" is a disabled placeholder for the sibling axis in
 // #1049 that has not shipped yet, so the menu shows where this is going without promising it.
@@ -60,7 +81,7 @@ const RUN_TARGET_ROWS: { value: RunTarget; label: string; description: string }[
   { value: 'actions', label: 'GitHub Actions', description: 'Run on a fresh GitHub Actions runner.' },
 ]
 
-function RunTargetSub({ control, busy }: { control: RunTargetControl; busy: boolean }) {
+function RunTargetSub({ control, connection, busy }: { control: RunTargetControl; connection?: ConnectionControl | undefined; busy: boolean }) {
   const current = RUN_TARGET_ROWS.find(r => r.value === control.value) ?? RUN_TARGET_ROWS[0]!
   return (
     <DropdownMenuSub>
@@ -69,6 +90,7 @@ function RunTargetSub({ control, busy }: { control: RunTargetControl; busy: bool
         <span className="text-muted-foreground">{current.label}</span>
       </DropdownMenuSubTrigger>
       <DropdownMenuSubContent>
+        {/* Driver rows (#1050): a per-run preference, written straight through. */}
         {RUN_TARGET_ROWS.map(row => (
           <DropdownMenuItem key={row.value} className="items-start" onClick={() => control.onChange(row.value)}>
             <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', row.value === control.value ? 'opacity-100' : 'opacity-0')} />
@@ -79,8 +101,38 @@ function RunTargetSub({ control, busy }: { control: RunTargetControl; busy: bool
           <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 opacity-0" />
           <OptionLabel label="Claude web" description="Coming soon." />
         </DropdownMenuItem>
+        {connection && <ConnectionSection connection={connection} busy={busy} />}
       </DropdownMenuSubContent>
     </DropdownMenuSub>
+  )
+}
+
+/** The "A device I have" rows (#1052). Unlike the driver rows above, a click here NAVIGATES the
+ * browser to that daemon's origin (carrying the token) rather than writing a preference. */
+function ConnectionSection({ connection, busy }: { connection: ConnectionControl; busy: boolean }) {
+  return (
+    <>
+      <DropdownMenuSeparator />
+      <DropdownMenuGroup>
+        <DropdownMenuLabel>A device I have</DropdownMenuLabel>
+        <DropdownMenuItem className="items-start" onClick={() => connection.onConnectLocal()}>
+          <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', connection.isLocal ? 'opacity-100' : 'opacity-0')} />
+          <Laptop className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+          <OptionLabel label="Local" description="This machine's own daemon." />
+        </DropdownMenuItem>
+        {connection.profiles.map(profile => (
+          <DropdownMenuItem key={profile.id} className="items-start" onClick={() => connection.onConnect(profile)}>
+            <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', !connection.isLocal && profile.url === connection.currentUrl ? 'opacity-100' : 'opacity-0')} />
+            <MonitorSmartphone className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+            <OptionLabel label={profile.label} description={profile.url} />
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuItem className="items-start" disabled={busy} onClick={() => connection.onAddDevice()}>
+          <Plus className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+          <OptionLabel label="Add a device…" description="Paste the URL a box prints on its network bind." />
+        </DropdownMenuItem>
+      </DropdownMenuGroup>
+    </>
   )
 }
 
@@ -110,6 +162,7 @@ export function OptionsMenu({
   busy,
   label = 'Session options',
   runTarget,
+  connection,
 }: {
   options: OptionRow[]
   ecoOptions: OptionRow[]
@@ -122,6 +175,9 @@ export function OptionsMenu({
   /** The "Run on" driver axis (#1050), at the top of the gear. Omitted in-session, where the
    *  target is baked in at spawn — same as the agent select. */
   runTarget?: RunTargetControl | undefined
+  /** The saved-devices connection section (#1052), rendered inside the "Run on" sub under the
+   *  driver rows. Rides the same sub as runTarget, so it shows only where that does. */
+  connection?: ConnectionControl | undefined
 }) {
   const activeCount = options.filter(o => o.checked && !o.disabled).length
   return (
@@ -143,7 +199,7 @@ export function OptionsMenu({
       <DropdownMenuContent align="end" className="min-w-[19rem] max-w-[22rem]">
         {runTarget && (
           <>
-            <RunTargetSub control={runTarget} busy={busy} />
+            <RunTargetSub control={runTarget} connection={connection} busy={busy} />
             {options.length > 0 && <DropdownMenuSeparator />}
           </>
         )}

--- a/packages/framework-dashboard/lib/profiles.test.ts
+++ b/packages/framework-dashboard/lib/profiles.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import {
+  listProfiles,
+  addProfile,
+  removeProfile,
+  parseDeviceUrl,
+  connectUrl,
+  currentConnection,
+  isLoopbackHost,
+  localOrigin,
+  rememberLocalOrigin,
+} from './profiles.js'
+
+// jsdom provides a real localStorage, so these round-trip through it directly.
+afterEach(() => localStorage.clear())
+
+describe('profiles.ts (#1052)', () => {
+  test('add / list / remove round-trips through localStorage', () => {
+    expect(listProfiles()).toEqual([])
+    const a = addProfile({ url: 'http://192.168.1.5:4200', token: 'aaa', label: 'Studio' })
+    const b = addProfile({ url: 'http://box.tail.ts:4200', token: 'bbb' })
+    expect(listProfiles().map(p => p.label)).toEqual(['box.tail.ts:4200', 'Studio']) // newest first
+    expect(b.label).toBe('box.tail.ts:4200') // falls back to the host
+    removeProfile(a.id)
+    expect(listProfiles().map(p => p.id)).toEqual([b.id])
+  })
+
+  test('re-adding the same origin refreshes rather than duplicates', () => {
+    addProfile({ url: 'http://192.168.1.5:4200', token: 'old', label: 'Studio' })
+    addProfile({ url: 'http://192.168.1.5:4200', token: 'new' })
+    const list = listProfiles()
+    expect(list).toHaveLength(1)
+    expect(list[0]!.token).toBe('new')
+  })
+
+  test('profiles survive a reload (a fresh read of localStorage)', () => {
+    addProfile({ url: 'http://192.168.1.5:4200', token: 'aaa' })
+    // Nothing cached across a real navigation — read straight from storage.
+    const reread = JSON.parse(localStorage.getItem('fw.devices')!)
+    expect(reread[0].token).toBe('aaa')
+  })
+
+  test('parseDeviceUrl pulls the origin and token out of a pasted URL', () => {
+    expect(parseDeviceUrl('http://192.168.1.5:4200/?token=abc123')).toEqual({ url: 'http://192.168.1.5:4200', token: 'abc123' })
+    expect(parseDeviceUrl('  http://box:4200/some/path?token=xyz  ')).toEqual({ url: 'http://box:4200', token: 'xyz' })
+    expect(parseDeviceUrl('http://box:4200')).toEqual({ url: 'http://box:4200', token: '' })
+    expect(parseDeviceUrl('not a url')).toBeNull()
+  })
+
+  test('connectUrl carries the token for the bootstrap hop', () => {
+    expect(connectUrl({ url: 'http://box:4200', token: 'abc' })).toBe('http://box:4200/?token=abc')
+    expect(connectUrl({ url: 'http://127.0.0.1:4200', token: '' })).toBe('http://127.0.0.1:4200') // Local, no token
+  })
+
+  test('isLoopbackHost knows the local machine', () => {
+    expect(isLoopbackHost('127.0.0.1')).toBe(true)
+    expect(isLoopbackHost('localhost')).toBe(true)
+    expect(isLoopbackHost('192.168.1.5')).toBe(false)
+  })
+
+  test('currentConnection labels the daemon the browser is on', () => {
+    const profiles = [{ id: 'http://192.168.1.5:4200', label: 'Studio', url: 'http://192.168.1.5:4200', token: 'aaa' }]
+    expect(currentConnection(profiles, 'http://127.0.0.1:4200', '127.0.0.1')).toEqual({ label: 'Local', isLocal: true })
+    expect(currentConnection(profiles, 'http://192.168.1.5:4200', '192.168.1.5')).toEqual({ label: 'Studio', isLocal: false })
+    expect(currentConnection(profiles, 'http://10.0.0.9:4200', '10.0.0.9')).toEqual({ label: '10.0.0.9', isLocal: false }) // unsaved
+  })
+
+  test('localOrigin returns the remembered loopback origin, else the default', () => {
+    expect(localOrigin()).toBe('http://127.0.0.1:4200')
+    rememberLocalOrigin('http://localhost:9999', 'localhost')
+    expect(localOrigin()).toBe('http://localhost:9999')
+    rememberLocalOrigin('http://192.168.1.5:4200', '192.168.1.5') // ignored off loopback
+    expect(localOrigin()).toBe('http://localhost:9999')
+  })
+})

--- a/packages/framework-dashboard/lib/profiles.ts
+++ b/packages/framework-dashboard/lib/profiles.ts
@@ -1,0 +1,162 @@
+import { useSyncExternalStore } from 'react'
+
+// Client connection profiles (#1052): the saved daemons this browser can hop to. "A device I have"
+// is a CONNECTION, not a run driver — the SPA is served by its daemon and every transport is
+// same-origin, so switching devices means navigating the browser to that daemon's origin, where the
+// #1051 bootstrap sets the fw_daemon cookie from `?token=` and everything is same-origin again.
+//
+// Storage is client-side localStorage on purpose: the token is a per-browser secret, so it must
+// never reach the daemon's registry file (the wrong home, shared across browsers). Node-free leaf
+// like agent-names.ts / preference-defaults.ts, so nothing node leaks into the SPA bundle.
+
+/** A saved daemon this browser can connect to. `token` is empty only for the loopback Local one. */
+export type ConnectionProfile = { id: string; label: string; url: string; token: string }
+
+/** localStorage key for the saved remote devices (an array of {@link ConnectionProfile}). */
+const DEVICES_KEY = 'fw.devices'
+
+/** localStorage key remembering the loopback origin the dashboard was launched from (#1052), so
+ * "Local" returns to the right port even from a remote box. */
+const LOCAL_ORIGIN_KEY = 'fw.local-origin'
+
+/** Fallback loopback origin when none was remembered — the default daemon port (daemon.ts). */
+const DEFAULT_LOCAL_ORIGIN = 'http://127.0.0.1:4200'
+
+/** localStorage, or undefined during prerender (ssr:false) where there is no browser. */
+function store(): Storage | undefined {
+  try {
+    return globalThis.localStorage
+  } catch {
+    return undefined
+  }
+}
+
+function isProfile(value: unknown): value is ConnectionProfile {
+  const p = value as Partial<ConnectionProfile> | null
+  return !!p && typeof p.id === 'string' && typeof p.label === 'string' && typeof p.url === 'string' && typeof p.token === 'string'
+}
+
+/** The saved remote devices, newest first, filtered to well-formed entries. */
+export function listProfiles(): ConnectionProfile[] {
+  try {
+    const raw = store()?.getItem(DEVICES_KEY)
+    if (!raw) return []
+    const parsed: unknown = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed.filter(isProfile) : []
+  } catch {
+    return []
+  }
+}
+
+function writeProfiles(list: ConnectionProfile[]): void {
+  store()?.setItem(DEVICES_KEY, JSON.stringify(list))
+  notify()
+}
+
+/** Save (or update, keyed by origin) a device. Returns the stored profile. A repeat paste of the
+ * same box refreshes its token rather than stacking a duplicate. */
+export function addProfile(input: { url: string; token: string; label?: string }): ConnectionProfile {
+  const profile: ConnectionProfile = {
+    id: input.url,
+    label: input.label?.trim() || hostLabel(input.url),
+    url: input.url,
+    token: input.token,
+  }
+  writeProfiles([profile, ...listProfiles().filter(p => p.id !== profile.id)])
+  return profile
+}
+
+/** Drop a saved device by id. */
+export function removeProfile(id: string): void {
+  writeProfiles(listProfiles().filter(p => p.id !== id))
+}
+
+/** The origin's host as a fallback label (e.g. `192.168.1.5:4200`) when none was given. */
+function hostLabel(url: string): string {
+  try {
+    return new URL(url).host
+  } catch {
+    return url
+  }
+}
+
+/**
+ * Pull the origin and token out of the full `http://host:port/?token=…` URL the box prints on its
+ * non-loopback bind (cli.ts). Returns null if the paste is not a URL. The url is normalized to the
+ * bare origin so it matches `window.location.origin` for the connected indicator.
+ */
+export function parseDeviceUrl(pasted: string): { url: string; token: string } | null {
+  try {
+    const u = new URL(pasted.trim())
+    return { url: u.origin, token: u.searchParams.get('token') ?? '' }
+  } catch {
+    return null
+  }
+}
+
+/** Whether a host is loopback (so the dashboard is talking to this machine's own daemon). */
+export function isLoopbackHost(host: string): boolean {
+  return host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1'
+}
+
+/** Remember the loopback origin the dashboard is served from, so "Local" can return to the right
+ * port from a remote box. A no-op off loopback. */
+export function rememberLocalOrigin(origin: string, host: string): void {
+  if (isLoopbackHost(host)) store()?.setItem(LOCAL_ORIGIN_KEY, origin)
+}
+
+/** The loopback origin to send "Local" to: the remembered launch origin, else the default port. */
+export function localOrigin(): string {
+  return store()?.getItem(LOCAL_ORIGIN_KEY) ?? DEFAULT_LOCAL_ORIGIN
+}
+
+/** The connect URL for a device: its origin plus the token for the one bootstrap hop (#1051). */
+export function connectUrl(profile: Pick<ConnectionProfile, 'url' | 'token'>): string {
+  return profile.token ? `${profile.url}/?token=${encodeURIComponent(profile.token)}` : profile.url
+}
+
+/** Navigate the browser to a saved device (carrying its token). This is the connection hop, NOT a
+ * run submit: the remote SPA re-authenticates same-origin from the cookie the bootstrap sets. */
+export function connectTo(profile: ConnectionProfile): void {
+  globalThis.location?.assign(connectUrl(profile))
+}
+
+/** Navigate back to this machine's own loopback daemon (no token). */
+export function connectLocal(): void {
+  globalThis.location?.assign(localOrigin())
+}
+
+/** Which daemon the dashboard is currently talking to, for the connected indicator. Loopback = the
+ * local machine; else the matching saved device's label, or the bare host if it is unsaved. */
+export function currentConnection(profiles: ConnectionProfile[], origin: string, host: string): { label: string; isLocal: boolean } {
+  if (isLoopbackHost(host)) return { label: 'Local', isLocal: true }
+  return { label: profiles.find(p => p.url === origin)?.label ?? host, isLocal: false }
+}
+
+// A tiny store so the gear and the connected indicator re-render when devices change. localStorage
+// has no in-tab change event, so writes notify explicitly; the snapshot is cached until then
+// (useSyncExternalStore compares by identity, so re-reading fresh each call would loop).
+let snapshotCache: ConnectionProfile[] | null = null
+const listeners = new Set<() => void>()
+
+function notify(): void {
+  snapshotCache = null
+  for (const listener of listeners) listener()
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+function getSnapshot(): ConnectionProfile[] {
+  return (snapshotCache ??= listProfiles())
+}
+
+/** The saved devices as reactive state. Prerender has no localStorage, so it renders the empty list
+ * and the real one loads on the client. */
+export function useConnectionProfiles(): ConnectionProfile[] {
+  return useSyncExternalStore(subscribe, getSnapshot, () => EMPTY)
+}
+
+const EMPTY: ConnectionProfile[] = []

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -5,6 +5,7 @@ import { onProjects } from '../../server/projects.telefunc.js'
 import { ProjectPicker } from '../../components/ProjectPicker.js'
 import { BrandLink } from '../../components/BrandLink.js'
 import { ThemeToggle } from '../../components/ThemeToggle.js'
+import { ConnectionIndicator } from '../../components/ConnectionIndicator.js'
 import { NotificationsMenu } from '../../components/NotificationsMenu.js'
 import { Button } from '../../components/ui/button.js'
 import { RunHistory } from '../../components/RunHistory.js'
@@ -290,6 +291,8 @@ export default function Page() {
         />
         <div className="min-w-0 flex-1" />
         <div className="flex shrink-0 items-center gap-1">
+          {/* Which daemon this dashboard is talking to (#1052) — obvious once you can hop devices. */}
+          <ConnectionIndicator />
           <Button
             variant="outline"
             size="sm"


### PR DESCRIPTION
Part of #1049. The client half of "a device I have": saving daemons this browser can hop to, and connecting by navigation. Builds on the merged Wave 1 (#1050 "Run on" sub, #1051 bind+token bootstrap).

## The model
"A device I have" is a connection choice, not a per-run driver choice. The SPA is served by its daemon and every transport is same-origin, so switching devices means navigating the browser to the remote daemon's origin carrying the token; the #1051 bootstrap sets the fw_daemon cookie from `?token=` and 302s to a clean path, so the remote SPA loads same-origin and authenticated. It does not ride onSubmit. This is why the one "Run on" list has diverging click handlers: driver rows (Current device / GitHub Actions) call updatePreferences; device rows call a connect navigation. The divergence is documented on the component.

## What is here
- `lib/profiles.ts`: a node-free leaf (like agent-names.ts / preference-defaults.ts). A profile is `{ id, label, url, token }`. Storage is client-side localStorage, so the token is a per-browser secret and never reaches the daemon's registry file. Exports add/list/remove, `parseDeviceUrl` (origin + token out of a pasted URL), `connectTo`/`connectLocal` navigation, and `currentConnection` labeling. Keyed by origin, so re-pasting a box refreshes its token instead of duplicating.
- `OptionsMenu`: an "A device I have" section extends the existing "Run on" sub. Local (loopback, no token), the saved devices, and "Add a device". The active connection is Check-marked. Rides the same sub as the run-target control, so it is launcher-only.
- `AddDeviceDialog`: paste the full `http://host:port/?token=…` URL a box prints on its non-loopback bind (any reachable host: LAN IP, tailnet name, tunnel URL), parse origin + token, persist. A URL with no token cannot be saved.
- `ConnectionIndicator`: a small header "connected to <device>" pill, accented off Local so a remote box is obvious. This indicator is owned here (#1053 does not build it).

## Notes vs the issue
- Default daemon port is 4200 (not the port in the issue prose); the Local fallback uses it, and the loopback origin the dashboard launched from is remembered so Local returns to the right port even from a remote box.
- The device section rides the launcher-only "Run on" sub; in-session the header indicator still shows the current device.

## Tests
- `lib/profiles.test.ts`: add/list/remove round-trip through localStorage, upsert-by-origin, reload survival, URL parsing, connect-URL construction, current-connection labeling, remembered local origin.
- `OptionsMenu.test.tsx`: the section lists saved profiles; a device row calls onConnect and does not write a preference; Local and Add fire their handlers; absent without a connection control.
- `AddDeviceDialog.test.tsx`: a pasted `?token=` URL saves a profile; a tokenless URL cannot; an optional label overrides the host default.

Verify: `@gemstack/framework-dashboard` typecheck clean; full dashboard suite 53 files / 348 tests pass; SPA build clean.

Sibling #1053 (run-view polish) is disjoint from the gear; whichever merges second may need `git merge origin/main`.

Closes #1052