### PR TITLE
feat(framework): run a session on a connected device via a server-side relay (#1067, slice 1)

### DIFF
--- a/.changeset/remote-run-relay-slice1.md
+++ b/.changeset/remote-run-relay-slice1.md
@@ -1,0 +1,12 @@
+---
+"@gemstack/framework": minor
+"@gemstack/framework-dashboard": minor
+---
+
+feat(framework): run a session on a connected device via a server-side relay (#1067, slice 1)
+
+Picking a saved device in the "Run on" gear now makes it a true run target: you stay on this dashboard, submit, and the session runs on the remote device and streams its events back into the current run view. A device row no longer navigates the browser; it selects the device in place (the token stays a per-browser secret, memory-only, never persisted).
+
+Under the hood the local daemon relays the run: it POSTs the run to the remote daemon's new `/_relay/start` (authenticating with the device token as the `fw_daemon` cookie, no Origin) and fetch-streams the remote's `/_relay/events` back into the local run view over the normal same-origin channel. The browser never talks cross-origin and the token never leaves the two daemons. Both `/_relay/*` endpoints are fronted by the same #1051 token guard.
+
+Slice 1 is submit + live events. The remote run executes in the device's own home checkout, and the diff, PR, push/handoff, and browser screencast panels show a "not available for remote runs yet" placeholder; those (and per-project remote targeting) land in later slices.

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -21,7 +21,8 @@ import { PresetsMenu } from './PresetsMenu.js'
 import { AgentModelMenu, type AgentOption } from './AgentModelMenu.js'
 import { OptionsMenu, type OptionRow, type RunTarget } from './OptionsMenu.js'
 import { AddDeviceDialog } from './AddDeviceDialog.js'
-import { useConnectionProfiles, connectTo, connectLocal, isLoopbackHost, type ConnectionProfile } from '../lib/profiles.js'
+import { useConnectionProfiles, connectLocal, isLoopbackHost, type ConnectionProfile } from '../lib/profiles.js'
+import { useSelectedRemoteDeviceId, selectRemoteDevice } from '../lib/remote-target.js'
 import { stashDraftFromUrl, takePendingDraft } from '../lib/draft-handoff.js'
 import { ResolvedOptions } from './ResolvedOptions.js'
 import { ClaudeLogo, CodexLogo } from './agent-logos.js'
@@ -128,6 +129,7 @@ export const Composer = forwardRef<ComposerHandle, {
   // The saved daemons this browser can hop to (#1052). Which one we are on now comes from the URL,
   // fixed for the page's life (a device switch reloads), so it is read once rather than as state.
   const profiles = useConnectionProfiles()
+  const selectedDeviceId = useSelectedRemoteDeviceId() // #1067: the device this run targets, if any
   const currentUrl = typeof window === 'undefined' ? null : window.location.origin
   const isLocalConnection = typeof window === 'undefined' ? true : isLoopbackHost(window.location.hostname)
   // The registered projects for the `@` picker — the same list the launcher reads.
@@ -335,8 +337,10 @@ export const Composer = forwardRef<ComposerHandle, {
               profiles,
               currentUrl,
               isLocal: isLocalConnection,
-              // Carry the live draft across the hop (#1066) so switching devices never nukes it.
-              onConnect: (p: ConnectionProfile) => connectTo(p, prompt),
+              selectedDeviceId,
+              // #1067: selecting a device makes it the run target in place, no navigation.
+              onSelect: (p: ConnectionProfile) => selectRemoteDevice(p.id),
+              onSelectDriver: () => selectRemoteDevice(null),
               onConnectLocal: connectLocal,
               onAddDevice: () => setAddingDevice(true),
             },

--- a/packages/framework-dashboard/components/OptionsMenu.test.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.test.tsx
@@ -106,7 +106,9 @@ describe('OptionsMenu (#654)', () => {
     profiles: profiles(),
     currentUrl: 'http://127.0.0.1:4200',
     isLocal: true,
-    onConnect: vi.fn(),
+    selectedDeviceId: null,
+    onSelect: vi.fn(),
+    onSelectDriver: vi.fn(),
     onConnectLocal: vi.fn(),
     onAddDevice: vi.fn(),
     ...over,
@@ -143,11 +145,19 @@ describe('OptionsMenu (#654)', () => {
     expect(rowOf('Claude web').hasAttribute('data-disabled')).toBe(true)
   })
 
-  test('on the local daemon the checkmark tracks the driver target, not a device (#1066)', () => {
-    openRunOn(connectionControl({ isLocal: true }), 'actions')
+  test('on the local daemon with no device picked, the checkmark tracks the driver target (#1066)', () => {
+    openRunOn(connectionControl({ isLocal: true, selectedDeviceId: null }), 'actions')
     expect(isChecked(ACTIONS)).toBe(true) // the selected driver target
     expect(isChecked(THIS_MACHINE)).toBe(false)
-    expect(isChecked(STUDIO_URL)).toBe(false) // no device is the connection
+    expect(isChecked(STUDIO_URL)).toBe(false) // no device is the target
+  })
+
+  test('selecting a device puts the checkmark on it and quiets the driver rows (#1067)', () => {
+    // On the local daemon, a selected device is the run target in place, with no navigation involved.
+    openRunOn(connectionControl({ isLocal: true, selectedDeviceId: STUDIO_URL }), 'actions')
+    expect(isChecked(STUDIO_URL)).toBe(true)
+    expect(isChecked(THIS_MACHINE)).toBe(false)
+    expect(isChecked(ACTIONS)).toBe(false) // the driver target no longer carries the mark
   })
 
   test('connected to a device the checkmark is on that device, driver rows quiet (#1066)', () => {
@@ -157,12 +167,12 @@ describe('OptionsMenu (#654)', () => {
     expect(isChecked(ACTIONS)).toBe(false)
   })
 
-  test('clicking a device navigates (does not write a preference) (#1066)', () => {
-    const onConnect = vi.fn()
-    openRunOn(connectionControl({ onConnect }))
+  test('clicking a device selects it as the run target (no navigation, no preference) (#1067)', () => {
+    const onSelect = vi.fn()
+    openRunOn(connectionControl({ onSelect }))
     fireEvent.click(rowOf(STUDIO_URL))
-    expect(onConnect).toHaveBeenCalledWith(profiles()[0])
-    // A device row is a connection hop, not a driver preference.
+    expect(onSelect).toHaveBeenCalledWith(profiles()[0])
+    // A device row is a run-target selection now, not a driver preference or a navigation.
     expect(updatePreferences).not.toHaveBeenCalled()
   })
 
@@ -186,8 +196,9 @@ describe('OptionsMenu (#654)', () => {
     expect(onChange).not.toHaveBeenCalled()
   })
 
-  test('clicking "This machine" on the local daemon writes the driver target (#1066)', () => {
+  test('clicking "This machine" on the local daemon writes the driver target and clears any device (#1066/#1067)', () => {
     const onConnectLocal = vi.fn()
+    const onSelectDriver = vi.fn()
     const onChange = vi.fn()
     render(
       <OptionsMenu
@@ -196,13 +207,14 @@ describe('OptionsMenu (#654)', () => {
         showEco={false}
         busy={false}
         runTarget={{ value: 'actions', onChange }}
-        connection={connectionControl({ isLocal: true, onConnectLocal })}
+        connection={connectionControl({ isLocal: true, selectedDeviceId: STUDIO_URL, onConnectLocal, onSelectDriver })}
       />,
     )
     open()
     fireEvent.click(screen.getByText('Run on'))
     fireEvent.click(rowOf(THIS_MACHINE))
     expect(onChange).toHaveBeenCalledWith('local')
+    expect(onSelectDriver).toHaveBeenCalled() // a driver row clears the device selection (#1067)
     expect(onConnectLocal).not.toHaveBeenCalled()
   })
 

--- a/packages/framework-dashboard/components/OptionsMenu.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.tsx
@@ -54,20 +54,26 @@ export type RunTargetControl = {
 }
 
 /**
- * The saved-devices half of the flat "Run on" list (#1052/#1066). A device is a CONNECTION, not a
- * driver: the driver rows rewrite a preference, these NAVIGATE the browser to another daemon's
- * origin. That divergence is why the one list holds both: driver rows call `onChange` (per-run),
- * device rows call `onConnect` (a page navigation carrying the token), and "This machine" while
- * remote calls `onConnectLocal` (go home) rather than writing the driver preference.
+ * The saved-devices half of the flat "Run on" list (#1052/#1066/#1067). A device is a run TARGET,
+ * selected in place: picking one no longer navigates the browser (#1067). The local daemon relays
+ * the run to it. So a device row calls `onSelect` (ephemeral UI state, the checkmark follows it) just
+ * as a driver row calls `onChange`; the difference is only that a device is not persisted. "This
+ * machine" while genuinely on a remote daemon still calls `onConnectLocal` (go home).
  */
 export type ConnectionControl = {
-  /** The saved remote daemons this browser can hop to. */
+  /** The saved remote daemons this browser can run on. */
   profiles: ConnectionProfile[]
   /** `window.location.origin`, to mark the daemon the dashboard is on now. */
   currentUrl: string | null
-  /** Whether the current origin is loopback, so a driver row (not a device) carries the checkmark. */
+  /** Whether the current origin is loopback (this machine's own daemon). */
   isLocal: boolean
-  onConnect: (profile: ConnectionProfile) => void
+  /** The device selected as the run target (its profile id), or null when a driver row is (#1067). */
+  selectedDeviceId: string | null
+  /** Select a saved device as the run target, with no navigation (#1067). */
+  onSelect: (profile: ConnectionProfile) => void
+  /** Clear the device selection back to a driver target (#1067). */
+  onSelectDriver: () => void
+  /** Return to this machine's own daemon when currently on a remote one (#1066). */
   onConnectLocal: () => void
   onAddDevice: () => void
 }
@@ -80,17 +86,29 @@ const RUN_TARGET_ROWS: { value: RunTarget; label: string; description: string }[
   { value: 'actions', label: 'GitHub Actions', description: 'Run on a fresh GitHub Actions runner.' },
 ]
 
-// One flat "Run on" list (#1066): the driver rows, then the saved devices and "Add a device", with a
-// single checkmark. Which daemon the dashboard is on decides it: a driver row when on the local
-// daemon, else the connected device's row. The two axes read as one list, so a device hop never
-// looks like a second, redundant "Local".
+// One flat "Run on" list (#1066/#1067): the driver rows, then the saved devices and "Add a device",
+// with a single checkmark. Selecting a device makes it the run target in place (#1067), so the
+// checkmark can sit on a device while the dashboard stays on the local daemon (no navigation).
+// When genuinely on a remote daemon (a manual connection), that device carries the mark instead.
 function RunTargetSub({ control, connection, busy }: { control: RunTargetControl; connection?: ConnectionControl | undefined; busy: boolean }) {
   // No connection control means only the driver axis exists, so treat it as the local daemon.
   const onLocalDaemon = connection ? connection.isLocal : true
+  // The selected device (#1067), meaningful only on the local daemon; on a remote daemon the
+  // connected device is the target instead. An id pointing at a removed device reads as none.
+  const selectedDevice =
+    connection && onLocalDaemon && connection.selectedDeviceId
+      ? connection.profiles.find(p => p.id === connection.selectedDeviceId)
+      : undefined
+  const isTargetDevice = (profile: ConnectionProfile): boolean =>
+    onLocalDaemon ? selectedDevice?.id === profile.id : !!connection && profile.url === connection.currentUrl
   const summary =
     connection && !connection.isLocal
       ? connection.profiles.find(p => p.url === connection.currentUrl)?.label ?? 'A device'
-      : RUN_TARGET_ROWS.find(r => r.value === control.value)?.label ?? RUN_TARGET_ROWS[0]!.label
+      : selectedDevice
+        ? selectedDevice.label
+        : RUN_TARGET_ROWS.find(r => r.value === control.value)?.label ?? RUN_TARGET_ROWS[0]!.label
+  // A driver row is checked only when no device is the target, so the one checkmark never doubles up.
+  const driverChecked = (value: RunTarget): boolean => onLocalDaemon && !selectedDevice && value === control.value
   return (
     <DropdownMenuSub>
       <DropdownMenuSubTrigger disabled={busy}>
@@ -98,17 +116,19 @@ function RunTargetSub({ control, connection, busy }: { control: RunTargetControl
         <span className="text-muted-foreground">{summary}</span>
       </DropdownMenuSubTrigger>
       <DropdownMenuSubContent>
-        {/* Driver rows (#1050). On a device, "This machine" goes home (#1066) rather than writing the
-            driver preference; the other driver rows still write straight through. */}
+        {/* Driver rows (#1050). On a remote daemon, "This machine" goes home (#1066); otherwise it
+            writes the driver preference and clears any selected device (#1067). */}
         {RUN_TARGET_ROWS.map(row => (
           <DropdownMenuItem
             key={row.value}
             className="items-start"
-            onClick={() =>
-              row.value === 'local' && connection && !connection.isLocal ? connection.onConnectLocal() : control.onChange(row.value)
-            }
+            onClick={() => {
+              if (row.value === 'local' && connection && !connection.isLocal) return connection.onConnectLocal()
+              control.onChange(row.value)
+              connection?.onSelectDriver()
+            }}
           >
-            <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', onLocalDaemon && row.value === control.value ? 'opacity-100' : 'opacity-0')} />
+            <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', driverChecked(row.value) ? 'opacity-100' : 'opacity-0')} />
             <OptionLabel label={row.label} description={row.description} />
           </DropdownMenuItem>
         ))}
@@ -116,11 +136,11 @@ function RunTargetSub({ control, connection, busy }: { control: RunTargetControl
           <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 opacity-0" />
           <OptionLabel label="Claude web" description="Coming soon." />
         </DropdownMenuItem>
-        {/* Saved devices (#1052/#1066): a click NAVIGATES to that daemon's origin (carrying token +
-            draft), not a preference write. Folded into this same list. */}
+        {/* Saved devices (#1052/#1066/#1067): a click SELECTS the device as the run target (no
+            navigation): the local daemon relays the run to it and streams its events back. */}
         {connection?.profiles.map(profile => (
-          <DropdownMenuItem key={profile.id} className="items-start" onClick={() => connection.onConnect(profile)}>
-            <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', !connection.isLocal && profile.url === connection.currentUrl ? 'opacity-100' : 'opacity-0')} />
+          <DropdownMenuItem key={profile.id} className="items-start" onClick={() => connection.onSelect(profile)}>
+            <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', isTargetDevice(profile) ? 'opacity-100' : 'opacity-0')} />
             <MonitorSmartphone className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
             <OptionLabel label={profile.label} description={profile.url} />
           </DropdownMenuItem>

--- a/packages/framework-dashboard/components/RemoteRunNotice.tsx
+++ b/packages/framework-dashboard/components/RemoteRunNotice.tsx
@@ -1,0 +1,18 @@
+import { MonitorSmartphone } from 'lucide-react'
+
+// The run view's banner for a session running on a connected device (#1067, slice 1). The live feed
+// streams back through the local daemon and renders normally; what does NOT work yet lives on the
+// remote device (its worktree, diff, PR, handoff, and browser screencast), so this says where the
+// run executes and that those panels are not wired for remote runs yet. Renders nothing without a
+// device label, so the run view can mount it unconditionally.
+export function RemoteRunNotice({ device }: { device?: string | undefined }) {
+  if (!device) return null
+  return (
+    <div role="status" className="flex items-center gap-2 border-b border-border bg-muted/40 px-4 py-2 text-xs text-muted-foreground">
+      <MonitorSmartphone className="h-3.5 w-3.5 shrink-0" aria-hidden />
+      <span className="min-w-0 flex-1">
+        Running on {device}. The live output streams here; the diff, PR, and browser panels are not available for remote runs yet.
+      </span>
+    </div>
+  )
+}

--- a/packages/framework-dashboard/components/RunView.tsx
+++ b/packages/framework-dashboard/components/RunView.tsx
@@ -9,6 +9,7 @@ import { RunActionBar } from './RunActionBar.js'
 import { RunComposer } from './RunComposer.js'
 import { RunFeed } from './RunFeed.js'
 import { ActionsRunNotice } from './ActionsRunNotice.js'
+import { RemoteRunNotice } from './RemoteRunNotice.js'
 import { ChangesSummary, RunChanges } from './RunChanges.js'
 import { HandoffActions, HandoffSummary, RunHandoffDetails, handoffExpandable } from './RunHandoff.js'
 
@@ -31,6 +32,7 @@ export function RunView({
   live,
   label,
   target,
+  remoteLabel,
   files,
   addContext,
   removeContext,
@@ -51,6 +53,10 @@ export function RunView({
   label?: string | undefined
   /** Where the run executes (#1053): `actions` swaps the live feed for a burst-mode affordance. */
   target?: 'local' | 'actions' | undefined
+  /** The device this run executes on (#1067), when it is relayed to a connected one. Set only for a
+   *  just-started remote run: the local daemon has no worktree/diff/PR for it, so the panels that
+   *  read those are suppressed and a "runs on <device>" notice takes their place. */
+  remoteLabel?: string | undefined
   files: string[]
   addContext: (path: string) => void
   removeContext?: ((path: string) => void) | undefined
@@ -123,12 +129,16 @@ export function RunView({
       {/* What the session has touched, behind the branch row's disclosure. While it runs that is
           its worktree; once it ends, the branch it left behind. The live read needs the run's id:
           without one it falls back to the project root and would report the user's own dirty
-          files as the run's. */}
-      {live && runId && <RunChanges projectId={projectId} runId={runId} open={open} onSummary={onChangesSummary} />}
+          files as the run's. A remote run's worktree lives on the device, not here (#1067), so this
+          local read is suppressed for it rather than reporting the wrong tree. */}
+      {live && runId && !remoteLabel && <RunChanges projectId={projectId} runId={runId} open={open} onSummary={onChangesSummary} />}
       {!live && open && <RunHandoffDetails handoff={handoff.handoff} />}
       {/* A GitHub Actions run replays in a burst at the end (#1053), so the live feed looks stalled:
           say the wait is expected and link through to the live Actions run. */}
       <ActionsRunNotice target={target} events={shown} live={live} />
+      {/* A run relayed to a connected device (#1067): the live feed streams here, but its diff, PR,
+          and browser panels are not wired for remote runs yet. */}
+      <RemoteRunNotice device={remoteLabel} />
       {/* Nothing to show yet is not the same thing in both states: a live run is waiting for its
           first event, a finished one is still reading its log. */}
       {!live && archived === null && shown.length === 0 ? (

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -4,6 +4,8 @@ import { runOptionsFromPreferences } from '@gemstack/framework/client'
 import { onProjects } from '../server/projects.telefunc.js'
 import { onSystemPromptUser } from '../server/reads.telefunc.js'
 import { usePreferences, updatePreferences, autopilotEnabled } from '../lib/preferences.js'
+import { useConnectionProfiles } from '../lib/profiles.js'
+import { useSelectedRemoteDeviceId } from '../lib/remote-target.js'
 import { useStartRun } from '../lib/use-start-run.js'
 import { useLoaded } from '../lib/use-async.js'
 import { Composer, type ComposerHandle } from './Composer.js'
@@ -25,7 +27,8 @@ export function StartRunForm({
   toggleContext,
 }: {
   projectId: string
-  onRunStarted?: ((intent: string, runId?: string) => void) | undefined
+  /** `runsOn` names the device a remote run executes on (#1067), for the "runs on <device>" marker. */
+  onRunStarted?: ((intent: string, runId?: string, runsOn?: string) => void) | undefined
   /** The project's files for the `#` picker (#504), owned by the shell. */
   files: string[]
   /** The run Context set, shared with the right-rail file tree (#492) — owned by the shell. */
@@ -70,9 +73,19 @@ export function StartRunForm({
     .filter(Boolean)
     .join(' · ')
 
+  // The device this run targets (#1067), if one is picked in the "Run on" gear. Its token is a
+  // per-browser secret, so it rides the run as memory-only `options.remote` and is never persisted.
+  const profiles = useConnectionProfiles()
+  const selectedDeviceId = useSelectedRemoteDeviceId()
+  const remoteDevice = selectedDeviceId ? profiles.find(p => p.id === selectedDeviceId) : undefined
+
   // The options this run will start with: the daemon's own mapping (#858), read once, so the
-  // submit and the system-prompt preview below cannot disagree with the run they describe.
-  const options = runOptionsFromPreferences(preferences, [...context])
+  // submit and the system-prompt preview below cannot disagree with the run they describe. A picked
+  // device adds the relay target (#1067); absent, this is byte-identical to a local start.
+  const options = {
+    ...runOptionsFromPreferences(preferences, [...context]),
+    ...(remoteDevice ? { remote: { url: remoteDevice.url, token: remoteDevice.token } } : {}),
+  }
 
   const submit = async (text: string, submitKind: 'build' | 'prompt') => {
     if (busy) return
@@ -82,7 +95,8 @@ export function StartRunForm({
     if (result) {
       // Show the run in the Runs rail immediately (#405): the spawned process writes its run.json
       // a beat later, so seed an optimistic row with the typed prompt until the real meta takes over.
-      onRunStarted?.(text, result.runId) // select the run we just started (#761)
+      // A remote run (#1067) carries the device label so the view can mark where it executes.
+      onRunStarted?.(text, result.runId, remoteDevice?.label) // select the run we just started (#761)
       composerRef.current?.clear()
       setPrompt('')
     }

--- a/packages/framework-dashboard/lib/remote-target.ts
+++ b/packages/framework-dashboard/lib/remote-target.ts
@@ -1,0 +1,32 @@
+import { useSyncExternalStore } from 'react'
+
+// The saved device selected as this browser's run target (#1067). Ephemeral, in-memory only: a
+// device's token is a per-browser secret, so which device a run goes to is transient UI state, never
+// a persisted preference (that is why it is not in Preferences alongside `local`/`actions`). Null
+// means a driver target (this machine / GitHub Actions) is selected. Node-free leaf like profiles.ts,
+// so nothing leaks into the SPA bundle. The value is the device's profile id (its origin url).
+
+let selectedDeviceId: string | null = null
+const listeners = new Set<() => void>()
+
+/** Select a saved device (by profile id) as the run target, or null to go back to a driver target. */
+export function selectRemoteDevice(id: string | null): void {
+  if (selectedDeviceId === id) return
+  selectedDeviceId = id
+  for (const listener of listeners) listener()
+}
+
+/** The selected device id, read at submit time to attach the run's relay target. */
+export function getSelectedRemoteDeviceId(): string | null {
+  return selectedDeviceId
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+/** The selected device id as reactive state; null on the server and until a device is picked. */
+export function useSelectedRemoteDeviceId(): string | null {
+  return useSyncExternalStore(subscribe, getSelectedRemoteDeviceId, () => null)
+}

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -64,7 +64,9 @@ export default function Page() {
   // with the typed prompt at once, before the spawned process writes its run.json. `id` is the
   // one the daemon allocated for it (#761) — the URL already points there, and this is what tells
   // the main pane that a session missing from the list is starting, not gone.
-  const [runStart, setRunStart] = useState<{ tick: number; intent: string; id: string | null }>({ tick: 0, intent: '', id: null })
+  // `runsOn` names the device a just-started remote run executes on (#1067), so the live view can
+  // mark where it runs and degrade the panels that are local-only. Undefined for a local run.
+  const [runStart, setRunStart] = useState<{ tick: number; intent: string; id: string | null; runsOn?: string }>({ tick: 0, intent: '', id: null })
   // A project with no git checkout gets no worktree, so Start hands back no id and there is
   // nothing to navigate to yet. That fallback is one run at a time (daemon.ts keys the busy guard
   // by project there), so "the running one" is still a safe guess — adopt it the moment the poll
@@ -128,8 +130,8 @@ export default function Page() {
   const { value: activity } = usePolled<Activity[]>(browserActivity ? onActivity : null, EMPTY_ACTIVITY, 15000, [browserActivity])
   useActivityNotifications(activity, browserActivity)
 
-  const onRunStarted = (intent: string, startedId?: string) => {
-    setRunStart(prev => ({ tick: prev.tick + 1, intent, id: startedId ?? null }))
+  const onRunStarted = (intent: string, startedId?: string, runsOn?: string) => {
+    setRunStart(prev => ({ tick: prev.tick + 1, intent, id: startedId ?? null, ...(runsOn ? { runsOn } : {}) }))
     setAdopting(startedId === undefined)
     // The picked context went with that run; the next launch starts from a clean focus (#948).
     resetContext()
@@ -224,7 +226,7 @@ export default function Page() {
     if (runId === null) {
       // Just pressed Start on a project with no worktree: follow the live output until the poll
       // surfaces the run and the effect above adopts its id.
-      if (adopting) return <RunView projectId={projectId} runId={null} events={events} live label={runStart.intent || undefined} files={files} addContext={addContext} removeContext={removeContext} lost={lost} onRunStarted={onRunStarted} />
+      if (adopting) return <RunView projectId={projectId} runId={null} events={events} live label={runStart.intent || undefined} remoteLabel={runStart.runsOn} files={files} addContext={addContext} removeContext={removeContext} lost={lost} onRunStarted={onRunStarted} />
       return (
         <ProjectHome
           projectId={projectId}
@@ -243,7 +245,7 @@ export default function Page() {
       // list we have not read yet. Both are live views; only a session that is genuinely absent
       // from a list we did read is gone.
       if (runId === runStart.id || !runsLoaded)
-        return <RunView projectId={projectId} runId={runId} events={events} live label={runStart.intent || undefined} files={files} addContext={addContext} removeContext={removeContext} lost={lost} onRunStarted={onRunStarted} />
+        return <RunView projectId={projectId} runId={runId} events={events} live label={runStart.intent || undefined} remoteLabel={runId === runStart.id ? runStart.runsOn : undefined} files={files} addContext={addContext} removeContext={removeContext} lost={lost} onRunStarted={onRunStarted} />
       return (
         <NotFound
           title="This session is gone"

--- a/packages/framework/src/daemon-runtime.ts
+++ b/packages/framework/src/daemon-runtime.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from 'node:child_process'
-import { basename, resolve } from 'node:path'
+import { basename, join, resolve } from 'node:path'
 import { rm, stat } from 'node:fs/promises'
 import {
   runIdFromStartedAt,
@@ -17,12 +17,18 @@ import {
   removeWorktree,
   pruneWorktrees,
   readLiveMetas,
+  resolveRunCheckout,
+  FRAMEWORK_DIR,
+  EVENTS_FILE,
   isPidAlive,
   writeSuspendedRuns,
   type SuspendedRun,
 } from './store/index.js'
+import type { FrameworkEvent } from './events.js'
 import type { StartRunKind, StartRunOptions, StartRunResult, AddProjectResult } from './dashboard/index.js'
-import type { PreviewHandlers } from './dashboard/telefunc-serve.js'
+import type { EventsSource, PreviewHandlers } from './dashboard/telefunc-serve.js'
+import { RelayedRuns, startRemoteRun } from './dashboard/remote-run.js'
+import { tailEvents } from './dashboard-rpc/events-tail.js'
 import { isSafeVia } from './conversations.js'
 import { createPreviewRuntime } from './preview-runtime.js'
 import { scopedKey, parseScopedKey, keyBelongsTo } from './runtime-keys.js'
@@ -177,6 +183,12 @@ export interface ProjectRuntime {
   onAddProject: (path: string, directory: boolean) => Promise<AddProjectResult>
   /** The Preview handler set (#475/#797), handed to the dashboard as one value so `runId` survives. */
   preview: PreviewHandlers
+  /** The live event stream for a run this daemon is relaying from a device (#1067), else undefined
+   *  so `onEvents` falls back to tailing the on-disk log. Wired as the dashboard's events source. */
+  remoteEventsSource: EventsSource
+  /** Tail a relay-started run's on-disk events (#1067): the daemon's `/_relay/events` endpoint uses
+   *  it to stream one run back to whichever daemon relayed it here. */
+  tailRelayEvents: (runId: string, onEvent: (event: FrameworkEvent) => void) => () => void
   /** Live runs on a project (#685), so a background job can tell an idle project from a busy one. */
   activeRunCount: (targetProjectId: string) => number
   /**
@@ -200,6 +212,8 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
   // Live run pids, keyed per run rather than per project (#736) — see onStart for the key.
   const activeRuns = new Map<string, number>()
   const starting = new Set<string>() // reserved keys mid-spawn, to close the async gap
+  // Runs this daemon is relaying to/from a connected device (#1067): the local half of a remote run.
+  const relayedRuns = new RelayedRuns()
 
   // A project id resolves to its repo path via the registry; the home id (or none)
   // resolves to the daemon's own `cwd` without a lookup.
@@ -333,6 +347,16 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
     options: StartRunOptions = {},
     targetProjectId?: string,
   ): Promise<StartRunResult> => {
+    // Run on a connected device (#1067): forward the run to the remote daemon and relay its events
+    // back, without allocating a worktree or touching this daemon's busy guard; the remote owns
+    // both. `remote` is stripped so the remote starts an ordinary local run and does not relay on.
+    // Slice 1 runs in the device's own home checkout; which remote project it targets is a later slice.
+    if (options.remote) {
+      const { remote, ...forwarded } = options
+      const result = await startRemoteRun(remote, { prompt, kind, options: forwarded })
+      if (result.ok && result.runId) relayedRuns.register(result.runId, remote)
+      return result
+    }
     const projectKey = targetProjectId ?? homeId
     const projectCwd = await resolveProject(targetProjectId)
     if (!projectCwd) return { ok: false, error: `unknown project: ${targetProjectId}` }
@@ -480,12 +504,40 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
     return suspended
   }
 
+  // The dashboard's events source (#1067): a stream for a run this daemon is relaying from a device,
+  // else undefined so `onEvents` tails the on-disk log as usual for an ordinary local run.
+  const remoteEventsSource: EventsSource = (_projectId, runId) => relayedRuns.get(runId)
+
+  // Tail a relay-started run's own log (#1067) for the `/_relay/events` endpoint. Resolving the run's
+  // worktree is async, so a stop is returned immediately and the tail attaches once the path is known.
+  const tailRelayEvents = (runId: string, onEvent: (event: FrameworkEvent) => void): (() => void) => {
+    let stop = (): void => {}
+    let cancelled = false
+    void resolveRunCheckout(cwd, runId)
+      .then(checkout => {
+        if (cancelled) return
+        stop = tailEvents(join(checkout, FRAMEWORK_DIR, EVENTS_FILE), onEvent)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+      stop()
+    }
+  }
+
+  const dispose = async (): Promise<void> => {
+    relayedRuns.dispose()
+    await previews.dispose()
+  }
+
   return {
     onStart,
     onAddProject,
     preview: previews.preview,
+    remoteEventsSource,
+    tailRelayEvents,
     activeRunCount,
     suspendRuns,
-    dispose: previews.dispose,
+    dispose,
   }
 }

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -366,6 +366,10 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     onStart: runtime.onStart,
     onAddProject: runtime.onAddProject,
     preview: runtime.preview,
+    // Relay a run to/from a connected device (#1067): the events source streams a run this daemon
+    // is relaying, and the `/_relay/*` endpoints let another daemon run a session here.
+    eventsSource: runtime.remoteEventsSource,
+    relay: { tailEvents: runtime.tailRelayEvents },
     ...(token ? { token } : {}),
     ...(clientBundleDir ? { clientBundleDir } : {}),
   })

--- a/packages/framework/src/dashboard-rpc/events.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/events.telefunc.ts
@@ -33,17 +33,16 @@ async function resolveEventsPath(projectId: string, runId?: string): Promise<str
  * that run's rather than a mix — and without it the feed for a worktree run is empty.
  * Omitting it keeps the pre-#736 behavior of tailing the project root.
  *
- * Two sources, chosen by the mount: the relay (#426) streams from an in-memory run on
- * the context; everywhere else there is no such source, so it tails the log on disk.
+ * Two sources, chosen by the mount. An in-memory stream on the context wins: the relay's own run
+ * (#426), or a run the daemon is relaying from a device (#1067). Otherwise the on-disk log. The
+ * daemon sets a source that answers only for relayed runs, so an ordinary local run yields undefined
+ * here and falls through to tailing the log, exactly as before.
  */
 export async function onEvents(projectId: string, runId?: string): Promise<ClientChannel<never, FrameworkEvent>> {
-  const source = contextEventsSource()
-  if (source) {
-    // The relay: replay + follow its in-memory run, mirroring how serveSSE consumes it.
-    return streamChannel<FrameworkEvent>(send => {
-      const stream = source(projectId)
-      return stream ? forwardStream(stream, send) : undefined
-    })
+  const stream = contextEventsSource()?.(projectId, runId)
+  if (stream) {
+    // An in-memory run: replay + follow it, mirroring how serveSSE consumes it.
+    return streamChannel<FrameworkEvent>(send => forwardStream(stream, send))
   }
   // Everywhere else: tail the run's on-disk events.jsonl (undefined path -> closed channel).
   const path = await resolveEventsPath(projectId, runId)

--- a/packages/framework/src/dashboard/relay-endpoints.ts
+++ b/packages/framework/src/dashboard/relay-endpoints.ts
@@ -1,0 +1,119 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { FrameworkEvent } from '../events.js'
+import type { StartRunKind, StartRunOptions, StartRunResult } from './types.js'
+
+/**
+ * The device-side of the remote-run relay (#1067): the two endpoints a daemon exposes so another
+ * daemon (holding this device's token) can run a session here and watch it. They live under
+ * `/_relay`, behind the #1051 token guard in {@link startDashboard}. The guard admits a matching
+ * `fw_daemon` cookie without the browser-only `?token=` 302, so a daemon-to-daemon call passes with
+ * a cookie and a token-less caller is already 401'd before it reaches here.
+ *
+ * - `POST /_relay/start`  starts an ordinary local run and returns its {@link StartRunResult}. It
+ *   runs in this device's own home checkout (slice 1); which project it targets is a later slice.
+ * - `GET  /_relay/events?run=<id>` streams that run's events as newline-delimited JSON until it
+ *   ends or the caller disconnects.
+ */
+export const RELAY_PREFIX = '/_relay'
+
+/** What the daemon wires behind the relay endpoints: its own start closure and an events tail. */
+export interface RelayHandlers {
+  start: (prompt: string, kind: StartRunKind, options: StartRunOptions, projectId?: string) => StartRunResult | Promise<StartRunResult>
+  tailEvents: (runId: string, onEvent: (event: FrameworkEvent) => void) => () => void
+}
+
+/** The body `POST /_relay/start` accepts: exactly what a local Start needs, minus any project id. */
+interface RelayStartBody {
+  prompt?: unknown
+  kind?: unknown
+  options?: unknown
+}
+
+const MAX_START_BODY = 256 * 1024
+
+/** Route a `/_relay/*` request. A host that wired no relay handlers 404s every relay route. */
+export async function handleRelayRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  pathname: string,
+  handlers: RelayHandlers | undefined,
+): Promise<void> {
+  if (!handlers) return end(res, 404, 'relay not enabled')
+  if (pathname === `${RELAY_PREFIX}/start`) return handleStart(req, res, handlers)
+  if (pathname === `${RELAY_PREFIX}/events`) return handleEvents(req, res, handlers)
+  end(res, 404, 'not found')
+}
+
+/** `POST /_relay/start`: read the run request, start it locally, and answer with the result JSON. */
+async function handleStart(req: IncomingMessage, res: ServerResponse, handlers: RelayHandlers): Promise<void> {
+  if (req.method !== 'POST') return end(res, 405, 'method not allowed', { allow: 'POST' })
+  let body: RelayStartBody
+  try {
+    body = (await readJsonBody(req, MAX_START_BODY)) as RelayStartBody
+  } catch {
+    return end(res, 400, 'invalid request body')
+  }
+  const prompt = typeof body.prompt === 'string' ? body.prompt : ''
+  const kind: StartRunKind = body.kind === 'research' || body.kind === 'prompt' ? body.kind : 'build'
+  const options = (body.options && typeof body.options === 'object' ? body.options : {}) as StartRunOptions
+  // Never relay onward from a relayed run: strip any nested target before starting it here.
+  const { remote: _drop, ...local } = options
+  let result: StartRunResult
+  try {
+    result = await handlers.start(prompt, kind, local, undefined)
+  } catch (err) {
+    result = { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+  res.writeHead(200, { 'content-type': 'application/json' })
+  res.end(JSON.stringify(result))
+}
+
+/** `GET /_relay/events?run=<id>`: stream the run's events as newline-delimited JSON. */
+function handleEvents(req: IncomingMessage, res: ServerResponse, handlers: RelayHandlers): void {
+  if (req.method !== 'GET') return end(res, 405, 'method not allowed', { allow: 'GET' })
+  const runId = new URL(req.url ?? '/', 'http://localhost').searchParams.get('run')
+  if (!runId) return end(res, 400, 'missing run id')
+  res.writeHead(200, { 'content-type': 'application/x-ndjson', 'cache-control': 'no-cache' })
+  const stop = handlers.tailEvents(runId, event => {
+    // A dropped write (the caller went away mid-line) must not throw out of the tail callback.
+    try {
+      res.write(`${JSON.stringify(event)}\n`)
+    } catch {
+      // the socket is gone; the close handler below tears the tail down
+    }
+  })
+  const close = (): void => stop()
+  res.on('close', close)
+  req.on('close', close)
+}
+
+/** Read a capped JSON request body, rejecting on overflow or malformed JSON. */
+function readJsonBody(req: IncomingMessage, maxBytes: number): Promise<unknown> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const chunks: Buffer[] = []
+    let bytes = 0
+    req.on('data', (chunk: Buffer) => {
+      bytes += chunk.length
+      if (bytes > maxBytes) {
+        rejectPromise(new Error('payload too large'))
+        req.destroy()
+        return
+      }
+      chunks.push(chunk)
+    })
+    req.on('end', () => {
+      try {
+        resolvePromise(JSON.parse(Buffer.concat(chunks).toString('utf8')))
+      } catch (err) {
+        rejectPromise(err instanceof Error ? err : new Error('invalid json'))
+      }
+    })
+    req.on('error', rejectPromise)
+  })
+}
+
+/** Answer a relay request with a plain-text status. */
+function end(res: ServerResponse, status: number, message: string, headers: Record<string, string> = {}): void {
+  res.writeHead(status, { 'content-type': 'text/plain', ...headers })
+  res.end(message)
+}

--- a/packages/framework/src/dashboard/remote-run.integration.test.ts
+++ b/packages/framework/src/dashboard/remote-run.integration.test.ts
@@ -1,0 +1,96 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { EventStream } from '@gemstack/ai-autopilot'
+import { startDashboard } from './server.js'
+import { createProjectRuntime, delay } from '../daemon-runtime.js'
+import { forwardStream } from '../dashboard-rpc/stream-channel.js'
+import { projectId } from '../registry.js'
+import type { StartRunKind, StartRunOptions, StartRunResult } from './types.js'
+import type { FrameworkEvent } from '../events.js'
+
+// The real two-daemon proof for "run on a connected device" (#1067). Two HTTP servers stand up on
+// loopback: daemon A (the browser's local daemon, a real project runtime) relays a run to daemon B
+// (the device, a dashboard whose Start is stubbed so no agent actually spawns). We assert the run
+// is created on B, that A never touched its own busy guard, and that B's events stream back through
+// A's relayed-run source in order. That is the whole path minus the final same-origin Telefunc hop on A,
+// which relay.test.ts / server.test.ts cover on their own.
+
+const TOKEN = 'zX2p8Q0hqk3m9tR7vN1cW4bY6sJ5aL0dFgHiKlMnOp'
+
+async function fakeBundle(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'relay-int-'))
+  await writeFile(join(dir, 'index.html'), '<!doctype html><div id="root"></div>')
+  await mkdir(join(dir, 'assets'), { recursive: true })
+  await writeFile(join(dir, 'assets', 'app.js'), '')
+  return dir
+}
+
+/** Consume a stream until an event of `stopKind` arrives, or a timeout trips. */
+async function collectUntil(stream: AsyncIterable<FrameworkEvent>, stopKind: string, timeoutMs = 4000): Promise<FrameworkEvent[]> {
+  const got: FrameworkEvent[] = []
+  const loop = (async () => {
+    for await (const e of stream) {
+      got.push(e)
+      if ((e as { kind?: string }).kind === stopKind) return
+    }
+  })()
+  await Promise.race([loop, delay(timeoutMs)])
+  return got
+}
+
+test('a run submitted with options.remote is created on the other daemon and its events stream back (#1067)', async () => {
+  // Daemon B: the device. Its Start is stubbed to record the call and emit a short event stream,
+  // so the relay path is exercised without spawning a real agent.
+  const bStarts: Array<{ prompt: string; kind: StartRunKind; options: StartRunOptions; projectId?: string }> = []
+  const bStreams = new Map<string, EventStream<FrameworkEvent>>()
+  const B_RUN = 'remote-run-1'
+  const bStart = (prompt: string, kind: StartRunKind, options: StartRunOptions, pid?: string): StartRunResult => {
+    bStarts.push({ prompt, kind, options, ...(pid ? { projectId: pid } : {}) })
+    const stream = new EventStream<FrameworkEvent>()
+    stream.push({ kind: 'log', message: 'hello from B' } as FrameworkEvent)
+    stream.push({ kind: 'end', ok: true } as FrameworkEvent)
+    stream.close()
+    bStreams.set(B_RUN, stream)
+    return { ok: true, runId: B_RUN }
+  }
+  const bTail = (runId: string, onEvent: (event: FrameworkEvent) => void): (() => void) => forwardStream(bStreams.get(runId), onEvent)
+  const bundle = await fakeBundle()
+  const deviceB = await startDashboard({ port: 0, clientBundleDir: bundle, token: TOKEN, onStart: bStart, relay: { tailEvents: bTail } })
+
+  // Daemon A: the browser's own daemon, a real project runtime. Its onStart takes the remote branch.
+  const cwdA = await mkdtemp(join(tmpdir(), 'relay-a-'))
+  const runtimeA = createProjectRuntime({ cwd: cwdA, env: process.env })
+  const homeIdA = projectId(resolve(cwdA))
+
+  try {
+    const result = await runtimeA.onStart('build the thing', 'build', { remote: { url: deviceB.url, token: TOKEN } })
+
+    // The run was created on B, and A returned B's own run id (not a locally allocated one).
+    assert.equal(result.ok, true)
+    assert.equal(result.ok && result.runId, B_RUN)
+    assert.equal(bStarts.length, 1)
+    assert.equal(bStarts[0]!.prompt, 'build the thing')
+    assert.equal(bStarts[0]!.options.remote, undefined) // stripped before forwarding, no onward relay
+    assert.equal(bStarts[0]!.projectId, undefined) // slice 1: the device's own home checkout
+
+    // A's own busy guard never fired: it allocated no worktree and spawned nothing.
+    assert.equal(runtimeA.activeRunCount(homeIdA), 0)
+
+    // The events stream back through A's relayed-run source, in order.
+    const stream = runtimeA.remoteEventsSource(homeIdA, B_RUN)
+    assert.ok(stream, 'A should expose a live stream for the relayed run')
+    const events = await collectUntil(stream!, 'end')
+    assert.deepEqual(
+      events.map(e => (e as { message?: string; kind?: string }).message ?? (e as { kind?: string }).kind),
+      ['hello from B', 'end'],
+    )
+  } finally {
+    await runtimeA.dispose()
+    await deviceB.close()
+    await rm(bundle, { recursive: true, force: true })
+    await rm(cwdA, { recursive: true, force: true })
+  }
+})

--- a/packages/framework/src/dashboard/remote-run.test.ts
+++ b/packages/framework/src/dashboard/remote-run.test.ts
@@ -1,0 +1,149 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { startRemoteRun, streamRemoteEvents, RelayedRuns } from './remote-run.js'
+import type { FrameworkEvent } from '../events.js'
+
+// A throwaway loopback server; the handler decides how it answers. Returns its base url + close.
+async function server(handler: (req: IncomingMessage, res: ServerResponse) => void): Promise<{ url: string; close: () => Promise<void> }> {
+  const srv: Server = createServer(handler)
+  await new Promise<void>(r => srv.listen(0, '127.0.0.1', () => r()))
+  const port = (srv.address() as AddressInfo).port
+  return { url: `http://127.0.0.1:${port}`, close: () => new Promise<void>(r => srv.close(() => r())) }
+}
+
+/** Wait until the stream ends (its `onEnd` fires) or a timeout trips, collecting events meanwhile. */
+function drain(target: { url: string; token: string }, runId: string, timeoutMs = 4000): Promise<{ events: FrameworkEvent[]; ended: boolean }> {
+  return new Promise(resolvePromise => {
+    const events: FrameworkEvent[] = []
+    const timer = setTimeout(() => resolvePromise({ events, ended: false }), timeoutMs)
+    streamRemoteEvents(target, runId, e => events.push(e), () => {
+      clearTimeout(timer)
+      resolvePromise({ events, ended: true })
+    })
+  })
+}
+
+test('startRemoteRun posts to /_relay/start with the fw_daemon cookie, no Origin, and the run body (#1067)', async () => {
+  let captured: { method?: string | undefined; url?: string | undefined; cookie?: string | undefined; origin?: string | undefined; body: unknown } = { body: null }
+  const srv = await server((req, res) => {
+    let raw = ''
+    req.on('data', c => (raw += c))
+    req.on('end', () => {
+      captured = { method: req.method, url: req.url, cookie: req.headers.cookie, origin: req.headers.origin, body: JSON.parse(raw) }
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ ok: true, runId: 'r1' }))
+    })
+  })
+  try {
+    const result = await startRemoteRun({ url: srv.url, token: 'sekret' }, { prompt: 'do it', kind: 'build', options: { autopilot: true } })
+    assert.deepEqual(result, { ok: true, runId: 'r1' })
+    assert.equal(captured.method, 'POST')
+    assert.equal(captured.url, '/_relay/start')
+    assert.equal(captured.cookie, 'fw_daemon=sekret') // the #1051 cookie, daemon to daemon
+    assert.equal(captured.origin, undefined) // NO Origin header, so it passes the remote CSRF guard
+    assert.deepEqual(captured.body, { prompt: 'do it', kind: 'build', options: { autopilot: true } })
+  } finally {
+    await srv.close()
+  }
+})
+
+test('startRemoteRun surfaces a non-2xx from the device as an ok:false result (#1067)', async () => {
+  const srv = await server((_req, res) => {
+    res.writeHead(403, { 'content-type': 'text/plain' })
+    res.end('unauthorized')
+  })
+  try {
+    const result = await startRemoteRun({ url: srv.url, token: 'wrong' }, { prompt: 'x', kind: 'build', options: {} })
+    assert.equal(result.ok, false)
+    if (!result.ok) assert.match(result.error, /403|device/)
+  } finally {
+    await srv.close()
+  }
+})
+
+test('streamRemoteEvents parses ndjson lines in order and ends when the body closes (#1067)', async () => {
+  const srv = await server((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/x-ndjson' })
+    res.write(`${JSON.stringify({ kind: 'log', message: 'a' })}\n`)
+    res.write(`${JSON.stringify({ kind: 'log', message: 'b' })}\n`)
+    res.end()
+  })
+  try {
+    const { events, ended } = await drain({ url: srv.url, token: 't' }, 'r1')
+    assert.deepEqual(events.map(e => (e as { message?: string }).message), ['a', 'b'])
+    assert.equal(ended, true)
+  } finally {
+    await srv.close()
+  }
+})
+
+test('a line split across two chunks is reassembled, not dropped (#1067)', async () => {
+  const line = `${JSON.stringify({ kind: 'log', message: 'split' })}\n`
+  const srv = await server(async (_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/x-ndjson' })
+    res.write(line.slice(0, 10)) // half a JSON line
+    await new Promise(r => setTimeout(r, 20))
+    res.write(line.slice(10)) // the rest, arriving in a second chunk
+    res.end()
+  })
+  try {
+    const { events } = await drain({ url: srv.url, token: 't' }, 'r1')
+    assert.deepEqual(events.map(e => (e as { message?: string }).message), ['split'])
+  } finally {
+    await srv.close()
+  }
+})
+
+test('a 401 from the remote (rotated token) surfaces as a clean stream-end, no events (#1067)', async () => {
+  const srv = await server((_req, res) => {
+    res.writeHead(401, { 'content-type': 'text/plain' })
+    res.end('unauthorized')
+  })
+  try {
+    const { events, ended } = await drain({ url: srv.url, token: 'stale' }, 'r1')
+    assert.equal(events.length, 0)
+    assert.equal(ended, true) // ended cleanly (a done), not an error the caller has to retry
+  } finally {
+    await srv.close()
+  }
+})
+
+test('RelayedRuns feeds a run stream from the device and drops its token when the stream ends (#1067)', async () => {
+  const srv = await server((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/x-ndjson' })
+    res.write(`${JSON.stringify({ kind: 'log', message: 'hi' })}\n`)
+    res.end()
+  })
+  try {
+    const runs = new RelayedRuns()
+    runs.register('r1', { url: srv.url, token: 't' })
+    const stream = runs.get('r1') // grabbed synchronously, before the remote stream ends
+    assert.ok(stream)
+    const got: FrameworkEvent[] = []
+    for await (const e of stream!) got.push(e) // replays, then ends when the device closes the body
+    assert.deepEqual(got.map(e => (e as { message?: string }).message), ['hi'])
+    assert.equal(runs.get('r1'), undefined) // dropped: the token no longer lives here
+  } finally {
+    await srv.close()
+  }
+})
+
+test('RelayedRuns closes cleanly on a 401 with no events (#1067)', async () => {
+  const srv = await server((_req, res) => {
+    res.writeHead(401)
+    res.end()
+  })
+  try {
+    const runs = new RelayedRuns()
+    runs.register('r1', { url: srv.url, token: 'stale' })
+    const stream = runs.get('r1')
+    assert.ok(stream)
+    const got: FrameworkEvent[] = []
+    for await (const e of stream!) got.push(e)
+    assert.equal(got.length, 0) // a clean close, so the browser sees `done`, not `lost`
+  } finally {
+    await srv.close()
+  }
+})

--- a/packages/framework/src/dashboard/remote-run.ts
+++ b/packages/framework/src/dashboard/remote-run.ts
@@ -1,0 +1,171 @@
+import { EventStream } from '@gemstack/ai-autopilot'
+import type { FrameworkEvent } from '../events.js'
+import type { StartRunKind, StartRunOptions, StartRunResult } from './types.js'
+import { errorMessage } from '../error-message.js'
+
+/**
+ * The server-side half of "run on a connected device" (#1067). The local daemon holds the saved
+ * device's token, so it - not the browser - drives the remote daemon: it POSTs the run to the
+ * remote's `/_relay/start` and then fetch-streams the remote's `/_relay/events` back into a local
+ * {@link EventStream}, which the dashboard reads over its normal same-origin `onEvents` channel. So
+ * the browser never talks cross-origin and the token never leaves the two daemons (issue #1067 (b)).
+ *
+ * Authentication is the #1051 cookie, sent daemon-to-daemon: `Cookie: fw_daemon=<token>` with no
+ * `Origin` header. The remote's guard admits a matching cookie without the browser-only `?token=`
+ * 302, and its `/_telefunc` CSRF check (absent Origin passes) is not even on these raw routes.
+ */
+
+/** Where a relayed run executes: the remote daemon's origin and its #1051 token. Memory-only. */
+export interface RemoteTarget {
+  url: string
+  token: string
+}
+
+/** The body a relay start forwards to the remote's `/_relay/start`. */
+export interface RelayStartBody {
+  prompt: string
+  kind: StartRunKind
+  options: StartRunOptions
+}
+
+const START_TIMEOUT_MS = 15_000
+
+/** The two headers every relay request carries: JSON, and the #1051 cookie. No Origin on purpose. */
+function relayHeaders(token: string): Record<string, string> {
+  return { 'content-type': 'application/json', cookie: `fw_daemon=${token}` }
+}
+
+/**
+ * Start a run on the remote daemon and return its {@link StartRunResult} (with the remote's own run
+ * id). A non-2xx or a transport failure surfaces as an `ok: false` result the dashboard shows, the
+ * same shape a local refusal has, so the caller does not special-case remote errors.
+ */
+export async function startRemoteRun(target: RemoteTarget, body: RelayStartBody): Promise<StartRunResult> {
+  try {
+    const res = await fetch(`${trimSlashes(target.url)}/_relay/start`, {
+      method: 'POST',
+      headers: relayHeaders(target.token),
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(START_TIMEOUT_MS),
+    })
+    if (!res.ok) return { ok: false, error: `the device refused the run (${res.status})` }
+    return (await res.json()) as StartRunResult
+  } catch (err) {
+    return { ok: false, error: `could not reach the device: ${errorMessage(err)}` }
+  }
+}
+
+/**
+ * Fetch-stream a remote run's newline-delimited events into `onEvent` until the remote closes the
+ * body, the run ends, or `cancel()` is called. A 401 (the token was rotated) ends the stream
+ * cleanly rather than as an error, so the dashboard sees a normal `done`, not a lost connection.
+ * Returns a cancel function; calling it aborts the fetch and releases the reader.
+ */
+export function streamRemoteEvents(
+  target: RemoteTarget,
+  runId: string,
+  onEvent: (event: FrameworkEvent) => void,
+  onEnd?: () => void,
+): () => void {
+  const controller = new AbortController()
+  let ended = false
+  const end = (): void => {
+    if (ended) return
+    ended = true
+    onEnd?.()
+  }
+  void (async () => {
+    try {
+      const url = `${trimSlashes(target.url)}/_relay/events?run=${encodeURIComponent(runId)}`
+      const res = await fetch(url, { headers: relayHeaders(target.token), signal: controller.signal })
+      // 401 = the device rotated its token. Nothing more will stream; end cleanly (a done, not a loss).
+      if (!res.ok || !res.body) return end()
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+      for (;;) {
+        const { value, done } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        // Emit every complete line, keeping the trailing partial for the next chunk.
+        let newline = buffer.indexOf('\n')
+        while (newline !== -1) {
+          emitLine(buffer.slice(0, newline), onEvent)
+          buffer = buffer.slice(newline + 1)
+          newline = buffer.indexOf('\n')
+        }
+      }
+      emitLine(buffer, onEvent) // a final line with no trailing newline
+    } catch {
+      // Aborted by cancel(), or the transport dropped: either way the stream is over.
+    } finally {
+      end()
+    }
+  })()
+  return () => {
+    controller.abort()
+    end()
+  }
+}
+
+/** Parse one NDJSON line as a {@link FrameworkEvent} and forward it; a blank or malformed line is skipped. */
+function emitLine(line: string, onEvent: (event: FrameworkEvent) => void): void {
+  const trimmed = line.trim()
+  if (!trimmed) return
+  try {
+    onEvent(JSON.parse(trimmed) as FrameworkEvent)
+  } catch {
+    // A partial or malformed line is dropped rather than crashing the pump.
+  }
+}
+
+interface RelayedRun {
+  target: RemoteTarget
+  stream: EventStream<FrameworkEvent>
+  cancel: () => void
+}
+
+/**
+ * The local daemon's live relayed runs (#1067), keyed by the remote run id. Registering a run opens
+ * an {@link EventStream} the dashboard reads through `onEvents`, fed by {@link streamRemoteEvents}
+ * from the remote. This map is the only place a saved device's token lives daemon-side: in memory,
+ * for the run's lifetime, dropped the moment the remote stream ends.
+ */
+export class RelayedRuns {
+  private readonly runs = new Map<string, RelayedRun>()
+
+  /** Open a local stream for a remote run and start pumping the remote's events into it. */
+  register(runId: string, target: RemoteTarget): void {
+    this.runs.get(runId)?.cancel() // a re-register (same id) replaces the old pump
+    const stream = new EventStream<FrameworkEvent>()
+    const cancel = streamRemoteEvents(target, runId, event => stream.push(event), () => this.drop(runId))
+    this.runs.set(runId, { target, stream, cancel })
+  }
+
+  /** The live event stream for a relayed run, or undefined when this daemon is not relaying it. */
+  get(runId: string | undefined): EventStream<FrameworkEvent> | undefined {
+    return runId ? this.runs.get(runId)?.stream : undefined
+  }
+
+  /** Close a relayed run's stream and forget its token. Idempotent. */
+  private drop(runId: string): void {
+    const run = this.runs.get(runId)
+    if (!run) return
+    this.runs.delete(runId)
+    run.stream.close() // a clean close surfaces as `done` in the browser, not a lost stream
+  }
+
+  /** Stop every pump and close every stream, on daemon shutdown. */
+  dispose(): void {
+    for (const [runId, run] of this.runs) {
+      run.cancel()
+      run.stream.close()
+      this.runs.delete(runId)
+    }
+  }
+}
+
+/** Trim trailing slashes off a base URL so `${base}/_relay/...` never doubles them. */
+function trimSlashes(url: string): string {
+  return url.replace(/\/+$/, '')
+}

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -7,6 +7,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { startDashboard } from './server.js'
 import { isSameOriginRequest } from './telefunc-serve.js'
+import type { FrameworkEvent } from '../events.js'
+import type { StartRunKind, StartRunOptions, StartRunResult } from './types.js'
 import type { IncomingMessage } from 'node:http'
 
 function fetchText(url: string): Promise<{ status: number; body: string; type: string }> {
@@ -266,6 +268,133 @@ test('a loopback bind sets no token, so the gate is a no-op (byte-identical) (#1
   } finally {
     await dash.close()
     await rm(bundle, { recursive: true, force: true })
+  }
+})
+
+// A POST with an optional Cookie header, returning the status + body.
+function postAuth(url: string, body: string, cookie?: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const req = request(url, { method: 'POST', headers: { 'content-type': 'application/json', ...(cookie ? { cookie } : {}) } }, res => {
+      let b = ''
+      res.on('data', c => (b += c))
+      res.on('end', () => resolvePromise({ status: res.statusCode ?? 0, body: b }))
+    })
+    req.on('error', rejectPromise)
+    req.end(body)
+  })
+}
+
+// GET a newline-delimited event stream, collecting the first `count` lines then tearing the
+// socket down (the endpoint follows forever, so it never ends on its own).
+function readNdjson(url: string, cookie: string, count: number): Promise<{ status: number; lines: unknown[] }> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const req = get(url, { headers: { cookie } }, res => {
+      if (res.statusCode !== 200) {
+        res.resume()
+        resolvePromise({ status: res.statusCode ?? 0, lines: [] })
+        return
+      }
+      let buffer = ''
+      const lines: unknown[] = []
+      res.on('data', c => {
+        buffer += c
+        let nl = buffer.indexOf('\n')
+        while (nl !== -1) {
+          const line = buffer.slice(0, nl).trim()
+          if (line) lines.push(JSON.parse(line))
+          buffer = buffer.slice(nl + 1)
+          nl = buffer.indexOf('\n')
+        }
+        if (lines.length >= count) {
+          req.destroy()
+          resolvePromise({ status: 200, lines })
+        }
+      })
+      res.on('end', () => resolvePromise({ status: 200, lines }))
+    })
+    req.on('error', () => {}) // destroy() rejects the request; the lines are already resolved
+    setTimeout(() => {
+      req.destroy()
+      rejectPromise(new Error('timed out reading ndjson'))
+    }, 4000).unref?.()
+  })
+}
+
+// A guarded dashboard wired for the device relay (#1067): a stub start that records its calls, and
+// an events tail backed by a fixed list. Mirrors what the daemon wires, minus a real spawn.
+async function relayDashboard(): Promise<{
+  base: string
+  starts: Array<{ prompt: string; kind: StartRunKind; options: StartRunOptions; projectId?: string }>
+  close: () => Promise<void>
+}> {
+  const bundle = await fakeBundle()
+  const starts: Array<{ prompt: string; kind: StartRunKind; options: StartRunOptions; projectId?: string }> = []
+  const onStart = (prompt: string, kind: StartRunKind, options: StartRunOptions, projectId?: string): StartRunResult => {
+    starts.push({ prompt, kind, options, ...(projectId ? { projectId } : {}) })
+    return { ok: true, runId: 'srv-run' }
+  }
+  const events: FrameworkEvent[] = [
+    { kind: 'log', message: 'e1' } as FrameworkEvent,
+    { kind: 'log', message: 'e2' } as FrameworkEvent,
+  ]
+  const tailEvents = (_runId: string, onEvent: (event: FrameworkEvent) => void): (() => void) => {
+    for (const e of events) onEvent(e)
+    return () => {}
+  }
+  const dash = await startDashboard({ port: 0, clientBundleDir: bundle, token: TOKEN, onStart, relay: { tailEvents } })
+  return {
+    base: dash.url,
+    starts,
+    close: async () => {
+      await dash.close()
+      await rm(bundle, { recursive: true, force: true })
+    },
+  }
+}
+
+test('/_relay/start needs the cookie: 401 without it, starts the run with it (#1067)', async () => {
+  const { base, starts, close } = await relayDashboard()
+  try {
+    const body = JSON.stringify({ prompt: 'do it', kind: 'build', options: { autopilot: true } })
+    const unauth = await postAuth(`${base}/_relay/start`, body)
+    assert.equal(unauth.status, 401) // the #1051 guard fronts the relay too
+    assert.equal(starts.length, 0)
+
+    const ok = await postAuth(`${base}/_relay/start`, body, `fw_daemon=${TOKEN}`)
+    assert.equal(ok.status, 200)
+    assert.deepEqual(JSON.parse(ok.body), { ok: true, runId: 'srv-run' })
+    assert.equal(starts.length, 1)
+    assert.equal(starts[0]!.prompt, 'do it')
+    assert.equal(starts[0]!.projectId, undefined) // slice 1 runs in the device's own home checkout
+  } finally {
+    await close()
+  }
+})
+
+test('/_relay/start strips a nested remote target so a relayed run never relays onward (#1067)', async () => {
+  const { base, starts, close } = await relayDashboard()
+  try {
+    const body = JSON.stringify({ prompt: 'x', kind: 'build', options: { remote: { url: 'http://evil', token: 'z' }, autopilot: true } })
+    const ok = await postAuth(`${base}/_relay/start`, body, `fw_daemon=${TOKEN}`)
+    assert.equal(ok.status, 200)
+    assert.equal(starts[0]!.options.remote, undefined) // the onward target was dropped
+    assert.equal(starts[0]!.options.autopilot, true) // the rest of the options survive
+  } finally {
+    await close()
+  }
+})
+
+test('/_relay/events needs the cookie and streams the run\'s events as ndjson (#1067)', async () => {
+  const { base, close } = await relayDashboard()
+  try {
+    const unauth = await fetchAuth(`${base}/_relay/events?run=srv-run`)
+    assert.equal(unauth.status, 401)
+
+    const streamed = await readNdjson(`${base}/_relay/events?run=srv-run`, `fw_daemon=${TOKEN}`, 2)
+    assert.equal(streamed.status, 200)
+    assert.deepEqual(streamed.lines.map(l => (l as { message?: string }).message), ['e1', 'e2'])
+  } finally {
+    await close()
   }
 })
 

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -9,7 +9,8 @@ import { BROWSER_PROXY_PREFIX, handleBrowserProxy } from './browser-proxy.js'
 import { makeTelefuncMount } from './telefunc-serve.js'
 import { requestPathname } from '../request-path.js'
 import type { AddProjectResult, PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from './types.js'
-import type { PreviewHandlers } from './telefunc-serve.js'
+import type { EventsSource, PreviewHandlers } from './telefunc-serve.js'
+import { handleRelayRequest, RELAY_PREFIX, type RelayHandlers } from './relay-endpoints.js'
 
 /** Options for {@link startDashboard}. */
 export interface DashboardOptions {
@@ -75,11 +76,23 @@ export interface DashboardOptions {
   clientBundleDir?: string
   /**
    * The shared token that guards a non-loopback bind (#1051): with it set, every route (static
-   * bundle, `/_telefunc`, `/browser`) needs a valid `fw_daemon` cookie or a matching `?token=`,
-   * else 401. Omit for a loopback bind, where the guard is a no-op and local UX is byte-identical.
-   * A separate concern from the CSRF origin check in telefunc-serve.ts, which it composes with.
+   * bundle, `/_telefunc`, `/browser`, `/_relay`) needs a valid `fw_daemon` cookie or a matching
+   * `?token=`, else 401. Omit for a loopback bind, where the guard is a no-op and local UX is
+   * byte-identical. A separate concern from the CSRF origin check in telefunc-serve.ts.
    */
   token?: string
+  /**
+   * The live-events source for a run this daemon is relaying from a connected device (#1067): a
+   * stream for such a run, else undefined so `onEvents` tails the on-disk log. Only the daemon
+   * wires one; the per-run dashboard and the relay leave it unset.
+   */
+  eventsSource?: EventsSource
+  /**
+   * Serve a relay-started run's events back to the daemon that relayed it here (#1067): the two
+   * `/_relay/*` endpoints (start + events). Only the daemon wires one, and both are fronted by the
+   * same `token` guard above, so a device without the cookie cannot start or read a run.
+   */
+  relay?: { tailEvents: (runId: string, onEvent: (event: import('../events.js').FrameworkEvent) => void) => () => void }
 }
 
 /** A running localhost dashboard: the prerendered SPA + its Telefunc mount. */
@@ -126,9 +139,15 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
     ...(opts.projects ? { projects: opts.projects } : {}),
     ...(opts.onAddProject ? { addProject: opts.onAddProject } : {}),
     ...(opts.preview ? { preview: opts.preview } : {}),
+    ...(opts.eventsSource ? { eventsSource: opts.eventsSource } : {}),
     preferences: opts.preferences ?? registryPreferencesStore(),
     quota,
   })
+
+  // The device-to-daemon relay endpoints (#1067): wired only when the daemon supplies both a start
+  // and an events tail. Fronted by the same token guard as every other route below.
+  const relayHandlers: RelayHandlers | undefined =
+    opts.onStart && opts.relay ? { start: opts.onStart, tailEvents: opts.relay.tailEvents } : undefined
 
   const token = opts.token
   const server = createServer((req, res) => {
@@ -139,6 +158,12 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
     }
     // #1051: one guard fronting every route on a non-loopback bind; a no-op when no token is set.
     if (token !== undefined && !authorizeDaemonRequest(req, res, token)) return
+    // The device relay (#1067): another daemon posts a run here and streams its events back. Behind
+    // the guard above, so a device without the cookie is already 401'd; unwired hosts 404 it.
+    if (pathname === RELAY_PREFIX || pathname.startsWith(`${RELAY_PREFIX}/`)) {
+      void handleRelayRequest(req, res, pathname, relayHandlers)
+      return
+    }
     if (pathname === '/_telefunc' || pathname.startsWith('/_telefunc/')) {
       void telefuncMount(req, res)
       return

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -203,6 +203,8 @@ function listenDashboard(server: Server, host: string, port: number, close: () =
 }
 
 function closeServer(server: Server): Promise<void> {
+  // Force-close keep-alive + streaming sockets (e.g. an open /_relay/events body, #1067) so close() resolves instead of waiting on them.
+  server.closeAllConnections()
   return new Promise(resolvePromise => server.close(() => resolvePromise()))
 }
 

--- a/packages/framework/src/dashboard/telefunc-serve.ts
+++ b/packages/framework/src/dashboard/telefunc-serve.ts
@@ -30,9 +30,10 @@ export interface PreviewHandlers {
   status: (projectId?: string, runId?: string) => PreviewStatus | Promise<PreviewStatus>
 }
 
-/** Resolve a project id to its live event stream (#426): the relay feeds `onEvents` from
- * its own in-memory stream rather than a file on disk. */
-export type EventsSource = (projectId: string) => AsyncIterable<FrameworkEvent> | undefined
+/** Resolve a run to its live event stream: the relay feeds `onEvents` from its own in-memory stream
+ * rather than a file on disk (#426), and the daemon feeds a run it is relaying from a device (#1067).
+ * Returns undefined when there is no in-memory stream, so `onEvents` falls back to tailing the log. */
+export type EventsSource = (projectId: string, runId?: string) => AsyncIterable<FrameworkEvent> | undefined
 
 /**
  * The Telefunc request context the mount provides. `sendStart` reads `startRun` from it;

--- a/packages/framework/src/dashboard/types.ts
+++ b/packages/framework/src/dashboard/types.ts
@@ -66,6 +66,15 @@ export interface StartRunOptions {
    * instead of spawning an unrelated-looking second one.
    */
   continueRunId?: string
+  /**
+   * Run this session on a connected device (#1067): the local daemon relays the run to the remote
+   * daemon at `url` (authenticating with `token` as the `fw_daemon` cookie) and streams its events
+   * back into the local run view. Memory-only relay config the dashboard sets at submit time from a
+   * saved device. NEVER persisted to Preferences or the registry, and never a CLI flag: a device
+   * token is a per-browser secret. Absent = run locally, exactly as today. Stripped before the run
+   * is forwarded, so the remote starts an ordinary local run and does not relay onward.
+   */
+  remote?: { url: string; token: string }
 }
 
 /**


### PR DESCRIPTION
Part of #1067 (Tier 2 of the #1049 "Run on" work). **Slice 1: submit + live events.**

Pick a saved device in the "Run on" gear, **stay on this dashboard**, submit, and the session runs on that device and streams its events back into the current run view. No navigation, no lost prompt.

## How (server-side relay, the decided approach)
The browser never talks cross-origin. The **local daemon** holds the device's token (passed per-run, in-memory, never persisted, via `StartRunOptions.remote`) and drives the remote: it POSTs the remote's `/_relay/start`, then fetch-streams the remote's `/_relay/events` back into a local `EventStream` the dashboard reads over its normal same-origin `onEvents`. Auth is the #1051 cookie sent daemon-to-daemon (`Cookie: fw_daemon=<token>`, no Origin). New: `dashboard/remote-run.ts` (relay client + `RelayedRuns`), `dashboard/relay-endpoints.ts` (`/_relay/start` + `/_relay/events`, cookie-guarded), `lib/remote-target.ts`, `RemoteRunNotice.tsx`; wiring in `daemon-runtime.ts` (onStart takes the remote branch, skips the local worktree + busy-guard), `server.ts`, `OptionsMenu.tsx`/`Composer.tsx`/`StartRunForm.tsx`.

## Deferred to slices 2-3 (shown as a graceful "not available for remote runs yet" state)
Diff/code panels, push/PR/handoff relay, and the browser screencast for a remote run.

## Verified
- **Two-daemon integration test (the real proof): green** - a run submitted with `options.remote` is created on the *other* daemon, the local busy-guard never fires, and the events stream back in order.
- Framework 1154 pass / 0 fail / 1 pre-existing skip (incl. new `/_relay/*` endpoint + relay-client + relay-events tests). Dashboard 371 pass.
- Includes a real shutdown fix: `closeServer` now `closeAllConnections()` so an open relay-events stream can't hang `server.close()`.

## Known follow-up
The `/_relay/events` response stays open after a run completes (the tail has no completion signal); a finished remote run relies on the terminal event to flip the UI, and the socket is freed on disconnect/shutdown. Tightening this (end the response on run completion) is a small slice-1.1 / slice-2 item.

Part of #1067