### PR TITLE
feat(framework): accurate remote-run status in the session list + a device glyph

### DIFF
--- a/.changeset/remote-run-status-and-device-glyph.md
+++ b/.changeset/remote-run-status-and-device-glyph.md
@@ -1,0 +1,6 @@
+---
+"@gemstack/framework": minor
+"@gemstack/framework-dashboard": minor
+---
+
+Make a remote run's session-list row accurate and legible (#1067). The local in-memory stub for a relayed run now folds every streamed event through the store's own reducer, so it mirrors the device: it shows WAITING while the run is parked on you (not a permanent RUNNING), settles to the right terminal status, and picks up the agent logo and any pending-choice state. The row also gets a small device glyph (with the device name on hover) so a session running on a connected device is distinguishable at a glance from a local one.

--- a/packages/framework-dashboard/components/RunHistory.test.tsx
+++ b/packages/framework-dashboard/components/RunHistory.test.tsx
@@ -102,4 +102,14 @@ describe('RunHistory collapsed (#862)', () => {
     const panel = rail(container).firstElementChild as HTMLElement
     expect(panel.className).toContain('absolute')
   })
+
+  test('a run on a connected device shows a device glyph naming the device (#1067)', () => {
+    render(<RunHistory projectId="p1" runs={[run({ target: 'remote', remoteLabel: 'my-laptop' })]} selectedRunId={null} onSelect={() => {}} />)
+    expect(screen.getByLabelText('Runs on my-laptop')).toBeTruthy()
+  })
+
+  test('a local run has no device glyph (#1067)', () => {
+    render(<RunHistory projectId="p1" runs={[run()]} selectedRunId={null} onSelect={() => {}} />)
+    expect(screen.queryByLabelText(/Runs on/)).toBeNull()
+  })
 })

--- a/packages/framework-dashboard/components/RunHistory.tsx
+++ b/packages/framework-dashboard/components/RunHistory.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Plus } from 'lucide-react'
+import { Plus, MonitorSmartphone } from 'lucide-react'
 import type { RunMeta, RunStatus } from '@gemstack/framework'
 import { AGENT_LABELS, agentForDriver } from '@gemstack/framework/client'
 import { Button } from './ui/button.js'
