### PR TITLE
docs: tighten README and fix dependency graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Stop babysitting your coding agents. You make the important decisions; AI does t
 
 <br clear="left" />
 
-The Framework turns your coding agent into an autonomous teammate: it plans, researches, implements, reviews, and improves its own work, while keeping you in control of the decisions that matter. It wraps a coding-agent CLI (Claude Code today) as a black box and takes you from an idea to a running app, with a localhost dashboard that shows the orchestration the agent's own chat cannot: the loop status, the review passes, and the queue of what is next.
+The Framework turns your coding agent into an autonomous teammate that plans, researches, implements, and reviews its own work, while you keep control of the decisions that matter. It wraps a coding-agent CLI (Claude Code today) as a black box and takes you from an idea to a running app. A localhost dashboard shows what the agent's chat cannot: loop status, review passes, and the queue of what is next.
 
-It is 100% open source, runs 100% locally, and uses your existing AI subscription (bring your own Claude Code).
+100% open source, 100% local, on your existing AI subscription (bring your own Claude Code).
 
 ## Quickstart
 
@@ -28,45 +28,45 @@ framework --fake
 
 ## Stop babysitting
 
-AI is capable, yet left alone it is lazy, forgetful, and quietly makes decisions it should be asking you about. The Framework fixes that at the prompt layer:
+Left alone, AI is lazy, forgetful, and quietly makes decisions it should be asking you about. The Framework fixes that at the prompt layer:
 
-- **AI is lazy.** It splits large tasks into subtasks and works through a checklist, so it spends real effort instead of taking shortcuts.
+- **AI is lazy.** It splits large tasks into a checklist of subtasks and works through them, instead of taking shortcuts.
 - **AI plans lazily.** A loop of critical feedback and research runs before any code is written.
-- **AI writes throwaway code.** It questions and reviews its own work until it is confident the result is correct, maintainable, and DRY.
-- **AI decides without asking.** When real alternatives with trade-offs exist, it surfaces them to you instead of silently picking one.
+- **AI writes throwaway code.** It reviews its own work until the result is correct, maintainable, and DRY.
+- **AI decides without asking.** When real alternatives with trade-offs exist, it surfaces them instead of silently picking one.
 - **AI forgets.** Decisions and context are saved to `knowledge-base/*.md` in your repo, so you stop repeating yourself.
 
 ## How it works
 
-The Framework does not run its own agent. It drives a coding agent as a black box: it sends a prompt, lets the agent's own loop run, reads the code produced, gates on the outcome (builds, serves, review passes), then re-prompts. The seam is the code, never the agent's individual tool calls, so the wrapped agent keeps its subscription-based auth and stays swappable.
+The Framework does not run its own agent. It drives a coding agent as a black box: sends a prompt, lets the agent's loop run, reads the code produced, gates on the outcome (builds, serves, review passes), then re-prompts. The seam is the code, never the agent's individual tool calls, so the wrapped agent keeps its subscription auth and stays swappable.
 
-- **Enhanced system prompt.** Best-practice instructions layered on top of your agent: divide and conquer, enumerate before coding, self-review, surface alternatives. Fully customizable, or opt out.
+- **Enhanced system prompt.** Best-practice instructions layered on your agent: divide and conquer, enumerate before coding, self-review, surface alternatives. Fully customizable, or opt out.
 - **Autopilot.** Pick how much runs unattended. Quick wins and quality refactors can run on their own; non-obvious decisions still come back to you.
-- **Dashboard.** A localhost dashboard shows the live run, the loop status, the review passes, the queue of upcoming tasks, the reviews waiting on you, and your subscription usage.
-- **Bring your own subscription.** Orchestrates agents through your existing Claude Code install, so there is no extra API bill.
-- **100% local.** Runs on your machine like a desktop app. No backdoors, no tracking; your knowledge base lives as `knowledge-base/*.md` in your own Git repository.
+- **Dashboard.** A localhost view of the live run: loop status, review passes, the queue of upcoming tasks, the reviews waiting on you, and your subscription usage.
+- **Bring your own subscription.** Orchestrates through your existing Claude Code install, so there is no extra API bill.
+- **100% local.** Runs on your machine like a desktop app. No backdoors, no tracking; your knowledge base lives as `knowledge-base/*.md` in your own Git repo.
 
 See the [`@gemstack/framework` README](./packages/framework/README.md) for the CLI, the library API, and the driver seam.
 
 ## Built on GemStack
 
