### PR TITLE
feat(framework): give Actions runs a branch the driver can read back and continue on (#1085)

### DIFF
--- a/.changeset/actions-run-branch.md
+++ b/.changeset/actions-run-branch.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/framework": patch
+---
+
+Let the GitHub Actions run target (#1050) read back a run's work and continue on it (#1085). `claude-code-action@v1` leaves its `branch_name` output empty for a `workflow_dispatch` agent run, so the driver never learned the branch the agent pushed: `readCode` failed and a follow-up turn started over on `main`. The driver now names the branch itself (`claude/framework-<session>`) and passes it to the workflow, which pushes the run's work there and records it, so the diff view works and each turn builds on the last.

--- a/.github/workflows/framework-agent.yml
+++ b/.github/workflows/framework-agent.yml
@@ -21,10 +21,13 @@ on:
       resume_session_id:
         description: A prior agent session id to continue instead of starting fresh.
         required: false
+      branch:
+        description: Branch to push the run's work to, so the driver can read it back and continue on it (#1085).
+        required: false
 
-# The agent pushes a branch and may open a PR. `id-token: write` is not optional: the
-# action exchanges an OIDC token to authenticate the subscription OAuth token, and without
-# it every run fails with "Could not fetch an OIDC token".
+# The workflow pushes the run branch and the agent may open a PR. `id-token: write` is not
+# optional: the action exchanges an OIDC token to authenticate the subscription OAuth token,
+# and without it every run fails with "Could not fetch an OIDC token".
 permissions:
   contents: write
   pull-requests: write
@@ -68,13 +71,46 @@ jobs:
           prompt: ${{ inputs.prompt }}
           claude_args: ${{ steps.args.outputs.value }}
 
+      # The runner and its checkout vanish when the job ends, so the only way the driver can
+      # read the agent's work (diffs, file contents) or run the next turn on top of it is a
+      # branch on origin. The action does not create one for a workflow_dispatch run, so we
+      # push it here, to the name the driver chose. This mirrors the local flow, where the
+      # framework (not the agent) pushes the session branch (#799); the agent just commits.
+      - name: Push the run branch
+        if: always()
+        id: runbranch
+        env:
+          RUN_BRANCH: ${{ inputs.branch }}
+          DISPATCH_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "$RUN_BRANCH" ]; then echo "no run branch requested"; exit 0; fi
+          git config user.name "framework-agent"
+          git config user.email "framework-agent@users.noreply.github.com"
+          # Commit anything the agent left uncommitted so it is not lost with the runner.
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -m "framework agent run ($RUN_BRANCH)" --quiet
+          fi
+          # Don't create an empty branch for a no-op turn: only push when the run advanced
+          # past the ref it checked out. If that ref can't be resolved, err toward pushing.
+          base="$(git rev-parse --verify --quiet "origin/$DISPATCH_REF" || true)"
+          if [ -n "$base" ] && [ "$(git rev-parse HEAD)" = "$base" ]; then
+            echo "no new commits; nothing to push"
+            exit 0
+          fi
+          git push origin "HEAD:refs/heads/$RUN_BRANCH"
+          echo "branch=$RUN_BRANCH" >> "$GITHUB_OUTPUT"
+
       # The only REST-readable channel out of a run. `always()` so a failed turn still
       # returns its transcript, which is exactly when we most want to read it.
       - name: Collect the transcript
         if: always()
         env:
           EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
-          BRANCH: ${{ steps.claude.outputs.branch_name }}
+          # The branch we actually pushed above, not the action's branch_name, which stays
+          # empty for a workflow_dispatch agent run (#1085).
+          BRANCH: ${{ steps.runbranch.outputs.branch }}
           SESSION_ID: ${{ steps.claude.outputs.session_id }}
         run: |
           set -euo pipefail

--- a/packages/framework/src/driver/actions.test.ts
+++ b/packages/framework/src/driver/actions.test.ts
@@ -171,6 +171,20 @@ test('ActionsDriver gives each session a unique correlation prefix so a fresh pr
   assert.notEqual(a.id, b.id)
 })
 
