### PR TITLE
feat(framework): relay a remote run's reads, diffs, steering and push/PR to the device (#1067, slice 2)

### DIFF
--- a/.changeset/remote-run-relay-slice2.md
+++ b/.changeset/remote-run-relay-slice2.md
@@ -1,0 +1,6 @@
+---
+"@gemstack/framework": minor
+"@gemstack/framework-dashboard": minor
+---
+
+A run started on a connected device is now a true peer: its file reads, diffs, git status, worktree, run-handoff, live steering, and push/open-PR all work by relaying each run-scoped RPC to the device over the #1051 token cookie, keyed by a durable per-run marker on the local daemon; push and PR run on the device's own checkout. The run view's diff and handoff panels are no longer suppressed for remote runs (#1067, slice 2). The browser preview stays local-only for now (slice 3).

--- a/packages/framework-dashboard/components/RemoteRunNotice.tsx
+++ b/packages/framework-dashboard/components/RemoteRunNotice.tsx
@@ -1,17 +1,17 @@
 import { MonitorSmartphone } from 'lucide-react'
 
-// The run view's banner for a session running on a connected device (#1067, slice 1). The live feed
-// streams back through the local daemon and renders normally; what does NOT work yet lives on the
-// remote device (its worktree, diff, PR, handoff, and browser screencast), so this says where the
-// run executes and that those panels are not wired for remote runs yet. Renders nothing without a
-// device label, so the run view can mount it unconditionally.
+// The run view's banner for a session running on a connected device (#1067, slice 2). Its live feed,
+// diff, worktree, handoff, and push/PR all relay back through the local daemon and render normally; the
+// one thing still local-only is the browser preview (slice 3), so this only flags where the run executes
+// and that the screencast is not available for a remote run yet. Renders nothing without a device label,
+// so the run view can mount it unconditionally.
 export function RemoteRunNotice({ device }: { device?: string | undefined }) {
   if (!device) return null
   return (
     <div role="status" className="flex items-center gap-2 border-b border-border bg-muted/40 px-4 py-2 text-xs text-muted-foreground">
       <MonitorSmartphone className="h-3.5 w-3.5 shrink-0" aria-hidden />
       <span className="min-w-0 flex-1">
-        Running on {device}. The live output streams here; the diff, PR, and browser panels are not available for remote runs yet.
+        Running on {device}. Its worktree, diff, and pull request live on the device; the browser preview is not available for remote runs yet.
       </span>
     </div>
   )

--- a/packages/framework-dashboard/components/RunView.tsx
+++ b/packages/framework-dashboard/components/RunView.tsx
@@ -54,8 +54,8 @@ export function RunView({
   /** Where the run executes (#1053): `actions` swaps the live feed for a burst-mode affordance. */
   target?: 'local' | 'actions' | undefined
   /** The device this run executes on (#1067), when it is relayed to a connected one. Set only for a
-   *  just-started remote run: the local daemon has no worktree/diff/PR for it, so the panels that
-   *  read those are suppressed and a "runs on <device>" notice takes their place. */
+   *  just-started remote run: its diff, handoff, and push/PR now relay to the device (slice 2), so the
+   *  panels are shown, and a "runs on <device>" notice only flags that the browser preview stays local. */
   remoteLabel?: string | undefined
   files: string[]
   addContext: (path: string) => void
@@ -129,15 +129,15 @@ export function RunView({
       {/* What the session has touched, behind the branch row's disclosure. While it runs that is
           its worktree; once it ends, the branch it left behind. The live read needs the run's id:
           without one it falls back to the project root and would report the user's own dirty
-          files as the run's. A remote run's worktree lives on the device, not here (#1067), so this
-          local read is suppressed for it rather than reporting the wrong tree. */}
-      {live && runId && !remoteLabel && <RunChanges projectId={projectId} runId={runId} open={open} onSummary={onChangesSummary} />}
+          files as the run's. A remote run's worktree lives on the device, but the diff now relays
+          there (#1067 slice 2), so it is shown like a local run's, not suppressed. */}
+      {live && runId && <RunChanges projectId={projectId} runId={runId} open={open} onSummary={onChangesSummary} />}
       {!live && open && <RunHandoffDetails handoff={handoff.handoff} />}
       {/* A GitHub Actions run replays in a burst at the end (#1053), so the live feed looks stalled:
           say the wait is expected and link through to the live Actions run. */}
       <ActionsRunNotice target={target} events={shown} live={live} />
-      {/* A run relayed to a connected device (#1067): the live feed streams here, but its diff, PR,
-          and browser panels are not wired for remote runs yet. */}
+      {/* A run relayed to a connected device (#1067): its diff, handoff, and push/PR now relay to the
+          device (slice 2), so this notice only flags that the browser preview stays local-only for now. */}
       <RemoteRunNotice device={remoteLabel} />
       {/* Nothing to show yet is not the same thing in both states: a live run is waiting for its
           first event, a finished one is still reading its log. */}

--- a/packages/framework/src/daemon-runtime.ts
+++ b/packages/framework/src/daemon-runtime.ts
@@ -26,8 +26,9 @@ import {
 } from './store/index.js'
 import type { FrameworkEvent } from './events.js'
 import type { StartRunKind, StartRunOptions, StartRunResult, AddProjectResult } from './dashboard/index.js'
-import type { EventsSource, PreviewHandlers } from './dashboard/telefunc-serve.js'
+import type { EventsSource, PreviewHandlers, RemoteRuns } from './dashboard/telefunc-serve.js'
 import { RelayedRuns, startRemoteRun } from './dashboard/remote-run.js'
+import { dispatchRelayRpc } from './dashboard-rpc/relay-dispatch.js'
 import { tailEvents } from './dashboard-rpc/events-tail.js'
 import { isSafeVia } from './conversations.js'
 import { createPreviewRuntime } from './preview-runtime.js'
@@ -189,6 +190,12 @@ export interface ProjectRuntime {
   /** Tail a relay-started run's on-disk events (#1067): the daemon's `/_relay/events` endpoint uses
    *  it to stream one run back to whichever daemon relayed it here. */
   tailRelayEvents: (runId: string, onEvent: (event: FrameworkEvent) => void) => () => void
+  /** The relayed-run lookup the dashboard's read RPCs consult (#1067 slice 2): which device a remote
+   *  run runs on, so a run-scoped RPC forwards there instead of resolving a local checkout. */
+  remoteRuns: RemoteRuns
+  /** The device side of the relay (#1067 slice 2): run one whitelisted read/steer/handoff RPC against
+   *  this daemon's own home checkout, for a daemon that relayed a run here. */
+  onRelayRpc: (fn: string, args: unknown[]) => Promise<unknown>
   /** Live runs on a project (#685), so a background job can tell an idle project from a busy one. */
   activeRunCount: (targetProjectId: string) => number
   /**
@@ -214,6 +221,12 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
   const starting = new Set<string>() // reserved keys mid-spawn, to close the async gap
   // Runs this daemon is relaying to/from a connected device (#1067): the local half of a remote run.
   const relayedRuns = new RelayedRuns()
+  // The relayed-run lookup the dashboard's read RPCs consult (#1067 slice 2): is this runId remote, and
+  // which device owns it. Outlives the event stream so a finished remote run's push/PR still reaches it.
+  const remoteRuns: RemoteRuns = { target: runId => relayedRuns.target(runId) }
+  // The device side of the relay (#1067 slice 2): run one whitelisted read/steer/handoff RPC against this
+  // daemon's own home checkout, for a daemon that relayed a run here. Home id forces the addressed project.
+  const onRelayRpc = (fn: string, args: unknown[]): Promise<unknown> => dispatchRelayRpc(homeId, fn, args)
 
   // A project id resolves to its repo path via the registry; the home id (or none)
   // resolves to the daemon's own `cwd` without a lookup.
@@ -536,6 +549,8 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
     preview: previews.preview,
     remoteEventsSource,
     tailRelayEvents,
+    remoteRuns,
+    onRelayRpc,
     activeRunCount,
     suspendRuns,
     dispose,

--- a/packages/framework/src/daemon.ts
+++ b/packages/framework/src/daemon.ts
@@ -367,9 +367,11 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     onAddProject: runtime.onAddProject,
     preview: runtime.preview,
     // Relay a run to/from a connected device (#1067): the events source streams a run this daemon
-    // is relaying, and the `/_relay/*` endpoints let another daemon run a session here.
+    // is relaying, `remote` lets the read RPCs forward a remote run's reads/steer/push to its device
+    // (slice 2), and the `/_relay/*` endpoints let another daemon run + read + steer a session here.
     eventsSource: runtime.remoteEventsSource,
-    relay: { tailEvents: runtime.tailRelayEvents },
+    remote: runtime.remoteRuns,
+    relay: { tailEvents: runtime.tailRelayEvents, rpc: runtime.onRelayRpc },
     ...(token ? { token } : {}),
     ...(clientBundleDir ? { clientBundleDir } : {}),
   })

--- a/packages/framework/src/dashboard-rpc/context.ts
+++ b/packages/framework/src/dashboard-rpc/context.ts
@@ -1,7 +1,7 @@
 import { getContext } from 'telefunc'
 import { resolveRunCheckout } from '../store/index.js'
 import { defaultProjectsProvider, type ProjectsProvider } from '../dashboard/projects.js'
-import type { DashboardContext, EventsSource } from '../dashboard/telefunc-serve.js'
+import type { DashboardContext, EventsSource, RemoteRuns } from '../dashboard/telefunc-serve.js'
 import type { PreferencesStore } from '../registry.js'
 import type { QuotaSource } from '../dashboard/quota.js'
 
@@ -66,6 +66,16 @@ export function contextPreview(): DashboardContext['preview'] {
  */
 export function contextEventsSource(): EventsSource | undefined {
   return fromContext(ctx => ctx.eventsSource)
+}
+
+/**
+ * The relayed-run lookup on the context (#1067 slice 2), or undefined off the daemon. Only the daemon
+ * wires it; a run-scoped RPC uses it to tell an ordinary local run (resolve a local checkout) from one
+ * running on a connected device (forward the call there). Unset everywhere else, so those RPCs behave
+ * exactly as before.
+ */
+export function contextRemote(): RemoteRuns | undefined {
+  return fromContext(ctx => ctx.remote)
 }
 
 /**

--- a/packages/framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/control.telefunc.ts
@@ -3,6 +3,7 @@ import { appendControl, type ControlEntry } from '../control.js'
 import { isSafeVia } from '../conversations.js'
 import { openInApp, type OpenTarget, type OpenResult } from '../dashboard/open-in-app.js'
 import { resolveProjectPath, resolveRunPath, contextPreferences, contextPreview } from './context.js'
+import { relayOr } from './relay-run.js'
 import { appendFlatTodoEntry } from '../todo-loop.js'
 import { findRun, isSafeRunId, type RunMeta } from '../store/index.js'
 import { removeProjectWorktree, deleteProjectRun } from '../worktrees.js'
@@ -45,7 +46,9 @@ async function appendControlFor(projectId: string, entry: ControlEntry, runId?: 
 
 /** Stop a live run (the Stop button): append a stop entry to the run's control log. */
 export async function sendStop(projectId: string, runId?: string): Promise<void> {
-  await appendControlFor(projectId, { kind: 'stop' }, runId)
+  return relayOr(runId, 'sendStop', [projectId, runId], async () => {
+    await appendControlFor(projectId, { kind: 'stop' }, runId)
+  }, undefined)
 }
 
 /**
@@ -60,7 +63,9 @@ export async function sendChoice(
   by: ChoiceBy = 'user',
   runId?: string,
 ): Promise<void> {
-  await appendControlFor(projectId, { kind: 'choice', id, pick, by }, runId)
+  return relayOr(runId, 'sendChoice', [projectId, id, pick, by, runId], async () => {
+    await appendControlFor(projectId, { kind: 'choice', id, pick, by }, runId)
+  }, undefined)
 }
 
 /**
@@ -76,8 +81,10 @@ export async function sendChoice(
 export async function sendMessage(projectId: string, text: string, runId?: string, via?: string): Promise<void> {
   const message = text.trim()
   if (!message) return
-  const origin = isSafeVia(via) ? { via } : {}
-  await appendControlFor(projectId, { kind: 'message', text: message, ...origin }, runId)
+  return relayOr(runId, 'sendMessage', [projectId, text, runId, via], async () => {
+    const origin = isSafeVia(via) ? { via } : {}
+    await appendControlFor(projectId, { kind: 'message', text: message, ...origin }, runId)
+  }, undefined)
 }
 
 /**
@@ -219,9 +226,11 @@ async function handoffTargetFor(projectId: string, runId: string): Promise<{ cwd
  * to a shared remote under the user's name, which is the user's call.
  */
 export async function sendPushBranch(projectId: string, runId: string): Promise<HandoffResult> {
-  const target = await handoffTargetFor(projectId, runId)
-  if (!target) return { ok: false, error: 'unknown session' }
-  return pushRunBranch(target.cwd, runBranchFor(target.run))
+  return relayOr(runId, 'sendPushBranch', [projectId, runId], async () => {
+    const target = await handoffTargetFor(projectId, runId)
+    if (!target) return { ok: false, error: 'unknown session' }
+    return pushRunBranch(target.cwd, runBranchFor(target.run))
+  }, { ok: false, error: 'could not reach the device' })
 }
 
 /**
@@ -232,9 +241,11 @@ export async function sendPushBranch(projectId: string, runId: string): Promise<
  * user, which is the point of "offer the next step rather than describe it".
  */
 export async function sendOpenPullRequest(projectId: string, runId: string): Promise<HandoffResult> {
-  const target = await handoffTargetFor(projectId, runId)
-  if (!target) return { ok: false, error: 'unknown session' }
-  return openSessionPullRequest(target.cwd, target.run)
+  return relayOr(runId, 'sendOpenPullRequest', [projectId, runId], async () => {
+    const target = await handoffTargetFor(projectId, runId)
+    if (!target) return { ok: false, error: 'unknown session' }
+    return openSessionPullRequest(target.cwd, target.run)
+  }, { ok: false, error: 'could not reach the device' })
 }
 
 /** What {@link sendQueueTicket} did: the backlog file written, or why it could not be. */

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -18,6 +18,7 @@ import { readFileStatuses, type FileGitStatus } from '../dashboard/file-status.j
 import { readFileDiff, readFileChanges, type FileDiff, type FileChange } from '../dashboard/file-diff.js'
 import { readFileContent, type FileContent } from '../dashboard/file-read.js'
 import { contextProjects, resolveProjectPath, resolveRunPath } from './context.js'
+import { relayOr } from './relay-run.js'
 import type { FrameworkEvent } from '../events.js'
 
 // The read model behind the new dashboard (#405): the run history, a run's replay, the
@@ -102,38 +103,42 @@ export async function onRetainedWorktrees(projectId: string): Promise<string[]> 
  * working tree is the user's, not the agent's.
  */
 export async function onRunWorktree(projectId: string, runId: string): Promise<RunWorktree | null> {
-  const root = await resolveProjectPath(projectId)
-  if (!root || !isSafeRunId(runId)) return null
-  const path = await resolveRunPath(projectId, runId)
-  if (!path) return null
-  const own = path !== root
-  const [status, live] = await Promise.all([
-    readGitStatus(path).catch(() => undefined),
-    readLiveMetas(root).catch(() => []),
-  ])
-  // Size is only read for a checkout nothing is writing to: a live run's tree changes under the
-  // poll, and `du` over a build directory mid-build is a cost with no answer worth having.
-  const running = live.some(run => run.id === runId && run.status === 'running')
-  const size = own && !running ? await worktreeSize(path) : undefined
-  return {
-    path,
-    own,
-    dirty: status?.dirty ?? false,
-    ...(status?.branch ? { branch: status.branch } : {}),
-    ...(size !== undefined ? { sizeBytes: size } : {}),
-    // The same read already looked the PR up (#809): a session's branch is exactly the thing
-    // that has one, so the session's bar can show it like the project's does.
-    ...(status?.pr ? { pr: status.pr } : {}),
-    // Still being looked up rather than absent (#1028), so the bar can ask again shortly.
-    ...(status?.prPending ? { prPending: true } : {}),
-  }
+  return relayOr(runId, 'onRunWorktree', [projectId, runId], async () => {
+    const root = await resolveProjectPath(projectId)
+    if (!root || !isSafeRunId(runId)) return null
+    const path = await resolveRunPath(projectId, runId)
+    if (!path) return null
+    const own = path !== root
+    const [status, live] = await Promise.all([
+      readGitStatus(path).catch(() => undefined),
+      readLiveMetas(root).catch(() => []),
+    ])
+    // Size is only read for a checkout nothing is writing to: a live run's tree changes under the
+    // poll, and `du` over a build directory mid-build is a cost with no answer worth having.
+    const running = live.some(run => run.id === runId && run.status === 'running')
+    const size = own && !running ? await worktreeSize(path) : undefined
+    return {
+      path,
+      own,
+      dirty: status?.dirty ?? false,
+      ...(status?.branch ? { branch: status.branch } : {}),
+      ...(size !== undefined ? { sizeBytes: size } : {}),
+      // The same read already looked the PR up (#809): a session's branch is exactly the thing
+      // that has one, so the session's bar can show it like the project's does.
+      ...(status?.pr ? { pr: status.pr } : {}),
+      // Still being looked up rather than absent (#1028), so the bar can ask again shortly.
+      ...(status?.prPending ? { prPending: true } : {}),
+    }
+  }, null)
 }
 
 /** One archived run's event log for replay (or `[]` when the run or project is gone). */
 export async function onRun(projectId: string, runId: string): Promise<FrameworkEvent[]> {
-  const cwd = await resolveProjectPath(projectId)
-  if (!cwd) return []
-  return (await loadRunEvents(cwd, runId).catch(() => undefined)) ?? []
+  return relayOr(runId, 'onRun', [projectId, runId], async () => {
+    const cwd = await resolveProjectPath(projectId)
+    if (!cwd) return []
+    return (await loadRunEvents(cwd, runId).catch(() => undefined)) ?? []
+  }, [])
 }
 
 /** The surfaced PLAN/TODO docs at the workspace root, in sidebar order (or `[]`). */
@@ -183,7 +188,7 @@ export async function onDashboard(): Promise<DashboardData> {
  * Pass a live `runId` to list that run's worktree instead of the project root (#738).
  */
 export async function onProjectFiles(projectId: string, runId?: string): Promise<string[]> {
-  return withRunPath(projectId, runId, crawlRepoFiles, [])
+  return relayOr(runId, 'onProjectFiles', [projectId, runId], () => withRunPath(projectId, runId, crawlRepoFiles, []), [])
 }
 
 /**
@@ -192,7 +197,13 @@ export async function onProjectFiles(projectId: string, runId?: string): Promise
  * Pass a live `runId` to see that run's own worktree rather than the project root (#738).
  */
 export async function onProjectFileStatus(projectId: string, runId?: string): Promise<Record<string, FileGitStatus>> {
-  return withRunPath<Record<string, FileGitStatus>>(projectId, runId, readFileStatuses, {})
+  return relayOr<Record<string, FileGitStatus>>(
+    runId,
+    'onProjectFileStatus',
+    [projectId, runId],
+    () => withRunPath<Record<string, FileGitStatus>>(projectId, runId, readFileStatuses, {}),
+    {},
+  )
 }
 
 /**
@@ -204,12 +215,14 @@ export async function onProjectFileStatus(projectId: string, runId?: string): Pr
  * that thinks a file is untracked must not be able to make the server read it as one.
  */
 export async function onFileDiff(projectId: string, path: string, runId?: string): Promise<FileDiff | null> {
-  const cwd = await resolveRunPath(projectId, runId)
-  if (!cwd) return null
-  const statuses = await readFileStatuses(cwd).catch((): Record<string, FileGitStatus> => ({}))
-  const status = statuses[path]
-  if (!status) return null
-  return readFileDiff(cwd, path, status).catch(() => null)
+  return relayOr(runId, 'onFileDiff', [projectId, path, runId], async () => {
+    const cwd = await resolveRunPath(projectId, runId)
+    if (!cwd) return null
+    const statuses = await readFileStatuses(cwd).catch((): Record<string, FileGitStatus> => ({}))
+    const status = statuses[path]
+    if (!status) return null
+    return readFileDiff(cwd, path, status).catch(() => null)
+  }, null)
 }
 
 /**
@@ -222,10 +235,12 @@ export async function onFileDiff(projectId: string, path: string, runId?: string
  * works for every agent, not just the ones whose stream carries an edit payload.
  */
 export async function onRunChanges(projectId: string, runId?: string): Promise<FileChange[]> {
-  const cwd = await resolveRunPath(projectId, runId)
-  if (!cwd) return []
-  const statuses = await readFileStatuses(cwd).catch((): Record<string, FileGitStatus> => ({}))
-  return readFileChanges(cwd, statuses).catch(() => [])
+  return relayOr(runId, 'onRunChanges', [projectId, runId], async () => {
+    const cwd = await resolveRunPath(projectId, runId)
+    if (!cwd) return []
+    const statuses = await readFileStatuses(cwd).catch((): Record<string, FileGitStatus> => ({}))
+    return readFileChanges(cwd, statuses).catch(() => [])
+  }, [])
 }
 
 /**
@@ -237,7 +252,13 @@ export async function onRunChanges(projectId: string, runId?: string): Promise<F
  * file has a diff worth seeing, an unchanged one has only itself.
  */
 export async function onFileContent(projectId: string, path: string, runId?: string): Promise<FileContent | null> {
-  return withRunPath<FileContent | null>(projectId, runId, cwd => readFileContent(cwd, path), null)
+  return relayOr<FileContent | null>(
+    runId,
+    'onFileContent',
+    [projectId, path, runId],
+    () => withRunPath<FileContent | null>(projectId, runId, cwd => readFileContent(cwd, path), null),
+    null,
+  )
 }
 
 /** The project's GitHub URL from its `origin` remote (#489), or null (no remote / not GitHub / relay). */
@@ -253,9 +274,11 @@ export async function onGithubUrl(projectId: string): Promise<string | null> {
  * state that actually belong to it (#738).
  */
 export async function onGitStatus(projectId: string, runId?: string): Promise<GitStatus | null> {
-  const cwd = await resolveRunPath(projectId, runId)
-  if (!cwd) return null
-  return (await readGitStatus(cwd)) ?? null
+  return relayOr(runId, 'onGitStatus', [projectId, runId], async () => {
+    const cwd = await resolveRunPath(projectId, runId)
+    if (!cwd) return null
+    return (await readGitStatus(cwd)) ?? null
+  }, null)
 }
 
 /**
@@ -269,11 +292,13 @@ export async function onGitStatus(projectId: string, runId?: string): Promise<Gi
  * the branch is what this asks about.
  */
 export async function onRunHandoff(projectId: string, runId: string): Promise<RunHandoff | null> {
-  const cwd = await resolveProjectPath(projectId)
-  if (!cwd || !isSafeRunId(runId)) return null
-  const run = await findRun(cwd, runId).catch(() => undefined)
-  if (!run) return null
-  return (await readRunHandoff(cwd, runBranchFor(run)).catch(() => undefined)) ?? null
+  return relayOr(runId, 'onRunHandoff', [projectId, runId], async () => {
+    const cwd = await resolveProjectPath(projectId)
+    if (!cwd || !isSafeRunId(runId)) return null
+    const run = await findRun(cwd, runId).catch(() => undefined)
+    if (!run) return null
+    return (await readRunHandoff(cwd, runBranchFor(run)).catch(() => undefined)) ?? null
+  }, null)
 }
 
 /**

--- a/packages/framework/src/dashboard-rpc/relay-dispatch.test.ts
+++ b/packages/framework/src/dashboard-rpc/relay-dispatch.test.ts
@@ -1,0 +1,35 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { dispatchRelayRpc, RELAY_RPC_NAMES } from './relay-dispatch.js'
+
+// The device-side whitelist dispatcher (#1067 slice 2): a daemon that relayed a run here calls one of a
+// fixed set of run-scoped RPCs against this device's own home checkout. These assert the whitelist is
+// exactly the run-scoped read/steer/handoff surface (and excludes start/delete), and that an unknown
+// name is refused. The real HTTP round-trip through /_relay/rpc is in remote-run.integration.test.ts.
+
+test('RELAY_RPC_NAMES is the run-scoped read/steer/handoff surface and excludes start/delete (#1067 slice 2)', () => {
+  for (const name of [
+    'onProjectFiles', 'onProjectFileStatus', 'onFileDiff', 'onRunChanges', 'onFileContent',
+    'onGitStatus', 'onRunWorktree', 'onRunHandoff', 'onRun',
+    'sendStop', 'sendChoice', 'sendMessage', 'sendPushBranch', 'sendOpenPullRequest',
+  ]) {
+    assert.ok(RELAY_RPC_NAMES.includes(name), `expected ${name} on the relay whitelist`)
+  }
+  // Starting a run, deleting a session, and removing a worktree are NOT relayable: a device runs its
+  // own guarded start, and destroying history/checkouts is not something a relaying daemon may reach.
+  for (const off of ['sendStart', 'sendDeleteSession', 'sendRemoveWorktree', 'sendPreview']) {
+    assert.ok(!RELAY_RPC_NAMES.includes(off), `${off} must not be relayable`)
+  }
+})
+
+test('dispatchRelayRpc rejects an unknown rpc name (#1067 slice 2)', async () => {
+  await assert.rejects(dispatchRelayRpc('home', 'sendStart', ['pid']), /unknown relay rpc/)
+  await assert.rejects(dispatchRelayRpc('home', 'nope', []), /unknown relay rpc/)
+})
+
+test('dispatchRelayRpc runs a whitelisted rpc against the home id and returns its empty shape (#1067 slice 2)', async () => {
+  // No project is registered under this id, so onGitStatus resolves no checkout and returns null - proof
+  // the call reached the whitelisted impl with the home id (the caller's arg[0] project id is dropped).
+  const result = await dispatchRelayRpc('the-framework:no-such-home', 'onGitStatus', ['remote-project-id', 'run-1'])
+  assert.equal(result, null)
+})

--- a/packages/framework/src/dashboard-rpc/relay-dispatch.ts
+++ b/packages/framework/src/dashboard-rpc/relay-dispatch.ts
@@ -1,0 +1,32 @@
+import { onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent, onGitStatus, onRunWorktree, onRunHandoff, onRun } from './reads.telefunc.js'
+import { sendStop, sendChoice, sendMessage, sendPushBranch, sendOpenPullRequest } from './control.telefunc.js'
+
+// The device side of the remote-run relay (#1067 slice 2). A daemon that relayed a run here asks this
+// to read/steer/hand off THAT run against THIS device's own checkout. Every entry is a run-scoped RPC
+// the dashboard already exposes to its own browser. The only change: arg[0] (the remote daemon's
+// project id, meaningless here) is replaced with this device's home project id, so a relayed call can
+// only ever address the device's own home checkout, never another registered project. These functions
+// resolve their path through the same registry the browser's own calls do (the home project is
+// registered at daemon start) and use no Telefunc request context, so calling them directly is sound.
+// Whitelist only: start/preview/delete stay OFF it.
+
+type RelayFn = (...args: unknown[]) => Promise<unknown>
+const RELAY_FNS = {
+  onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent,
+  onGitStatus, onRunWorktree, onRunHandoff, onRun,
+  sendStop, sendChoice, sendMessage, sendPushBranch, sendOpenPullRequest,
+} as unknown as Record<string, RelayFn>
+
+/** The names a relay caller may invoke. */
+export const RELAY_RPC_NAMES: readonly string[] = Object.keys(RELAY_FNS)
+
+/**
+ * Dispatch one relayed RPC against `homeId` (this device's own project). `args[0]` from the caller is
+ * the remote daemon's project id and is meaningless here, so it is replaced with `homeId`; the rest
+ * (path, runId, ...) carry through unchanged. Throws on an unknown name.
+ */
+export async function dispatchRelayRpc(homeId: string, fn: string, args: unknown[]): Promise<unknown> {
+  const impl = RELAY_FNS[fn]
+  if (!impl) throw new Error(`unknown relay rpc: ${fn}`)
+  return impl(homeId, ...args.slice(1))
+}

--- a/packages/framework/src/dashboard-rpc/relay-run.ts
+++ b/packages/framework/src/dashboard-rpc/relay-run.ts
@@ -1,0 +1,25 @@
+import { contextRemote } from './context.js'
+import { relayRpc } from '../dashboard/remote-run.js'
+
+/**
+ * Run a run-scoped RPC locally, or relay it to the device when `runId` names a run this daemon is
+ * relaying to a connected one (#1067 slice 2). For an ordinary local run the remote lookup is empty and
+ * `local()` runs unchanged. For a remote run there is no local checkout, so the call is forwarded to the
+ * device over the token; if the device is unreachable, `unreachable` is returned - the same empty/error
+ * shape `local()` gives on a failed read - so the caller never special-cases a remote run.
+ */
+export async function relayOr<T>(
+  runId: string | undefined,
+  fn: string,
+  args: unknown[],
+  local: () => Promise<T>,
+  unreachable: T,
+): Promise<T> {
+  const target = contextRemote()?.target(runId)
+  if (!target) return local()
+  try {
+    return (await relayRpc(target, fn, args)) as T
+  } catch {
+    return unreachable
+  }
+}

--- a/packages/framework/src/dashboard/relay-endpoints.ts
+++ b/packages/framework/src/dashboard/relay-endpoints.ts
@@ -16,6 +16,8 @@ import type { StartRunKind, StartRunOptions, StartRunResult } from './types.js'
  * - `GET  /_relay/ping` (#1072) a cookie-guarded reachability probe: 200 and an empty body, starts
  *   nothing. The online/offline status the dashboard shows is the local daemon calling this on each
  *   saved device with its token; a token-less caller is already 401'd by the #1051 guard above.
+ * - `POST /_relay/rpc` (#1067 slice 2) runs one whitelisted run-scoped RPC (a read/diff/steer/handoff/
+ *   push/PR) against this device's own checkout for the daemon relaying a run here, answering {result}.
  */
 export const RELAY_PREFIX = '/_relay'
 
@@ -23,6 +25,9 @@ export const RELAY_PREFIX = '/_relay'
 export interface RelayHandlers {
   start: (prompt: string, kind: StartRunKind, options: StartRunOptions, projectId?: string) => StartRunResult | Promise<StartRunResult>
   tailEvents: (runId: string, onEvent: (event: FrameworkEvent) => void) => () => void
+  /** Run one whitelisted read/steer/handoff RPC against THIS device's own checkout, for the daemon
+   *  relaying a run here (#1067 slice 2); the caller wraps the result as {result}. */
+  rpc?: (fn: string, args: unknown[]) => Promise<unknown>
 }
 
 /** The body `POST /_relay/start` accepts: exactly what a local Start needs, minus any project id. */
@@ -47,6 +52,7 @@ export async function handleRelayRequest(
   if (!handlers) return end(res, 404, 'relay not enabled')
   if (pathname === `${RELAY_PREFIX}/start`) return handleStart(req, res, handlers)
   if (pathname === `${RELAY_PREFIX}/events`) return handleEvents(req, res, handlers)
+  if (pathname === `${RELAY_PREFIX}/rpc`) return handleRpc(req, res, handlers)
   end(res, 404, 'not found')
 }
 
@@ -99,6 +105,29 @@ function handleEvents(req: IncomingMessage, res: ServerResponse, handlers: Relay
   const close = (): void => stop()
   res.on('close', close)
   req.on('close', close)
+}
+
+const MAX_RPC_BODY = 256 * 1024
+/** POST /_relay/rpc: run one whitelisted RPC on this device and answer {result}. */
+async function handleRpc(req: IncomingMessage, res: ServerResponse, handlers: RelayHandlers): Promise<void> {
+  if (req.method !== 'POST') return end(res, 405, 'method not allowed', { allow: 'POST' })
+  if (!handlers.rpc) return end(res, 404, 'relay rpc not enabled')
+  let body: { fn?: unknown; args?: unknown }
+  try {
+    body = (await readJsonBody(req, MAX_RPC_BODY)) as { fn?: unknown; args?: unknown }
+  } catch {
+    return end(res, 400, 'invalid request body')
+  }
+  const fn = typeof body.fn === 'string' ? body.fn : ''
+  const args = Array.isArray(body.args) ? body.args : []
+  if (!fn) return end(res, 400, 'missing rpc name')
+  try {
+    const result = await handlers.rpc(fn, args)
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ result }))
+  } catch (err) {
+    end(res, 500, err instanceof Error ? err.message : 'rpc failed')
+  }
 }
 
 /** Read a capped JSON request body, rejecting on overflow or malformed JSON. */

--- a/packages/framework/src/dashboard/remote-run.integration.test.ts
+++ b/packages/framework/src/dashboard/remote-run.integration.test.ts
@@ -5,11 +5,14 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { EventStream } from '@gemstack/ai-autopilot'
 import { startDashboard } from './server.js'
+import { relayRpc } from './remote-run.js'
 import { createProjectRuntime, delay } from '../daemon-runtime.js'
+import { dispatchRelayRpc } from '../dashboard-rpc/relay-dispatch.js'
 import { forwardStream } from '../dashboard-rpc/stream-channel.js'
 import { projectId } from '../registry.js'
 import type { StartRunKind, StartRunOptions, StartRunResult } from './types.js'
 import type { FrameworkEvent } from '../events.js'
+import type { HandoffResult } from './run-handoff.js'
 
 // The real two-daemon proof for "run on a connected device" (#1067). Two HTTP servers stand up on
 // loopback: daemon A (the browser's local daemon, a real project runtime) relays a run to daemon B
@@ -58,7 +61,14 @@ test('a run submitted with options.remote is created on the other daemon and its
   }
   const bTail = (runId: string, onEvent: (event: FrameworkEvent) => void): (() => void) => forwardStream(bStreams.get(runId), onEvent)
   const bundle = await fakeBundle()
-  const deviceB = await startDashboard({ port: 0, clientBundleDir: bundle, token: TOKEN, onStart: bStart, relay: { tailEvents: bTail } })
+  // B's own home checkout, whose id the device-side dispatch forces every relayed RPC onto (slice 2), so
+  // a relayed read can only ever address B's own project. A plain temp dir (no repo, not registered), which
+  // is enough to prove the /_relay/rpc path: an unregistered home resolves to no checkout, so onGitStatus
+  // comes back null - proof the call reached B's own onGitStatus and returned over the endpoint.
+  const cwdB = await mkdtemp(join(tmpdir(), 'relay-b-'))
+  const homeIdB = projectId(resolve(cwdB))
+  const bRpc = (fn: string, args: unknown[]): Promise<unknown> => dispatchRelayRpc(homeIdB, fn, args)
+  const deviceB = await startDashboard({ port: 0, clientBundleDir: bundle, token: TOKEN, onStart: bStart, relay: { tailEvents: bTail, rpc: bRpc } })
 
   // Daemon A: the browser's own daemon, a real project runtime. Its onStart takes the remote branch.
   const cwdA = await mkdtemp(join(tmpdir(), 'relay-a-'))
@@ -87,10 +97,22 @@ test('a run submitted with options.remote is created on the other daemon and its
       events.map(e => (e as { message?: string; kind?: string }).message ?? (e as { kind?: string }).kind),
       ['hello from B', 'end'],
     )
+
+    // Slice 2: a run-scoped read relays to B over /_relay/rpc and comes back. The caller's arg[0] is
+    // A's local project id; B's dispatch drops it and reads against its own home, which has no repo
+    // registered, so onGitStatus returns null - proof the call reached B's onGitStatus and returned.
+    const gitStatus = await relayRpc({ url: deviceB.url, token: TOKEN }, 'onGitStatus', [homeIdA, B_RUN])
+    assert.equal(gitStatus, null)
+
+    // And a push runs ON the device: B_RUN is not a real session on B, so its sendPushBranch returns an
+    // ok:false HandoffResult - proof the push ran on B's side (its checkout, its remote) and came back.
+    const push = (await relayRpc({ url: deviceB.url, token: TOKEN }, 'sendPushBranch', [homeIdA, B_RUN])) as HandoffResult
+    assert.equal(push.ok, false)
   } finally {
     await runtimeA.dispose()
     await deviceB.close()
     await rm(bundle, { recursive: true, force: true })
     await rm(cwdA, { recursive: true, force: true })
+    await rm(cwdB, { recursive: true, force: true })
   }
 })

--- a/packages/framework/src/dashboard/remote-run.test.ts
+++ b/packages/framework/src/dashboard/remote-run.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import type { AddressInfo } from 'node:net'
-import { startRemoteRun, streamRemoteEvents, pingRemote, RelayedRuns } from './remote-run.js'
+import { startRemoteRun, streamRemoteEvents, pingRemote, relayRpc, RelayedRuns } from './remote-run.js'
 import type { FrameworkEvent } from '../events.js'
 
 // A throwaway loopback server; the handler decides how it answers. Returns its base url + close.
@@ -177,6 +177,64 @@ test('RelayedRuns closes cleanly on a 401 with no events (#1067)', async () => {
     const got: FrameworkEvent[] = []
     for await (const e of stream!) got.push(e)
     assert.equal(got.length, 0) // a clean close, so the browser sees `done`, not `lost`
+  } finally {
+    await srv.close()
+  }
+})
+
+test('relayRpc posts to /_relay/rpc with the fw_daemon cookie, no Origin, and returns the device result (#1067 slice 2)', async () => {
+  let captured: { method?: string | undefined; url?: string | undefined; cookie?: string | undefined; origin?: string | undefined; body: unknown } = { body: null }
+  const srv = await server((req, res) => {
+    let raw = ''
+    req.on('data', c => (raw += c))
+    req.on('end', () => {
+      captured = { method: req.method, url: req.url, cookie: req.headers.cookie, origin: req.headers.origin, body: JSON.parse(raw) }
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ result: { dirty: true, branch: 'main' } }))
+    })
+  })
+  try {
+    const result = await relayRpc({ url: srv.url, token: 'sekret' }, 'onGitStatus', ['pid', 'r1'])
+    assert.deepEqual(result, { dirty: true, branch: 'main' }) // the device's own result, unwrapped from {result}
+    assert.equal(captured.method, 'POST')
+    assert.equal(captured.url, '/_relay/rpc')
+    assert.equal(captured.cookie, 'fw_daemon=sekret') // the #1051 cookie, daemon to daemon
+    assert.equal(captured.origin, undefined) // NO Origin header, so it passes the remote CSRF guard
+    assert.deepEqual(captured.body, { fn: 'onGitStatus', args: ['pid', 'r1'] })
+  } finally {
+    await srv.close()
+  }
+})
+
+test('relayRpc throws on a non-2xx from the device (#1067 slice 2)', async () => {
+  const srv = await server((_req, res) => {
+    res.writeHead(500, { 'content-type': 'text/plain' })
+    res.end('rpc failed')
+  })
+  try {
+    await assert.rejects(relayRpc({ url: srv.url, token: 't' }, 'onGitStatus', []), /500|device/)
+  } finally {
+    await srv.close()
+  }
+})
+
+test('RelayedRuns.target outlives the event stream and dispose clears it (#1067 slice 2)', async () => {
+  const srv = await server((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/x-ndjson' })
+    res.write(`${JSON.stringify({ kind: 'log', message: 'hi' })}\n`)
+    res.end()
+  })
+  try {
+    const runs = new RelayedRuns()
+    const target = { url: srv.url, token: 't' }
+    runs.register('r1', target)
+    const stream = runs.get('r1')
+    assert.ok(stream)
+    for await (const _e of stream!) { /* drain until the device closes the body, ending the pump */ }
+    assert.equal(runs.get('r1'), undefined) // the event stream is gone once the device closes
+    assert.deepEqual(runs.target('r1'), target) // but the device target outlives it, for a post-run push/PR
+    runs.dispose()
+    assert.equal(runs.target('r1'), undefined) // cleared on shutdown
   } finally {
     await srv.close()
   }

--- a/packages/framework/src/dashboard/remote-run.ts
+++ b/packages/framework/src/dashboard/remote-run.ts
@@ -76,6 +76,27 @@ export async function startRemoteRun(target: RemoteTarget, body: RelayStartBody)
   }
 }
 
+const RPC_TIMEOUT_MS = 60_000 // a relayed git push/PR runs over the network on the device
+
+/**
+ * Relay one run-scoped RPC to the device that owns a remote run (#1067 slice 2). The local daemon
+ * holds the device token, so a read/diff/handoff/push/PR for a relayed run runs ON the device: POST
+ * {fn, args} to the remote's /_relay/rpc over the #1051 cookie (no Origin), returning the device's
+ * result. Throws on an unreachable device or a non-2xx so the caller falls back to its own empty/error
+ * shape, the same way a failed local read does.
+ */
+export async function relayRpc(target: RemoteTarget, fn: string, args: unknown[]): Promise<unknown> {
+  const res = await fetch(`${trimSlashes(target.url)}/_relay/rpc`, {
+    method: 'POST',
+    headers: relayHeaders(target.token),
+    body: JSON.stringify({ fn, args }),
+    signal: AbortSignal.timeout(RPC_TIMEOUT_MS),
+  })
+  if (!res.ok) throw new Error(`the device refused the request (${res.status})`)
+  const body = (await res.json()) as { result?: unknown }
+  return body.result
+}
+
 /**
  * Fetch-stream a remote run's newline-delimited events into `onEvent` until the remote closes the
  * body, the run ends, or `cancel()` is called. A 401 (the token was rotated) ends the stream
@@ -149,17 +170,23 @@ interface RelayedRun {
 /**
  * The local daemon's live relayed runs (#1067), keyed by the remote run id. Registering a run opens
  * an {@link EventStream} the dashboard reads through `onEvents`, fed by {@link streamRemoteEvents}
- * from the remote. This map is the only place a saved device's token lives daemon-side: in memory,
- * for the run's lifetime, dropped the moment the remote stream ends.
+ * from the remote. This map is where a saved device's token lives daemon-side: in memory, for the
+ * run's lifetime.
+ *
+ * The `targets` map outlives the event pump (#1067 slice 2): a finished remote run's post-run reads,
+ * push and open-PR still have to reach the device after its event stream has ended, so the device
+ * target is kept until {@link dispose} clears it, not dropped when the stream closes.
  */
 export class RelayedRuns {
   private readonly runs = new Map<string, RelayedRun>()
+  private readonly targets = new Map<string, RemoteTarget>()
 
   /** Open a local stream for a remote run and start pumping the remote's events into it. */
   register(runId: string, target: RemoteTarget): void {
+    this.targets.set(runId, target) // kept past the stream, for post-run reads/push/PR (slice 2)
     this.runs.get(runId)?.cancel() // a re-register (same id) replaces the old pump
     const stream = new EventStream<FrameworkEvent>()
-    const cancel = streamRemoteEvents(target, runId, event => stream.push(event), () => this.drop(runId))
+    const cancel = streamRemoteEvents(target, runId, event => stream.push(event), () => this.endStream(runId))
     this.runs.set(runId, { target, stream, cancel })
   }
 
@@ -168,21 +195,27 @@ export class RelayedRuns {
     return runId ? this.runs.get(runId)?.stream : undefined
   }
 
-  /** Close a relayed run's stream and forget its token. Idempotent. */
-  private drop(runId: string): void {
+  /** The device a relayed run runs on, kept past the event stream so post-run push/PR still reach it. */
+  target(runId: string | undefined): RemoteTarget | undefined {
+    return runId ? this.targets.get(runId) : undefined
+  }
+
+  /** Close a relayed run's event stream (not its target). Idempotent. */
+  private endStream(runId: string): void {
     const run = this.runs.get(runId)
     if (!run) return
     this.runs.delete(runId)
     run.stream.close() // a clean close surfaces as `done` in the browser, not a lost stream
   }
 
-  /** Stop every pump and close every stream, on daemon shutdown. */
+  /** Stop every pump, close every stream, and forget every device target, on daemon shutdown. */
   dispose(): void {
     for (const [runId, run] of this.runs) {
       run.cancel()
       run.stream.close()
       this.runs.delete(runId)
     }
+    this.targets.clear()
   }
 }
 

--- a/packages/framework/src/dashboard/server.ts
+++ b/packages/framework/src/dashboard/server.ts
@@ -9,7 +9,7 @@ import { BROWSER_PROXY_PREFIX, handleBrowserProxy } from './browser-proxy.js'
 import { makeTelefuncMount } from './telefunc-serve.js'
 import { requestPathname } from '../request-path.js'
 import type { AddProjectResult, PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from './types.js'
-import type { EventsSource, PreviewHandlers } from './telefunc-serve.js'
+import type { EventsSource, PreviewHandlers, RemoteRuns } from './telefunc-serve.js'
 import { handleRelayRequest, RELAY_PREFIX, type RelayHandlers } from './relay-endpoints.js'
 
 /** Options for {@link startDashboard}. */
@@ -88,11 +88,20 @@ export interface DashboardOptions {
    */
   eventsSource?: EventsSource
   /**
-   * Serve a relay-started run's events back to the daemon that relayed it here (#1067): the two
-   * `/_relay/*` endpoints (start + events). Only the daemon wires one, and both are fronted by the
-   * same `token` guard above, so a device without the cookie cannot start or read a run.
+   * The relayed-run lookup the read RPCs consult (#1067 slice 2); only the daemon wires it. A run-scoped
+   * RPC uses it to forward a remote run's read/steer/handoff to the device that owns it.
    */
-  relay?: { tailEvents: (runId: string, onEvent: (event: import('../events.js').FrameworkEvent) => void) => () => void }
+  remote?: RemoteRuns
+  /**
+   * Serve a relay-started run's events back to the daemon that relayed it here (#1067): the
+   * `/_relay/*` endpoints (start + events, plus the slice-2 `rpc`). Only the daemon wires one, and all
+   * are fronted by the same `token` guard above, so a device without the cookie cannot start or read a run.
+   */
+  relay?: {
+    tailEvents: (runId: string, onEvent: (event: import('../events.js').FrameworkEvent) => void) => () => void
+    /** Run one whitelisted run-scoped RPC against this daemon's own checkout (#1067 slice 2). */
+    rpc?: (fn: string, args: unknown[]) => Promise<unknown>
+  }
 }
 
 /** A running localhost dashboard: the prerendered SPA + its Telefunc mount. */
@@ -140,6 +149,7 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
     ...(opts.onAddProject ? { addProject: opts.onAddProject } : {}),
     ...(opts.preview ? { preview: opts.preview } : {}),
     ...(opts.eventsSource ? { eventsSource: opts.eventsSource } : {}),
+    ...(opts.remote ? { remote: opts.remote } : {}),
     preferences: opts.preferences ?? registryPreferencesStore(),
     quota,
   })
@@ -147,7 +157,9 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
   // The device-to-daemon relay endpoints (#1067): wired only when the daemon supplies both a start
   // and an events tail. Fronted by the same token guard as every other route below.
   const relayHandlers: RelayHandlers | undefined =
-    opts.onStart && opts.relay ? { start: opts.onStart, tailEvents: opts.relay.tailEvents } : undefined
+    opts.onStart && opts.relay
+      ? { start: opts.onStart, tailEvents: opts.relay.tailEvents, ...(opts.relay.rpc ? { rpc: opts.relay.rpc } : {}) }
+      : undefined
 
   const token = opts.token
   const server = createServer((req, res) => {

--- a/packages/framework/src/dashboard/telefunc-serve.ts
+++ b/packages/framework/src/dashboard/telefunc-serve.ts
@@ -35,6 +35,13 @@ export interface PreviewHandlers {
  * Returns undefined when there is no in-memory stream, so `onEvents` falls back to tailing the log. */
 export type EventsSource = (projectId: string, runId?: string) => AsyncIterable<FrameworkEvent> | undefined
 
+/** Look up the device a relayed run (#1067) executes on, or undefined for an ordinary local run. The
+ *  daemon wires this from its live relayed-run map; a run-scoped RPC uses it to forward a remote run's
+ *  read/steer/handoff to that device instead of resolving a (nonexistent) local checkout. */
+export interface RemoteRuns {
+  target(runId: string | undefined): { url: string; token: string } | undefined
+}
+
 /**
  * The Telefunc request context the mount provides. `sendStart` reads `startRun` from it;
  * every project-keyed RPC reads `projects` (#427) — the daemon leaves it unset to use the
@@ -49,6 +56,9 @@ export interface DashboardContext {
   preview?: PreviewHandlers
   projects?: ProjectsProvider
   eventsSource?: EventsSource
+  /** The relayed-run lookup (#1067 slice 2): only the daemon wires it, so a run-scoped RPC can tell a
+   *  local run from one running on a connected device and forward the call there. */
+  remote?: RemoteRuns
   /** The user-preferences store (#410). The daemon/foreground wire the real registry file;
    * a public host (the relay) leaves it unset so `onPreferences`/`savePreferences` are inert. */
   preferences?: PreferencesStore


### PR DESCRIPTION
Slice 2 of the "run on a connected device" work: a remote run becomes a true peer.

## What
Every run-scoped RPC (file reads, diffs, git status, worktree, run-handoff, live steering, push, open-PR) now relays to the device that owns the run, over the #1051 token cookie (no Origin), keyed by a durable per-run marker on the local daemon. Push and open-PR run on the device's own checkout, its git remote, its gh auth.

## How
- `relayRpc(target, fn, args)` POSTs `{fn, args}` to the device's new `POST /_relay/rpc`, returning the device's `{result}`; throws on unreachable/non-2xx so the caller falls back to its own empty/error shape.
- `RelayedRuns` now keeps a `targets` map that outlives the event stream, so a finished remote run's push/PR still reaches the device; cleared only on dispose.
- Device side: `dispatchRelayRpc(homeId, fn, args)` is a whitelist of the run-scoped telefunctions and forces `arg[0]` to the device's own home project id, so a relayed call can only ever address the device's own home checkout. Start/preview/delete stay off the whitelist.
- Local side: `relayOr(runId, fn, args, local, unreachable)` runs the read locally for an ordinary run, or relays it when `runId` names a run this daemon relays. Wired via a `remote` lookup on the Telefunc request context, set only by the daemon.
- The run view's diff and handoff panels are no longer suppressed for remote runs; the notice now only flags that the browser preview stays local-only.

## Tests
- `relayRpc` cookie/no-Origin/body/result and non-2xx throw; `RelayedRuns.target` outlives the stream and is cleared on dispose.
- `dispatchRelayRpc` whitelist names + unknown-fn-throws + a real dispatch against an unregistered home.
- The two-daemon integration test drives a relayed `onGitStatus` and `sendPushBranch` end to end over `/_relay/rpc`.

Framework: 1166 pass, 0 fail. Dashboard: typecheck + build clean, 379 pass.

Note: this is slice 2 of the issue; slice 3 (the browser preview screencast for remote runs) remains.

Closes #1067