### PR TITLE
fix(framework): SameSite=Lax for the daemon token cookie so the device connect hop works

### DIFF
--- a/.changeset/samesite-lax-device-hop.md
+++ b/.changeset/samesite-lax-device-hop.md
@@ -1,0 +1,7 @@
+---
+"@gemstack/framework": patch
+---
+
+fix(framework): set the daemon token cookie SameSite=Lax so the "a device I have" connection hop works
+
+The non-loopback bind guard (#1051) set the fw_daemon cookie SameSite=Strict. Connecting to a saved device (#1052) is a cross-origin top-level navigation, and a Strict cookie set during that navigation is withheld by the browser on the immediate redirect to the clean path, so the device connect landed on a 401. Lax still rides top-level GET navigations, and CSRF protection is unchanged (the same-origin check still fronts /_telefunc).

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -219,7 +219,8 @@ test('a valid ?token= sets the HttpOnly fw_daemon cookie and 302s to the clean p
     assert.equal(res.location, '/') // the token is stripped from the redirect target
     assert.match(res.setCookie ?? '', /^fw_daemon=/)
     assert.match(res.setCookie ?? '', /HttpOnly/)
-    assert.match(res.setCookie ?? '', /SameSite=Strict/)
+    // Lax, not Strict, so the cookie survives the cross-origin device-hop redirect (#1052).
+    assert.match(res.setCookie ?? '', /SameSite=Lax/)
     assert.match(res.setCookie ?? '', /Path=\//)
   } finally {
     await close()

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -199,7 +199,8 @@ export function authorizeDaemonRequest(req: IncomingMessage, res: ServerResponse
     url.searchParams.delete('token')
     const query = url.searchParams.toString()
     res.writeHead(302, {
-      'set-cookie': `${DAEMON_COOKIE}=${token}; HttpOnly; SameSite=Strict; Path=/`,
+      // Lax, not Strict: the #1052 device-hop is a cross-origin top-level nav, and a Strict cookie set on it is withheld from the redirect right after, so the clean path 401s. Lax still rides top-level GET navs; CSRF stays covered by the same-origin check on /_telefunc.
+      'set-cookie': `${DAEMON_COOKIE}=${token}; HttpOnly; SameSite=Lax; Path=/`,
       location: url.pathname + (query ? `?${query}` : ''),
     })
     res.end()


### PR DESCRIPTION
Found by live-driving the "a device I have" lane: connecting to a saved device navigated to the remote daemon and got **unauthorized** (401).

**Cause.** The #1051 bind guard set the `fw_daemon` cookie `SameSite=Strict`. The #1052 connect is a **cross-origin top-level navigation** (`127.0.0.1:4200` -> `host:4300`). A Strict cookie set *during* a cross-site-initiated navigation is withheld by the browser on the very next hop (the 302 to the clean path), so `/` sees no cookie and 401s.

**Fix.** `SameSite=Lax`. Lax cookies ride top-level GET navigations (so the post-302 `/` gets it), and CSRF protection is unchanged: Lax is not sent on cross-site subresource requests or POSTs, and the existing same-origin check still fronts `/_telefunc`.

**Verified** (loopback + real non-loopback bind): no-token -> 401; `?token=` -> 302 + `SameSite=Lax`; follow the redirect carrying the cookie -> 200. Guard test updated. Full framework suite 1143 pass / 1 skip.