### PR TITLE
docs: bump README logo to 170px

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="./logo.svg?v=2" alt="The Framework" align="left" width="150" />
+<img src="./logo.svg?v=2" alt="The Framework" align="left" width="170" />
 
 ### The Framework
 


### PR DESCRIPTION
Bumps the README hero logo width from 150px to 170px.