### PR TITLE
fix(framework): authenticate the Actions run-branch push explicitly (#1085)

### DIFF
--- a/.github/workflows/framework-agent.yml
+++ b/.github/workflows/framework-agent.yml
@@ -82,6 +82,10 @@ jobs:
         env:
           RUN_BRANCH: ${{ inputs.branch }}
           DISPATCH_REF: ${{ github.ref_name }}
+          # Authenticate the push explicitly. The agent step runs its own git setup and leaves
+          # the checkout's persisted credentials unusable, so a plain `git push origin` fails
+          # with "Authentication failed"; push through a tokenized URL instead.
+          GH_PUSH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           if [ -z "$RUN_BRANCH" ]; then echo "no run branch requested"; exit 0; fi
@@ -99,7 +103,7 @@ jobs:
             echo "no new commits; nothing to push"
             exit 0
           fi
-          git push origin "HEAD:refs/heads/$RUN_BRANCH"
+          git push "https://x-access-token:${GH_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:refs/heads/$RUN_BRANCH"
           echo "branch=$RUN_BRANCH" >> "$GITHUB_OUTPUT"
 
       # The only REST-readable channel out of a run. `always()` so a failed turn still


### PR DESCRIPTION
Follow-up to #1087. Live-testing the two-turn Actions flow showed the run's agent commits fine, but the new "Push the run branch" step failed:

```
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/gemstack-land/gemstack.git/'
```

The step used a plain `git push origin`, which relies on the credentials `actions/checkout` persists. The `claude-code-action` step runs its own git setup during the run and leaves those unusable, so the later push has no valid auth. The commit and no-op-skip logic were correct; only the push auth was wrong.

Fix: push through an `x-access-token:<workflow-token>` URL (masked in logs), so the push carries its own auth regardless of what the agent step left in the git config.

Workflow-only change, no changeset. Verifies after merge (workflow-validation gate): I'll re-run the two-turn test and confirm `readCode` reads the pushed file and turn 2 builds on turn 1's branch.

Refs #1085 #1087