### PR TITLE
docs: drop the underline under the README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="./logo.svg" alt="The Framework" align="left" width="120" />
 
-# The Framework
+### The Framework
 
 **Autonomous AI programming.**  
 Stop babysitting your coding agents. You make the important decisions; AI does the rest.


### PR DESCRIPTION
The horizontal line across the hero was GitHub's automatic bottom-border under h1/h2 headings, not something in our markup. GitHub only underlines those two heading levels, so the title is now an h3 (no border). Everything else in the hero is unchanged.