### PR TITLE
feat(dashboard): manage saved devices from the settings page

### DIFF
--- a/.changeset/devices-settings-section.md
+++ b/.changeset/devices-settings-section.md
@@ -1,0 +1,11 @@
+---
+"@gemstack/the-framework": minor
+---
+
+Manage saved devices from the settings page.
+
+Adding and removing a device already worked, but only from the composer's "Run on" menu, and the composer only exists on a project launcher. From the Overview or the settings page there was no way to manage the roster at all. The settings page now has a **Devices** section listing each saved device with its origin and online/offline status, an Add device button, and a remove per row. The "Run on" picker still lists devices, because choosing a run target is a per-run act; which devices exist is configuration.
+
+Removing a device from settings clears the run target when that device was the one selected, the same guard the composer already applied, so a run can never point at a device that is no longer saved.
+
+The section states that devices are saved in the browser rather than on the server: unlike every other setting on the page, a device carries a token, so it stays in this browser's storage and never reaches the daemon.

--- a/packages/framework-dashboard/components/DevicesSettings.test.tsx
+++ b/packages/framework-dashboard/components/DevicesSettings.test.tsx
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+// The device health poll (#1072) reaches the daemon over Telefunc; hoisted so the factory below can
+// close over it (a plain const is initialised after vi.mock hoists).
+const checkDevices = vi.hoisted(() => vi.fn())
+vi.mock('../server/devices.telefunc.js', () => ({ checkDevices }))
+
+import { DevicesSettings } from './DevicesSettings.js'
+import { addProfile, listProfiles } from '../lib/profiles.js'
+import { selectRemoteDevice, getSelectedRemoteDeviceId } from '../lib/remote-target.js'
+
+const STUDIO = 'http://192.168.1.5:4200'
+const BOX = 'http://box.tail.ts:4200'
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+  selectRemoteDevice(null) // module-level state, so it outlives a test unless reset
+  checkDevices.mockReset()
+})
+
+describe('DevicesSettings (#1052/#1072)', () => {
+  test('says so when there are no devices, rather than showing an empty list', () => {
+    checkDevices.mockResolvedValue({})
+    render(<DevicesSettings />)
+    expect(screen.getByText(/No devices saved/)).toBeTruthy()
+  })
+
+  test('lists each saved device with its origin', () => {
+    checkDevices.mockResolvedValue({})
+    addProfile({ url: STUDIO, token: 'aaa', label: 'Studio' })
+    render(<DevicesSettings />)
+    expect(screen.getByText('Studio')).toBeTruthy()
+    expect(screen.getByText(STUDIO)).toBeTruthy()
+  })
+
+  test('removing a device drops it from storage', () => {
+    checkDevices.mockResolvedValue({})
+    addProfile({ url: STUDIO, token: 'aaa', label: 'Studio' })
+    render(<DevicesSettings />)
+
+    fireEvent.click(screen.getByLabelText('Remove Studio'))
+
+    expect(listProfiles()).toEqual([])
+  })
+
+  test('removing the device a run is targeting clears the run target (#1072)', () => {
+    // The composer applies this guard on its own remove; managing the roster from settings has to
+    // apply it too, or the next run points at a device that is no longer in the list.
+    checkDevices.mockResolvedValue({})
+    const studio = addProfile({ url: STUDIO, token: 'aaa', label: 'Studio' })
+    selectRemoteDevice(studio.id)
+    render(<DevicesSettings />)
+
+    fireEvent.click(screen.getByLabelText('Remove Studio'))
+
+    expect(getSelectedRemoteDeviceId()).toBe(null)
+  })
+
+  test('removing some other device leaves the run target alone', () => {
+    checkDevices.mockResolvedValue({})
+    const studio = addProfile({ url: STUDIO, token: 'aaa', label: 'Studio' })
+    addProfile({ url: BOX, token: 'bbb', label: 'Box' })
+    selectRemoteDevice(studio.id)
+    render(<DevicesSettings />)
+
+    fireEvent.click(screen.getByLabelText('Remove Box'))
+
+    expect(getSelectedRemoteDeviceId()).toBe(studio.id)
+    expect(listProfiles().map(p => p.label)).toEqual(['Studio'])
+  })
+})