@@ -139,6 +139,8 @@ export function RunHistory({
             // `runs` is newest-first, so that is the first with a running status.
             active={run.id === selectedRunId || (followLive && run.id === newestRunningId)}
             waiting={run.settledAt !== undefined}
+            remote={run.target === 'remote'}
+            {...(run.remoteLabel ? { remoteLabel: run.remoteLabel } : {})}
             collapsed={collapsed}
             onClick={() => onSelect(run.id)}
           />
@@ -161,6 +163,8 @@ function RunRow({
   driver,
   dim = false,
   waiting = false,
+  remote = false,
+  remoteLabel,
   collapsed = false,
 }: {
   status: RunStatus
@@ -173,6 +177,10 @@ function RunRow({
   dim?: boolean
   /** Live, but parked on the user rather than working (#785). */
   waiting?: boolean
+  /** Runs on a connected device (#1067): the row gets a device glyph next to the agent logo. */
+  remote?: boolean
+  /** The device's label, for the glyph's tooltip. */
+  remoteLabel?: string | undefined
   /** In the narrow strip (#862): labels fade out, so the row is carried by its dot alone. */
   collapsed?: boolean
 }) {
@@ -210,14 +218,18 @@ function RunRow({
           {parked ? 'waiting' : status}
         </Badge>
         <span className={cn('truncate text-xs font-normal text-muted-foreground', label)}>{subtitle}</span>
-        {/* Which agent ran it. The logo is the only thing naming the agent on this row, so it
+        {/* Right cluster: a device glyph when the run is relayed to a connected device (#1067),
+            then the agent logo. The logo is the only thing naming the agent on this row, so it
             carries a title rather than being decorative. */}
-        {agent && (
-          <AgentLogo
-            agent={agent}
-            title={AGENT_LABELS[agent]}
-            className={cn('ml-auto h-3 w-3 shrink-0 text-muted-foreground', label)}
-          />
+        {(remote || agent) && (
+          <span className={cn('ml-auto flex shrink-0 items-center gap-1.5', label)}>
+            {remote && (
+              <span title={remoteLabel ? `Runs on ${remoteLabel}` : 'Runs on a connected device'} className="flex items-center">
+                <MonitorSmartphone className="h-3 w-3 text-muted-foreground" aria-label={remoteLabel ? `Runs on ${remoteLabel}` : 'Runs on a connected device'} />
+              </span>
+            )}
+            {agent && <AgentLogo agent={agent} title={AGENT_LABELS[agent]} className="h-3 w-3 text-muted-foreground" />}
+          </span>
         )}
       </span>
       <span className={cn('w-full truncate text-sm font-medium', label)}>{intent || 'New session'}</span>

--- a/packages/framework/src/dashboard/remote-run.test.ts
+++ b/packages/framework/src/dashboard/remote-run.test.ts
@@ -278,6 +278,26 @@ test("a relayed run's list row flips to the device's ending, or stopped if the s
   assert.equal(await relayEndStatus(null), 'stopped') // no end event: the stream dropped, so it is no longer live
 })
 
+test('a relayed run reads as waiting while the device has it parked on the user (#1067/#785)', async () => {
+  // The device streams `settled` and keeps the run alive: the local list row must mirror that as
+  // waiting (settledAt set, still running), not a permanent running, so the badge matches the device.
+  const srv = await server((_req, res) => {
+    res.writeHead(200, { 'content-type': 'application/x-ndjson' })
+    res.write(`${JSON.stringify({ kind: 'settled' })}\n`) // stays open: parked, not finished
+  })
+  try {
+    const runs = new RelayedRuns()
+    runs.register('r1', { url: srv.url, token: 't' }, stubMeta('r1'), 'proj-1')
+    for (let i = 0; i < 40 && !runs.list('proj-1')[0]?.settledAt; i++) await new Promise(r => setTimeout(r, 25))
+    const row = runs.list('proj-1')[0]
+    assert.ok(row?.settledAt, 'a parked remote run carries settledAt, so its row reads waiting')
+    assert.equal(row?.status, 'running') // still live, so waiting (not a terminal status)
+    runs.dispose()
+  } finally {
+    await srv.close()
+  }
+})
+
 test('dispose clears the relayed run list and its device target (#1077)', async () => {
   const srv = await server((_req, res) => {
     res.writeHead(200, { 'content-type': 'application/x-ndjson' })

--- a/packages/framework/src/dashboard/remote-run.ts
+++ b/packages/framework/src/dashboard/remote-run.ts
@@ -1,6 +1,6 @@
 import { EventStream } from '@gemstack/ai-autopilot'
 import type { FrameworkEvent } from '../events.js'
-import type { RunMeta } from '../store/index.js'
+import { applyEventToMeta, type RunMeta } from '../store/index.js'
 import type { StartRunKind, StartRunOptions, StartRunResult } from './types.js'
 import { errorMessage } from '../error-message.js'
 
@@ -197,7 +197,7 @@ export class RelayedRuns {
     const stream = new EventStream<FrameworkEvent>()
     const cancel = streamRemoteEvents(target, runId, event => {
       stream.push(event)
-      if (event.kind === 'end') this.settle(runId, event) // record the run's ending on its list row
+      this.apply(runId, event) // fold the event into the run's list row, mirroring the device
     }, () => this.endStream(runId))
     this.runs.set(runId, { target, stream, cancel })
   }
@@ -220,11 +220,13 @@ export class RelayedRuns {
     return rows.sort((a, b) => (a.startedAt < b.startedAt ? 1 : a.startedAt > b.startedAt ? -1 : 0))
   }
 
-  /** Flip a relayed run's list row to its ending when the device's stream reports one (#1077). */
-  private settle(runId: string, end: Extract<FrameworkEvent, { kind: 'end' }>): void {
+  /** Fold each relayed event into the run's list row via the store's own reducer (#1077), so the
+   *  local stub mirrors the device: the terminal status on `end`, the waiting flag while it is parked
+   *  (#785), the driver once its session starts. Events carry no write time, so this stamps its own. */
+  private apply(runId: string, event: FrameworkEvent): void {
     const entry = this.metas.get(runId)
     if (!entry) return
-    entry.meta.status = end.stopped ? 'stopped' : end.ok ? 'done' : 'failed'
+    entry.meta = applyEventToMeta(entry.meta, event, new Date().toISOString())
   }
 
   /** Close a relayed run's event stream (not its target). Idempotent. */


### PR DESCRIPTION
Part of #1049 (the "Run on" epic), polish on top of #1078 found while live-testing two machines.

Two things a remote run's session-list row got wrong or missing:

## Accurate status (WAITING, agent logo, choices)
The local in-memory stub for a relayed run only tracked a coarse `status`, so a run the device had **parked on the user** still read RUNNING here while the device correctly showed WAITING. The stub now folds every streamed event through the store's own `applyEventToMeta` reducer, so it mirrors the device: WAITING while parked (#785), the right terminal status on `end`, plus the agent logo (`driver`) and any pending-choice state, all for free.

## Device glyph
A run relayed to a connected device now shows a small `MonitorSmartphone` glyph in its session-list row (device name on hover), so it is distinguishable at a glance from a local run.

## Tests
- Framework: a parked device (streams `settled`, stays open) leaves the local row running+settled, i.e. waiting.
- Dashboard: a remote run's row shows the device glyph naming the device; a local run's does not.
- Full suites green (framework 1170, dashboard 383).

Independent of the #1079 context-before-await fix (different files); both are remote-run session-list work.