### PR TITLE
feat(dashboard): flatten the Run on picker into one list and preserve the draft across a device hop (#1066)

### DIFF
--- a/.changeset/run-on-flat-list.md
+++ b/.changeset/run-on-flat-list.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework-dashboard": minor
+---
+
+Flatten the "Run on" picker into one list and preserve the composer draft across a device hop (#1066). The gear's "Run on" submenu was two axes stacked as one confusing list: driver rows (where a run executes) plus a separate "A device I have" section (which daemon the dashboard talks to), which also duplicated "Local" with "Current device". It is now a single flat list: This machine / GitHub Actions / Claude web (coming soon) / your saved devices / Add a device, with exactly one checkmark. On the local daemon the checkmark tracks the driver target; connected to a device it sits on that device, and clicking "This machine" goes home instead of writing a driver preference. Switching devices no longer nukes the typed prompt: the connect hop carries the draft alongside the token, the remote SPA moves it out of the URL into sessionStorage at boot (so it never sits in the address bar, history, or a Referer), and the launcher rehydrates it. Oversize drafts fall back to a plain connect so a huge paste can't blow the URL length.

--- a/packages/framework-dashboard/components/Composer.test.tsx
+++ b/packages/framework-dashboard/components/Composer.test.tsx
@@ -70,6 +70,7 @@ function renderComposer(over: Partial<Parameters<typeof Composer>[0]> = {}) {
 beforeEach(() => {
   prefs = {}
   updatePreferences.mockReset()
+  sessionStorage.clear()
 })
 afterEach(cleanup)
 
@@ -179,6 +180,23 @@ describe('Composer (#721)', () => {
     fireEvent.click(screen.getByText('Security audit'))
     fireEvent.click(screen.getByRole('button', { name: 'Send' }))
     expect(second.onSubmit).toHaveBeenCalledWith(expect.stringContaining('Security audit'), 'prompt', { newSession: false })
+  })
+
+  // #1066: a draft carried across a device hop lands in sessionStorage; the launcher seeds it into
+  // the editor on mount, as a build (not a preset), and takes it once.
+  test('the launcher rehydrates a draft carried from another device (#1066)', () => {
+    sessionStorage.setItem('fw.pending-draft', 'carried from the studio box')
+    const { onSubmit } = renderComposer({ submitLabel: 'Start session' })
+    fireEvent.click(screen.getByRole('button', { name: /Start session/ }))
+    expect(onSubmit).toHaveBeenCalledWith('carried from the studio box', 'build', { newSession: false })
+    expect(sessionStorage.getItem('fw.pending-draft')).toBeNull() // taken once
+  })
+
+  test('an in-session composer does not rehydrate a carried draft (#1066)', () => {
+    sessionStorage.setItem('fw.pending-draft', 'not for here')
+    renderComposer({ inSession: true })
+    expect(sessionStorage.getItem('fw.pending-draft')).toBe('not for here') // launcher-only
+    expect(screen.queryByRole('button', { name: 'Send' })).toBeNull() // nothing seeded
   })
 
   test('emptying the box drops the preset\'s new-session rule with the preset (#959)', () => {

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useImperativeHandle, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react'
 import { ArrowUp, Loader2 } from 'lucide-react'
 import type { ProjectSummary } from '@gemstack/framework'
 import { AGENTS, AGENT_LABELS, LAUNCHER_PRESETS, type AgentName } from '@gemstack/framework/client'
@@ -21,7 +21,8 @@ import { PresetsMenu } from './PresetsMenu.js'
 import { AgentModelMenu, type AgentOption } from './AgentModelMenu.js'
 import { OptionsMenu, type OptionRow, type RunTarget } from './OptionsMenu.js'
 import { AddDeviceDialog } from './AddDeviceDialog.js'
-import { useConnectionProfiles, connectTo, connectLocal, isLoopbackHost } from '../lib/profiles.js'
+import { useConnectionProfiles, connectTo, connectLocal, isLoopbackHost, type ConnectionProfile } from '../lib/profiles.js'
+import { stashDraftFromUrl, takePendingDraft } from '../lib/draft-handoff.js'
 import { ResolvedOptions } from './ResolvedOptions.js'
 import { ClaudeLogo, CodexLogo } from './agent-logos.js'
 import { Button } from './ui/button.js'
@@ -183,6 +184,19 @@ export const Composer = forwardRef<ComposerHandle, {
     focus: () => editorRef.current?.focus(),
   }))
 
+  // Rehydrate a draft carried from another device (#1066), launcher-only. stashDraftFromUrl is
+  // idempotent, so calling it here is race-safe even if the SPA-entry call has not run yet. A carried
+  // draft is still a 'build', so seed the editor without flipping kind.
+  useEffect(() => {
+    if (compact || inSession) return
+    stashDraftFromUrl()
+    const carried = takePendingDraft()
+    if (carried) {
+      editorRef.current?.loadTemplate(carried)
+      setPrompt(carried)
+    }
+  }, [compact, inSession])
+
   // A synchronous latch alongside the async `busy` prop (#948): two fast ⌘↵ presses both read
   // `busy === false` (React state lags), fired two starts, and the second surfaced a spurious
   // "already active" error. The ref flips before any await.
@@ -321,7 +335,8 @@ export const Composer = forwardRef<ComposerHandle, {
               profiles,
               currentUrl,
               isLocal: isLocalConnection,
-              onConnect: connectTo,
+              // Carry the live draft across the hop (#1066) so switching devices never nukes it.
+              onConnect: (p: ConnectionProfile) => connectTo(p, prompt),
               onConnectLocal: connectLocal,
               onAddDevice: () => setAddingDevice(true),
             },

--- a/packages/framework-dashboard/components/ConnectionIndicator.tsx
+++ b/packages/framework-dashboard/components/ConnectionIndicator.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { Laptop, MonitorSmartphone } from 'lucide-react'
 import { useConnectionProfiles, currentConnection, rememberLocalOrigin } from '../lib/profiles.js'
+import { stashDraftFromUrl } from '../lib/draft-handoff.js'
 
 // The "connected to <label>" indicator (#1052): which daemon the dashboard is talking to. Every
 // transport is same-origin, so the browser's origin IS the connection — loopback is this machine's
@@ -9,8 +10,11 @@ import { useConnectionProfiles, currentConnection, rememberLocalOrigin } from '.
 export function ConnectionIndicator() {
   const profiles = useConnectionProfiles()
   // Remember the loopback origin we launched from, so "Local" can return to the right port later.
+  // Also move any carried draft (#1066) out of the URL at SPA boot, before it reaches the address bar.
   useEffect(() => {
-    if (typeof window !== 'undefined') rememberLocalOrigin(window.location.origin, window.location.hostname)
+    if (typeof window === 'undefined') return
+    stashDraftFromUrl()
+    rememberLocalOrigin(window.location.origin, window.location.hostname)
   }, [])
   if (typeof window === 'undefined') return null
   const { label, isLocal } = currentConnection(profiles, window.location.origin, window.location.hostname)

--- a/packages/framework-dashboard/components/OptionsMenu.test.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import type { OptionRow, ConnectionControl } from './OptionsMenu.js'
+import type { OptionRow, ConnectionControl, RunTarget } from './OptionsMenu.js'
 import type { ConnectionProfile } from '../lib/profiles.js'
 
 const updatePreferences = vi.hoisted(() => vi.fn())
@@ -112,58 +112,112 @@ describe('OptionsMenu (#654)', () => {
     ...over,
   })
 
-  test('the "A device I have" section lists saved profiles under Run on (#1052)', () => {
+  // Rows are matched by tokens that never appear in the sub-trigger summary (unique descriptions,
+  // or the device url), so the summary echoing a driver/device label can't make a query ambiguous.
+  const THIS_MACHINE = 'Run on this machine, as today.'
+  const ACTIONS = 'Run on a fresh GitHub Actions runner.'
+  const STUDIO_URL = 'http://192.168.1.5:4200'
+  const rowOf = (token: string): HTMLElement => screen.getByText(token).closest('[role="menuitem"]') as HTMLElement
+  const isChecked = (token: string): boolean => !!rowOf(token).querySelector('svg')?.classList.contains('opacity-100')
+
+  function openRunOn(connection: ConnectionControl, value: RunTarget = 'local') {
     render(
-      <OptionsMenu options={[]} ecoOptions={[]} showEco={false} busy={false} runTarget={{ value: 'local', onChange: vi.fn() }} connection={connectionControl()} />,
+      <OptionsMenu options={[]} ecoOptions={[]} showEco={false} busy={false} runTarget={{ value, onChange: vi.fn() }} connection={connection} />,
     )
     open()
     fireEvent.click(screen.getByText('Run on'))
-    expect(screen.getByText('A device I have')).toBeTruthy()
-    expect(screen.getByText('Local')).toBeTruthy()
-    expect(screen.getByText('Studio')).toBeTruthy()
+  }
+
+  test('Run on is one flat list, no "A device I have" header and no separate "Local" row (#1066)', () => {
+    openRunOn(connectionControl())
+    // The old two-axis framing is gone: no section header, no redundant "Local" duplicating this machine.
+    expect(screen.queryByText('A device I have')).toBeNull()
+    expect(screen.queryByText('Local')).toBeNull()
+    // The whole list renders as one: driver rows (renamed), the disabled placeholder, the device, and Add.
+    expect(screen.getByText(THIS_MACHINE)).toBeTruthy()
+    expect(screen.getByText(ACTIONS)).toBeTruthy()
+    expect(screen.getByText('Claude web')).toBeTruthy()
+    expect(screen.getByText(STUDIO_URL)).toBeTruthy()
     expect(screen.getByText('Add a device…')).toBeTruthy()
+    // Claude web stays a disabled placeholder for the sibling axis that has not shipped.
+    expect(rowOf('Claude web').hasAttribute('data-disabled')).toBe(true)
   })
 
-  test('selecting a device navigates (does not write a preference) (#1052)', () => {
+  test('on the local daemon the checkmark tracks the driver target, not a device (#1066)', () => {
+    openRunOn(connectionControl({ isLocal: true }), 'actions')
+    expect(isChecked(ACTIONS)).toBe(true) // the selected driver target
+    expect(isChecked(THIS_MACHINE)).toBe(false)
+    expect(isChecked(STUDIO_URL)).toBe(false) // no device is the connection
+  })
+
+  test('connected to a device the checkmark is on that device, driver rows quiet (#1066)', () => {
+    openRunOn(connectionControl({ isLocal: false, currentUrl: STUDIO_URL }), 'local')
+    expect(isChecked(STUDIO_URL)).toBe(true)
+    expect(isChecked(THIS_MACHINE)).toBe(false)
+    expect(isChecked(ACTIONS)).toBe(false)
+  })
+
+  test('clicking a device navigates (does not write a preference) (#1066)', () => {
     const onConnect = vi.fn()
-    render(
-      <OptionsMenu options={[]} ecoOptions={[]} showEco={false} busy={false} runTarget={{ value: 'local', onChange: vi.fn() }} connection={connectionControl({ onConnect })} />,
-    )
-    open()
-    fireEvent.click(screen.getByText('Run on'))
-    fireEvent.click(screen.getByText('Studio'))
+    openRunOn(connectionControl({ onConnect }))
+    fireEvent.click(rowOf(STUDIO_URL))
     expect(onConnect).toHaveBeenCalledWith(profiles()[0])
     // A device row is a connection hop, not a driver preference.
     expect(updatePreferences).not.toHaveBeenCalled()
   })
 
-  test('Local fires its connect handler (#1052)', () => {
+  test('clicking "This machine" while on a remote device goes home, not a driver write (#1066)', () => {
     const onConnectLocal = vi.fn()
+    const onChange = vi.fn()
     render(
-      <OptionsMenu options={[]} ecoOptions={[]} showEco={false} busy={false} runTarget={{ value: 'local', onChange: vi.fn() }} connection={connectionControl({ onConnectLocal })} />,
+      <OptionsMenu
+        options={[]}
+        ecoOptions={[]}
+        showEco={false}
+        busy={false}
+        runTarget={{ value: 'local', onChange }}
+        connection={connectionControl({ isLocal: false, currentUrl: STUDIO_URL, onConnectLocal })}
+      />,
     )
     open()
     fireEvent.click(screen.getByText('Run on'))
-    fireEvent.click(screen.getByText('Local'))
+    fireEvent.click(rowOf(THIS_MACHINE))
     expect(onConnectLocal).toHaveBeenCalled()
+    expect(onChange).not.toHaveBeenCalled()
   })
 
-  test('Add a device opens the add flow (#1052)', () => {
-    const onAddDevice = vi.fn()
+  test('clicking "This machine" on the local daemon writes the driver target (#1066)', () => {
+    const onConnectLocal = vi.fn()
+    const onChange = vi.fn()
     render(
-      <OptionsMenu options={[]} ecoOptions={[]} showEco={false} busy={false} runTarget={{ value: 'local', onChange: vi.fn() }} connection={connectionControl({ onAddDevice })} />,
+      <OptionsMenu
+        options={[]}
+        ecoOptions={[]}
+        showEco={false}
+        busy={false}
+        runTarget={{ value: 'actions', onChange }}
+        connection={connectionControl({ isLocal: true, onConnectLocal })}
+      />,
     )
     open()
     fireEvent.click(screen.getByText('Run on'))
+    fireEvent.click(rowOf(THIS_MACHINE))
+    expect(onChange).toHaveBeenCalledWith('local')
+    expect(onConnectLocal).not.toHaveBeenCalled()
+  })
+
+  test('Add a device opens the add flow (#1066)', () => {
+    const onAddDevice = vi.fn()
+    openRunOn(connectionControl({ onAddDevice }))
     fireEvent.click(screen.getByText('Add a device…'))
     expect(onAddDevice).toHaveBeenCalled()
   })
 
-  test('the device section is absent without a connection control (#1052)', () => {
+  test('the device rows are absent without a connection control (#1066)', () => {
     render(<OptionsMenu options={[]} ecoOptions={[]} showEco={false} busy={false} runTarget={{ value: 'local', onChange: vi.fn() }} />)
     open()
     fireEvent.click(screen.getByText('Run on'))
-    expect(screen.queryByText('A device I have')).toBeNull()
+    expect(screen.queryByText(STUDIO_URL)).toBeNull()
+    expect(screen.queryByText('Add a device…')).toBeNull()
   })
-
 })

--- a/packages/framework-dashboard/components/OptionsMenu.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.tsx
@@ -1,5 +1,5 @@
 import type { Preferences } from '@gemstack/framework'
-import { Settings, Check, Laptop, MonitorSmartphone, Plus } from 'lucide-react'
+import { Settings, Check, MonitorSmartphone, Plus } from 'lucide-react'
 import { updatePreferences } from '../lib/preferences.js'
 import type { ConnectionProfile } from '../lib/profiles.js'
 import { cn } from '../lib/utils.js'
@@ -9,9 +9,7 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuCheckboxItem,
-  DropdownMenuGroup,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubTrigger,
@@ -56,17 +54,18 @@ export type RunTargetControl = {
 }
 
 /**
- * The "A device I have" section of the "Run on" sub (#1052). A device is a CONNECTION, not a driver:
- * the driver rows above rewrite a preference, these NAVIGATE the browser to another daemon's origin.
- * That is the divergence the gear holds in one list — driver rows call `updatePreferences` (per-run),
- * device rows call `onConnect`/`onConnectLocal` (a page navigation carrying the token).
+ * The saved-devices half of the flat "Run on" list (#1052/#1066). A device is a CONNECTION, not a
+ * driver: the driver rows rewrite a preference, these NAVIGATE the browser to another daemon's
+ * origin. That divergence is why the one list holds both: driver rows call `onChange` (per-run),
+ * device rows call `onConnect` (a page navigation carrying the token), and "This machine" while
+ * remote calls `onConnectLocal` (go home) rather than writing the driver preference.
  */
 export type ConnectionControl = {
   /** The saved remote daemons this browser can hop to. */
   profiles: ConnectionProfile[]
   /** `window.location.origin`, to mark the daemon the dashboard is on now. */
   currentUrl: string | null
-  /** Whether the current origin is loopback, so "Local" is the checked row. */
+  /** Whether the current origin is loopback, so a driver row (not a device) carries the checkmark. */
   isLocal: boolean
   onConnect: (profile: ConnectionProfile) => void
   onConnectLocal: () => void
@@ -77,23 +76,39 @@ export type ConnectionControl = {
 // rows), not the boolean OptionRow. "Claude web" is a disabled placeholder for the sibling axis in
 // #1049 that has not shipped yet, so the menu shows where this is going without promising it.
 const RUN_TARGET_ROWS: { value: RunTarget; label: string; description: string }[] = [
-  { value: 'local', label: 'Current device', description: 'Run on this machine, as today.' },
+  { value: 'local', label: 'This machine', description: 'Run on this machine, as today.' },
   { value: 'actions', label: 'GitHub Actions', description: 'Run on a fresh GitHub Actions runner.' },
 ]
 
+// One flat "Run on" list (#1066): the driver rows, then the saved devices and "Add a device", with a
+// single checkmark. Which daemon the dashboard is on decides it: a driver row when on the local
+// daemon, else the connected device's row. The two axes read as one list, so a device hop never
+// looks like a second, redundant "Local".
 function RunTargetSub({ control, connection, busy }: { control: RunTargetControl; connection?: ConnectionControl | undefined; busy: boolean }) {
-  const current = RUN_TARGET_ROWS.find(r => r.value === control.value) ?? RUN_TARGET_ROWS[0]!
+  // No connection control means only the driver axis exists, so treat it as the local daemon.
+  const onLocalDaemon = connection ? connection.isLocal : true
+  const summary =
+    connection && !connection.isLocal
+      ? connection.profiles.find(p => p.url === connection.currentUrl)?.label ?? 'A device'
+      : RUN_TARGET_ROWS.find(r => r.value === control.value)?.label ?? RUN_TARGET_ROWS[0]!.label
   return (
     <DropdownMenuSub>
       <DropdownMenuSubTrigger disabled={busy}>
         <span className="flex-1">Run on</span>
-        <span className="text-muted-foreground">{current.label}</span>
+        <span className="text-muted-foreground">{summary}</span>
       </DropdownMenuSubTrigger>
       <DropdownMenuSubContent>
-        {/* Driver rows (#1050): a per-run preference, written straight through. */}
+        {/* Driver rows (#1050). On a device, "This machine" goes home (#1066) rather than writing the
+            driver preference; the other driver rows still write straight through. */}
         {RUN_TARGET_ROWS.map(row => (
-          <DropdownMenuItem key={row.value} className="items-start" onClick={() => control.onChange(row.value)}>
-            <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', row.value === control.value ? 'opacity-100' : 'opacity-0')} />
+          <DropdownMenuItem
+            key={row.value}
+            className="items-start"
+            onClick={() =>
+              row.value === 'local' && connection && !connection.isLocal ? connection.onConnectLocal() : control.onChange(row.value)
+            }
+          >
+            <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', onLocalDaemon && row.value === control.value ? 'opacity-100' : 'opacity-0')} />
             <OptionLabel label={row.label} description={row.description} />
           </DropdownMenuItem>
         ))}
@@ -101,38 +116,23 @@ function RunTargetSub({ control, connection, busy }: { control: RunTargetControl
           <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 opacity-0" />
           <OptionLabel label="Claude web" description="Coming soon." />
         </DropdownMenuItem>
-        {connection && <ConnectionSection connection={connection} busy={busy} />}
-      </DropdownMenuSubContent>
-    </DropdownMenuSub>
-  )
-}
-
-/** The "A device I have" rows (#1052). Unlike the driver rows above, a click here NAVIGATES the
- * browser to that daemon's origin (carrying the token) rather than writing a preference. */
-function ConnectionSection({ connection, busy }: { connection: ConnectionControl; busy: boolean }) {
-  return (
-    <>
-      <DropdownMenuSeparator />
-      <DropdownMenuGroup>
-        <DropdownMenuLabel>A device I have</DropdownMenuLabel>
-        <DropdownMenuItem className="items-start" onClick={() => connection.onConnectLocal()}>
-          <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', connection.isLocal ? 'opacity-100' : 'opacity-0')} />
-          <Laptop className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
-          <OptionLabel label="Local" description="This machine's own daemon." />
-        </DropdownMenuItem>
-        {connection.profiles.map(profile => (
+        {/* Saved devices (#1052/#1066): a click NAVIGATES to that daemon's origin (carrying token +
+            draft), not a preference write. Folded into this same list. */}
+        {connection?.profiles.map(profile => (
           <DropdownMenuItem key={profile.id} className="items-start" onClick={() => connection.onConnect(profile)}>
             <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', !connection.isLocal && profile.url === connection.currentUrl ? 'opacity-100' : 'opacity-0')} />
             <MonitorSmartphone className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
             <OptionLabel label={profile.label} description={profile.url} />
           </DropdownMenuItem>
         ))}
-        <DropdownMenuItem className="items-start" disabled={busy} onClick={() => connection.onAddDevice()}>
-          <Plus className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
-          <OptionLabel label="Add a device…" description="Paste the URL a box prints on its network bind." />
-        </DropdownMenuItem>
-      </DropdownMenuGroup>
-    </>
+        {connection && (
+          <DropdownMenuItem className="items-start" disabled={busy} onClick={() => connection.onAddDevice()}>
+            <Plus className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+            <OptionLabel label="Add a device…" description="Paste the URL a box prints on its network bind." />
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
   )
 }
 

--- a/packages/framework-dashboard/lib/draft-handoff.test.ts
+++ b/packages/framework-dashboard/lib/draft-handoff.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, test } from 'vitest'
+import { stashDraftFromUrl, takePendingDraft } from './draft-handoff.js'
+
+// jsdom provides sessionStorage, window.location and history.replaceState, so these round-trip real.
+afterEach(() => {
+  sessionStorage.clear()
+  history.replaceState(null, '', '/')
+})
+
+describe('draft-handoff (#1066)', () => {
+  test('stashDraftFromUrl moves ?draft= into sessionStorage and strips it from the URL', () => {
+    history.replaceState(null, '', '/?draft=' + encodeURIComponent('ship the thing') + '&keep=1')
+    stashDraftFromUrl()
+    expect(sessionStorage.getItem('fw.pending-draft')).toBe('ship the thing')
+    // The prompt leaves the address bar (and so history + Referer); other params stay.
+    expect(window.location.search).toBe('?keep=1')
+  })
+
+  test('takePendingDraft returns then clears the stash', () => {
+    history.replaceState(null, '', '/?draft=hello')
+    stashDraftFromUrl()
+    expect(takePendingDraft()).toBe('hello')
+    expect(takePendingDraft()).toBeNull() // cleared, so a reload does not re-seed it
+  })
+
+  test('no draft param is a no-op that leaves the URL alone', () => {
+    history.replaceState(null, '', '/?other=1')
+    stashDraftFromUrl()
+    expect(takePendingDraft()).toBeNull()
+    expect(window.location.search).toBe('?other=1')
+  })
+})

--- a/packages/framework-dashboard/lib/draft-handoff.ts
+++ b/packages/framework-dashboard/lib/draft-handoff.ts
@@ -1,0 +1,37 @@
+// The composer draft carried across a device hop (#1066). connectTo() appends `?draft=` alongside
+// the token; the #1051 bootstrap 302 strips only `?token=`, so the draft lands on the remote SPA as
+// `/?draft=…`. This moves it out of the URL into sessionStorage at boot so the typed prompt never
+// sits in the address bar, history, or a Referer header, and the launcher rehydrates from it once.
+
+/** sessionStorage key holding a draft carried from another device, until the launcher takes it. */
+const PENDING_DRAFT_KEY = 'fw.pending-draft'
+
+/** sessionStorage, or undefined during prerender (ssr:false) where there is no browser. */
+function session(): Storage | undefined {
+  try {
+    return globalThis.sessionStorage
+  } catch {
+    return undefined
+  }
+}
+
+/** At SPA boot: move `?draft=` out of the URL into sessionStorage and strip it from the address bar
+ * (and so from history and any Referer). Idempotent and a no-op when there is no draft param. */
+export function stashDraftFromUrl(): void {
+  if (typeof window === 'undefined') return
+  const url = new URL(window.location.href)
+  const draft = url.searchParams.get('draft')
+  if (draft === null) return
+  session()?.setItem(PENDING_DRAFT_KEY, draft)
+  url.searchParams.delete('draft')
+  window.history.replaceState(null, '', url.pathname + url.search + url.hash)
+}
+
+/** The carried draft, if any, cleared as it is read so a reload does not re-seed it. */
+export function takePendingDraft(): string | null {
+  const s = session()
+  if (!s) return null
+  const draft = s.getItem(PENDING_DRAFT_KEY)
+  if (draft !== null) s.removeItem(PENDING_DRAFT_KEY)
+  return draft
+}

--- a/packages/framework-dashboard/lib/profiles.test.ts
+++ b/packages/framework-dashboard/lib/profiles.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 import {
   listProfiles,
   addProfile,
   removeProfile,
   parseDeviceUrl,
   connectUrl,
+  connectTo,
   currentConnection,
   isLoopbackHost,
   localOrigin,
@@ -50,6 +51,26 @@ describe('profiles.ts (#1052)', () => {
   test('connectUrl carries the token for the bootstrap hop', () => {
     expect(connectUrl({ url: 'http://box:4200', token: 'abc' })).toBe('http://box:4200/?token=abc')
     expect(connectUrl({ url: 'http://127.0.0.1:4200', token: '' })).toBe('http://127.0.0.1:4200') // Local, no token
+  })
+
+  test('connectUrl carries the composer draft alongside the token (#1066)', () => {
+    expect(connectUrl({ url: 'http://box:4200', token: 'abc' }, 'ship it')).toBe('http://box:4200/?token=abc&draft=ship%20it')
+    // No token (Local): the draft still rides.
+    expect(connectUrl({ url: 'http://127.0.0.1:4200', token: '' }, 'hi')).toBe('http://127.0.0.1:4200/?draft=hi')
+    // An oversize draft is dropped so it can't blow the URL length; the hop still connects.
+    expect(connectUrl({ url: 'http://box:4200', token: 'abc' }, 'x'.repeat(8000))).toBe('http://box:4200/?token=abc')
+  })
+
+  test('connectTo navigates carrying the token and the draft (#1066)', () => {
+    // jsdom won't let location.assign be redefined, so stub the whole location the code reads.
+    const assign = vi.fn()
+    vi.stubGlobal('location', { assign })
+    connectTo({ id: 'x', label: 'Studio', url: 'http://box:4200', token: 'abc' }, 'my prompt')
+    expect(assign).toHaveBeenCalledTimes(1)
+    const url = assign.mock.calls[0]![0] as string
+    expect(url).toContain('token=abc')
+    expect(url).toContain('draft=' + encodeURIComponent('my prompt'))
+    vi.unstubAllGlobals()
   })
 
   test('isLoopbackHost knows the local machine', () => {

--- a/packages/framework-dashboard/lib/profiles.ts
+++ b/packages/framework-dashboard/lib/profiles.ts
@@ -110,15 +110,25 @@ export function localOrigin(): string {
   return store()?.getItem(LOCAL_ORIGIN_KEY) ?? DEFAULT_LOCAL_ORIGIN
 }
 
-/** The connect URL for a device: its origin plus the token for the one bootstrap hop (#1051). */
-export function connectUrl(profile: Pick<ConnectionProfile, 'url' | 'token'>): string {
-  return profile.token ? `${profile.url}/?token=${encodeURIComponent(profile.token)}` : profile.url
+/** Cap on a carried composer draft (#1066): above this the hop drops the draft (plain connect) so a
+ * huge paste can't blow the URL length. */
+const MAX_CARRIED_DRAFT = 7000
+
+/** The connect URL for a device: its origin plus the token for the one bootstrap hop (#1051), and
+ * the composer draft (#1066) so a device hop never nukes the typed prompt. The bootstrap 302 strips
+ * only `token`, so `draft` survives to land on the remote SPA. */
+export function connectUrl(profile: Pick<ConnectionProfile, 'url' | 'token'>, draft?: string): string {
+  const parts: string[] = []
+  if (profile.token) parts.push(`token=${encodeURIComponent(profile.token)}`)
+  if (draft && draft.length <= MAX_CARRIED_DRAFT) parts.push(`draft=${encodeURIComponent(draft)}`)
+  return parts.length ? `${profile.url}/?${parts.join('&')}` : profile.url
 }
 
-/** Navigate the browser to a saved device (carrying its token). This is the connection hop, NOT a
- * run submit: the remote SPA re-authenticates same-origin from the cookie the bootstrap sets. */
-export function connectTo(profile: ConnectionProfile): void {
-  globalThis.location?.assign(connectUrl(profile))
+/** Navigate the browser to a saved device, carrying its token and the live composer draft (#1066).
+ * This is the connection hop, NOT a run submit: the remote SPA re-authenticates same-origin from the
+ * cookie the bootstrap sets, and rehydrates the draft into its composer. */
+export function connectTo(profile: ConnectionProfile, draft?: string): void {
+  globalThis.location?.assign(connectUrl(profile, draft))
 }
 
 /** Navigate back to this machine's own loopback daemon (no token). */


### PR DESCRIPTION
## What

Live-testing the shipped "Run on" gear (#1050/#1052) surfaced a UX problem (#1066): the menu presented two different axes as one list, which confused a real user.

- The driver rows (where a run executes) plus a separate "A device I have" section (which daemon the dashboard talks to).
- "Local" and "Current device" were effectively the same machine, so the list read as having a duplicate.
- Picking a device did a full-page navigation that discarded the typed prompt.

## Changes

**One flat "Run on" list** (`OptionsMenu.tsx`). Deleted `ConnectionSection` and the redundant "Local" row; folded the saved devices and "Add a device" into `RunTargetSub`. The list is now: This machine (renamed from "Current device") / GitHub Actions / Claude web (coming soon, disabled) / each saved device / Add a device. Device icon and Plus icon kept.

**Single-selection checkmark**, decided by which daemon the dashboard is on:
- On the local daemon: the driver target is checked ("This machine" or "GitHub Actions"); no device checked.
- Connected to a device: that device's row is checked; driver rows go quiet, and clicking "This machine" calls `onConnectLocal` (go home) rather than the driver `onChange`.

**Draft preserved across the device hop** (`lib/profiles.ts`, `lib/draft-handoff.ts`, `Composer.tsx`):
- `connectTo(profile, draft)` appends the draft alongside the token. The #1051 bootstrap 302 strips only `token`, so `draft` lands on the remote SPA.
- `stashDraftFromUrl()` runs once at SPA boot (in `ConnectionIndicator`, which already runs `rememberLocalOrigin`): moves `?draft=` into sessionStorage and `history.replaceState`s it out of the URL, so the prompt never sits in the address bar, history, or a Referer.
- The launcher calls `takePendingDraft()` on mount and seeds the editor via the existing `loadTemplate` path. A carried draft is still a `build`, so `kind` does not flip.
- Oversize drafts (>7KB) fall back to a plain connect so a huge paste can't blow the URL length.

Kept the navigate-on-connect mechanic (a true no-navigation remote run target is out of scope, tracked separately).

## Tests

`framework-dashboard` typecheck clean. Added unit tests: the flat list renders with no "A device I have" header and no "Local" row; the checkmark model (local+target vs connected-to-device); handlers (device click navigates, "This machine" while remote goes home, on local writes the target, Add opens the flow); `connectUrl`/`connectTo` carry `token` and `draft`; `stashDraftFromUrl`/`takePendingDraft` round-trip; the launcher rehydrates a pending draft and an in-session composer does not. 42 tests across the touched files pass. (The unrelated `PreviewBar.test.tsx` is a known pre-existing flake; it passes in isolation.)

Closes #1066