--- a/packages/framework-dashboard/components/DevicesSettings.tsx
+++ b/packages/framework-dashboard/components/DevicesSettings.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react'
+import { Trash2 } from 'lucide-react'
+import { useConnectionProfiles, removeProfile, type ConnectionProfile } from '../lib/profiles.js'
+import { useDeviceStatus } from '../lib/use-device-status.js'
+import { useSelectedRemoteDeviceId, selectRemoteDevice } from '../lib/remote-target.js'
+import { AddDeviceDialog } from './AddDeviceDialog.js'
+import { Button } from './ui/button.js'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card.js'
+import { cn } from '../lib/utils.js'
+
+// Saved devices, as a settings section (#1052/#1072).
+//
+// Adding and removing a device already worked, but only from the composer's "Run on" menu, and the
+// composer exists on a project launcher and nowhere else: from the Overview or the settings page
+// there was no way to manage the roster at all. The picker keeps listing devices, because choosing
+// a run target is a per-run act; which devices exist is configuration, so it belongs here.
+//
+// Unlike everything else on the settings page these are NOT preferences. A device carries a token,
+// so it lives in this browser's localStorage and never reaches the daemon (see profiles.ts). The
+// section says so, because the reasonable assumption for a settings row is that it follows you to
+// the next browser, and this one does not.
+
+export function DevicesSettings() {
+  const profiles = useConnectionProfiles()
+  const status = useDeviceStatus(profiles)
+  const selectedDeviceId = useSelectedRemoteDeviceId()
+  const [adding, setAdding] = useState(false)
+
+  // The same guard the composer applies (#1072): a device that is removed must not stay the run
+  // target, or the next run points at something that is no longer in the list.
+  const remove = (profile: ConnectionProfile) => {
+    if (selectedDeviceId === profile.id) selectRemoteDevice(null)
+    removeProfile(profile.id)
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-3">
+        <div>
+          <CardTitle>Devices</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Other machines running The Framework that you can run a session on. Saved in this browser, not on the
+            server, because each one is reached with its own token.
+          </p>
+        </div>
+        <Button size="sm" variant="outline" className="shrink-0 whitespace-nowrap" onClick={() => setAdding(true)}>
+          Add device
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {profiles.length === 0 ? (
+          <p className="py-2 text-sm text-muted-foreground">
+            No devices saved. Add one with the URL another machine prints when it starts.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {profiles.map(profile => (
+              <li key={profile.id} className="flex items-center justify-between gap-4 py-3 first:pt-0 last:pb-0">
+                <div className="min-w-0">
+                  <p className="truncate text-sm">{profile.label}</p>
+                  <p className="truncate text-xs text-muted-foreground">{profile.url}</p>
+                </div>
+                <div className="flex shrink-0 items-center gap-3">
+                  <DeviceStatusBadge state={status[profile.id]} />
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => remove(profile)}
+                    title={`Remove ${profile.label}`}
+                    aria-label={`Remove ${profile.label}`}
+                  >
+                    <Trash2 className="h-4 w-4" aria-hidden />
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+
+      {adding && <AddDeviceDialog onClose={() => setAdding(false)} onAdded={() => setAdding(false)} />}
+    </Card>
+  )
+}
+
+/** Online / offline, or neither while the first ping is still out. */
+function DeviceStatusBadge({ state }: { state: 'online' | 'offline' | undefined }) {
+  const label = state === 'online' ? 'Online' : state === 'offline' ? 'Offline' : 'Checking…'
+  return (
+    <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <span
+        aria-hidden
+        className={cn(
+          'h-1.5 w-1.5 rounded-full',
+          state === 'online' ? 'bg-[var(--color-primary)]' : 'bg-muted-foreground/40',
+        )}
+      />
+      {label}
+    </span>
+  )
+}

--- a/packages/framework-dashboard/components/SettingsPage.tsx
+++ b/packages/framework-dashboard/components/SettingsPage.tsx
@@ -3,6 +3,7 @@ import { AGENTS, AGENT_LABELS } from '@gemstack/the-framework/client'
 import { useDetectedEditors } from '../lib/editors.js'
 import { usePreferences, updatePreferences, themePreference, type ThemePreference } from '../lib/preferences.js'
 import { OnboardingChecklist } from './OnboardingChecklist.js'
+import { DevicesSettings } from './DevicesSettings.js'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card.js'
 import { Checkbox } from './ui/checkbox.js'
 import { ScrollArea } from './ui/scroll-area.js'
@@ -86,6 +87,9 @@ export function SettingsPage({ onSelectProject }: { onSelectProject?: ((id: stri
             onChange={value => updatePreferences({ target: value as 'local' | 'actions' })}
           />
         </Section>
+
+        {/* Beside "Run on", since a saved device is the other thing a session can run on. */}
+        <DevicesSettings />
 
         <Section title="Run options">
           <ToggleRow


### PR DESCRIPTION
Follow-up to #958, extending the settings page.

## The gap
Device add and remove already worked (#1052/#1072), but only from the composer's "Run on" menu, and the composer only exists on a project launcher. So from the **Overview** or the **settings page** there was no way to manage the roster at all. That is the same "configuration buried in a run-time menu" problem the settings page was created to fix.

## What this adds
A **Devices** section on `/settings`, placed right after "Run on" since a saved device is the other thing a session can run on:
- each saved device with its origin and an online/offline dot (reusing `useDeviceStatus`)
- **Add device**, opening the existing `AddDeviceDialog`
- remove per row, with an empty state when none are saved

The "Run on" picker is unchanged and still lists devices: **choosing** a run target is a per-run act, **which devices exist** is configuration. Only the second moves here.

## Two things worth reviewing
1. **Same removal guard as the composer.** Removing the device that is the current run target clears the selection (`selectRemoteDevice(null)`), exactly as `Composer.tsx` already did. Without it, settings could leave a run pointing at a device no longer in the list. Pinned by a test, plus its complement (removing a *different* device leaves the target alone).
2. **Devices are not preferences, and the section says so.** Every other row on that page is server-persisted and follows you to another browser. A device carries a token, so per `profiles.ts` it lives in this browser's localStorage and never reaches the daemon. The blurb states this outright, because the reasonable assumption for a settings row is the opposite.

**No second source of truth:** the presentation is new, the state is not. It reads the existing `useConnectionProfiles` / `useDeviceStatus` hooks and `profiles.ts`. I deliberately did **not** extract a component shared with the "Run on" menu: the containers differ (dropdown items vs page rows) while the logic already lives in shared hooks, so sharing markup would have coupled two unrelated shells for no gain.

## Verification
- `pnpm typecheck` 22/22, `pnpm build` 12/12
- dashboard **391 pass** (+5 new), framework **1176 pass / 0 fail**
- **Driven in a real browser**: section renders with two seeded devices and their status, remove drops the row and the stored entry, the empty state appears, and Add device opens the dialog from this page.