### PR TITLE
chore: point in-repo references at gemstack-land/the-framework (#655)

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -98,7 +98,7 @@ There is a tiny surface overlap (both can "produce an MCP server"), but from dif
 
 `@gemstack/mcp-connectors` is a small, agent-agnostic family on top of the server framework: a **connector contract** for wiring external services (GitHub, Google Drive, ...) into an agent as MCP tools. A connector `defineConnector`s its auth requirement and its tools and nothing else — it never reaches for env vars, OAuth, or a transport — and an orchestrator `mountConnectors` composes any number into one `@gemstack/mcp` server, supplying credentials and choosing the transport. That declare-needs / supply-later split is what lets first-party (`@gemstack/mcp-connector-*`) and third-party `mcp-connector-*` packages compose interchangeably. It sits on the `mcp` (server framework) axis, not the `ai-*` runtime axis: connectors depend on `@gemstack/mcp`, not on `ai-sdk`.
 
-## `ai-mcp` carve-out (decided - see [issue #7](https://github.com/gemstack-land/gemstack/issues/7))
+## `ai-mcp` carve-out (decided - see [issue #7](https://github.com/gemstack-land/the-framework/issues/7))
 
 The bridge is two functions today. Decisions:
 
@@ -108,7 +108,7 @@ The bridge is two functions today. Decisions:
 
 The seam is small and one-directional: `mcp/*` imports one runtime value (`dynamicTool`) plus four types (`Agent`, `HasTools`, `Tool`, `ToolCallContext`) from `ai-sdk`; `ai-sdk` imports nothing back. Still gated on family alignment with the Vike team before code lands.
 
-## `ai-skills` design (decided - see [issue #8](https://github.com/gemstack-land/gemstack/issues/8))
+## `ai-skills` design (decided - see [issue #8](https://github.com/gemstack-land/the-framework/issues/8))
 
 Largely greenfield: it builds the registry + loader + runtime around the existing `boost/skills` convention. Decisions:
 
@@ -119,7 +119,7 @@ Largely greenfield: it builds the registry + loader + runtime around the existin
 
 Follow-up authoring options (low priority, revisit on demand): TS-first `defineSkill` (#11), a skill-scoped `skillTool()` wrapper (#12), and imperative `agent.use(skill)` runtime composition (#13). Still gated on family alignment before code lands.
 
-## `ai-autopilot` design (shipped - see [issue #9](https://github.com/gemstack-land/gemstack/issues/9))
+## `ai-autopilot` design (shipped - see [issue #9](https://github.com/gemstack-land/the-framework/issues/9))
 
 Began as the most speculative of the family (a Supervisor seed) and grew into the AI-building framework. It sits above the real `ai-sdk` primitives (`asTool`, `resumeAsTool`, `resumeManyAsTool`, `SubAgentRunStore`, stop conditions).
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
       {
         text: 'Reference',
         items: [
-          { text: 'Changelog', link: 'https://github.com/gemstack-land/gemstack/releases' },
+          { text: 'Changelog', link: 'https://github.com/gemstack-land/the-framework/releases' },
           { text: 'npm — @gemstack', link: 'https://www.npmjs.com/org/gemstack' },
         ],
       },
@@ -109,7 +109,7 @@ export default defineConfig({
     },
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/gemstack-land/gemstack' },
+      { icon: 'github', link: 'https://github.com/gemstack-land/the-framework' },
     ],
 
     footer: {
@@ -118,7 +118,7 @@ export default defineConfig({
     },
 
     editLink: {
-      pattern: 'https://github.com/gemstack-land/gemstack/edit/main/docs/:path',
+      pattern: 'https://github.com/gemstack-land/the-framework/edit/main/docs/:path',
       text: 'Edit this page on GitHub',
     },
   },

--- a/docs/guide/contributing.md
+++ b/docs/guide/contributing.md
@@ -28,7 +28,7 @@ If you maintain a framework, the path is: depend on the GemStack engine, impleme
 - **Propose a graduation.** If you have a framework-agnostic package that fits the bar above, open an issue describing what it does and why it belongs in GemStack rather than in a single framework.
 - **Build a binding.** Wire the engine into your framework and let us link it from here.
 
-The repository, issues, and discussions live at [github.com/gemstack-land/gemstack](https://github.com/gemstack-land/gemstack).
+The repository, issues, and discussions live at [github.com/gemstack-land/the-framework](https://github.com/gemstack-land/the-framework).
 
 ## Next
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ hero:
       link: /guide/
     - theme: alt
       text: View on GitHub
-      link: https://github.com/gemstack-land/gemstack
+      link: https://github.com/gemstack-land/the-framework
 
 features:
   - icon: 🧠

--- a/docs/packages/ai-autopilot.md
+++ b/docs/packages/ai-autopilot.md
@@ -20,7 +20,7 @@ The Supervisor (below) is the seed topology. Built up from it, the package is a 
 - **Bootstrap** — the spine that sequences all of the above into scope → build → full-fledged loop → deploy, taking an app from nothing to production-grade.
 - **Scale mode** — a self-maintaining `CODE-OVERVIEW.md`, refreshed only on material change.
 
-See [`examples/bootstrap-quickstart`](https://github.com/gemstack-land/gemstack/tree/main/examples/bootstrap-quickstart) for all of it wired together offline.
+See [`examples/bootstrap-quickstart`](https://github.com/gemstack-land/the-framework/tree/main/examples/bootstrap-quickstart) for all of it wired together offline.
 
 ## Supervisor (plan, dispatch, synthesize)
 

--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -31,4 +31,4 @@ Both can "produce an MCP server", but from different inputs (`mcpServerFromAgent
 
 ## Versioning
 
-Each package versions independently via Changesets. The API is settling toward `1.0` in the open; the AI family currently tracks the `0.x` line while contracts stabilize. See the [releases](https://github.com/gemstack-land/gemstack/releases) for changelogs.
+Each package versions independently via Changesets. The API is settling toward `1.0` in the open; the AI family currently tracks the `0.x` line while contracts stabilize. See the [releases](https://github.com/gemstack-land/the-framework/releases) for changelogs.

--- a/docs/packages/mcp-connectors-registry.md
+++ b/docs/packages/mcp-connectors-registry.md
@@ -24,7 +24,7 @@ The convention is what makes connectors discoverable: a search for `connector-` 
 3. Declare its `auth` honestly (`none` / `pat` / `oauth`) so an orchestrator knows what credential to resolve.
 4. Publish to npm. That's it — there's no registry to register with; the naming convention *is* the registry.
 
-To get a third-party connector linked from this page, open a PR or an issue on [gemstack-land/gemstack](https://github.com/gemstack-land/gemstack/issues).
+To get a third-party connector linked from this page, open a PR or an issue on [gemstack-land/the-framework](https://github.com/gemstack-land/the-framework/issues).
 
 ## See also
 

--- a/docs/packages/mcp-connectors.md
+++ b/docs/packages/mcp-connectors.md
@@ -132,7 +132,7 @@ await client.listTools() // [{ name: 'library_list-books', ... }, ...]
 await client.callTool('library_get-book', { id: 'b1' })
 ```
 
-To test a connector that calls a real API, stub global `fetch` and assert on the requests it makes — that is exactly how the [GitHub](https://github.com/gemstack-land/gemstack/blob/main/packages/mcp-connector-github/src/index.test.ts) and [Google Drive](https://github.com/gemstack-land/gemstack/blob/main/packages/mcp-connector-google-drive/src/index.test.ts) connectors are tested.
+To test a connector that calls a real API, stub global `fetch` and assert on the requests it makes — that is exactly how the [GitHub](https://github.com/gemstack-land/the-framework/blob/main/packages/mcp-connector-github/src/index.test.ts) and [Google Drive](https://github.com/gemstack-land/the-framework/blob/main/packages/mcp-connector-google-drive/src/index.test.ts) connectors are tested.
 
 ## API
 

--- a/docs/packages/mcp.md
+++ b/docs/packages/mcp.md
@@ -254,7 +254,7 @@ import { startStdio } from '@gemstack/mcp/runtime'
 await startStdio(new DemoServer())
 ```
 
-> **Runnable example.** [`examples/mcp-quickstart`](https://github.com/gemstack-land/gemstack/tree/main/examples/mcp-quickstart) is a complete, framework-neutral server (tool, resource, prompt, `@Handle` DI, OAuth 2.1) served over both `node:http` and Hono, with a CI smoke test and zero framework dependencies.
+> **Runnable example.** [`examples/mcp-quickstart`](https://github.com/gemstack-land/the-framework/tree/main/examples/mcp-quickstart) is a complete, framework-neutral server (tool, resource, prompt, `@Handle` DI, OAuth 2.1) served over both `node:http` and Hono, with a CI smoke test and zero framework dependencies.
 
 ## OAuth 2.1
 

--- a/experiments/instagram-clone/SPEC.md
+++ b/experiments/instagram-clone/SPEC.md
@@ -1,6 +1,6 @@
 # Instagram clone: spec + rubric
 
-Closes gemstack-land/gemstack#292. This is the fixed definition of the test app and how a
+Closes gemstack-land/the-framework#292. This is the fixed definition of the test app and how a
 generated app is scored, so "the AI was lazy" becomes a number instead of a vibe. Every run
 in #293/#294 is judged against this file and nothing else.
 

--- a/packages/ai-autopilot/README.md
+++ b/packages/ai-autopilot/README.md
@@ -1,6 +1,6 @@
 # @gemstack/ai-autopilot
 
-Orchestration for [`@gemstack/ai-sdk`](https://github.com/gemstack-land/gemstack/tree/main/packages/ai-sdk) agents — the "director" layer that runs **many** agent runs under a control policy.
+Orchestration for [`@gemstack/ai-sdk`](https://github.com/gemstack-land/the-framework/tree/main/packages/ai-sdk) agents — the "director" layer that runs **many** agent runs under a control policy.
 
 `ai-sdk` owns the single-agent loop and the handoff / subagent primitives. `ai-autopilot` owns orchestrating multiple runs: which agents run, in what order, how their results combine, and when to stop. If a feature is just calling an `ai-sdk` primitive, it belongs in `ai-sdk` — autopilot earns its keep only as the topology / control-policy layer.
 

--- a/packages/ai-autopilot/package.json
+++ b/packages/ai-autopilot/package.json
@@ -14,13 +14,13 @@
     "gemstack"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/gemstack-land/gemstack/tree/main/packages/ai-autopilot#readme",
+  "homepage": "https://github.com/gemstack-land/the-framework/tree/main/packages/ai-autopilot#readme",
   "bugs": {
-    "url": "https://github.com/gemstack-land/gemstack/issues"
+    "url": "https://github.com/gemstack-land/the-framework/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gemstack-land/gemstack",
+    "url": "https://github.com/gemstack-land/the-framework",
     "directory": "packages/ai-autopilot"
   },
   "type": "module",

--- a/packages/ai-mcp/README.md
+++ b/packages/ai-mcp/README.md
@@ -1,6 +1,6 @@
 # @gemstack/ai-mcp
 
-The bridge between [`@gemstack/ai-sdk`](https://github.com/gemstack-land/gemstack/tree/main/packages/ai-sdk) Agents and [Model Context Protocol](https://modelcontextprotocol.io) servers. Two connectors:
+The bridge between [`@gemstack/ai-sdk`](https://github.com/gemstack-land/the-framework/tree/main/packages/ai-sdk) Agents and [Model Context Protocol](https://modelcontextprotocol.io) servers. Two connectors:
 
 - **`mcpClientTools(transport, opts?)`** — consume a remote MCP server's tools as Agent tools.
 - **`mcpServerFromAgent(AgentClass, opts?)`** — expose an Agent as an MCP server that external clients (Claude Desktop, Cursor, etc.) can call.

--- a/packages/ai-mcp/package.json
+++ b/packages/ai-mcp/package.json
@@ -14,13 +14,13 @@
     "gemstack"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/gemstack-land/gemstack/tree/main/packages/ai-mcp#readme",
+  "homepage": "https://github.com/gemstack-land/the-framework/tree/main/packages/ai-mcp#readme",
   "bugs": {
-    "url": "https://github.com/gemstack-land/gemstack/issues"
+    "url": "https://github.com/gemstack-land/the-framework/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gemstack-land/gemstack",
+    "url": "https://github.com/gemstack-land/the-framework",
     "directory": "packages/ai-mcp"
   },
   "type": "module",

--- a/packages/ai-sdk/README.md
+++ b/packages/ai-sdk/README.md
@@ -2,7 +2,7 @@
 
 AI engine: providers, agents, tools, streaming, middleware, structured output, conversation memory, evals, computer-use, and testing fakes.
 
-The first [GemStack](https://github.com/gemstack-land/gemstack) package. Spun out of Rudder's `@rudderjs/ai` (carried forward from the 1.17.x line, renamed and re-versioned under the GemStack umbrella). The Rudder package, `@rudderjs/ai`, now re-exports this engine and adds the Rudder-specific bindings on top (the `AiProvider`, ORM-backed stores, doctor check, and `make:agent` / `ai:eval` CLI) — it is the Rudder binding over this engine, not a dying shim.
+The first [GemStack](https://github.com/gemstack-land/the-framework) package. Spun out of Rudder's `@rudderjs/ai` (carried forward from the 1.17.x line, renamed and re-versioned under the GemStack umbrella). The Rudder package, `@rudderjs/ai`, now re-exports this engine and adds the Rudder-specific bindings on top (the `AiProvider`, ORM-backed stores, doctor check, and `make:agent` / `ai:eval` CLI) — it is the Rudder binding over this engine, not a dying shim.
 
 ## Installation
 
@@ -43,7 +43,7 @@ The engine is now fully framework-agnostic: it has **no `@rudderjs/*` peer depen
 | `./gateway` | Gateway helpers |
 | `./react` | React bindings |
 
-> **Moved in `0.3.0`:** the MCP bridge (`mcpClientTools` / `mcpServerFromAgent`), previously the `./mcp` subpath, is now its own package, [`@gemstack/ai-mcp`](https://github.com/gemstack-land/gemstack/tree/main/packages/ai-mcp). Update `@gemstack/ai-sdk/mcp` imports to `@gemstack/ai-mcp` and move the `@modelcontextprotocol/sdk` peer there.
+> **Moved in `0.3.0`:** the MCP bridge (`mcpClientTools` / `mcpServerFromAgent`), previously the `./mcp` subpath, is now its own package, [`@gemstack/ai-mcp`](https://github.com/gemstack-land/the-framework/tree/main/packages/ai-mcp). Update `@gemstack/ai-sdk/mcp` imports to `@gemstack/ai-mcp` and move the `@modelcontextprotocol/sdk` peer there.
 >
 > **Moved to `@rudderjs/ai`:** the ORM-backed stores (`./conversation-orm`, `./memory-orm`, `./budget-orm`, `./memory-embedding`) coupled the engine to `@rudderjs/orm`, so they now live in [`@rudderjs/ai`](https://www.npmjs.com/package/@rudderjs/ai) under the same subpath names. Update `@gemstack/ai-sdk/conversation-orm` imports to `@rudderjs/ai/conversation-orm` (etc.). They implement the same `ConversationStore` / `UserMemory` / `BudgetStorage` contracts, still exported from here.
 >

--- a/packages/ai-sdk/package.json
+++ b/packages/ai-sdk/package.json
@@ -23,13 +23,13 @@
     "gemstack"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/gemstack-land/gemstack/tree/main/packages/ai-sdk#readme",
+  "homepage": "https://github.com/gemstack-land/the-framework/tree/main/packages/ai-sdk#readme",
   "bugs": {
-    "url": "https://github.com/gemstack-land/gemstack/issues"
+    "url": "https://github.com/gemstack-land/the-framework/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gemstack-land/gemstack",
+    "url": "https://github.com/gemstack-land/the-framework",
     "directory": "packages/ai-sdk"
   },
   "type": "module",

--- a/packages/ai-sdk/src/providers/bedrock.ts
+++ b/packages/ai-sdk/src/providers/bedrock.ts
@@ -99,7 +99,7 @@ class BedrockAdapter implements ProviderAdapter {
     if (!isAnthropicOnBedrock(model)) {
       throw new Error(
         `[ai-sdk] Bedrock model "${model}" is not yet supported. v1 only supports Anthropic Claude models on Bedrock ` +
-        `(model id starts with "anthropic."). File an issue at https://github.com/gemstack-land/gemstack/issues if you need another family.`,
+        `(model id starts with "anthropic."). File an issue at https://github.com/gemstack-land/the-framework/issues if you need another family.`,
       )
     }
   }

--- a/packages/ai-skills/README.md
+++ b/packages/ai-skills/README.md
@@ -1,6 +1,6 @@
 # @gemstack/ai-skills
 
-Portable capability bundles for [`@gemstack/ai-sdk`](https://github.com/gemstack-land/gemstack/tree/main/packages/ai-sdk) agents. A **skill** is a shippable folder — instructions + tools + resources — that you compose onto an `Agent` on demand. This mirrors the [Anthropic Agent Skills](https://www.anthropic.com/news/agent-skills) shape: a skill authored for Claude loads here, and a gemstack skill ships as a plain folder.
+Portable capability bundles for [`@gemstack/ai-sdk`](https://github.com/gemstack-land/the-framework/tree/main/packages/ai-sdk) agents. A **skill** is a shippable folder — instructions + tools + resources — that you compose onto an `Agent` on demand. This mirrors the [Anthropic Agent Skills](https://www.anthropic.com/news/agent-skills) shape: a skill authored for Claude loads here, and a gemstack skill ships as a plain folder.
 
 ```
 my-skill/

--- a/packages/ai-skills/package.json
+++ b/packages/ai-skills/package.json
@@ -14,13 +14,13 @@
     "gemstack"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/gemstack-land/gemstack/tree/main/packages/ai-skills#readme",
+  "homepage": "https://github.com/gemstack-land/the-framework/tree/main/packages/ai-skills#readme",
   "bugs": {
-    "url": "https://github.com/gemstack-land/gemstack/issues"
+    "url": "https://github.com/gemstack-land/the-framework/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gemstack-land/gemstack",
+    "url": "https://github.com/gemstack-land/the-framework",
     "directory": "packages/ai-skills"
   },
   "type": "module",

--- a/packages/framework-dashboard/vite.config.ts
+++ b/packages/framework-dashboard/vite.config.ts
@@ -47,6 +47,6 @@ export default defineConfig({
   },
   // TO-DO/eventually: remove this workaround once upstream fixed the issue
   // Temporary workaround for Vike error
-  // https://github.com/gemstack-land/gemstack/issues/460
+  // https://github.com/gemstack-land/the-framework/issues/460
   vitePluginServerEntry: { disableAutoImport: true },
 } as UserConfig)

--- a/packages/framework/VISION-ROADMAP.md
+++ b/packages/framework/VISION-ROADMAP.md
@@ -13,7 +13,7 @@ Selected: implement now-ish.
 
 - Bootstrap mode
   - VALUE-HIGH (potentially groundbreaking, if we manage to make AI autonomously create advanced apps)
-  - The `PLAN.md` + `TODO.md` trick: https://github.com/gemstack-land/gemstack/issues/297#issuecomment-4913683778
+  - The `PLAN.md` + `TODO.md` trick: https://github.com/gemstack-land/the-framework/issues/297#issuecomment-4913683778
     - Try: also install it as system prompt injected to *all* prompts (not only when boostraping, let's see if it's sometimes counterproductive)
   - Ideas/brainstorming (don't implement yet)
     - PM system prompts:
@@ -28,7 +28,7 @@ Selected: implement now-ish.
   - VALUE-HIGH
   - Cron jobs to max-out daily usage limits (fires queue)
   - Implementation
-    - Accessing usage limits: https://github.com/gemstack-land/gemstack/pull/300#issuecomment-4918256151
+    - Accessing usage limits: https://github.com/gemstack-land/the-framework/pull/300#issuecomment-4918256151
   - Marketing
     - Easy sell (sexy feature, clear added value)
     - Unique USP (since Claude has no interest to implement this)

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -14,13 +14,13 @@
     "gemstack"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/gemstack-land/gemstack/tree/main/packages/framework#readme",
+  "homepage": "https://github.com/gemstack-land/the-framework/tree/main/packages/framework#readme",
   "bugs": {
-    "url": "https://github.com/gemstack-land/gemstack/issues"
+    "url": "https://github.com/gemstack-land/the-framework/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gemstack-land/gemstack",
+    "url": "https://github.com/gemstack-land/the-framework",
     "directory": "packages/framework"
   },
   "type": "module",

--- a/packages/framework/scripts/check-prompt-drift.mjs
+++ b/packages/framework/scripts/check-prompt-drift.mjs
@@ -21,7 +21,7 @@ const here = dirname(fileURLToPath(import.meta.url))
 const systemPromptFile = join(here, '..', 'prompts', 'system_prompt.md')
 const snapshotFile = join(here, 'op-326-on-before-mergeable.snapshot.md')
 
-const REPO = 'gemstack-land/gemstack'
+const REPO = 'gemstack-land/the-framework'
 const ISSUE = 326
 
 /** The ```md blocks of the issue body, in order. Block 1 = system prompt, block 2 = on-before-mergeable. */

--- a/packages/framework/src/dashboard/github.test.ts
+++ b/packages/framework/src/dashboard/github.test.ts
@@ -3,13 +3,13 @@ import { test } from 'node:test'
 import { githubUrlFromRemote, githubUrlFor, githubSlugFromRemote, githubSlugFor } from './github.js'
 
 test('githubUrlFromRemote normalizes the common remote forms', () => {
-  const expected = 'https://github.com/gemstack-land/gemstack'
-  assert.equal(githubUrlFromRemote('git@github.com:gemstack-land/gemstack.git'), expected)
-  assert.equal(githubUrlFromRemote('git@github.com:gemstack-land/gemstack'), expected)
-  assert.equal(githubUrlFromRemote('ssh://git@github.com/gemstack-land/gemstack.git'), expected)
-  assert.equal(githubUrlFromRemote('https://github.com/gemstack-land/gemstack.git'), expected)
-  assert.equal(githubUrlFromRemote('https://github.com/gemstack-land/gemstack'), expected)
-  assert.equal(githubUrlFromRemote('https://user@github.com/gemstack-land/gemstack.git\n'), expected)
+  const expected = 'https://github.com/gemstack-land/the-framework'
+  assert.equal(githubUrlFromRemote('git@github.com:gemstack-land/the-framework.git'), expected)
+  assert.equal(githubUrlFromRemote('git@github.com:gemstack-land/the-framework'), expected)
+  assert.equal(githubUrlFromRemote('ssh://git@github.com/gemstack-land/the-framework.git'), expected)
+  assert.equal(githubUrlFromRemote('https://github.com/gemstack-land/the-framework.git'), expected)
+  assert.equal(githubUrlFromRemote('https://github.com/gemstack-land/the-framework'), expected)
+  assert.equal(githubUrlFromRemote('https://user@github.com/gemstack-land/the-framework.git\n'), expected)
 })
 
 test('githubUrlFromRemote returns undefined for non-GitHub or junk remotes', () => {
@@ -21,15 +21,15 @@ test('githubUrlFromRemote returns undefined for non-GitHub or junk remotes', () 
 })
 
 test('githubSlugFromRemote splits owner and repo, or undefined for a non-GitHub remote (#1050)', () => {
-  assert.deepEqual(githubSlugFromRemote('git@github.com:gemstack-land/gemstack.git'), { owner: 'gemstack-land', repo: 'gemstack' })
+  assert.deepEqual(githubSlugFromRemote('git@github.com:gemstack-land/the-framework.git'), { owner: 'gemstack-land', repo: 'the-framework' })
   assert.equal(githubSlugFromRemote('git@gitlab.com:o/r.git'), undefined)
   assert.equal(githubSlugFromRemote('https://github.com/only-owner'), undefined)
 })
 
 test('githubSlugFor reads origin and returns undefined when git fails (#1050)', async () => {
   assert.deepEqual(
-    await githubSlugFor('/x', async () => 'https://github.com/gemstack-land/gemstack.git\n'),
-    { owner: 'gemstack-land', repo: 'gemstack' },
+    await githubSlugFor('/x', async () => 'https://github.com/gemstack-land/the-framework.git\n'),
+    { owner: 'gemstack-land', repo: 'the-framework' },
   )
   assert.equal(
     await githubSlugFor('/x', async () => {
@@ -41,8 +41,8 @@ test('githubSlugFor reads origin and returns undefined when git fails (#1050)', 
 
 test('githubUrlFor reads origin and returns undefined when git fails', async () => {
   assert.equal(
-    await githubUrlFor('/x', async () => 'git@github.com:gemstack-land/gemstack.git\n'),
-    'https://github.com/gemstack-land/gemstack',
+    await githubUrlFor('/x', async () => 'git@github.com:gemstack-land/the-framework.git\n'),
+    'https://github.com/gemstack-land/the-framework',
   )
   assert.equal(
     await githubUrlFor('/x', async () => {

--- a/packages/framework/src/steps.ts
+++ b/packages/framework/src/steps.ts
@@ -20,7 +20,7 @@ import type { DriverSession } from './driver/index.js'
 import { continuationPrompt, parseAwaitGate, type ParsedAwaitGate } from './turn-gate.js'
 
 /**
- * Driver-backed {@link https://github.com/gemstack-land/gemstack | Bootstrap} steps.
+ * Driver-backed {@link https://github.com/gemstack-land/the-framework | Bootstrap} steps.
  *
  * These implement the injectable steps of ai-autopilot's `Bootstrap` by running
  * everything *through* a {@link DriverSession} (option A, #166): build / improve

--- a/packages/mcp-connector-github/package.json
+++ b/packages/mcp-connector-github/package.json
@@ -12,13 +12,13 @@
     "gemstack"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/gemstack-land/gemstack/tree/main/packages/mcp-connector-github#readme",
+  "homepage": "https://github.com/gemstack-land/the-framework/tree/main/packages/mcp-connector-github#readme",
   "bugs": {
-    "url": "https://github.com/gemstack-land/gemstack/issues"
+    "url": "https://github.com/gemstack-land/the-framework/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gemstack-land/gemstack",
+    "url": "https://github.com/gemstack-land/the-framework",
     "directory": "packages/mcp-connector-github"
   },
   "type": "module",

--- a/packages/mcp-connector-google-drive/package.json
+++ b/packages/mcp-connector-google-drive/package.json
@@ -12,13 +12,13 @@
     "gemstack"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/gemstack-land/gemstack/tree/main/packages/mcp-connector-google-drive#readme",
+  "homepage": "https://github.com/gemstack-land/the-framework/tree/main/packages/mcp-connector-google-drive#readme",
   "bugs": {
-    "url": "https://github.com/gemstack-land/gemstack/issues"
+    "url": "https://github.com/gemstack-land/the-framework/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gemstack-land/gemstack",
+    "url": "https://github.com/gemstack-land/the-framework",
     "directory": "packages/mcp-connector-google-drive"
   },
   "type": "module",

--- a/packages/mcp-connectors/package.json
+++ b/packages/mcp-connectors/package.json
@@ -14,13 +14,13 @@
     "gemstack"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/gemstack-land/gemstack/tree/main/packages/mcp-connectors#readme",
+  "homepage": "https://github.com/gemstack-land/the-framework/tree/main/packages/mcp-connectors#readme",
   "bugs": {
-    "url": "https://github.com/gemstack-land/gemstack/issues"
+    "url": "https://github.com/gemstack-land/the-framework/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gemstack-land/gemstack",
+    "url": "https://github.com/gemstack-land/the-framework",
     "directory": "packages/mcp-connectors"
   },
   "type": "module",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -15,13 +15,13 @@
     "gemstack"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/gemstack-land/gemstack/tree/main/packages/mcp#readme",
+  "homepage": "https://github.com/gemstack-land/the-framework/tree/main/packages/mcp#readme",
   "bugs": {
-    "url": "https://github.com/gemstack-land/gemstack/issues"
+    "url": "https://github.com/gemstack-land/the-framework/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gemstack-land/gemstack",
+    "url": "https://github.com/gemstack-land/the-framework",
     "directory": "packages/mcp"
   },
   "type": "module",

--- a/packages/the-framework.ai/pages/index/ui.tsx
+++ b/packages/the-framework.ai/pages/index/ui.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties, ReactNode } from 'react'
 
 export const DISCORD_URL = 'https://discord.gg/qc8zvdzWNR'
-export const GITHUB_URL = 'https://github.com/gemstack-land/gemstack'
+export const GITHUB_URL = 'https://github.com/gemstack-land/the-framework'
 export const NPM_URL = 'https://www.npmjs.com/package/@gemstack/the-framework'
 
 export const mono = "'IBM Plex Mono', monospace" as const

--- a/tickets/109-ai-autopilot%3A_sandboxed_runner_adapters_(Docker_%2F_WebContainer_%2F_Flue).md
+++ b/tickets/109-ai-autopilot%3A_sandboxed_runner_adapters_(Docker_%2F_WebContainer_%2F_Flue).md
@@ -9,4 +9,4 @@ Follow-up from the ai-autopilot epic (#97). The runner seam and the first real a
 `LocalRunner` is the reference each mirrors; `FakeRunner` covers tests. Docker is done; WebContainer and Flue remain infra-gated (can't be built and honestly verified without provisioning that infra first).
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/109
+Source: https://github.com/gemstack-land/the-framework/issues/109

--- a/tickets/11-Design%3A_optional_TS-first_skill_authoring_(defineSkill)_alongside_SKILL.md.md
+++ b/tickets/11-Design%3A_optional_TS-first_skill_authoring_(defineSkill)_alongside_SKILL.md.md
@@ -22,4 +22,4 @@ Offer a typed `defineSkill({ name, description, instructions, tools, resources }
 Gated on the same family alignment as #8; design-only for now.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/11
+Source: https://github.com/gemstack-land/the-framework/issues/11

--- a/tickets/110-Epic%3A_The_AI_framework_—_turnkey_end-to-end_AI_orchestration_for_building_software_(web-app_first).md
+++ b/tickets/110-Epic%3A_The_AI_framework_—_turnkey_end-to-end_AI_orchestration_for_building_software_(web-app_first).md
@@ -54,4 +54,4 @@ Our bet (review/QA loops + persistent state) differs from the spec-driven pack. 
 **Business model:** keep the OSS local version from being so complete that hosting is pointless. The paid wedge is team/multiplayer (shared decision log, review history, org-wide business context), not "we run it for you."
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/110
+Source: https://github.com/gemstack-land/the-framework/issues/110

--- a/tickets/12-Design%3A_optional_skill-scoped_tool_wrapper_(skillTool)_over_tool().md
+++ b/tickets/12-Design%3A_optional_skill-scoped_tool_wrapper_(skillTool)_over_tool().md
@@ -24,4 +24,4 @@ Open evidence here if/when: multi-skill loading produces real tool-name collisio
 Gated on the same family alignment as #8; design-only for now.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/12
+Source: https://github.com/gemstack-land/the-framework/issues/12

--- a/tickets/13-Design%3A_optional_imperative_agent.use(skill)_runtime_composition.md
+++ b/tickets/13-Design%3A_optional_imperative_agent.use(skill)_runtime_composition.md
@@ -29,4 +29,4 @@ Allow attaching skills at runtime, after construction:
 Gated on the same family alignment as #8; design-only for now.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/13
+Source: https://github.com/gemstack-land/the-framework/issues/13

--- a/tickets/291-Dogfooding%3A_publish_the_vike-%2A_packages_to_npm.md
+++ b/tickets/291-Dogfooding%3A_publish_the_vike-%2A_packages_to_npm.md
@@ -14,4 +14,4 @@ To close (work happens in the vike-data repo):
 Once this lands, the integrated reference app (#288) can be built anywhere, not just inside vike-data.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/291
+Source: https://github.com/gemstack-land/the-framework/issues/291

--- a/tickets/297-[The_Framework]_Bootstrap_mode.md
+++ b/tickets/297-[The_Framework]_Bootstrap_mode.md
@@ -11,4 +11,4 @@ Label: "You can describe what you want approximately (e.g. just a hunch, just a 
 Low-prio for now I think (because I ain't sure how well we can make it work, to be tested).
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/297
+Source: https://github.com/gemstack-land/the-framework/issues/297

--- a/tickets/298-[The_Framework]_Background_jobs.md
+++ b/tickets/298-[The_Framework]_Background_jobs.md
@@ -4,7 +4,7 @@ Implements:
 - Listeners
   - Error in production (Sentry, Cloudfalre, ...) => triggers agent
   - CI is red on `main` (GitHub) => triggers agent
-- The [usage max-out idea](https://github.com/gemstack-land/gemstack/pull/287/changes):
+- The [usage max-out idea](https://github.com/gemstack-land/the-framework/pull/287/changes):
   - Check the current usage limit + when the limit resets
     - If usage limit reached (with a configurable margin) => abort, don't do any maintenance
     - Make sure to also check the usage limit of the current default model => use a fallback model if usage limit is reached (with a configurable margin)
@@ -13,4 +13,4 @@ Implements:
 - More?
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/298
+Source: https://github.com/gemstack-land/the-framework/issues/298

--- a/tickets/312-CLI.md
+++ b/tickets/312-CLI.md
@@ -5,7 +5,7 @@
 
 I suggest that running `$ framework` does the following:
 - [x] Ensure The background process that runs the localhost dashboard (e.g. `localhost:4200`) is running
-- [ ] Runs [background jobs](https://github.com/gemstack-land/gemstack/issues/298)
+- [ ] Runs [background jobs](https://github.com/gemstack-land/the-framework/issues/298)
 - [x] Prints the list of commands (just convenience commands like `framework run [prompt]`, `framework logs`, ... — not important since the UI already implements all features)
 - [ ] Prints the CLI version
   - [Only if trivial to implement] Show whether the version is up-to-date (by using `$ npm info`).
@@ -14,4 +14,4 @@ I suggest that running `$ framework` does the following:
     - Also show `(✅ auto-update enabled)`.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/312
+Source: https://github.com/gemstack-land/the-framework/issues/312

--- a/tickets/313-Database.md
+++ b/tickets/313-Database.md
@@ -29,7 +29,7 @@ A special Git repo named `my-framework` (convention, but the user can save the `
 
 ## See also
 
-- https://github.com/gemstack-land/gemstack/issues/454
+- https://github.com/gemstack-land/the-framework/issues/454
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/313
+Source: https://github.com/gemstack-land/the-framework/issues/313

--- a/tickets/326-System_prompt.md
+++ b/tickets/326-System_prompt.md
@@ -102,12 +102,12 @@ If the changes introduced by ${{ tf.session_name }} can potentially lead to secu
 
 ## See also
 
-- https://github.com/gemstack-land/gemstack/issues/323
-- https://github.com/gemstack-land/gemstack/issues/297#issuecomment-4913683778
-- https://github.com/gemstack-land/gemstack/issues/331
-- https://github.com/gemstack-land/gemstack/issues/361
-- https://github.com/gemstack-land/gemstack/issues/360
-- https://github.com/gemstack-land/gemstack/issues/461
+- https://github.com/gemstack-land/the-framework/issues/323
+- https://github.com/gemstack-land/the-framework/issues/297#issuecomment-4913683778
+- https://github.com/gemstack-land/the-framework/issues/331
+- https://github.com/gemstack-land/the-framework/issues/361
+- https://github.com/gemstack-land/the-framework/issues/360
+- https://github.com/gemstack-land/the-framework/issues/461
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/326
+Source: https://github.com/gemstack-land/the-framework/issues/326

--- a/tickets/411-App_instead_of_`localhost`%3F.md
+++ b/tickets/411-App_instead_of_`localhost`%3F.md
@@ -9,4 +9,4 @@ Upside: looks professional.
 I think it's worth it... especially if we can use a solution that doesn't bloat the user's memory. Is Tauri (or some other tool) a good option?
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/411
+Source: https://github.com/gemstack-land/the-framework/issues/411

--- a/tickets/453-Git_worktrees.md
+++ b/tickets/453-Git_worktrees.md
@@ -5,4 +5,4 @@ If we want Claude Code to be able to work on multiple tasks at the same time for
 We'll probably need it fairly soon, but I ain't sure how complex it is to fully implement, so we can make it post-MVP.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/453
+Source: https://github.com/gemstack-land/the-framework/issues/453

--- a/tickets/454-Syncing_UI%3C-%3Edata.md
+++ b/tickets/454-Syncing_UI%3C-%3Edata.md
@@ -11,7 +11,7 @@ The follow up question is about Telefunc. How can we use Telefunc to automatical
 @suleimansh In then meantime, for the MVP, I guess it's enough if the UI requests the data at load time (no syncing, user has to F5 the page to get fresh data), while the main view is synced via Telefunc Stream.
 
 See also:
-- https://github.com/gemstack-land/gemstack/issues/313
+- https://github.com/gemstack-land/the-framework/issues/313
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/454
+Source: https://github.com/gemstack-land/the-framework/issues/454

--- a/tickets/455-Marketing.md
+++ b/tickets/455-Marketing.md
@@ -11,4 +11,4 @@ Intro text (WIP, I will polish this a *lot*):
 > It's kinda like open source Autopilot for Software Development: engineers take care of complex decisions, while AI fully and automatically takes care of the rest. The Framework automatically orchestrates the entire lifecycle as an automatic loop of product management, writing code, reviewing, refactoring for high-quality code, bug fixing, security audit, maintenance, ...).
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/455
+Source: https://github.com/gemstack-land/the-framework/issues/455

--- a/tickets/460-Vike_error.md
+++ b/tickets/460-Vike_error.md
@@ -20,4 +20,4 @@ Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/rom/code/gemstack/packag
 ```
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/460
+Source: https://github.com/gemstack-land/the-framework/issues/460

--- a/tickets/462-Product_Management%3A_ticketing.md
+++ b/tickets/462-Product_Management%3A_ticketing.md
@@ -32,4 +32,4 @@ See also:
 - [Script one-way-syncing `CHANGELOG.md` => GitHub releases](https://github.com/vikejs/vike/tree/main/.github/workflows/sync-github-releases) ([permalink](https://github.com/vikejs/vike/tree/15c05abaeae57bc3112702a8faeca36c20ee13ea/.github/workflows/sync-github-releases)) — shows GitHub API usage, including some gotchas
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/462
+Source: https://github.com/gemstack-land/the-framework/issues/462

--- a/tickets/469-Browser_Phase_2%3A_bundle_Chromium_into_the_sandbox_runner_image.md
+++ b/tickets/469-Browser_Phase_2%3A_bundle_Chromium_into_the_sandbox_runner_image.md
@@ -14,4 +14,4 @@ Scope when unblocked:
 Also worth deciding first, from Phase 1 real-world use: is browser access valuable enough to carry into the sandbox story at all?
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/469
+Source: https://github.com/gemstack-land/the-framework/issues/469

--- a/tickets/495-Epic%3A_Bring_your_own_subscription_(BYOS)_—_run_the_user's_own_coding-agent_CLI.md
+++ b/tickets/495-Epic%3A_Bring_your_own_subscription_(BYOS)_—_run_the_user's_own_coding-agent_CLI.md
@@ -20,4 +20,4 @@ Open calls for Rom:
 - config location: framework config (env-paths/XDG) vs a separate dotfile
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/495
+Source: https://github.com/gemstack-land/the-framework/issues/495

--- a/tickets/538-Roadmap_(MVP)_🚀.md
+++ b/tickets/538-Roadmap_(MVP)_🚀.md
@@ -2,26 +2,26 @@
 
 ## 1. MVP v1
 
-- [x] https://github.com/gemstack-land/gemstack/issues/326
+- [x] https://github.com/gemstack-land/the-framework/issues/326
   - [ ] Test: is everything working? Any issues with it?
     - The result should be: analyzes user prompt, auto-plan, ask user sensible questions, no implicit-laziness
   - [ ] Test: "Build instgram clone" => high quality AI work (thanks to the system prompt) with zero human intervention?
-- [x] https://github.com/gemstack-land/gemstack/issues/314
+- [x] https://github.com/gemstack-land/the-framework/issues/314
   - [ ] Test: is everything working? Any issues with it? Let's polish quick-win? Big UX paper cuts we should fix (we can fix minor paper cuts in post-MVP)
 - [ ] Dogfooding — the ultimate test here is we start using The Framework ourselves: what missing to get there?
 
 ## 2. MVP v2
 
-- [ ] https://github.com/gemstack-land/gemstack/issues/624
+- [ ] https://github.com/gemstack-land/the-framework/issues/624
 - [ ] Agentic PM (Product Mangement)
-  - [ ] https://github.com/gemstack-land/gemstack/issues/462
-  - [x] https://github.com/gemstack-land/gemstack/issues/537
+  - [ ] https://github.com/gemstack-land/the-framework/issues/462
+  - [x] https://github.com/gemstack-land/the-framework/issues/537
   - [ ] New preset "Suggest new features"
-- [ ] https://github.com/gemstack-land/gemstack/issues/625
-- [ ] https://github.com/gemstack-land/gemstack/issues/626
-- [ ] https://github.com/gemstack-land/gemstack/issues/627
+- [ ] https://github.com/gemstack-land/the-framework/issues/625
+- [ ] https://github.com/gemstack-land/the-framework/issues/626
+- [ ] https://github.com/gemstack-land/the-framework/issues/627
 
 The vision here is to automatize as much as possible, with minimal human intervention.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/538
+Source: https://github.com/gemstack-land/the-framework/issues/538

--- a/tickets/554-Open_Skills.md
+++ b/tickets/554-Open_Skills.md
@@ -7,4 +7,4 @@
 Not sure yet whether post-MVP.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/554
+Source: https://github.com/gemstack-land/the-framework/issues/554

--- a/tickets/605-Epic%3A_Daemon_+_gateway_split_—_headless_24%2F7_runtime,_composable_frontend.md
+++ b/tickets/605-Epic%3A_Daemon_+_gateway_split_—_headless_24%2F7_runtime,_composable_frontend.md
@@ -27,4 +27,4 @@ Split the runtime into composable pieces so The Framework can run anywhere from 
 - #297 (bootstrap mode), #453 (git worktrees), #454 (syncing UI <-> data): all assume a runtime that can host long-lived, multi-repo work.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/605
+Source: https://github.com/gemstack-land/the-framework/issues/605

--- a/tickets/606-Epic%3A_Collaboration_layer_—_agents_as_teammates_in_the_comms_layer.md
+++ b/tickets/606-Epic%3A_Collaboration_layer_—_agents_as_teammates_in_the_comms_layer.md
@@ -25,4 +25,4 @@ Agents get real identities and presence and live in the company's communication 
 - #462 (ticketing / PM): the tasks and issues agents maintain from chat.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/606
+Source: https://github.com/gemstack-land/the-framework/issues/606

--- a/tickets/607-Epic%3A_Org_layer_—_company_%2F_department_%2F_project_scopes.md
+++ b/tickets/607-Epic%3A_Org_layer_—_company_%2F_department_%2F_project_scopes.md
@@ -21,4 +21,4 @@ An organization layer so agents work like scoped teammates inside a company:
 - #462 (tickets/knowledge saved in Git per repo): the per-scope knowledge bases build on this.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/607
+Source: https://github.com/gemstack-land/the-framework/issues/607

--- a/tickets/608-Modularity%3A_%22pick_only_the_features_you_need%22_(all_off_=_transparent_Claude_Code_wrapper).md
+++ b/tickets/608-Modularity%3A_%22pick_only_the_features_you_need%22_(all_off_=_transparent_Claude_Code_wrapper).md
@@ -23,4 +23,4 @@ Make The Framework fully opt-in at the feature level: the user picks only the fe
 - The existing `--vanilla` / `--eco-*` / `--no-todo-loop` flags are the seed of a feature-toggle model.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/608
+Source: https://github.com/gemstack-land/the-framework/issues/608

--- a/tickets/609-Preview%3A_stream_the_agent's_headless_browser_so_a_human_can_step_in_when_it's_blocked.md
+++ b/tickets/609-Preview%3A_stream_the_agent's_headless_browser_so_a_human_can_step_in_when_it's_blocked.md
@@ -31,4 +31,4 @@ The point is not debugging or inspecting elements. The point is to see when the 
 - #605 (daemon): the likely host for the headless browser.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/609
+Source: https://github.com/gemstack-land/the-framework/issues/609

--- a/tickets/610-Drive_Claude_Code_on_the_web_instead_of_the_CLI_(MVP_shortcut%3A_free_worktrees_+_PR,_0%25_local_CPU).md
+++ b/tickets/610-Drive_Claude_Code_on_the_web_instead_of_the_CLI_(MVP_shortcut%3A_free_worktrees_+_PR,_0%25_local_CPU).md
@@ -30,4 +30,4 @@ Add a driver that uses Claude Code on the web instead of the Claude Code CLI. We
 - #605 (daemon): where a server-side headless driver would run.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/610
+Source: https://github.com/gemstack-land/the-framework/issues/610

--- a/tickets/624-Queue.md
+++ b/tickets/624-Queue.md
@@ -12,4 +12,4 @@ Two queues:
   - finished tasks (i.e. history)
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/624
+Source: https://github.com/gemstack-land/the-framework/issues/624

--- a/tickets/625-Modular%3A_only-pick-what-you-need.md
+++ b/tickets/625-Modular%3A_only-pick-what-you-need.md
@@ -9,4 +9,4 @@ This isn't a feature per-se — it's more a constant requirement: let's met sure
 For example, The Framework presets are already very valuable in themselves. Some users might user The Framework only for its presets.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/625
+Source: https://github.com/gemstack-land/the-framework/issues/625

--- a/tickets/626-Custom_presets.md
+++ b/tickets/626-Custom_presets.md
@@ -9,4 +9,4 @@ Custom presets might already be a reason enough for us to use The Framework.
 If it's a quick-win (I think it is?) then I'd say let's do it now.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/626
+Source: https://github.com/gemstack-land/the-framework/issues/626

--- a/tickets/627-Notifications.md
+++ b/tickets/627-Notifications.md
@@ -20,4 +20,4 @@ For me, that would be a feature enough to start using The Framework.
 If it's a quick-win (I think it is), then I'd say let's do it now.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/627
+Source: https://github.com/gemstack-land/the-framework/issues/627

--- a/tickets/628-Select_Model.md
+++ b/tickets/628-Select_Model.md
@@ -5,4 +5,4 @@ Setting (below the texatrea prompt) to select the model.
 @suleimansh Feel free to create such tickets when you see such major paper cut (a road blocker actually). FYI that's one major motivation for dogfooding.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/628
+Source: https://github.com/gemstack-land/the-framework/issues/628

--- a/tickets/629-New_root_directory_`tickets%2F`.md
+++ b/tickets/629-New_root_directory_`tickets%2F`.md
@@ -7,4 +7,4 @@ Only if it's a quick-win (I think it is?), otherwise post-MVP.
 The general idea here is that TF rides on conventions like a root `DECISIONS.md` instead of using "proprietary" files.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/629
+Source: https://github.com/gemstack-land/the-framework/issues/629

--- a/tickets/63-Attach_gemstack.land_custom_domain_to_the_docs_site.md
+++ b/tickets/63-Attach_gemstack.land_custom_domain_to_the_docs_site.md
@@ -4,7 +4,7 @@ The docs site is live on GitHub Pages at https://gemstack-land.github.io/gemstac
 
 ### Cutover checklist
 - [ ] DNS: point `gemstack.land` at GitHub Pages (CNAME/ALIAS to `gemstack-land.github.io`, or per the hosting decision below)
-- [ ] Set the Pages custom domain (`gh api -X PUT repos/gemstack-land/gemstack/pages -f cname=gemstack.land`) and wait for GitHub to provision TLS
+- [ ] Set the Pages custom domain (`gh api -X PUT repos/gemstack-land/the-framework/pages -f cname=gemstack.land`) and wait for GitHub to provision TLS
 - [ ] Drop `DOCS_BASE=/gemstack/` from `.github/workflows/deploy-docs.yml` so the VitePress base returns to `/`
 - [ ] Re-swap the interim `github.io` links to `gemstack.land`:
   - rudder `docs/guide/ai.md` + `docs/guide/mcp.md` (currently github.io, rudder PR #1465)
@@ -17,4 +17,4 @@ The governance questions (whose Cloudflare account owns the domain, GitHub Pages
 Non-urgent: the github.io URL works today and will redirect once the custom domain is attached.
 
 ---
-Source: https://github.com/gemstack-land/gemstack/issues/63
+Source: https://github.com/gemstack-land/the-framework/issues/63


### PR DESCRIPTION
Closes #655.

The repo has been renamed `gemstack-land/gemstack` -> `gemstack-land/the-framework` in GitHub Settings (old URLs auto-redirect). This updates the **64 in-repo references** to the new slug so they're canonical.

## What changed
- **`package.json` metadata** across the published packages: `repository.url`, `homepage`, `bugs.url`.
- **Docs**: vitepress social/edit/changelog links, guide links.
- **Code**: the Bedrock provider's "file an issue" URL (user-facing error text), plus comment/doc-link references in `steps.ts`, `vite.config.ts`, `check-prompt-drift.mjs`.
- **Tickets**: the auto-generated `Source:` / issue links (34 files).
- **`github.test.ts`**: the remote-parser fixtures, renamed consistently (inputs + `expected` + parsed `repo`) so the suite stays green.

## Deliberately untouched
- **`CHANGELOG.md` history** (accurate record).
- **GitHub Pages base path** `gemstack-land.github.io/gemstack/` (in `docs/.vitepress/config.ts` and `deploy-docs.yml`) — this is a separate deploy/domain concern (see the flag below), not a plain URL swap.

## Verification
- `pnpm typecheck` 22/22, `pnpm build` 12/12
- framework tests **1172 pass / 0 fail / 1 skip** (incl. the renamed `github.test.ts`)

## ⚠️ Follow-ups NOT in this PR
1. **GitHub Pages base path**: renaming the repo changes the project-pages URL to `gemstack-land.github.io/the-framework/`. The docs `base: '/gemstack/'` and `deploy-docs.yml` still say `/gemstack/`, so the Pages docs site will serve broken asset paths until this is reconciled — best folded into the `gemstack.land` / custom-domain cutover (#63) rather than swapped blind.
2. **npm deprecate**: once the release publishes `@gemstack/the-framework`, run `npm deprecate @gemstack/framework "renamed to @gemstack/the-framework"`.