### PR TITLE
fix(release): put @gemstack/the-framework back on the 1.x line

### DIFF
--- a/packages/the-framework/CHANGELOG.md
+++ b/packages/the-framework/CHANGELOG.md
@@ -1,14 +1,12 @@
-# @gemstack/framework
+# @gemstack/the-framework
 
-## 2.0.0
+## 1.2.0
 
-### Major Changes
+### Minor Changes
 
 - b2d23ed: Rename the package from `@gemstack/framework` to `@gemstack/the-framework`, and the CLI command from `framework` to `the-framework` (#1071), for consistency with the product name **The Framework**.
 
-  This is a breaking change: update installs to `@gemstack/the-framework` and invocations to `the-framework`. The old `@gemstack/framework` package will be deprecated on npm with a pointer to the new name.
-
-### Minor Changes
+  Shipped as a new package name rather than a break in the old one: `@gemstack/framework` keeps resolving and is deprecated with a pointer here, so nothing installed today stops working. Update installs to `@gemstack/the-framework` and invocations to `the-framework`.
 
 - 61451a1: Dashboard: the session page says its branch once. The handoff card that repeated the branch name under the action bar is gone; its verdict ("2 commits · 0 files", "no changes", "branch gone") and its Push branch / Open PR buttons now ride in the branch row itself, and clicking that row expands the commits and changed files. A live session's Changes panel folds into the same row: the file count sits beside the branch, the rows open underneath.
 - ecf2ce4: feat(framework): context fragment lists the recorded conversations (#683)

--- a/packages/the-framework/package.json
+++ b/packages/the-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gemstack/the-framework",
-  "version": "2.0.0",
+  "version": "1.2.0",
   "description": "The (AI) Framework: turnkey, zero-config AI orchestration that wraps a coding-agent CLI (Claude Code) as a black box and takes you from an idea to a running app. Vite for AI.",
   "keywords": [
     "ai",


### PR DESCRIPTION
The first release under the new package name went out as **2.0.0**, because the rename carried a `major` changeset (mine, in #1089). We want to stay on 1.x.

## Why minor is the right call
A rename to a **new package name** breaks nobody. `@gemstack/framework` keeps resolving exactly as before and gets deprecated with a pointer to the new name, so nothing installed today stops working. There is no break to signal, so major overstated it.

## What this changes
- `packages/the-framework/package.json`: `2.0.0` → **`1.2.0`** (the old package sat at 1.1.0)
- CHANGELOG: the rename entry moves from **Major Changes** to **Minor Changes**, reworded so it no longer claims to be breaking
- CHANGELOG title fixed — it still read `# @gemstack/framework`

**No changeset in this PR on purpose.** It corrects a version rather than shipping a change, and a changeset would bump it straight back up.

## Note on npm state
`@gemstack/the-framework@2.0.0` **is already published** (public, and currently `latest` since it is the only version). This PR only fixes the repo. Getting the registry onto 1.x needs three steps after merge, in this order:

1. publish `1.2.0`
2. `npm dist-tag add @gemstack/the-framework@1.2.0 latest` — required, because npm keeps `latest` on the highest semver
3. `npm unpublish @gemstack/the-framework@2.0.0` (or `npm deprecate` it)

Step 3 must come **after** 1.2.0 exists: 2.0.0 is currently the only version, so unpublishing it first would remove the whole package and block republishing the name for 24 hours.

The `@gemstack/the-framework@2.0.0` git tag and its GitHub Release also want removing.