### PR TITLE
fix(the-framework.ai): give the landing page a name so Release doesn't fail

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -21,7 +21,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       # Vike prerenders the landing page (the-framework.ai) to static HTML in dist/client/.
-      - run: pnpm --filter @gemstack/the-framework.ai build
+      - run: pnpm --filter the-framework.ai-website build
 
       # public/ ships `CNAME` and `.nojekyll` into dist/client/, so `clean: true`
       # can wipe the branch on each deploy without losing them.

--- a/packages/the-framework.ai/package.json
+++ b/packages/the-framework.ai/package.json
@@ -1,4 +1,7 @@
 {
+  "name": "the-framework.ai-website",
+  "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -17,6 +20,5 @@
     "@vitejs/plugin-react": "^6.0.3",
     "typescript": "^5.4.0",
     "vite": "^8.0.0"
-  },
-  "type": "module"
+  }
 }


### PR DESCRIPTION
## Problem

The **Release** workflow is failing on `main` ([run 30034414802](https://github.com/gemstack-land/gemstack/actions/runs/30034414802/job/89298648938)):

```
Error: The following package.jsons are missing the "name" field:
packages/the-framework.ai/package.json
```

changesets reads the workspace through `@manypkg/get-packages`, which requires every package to have a `name`. That validation runs **before** any ignore/skip logic, so a nameless package aborts the version/publish job outright. The `packages/the-framework.ai` landing page added in #1083 had no `name` at all.

The same omission also broke the **Website Deployment** workflow, which built the site with `pnpm --filter @gemstack/the-framework.ai build` — a filter that matched no package.

## Fix

Give the package a name and mark it private — the minimal change that resolves the error and keeps the site out of the release process:

- **`name: "the-framework.ai-website"`** — unscoped and `-website`-suffixed so it obviously reads as a non-published site rather than an `@gemstack/*` npm package. `website-deploy.yml`'s build filter is updated to match.
- **`private: true`** — this *is* the "skip it from release": `changeset publish` (run by `pnpm release`) won't publish private packages, and they never enter the version PR. Same treatment as the other non-published apps here (`framework-dashboard`, the `example-*` packages).

No `version`/`description`/`license` — not needed for a private, non-published site, and `changeset status` confirms the workspace validates without them.

## Verification

Run locally against the fix:

- ✅ `pnpm install --frozen-lockfile` — lockfile unaffected (importers are keyed by path, not name)
- ✅ `pnpm changeset status` — the previously-failing `getPackages` validation passes, and `the-framework.ai-website` is correctly **absent** from the bump set (private)
- ✅ `pnpm --filter the-framework.ai-website build` / `typecheck` — the renamed filter resolves; Vike prerenders the site to `dist/client/`

## Files

- `packages/the-framework.ai/package.json` — add `name` + `private: true`
- `.github/workflows/website-deploy.yml` — point the build filter at the new name

🤖 Generated with [Claude Code](https://claude.com/claude-code)