### PR TITLE
feat(dashboard): block Start on an offline "Run on" device and ask the user to pick another target

### DIFF
--- a/.changeset/offline-device-start-gate.md
+++ b/.changeset/offline-device-start-gate.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework-dashboard": minor
+---
+
+Block Start when the selected "Run on" device is offline. When the run target is a saved device whose live status (from #1072) is offline, the submit button is disabled and a note asks you to pick another target in the "Run on" gear. Pressing Start no longer silently attempts the slow relay, and the target is never switched automatically (#1073). An unknown or still-checking status does not block.

--- a/packages/framework-dashboard/components/Composer.test.tsx
+++ b/packages/framework-dashboard/components/Composer.test.tsx
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import type { Preferences } from '@gemstack/framework'
+import { addProfile } from '../lib/profiles.js'
+import { selectRemoteDevice } from '../lib/remote-target.js'
 
 // Preferences are the shared daemon store; stub them so the composer reads a fixed value.
 const updatePreferences = vi.hoisted(() => vi.fn())
@@ -22,8 +24,10 @@ vi.mock('../lib/preferences.js', () => ({
 vi.mock('../lib/editors.js', () => ({ useDetectedEditors: () => [] }))
 // Composer loads its own projects for the `@` picker (#743); stub the read to none.
 vi.mock('../server/projects.telefunc.js', () => ({ onProjects: () => Promise.resolve([]) }))
-// The device health poll (#1072) reaches the daemon over Telefunc; stub it to no devices reachable.
-vi.mock('../server/devices.telefunc.js', () => ({ checkDevices: () => Promise.resolve({}) }))
+// The device health poll (#1072) reaches the daemon over Telefunc; a hoisted stub so each test can
+// answer online/offline for the "Run on" target (#1073).
+const checkDevices = vi.hoisted(() => vi.fn())
+vi.mock('../server/devices.telefunc.js', () => ({ checkDevices }))
 
 // Stub the Tiptap editor (it needs a real DOM/ProseMirror): a plain input driving onChange, a
 // "type-submit" button firing onSubmit, and a ref exposing the same handle the composer calls.
@@ -73,8 +77,14 @@ beforeEach(() => {
   prefs = {}
   updatePreferences.mockReset()
   sessionStorage.clear()
+  localStorage.clear()
+  selectRemoteDevice(null)
+  checkDevices.mockReset()
+  checkDevices.mockResolvedValue({}) // default: no devices reachable
 })
 afterEach(cleanup)
+
+const STUDIO = 'http://192.168.1.5:4200'
 
 describe('Composer (#721)', () => {
   test('renders the full control row: agent/model, options gear, and the submit button', () => {
@@ -213,5 +223,36 @@ describe('Composer (#721)', () => {
     fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'just a question' } })
     fireEvent.click(screen.getByRole('button', { name: 'Send' }))
     expect(onSubmit).toHaveBeenCalledWith('just a question', 'build', { newSession: false })
+  })
+
+  // #1073: pressing Start on an offline "Run on" device would silently attempt the ~15s relay, so
+  // Start is blocked with a reason pointing back to the gear. No auto-fallback: the target stays.
+  test('an offline "Run on" device disables Start and shows the reason (#1073)', async () => {
+    checkDevices.mockResolvedValue({ [STUDIO]: false })
+    addProfile({ url: STUDIO, token: 'aaa', label: 'Studio' })
+    selectRemoteDevice(STUDIO)
+    const { onSubmit } = renderComposer()
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'ship it' } })
+    await waitFor(() => expect(screen.getByText(/Studio is offline/)).toBeTruthy())
+    const submit = screen.getByRole('button', { name: 'Send' })
+    expect(submit.hasAttribute('disabled')).toBe(true)
+    // Both the click and the editor shortcut are blocked.
+    fireEvent.click(submit)
+    fireEvent.click(screen.getByText('editor-submit'))
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  test('an online "Run on" device leaves Start enabled with no offline note (#1073)', async () => {
+    checkDevices.mockResolvedValue({ [STUDIO]: true })
+    addProfile({ url: STUDIO, token: 'aaa', label: 'Studio' })
+    selectRemoteDevice(STUDIO)
+    const { onSubmit } = renderComposer()
+    fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'ship it' } })
+    await waitFor(() => expect(checkDevices).toHaveBeenCalled())
+    expect(screen.queryByText(/is offline/)).toBeNull()
+    const submit = screen.getByRole('button', { name: 'Send' })
+    expect(submit.hasAttribute('disabled')).toBe(false)
+    fireEvent.click(submit)
+    expect(onSubmit).toHaveBeenCalledWith('ship it', 'build', { newSession: false })
   })
 })

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -132,6 +132,9 @@ export const Composer = forwardRef<ComposerHandle, {
   const profiles = useConnectionProfiles()
   const deviceStatus = useDeviceStatus(profiles) // #1072: online/offline per saved device
   const selectedDeviceId = useSelectedRemoteDeviceId() // #1067: the device this run targets, if any
+  const selectedDevice = selectedDeviceId ? profiles.find(p => p.id === selectedDeviceId) : undefined
+  // #1073: block Start when the target device is known-offline; an absent/unknown status must not block.
+  const targetOffline = !!selectedDeviceId && deviceStatus[selectedDeviceId] === 'offline'
   const currentUrl = typeof window === 'undefined' ? null : window.location.origin
   const isLocalConnection = typeof window === 'undefined' ? true : isLoopbackHost(window.location.hostname)
   // The registered projects for the `@` picker — the same list the launcher reads.
@@ -208,7 +211,8 @@ export const Composer = forwardRef<ComposerHandle, {
   const submit = (e?: FormEvent) => {
     e?.preventDefault()
     const text = prompt.trim()
-    if (!text || busy || submittingRef.current) return
+    // #1073: a keyboard submit must be blocked too when the target device is offline.
+    if (!text || busy || submittingRef.current || targetOffline) return
     submittingRef.current = true
     void Promise.resolve(onSubmit(text, kind, { newSession })).finally(() => {
       submittingRef.current = false
@@ -368,7 +372,7 @@ export const Composer = forwardRef<ComposerHandle, {
       type="submit"
       size="icon-sm"
       onClick={submit}
-      disabled={busy || !hasPrompt}
+      disabled={busy || !hasPrompt || targetOffline}
       aria-hidden={!hasPrompt}
       tabIndex={hasPrompt ? undefined : -1}
       aria-label={submitLabel}
@@ -386,6 +390,13 @@ export const Composer = forwardRef<ComposerHandle, {
     >
       {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowUp className="h-4 w-4" />}
     </Button>
+  )
+
+  // #1073: an offline target blocks Start; say so and point back to the "Run on" gear. No auto-fallback.
+  const offlineNote = targetOffline && (
+    <p role="alert" className="mt-2 text-xs text-danger">
+      {`${selectedDevice?.label ?? 'The selected device'} is offline. Pick another target in "Run on" to start.`}
+    </p>
   )
 
   // The "Add a device" modal (#1052), rendered by both forms since the gear is in both. A portal, so
@@ -425,6 +436,8 @@ export const Composer = forwardRef<ComposerHandle, {
           </div>
         </div>
       </div>
+
+      {offlineNote}
 
       {/* The "In play" row (#842/#1046): the Enhanced System Prompt dropdown at the start, the
           resolved-options strip at the end. Off in the compact row (one line) and in-session


### PR DESCRIPTION
When the selected run target is a saved device whose live status (#1072) is offline, pressing Start would silently attempt the slow relay. This disables the submit button and shows a short note pointing back to the "Run on" gear so the user picks another target. There is no automatic fallback: the selected target is never switched for the user. An unknown or still-checking status does not block, only an explicit offline does. The keyboard submit path is blocked too.

Closes #1073