### PR TITLE
fix(docs): update Pages base path to /the-framework/ after repo rename (#655)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,9 +33,9 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Build docs
         env:
-          # Project-pages base path (gemstack-land.github.io/gemstack/).
+          # Project-pages base path (gemstack-land.github.io/the-framework/).
           # Remove this once a custom domain serves the site at the root.
-          DOCS_BASE: /gemstack/
+          DOCS_BASE: /the-framework/
         run: pnpm --filter @gemstack/docs docs:build
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
   description: 'Framework-agnostic tools for building AI applications in Node.',
   lang: 'en-US',
   // Served at the site root by default (local dev, and a custom domain like
-  // gemstack.land). The GitHub Pages workflow sets DOCS_BASE=/gemstack/ for the
-  // project-pages URL (gemstack-land.github.io/gemstack/). Drop that env once a
+  // gemstack.land). The GitHub Pages workflow sets DOCS_BASE=/the-framework/ for the
+  // project-pages URL (gemstack-land.github.io/the-framework/). Drop that env once a
   // custom domain is attached so the base returns to '/'.
   base: process.env.DOCS_BASE || '/',
   ignoreDeadLinks: 'localhostLinks',


### PR DESCRIPTION
Follow-up to #655 (repo rename).

The GitHub project-pages URL changed from `gemstack-land.github.io/gemstack/` to `gemstack-land.github.io/the-framework/`. The docs deploy builds vitepress with `base = process.env.DOCS_BASE || '/'`, and `deploy-docs.yml` still set `DOCS_BASE=/gemstack/` — so the live docs site would 404 on every asset (CSS/JS/links) until this is corrected.

## Change
- `deploy-docs.yml`: `DOCS_BASE: /gemstack/` -> `/the-framework/`
- Refreshed the two explanatory comments (workflow + `docs/.vitepress/config.ts`)

Local dev and any future custom domain are unaffected (base stays `/` when `DOCS_BASE` is unset).

## Verification
`DOCS_BASE=/the-framework/ pnpm --filter @gemstack/docs docs:build` completes cleanly.

> If you plan to attach a custom domain to the docs site instead (e.g. `gemstack.land`), the right move is to drop `DOCS_BASE` entirely rather than this patch — say the word and I'll do that version instead.