-The Framework is the turnkey product on top of **GemStack**: a collection of high-quality, framework-agnostic packages built with the [Vike](https://vike.dev) team. Each package is standalone, well tested, and works in any Node app; The Framework composes them into one product. Packages join GemStack by *graduating* one at a time, when they prove framework-agnostic value, not by bulk-moving a framework's package set in.
+The Framework is the turnkey product on top of **GemStack**: a collection of high-quality, framework-agnostic packages built with the [Vike](https://vike.dev) team. Each package is standalone, well tested, and works in any Node app; The Framework composes them into one product. Packages join GemStack by *graduating* one at a time when they prove framework-agnostic value, not by bulk-moving a framework's package set in.
 
 All packages publish under the **`@gemstack/`** scope (e.g. `npm install @gemstack/ai-sdk`).
 
-Full documentation lives in [`docs/`](./docs/guide/index.md) (a hosted site is on the way): a [guide](./docs/guide/index.md), a [getting-started walkthrough](./docs/guide/first-agent.md), and a deep guide per package (linked in the **Docs** column below).
+Full docs live in [`docs/`](./docs/guide/index.md) (a hosted site is on the way): a [guide](./docs/guide/index.md), a [getting-started walkthrough](./docs/guide/first-agent.md), and a deep guide per package (linked in the **Docs** column below).
 
 <!-- Package-name cells use a non-breaking hyphen (U+2011) so names like `ai-autopilot` do not wrap mid-name in GitHub's table. The real install names (normal hyphens) are in the scope line above and each package's README. -->
 
 | Package | Description | Docs | Version |
 |---|---|---|---|
-| [`ai‑sdk`](./packages/ai-sdk) | The agent runtime: providers, the agent loop, tools, streaming, middleware, structured output, memory, and evals. The engine the rest of the AI family builds on. | [Guide](./docs/packages/ai-sdk/index.md) | [![npm](https://img.shields.io/npm/v/@gemstack/ai-sdk)](https://www.npmjs.com/package/@gemstack/ai-sdk) |
-| [`ai‑skills`](./packages/ai-skills) | Portable capability bundles: load `SKILL.md` skills (instructions + tools + resources) and compose them onto an agent on demand. | [Guide](./docs/packages/ai-skills.md) | [![npm](https://img.shields.io/npm/v/@gemstack/ai-skills)](https://www.npmjs.com/package/@gemstack/ai-skills) |
-| [`ai‑autopilot`](./packages/ai-autopilot) | The AI‑building framework: a Supervisor (plan → dispatch → synthesize) plus a runner sandbox, surfaces, an event‑triggered review/QA loop with a built‑in prompt library, framework presets (Vike/Next), and a bootstrap flow that takes an app from nothing to production‑grade. | [Guide](./docs/packages/ai-autopilot.md) | [![npm](https://img.shields.io/npm/v/@gemstack/ai-autopilot)](https://www.npmjs.com/package/@gemstack/ai-autopilot) |
-| [`framework`](./packages/framework) | **The (AI) Framework**: turnkey, zero‑config orchestration built on `ai-autopilot`. Wraps a coding‑agent CLI (Claude Code) as a black box and takes an idea to a running app, with a live dashboard, Open Loop domain presets, an optional Docker sandbox, and a run relay for shared sessions. | [README](./packages/framework/README.md) | [![npm](https://img.shields.io/npm/v/@gemstack/framework)](https://www.npmjs.com/package/@gemstack/framework) |
+| [`ai‑sdk`](./packages/ai-sdk) | The agent runtime the rest of the AI family builds on: providers, agent loop, tools, streaming, middleware, structured output, memory, and evals. | [Guide](./docs/packages/ai-sdk/index.md) | [![npm](https://img.shields.io/npm/v/@gemstack/ai-sdk)](https://www.npmjs.com/package/@gemstack/ai-sdk) |
+| [`ai‑skills`](./packages/ai-skills) | Portable capability bundles: load `SKILL.md` skills (instructions, tools, resources) and compose them onto an agent on demand. | [Guide](./docs/packages/ai-skills.md) | [![npm](https://img.shields.io/npm/v/@gemstack/ai-skills)](https://www.npmjs.com/package/@gemstack/ai-skills) |
+| [`ai‑autopilot`](./packages/ai-autopilot) | The AI-building framework: a Supervisor (plan, dispatch, synthesize), a runner sandbox, surfaces, an event-triggered review/QA loop with a prompt library, framework presets (Vike/Next), and a bootstrap flow from nothing to a production-grade app. | [Guide](./docs/packages/ai-autopilot.md) | [![npm](https://img.shields.io/npm/v/@gemstack/ai-autopilot)](https://www.npmjs.com/package/@gemstack/ai-autopilot) |
+| [`framework`](./packages/framework) | **The (AI) Framework**: turnkey, zero-config orchestration on `ai-autopilot`. Wraps a coding-agent CLI (Claude Code) as a black box and takes an idea to a running app, with a live dashboard, Open Loop presets, an optional Docker sandbox, and a run relay for shared sessions. | [README](./packages/framework/README.md) | [![npm](https://img.shields.io/npm/v/@gemstack/framework)](https://www.npmjs.com/package/@gemstack/framework) |
 | [`ai‑mcp`](./packages/ai-mcp) | The agent/MCP bridge: consume a remote MCP server's tools as agent tools, and expose an agent as an MCP server. | [Guide](./docs/packages/ai-mcp.md) | [![npm](https://img.shields.io/npm/v/@gemstack/ai-mcp)](https://www.npmjs.com/package/@gemstack/ai-mcp) |
 | [`mcp`](./packages/mcp) | A standalone framework for *authoring* MCP servers: tools, resources, prompts, decorators, OAuth 2.1, a framework-neutral HTTP handler, and a test client. Agent-agnostic. | [Guide](./docs/packages/mcp.md) | [![npm](https://img.shields.io/npm/v/@gemstack/mcp)](https://www.npmjs.com/package/@gemstack/mcp) |
-| [`mcp‑connectors`](./packages/mcp-connectors) | The connector contract: define a tool connector to an external service once with `defineConnector`, and compose any number into a single MCP server with `mountConnectors`. Built on `@gemstack/mcp`; agent-agnostic. | [Guide](./docs/packages/mcp-connectors.md) | [![npm](https://img.shields.io/npm/v/@gemstack/mcp-connectors)](https://www.npmjs.com/package/@gemstack/mcp-connectors) |
+| [`mcp‑connectors`](./packages/mcp-connectors) | The connector contract: define a service connector once with `defineConnector`, and compose any number into one MCP server with `mountConnectors`. Built on `@gemstack/mcp`; agent-agnostic. | [Guide](./docs/packages/mcp-connectors.md) | [![npm](https://img.shields.io/npm/v/@gemstack/mcp-connectors)](https://www.npmjs.com/package/@gemstack/mcp-connectors) |
 | [`mcp‑connector‑github`](./packages/mcp-connector-github) | First-party connector: read and act on GitHub issues, pull requests, and repo files. | [Guide](./docs/packages/mcp-connector-github.md) | [![npm](https://img.shields.io/npm/v/@gemstack/mcp-connector-github)](https://www.npmjs.com/package/@gemstack/mcp-connector-github) |
 | [`mcp‑connector‑google‑drive`](./packages/mcp-connector-google-drive) | First-party connector: browse, read, and share Google Drive files. | [Guide](./docs/packages/mcp-connector-google-drive.md) | [![npm](https://img.shields.io/npm/v/@gemstack/mcp-connector-google-drive)](https://www.npmjs.com/package/@gemstack/mcp-connector-google-drive) |
 
@@ -77,9 +77,10 @@ Two independent stacks. Arrows point to what a package depends on; nothing point
 ```mermaid
 graph TD
     subgraph fam["AI family · depends on the agent runtime"]
-        skills["<b>ai-skills</b><br/>capability bundles"] --> sdk["<b>ai-sdk</b><br/>agent runtime"]
-        autopilot["<b>ai-autopilot</b><br/>orchestration"] --> sdk
-        framework["<b>framework</b><br/>turnkey app builder"] --> autopilot
+        framework["<b>framework</b><br/>turnkey app builder"] --> autopilot["<b>ai-autopilot</b><br/>orchestration"]
+        autopilot --> skills["<b>ai-skills</b><br/>capability bundles"]
+        autopilot --> sdk["<b>ai-sdk</b><br/>agent runtime"]
+        skills --> sdk
         aimcp["<b>ai-mcp</b><br/>agent ↔ MCP bridge"] --> sdk
     end
     subgraph agn["Agent-agnostic · not ai-*"]
@@ -87,11 +88,11 @@ graph TD
     end
 ```
 
-The `ai-` prefix means **"depends on the agent runtime."** `skills`, `autopilot`, and `ai-mcp` all depend on `ai-sdk`, which depends on none of them. A package about AI that is agent-agnostic (like `@gemstack/mcp`) is a peer of the family, not a member of it.
+The `ai-` prefix means **"depends on the agent runtime."** `ai-skills`, `ai-autopilot`, and `ai-mcp` all reach `ai-sdk`, which depends on none of them; `ai-autopilot` also builds on `ai-skills`. A package about AI that is agent-agnostic (like `@gemstack/mcp`) is a peer of the family, not a member of it.
 
 ### Connectors
 
-`@gemstack/mcp-connectors` is the contract for wiring external services (GitHub, Google Drive, ...) into an agent as MCP tools. A connector declares its auth needs and its tools with `defineConnector`; the orchestrator supplies credentials and composes any number of them into one server with `mountConnectors`. First-party connectors ship as `@gemstack/mcp-connector-*`, and third parties publish their own `mcp-connector-*` against the same contract.
+`@gemstack/mcp-connectors` is the contract for wiring external services (GitHub, Google Drive, ...) into an agent as MCP tools. A connector declares its auth needs and its tools with `defineConnector`; the orchestrator supplies credentials and composes any number into one server with `mountConnectors`. First-party connectors ship as `@gemstack/mcp-connector-*`, and third parties publish their own `mcp-connector-*` against the same contract.
 
 See [`Architecture.md`](./Architecture.md) for the full layering, naming rule, and graduation policy.
 
@@ -115,7 +116,7 @@ pnpm test
 
 Working on `@gemstack/framework`, run `pnpm build` first: the framework tests need the dashboard bundle. Without `packages/framework-dashboard/dist/client`, the daemon answers `/_telefunc` with a 503 text body and `daemon.test.ts` fails on `JSON.parse` (`SyntaxError: Unexpected token 'h'`), which reads like a real regression but is a missing build step.
 
-This is a pnpm + Turborepo + Changesets monorepo. Runnable examples live under [`examples/`](./examples) — e.g. [`mcp-quickstart`](./examples/mcp-quickstart), [`autopilot-quickstart`](./examples/autopilot-quickstart) (Supervisor + runner + surfaces), and [`bootstrap-quickstart`](./examples/bootstrap-quickstart) (the whole bootstrap flow, offline). See [`.changeset/README.md`](./.changeset/README.md) for the release flow.
+This is a pnpm + Turborepo + Changesets monorepo. Runnable examples live under [`examples/`](./examples): e.g. [`mcp-quickstart`](./examples/mcp-quickstart), [`autopilot-quickstart`](./examples/autopilot-quickstart) (Supervisor + runner + surfaces), and [`bootstrap-quickstart`](./examples/bootstrap-quickstart) (the whole bootstrap flow, offline). See [`.changeset/README.md`](./.changeset/README.md) for the release flow.
 
 ## Origin
 


### PR DESCRIPTION
Tightens the root README and corrects the dependency graph now that the repo has moved on.

## What changed
- **Tighter prose.** Trimmed the intro, the `Stop babysitting` / `How it works` bullets, and the `Built on GemStack` copy. No content dropped, just less filler.
- **Readable table.** Shortened every package description so cells read cleanly in GitHub's rendered table instead of wrapping into walls of text.
- **Fixed the flow graph.** `ai-autopilot` now depends on `ai-skills` (per its `package.json`), so the AI-family graph now shows `framework -> ai-autopilot -> {ai-skills, ai-sdk}` and `ai-skills -> ai-sdk`, instead of skills and autopilot drawn as siblings. The prose note under the graph is updated to match.
- Removed em-dashes from the touched lines.

Graph edges verified against each package's `@gemstack/*` dependencies. `framework-dashboard` stays out of the table (it is `private: true`).