+test('ActionsDriver names the branch each run pushes to, stable across turns (#1085)', async () => {
+  const { driver, calls } = makeDriver()
+  const session = await driver.start({ cwd: '/ws' })
+  await session.prompt('first')
+  await session.prompt('second')
+
+  const branches = calls.filter(c => c.url.includes('/dispatches')).map(c => (c.body as { inputs: Record<string, string> }).inputs['branch'])
+  // The driver names the branch instead of discovering it: the action leaves branch_name empty
+  // for a workflow_dispatch run, so this is the only thing that lets readCode + continuity work.
+  assert.equal(branches[0], `claude/framework-${session.id}`)
+  // Same branch every turn, so a later turn's push builds on the earlier one.
+  assert.equal(branches[0], branches[1])
+})
+
 test('ActionsDriver runs the next turn on the branch the last one pushed (#610)', async () => {
   const { driver, calls } = makeDriver()
   const session = await driver.start({ cwd: '/ws' })

--- a/packages/framework/src/driver/actions.ts
+++ b/packages/framework/src/driver/actions.ts
@@ -78,6 +78,13 @@ export interface ActionsDriverOptions {
    * every run's first turn is `actions-1-turn-1` and runs collide (see {@link ActionsSession}).
    */
   runTag?: () => string
+  /**
+   * Prefix for the branch each run pushes its work to (#1085). Default `"claude/"`. The
+   * driver names the branch (prefix + session id) and passes it to the workflow, rather than
+   * discovering it after the fact: the action leaves `branch_name` empty for a
+   * `workflow_dispatch` run, so there is nothing to discover.
+   */
+  branchPrefix?: string
 }
 
 /** The slice of `fetch` this driver uses. */
@@ -92,8 +99,10 @@ const randomRunTag = (): string => randomUUID().slice(0, 8)
 export class ActionsSession implements DriverSession {
   readonly id: string
   readonly cwd: string
-  /** The branch the last successful run pushed; the next turn builds on it. */
+  /** The branch the last run pushed; set once the run reports it, and the next turn builds on it. */
   private branch: string | undefined
+  /** The branch this session asks each run to push to. Stable across turns, so they chain. */
+  private readonly runBranch: string
   /** The agent's own session id, carried across turns so `resume` can continue it. */
   private lastSessionId: string | undefined
   private turnCounter = 0
@@ -106,6 +115,7 @@ export class ActionsSession implements DriverSession {
     // The counter reads well in logs within one process; the random tag is what keeps the
     // correlation id unique across processes, since the daemon spawns a fresh one per run.
     this.id = `actions-${++sessionCounter}-${(config.runTag ?? randomRunTag)()}`
+    this.runBranch = `${config.branchPrefix ?? 'claude/'}framework-${this.id}`
     this.lastSessionId = startOpts.resumeSessionId
   }
 
@@ -159,7 +169,7 @@ export class ActionsSession implements DriverSession {
   /** Fire the workflow. Returns nothing useful: dispatch is 204 with no body, hence the correlation id. */
   private async dispatch(prompt: string, correlationId: string, resume: string | undefined): Promise<void> {
     const workflow = this.config.workflow ?? 'framework-agent.yml'
-    const inputs: Record<string, string> = { prompt, correlation_id: correlationId }
+    const inputs: Record<string, string> = { prompt, correlation_id: correlationId, branch: this.runBranch }
     // These reach a shell on the runner as environment variables. They are ids and
     // model names, so anything outside that alphabet is a bug or an attack.
     if (this.startOpts.model) inputs['model'] = assertToken(this.startOpts.model, 'model')


### PR DESCRIPTION
Closes #1085. Follow-up from live-testing the GitHub Actions run target (#1050): single-turn runs work, but the diff panel and multi-turn follow-ups didn't, because the driver couldn't learn the branch the agent pushed.

## Why

`claude-code-action@v1` only creates branches in tag mode (issue/PR events); for our `workflow_dispatch` agent runs its `branch_name` output is empty, even when the agent pushes. So `meta.branch` was empty, `session.branch` stayed undefined, `readCode` threw, and turn N+1 dispatched on `main` instead of turn N's work.

## What

The driver names the branch instead of discovering it, mirroring the local flow where the framework (not the agent) pushes the session branch (#799):

- **Driver:** each session mints `claude/framework-<session>` and passes it as a `branch` dispatch input (stable across turns, so they chain). The existing read-back (`meta.branch` -> `session.branch`) then lights up `readCode` and next-turn continuity with no further change.
- **Workflow:** a new `branch` input and a "Push the run branch" step that commits anything the agent left uncommitted and pushes the run's work to that branch (only when the run actually advanced, so a no-op turn makes no empty branch). The collect step records that branch in `meta.json` instead of the empty `branch_name`.

New driver test; 16 driver tests pass, typecheck + build clean.

## Verification

Driver side is unit-tested. The workflow half can only be proven once it is on `main` (the action refuses to run unless the workflow matches the default branch). After merge I'll drive a two-turn run and confirm `readCode` reads the pushed file and turn 2 builds on turn 1's branch.

Refs #1050 #1049