### PR TITLE
feat(framework): keep a remote run in the local session list so it survives a dashboard reload (#1077)

### DIFF
--- a/.changeset/remote-run-reload-survival.md
+++ b/.changeset/remote-run-reload-survival.md
@@ -1,0 +1,6 @@
+---
+"@gemstack/framework": minor
+"@gemstack/framework-dashboard": minor
+---
+
+A run relayed to a connected device (#1067) now appears in the local project's session list and re-opens after a dashboard reload, instead of showing "This session is gone". The local daemon keeps a lightweight in-memory RunMeta for each relayed run (target 'remote', the device label, a status that flips when the relay stream ends) and merges it into the run list; the event backlog already survives via the daemon-side stream (#1077).

--- a/packages/framework-dashboard/components/ActionsRunNotice.tsx
+++ b/packages/framework-dashboard/components/ActionsRunNotice.tsx
@@ -11,7 +11,7 @@ export function ActionsRunNotice({
   events,
   live,
 }: {
-  target?: 'local' | 'actions' | undefined
+  target?: 'local' | 'actions' | 'remote' | undefined
   events: readonly FrameworkEvent[]
   /** Whether the run is still going: the "updates on completion" line only applies while it runs. */
   live: boolean

--- a/packages/framework-dashboard/components/RightRail.tsx
+++ b/packages/framework-dashboard/components/RightRail.tsx
@@ -44,8 +44,8 @@ export function RightRail({
   toggleContext: (path: string) => void
   /** Whether the selected run is serving a browser preview (#813), i.e. it was started with Browser on. */
   hasBrowser?: boolean
-  /** Where the selected run executes (#1053): an `actions` run has no browser on the runner, so no pane. */
-  target?: 'local' | 'actions' | undefined
+  /** Where the selected run executes (#1053): an `actions` run has no browser on the runner, so no pane; `remote` (#1067) has none locally either. */
+  target?: 'local' | 'actions' | 'remote' | undefined
   /** Told when a panel starts a session (the tickets import, #948), so the shell shows it. */
   onRunStarted?: ((intent: string, runId?: string) => void) | undefined
 }) {

--- a/packages/framework-dashboard/components/RunView.tsx
+++ b/packages/framework-dashboard/components/RunView.tsx
@@ -51,8 +51,8 @@ export function RunView({
    * the stable identity, so the branch renaming itself near the end of a run (#736) reads as a
    * detail changing rather than the whole view changing. */
   label?: string | undefined
-  /** Where the run executes (#1053): `actions` swaps the live feed for a burst-mode affordance. */
-  target?: 'local' | 'actions' | undefined
+  /** Where the run executes (#1053): `actions` swaps the live feed for a burst-mode affordance; `remote` is relayed to a device (#1067). */
+  target?: 'local' | 'actions' | 'remote' | undefined
   /** The device this run executes on (#1067), when it is relayed to a connected one. Set only for a
    *  just-started remote run: its diff, handoff, and push/PR now relay to the device (slice 2), so the
    *  panels are shown, and a "runs on <device>" notice only flags that the browser preview stays local. */

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -84,7 +84,7 @@ export function StartRunForm({
   // device adds the relay target (#1067); absent, this is byte-identical to a local start.
   const options = {
     ...runOptionsFromPreferences(preferences, [...context]),
-    ...(remoteDevice ? { remote: { url: remoteDevice.url, token: remoteDevice.token } } : {}),
+    ...(remoteDevice ? { remote: { url: remoteDevice.url, token: remoteDevice.token, label: remoteDevice.label } } : {}),
   }
 
   const submit = async (text: string, submitKind: 'build' | 'prompt') => {

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -269,6 +269,7 @@ export default function Page() {
         removeContext={removeContext}
         lost={lost}
         target={selectedRun.target}
+        remoteLabel={selectedRun.remoteLabel}
         onRunStarted={onRunStarted}
         onDeleted={() => {
           // Its view is about to point at a session that no longer exists; go home and refresh

--- a/packages/framework/src/daemon-runtime.ts
+++ b/packages/framework/src/daemon-runtime.ts
@@ -20,8 +20,10 @@ import {
   resolveRunCheckout,
   FRAMEWORK_DIR,
   EVENTS_FILE,
+  RUN_META_VERSION,
   isPidAlive,
   writeSuspendedRuns,
+  type RunMeta,
   type SuspendedRun,
 } from './store/index.js'
 import type { FrameworkEvent } from './events.js'
@@ -223,7 +225,10 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
   const relayedRuns = new RelayedRuns()
   // The relayed-run lookup the dashboard's read RPCs consult (#1067 slice 2): is this runId remote, and
   // which device owns it. Outlives the event stream so a finished remote run's push/PR still reaches it.
-  const remoteRuns: RemoteRuns = { target: runId => relayedRuns.target(runId) }
+  const remoteRuns: RemoteRuns = {
+    target: runId => relayedRuns.target(runId),
+    list: projectId => relayedRuns.list(projectId),
+  }
   // The device side of the relay (#1067 slice 2): run one whitelisted read/steer/handoff RPC against this
   // daemon's own home checkout, for a daemon that relayed a run here. Home id forces the addressed project.
   const onRelayRpc = (fn: string, args: unknown[]): Promise<unknown> => dispatchRelayRpc(homeId, fn, args)
@@ -367,7 +372,23 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
     if (options.remote) {
       const { remote, ...forwarded } = options
       const result = await startRemoteRun(remote, { prompt, kind, options: forwarded })
-      if (result.ok && result.runId) relayedRuns.register(result.runId, remote)
+      if (result.ok && result.runId) {
+        // A relayed run has no local worktree or pid, so its list row is a memory-only stub (#1077):
+        // registered here so onRuns can show it and a dashboard reload re-opens it. Never written to disk.
+        const now = new Date().toISOString()
+        const meta: RunMeta = {
+          version: RUN_META_VERSION,
+          status: 'running',
+          id: result.runId,
+          startedAt: now,
+          updatedAt: now,
+          passes: 0,
+          target: 'remote',
+          ...(prompt ? { intent: prompt } : {}),
+          ...(remote.label ? { remoteLabel: remote.label } : {}),
+        }
+        relayedRuns.register(result.runId, remote, meta, targetProjectId ?? homeId)
+      }
       return result
     }
     const projectKey = targetProjectId ?? homeId

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -17,7 +17,7 @@ import { crawlRepoFiles } from '../project.js'
 import { readFileStatuses, type FileGitStatus } from '../dashboard/file-status.js'
 import { readFileDiff, readFileChanges, type FileDiff, type FileChange } from '../dashboard/file-diff.js'
 import { readFileContent, type FileContent } from '../dashboard/file-read.js'
-import { contextProjects, resolveProjectPath, resolveRunPath } from './context.js'
+import { contextProjects, contextRemote, resolveProjectPath, resolveRunPath } from './context.js'
 import { relayOr } from './relay-run.js'
 import type { FrameworkEvent } from '../events.js'
 
@@ -70,11 +70,19 @@ async function withProjects<T>(build: (projects: Awaited<ReturnType<ReturnType<t
  * would otherwise show a running run as finished. The status is not filtered on: `readLiveMeta`
  * may have just self-healed a dead run to `stopped` (#716), and that freshly-archived row can
  * lag `listRuns` by a poll — keeping it regardless leaves the row visible with no flicker.
+ *
+ * A run relayed to a connected device (#1067) lives only in the daemon's memory, never on disk, so
+ * its in-memory stub is merged in too (#1077): that is what re-opens it after a dashboard reload
+ * instead of losing it.
  */
 export async function onRuns(projectId: string): Promise<RunMeta[]> {
   const cwd = await resolveProjectPath(projectId)
-  if (!cwd) return []
-  return readAllRuns(cwd)
+  const local = cwd ? await readAllRuns(cwd) : []
+  const remote = contextRemote()?.list(projectId) ?? []
+  if (remote.length === 0) return local
+  // A relayed run (#1067) lives only in the daemon's memory, not on disk; surface it in the list so
+  // a reload re-opens it instead of losing it. Remote wins an id tie (it is the live authority).
+  return [...remote, ...local.filter(run => !remote.some(r => r.id === run.id))]
 }
 
 /**

--- a/packages/framework/src/dashboard/remote-run.integration.test.ts
+++ b/packages/framework/src/dashboard/remote-run.integration.test.ts
@@ -76,7 +76,7 @@ test('a run submitted with options.remote is created on the other daemon and its
   const homeIdA = projectId(resolve(cwdA))
 
   try {
-    const result = await runtimeA.onStart('build the thing', 'build', { remote: { url: deviceB.url, token: TOKEN } })
+    const result = await runtimeA.onStart('build the thing', 'build', { remote: { url: deviceB.url, token: TOKEN, label: 'my-laptop' } })
 
     // The run was created on B, and A returned B's own run id (not a locally allocated one).
     assert.equal(result.ok, true)
@@ -89,6 +89,17 @@ test('a run submitted with options.remote is created on the other daemon and its
     // A's own busy guard never fired: it allocated no worktree and spawned nothing.
     assert.equal(runtimeA.activeRunCount(homeIdA), 0)
 
+    // The relayed run keeps a local list row on A (#1077), so a dashboard reload re-opens it instead of
+    // losing it: a remote stub carrying B's run id, the device label, and the prompt, running until the
+    // relay stream ends. Read before draining, while it is still live.
+    const listed = runtimeA.remoteRuns.list(homeIdA)
+    assert.equal(listed.length, 1)
+    assert.equal(listed[0]!.id, B_RUN)
+    assert.equal(listed[0]!.target, 'remote')
+    assert.equal(listed[0]!.status, 'running')
+    assert.equal(listed[0]!.remoteLabel, 'my-laptop')
+    assert.equal(listed[0]!.intent, 'build the thing')
+
     // The events stream back through A's relayed-run source, in order.
     const stream = runtimeA.remoteEventsSource(homeIdA, B_RUN)
     assert.ok(stream, 'A should expose a live stream for the relayed run')
@@ -97,6 +108,10 @@ test('a run submitted with options.remote is created on the other daemon and its
       events.map(e => (e as { message?: string; kind?: string }).message ?? (e as { kind?: string }).kind),
       ['hello from B', 'end'],
     )
+
+    // B's stubbed start pushed `{kind:'end', ok:true}` and closed, so once A has drained the relayed
+    // stream the list row settles to done (#1077): the state a reload would now read off the list.
+    assert.equal(runtimeA.remoteRuns.list(homeIdA)[0]!.status, 'done')
 
     // Slice 2: a run-scoped read relays to B over /_relay/rpc and comes back. The caller's arg[0] is
     // A's local project id; B's dispatch drops it and reads against its own home, which has no repo

--- a/packages/framework/src/dashboard/remote-run.test.ts
+++ b/packages/framework/src/dashboard/remote-run.test.ts
@@ -3,6 +3,7 @@ import { test } from 'node:test'
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { startRemoteRun, streamRemoteEvents, pingRemote, relayRpc, RelayedRuns } from './remote-run.js'
+import { RUN_META_VERSION, type RunMeta } from '../store/index.js'
 import type { FrameworkEvent } from '../events.js'
 
 // A throwaway loopback server; the handler decides how it answers. Returns its base url + close.
@@ -11,6 +12,19 @@ async function server(handler: (req: IncomingMessage, res: ServerResponse) => vo
   await new Promise<void>(r => srv.listen(0, '127.0.0.1', () => r()))
   const port = (srv.address() as AddressInfo).port
   return { url: `http://127.0.0.1:${port}`, close: () => new Promise<void>(r => srv.close(() => r())) }
+}
+
+// A minimal running RunMeta stub, the local list row RelayedRuns keeps for a relayed run (#1077).
+function stubMeta(id: string, overrides: Partial<RunMeta> = {}): RunMeta {
+  const now = new Date().toISOString()
+  return { version: RUN_META_VERSION, status: 'running', id, startedAt: now, updatedAt: now, passes: 0, target: 'remote', ...overrides }
+}
+
+// Drain a RelayedRuns stream to completion, so both its `end`-driven settle and its close flip have run.
+async function drainRun(runs: RelayedRuns, runId: string): Promise<void> {
+  const stream = runs.get(runId)
+  assert.ok(stream)
+  for await (const _e of stream!) { /* consume until the device closes the body */ }
 }
 
 /** Wait until the stream ends (its `onEnd` fires) or a timeout trips, collecting events meanwhile. */
@@ -152,7 +166,7 @@ test('RelayedRuns feeds a run stream from the device and drops its token when th
   })
   try {
     const runs = new RelayedRuns()
-    runs.register('r1', { url: srv.url, token: 't' })
+    runs.register('r1', { url: srv.url, token: 't' }, stubMeta('r1'), 'proj-1')
     const stream = runs.get('r1') // grabbed synchronously, before the remote stream ends
     assert.ok(stream)
     const got: FrameworkEvent[] = []
@@ -171,7 +185,7 @@ test('RelayedRuns closes cleanly on a 401 with no events (#1067)', async () => {
   })
   try {
     const runs = new RelayedRuns()
-    runs.register('r1', { url: srv.url, token: 'stale' })
+    runs.register('r1', { url: srv.url, token: 'stale' }, stubMeta('r1'), 'proj-1')
     const stream = runs.get('r1')
     assert.ok(stream)
     const got: FrameworkEvent[] = []
@@ -218,6 +232,69 @@ test('relayRpc throws on a non-2xx from the device (#1067 slice 2)', async () =>
   }
 })
 
+test('RelayedRuns.list surfaces a relayed run as a remote row, scoped to its project (#1077)', async () => {
+  // A server that never closes the body, so the pump stays live and the row stays `running` while
+  // we read it synchronously; dispose() aborts the fetch on the way out.
+  const srv = await server((_req, res) => res.writeHead(200, { 'content-type': 'application/x-ndjson' }))
+  try {
+    const runs = new RelayedRuns()
+    runs.register('r1', { url: srv.url, token: 't' }, stubMeta('r1', { intent: 'do it' }), 'proj-1')
+    const rows = runs.list('proj-1') // read before the fetch does anything: the stub is set synchronously
+    assert.equal(rows.length, 1)
+    assert.equal(rows[0]?.id, 'r1')
+    assert.equal(rows[0]?.target, 'remote')
+    assert.equal(rows[0]?.status, 'running')
+    assert.equal(rows[0]?.intent, 'do it')
+    assert.deepEqual(runs.list('other'), []) // another project sees none of it
+    runs.dispose()
+  } finally {
+    await srv.close()
+  }
+})
+
+// Register a relayed run against a device that emits one log line then an optional end line and closes,
+// and return the status left on its list row once RelayedRuns has fully drained the stream (#1077).
+async function relayEndStatus(endEvent: FrameworkEvent | null): Promise<string | undefined> {
+  const srv = await server((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/x-ndjson' })
+    res.write(`${JSON.stringify({ kind: 'log', message: 'working' })}\n`)
+    if (endEvent) res.write(`${JSON.stringify(endEvent)}\n`)
+    res.end()
+  })
+  try {
+    const runs = new RelayedRuns()
+    runs.register('r1', { url: srv.url, token: 't' }, stubMeta('r1'), 'proj-1')
+    await drainRun(runs, 'r1')
+    return runs.list('proj-1')[0]?.status
+  } finally {
+    await srv.close()
+  }
+}
+
+test("a relayed run's list row flips to the device's ending, or stopped if the stream just drops (#1077)", async () => {
+  assert.equal(await relayEndStatus({ kind: 'end', ok: true } as FrameworkEvent), 'done')
+  assert.equal(await relayEndStatus({ kind: 'end', stopped: true, ok: false } as FrameworkEvent), 'stopped')
+  assert.equal(await relayEndStatus({ kind: 'end', ok: false } as FrameworkEvent), 'failed')
+  assert.equal(await relayEndStatus(null), 'stopped') // no end event: the stream dropped, so it is no longer live
+})
+
+test('dispose clears the relayed run list and its device target (#1077)', async () => {
+  const srv = await server((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/x-ndjson' })
+    res.end()
+  })
+  try {
+    const runs = new RelayedRuns()
+    runs.register('r1', { url: srv.url, token: 't' }, stubMeta('r1'), 'proj-1')
+    assert.equal(runs.list('proj-1').length, 1) // present before shutdown
+    runs.dispose()
+    assert.deepEqual(runs.list('proj-1'), []) // and gone after
+    assert.equal(runs.target('r1'), undefined)
+  } finally {
+    await srv.close()
+  }
+})
+
 test('RelayedRuns.target outlives the event stream and dispose clears it (#1067 slice 2)', async () => {
   const srv = await server((_req, res) => {
     res.writeHead(200, { 'content-type': 'application/x-ndjson' })
@@ -227,7 +304,7 @@ test('RelayedRuns.target outlives the event stream and dispose clears it (#1067 
   try {
     const runs = new RelayedRuns()
     const target = { url: srv.url, token: 't' }
-    runs.register('r1', target)
+    runs.register('r1', target, stubMeta('r1'), 'proj-1')
     const stream = runs.get('r1')
     assert.ok(stream)
     for await (const _e of stream!) { /* drain until the device closes the body, ending the pump */ }

--- a/packages/framework/src/dashboard/remote-run.ts
+++ b/packages/framework/src/dashboard/remote-run.ts
@@ -1,5 +1,6 @@
 import { EventStream } from '@gemstack/ai-autopilot'
 import type { FrameworkEvent } from '../events.js'
+import type { RunMeta } from '../store/index.js'
 import type { StartRunKind, StartRunOptions, StartRunResult } from './types.js'
 import { errorMessage } from '../error-message.js'
 
@@ -176,17 +177,28 @@ interface RelayedRun {
  * The `targets` map outlives the event pump (#1067 slice 2): a finished remote run's post-run reads,
  * push and open-PR still have to reach the device after its event stream has ended, so the device
  * target is kept until {@link dispose} clears it, not dropped when the stream closes.
+ *
+ * The `metas` map (#1077) holds a local {@link RunMeta} stub per relayed run so `onRuns` can show a
+ * remote run in the session list and re-open it after a dashboard reload; {@link list} projects it
+ * per project. Same lifetime as `targets`: it outlives the event stream and is cleared on dispose.
  */
 export class RelayedRuns {
   private readonly runs = new Map<string, RelayedRun>()
   private readonly targets = new Map<string, RemoteTarget>()
+  // The local RunMeta stub for each relayed run, so onRuns can show a remote run in the session list
+  // and re-open it after a reload; outlives the event stream, cleared on dispose (same lifetime as targets).
+  private readonly metas = new Map<string, { meta: RunMeta; projectId: string }>()
 
   /** Open a local stream for a remote run and start pumping the remote's events into it. */
-  register(runId: string, target: RemoteTarget): void {
+  register(runId: string, target: RemoteTarget, meta: RunMeta, projectId: string): void {
     this.targets.set(runId, target) // kept past the stream, for post-run reads/push/PR (slice 2)
+    this.metas.set(runId, { meta, projectId }) // the local list row, so a reload re-opens the run (#1077)
     this.runs.get(runId)?.cancel() // a re-register (same id) replaces the old pump
     const stream = new EventStream<FrameworkEvent>()
-    const cancel = streamRemoteEvents(target, runId, event => stream.push(event), () => this.endStream(runId))
+    const cancel = streamRemoteEvents(target, runId, event => {
+      stream.push(event)
+      if (event.kind === 'end') this.settle(runId, event) // record the run's ending on its list row
+    }, () => this.endStream(runId))
     this.runs.set(runId, { target, stream, cancel })
   }
 
@@ -200,15 +212,33 @@ export class RelayedRuns {
     return runId ? this.targets.get(runId) : undefined
   }
 
+  /** A project's relayed run stubs (#1077), newest-first, so `onRuns` can surface them in the list. */
+  list(projectId: string): RunMeta[] {
+    const rows: RunMeta[] = []
+    for (const entry of this.metas.values()) if (entry.projectId === projectId) rows.push(entry.meta)
+    // Newest first: startedAt is ISO, so a string compare is the time order (no parse).
+    return rows.sort((a, b) => (a.startedAt < b.startedAt ? 1 : a.startedAt > b.startedAt ? -1 : 0))
+  }
+
+  /** Flip a relayed run's list row to its ending when the device's stream reports one (#1077). */
+  private settle(runId: string, end: Extract<FrameworkEvent, { kind: 'end' }>): void {
+    const entry = this.metas.get(runId)
+    if (!entry) return
+    entry.meta.status = end.stopped ? 'stopped' : end.ok ? 'done' : 'failed'
+  }
+
   /** Close a relayed run's event stream (not its target). Idempotent. */
   private endStream(runId: string): void {
     const run = this.runs.get(runId)
     if (!run) return
     this.runs.delete(runId)
     run.stream.close() // a clean close surfaces as `done` in the browser, not a lost stream
+    // The stream dropped with no terminal event: the run is no longer live, so stop showing it as such.
+    const entry = this.metas.get(runId)
+    if (entry && entry.meta.status === 'running') entry.meta.status = 'stopped'
   }
 
-  /** Stop every pump, close every stream, and forget every device target, on daemon shutdown. */
+  /** Stop every pump, close every stream, and forget every device target + list stub, on daemon shutdown. */
   dispose(): void {
     for (const [runId, run] of this.runs) {
       run.cancel()
@@ -216,6 +246,7 @@ export class RelayedRuns {
       this.runs.delete(runId)
     }
     this.targets.clear()
+    this.metas.clear()
   }
 }
 

--- a/packages/framework/src/dashboard/telefunc-serve.ts
+++ b/packages/framework/src/dashboard/telefunc-serve.ts
@@ -8,6 +8,7 @@ import type { PreferencesStore } from '../registry.js'
 import type { QuotaSource } from './quota.js'
 import type { AddProjectResult, PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from './types.js'
 import type { ServeTarget } from '../preview.js'
+import type { RunMeta } from '../store/index.js'
 
 /** Wired by the daemon so `sendStart` can reach the daemon's own `startRun` closure. */
 export type StartRunHandler = (
@@ -40,6 +41,8 @@ export type EventsSource = (projectId: string, runId?: string) => AsyncIterable<
  *  read/steer/handoff to that device instead of resolving a (nonexistent) local checkout. */
 export interface RemoteRuns {
   target(runId: string | undefined): { url: string; token: string } | undefined
+  /** A project's relayed run stubs (#1077), so `onRuns` can show a remote run in the list and re-open it after a reload. */
+  list(projectId: string): RunMeta[]
 }
 
 /**

--- a/packages/framework/src/dashboard/types.ts
+++ b/packages/framework/src/dashboard/types.ts
@@ -69,12 +69,14 @@ export interface StartRunOptions {
   /**
    * Run this session on a connected device (#1067): the local daemon relays the run to the remote
    * daemon at `url` (authenticating with `token` as the `fw_daemon` cookie) and streams its events
-   * back into the local run view. Memory-only relay config the dashboard sets at submit time from a
-   * saved device. NEVER persisted to Preferences or the registry, and never a CLI flag: a device
-   * token is a per-browser secret. Absent = run locally, exactly as today. Stripped before the run
-   * is forwarded, so the remote starts an ordinary local run and does not relay onward.
+   * back into the local run view. The device `label` rides along (memory-only, like `url`/`token`) so
+   * the local session list + notice can show which device the run is on after a reload (#1077).
+   * Memory-only relay config the dashboard sets at submit time from a saved device. NEVER persisted to
+   * Preferences or the registry, and never a CLI flag: a device token is a per-browser secret. Absent =
+   * run locally, exactly as today. Stripped before the run is forwarded, so the remote starts an
+   * ordinary local run and does not relay onward.
    */
-  remote?: { url: string; token: string }
+  remote?: { url: string; token: string; label?: string }
 }
 
 /**

--- a/packages/framework/src/store/run-store.ts
+++ b/packages/framework/src/store/run-store.ts
@@ -130,11 +130,13 @@ export interface RunMeta {
    */
   browserStreamPort?: number
   /**
-   * Where this run executes (#1050/#1053): `actions` for a GitHub Actions run, absent for a local
-   * run. Persisted so the run view can tell a burst-mode Actions run from a stalled live feed and
-   * gate the browser pane off (#1053).
+   * Where this run executes (#1050/#1053): `actions` for a GitHub Actions run, `remote` when relayed
+   * to a connected device (#1067), absent for a local run. Persisted so the run view can tell a
+   * burst-mode Actions run from a stalled live feed and gate the browser pane off (#1053).
    */
-  target?: 'local' | 'actions'
+  target?: 'local' | 'actions' | 'remote'
+  /** The connected device a remote run (#1067) executes on, for the session list + notice after a reload. */
+  remoteLabel?: string
 }
 
 /**


### PR DESCRIPTION
A run relayed to a connected device (#1067) never got a local RunMeta: the `options.remote` branch in daemon-runtime returned before any RunStore opened, so the run was absent from the run list and a dashboard reload showed "This session is gone". The daemon-side event relay already survives a reload (the EventStream buffers and replays), so the fix is purely to give a relayed run an in-memory local RunMeta and merge it into onRuns.

- `RelayedRuns` now also holds a per-run RunMeta stub + project id, with a project-scoped `list()`. A terminal event flips the stub status (done/stopped/failed); a dropped stream flips a still-running stub to stopped. Nothing is written to disk (a remote run has no local worktree or pid).
- `onRuns` merges the remote stubs in, remote winning an id tie.
- The device label rides along on `options.remote` (memory-only) so the list row and the "runs on <device>" notice survive a reload; the found-run RunView now reads `remoteLabel` off the meta.

Closes #1077