### PR TITLE
feat(the-framework): auto-remove a session's worktree once its branch lands

### DIFF
--- a/.changeset/auto-remove-landed-worktrees.md
+++ b/.changeset/auto-remove-landed-worktrees.md
@@ -1,0 +1,15 @@
+---
+"@gemstack/the-framework": minor
+---
+
+Reclaim a session's worktree once its work has landed.
+
+A run that failed or was stopped keeps its checkout so you can read what it was holding, and nothing ever took those back, so a machine accumulated one full checkout per such session forever. The daemon now sweeps the registered projects every ten minutes and removes the checkouts whose branch has landed.
+
+Only the checkout goes. The branch, its commits, and the session's row and replayable log are kept, so everything this reclaims is a `git worktree add` away. That is what makes it safe to do without asking.
+
+A branch counts as landed on either of two signals, because neither alone is enough. `git branch --merged` is the stronger one, since it proves the commits are reachable from the local base, but it only holds for a merge that kept them: a squash or rebase merge rewrites the commits, so the branch never becomes an ancestor and the signal never fires. A merged PR closes that gap. A closed-unmerged PR does not count as landed, since the checkout of rejected work is the one you are most likely to still want.
+
+The sweep is conservative wherever the answer is unclear: a live run keeps its checkout, and so does a branch that no longer exists or one whose state cannot be read.
+
+`framework worktrees sweep` runs the same pass on demand, next to the existing `prune` (which removes every checkout whose session is no longer running, landed or not).

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -73,6 +73,7 @@ import {
   pruneProjectWorktrees,
   formatWorktreeList,
 } from './worktrees.js'
+import { removeMergedWorktrees } from './merged-worktrees.js'
 import { defaultWhat } from './preset-prompt.js'
 import { renderOnBeforeMergeablePrompt, type OnBeforeMergeableContext } from './on-before-mergeable-prompt.js'
 import { runPrompt } from './prompt-run.js'
@@ -151,7 +152,8 @@ Usage:
                                  --dry-run to preview; --max-repos / --max-cost to bound.
   framework worktrees             List the checkouts this project's sessions kept.
                                  rm <sessionId> removes one; prune removes every one
