### PR TITLE
feat(framework): device online/offline status + remove-device in the Run on gear (#1072)

### DIFF
--- a/.changeset/device-status-remove.md
+++ b/.changeset/device-status-remove.md
@@ -1,0 +1,8 @@
+---
+'@gemstack/framework': minor
+'@gemstack/framework-dashboard': minor
+---
+
+Devices: online/offline status and remove-device in the "Run on" gear (#1072).
+
+Each saved-device row in the gear gains a remove (X) control that drops the device; if the removed device was the selected run target, the selection clears back to a driver target. The gear device rows and the connection indicator now show a green (online) / grey (offline) reachability dot, and an offline row is muted and labelled. The device tokens stay browser-side (per #1052), so the browser hands the local daemon each device's {url, token} and the daemon does a cookie'd `GET /_relay/ping` to report reachable or not; a short client poll drives the dots. The new ping endpoint is cookie-guarded (401 without) and starts nothing.

--- a/packages/framework-dashboard/components/Composer.test.tsx
+++ b/packages/framework-dashboard/components/Composer.test.tsx
@@ -22,6 +22,8 @@ vi.mock('../lib/preferences.js', () => ({
 vi.mock('../lib/editors.js', () => ({ useDetectedEditors: () => [] }))
 // Composer loads its own projects for the `@` picker (#743); stub the read to none.
 vi.mock('../server/projects.telefunc.js', () => ({ onProjects: () => Promise.resolve([]) }))
+// The device health poll (#1072) reaches the daemon over Telefunc; stub it to no devices reachable.
+vi.mock('../server/devices.telefunc.js', () => ({ checkDevices: () => Promise.resolve({}) }))
 
 // Stub the Tiptap editor (it needs a real DOM/ProseMirror): a plain input driving onChange, a
 // "type-submit" button firing onSubmit, and a ref exposing the same handle the composer calls.

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -21,8 +21,9 @@ import { PresetsMenu } from './PresetsMenu.js'
 import { AgentModelMenu, type AgentOption } from './AgentModelMenu.js'
 import { OptionsMenu, type OptionRow, type RunTarget } from './OptionsMenu.js'
 import { AddDeviceDialog } from './AddDeviceDialog.js'
-import { useConnectionProfiles, connectLocal, isLoopbackHost, type ConnectionProfile } from '../lib/profiles.js'
+import { useConnectionProfiles, connectLocal, isLoopbackHost, removeProfile, type ConnectionProfile } from '../lib/profiles.js'
 import { useSelectedRemoteDeviceId, selectRemoteDevice } from '../lib/remote-target.js'
+import { useDeviceStatus } from '../lib/use-device-status.js'
 import { stashDraftFromUrl, takePendingDraft } from '../lib/draft-handoff.js'
 import { ResolvedOptions } from './ResolvedOptions.js'
 import { ClaudeLogo, CodexLogo } from './agent-logos.js'
@@ -129,6 +130,7 @@ export const Composer = forwardRef<ComposerHandle, {
   // The saved daemons this browser can hop to (#1052). Which one we are on now comes from the URL,
   // fixed for the page's life (a device switch reloads), so it is read once rather than as state.
   const profiles = useConnectionProfiles()
+  const deviceStatus = useDeviceStatus(profiles) // #1072: online/offline per saved device
   const selectedDeviceId = useSelectedRemoteDeviceId() // #1067: the device this run targets, if any
   const currentUrl = typeof window === 'undefined' ? null : window.location.origin
   const isLocalConnection = typeof window === 'undefined' ? true : isLoopbackHost(window.location.hostname)
@@ -343,6 +345,12 @@ export const Composer = forwardRef<ComposerHandle, {
               onSelectDriver: () => selectRemoteDevice(null),
               onConnectLocal: connectLocal,
               onAddDevice: () => setAddingDevice(true),
+              // #1072: drop a saved device; clear the selection if it was the run target.
+              onRemove: (p: ConnectionProfile) => {
+                if (selectedDeviceId === p.id) selectRemoteDevice(null)
+                removeProfile(p.id)
+              },
+              status: deviceStatus,
             },
           })}
     />

--- a/packages/framework-dashboard/components/ConnectionIndicator.tsx
+++ b/packages/framework-dashboard/components/ConnectionIndicator.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from 'react'
 import { Laptop, MonitorSmartphone } from 'lucide-react'
 import { useConnectionProfiles, currentConnection, rememberLocalOrigin } from '../lib/profiles.js'
+import { useDeviceStatus } from '../lib/use-device-status.js'
 import { stashDraftFromUrl } from '../lib/draft-handoff.js'
+import { cn } from '../lib/utils.js'
 
 // The "connected to <label>" indicator (#1052): which daemon the dashboard is talking to. Every
 // transport is same-origin, so the browser's origin IS the connection — loopback is this machine's
@@ -9,6 +11,7 @@ import { stashDraftFromUrl } from '../lib/draft-handoff.js'
 // a remote box (where the agent runs on someone else's hardware) is never mistaken for your own.
 export function ConnectionIndicator() {
   const profiles = useConnectionProfiles()
+  const deviceStatus = useDeviceStatus(profiles) // #1072: reachability of the saved devices
   // Remember the loopback origin we launched from, so "Local" can return to the right port later.
   // Also move any carried draft (#1066) out of the URL at SPA boot, before it reaches the address bar.
   useEffect(() => {
@@ -17,8 +20,11 @@ export function ConnectionIndicator() {
     rememberLocalOrigin(window.location.origin, window.location.hostname)
   }, [])
   if (typeof window === 'undefined') return null
-  const { label, isLocal } = currentConnection(profiles, window.location.origin, window.location.hostname)
+  const origin = window.location.origin
+  const { label, isLocal } = currentConnection(profiles, origin, window.location.hostname)
   const Icon = isLocal ? Laptop : MonitorSmartphone
+  // On this machine the dot is trivially online; on a remote device it follows the poll (#1072).
+  const online = isLocal || deviceStatus[profiles.find(p => p.url === origin)?.id ?? ''] === 'online'
   return (
     <span
       title={isLocal ? 'Connected to this machine' : `Connected to ${label} — the agent runs on that device`}
@@ -28,6 +34,10 @@ export function ConnectionIndicator() {
           : 'inline-flex items-center gap-1.5 rounded-md border border-[var(--color-primary)]/40 bg-[var(--color-primary)]/10 px-2 py-1 text-xs text-[var(--color-primary)]'
       }
     >
+      <span
+        aria-hidden
+        className={cn('h-2 w-2 shrink-0 rounded-full', online ? 'bg-success' : 'bg-muted-foreground/40')}
+      />
       <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden />
       <span className="max-w-[10rem] truncate">{label}</span>
     </span>

--- a/packages/framework-dashboard/components/OptionsMenu.test.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.test.tsx
@@ -111,6 +111,8 @@ describe('OptionsMenu (#654)', () => {
     onSelectDriver: vi.fn(),
     onConnectLocal: vi.fn(),
     onAddDevice: vi.fn(),
+    onRemove: vi.fn(),
+    status: {},
     ...over,
   })
 
@@ -223,6 +225,30 @@ describe('OptionsMenu (#654)', () => {
     openRunOn(connectionControl({ onAddDevice }))
     fireEvent.click(screen.getByText('Add a device…'))
     expect(onAddDevice).toHaveBeenCalled()
+  })
+
+  test('the X removes a device without selecting it (#1072)', () => {
+    const onRemove = vi.fn()
+    const onSelect = vi.fn()
+    openRunOn(connectionControl({ onRemove, onSelect }))
+    fireEvent.click(screen.getByRole('button', { name: /remove device Studio/i }))
+    expect(onRemove).toHaveBeenCalledWith(profiles()[0])
+    expect(onSelect).not.toHaveBeenCalled() // the row's own click stays out of it
+  })
+
+  test('an offline device row is marked offline (#1072)', () => {
+    openRunOn(connectionControl({ status: { [STUDIO_URL]: 'offline' } }))
+    // The url carries an "offline" note and the row is muted, so an unreachable device reads as such.
+    const offlineText = screen.getByText(/offline/i)
+    expect(offlineText).toBeTruthy()
+    expect((offlineText.closest('[role="menuitem"]') as HTMLElement).className).toMatch(/opacity-60/)
+  })
+
+  test('an online device row renders a status dot and is not marked offline (#1072)', () => {
+    openRunOn(connectionControl({ status: { [STUDIO_URL]: 'online' } }))
+    const row = rowOf(STUDIO_URL)
+    expect(row.querySelector('span.rounded-full')).not.toBeNull() // the dot renders per device
+    expect(row.className).not.toMatch(/opacity-60/)
   })
 
   test('the device rows are absent without a connection control (#1066)', () => {

--- a/packages/framework-dashboard/components/OptionsMenu.tsx
+++ b/packages/framework-dashboard/components/OptionsMenu.tsx
@@ -1,7 +1,8 @@
 import type { Preferences } from '@gemstack/framework'
-import { Settings, Check, MonitorSmartphone, Plus } from 'lucide-react'
+import { Settings, Check, MonitorSmartphone, Plus, X } from 'lucide-react'
 import { updatePreferences } from '../lib/preferences.js'
 import type { ConnectionProfile } from '../lib/profiles.js'
+import type { DeviceStatus } from '../lib/use-device-status.js'
 import { cn } from '../lib/utils.js'
 import { buttonVariants } from './ui/button.js'
 import {
@@ -76,6 +77,23 @@ export type ConnectionControl = {
   /** Return to this machine's own daemon when currently on a remote one (#1066). */
   onConnectLocal: () => void
   onAddDevice: () => void
+  /** Drop a saved device (#1072). The caller clears the selection if this was the run target. */
+  onRemove: (profile: ConnectionProfile) => void
+  /** Each device's online/offline status (#1072); an id absent from the map is still being checked. */
+  status: Record<string, DeviceStatus>
+}
+
+/** A small reachability dot on a device row (#1072): green online, muted offline or still unknown. */
+function StatusDot({ status }: { status: DeviceStatus | undefined }) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        'mt-1.5 h-2 w-2 shrink-0 rounded-full',
+        status === 'online' ? 'bg-success' : 'bg-muted-foreground/40',
+      )}
+    />
+  )
 }
 
 // The run targets the gear offers (#1050). A single-select modeled on the agent tree (Check-marked
@@ -137,14 +155,37 @@ function RunTargetSub({ control, connection, busy }: { control: RunTargetControl
           <OptionLabel label="Claude web" description="Coming soon." />
         </DropdownMenuItem>
         {/* Saved devices (#1052/#1066/#1067): a click SELECTS the device as the run target (no
-            navigation): the local daemon relays the run to it and streams its events back. */}
-        {connection?.profiles.map(profile => (
-          <DropdownMenuItem key={profile.id} className="items-start" onClick={() => connection.onSelect(profile)}>
-            <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', isTargetDevice(profile) ? 'opacity-100' : 'opacity-0')} />
-            <MonitorSmartphone className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
-            <OptionLabel label={profile.label} description={profile.url} />
-          </DropdownMenuItem>
-        ))}
+            navigation): the local daemon relays the run to it and streams its events back. The dot
+            shows reachability (#1072) and the X removes the saved device. */}
+        {connection?.profiles.map(profile => {
+          const status = connection.status[profile.id]
+          const offline = status === 'offline'
+          return (
+            <DropdownMenuItem
+              key={profile.id}
+              className={cn('items-start gap-2', offline && 'opacity-60')}
+              onClick={() => connection.onSelect(profile)}
+            >
+              <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', isTargetDevice(profile) ? 'opacity-100' : 'opacity-0')} />
+              <MonitorSmartphone className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+              <StatusDot status={status} />
+              <OptionLabel label={profile.label} description={offline ? `${profile.url} (offline)` : profile.url} />
+              <button
+                type="button"
+                onClick={e => {
+                  // Remove, not select: keep the row's own click out of it (#1072).
+                  e.stopPropagation()
+                  connection.onRemove(profile)
+                }}
+                title={`Remove ${profile.label}`}
+                aria-label={`Remove device ${profile.label}`}
+                className="mt-0.5 rounded p-0.5 text-[var(--color-muted-foreground)] hover:text-danger"
+              >
+                <X className="h-3.5 w-3.5" aria-hidden />
+              </button>
+            </DropdownMenuItem>
+          )
+        })}
         {connection && (
           <DropdownMenuItem className="items-start" disabled={busy} onClick={() => connection.onAddDevice()}>
             <Plus className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />

--- a/packages/framework-dashboard/lib/use-device-status.test.tsx
+++ b/packages/framework-dashboard/lib/use-device-status.test.tsx
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import type { ConnectionProfile } from './profiles.js'
+
+const checkDevices = vi.hoisted(() => vi.fn())
+vi.mock('../server/devices.telefunc.js', () => ({ checkDevices }))
+
+const { useDeviceStatus } = await import('./use-device-status.js')
+
+afterEach(() => {
+  cleanup()
+  checkDevices.mockReset()
+})
+
+const STUDIO = 'http://192.168.1.5:4200'
+const profiles: ConnectionProfile[] = [{ id: STUDIO, label: 'Studio', url: STUDIO, token: 'aaa' }]
+
+function Probe({ list = profiles }: { list?: ConnectionProfile[] }) {
+  const status = useDeviceStatus(list)
+  return <span>{status[STUDIO] ?? 'unknown'}</span>
+}
+
+// #1072: the browser holds the tokens, so it hands the daemon each device and reads back a reachable
+// map. The dots are display-only, so this just has to surface online/offline as the poll answers.
+describe('useDeviceStatus', () => {
+  test('a reachable device surfaces online', async () => {
+    checkDevices.mockResolvedValue({ [STUDIO]: true })
+    render(<Probe />)
+    await waitFor(() => expect(screen.getByText('online')).toBeTruthy())
+    // It passed the device's id/url/token to the daemon for the cookie'd ping.
+    expect(checkDevices).toHaveBeenCalledWith([{ id: STUDIO, url: STUDIO, token: 'aaa' }])
+  })
+
+  test('an unreachable device surfaces offline', async () => {
+    checkDevices.mockResolvedValue({ [STUDIO]: false })
+    render(<Probe />)
+    await waitFor(() => expect(screen.getByText('offline')).toBeTruthy())
+  })
+
+  test('with no saved devices it never polls', async () => {
+    render(<Probe list={[]} />)
+    await new Promise(resolve => setTimeout(resolve, 30))
+    expect(checkDevices).not.toHaveBeenCalled()
+    expect(screen.getByText('unknown')).toBeTruthy()
+  })
+})

--- a/packages/framework-dashboard/lib/use-device-status.ts
+++ b/packages/framework-dashboard/lib/use-device-status.ts
@@ -1,0 +1,37 @@
+import { useMemo } from 'react'
+import type { ConnectionProfile } from './profiles.js'
+import { usePolled } from './use-async.js'
+import { checkDevices } from '../server/devices.telefunc.js'
+
+// The saved devices' online/offline status (#1072). The daemon holds no device token (they are a
+// per-browser secret, #1052), so the browser hands it each device's {id, url, token} and the daemon
+// does the cookie'd ping; this polls that on a short interval. Display-only, so nothing binds a
+// control to the poll value: the status dots just read the map.
+
+/** A saved device's reachability, or absent while the first check is still out (reads as "unknown"). */
+export type DeviceStatus = 'online' | 'offline'
+
+/** How often to re-check the saved devices. Cheap: one 3s-capped ping each, no agent involved. */
+const POLL_MS = 10_000
+
+/**
+ * Poll each saved device's reachability and return an id -> status map. An id missing from the map
+ * means the first check has not come back yet (draw it neutral, not offline). Prerender has no
+ * daemon, so it starts empty and fills on the client.
+ */
+export function useDeviceStatus(profiles: ConnectionProfile[]): Record<string, DeviceStatus> {
+  const targets = profiles.filter(p => p.token).map(p => ({ id: p.id, url: p.url, token: p.token }))
+  // Re-poll only when the device set itself changes, not on every render (targets is a fresh array).
+  const key = targets.map(t => t.id).join('|')
+  const load = useMemo(
+    () => (targets.length ? () => checkDevices(targets) : null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [key],
+  )
+  const reachable = usePolled<Record<string, boolean>>(load, {}, POLL_MS, [key]).value
+  return useMemo(() => {
+    const out: Record<string, DeviceStatus> = {}
+    for (const [id, ok] of Object.entries(reachable)) out[id] = ok ? 'online' : 'offline'
+    return out
+  }, [reachable])
+}

--- a/packages/framework-dashboard/server/devices.telefunc.ts
+++ b/packages/framework-dashboard/server/devices.telefunc.ts
@@ -1,0 +1,9 @@
+// Re-export shim (#1072): the saved-devices health telefunction lives in @gemstack/framework so the
+// daemon serves it in-process and does the cookie'd cross-origin ping. Keeping this file at
+// `server/devices.telefunc.ts` bakes the RPC key `/server/devices.telefunc.ts` the daemon registers
+// under (framework's dashboard-rpc/register.ts). Imported then exported, not re-exported (#1014):
+// telefunc's dev transform appends `__decorateTelefunction(<name>, ...)` per export, which an
+// `export ... from` gives no local binding for.
+import { checkDevices } from '@gemstack/framework/dashboard-rpc'
+
+export { checkDevices }

--- a/packages/framework/src/dashboard-rpc/devices.telefunc.test.ts
+++ b/packages/framework/src/dashboard-rpc/devices.telefunc.test.ts
@@ -1,0 +1,38 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { checkDevices } from './devices.telefunc.js'
+
+// A throwaway daemon that answers /_relay/ping with a fixed status (or nothing on 000 = down).
+async function device(status: number): Promise<{ url: string; close: () => Promise<void> }> {
+  const srv: Server = createServer((_req, res) => {
+    res.writeHead(status)
+    res.end()
+  })
+  await new Promise<void>(r => srv.listen(0, '127.0.0.1', () => r()))
+  const port = (srv.address() as AddressInfo).port
+  return { url: `http://127.0.0.1:${port}`, close: () => new Promise<void>(r => srv.close(() => r())) }
+}
+
+test('checkDevices maps each device id to whether it answered (#1072)', async () => {
+  const up = await device(200)
+  const down = await device(401)
+  try {
+    const result = await checkDevices([
+      { id: 'up', url: up.url, token: 't' },
+      { id: 'down', url: down.url, token: 't' },
+      { id: 'gone', url: 'http://127.0.0.1:1', token: 't' }, // nothing listening
+    ])
+    assert.deepEqual(result, { up: true, down: false, gone: false })
+  } finally {
+    await up.close()
+    await down.close()
+  }
+})
+
+test('checkDevices drops malformed entries and returns {} for none (#1072)', async () => {
+  assert.deepEqual(await checkDevices([]), {})
+  // Bad shapes from the browser are filtered, not pinged, so they never appear in the map.
+  assert.deepEqual(await checkDevices([{ id: 1 } as never, null as never]), {})
+})

--- a/packages/framework/src/dashboard-rpc/devices.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/devices.telefunc.ts
@@ -1,0 +1,25 @@
+import { pingRemote } from '../dashboard/remote-run.js'
+
+// The saved-devices health surface (#1072). The tokens live browser-side (per #1052), so the browser
+// hands this daemon each device's {id, url, token} and the daemon does the cookie'd cross-origin
+// ping; the token is used for the check and never persisted. Returns a reachable map the status dots
+// read. No context needed: it acts only on what the browser passed, so it is inert on any host.
+
+/** One device to health-check: its profile id plus the origin and token to reach it with. */
+export interface DeviceCheck {
+  id: string
+  url: string
+  token: string
+}
+
+function isDeviceCheck(value: unknown): value is DeviceCheck {
+  const d = value as Partial<DeviceCheck> | null
+  return !!d && typeof d.id === 'string' && typeof d.url === 'string' && typeof d.token === 'string'
+}
+
+/** Ping each saved device and map its id to whether it answered (#1072). Bad entries are dropped. */
+export async function checkDevices(devices: DeviceCheck[]): Promise<Record<string, boolean>> {
+  const valid = (Array.isArray(devices) ? devices : []).filter(isDeviceCheck)
+  const entries = await Promise.all(valid.map(async d => [d.id, await pingRemote({ url: d.url, token: d.token })] as const))
+  return Object.fromEntries(entries)
+}

--- a/packages/framework/src/dashboard-rpc/index.ts
+++ b/packages/framework/src/dashboard-rpc/index.ts
@@ -20,4 +20,5 @@ export {
 } from './preferences.telefunc.js'
 export { type EditorInfo } from '../dashboard/open-in-app.js'
 export { onQuota } from './quota.telefunc.js'
+export { checkDevices, type DeviceCheck } from './devices.telefunc.js'
 export { registerDashboardTelefunctions, DASHBOARD_TELEFUNC_KEYS } from './register.js'

--- a/packages/framework/src/dashboard-rpc/register.test.ts
+++ b/packages/framework/src/dashboard-rpc/register.test.ts
@@ -7,6 +7,7 @@ import * as events from './events.telefunc.js'
 import * as projects from './projects.telefunc.js'
 import * as preferences from './preferences.telefunc.js'
 import * as quota from './quota.telefunc.js'
+import * as devices from './devices.telefunc.js'
 
 // Every telefunction the dashboard can call has to be registered here, because the daemon
 // serves a prebuilt bundle and has no Vite transform to discover them by file path. One that
@@ -20,6 +21,7 @@ const MODULES: Array<[string, Record<string, unknown>]> = [
   ['projects', projects],
   ['preferences', preferences],
   ['quota', quota],
+  ['devices', devices],
 ]
 
 test('every exported telefunction is registered (#866)', () => {

--- a/packages/framework/src/dashboard-rpc/register.ts
+++ b/packages/framework/src/dashboard-rpc/register.ts
@@ -5,6 +5,7 @@ import * as events from './events.telefunc.js'
 import * as projects from './projects.telefunc.js'
 import * as preferences from './preferences.telefunc.js'
 import * as quota from './quota.telefunc.js'
+import * as devices from './devices.telefunc.js'
 
 // The client bakes each RPC key from the dashboard's source path (relative to its Vite
 // root, keeping the `.ts` extension) as `"<telefuncFilePath>:<exportName>"`. Since the
@@ -18,6 +19,7 @@ export const DASHBOARD_TELEFUNC_KEYS = {
   projects: '/server/projects.telefunc.ts',
   preferences: '/server/preferences.telefunc.ts',
   quota: '/server/quota.telefunc.ts',
+  devices: '/server/devices.telefunc.ts',
 } as const
 
 // Every function export of these modules is a telefunction; each is registered under its own
@@ -30,6 +32,7 @@ const TELEFUNC_MODULES: Record<keyof typeof DASHBOARD_TELEFUNC_KEYS, Record<stri
   projects,
   preferences,
   quota,
+  devices,
 }
 
 let registered = false

--- a/packages/framework/src/dashboard/relay-endpoints.ts
+++ b/packages/framework/src/dashboard/relay-endpoints.ts
@@ -13,6 +13,9 @@ import type { StartRunKind, StartRunOptions, StartRunResult } from './types.js'
  *   runs in this device's own home checkout (slice 1); which project it targets is a later slice.
  * - `GET  /_relay/events?run=<id>` streams that run's events as newline-delimited JSON until it
  *   ends or the caller disconnects.
+ * - `GET  /_relay/ping` (#1072) a cookie-guarded reachability probe: 200 and an empty body, starts
+ *   nothing. The online/offline status the dashboard shows is the local daemon calling this on each
+ *   saved device with its token; a token-less caller is already 401'd by the #1051 guard above.
  */
 export const RELAY_PREFIX = '/_relay'
 
@@ -38,10 +41,21 @@ export async function handleRelayRequest(
   pathname: string,
   handlers: RelayHandlers | undefined,
 ): Promise<void> {
+  // Ping is a pure reachability + auth probe (#1072): it needs no wired handlers and starts nothing,
+  // so it answers even on a host that enabled no relay. Reaching here means the cookie already passed.
+  if (pathname === `${RELAY_PREFIX}/ping`) return handlePing(req, res)
   if (!handlers) return end(res, 404, 'relay not enabled')
   if (pathname === `${RELAY_PREFIX}/start`) return handleStart(req, res, handlers)
   if (pathname === `${RELAY_PREFIX}/events`) return handleEvents(req, res, handlers)
   end(res, 404, 'not found')
+}
+
+/** `GET /_relay/ping` (#1072): answer 200 with an empty body. Starts nothing; only proves this
+ * daemon is reachable and the caller's cookie is valid (the #1051 guard already enforced that). */
+function handlePing(req: IncomingMessage, res: ServerResponse): void {
+  if (req.method !== 'GET') return end(res, 405, 'method not allowed', { allow: 'GET' })
+  res.writeHead(200, { 'content-type': 'text/plain' })
+  res.end()
 }
 
 /** `POST /_relay/start`: read the run request, start it locally, and answer with the result JSON. */

--- a/packages/framework/src/dashboard/remote-run.test.ts
+++ b/packages/framework/src/dashboard/remote-run.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import type { AddressInfo } from 'node:net'
-import { startRemoteRun, streamRemoteEvents, RelayedRuns } from './remote-run.js'
+import { startRemoteRun, streamRemoteEvents, pingRemote, RelayedRuns } from './remote-run.js'
 import type { FrameworkEvent } from '../events.js'
 
 // A throwaway loopback server; the handler decides how it answers. Returns its base url + close.
@@ -61,6 +61,40 @@ test('startRemoteRun surfaces a non-2xx from the device as an ok:false result (#
   } finally {
     await srv.close()
   }
+})
+
+test('pingRemote GETs /_relay/ping with the fw_daemon cookie and is true on a 2xx (#1072)', async () => {
+  let captured: { method?: string | undefined; url?: string | undefined; cookie?: string | undefined } = {}
+  const srv = await server((req, res) => {
+    captured = { method: req.method, url: req.url, cookie: req.headers.cookie }
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end()
+  })
+  try {
+    assert.equal(await pingRemote({ url: srv.url, token: 'sekret' }), true)
+    assert.equal(captured.method, 'GET')
+    assert.equal(captured.url, '/_relay/ping')
+    assert.equal(captured.cookie, 'fw_daemon=sekret') // the #1051 cookie, daemon to daemon
+  } finally {
+    await srv.close()
+  }
+})
+
+test('pingRemote is false on a non-2xx from the device (#1072)', async () => {
+  const srv = await server((_req, res) => {
+    res.writeHead(401, { 'content-type': 'text/plain' })
+    res.end('unauthorized')
+  })
+  try {
+    assert.equal(await pingRemote({ url: srv.url, token: 'wrong' }), false)
+  } finally {
+    await srv.close()
+  }
+})
+
+test('pingRemote is false when the device is unreachable (#1072)', async () => {
+  // A port nothing is listening on: the fetch rejects, which pingRemote swallows as offline.
+  assert.equal(await pingRemote({ url: 'http://127.0.0.1:1', token: 't' }), false)
 })
 
 test('streamRemoteEvents parses ndjson lines in order and ends when the body closes (#1067)', async () => {

--- a/packages/framework/src/dashboard/remote-run.ts
+++ b/packages/framework/src/dashboard/remote-run.ts
@@ -30,6 +30,27 @@ export interface RelayStartBody {
 
 const START_TIMEOUT_MS = 15_000
 
+/** How long a status ping waits before calling a device offline (#1072): short, since it polls. */
+const PING_TIMEOUT_MS = 3_000
+
+/**
+ * Health-check a saved device (#1072): a cookie'd `GET /_relay/ping`, true on any 2xx, false on a
+ * non-2xx, an unreachable host, or the timeout. The token stays in memory for the check only, never
+ * persisted, same as {@link startRemoteRun}. This is how the browser's status dots learn reachable
+ * from not: it has the tokens, the daemon does the cross-origin request.
+ */
+export async function pingRemote(target: RemoteTarget): Promise<boolean> {
+  try {
+    const res = await fetch(`${trimSlashes(target.url)}/_relay/ping`, {
+      headers: { cookie: `fw_daemon=${target.token}` },
+      signal: AbortSignal.timeout(PING_TIMEOUT_MS),
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
 /** The two headers every relay request carries: JSON, and the #1051 cookie. No Origin on purpose. */
 function relayHeaders(token: string): Record<string, string> {
   return { 'content-type': 'application/json', cookie: `fw_daemon=${token}` }

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -398,6 +398,21 @@ test('/_relay/events needs the cookie and streams the run\'s events as ndjson (#
   }
 })
 
+test('/_relay/ping is 401 without the cookie, 200 with it, and starts nothing (#1072)', async () => {
+  const { base, starts, close } = await relayDashboard()
+  try {
+    const unauth = await fetchAuth(`${base}/_relay/ping`)
+    assert.equal(unauth.status, 401) // the #1051 guard fronts the ping too
+
+    const ok = await fetchAuth(`${base}/_relay/ping`, `fw_daemon=${TOKEN}`)
+    assert.equal(ok.status, 200)
+    assert.equal(ok.body, '') // an empty body: it only proves reachability
+    assert.equal(starts.length, 0) // a health check must never spawn a run
+  } finally {
+    await close()
+  }
+})
+
 test('isSameOriginRequest: absent Origin passes; same host + loopback pass; evil.com fails', () => {
   const req = (headers: Record<string, string>): IncomingMessage => ({ headers } as IncomingMessage)
   assert.equal(isSameOriginRequest(req({})), true) // no Origin (curl / tests)


### PR DESCRIPTION
Wires the three "connect a device once" gaps from #1072.

## Remove device
Each saved-device row in the "Run on" gear gets a remove (X) control calling the existing `removeProfile(id)`. If the removed device was the selected run target, the selection clears back to a driver target (`selectRemoteDevice(null)`). The row's primary click still selects-as-target (no regression of #1067).

## Online/offline status
Tokens stay browser-side (#1052), so health-checking is: the browser hands the local daemon each saved device's `{url, token}` and the daemon does a cookie'd request to each.

- New cookie-guarded `GET /_relay/ping` on the device daemon (relay-endpoints.ts, routed alongside the other `/_relay/*` routes). 401 without the `fw_daemon` cookie, 200 with it, starts nothing.
- `pingRemote(target)` daemon-side: a cookie'd `GET .../_relay/ping` with a 3s `AbortSignal.timeout`, true on 2xx, false on any error/timeout. Token stays in memory for the check only.
- `checkDevices(devices)` telefunc mapping ids to booleans, registered under the baked key like the other RPCs.
- `useDeviceStatus(profiles)` client hook polling every 10s, returning `Record<id, 'online' | 'offline'>`. Display-only, so nothing binds a control to the poll value.
- The gear device rows and the `ConnectionIndicator` show a green (online) / grey (offline) dot; an offline row is muted and labelled `(offline)`.

## Verify
- typecheck: both packages clean.
- framework tests: 1160 pass (adds pingRemote true/non-2xx/unreachable, `/_relay/ping` 401-vs-200-and-starts-nothing, checkDevices id->bool mapping + malformed-drop).
- framework-dashboard tests: 379 pass (adds OptionsMenu remove-without-select + offline-marked + online-dot, useDeviceStatus polls online/offline).

Closes #1072