### PR TITLE
feat(cli): print the commands and version on bare `framework` (#312)

### DIFF
--- a/.changeset/bare-framework-startup-footer.md
+++ b/.changeset/bare-framework-startup-footer.md
@@ -1,0 +1,13 @@
+---
+"@gemstack/the-framework": minor
+---
+
+Print the commands and the version on bare `framework` too (#312).
+
+#312 describes what `$ framework` should do, and two of its items were already built: the convenience command list and the version footer with the npm "up to date" check. Both lived only in `ensureDaemonCmd`, the `framework --daemon` path. Bare `framework`, the command the issue is actually about, foregrounds the dashboard instead and printed two lines: the URL and "Ctrl+C to stop".
+
+Both paths now print one shared footer, so the version you are running is visible from the command people actually type, and so is a newer release when there is one.
+
+The update line is not awaited before the static lines. #312 asks for the static info first, and the foreground path blocks on the server until it is signalled, so anything held back until after the registry call would never have been printed there at all. The check keeps its existing 2.5s cap and stays silent when npm is unreachable.
+
+The foreground footer drops the `framework stop` line, which stops a detached dashboard; that path tells you Ctrl+C instead.

--- a/packages/the-framework/src/cli.test.ts
+++ b/packages/the-framework/src/cli.test.ts
@@ -17,6 +17,7 @@ import {
   frameworkVersion,
   mergeRunConfig,
   parseArgs,
+  printStartupFooter,
   promptRunArgs,
   resolveDomainPreset,
   runCli,
@@ -913,4 +914,49 @@ test('a terminal --no-dashboard run does not stay open for chat, daemon or not (
 test('a run with a dashboard, or one the daemon started, stays open for chat (#714)', () => {
   assert.equal(isInteractive({}, true), true)
   assert.equal(isInteractive({ runId: 'r1' }, false), true)
+})
+
+test('the startup footer prints the commands and the version (#312)', async () => {
+  const { io, out } = capture()
+  await printStartupFooter(io, { background: true, fetchLatest: async () => frameworkVersion() })
+  assert.ok(out.includes('Type a prompt on the dashboard to start a session, or use:'))
+  assert.ok(out.includes(`The Framework v${frameworkVersion()}`))
+  assert.ok(out.includes(`✅ Up to date (v${frameworkVersion()})`))
+})
+
+test('the foreground footer drops `framework stop`, which only stops a detached dashboard (#312)', async () => {
+  const background = capture()
+  await printStartupFooter(background.io, { background: true, fetchLatest: async () => undefined })
+  const foreground = capture()
+  await printStartupFooter(foreground.io, { background: false, fetchLatest: async () => undefined })
+  assert.ok(background.out.some(l => l.includes('framework stop')))
+  assert.ok(!foreground.out.some(l => l.includes('framework stop')))
+  // Everything else is the same footer, including the version.
+  assert.ok(foreground.out.includes(`The Framework v${frameworkVersion()}`))
+})
+
+test('the version prints before npm answers, and a newer release is announced after (#312)', async () => {
+  const { io, out } = capture()
+  let release: (v: string) => void = () => {}
+  const pending = printStartupFooter(io, {
+    background: true,
+    fetchLatest: () => new Promise<string>(resolve => (release = resolve)),
+  })
+  // The static half is out while the registry call is still in flight — bare `framework` blocks on
+  // the server forever, so anything held back until after the await would never be printed there.
+  assert.ok(out.includes(`The Framework v${frameworkVersion()}`))
+  assert.ok(!out.some(l => l.includes('Update available')))
+  release('999.0.0')
+  await pending
+  assert.ok(out.some(l => l.includes('⬆️  Update available: v999.0.0')))
+})
+
+test('an unreachable npm registry costs the footer nothing (#312)', async () => {
+  const { io, out } = capture()
+  await printStartupFooter(io, {
+    background: true,
+    fetchLatest: () => Promise.reject(new Error('offline')),
+  })
+  assert.ok(out.includes(`The Framework v${frameworkVersion()}`))
+  assert.ok(!out.some(l => l.includes('Up to date') || l.includes('Update available')))
 })

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -47,7 +47,7 @@ import {
 } from './config-layers.js'
 import { type EcoOptions } from './system-prompt.js'
 import { loadUserSystemPrompt, SYSTEM_PROMPT_FILE } from './system-prompt-file.js'
-import { checkForUpdate, formatUpdateStatus, nodeVersionFetcher } from './update-check.js'
+import { checkForUpdate, formatUpdateStatus, nodeVersionFetcher, type VersionFetcher } from './update-check.js'
 import { appendLog, type LogEntry } from './logs.js'
 import { appendMessage, isSafeVia } from './conversations.js'
 import type { RecordMessage } from './await-gate.js'
@@ -1727,6 +1727,8 @@ async function runForegroundDaemonCmd(opts: CliOptions, io: CliIO): Promise<numb
   if (existing) {
     io.out(`◆ dashboard already running in the background: ${existing.url}`)
     io.out('  Stop it with `framework stop`, or open the URL above.')
+    // The dashboard this defers to *is* the background one, so its footer is the background one.
+    await printStartupFooter(io, { background: true })
     return 0
   }
   // #1051: pre-generate the shared token for a non-loopback bind so onListening (sync) can print
@@ -1742,6 +1744,10 @@ async function runForegroundDaemonCmd(opts: CliOptions, io: CliIO): Promise<numb
           printNonLoopbackAccess(io, state.host ?? DEFAULT_DAEMON_HOST, state.url, token)
         }
         io.out('  Ctrl+C to stop. Server logs stream below.')
+        // #312 asks bare `framework` to print the commands + version too. onListening is sync and
+        // runDaemon then blocks until signalled, so this is fire-and-forget by necessity: the
+        // update line lands a moment later, above the server logs.
+        void printStartupFooter(io, { background: false })
       },
     })
   } catch (err) {
@@ -1792,17 +1798,40 @@ async function ensureDaemonCmd(opts: CliOptions, io: CliIO): Promise<number> {
   // host that is bound, not the flag, so re-reporting an already-running loopback daemon stays quiet.
   const boundHost = state.host ?? DEFAULT_DAEMON_HOST
   if (!isLoopbackHost(boundHost)) printNonLoopbackAccess(io, boundHost, state.url, await readDaemonToken())
+  await printStartupFooter(io, { background: true })
+  return 0
+}
+
+/**
+ * The startup footer every dashboard path prints (#312): the convenience commands, the version,
+ * and then — once npm answers — whether that version is the latest.
+ *
+ * The update line is deliberately not awaited before the static lines. #312 asks for the static
+ * info first, and the foreground path (bare `framework`) blocks on the server forever, so a line
+ * printed after the await would never appear there at all. `checkForUpdate` is already forgiving:
+ * offline or slow (2.5s cap) resolves to 'unknown', which prints nothing.
+ *
+ * `background: false` drops the `framework stop` line — that stops a *detached* dashboard, and the
+ * foreground path tells you Ctrl+C instead.
+ */
+export function printStartupFooter(
+  io: CliIO,
+  opts: { background: boolean; fetchLatest?: VersionFetcher },
+): Promise<void> {
+  const version = frameworkVersion()
   io.out('')
   io.out('Type a prompt on the dashboard to start a session, or use:')
   io.out('  framework "<what to build>"   Build (streams to the dashboard)')
-  io.out('  framework stop                Stop the background dashboard')
+  if (opts.background) io.out('  framework stop                Stop the background dashboard')
   io.out('  framework --help              All options')
   io.out('')
-  io.out(`The Framework v${frameworkVersion()}`)
-  const status = await checkForUpdate(frameworkVersion(), nodeVersionFetcher())
-  const line = formatUpdateStatus(status)
-  if (line) io.out(line)
-  return 0
+  io.out(`The Framework v${version}`)
+  return checkForUpdate(version, opts.fetchLatest ?? nodeVersionFetcher())
+    .then(status => {
+      const line = formatUpdateStatus(status)
+      if (line) io.out(line)
+    })
+    .catch(() => {})
 }
 
 /** What `framework worktrees` was asked to do (#752). */


### PR DESCRIPTION
Part of #312. Does not close it: #312 is a multi-item ticket and the rest is noted below.

## What was wrong

#312 says what running `$ framework` should do. Two of its items are ticked, and both were built: the convenience command list, and the version footer with the npm up-to-date check (`update-check.ts`, wired at `cli.ts:1801`).

They were only ever printed by `ensureDaemonCmd`, which is `framework --daemon`. Bare `framework` goes to `runForegroundDaemonCmd` and printed two lines:

```
◆ dashboard running: http://127.0.0.1:4200
  Ctrl+C to stop. Server logs stream below.
```

No commands, no version. So the two ticked items were not true of the command the ticket is about, and the CLI version was reachable only via `--version` or the flag most people do not use.

## What this does

One `printStartupFooter` shared by every dashboard path: `framework --daemon`, bare `framework`, and the branch where bare `framework` finds a background daemon already up. Live drive of the built binary, foreground path:

```
◆ dashboard running: http://127.0.0.1:44955
  Ctrl+C to stop. Server logs stream below.

Type a prompt on the dashboard to start a session, or use:
  framework "<what to build>"   Build (streams to the dashboard)
  framework --help              All options

The Framework v1.2.0
✅ Up to date (v1.2.0)
```

Two design calls, both from the OP:

**The update line is not awaited before the static lines.** The OP asks for the static info first, and this is load-bearing rather than cosmetic on the foreground path: `runDaemon` blocks until the process is signalled, so a line printed after the await would never appear there at all. `checkForUpdate` keeps its 2.5s cap and its silent-on-failure behaviour, so an offline machine prints the version and nothing else.

**The foreground footer drops the `framework stop` line.** That stops a detached dashboard; the foreground path already says Ctrl+C. Everything else, including the version, is identical.

## The rest of #312

- **"Runs background jobs (#298)"** is already true in substance, on both paths, since both go through `runDaemon` -> `startBackgroundServices`: auto PM (#685/#773), the weekly maintenance sweep (#882), the conversation committer (#912) and the Discord watchers (#627), with auto PM gated on the #879 quota boundary, which is #298's "usage max-out idea". What #298 still lacks is its listeners half (a production error or a red CI on main triggering an agent). That is #298's own scope, not a CLI change, so this PR does not tick the box for you.
- **Auto-update and its `(✅ auto-update enabled)` label are not implemented**, so nothing prints that label. Claiming auto-update while nothing updates is worse than saying nothing. Happy to file it separately if you want it in the MVP.

## Verification

- 1204 tests in `@gemstack/the-framework`, 1203 pass, 1 skipped, 0 fail (4 new).
- Root `pnpm typecheck` clean across 22 packages.
- Mutation check: holding the version line behind the registry await fails exactly the two tests that pin the ordering and the offline case.
- Live drive above is the real built `dist/bin.js` against the real npm registry, on an isolated `XDG_CONFIG_HOME`.