### PR TITLE
fix(framework): stop the agent workflow uploading its transcript to a hidden path

### DIFF
--- a/.github/workflows/framework-agent.yml
+++ b/.github/workflows/framework-agent.yml
@@ -75,19 +75,22 @@ jobs:
           SESSION_ID: ${{ steps.claude.outputs.session_id }}
         run: |
           set -euo pipefail
-          mkdir -p .framework-run
+          # Not dot-prefixed: upload-artifact@v4 defaults include-hidden-files to false and
+          # drops every file under a hidden path segment, so a `.framework-run/` dir uploads
+          # nothing and the driver finds no artifact to read.
+          mkdir -p framework-run
           # An empty array still parses, so a crashed action yields an empty turn, not a driver error.
           if [ -n "$EXECUTION_FILE" ] && [ -f "$EXECUTION_FILE" ]; then
-            cp "$EXECUTION_FILE" .framework-run/execution.json
+            cp "$EXECUTION_FILE" framework-run/execution.json
           else
-            echo '[]' > .framework-run/execution.json
+            echo '[]' > framework-run/execution.json
           fi
           jq -n --arg branch "$BRANCH" --arg session_id "$SESSION_ID" \
-            '{branch: $branch, session_id: $session_id}' > .framework-run/meta.json
+            '{branch: $branch, session_id: $session_id}' > framework-run/meta.json
 
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: framework-run-${{ inputs.correlation_id }}
-          path: .framework-run
+          path: framework-run
           retention-days: 7


### PR DESCRIPTION
## What

The `framework-agent` workflow that `ActionsDriver` dispatches (#1050) wrote its transcript into a **dot-prefixed** directory, `.framework-run/`, and then uploaded it with `actions/upload-artifact@v4`. That action defaults `include-hidden-files` to `false` and drops every file that sits under a hidden path segment, so the upload found nothing:

```
##[warning]No files were found with the provided path: .framework-run. No artifacts will be uploaded.
```

With no artifact, `ActionsSession.readRunArtifact` throws `Run … uploaded no artifact`, so **every real run failed**. The step still reports success (upload-artifact only warns), which is why it slipped through until the target was driven live.

Fix: drop the dot. The transcript now lands in `framework-run/` and uploads normally.

## How it was found and verified

Found by driving the GitHub Actions run target end to end for the first time. Verified on this branch without any secret configured (the agent step fails on the missing token, but the `always()` collect + upload steps still run):

- Before: run artifacts `count: 0`.
- After: artifact `framework-run-<cid>` uploads (292 bytes, `count: 1`).
- The driver's `readZip` + `replayTranscript` read that real GitHub artifact zip correctly (`execution.json` -> `[]`, `meta.json` -> `{branch, session_id}`, empty turn), confirming the read side against real GitHub data too.

## Scope / changeset

Repo-config only: the workflow lives at `.github/workflows/`, not inside any published package (`@gemstack/framework` ships `dist` + `prompts`), so there is no package delta to version and no changeset.

## Not yet closed

The remaining live run needs the `CLAUDE_CODE_OAUTH_TOKEN` repo secret and this fix on the default branch (`workflow_dispatch` uses the workflow definition from the dispatched ref). Tracking the full live-run sign-off on #1050.

Refs #1050