-                                 whose session is no longer running.
+                                 whose session is no longer running; sweep removes only
+                                 those whose branch has landed (#1036), keeping the branch.
   framework --fake                Run the offline demo (no CLI, no model, deterministic).
   framework doctor                Check prerequisites (Claude Code installed, etc.).
   framework relay                 Host a session relay so teammates can watch a session (#230).
@@ -642,6 +644,7 @@ export function parseArgs(argv: string[]): CliOptions {
     const sub = words.shift()
     if (sub === undefined || sub === 'list') opts.worktrees = { action: 'list' }
     else if (sub === 'prune') opts.worktrees = { action: 'prune' }
+    else if (sub === 'sweep') opts.worktrees = { action: 'sweep' }
     else if (sub === 'rm') {
       const runId = words.shift()
       opts.worktrees = { action: 'rm', ...(runId ? { runId } : {}) }
@@ -1806,7 +1809,12 @@ async function ensureDaemonCmd(opts: CliOptions, io: CliIO): Promise<number> {
 }
 
 /** What `framework worktrees` was asked to do (#752). */
-export type WorktreesCommand = { action: 'list' } | { action: 'rm'; runId?: string } | { action: 'prune' }
+export type WorktreesCommand =
+  | { action: 'list' }
+  | { action: 'rm'; runId?: string }
+  | { action: 'prune' }
+  /** Remove only the checkouts whose branch has landed (#1036) — the daemon's sweep, on demand. */
+  | { action: 'sweep' }
 
 /**
  * `framework worktrees` (#752): the retained-worktree cleanup the dashboard already has (#737),
@@ -1833,6 +1841,18 @@ async function worktreesCmd(command: WorktreesCommand, cwd: string, io: CliIO): 
     }
     io.out(`◆ removed the worktree for session ${command.runId}.`)
     return 0
+  }
+  // The daemon runs this on a timer (#1036); here it is on demand, for a machine whose daemon is
+  // not running and for seeing what the sweep would say.
+  if (command.action === 'sweep') {
+    const { removed, failed } = await removeMergedWorktrees(cwd)
+    for (const item of removed) {
+      io.out(`◆ removed ${item.runId}: ${item.branch} ${item.via === 'pr' ? 'was merged on GitHub' : 'is merged into the base'}.`)
+    }
+    for (const item of failed) io.err(`✗ ${item.runId}: ${item.error}`)
+    if (removed.length === 0 && failed.length === 0) io.out('No landed worktrees to remove.')
+    else if (removed.length > 0) io.out(`The branches and the sessions are kept; only the checkouts were removed.`)
+    return failed.length > 0 ? 1 : 0
   }
   const { removed, skipped } = await pruneProjectWorktrees(cwd)
   for (const skip of skipped) io.out(`  kept ${skip.runId}: ${skip.reason}`)

--- a/packages/the-framework/src/daemon-services.ts
+++ b/packages/the-framework/src/daemon-services.ts
@@ -14,6 +14,7 @@ import { maintenanceDue, readMaintenanceState, mergeMaintenanceState } from './m
 import { promoteQueue } from './queue-promote.js'
 import { findTodoBacklog } from './todo-loop.js'
 import { startConversationCommitter } from './conversation-commit.js'
+import { startMergedWorktreeSweep } from './merged-worktrees.js'
 import { readConversation } from './conversations.js'
 import { startDiscordBot, DISCORD_VIA } from './discord/bot.js'
 import { startDiscordReplyMirror } from './discord/reply-mirror.js'
@@ -156,6 +157,13 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
   // so it sat as an uncommitted change until a human noticed. Path-scoped and debounced, and it
   // skips a repo that is mid-rebase or index-locked rather than committing into someone's work.
   const conversationCommitter = startConversationCommitter({ projects, log })
+
+  // Reclaim the checkout of a session whose work has landed (#1036). A failed or stopped run keeps
+  // its worktree so you can read what it was holding (#752), and nothing ever took those back — so
+  // they accumulated one full checkout at a time. Once the branch is merged the checkout is the
+  // only copy that costs disk and says nothing new; the branch and the session's row are kept, so
+  // this reclaims space rather than throwing work away.
+  const mergedWorktrees = startMergedWorktreeSweep({ projects, log })
 
   const botEnabled = async () => notificationEnabled(await prefs(), 'discordBot')
   // `resolve` matters: projectId hashes the path string, and `--cwd` reaches us verbatim, so a
@@ -310,6 +318,7 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
       stopped = true
       stopDiscord()
       autoPm.stop()
+      mergedWorktrees.stop()
       // Stop the timer here, so `flushConversations` below is a single flush past the idle window
       // rather than a wait for a poll that is no longer coming.
       conversationCommitter.stop()

--- a/packages/the-framework/src/merged-worktrees.test.ts
+++ b/packages/the-framework/src/merged-worktrees.test.ts
@@ -1,0 +1,304 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { mkdtemp, realpath, rm, stat, writeFile } from 'node:fs/promises'
+import {
+  landedVia,
+  removeMergedWorktrees,
+  startMergedWorktreeSweep,
+  type MergedSweepResult,
+  type RemovedWorktree,
+} from './merged-worktrees.js'
+import { readRunHandoff, type RunHandoff } from './dashboard/run-handoff.js'
+import { addWorktree, runBranchName } from './store/index.js'
+import { nodeGitRunner } from './project.js'
+import type { WorktreeRow } from './worktrees.js'
+
+// #1036: a session's checkout is reclaimed once its work has landed. The branch, its commits and
+// the session's own records are kept, which is what makes deleting the checkout safe at all.
+
+const handoff = (over: Partial<RunHandoff> = {}): RunHandoff => ({
+  branch: 'the-framework/run-run1',
+  exists: true,
+  base: 'main',
+  commits: [],
+  files: [],
+  insertions: 0,
+  deletions: 0,
+  empty: false,
+  hasRemote: true,
+  pushed: true,
+  merged: false,
+  ...over,
+})
+
+const pr = (state: string) => ({ number: 7, url: 'https://example.test/pr/7', state, title: 'Add login' })
+
+test('a branch merged into the base has landed (#1036)', () => {
+  assert.equal(landedVia(handoff({ merged: true })), 'branch')
+})
+
+test('a merged PR has landed even when the local branch is not an ancestor (#1036)', () => {
+  // The squash-merge case: git says not merged, GitHub says it is in the base.
+  assert.equal(landedVia(handoff({ merged: false, pr: pr('MERGED') })), 'pr')
+})
+
+test('the local signal wins when both agree, so the reason reported is the stronger one (#1036)', () => {
+  assert.equal(landedVia(handoff({ merged: true, pr: pr('MERGED') })), 'branch')
+})
+
+test('an open PR has not landed (#1036)', () => {
+  assert.equal(landedVia(handoff({ pr: pr('OPEN') })), undefined)
+})
+
+test('a closed-unmerged PR has NOT landed: rejected work is what you most want to still read (#1036)', () => {
+  assert.equal(landedVia(handoff({ pr: pr('CLOSED') })), undefined)
+})
+
+test('a branch with neither signal has not landed (#1036)', () => {
+  assert.equal(landedVia(handoff()), undefined)
+})
+
+/** A sweep over fixed rows, recording which run ids removal was asked for. */
+function fakeSweep(rows: WorktreeRow[], states: Record<string, RunHandoff | undefined>) {
+  const asked: string[] = []
+  const run = (over: { remove?: (cwd: string, runId: string) => Promise<{ ok: true } | { ok: false; error: string }> } = {}) =>
+    removeMergedWorktrees('/repo', {
+      worktrees: async () => rows,
+      runs: async () => [],
+      handoff: async (_cwd, branch) => states[branch],
+      remove: async (_cwd, runId) => {
+        asked.push(runId)
+        return over.remove ? over.remove(_cwd, runId) : { ok: true }
+      },
+    })
+  return { asked, run }
+}
+
+const row = (over: Partial<WorktreeRow> & { runId: string }): WorktreeRow => ({ live: false, ...over })
+
+test('a landed session loses its checkout and an unlanded one keeps it (#1036)', async () => {
+  const { asked, run } = fakeSweep(
+    [row({ runId: 'landed' }), row({ runId: 'working' })],
+    {
+      'the-framework/run-landed': handoff({ branch: 'the-framework/run-landed', merged: true }),
+      'the-framework/run-working': handoff({ branch: 'the-framework/run-working' }),
+    },
+  )
+  const result = await run()
+  assert.deepEqual(asked, ['landed'])
+  assert.deepEqual(result.removed, [{ runId: 'landed', branch: 'the-framework/run-landed', via: 'branch' }])
+  assert.deepEqual(result.failed, [])
+})
+
+test('a live session keeps its checkout even when its branch already landed (#1036)', async () => {
+  // Its agent is working in there. Stop is how a run ends, not pulling the floor out from under it.
+  const { asked, run } = fakeSweep([row({ runId: 'live', live: true, status: 'running' })], {
+    'the-framework/run-live': handoff({ branch: 'the-framework/run-live', merged: true }),
+  })
+  const { removed } = await run()
+  assert.deepEqual(removed, [])
+  assert.deepEqual(asked, [])
+})
+
+test('a branch that no longer exists keeps its checkout: nothing to recover it from (#1036)', async () => {
+  const { asked, run } = fakeSweep([row({ runId: 'gone' })], {
+    'the-framework/run-gone': handoff({ branch: 'the-framework/run-gone', exists: false, merged: true }),
+  })
+  const { removed } = await run()
+  assert.deepEqual(removed, [])
+  assert.deepEqual(asked, [])
+})
+
+test('an unreadable branch state is skipped, never guessed at (#1036)', async () => {
+  const { removed } = await removeMergedWorktrees('/repo', {
+    worktrees: async () => [row({ runId: 'unreadable' })],
+    runs: async () => [],
+    handoff: async () => {
+      throw new Error('git exploded')
+    },
+    remove: async () => assert.fail('an unreadable repo must never be a reason to delete a checkout'),
+  })
+  assert.deepEqual(removed, [])
+})
+
+test('the branch a row recorded is preferred over the derived one (#799/#1036)', async () => {
+  const seen: string[] = []
+  await removeMergedWorktrees('/repo', {
+    worktrees: async () => [row({ runId: 'run1', branch: 'feat/agent-named-this' })],
+    runs: async () => [],
+    handoff: async (_cwd, branch) => (seen.push(branch), undefined),
+    remove: async () => ({ ok: true }),
+  })
+  assert.deepEqual(seen, ['feat/agent-named-this'])
+})
+
+test('a failed removal is reported rather than counted as reclaimed (#1036)', async () => {
+  const { run } = fakeSweep([row({ runId: 'stuck' })], {
+    'the-framework/run-stuck': handoff({ branch: 'the-framework/run-stuck', merged: true }),
+  })
+  const result = await run({ remove: async () => ({ ok: false, error: 'index.lock exists' }) })
+  assert.deepEqual(result.removed, [])
+  assert.deepEqual(result.failed, [{ runId: 'stuck', error: 'index.lock exists' }])
+})
+
+test('an unlisted project sweeps nothing rather than failing (#1036)', async () => {
+  const result = await removeMergedWorktrees('/repo', {
+    worktrees: async () => {
+      throw new Error('not a repo')
+    },
+  })
+  assert.deepEqual(result, { removed: [], failed: [] })
+})
+
+// The sweep loop over projects.
+
+test('the sweep says what it removed and why, per project (#1036)', async () => {
+  const lines: string[] = []
+  const results: Record<string, MergedSweepResult> = {
+    '/a': { removed: [{ runId: 'r1', branch: 'the-framework/run-r1', via: 'branch' } as RemovedWorktree], failed: [] },
+    '/b': { removed: [{ runId: 'r2', branch: 'feat/x', via: 'pr' } as RemovedWorktree], failed: [{ runId: 'r3', error: 'busy' }] },
+  }
+  const sweep = startMergedWorktreeSweep({
+    projects: async () => [{ path: '/a' }, { path: '/b' }],
+    log: line => lines.push(line),
+    sweep: async cwd => results[cwd] ?? { removed: [], failed: [] },
+    intervalMs: 60_000,
+  })
+  await sweep.tick()
+  sweep.stop()
+  assert.match(lines[0] ?? '', /removed the worktree for session r1: the-framework\/run-r1 is merged into the base/)
+  assert.match(lines[0] ?? '', /The branch and the session are kept/, 'a checkout vanishing silently reads as a bug')
+  assert.match(lines[1] ?? '', /removed the worktree for session r2: feat\/x was merged on GitHub/)
+  assert.match(lines[2] ?? '', /could not remove the landed worktree for session r3: busy/)
+})
+
+test('a stopped sweep does no further work (#1036)', async () => {
+  let swept = 0
+  const sweep = startMergedWorktreeSweep({
+    projects: async () => [{ path: '/a' }],
+    log: () => {},
+    sweep: async () => (swept++, { removed: [], failed: [] }),
+    intervalMs: 60_000,
+  })
+  await sweep.tick()
+  sweep.stop()
+  await sweep.tick()
+  assert.equal(swept, 1)
+})
+
+test('a project whose sweep throws does not stop the ones after it (#1036)', async () => {
+  const swept: string[] = []
+  const sweep = startMergedWorktreeSweep({
+    projects: async () => [{ path: '/bad' }, { path: '/good' }],
+    log: () => {},
+    sweep: async cwd => {
+      if (cwd === '/bad') throw new Error('nope')
+      swept.push(cwd)
+      return { removed: [], failed: [] }
+    },
+    intervalMs: 60_000,
+  })
+  await sweep.tick()
+  sweep.stop()
+  assert.deepEqual(swept, ['/good'])
+})
+
+// Against real git, because "is the work still there afterwards" is not a question a fake answers.
+
+const RUN_ID = 'run1'
+
+/** A repo with a session worktree that has a commit of its own on the run branch. */
+async function repoWithSessionWork(): Promise<{ repo: string; path: string; branch: string; base: string }> {
+  const git = nodeGitRunner()
+  // realpath so the mkdtemp path matches what git reports (the /var -> /private/var symlink).
+  const repo = await realpath(await mkdtemp(join(tmpdir(), 'framework-merged-')))
+  await git(['init'], repo)
+  await git(['config', 'user.email', 't@t'], repo)
+  await git(['config', 'user.name', 't'], repo)
+  await writeFile(join(repo, 'index.html'), '<h1>Hello, world!</h1>\n')
+  await git(['add', '-A'], repo)
+  await git(['commit', '-m', 'init'], repo)
+  const base = (await git(['rev-parse', '--abbrev-ref', 'HEAD'], repo)).trim()
+  const { path, branch } = await addWorktree(repo, { runId: RUN_ID, branch: runBranchName(RUN_ID) }, git)
+  await writeFile(join(path, 'index.html'), '<h1>Welcome!</h1>\n')
+  await git(['add', '-A'], path)
+  await git(['commit', '-m', 'the session did this'], path)
+  return { repo, path, branch, base }
+}
+
+/** The real branch reader, minus the `gh` call: these tests are about git, and have no remote. */
+const localHandoff = (cwd: string, branch: string) => readRunHandoff(cwd, branch, { pr: async () => undefined })
+
+test('a merged session loses its checkout and keeps its branch and commit (#1036)', async () => {
+  const { repo, path, branch, base } = await repoWithSessionWork()
+  const git = nodeGitRunner()
+  try {
+    await git(['merge', '--no-ff', '-m', 'merge the session', branch], repo)
+    const result = await removeMergedWorktrees(repo, { handoff: localHandoff })
+
+    assert.deepEqual(result.removed, [{ runId: RUN_ID, branch, via: 'branch' }])
+    await assert.rejects(() => stat(path), 'the checkout is gone')
+    // The half that makes this safe to do automatically.
+    assert.equal((await git(['rev-parse', '--verify', '--quiet', `refs/heads/${branch}`], repo)).trim().length, 40, 'the branch is kept')
+    const log = await git(['log', '--format=%s', branch], repo)
+    assert.match(log, /the session did this/, 'the commit is still on the branch')
+    assert.match(await git(['show', `${base}:index.html`], repo), /Welcome!/, 'and it landed on the base')
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})
+
+test('an unmerged session keeps its checkout (#1036)', async () => {
+  const { repo, path } = await repoWithSessionWork()
+  try {
+    assert.deepEqual(await removeMergedWorktrees(repo, { handoff: localHandoff }), { removed: [], failed: [] })
+    assert.ok((await stat(path)).isDirectory(), 'the checkout is still there')
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})
+
+test('a squash-merged branch is not an ancestor of the base, which is why the PR signal exists (#1036)', async () => {
+  const { repo, path, branch } = await repoWithSessionWork()
+  const git = nodeGitRunner()
+  try {
+    await git(['merge', '--squash', branch], repo)
+    await git(['commit', '-m', 'the session did this (#1)'], repo)
+
+    // The gap, against real git: the work is in the base, and `git branch --merged` says no.
+    const state = await localHandoff(repo, branch)
+    assert.equal(state?.merged, false, 'a squash merge rewrites the commits, so the branch never becomes an ancestor')
+    assert.deepEqual(await removeMergedWorktrees(repo, { handoff: localHandoff }), { removed: [], failed: [] })
+    assert.ok((await stat(path)).isDirectory(), 'so the local signal alone would keep this checkout forever')
+
+    // GitHub saying MERGED is what closes it.
+    const withPr = async (cwd: string, b: string) => {
+      const read = await localHandoff(cwd, b)
+      return read ? { ...read, pr: pr('MERGED') } : undefined
+    }
+    const result = await removeMergedWorktrees(repo, { handoff: withPr })
+    assert.deepEqual(result.removed, [{ runId: RUN_ID, branch, via: 'pr' }])
+    await assert.rejects(() => stat(path), 'the checkout is gone')
+    assert.equal((await git(['rev-parse', '--verify', '--quiet', `refs/heads/${branch}`], repo)).trim().length, 40, 'the branch is kept')
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})
+
+test('uncommitted work in a landed checkout is committed to the kept branch, not destroyed (#982/#1036)', async () => {
+  const { repo, path, branch } = await repoWithSessionWork()
+  const git = nodeGitRunner()
+  try {
+    await git(['merge', '--no-ff', '-m', 'merge the session', branch], repo)
+    await writeFile(join(path, 'notes.txt'), 'something the agent had not committed\n')
+
+    const result = await removeMergedWorktrees(repo, { handoff: localHandoff })
+    assert.deepEqual(result.failed, [])
+    await assert.rejects(() => stat(path), 'the checkout is gone')
+    assert.match(await git(['show', `${branch}:notes.txt`], repo), /had not committed/, 'the stray work is on the branch')
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})

--- a/packages/the-framework/src/merged-worktrees.ts
+++ b/packages/the-framework/src/merged-worktrees.ts
@@ -1,0 +1,211 @@
+import { listProjectWorktrees, removeProjectWorktree, type RemoveResult, type WorktreeRow } from './worktrees.js'
+import { listRuns, type RunMeta } from './store/index.js'
+import { readRunHandoff, runBranchFor, type RunHandoff } from './dashboard/run-handoff.js'
+
+// Auto-remove a session's worktree once its branch has landed (#1036).
+//
+// A run that failed or was stopped keeps its checkout so you can look at what it was holding
+// (#752), and nothing removed those on a timer — so a machine accumulated a full checkout per
+// such session forever, and the only cure was noticing and clicking Remove. Once the work has
+// landed, the checkout is the one copy of it that costs disk and carries no information: the
+// commits are in the base, the branch is still there, and the session's row and replayable log
+// are untouched.
+//
+// It removes the *checkout*, never the history. That is `removeProjectWorktree`'s existing
+// contract (#752/#982) and the whole reason this can be automatic: the branch stays, the session
+// stays, and everything this deletes is reconstructable with `git worktree add`.
+
+/** How a branch was found to have landed. */
+export type LandedVia = 'branch' | 'pr'
+
+/** One worktree this sweep removed. */
+export interface RemovedWorktree {
+  /** The run id, which is also the worktree's directory name. */
+  runId: string
+  branch: string
+  /** Which signal said it landed: merged into the base locally, or a merged PR on GitHub. */
+  via: LandedVia
+}
+
+/** A landed worktree that could not be removed, and git's reason. */
+export interface FailedRemoval {
+  runId: string
+  error: string
+}
+
+/** What {@link removeMergedWorktrees} did. */
+export interface MergedSweepResult {
+  removed: RemovedWorktree[]
+  /** Landed worktrees whose removal failed. A worktree that has *not* landed is not reported: it was never a candidate. */
+  failed: FailedRemoval[]
+}
+
+/** Injectable seams so the sweep is unit-testable off disk. */
+export interface MergedSweepDeps {
+  /** The worktrees on disk (default {@link listProjectWorktrees}). */
+  worktrees?: (cwd: string) => Promise<WorktreeRow[]>
+  /** The project's archived runs (default {@link listRuns}), for the branch a row did not record. */
+  runs?: (cwd: string) => Promise<RunMeta[]>
+  /** Reads a branch's state (default {@link readRunHandoff}). */
+  handoff?: (cwd: string, branch: string) => Promise<RunHandoff | undefined>
+  /** Removes one worktree (default {@link removeProjectWorktree}). */
+  remove?: (cwd: string, runId: string) => Promise<RemoveResult>
+}
+
+/**
+ * Whether a branch's state counts as landed, and by which signal.
+ *
+ * Both signals, because either one alone is wrong here.
+ *
+ * `merged` (`git branch --merged <base>`) is the stronger of the two: it is proof the commits are
+ * reachable from the local base, which is exactly the "still recoverable" bar this feature has to
+ * clear before deleting anything. But it only holds for a merge that kept the commits — a squash
+ * or rebase merge rewrites them, so the branch never becomes an ancestor of the base and this
+ * signal never fires. On a repo with squash-merge on (this one included) that is most merges, and
+ * a sweep gated on it alone would almost never run.
+ *
+ * A merged PR closes that gap: GitHub saying MERGED is a statement that the work is in the base
+ * branch, however it was squashed getting there. It is the weaker signal only in that it describes
+ * the remote — which is why the branch is kept either way, so a base you have not fetched yet
+ * still leaves the commits sitting locally on the branch.
+ *
+ * Deliberately not `pr.state === 'CLOSED'`: a closed-unmerged PR means the work was *rejected*,
+ * and the checkout of rejected work is the one a human is most likely to still want to read.
+ */
+export function landedVia(state: RunHandoff): LandedVia | undefined {
+  if (state.merged) return 'branch'
+  if (state.pr?.state === 'MERGED') return 'pr'
+  return undefined
+}
+
+/**
+ * Remove every retained worktree in `cwd` whose branch has landed (#1036).
+ *
+ * Conservative at every step where the answer is not clear: a live run keeps its checkout (it is
+ * where its agent is working), a branch that no longer exists is left alone, and a branch whose
+ * state cannot be read is skipped rather than guessed at — an unreadable repo must never be a
+ * reason to delete a checkout.
+ *
+ * Removal itself is {@link removeProjectWorktree}, not a second copy of it, so the automatic path
+ * and the two manual ones (`framework worktrees rm`, the dashboard's Remove button) are one
+ * behaviour. That also means uncommitted work in a landed checkout is committed to the kept branch
+ * before the checkout goes, exactly as it is when a human removes it: still recoverable, just no
+ * longer occupying disk.
+ */
+export async function removeMergedWorktrees(cwd: string, deps: MergedSweepDeps = {}): Promise<MergedSweepResult> {
+  // Sizes off: `du` over every retained checkout is the expensive part of the listing, and a sweep
+  // that only decides removal never reads the number.
+  const worktrees = deps.worktrees ?? ((path: string) => listProjectWorktrees(path, { sizes: false }))
+  const runs = deps.runs ?? listRuns
+  const handoff = deps.handoff ?? readRunHandoff
+  const remove = deps.remove ?? removeProjectWorktree
+
+  const result: MergedSweepResult = { removed: [], failed: [] }
+  const rows = await worktrees(cwd).catch((): WorktreeRow[] => [])
+  if (rows.length === 0) return result
+  // Read once for the whole sweep: `runBranchFor` falls back to the session name for a run
+  // archived before the branch was recorded (#799), and the row does not carry one.
+  const metas = await runs(cwd).catch((): RunMeta[] => [])
+
+  for (const row of rows) {
+    // A run's checkout is where its agent is working. Stop is how you end a run.
+    if (row.live) continue
+    const meta = metas.find(run => run.id === row.runId)
+    const branch = runBranchFor(meta ?? { id: row.runId, ...(row.branch ? { branch: row.branch } : {}) })
+    const state = await handoff(cwd, branch).catch(() => undefined)
+    // No answer, or the branch is gone: not evidence the work landed, so the checkout stays.
+    // A branch that no longer exists is the one case where the "recoverable from git" promise
+    // would be a lie, which makes it the last checkout to delete rather than the first.
+    if (!state || !state.exists) continue
+    const via = landedVia(state)
+    if (!via) continue
+    const outcome = await remove(cwd, row.runId)
+    if (outcome.ok) result.removed.push({ runId: row.runId, branch, via })
+    else result.failed.push({ runId: row.runId, error: outcome.error })
+  }
+  return result
+}
+
+/**
+ * How long between sweeps.
+ *
+ * Ten minutes, because merging is human-paced: nobody merges a PR and then watches for the
+ * checkout to disappear, and the reason this exists is disk reclaimed over days. It is also what
+ * the sweep costs — a `gh pr view` per retained worktree, behind a 60s cache — so a minute-poll
+ * would spend an order of magnitude more `gh` on an answer that changes a few times a day.
+ */
+export const DEFAULT_MERGED_SWEEP_INTERVAL_MS = 10 * 60 * 1000
+
+/** A running sweep, in the shape the daemon's other background services use. */
+export interface MergedWorktreeSweep {
+  /** Run one sweep now, awaiting it. Exposed for tests and for a caller that wants it on demand. */
+  tick: () => Promise<void>
+  stop: () => void
+}
+
+/** What {@link startMergedWorktreeSweep} needs from the daemon. */
+export interface MergedSweepOptions {
+  /** The registered projects to sweep. */
+  projects: () => Promise<readonly { path: string }[]>
+  log: (message: string) => void
+  intervalMs?: number
+  /** The per-project sweep (default {@link removeMergedWorktrees}). */
+  sweep?: (cwd: string) => Promise<MergedSweepResult>
+}
+
+/**
+ * Sweep every registered project's landed worktrees on a timer (#1036).
+ *
+ * Says what it removed rather than removing it silently: a checkout vanishing from under someone
+ * with no line explaining why reads as a bug, even when the work behind it is safe.
+ *
+ * Runs immediately on start and then every {@link DEFAULT_MERGED_SWEEP_INTERVAL_MS}; overlapping
+ * ticks are dropped, and the timer is unref'd so a background sweep is never the reason the
+ * process stays up.
+ */
+export function startMergedWorktreeSweep(opts: MergedSweepOptions): MergedWorktreeSweep {
+  const sweep = opts.sweep ?? removeMergedWorktrees
+  let stopped = false
+
+  const sweepAll = async (): Promise<void> => {
+    for (const project of await opts.projects().catch(() => [])) {
+      if (stopped) break
+      const { removed, failed } = await sweep(project.path).catch((): MergedSweepResult => ({ removed: [], failed: [] }))
+      for (const item of removed) {
+        opts.log(
+          `[framework] removed the worktree for session ${item.runId}: ${item.branch} ${
+            item.via === 'pr' ? 'was merged on GitHub' : 'is merged into the base'
+          }. The branch and the session are kept.`,
+        )
+      }
+      for (const item of failed) {
+        opts.log(`[framework] could not remove the landed worktree for session ${item.runId}: ${item.error}`)
+      }
+    }
+  }
+
+  // Overlapping ticks join the sweep already running rather than being dropped: awaiting `tick()`
+  // has to mean the sweep finished, or an on-demand caller (and a test) gets a silent no-op
+  // whenever the timer or the start-up sweep happens to be mid-flight.
+  let inflight: Promise<void> | undefined
+  const tick = (): Promise<void> => {
+    if (stopped) return Promise.resolve()
+    inflight ??= sweepAll().finally(() => {
+      inflight = undefined
+    })
+    return inflight
+  }
+
+  // Swept once at start-up, not only after the first interval: the case this exists for is a
+  // machine that was off (or a daemon that was down) while the work was merged.
+  void tick()
+  const timer = setInterval(() => void tick(), opts.intervalMs ?? DEFAULT_MERGED_SWEEP_INTERVAL_MS)
+  timer.unref?.()
+  return {
+    tick,
+    stop: () => {
+      stopped = true
+      clearInterval(timer)
+    },
+  }
+}


### PR DESCRIPTION
Closes #1036

A run that failed or was stopped keeps its checkout so you can read what it was holding (#752), and nothing ever took those back, so a machine accumulated one full checkout per such session forever. Once the work has landed, that checkout is the only copy that costs disk and carries no information.

The daemon now sweeps the registered projects every ten minutes and removes the checkouts whose branch has landed. `framework worktrees sweep` runs the same pass on demand, next to the existing `prune` (which removes every checkout whose session is no longer running, landed or not).

## What it deletes, and what it keeps

Only the checkout. The branch, its commits, and the session's row and replayable log are all kept — everything reclaimed is a `git worktree add` away. That is the OP's "recoverable from git history" bar, and it is what makes doing this without asking reasonable.

This is `removeProjectWorktree` (#752/#982), not a second copy of it, so the automatic path and the two manual ones (`worktrees rm`, the dashboard's Remove button) stay one behaviour. It also means uncommitted work in a landed checkout is committed to the kept branch before the checkout goes, exactly as when a human removes it.

The OP's second question — keep the branch and the session row, remove only the worktree — is answered yes, as it assumed.

## The open question: which trigger

The OP asks branch-merged-locally or PR-merged on GitHub. **Both**, because neither alone works:

- `git branch --merged <base>` is the stronger signal: it proves the commits are reachable from the local base, which is exactly the recoverability bar. But it only holds for a merge that kept the commits. A squash or rebase merge rewrites them, so the branch never becomes an ancestor of the base and this never fires. On a repo with squash-merge on (this one included) that is most merges, so a sweep gated on it alone would essentially never run. There is a test against real git asserting this gap is real, so the reason both exist stays visible.
- A merged PR closes that gap: GitHub saying `MERGED` is a statement that the work is in the base however it got squashed on the way. It describes the remote rather than local history, which is the other half of why the branch is kept either way — a base you have not fetched still leaves the commits locally on the branch.

Deliberately **not** `CLOSED`: a closed-unmerged PR means the work was rejected, and the checkout of rejected work is the one you are most likely to still want to read.

The PR state is already in `RunHandoff` and already cached (60s), so this adds a `gh pr view` per retained worktree per ten minutes, not per minute.

## Conservative where it is unsure

A live run keeps its checkout (its agent is working there; Stop is how a run ends). So does a branch that no longer exists — the one case where "recoverable from git" would be a lie, making it the last checkout to delete rather than the first — and one whose state cannot be read, since an unreadable repo must never be a reason to delete anything.

## No setting

Per #879's rule that a setting has to earn itself, and it does not here: the sweep keeps the branch and the session, so the cost of it being wrong is a `git worktree add`, not lost work. Happy to add a toggle if you would rather.

## Verification

- Root `pnpm typecheck` clean.
- Framework suite 1219 pass / 1 skipped (baseline 1199 + the 20 added here), dashboard 414 pass (unchanged — no UI touched).
- Four of the new tests run against real git rather than fakes, covering the merge, the squash-merge gap, the unmerged case, and that uncommitted work survives on the kept branch.
- Drove `framework worktrees sweep` against a real repo end to end: unmerged reports nothing to remove; after a merge it removes the checkout and leaves the branch and its commit intact.