### PR TITLE
fix(framework): keep a remote run in the session list on reload (read context before await)

### DIFF
--- a/.changeset/remote-run-list-context-before-await.md
+++ b/.changeset/remote-run-list-context-before-await.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Fix a remote run vanishing from the session list on a dashboard reload ("This session is gone"). `onRuns` read the relayed-run stubs through `contextRemote()` after two awaits, but telefunc only exposes `getContext()` synchronously at the top of a telefunction, so the call threw and every remote run was silently dropped from the list. The context is now read before the first await, so a relayed run stays in the list and re-opens after a reload as #1077 intended.

--- a/packages/framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/framework/src/dashboard-rpc/reads.telefunc.ts
@@ -76,9 +76,12 @@ async function withProjects<T>(build: (projects: Awaited<ReturnType<ReturnType<t
  * instead of losing it.
  */
 export async function onRuns(projectId: string): Promise<RunMeta[]> {
+  // Read the relayed-run stubs BEFORE any await (#1077): telefunc only exposes getContext()
+  // synchronously at the top of a telefunction, so calling contextRemote() after an await loses
+  // the request context and drops every remote run from the list on a reload.
+  const remote = contextRemote()?.list(projectId) ?? []
   const cwd = await resolveProjectPath(projectId)
   const local = cwd ? await readAllRuns(cwd) : []
-  const remote = contextRemote()?.list(projectId) ?? []
   if (remote.length === 0) return local
   // A relayed run (#1067) lives only in the daemon's memory, not on disk; surface it in the list so
   // a reload re-opens it instead of losing it. Remote wins an id tie (it is the live authority).


### PR DESCRIPTION
Follow-up fix to #1077 / #1078.

The reload-survival feature merged but never actually worked: a run relayed to a connected device still showed "This session is gone" after a dashboard refresh.

## Cause
`onRuns` read the relayed-run stubs via `contextRemote()` *after* two awaits (`resolveProjectPath`, `readAllRuns`). Telefunc 0.2.22 only exposes `getContext()` synchronously at the top of a telefunction; after the first await the request context is gone and `getContext()` throws, so every remote run was silently dropped from the list. Local runs still loaded (they fall back to the registry), which is why only remote runs disappeared.

## Fix
Read the remote list at the top of `onRuns`, before any await. One-line reorder.

## Verification
Confirmed live on a real two-machine setup: instrumentation showed `getContext()` throwing "Cannot access context object" on the after-await call, and `ctxRemote=false` in `onRuns`; reading the context first resolves it. The existing unit/integration tests pass this bug because they exercise `RelayedRuns.list` directly and never go through Telefunc's after-await context loss (that same limitation is why a regression unit test is impractical here without a full Telefunc serve harness).

Closes: reload-survival for remote runs (#1077).