### PR TITLE
fix(framework): make the GitHub Actions run target actually run end to end (#1050)

### DIFF
--- a/.changeset/actions-unique-correlation-id.md
+++ b/.changeset/actions-unique-correlation-id.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Give each GitHub Actions run (`--run-on actions`, #1050) a correlation id that is unique across driver processes. The id seeded a per-process counter, so a fresh `framework run` process restarted it at 1 and every run's first turn was `actions-1-turn-1`; a new run could then match an earlier, identically named run still in the recent-runs window and report its stale result. The session id now mixes in a random tag, so a run only ever finds its own workflow run.

--- a/.github/workflows/framework-agent.yml
+++ b/.github/workflows/framework-agent.yml
@@ -22,10 +22,13 @@ on:
         description: A prior agent session id to continue instead of starting fresh.
         required: false
 
-# The agent pushes a branch and may open a PR; nothing here needs write access to anything else.
+# The agent pushes a branch and may open a PR. `id-token: write` is not optional: the
+# action exchanges an OIDC token to authenticate the subscription OAuth token, and without
+# it every run fails with "Could not fetch an OIDC token".
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   agent:

--- a/packages/framework/src/driver/actions.test.ts
+++ b/packages/framework/src/driver/actions.test.ts
@@ -163,6 +163,14 @@ test('ActionsDriver dispatches the prompt with a correlation id and the framing 
   assert.equal(body.inputs['correlation_id'], `${session.id}-turn-1`)
 })
 
+test('ActionsDriver gives each session a unique correlation prefix so a fresh process never matches a stale run (#1050)', async () => {
+  // The daemon spawns a fresh process per run, restarting the session counter, so without a
+  // random tag two runs would both be `actions-1-...` and one could latch onto the other's run.
+  const a = await makeDriver().driver.start({ cwd: '/ws' })
+  const b = await makeDriver().driver.start({ cwd: '/ws' })
+  assert.notEqual(a.id, b.id)
+})
+
 test('ActionsDriver runs the next turn on the branch the last one pushed (#610)', async () => {
   const { driver, calls } = makeDriver()
   const session = await driver.start({ cwd: '/ws' })

--- a/packages/framework/src/driver/actions.ts
+++ b/packages/framework/src/driver/actions.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { StreamJsonParser } from './claude-code.js'
 import { readZip } from './actions-zip.js'
 import { combineFraming, makeEmit } from './session-support.js'
@@ -71,12 +72,21 @@ export interface ActionsDriverOptions {
   now?: () => number
   /** Sleep override for tests. Default a real timer. */
   sleep?: (ms: number) => Promise<void>
+  /**
+   * Unique tag mixed into the correlation id. Default a random token; injected in tests for
+   * a stable id. Without it a fresh driver process restarts the session counter at 1, so
+   * every run's first turn is `actions-1-turn-1` and runs collide (see {@link ActionsSession}).
+   */
+  runTag?: () => string
 }
 
 /** The slice of `fetch` this driver uses. */
 export type FetchLike = (url: string, init?: RequestInit) => Promise<Response>
 
 let sessionCounter = 0
+
+/** A short random tag so correlation ids stay unique across driver processes. */
+const randomRunTag = (): string => randomUUID().slice(0, 8)
 
 /** One Actions-backed session. Each `prompt` is one workflow run. */
 export class ActionsSession implements DriverSession {
@@ -93,7 +103,9 @@ export class ActionsSession implements DriverSession {
     private readonly startOpts: DriverStartOptions,
   ) {
     this.cwd = startOpts.cwd
-    this.id = `actions-${++sessionCounter}`
+    // The counter reads well in logs within one process; the random tag is what keeps the
+    // correlation id unique across processes, since the daemon spawns a fresh one per run.
+    this.id = `actions-${++sessionCounter}-${(config.runTag ?? randomRunTag)()}`
     this.lastSessionId = startOpts.resumeSessionId
   }
 
@@ -107,8 +119,9 @@ export class ActionsSession implements DriverSession {
     const prompt = framing ? `${framing}\n\n${text}` : text
     emit({ type: 'start', prompt })
 
-    // Deterministic, so no clock or randomness leaks into the correlation: the
-    // dispatch API returns no run id, and this is how we find our run among others.
+    // How we find our run: the dispatch API returns no run id, so the workflow echoes this
+    // into its run-name and artifact name and we match on it. It must be unique per run (the
+    // session's random tag) so a fresh process never latches onto a stale same-named run.
     const correlationId = `${this.id}-turn-${++this.turnCounter}`
     const resume = opts.resume ? this.lastSessionId : undefined
 


### PR DESCRIPTION
Driving the GitHub Actions run target (#1050) live for the first time surfaced two more bugs after the artifact-upload fix (#1081). Both are fixed here.

## 1. Missing `id-token: write` (workflow)

`anthropics/claude-code-action@v1` exchanges an OIDC token to authenticate the subscription OAuth token (`claude_code_oauth_token`). With only `contents`/`pull-requests` permissions, every run failed before the agent ran:

```
Attempt 1 failed: Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

Added `id-token: write` to the workflow's `permissions`. Verified live: with it, the run logs `OIDC token successfully obtained`.

## 2. Correlation id not unique across processes (driver)

The correlation id seeded a module-level session counter, so a fresh `framework run` process (the daemon spawns one per run) restarted it at 1 and **every run's first turn was `actions-1-turn-1`**. A new run could then match an earlier, identically named run still in the recent-runs window and return its stale conclusion, which is exactly what happened while testing (a new dispatch immediately "found" a previous failed run). The session id now mixes in a random tag, so a run only ever finds its own workflow run. New regression test; the 15 driver tests pass.

## Operational note (why this must merge before it fully works)

`claude-code-action@v1` refuses to run the agent unless the dispatched workflow is **byte-identical to the copy on the default branch**:

```
Skipping action due to workflow validation: Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch ... your workflow will begin working once you merge your PR.
```

So the `id-token` change can only be proven end-to-end once it is on `main` (a branch dispatch authenticates but then self-skips, uploading an empty transcript and pushing no branch). Everything else in the pipeline is verified: dispatch, correlation, artifact upload/download, transcript replay. Once merged I'll drive one real run on `main` to confirm the agent commits, pushes its branch, and the turn comes back into the dashboard.

Refs #1050