### PR TITLE
feat(handoff): make Push branch and Open PR checkboxes that fire by themselves

### DIFF
--- a/.changeset/handoff-checkboxes.md
+++ b/.changeset/handoff-checkboxes.md
@@ -1,0 +1,17 @@
+---
+"@gemstack/the-framework": minor
+---
+
+The end-of-session handoff happens by itself: Push branch and Open PR are now checkboxes, ticked by default.
+
+They used to be two buttons on a finished session, and the code was explicit that they should stay clicks, on the grounds that publishing the agent's work under your name is your call. In practice that meant a click per session for the thing you almost always want, and when nobody clicked, the work stayed on a local branch nobody was told about.
+
+The call is still yours, it is just made once instead of every time. The two controls are now **pre-commitments** in the session action bar: whatever is still ticked when the session settles happens on its own. Leave them alone and it is zero-config. Untick either one while the session runs to opt out, and the old button comes back, so the deliberate path is never lost. A failure falls back to the button too, with git's or `gh`'s own reason beside it.
+
+The pair is not independent, because `gh` will not open a PR for a branch the remote has never seen: ticking **Open PR** arms the push, and unticking **Push branch** unticks the PR.
+
+The PR is opened as a **draft**, so firing on every session does not put a review request in anyone's inbox. That needed one change elsewhere: the interventions queue skipped every draft, on the grounds that a draft is not asking for review. For a PR the framework opened for itself that reasoning inverts, since then nothing would tell you the work exists at all. The queue now lists a draft on a `the-framework/*` branch and still skips drafts opened by hand.
+
+New per-project preferences `autoPushBranch` and `autoOpenPr` set where the boxes start; both default on. The CLI has `--no-auto-push-branch` and `--no-auto-open-pr`, which travel as explicit `--no-*` flags for the same reason the repo-config toggles do: these default on, so silence would re-arm them.
+
+The handoff runs after the on-before-mergeable quality pass, so anything that pass committed is included, and it commits the session's own pending work first, which teardown would otherwise only do after the run process had exited. It declines rather than acting on a stopped run, a branch that is gone, a session that committed nothing, a repo with no remote, and a branch that already has a PR.

--- a/packages/framework-dashboard/components/RunHandoff.test.tsx
+++ b/packages/framework-dashboard/components/RunHandoff.test.tsx
@@ -4,10 +4,11 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 const onRunHandoff = vi.fn(async () => null as unknown)
 const sendPushBranch = vi.fn(async () => ({ ok: true }) as unknown)
 const sendOpenPullRequest = vi.fn(async () => ({ ok: true }) as unknown)
+const sendSetHandoff = vi.fn(async () => undefined as unknown)
 vi.mock('../server/reads.telefunc.js', () => ({ onRunHandoff }))
-vi.mock('../server/control.telefunc.js', () => ({ sendPushBranch, sendOpenPullRequest }))
+vi.mock('../server/control.telefunc.js', () => ({ sendPushBranch, sendOpenPullRequest, sendSetHandoff }))
 
-const { HandoffActions, HandoffSummary, RunHandoffDetails, handoffExpandable } = await import('./RunHandoff.js')
+const { HandoffActions, HandoffArm, HandoffSummary, RunHandoffDetails, handoffExpandable } = await import('./RunHandoff.js')
 const { useRunHandoff } = await import('../lib/use-run-handoff.js')
 
 /** A handoff for a session that did real work, on a repo with a remote and no PR yet. */
@@ -44,6 +45,8 @@ beforeEach(() => {
   sendPushBranch.mockClear()
   sendOpenPullRequest.mockClear()
   sendOpenPullRequest.mockResolvedValue({ ok: true })
+  sendSetHandoff.mockClear()
+  sendSetHandoff.mockResolvedValue(undefined)
 })
 afterEach(cleanup)
 
@@ -140,5 +143,47 @@ describe('run handoff (#799)', () => {
     onRunHandoff.mockReturnValue(new Promise(() => {}) as never)
     const { container } = render(<Harness />)
     expect(container.textContent).toBe('')
+  })
+})
+
+describe('the handoff checkboxes (#1102)', () => {
+  const armed = { push: true, pr: true }
+
+  test('both boxes start ticked, so a session left alone hands itself back', () => {
+    render(<HandoffArm projectId="p1" runId="run-1" state={armed} />)
+    expect(screen.getByText('Push branch')).toBeTruthy()
+    expect(screen.getByText('Open PR')).toBeTruthy()
+    const boxes = screen.getAllByRole('checkbox')
+    expect(boxes).toHaveLength(2)
+    for (const box of boxes) expect(box.getAttribute('data-checked')).not.toBeNull()
+  })
+
+  test('unticking Open PR leaves the push armed', async () => {
+    render(<HandoffArm projectId="p1" runId="run-1" state={armed} />)
+    fireEvent.click(screen.getByText('Open PR'))
+    await waitFor(() => expect(sendSetHandoff).toHaveBeenCalledWith('p1', 'run-1', true, false))
+  })
+
+  test('unticking Push branch unticks Open PR too: a PR cannot be opened for an unpushed branch', async () => {
+    render(<HandoffArm projectId="p1" runId="run-1" state={armed} />)
+    fireEvent.click(screen.getByText('Push branch'))
+    await waitFor(() => expect(sendSetHandoff).toHaveBeenCalledWith('p1', 'run-1', false, false))
+  })
+
+  test('ticking Open PR re-arms the push, since opening one needs the branch on the remote', async () => {
+    render(<HandoffArm projectId="p1" runId="run-1" state={{ push: false, pr: false }} />)
+    fireEvent.click(screen.getByText('Open PR'))
+    await waitFor(() => expect(sendSetHandoff).toHaveBeenCalledWith('p1', 'run-1', true, true))
+  })
+
+  test('the click holds until the run echoes it back, so the box does not bounce', async () => {
+    // The instruction round-trips through a file the run tails, so the events lag the click by a
+    // beat. Rendering the stale value in that window would flick the box back on under the cursor.
+    const { rerender } = render(<HandoffArm projectId="p1" runId="run-1" state={armed} />)
+    fireEvent.click(screen.getByText('Open PR'))
+    await waitFor(() => expect(sendSetHandoff).toHaveBeenCalled())
+    rerender(<HandoffArm projectId="p1" runId="run-1" state={armed} />)
+    const pr = screen.getAllByRole('checkbox')[1]
+    expect(pr?.getAttribute('data-checked')).toBeNull()
   })
 })

--- a/packages/framework-dashboard/components/RunHandoff.tsx
+++ b/packages/framework-dashboard/components/RunHandoff.tsx
@@ -1,10 +1,12 @@
-import type { RunHandoff } from '@gemstack/the-framework'
+import { useEffect, useState } from 'react'
+import type { HandoffState, RunHandoff } from '@gemstack/the-framework'
 import { GitPullRequest, Upload } from 'lucide-react'
-import { sendOpenPullRequest, sendPushBranch } from '../server/control.telefunc.js'
+import { sendOpenPullRequest, sendPushBranch, sendSetHandoff } from '../server/control.telefunc.js'
 import type { RunHandoffState } from '../lib/use-run-handoff.js'
 import { cn } from '../lib/utils.js'
 import { DiffStat } from './DiffView.js'
 import { Button } from './ui/button.js'
+import { Checkbox } from './ui/checkbox.js'
 
 // The end-of-session handoff (#799): what this session produced, and the next step offered rather
 // than described. Before this, a finished session showed no branch, no commits and no diff, so
@@ -50,12 +52,98 @@ export function HandoffSummary({ handoff }: { handoff: RunHandoff | null }) {
 }
 
 /**
+ * What this session will do with its work when it ends (#1102), as two checkboxes in the bar.
+ *
+ * Pre-commitments, not buttons: whatever is still ticked when the session settles happens by
+ * itself. Both start ticked, which is the whole point — the common case costs nothing, and the
+ * work stops arriving on a local branch nobody was told about (#860). Unticking either one is how
+ * a session opts out, and after that the old button is what is left.
+ *
+ * Shown only while the session is live, because once it has settled the decision has been taken
+ * and what matters is what happened, which the summary says.
+ */
+export function HandoffArm({
+  projectId,
+  runId,
+  state,
+}: {
+  projectId: string
+  runId: string
+  state: HandoffState
+}) {
+  const [busy, setBusy] = useState(false)
+  // The event stream is the truth, but it round-trips through a file the run tails, so a click
+  // would visibly bounce back for a beat. `pending` holds what we last asked for until the events
+  // agree, the same shape the quota slider needed for a polled value (#979).
+  const [pending, setPending] = useState<{ push: boolean; pr: boolean } | null>(null)
+  const shown = pending ?? state
+  useEffect(() => {
+    if (pending && pending.push === state.push && pending.pr === state.pr) setPending(null)
+  }, [pending, state.push, state.pr])
+
+  const set = (next: { push: boolean; pr: boolean }): void => {
+    setPending(next)
+    setBusy(true)
+    void sendSetHandoff(projectId, runId, next.push, next.pr)
+      .catch(() => setPending(null))
+      .finally(() => setBusy(false))
+  }
+
+  // A PR needs the branch on the remote, so the two boxes are not independent: each carries the
+  // other where the pair would otherwise be impossible. Deciding this per box, rather than by
+  // normalising a pair, is what keeps it right in both directions — a shared rule cannot tell
+  // "ticked PR" from "unticked push" once it only has the resulting pair to look at.
+  return (
+    <div className="flex items-center gap-x-3 whitespace-nowrap text-xs text-muted-foreground">
+      <Arm
+        label="Push branch"
+        title="Push this session's branch to origin when it finishes."
+        checked={shown.push}
+        disabled={busy}
+        onChange={push => set(push ? { push: true, pr: shown.pr } : { push: false, pr: false })}
+      />
+      <Arm
+        label="Open PR"
+        title="Open a draft pull request when this session finishes. Implies pushing the branch."
+        checked={shown.pr}
+        disabled={busy}
+        onChange={pr => set(pr ? { push: true, pr: true } : { push: shown.push, pr: false })}
+      />
+    </div>
+  )
+}
+
+/** One armed step: a checkbox whose whole label is the hit target. */
+function Arm({
+  label,
+  title,
+  checked,
+  disabled,
+  onChange,
+}: {
+  label: string
+  title: string
+  checked: boolean
+  disabled: boolean
+  onChange: (checked: boolean) => void
+}) {
+  return (
+    <label className="flex cursor-pointer items-center gap-x-1.5 select-none" title={title}>
+      <Checkbox checked={checked} disabled={disabled} onCheckedChange={next => onChange(next === true)} />
+      {label}
+    </label>
+  )
+}
+
+/**
  * The next step, as a button, at the end of the action bar.
  *
- * Push and Open PR are clicks, never automatic: both publish the agent's work to a shared remote
- * under the user's name. They stay in the bar rather than behind the disclosure, because the whole
- * point of the handoff is to be offered without being looked for. Once a PR exists neither shows —
- * the bar links the PR, and the interventions queue (#632) has picked it up by then.
+ * What is left once a session has settled without handing itself off: it opted out of the
+ * checkboxes above, or the automatic attempt failed. Both publish the agent's work to a shared
+ * remote under the user's name, so the button stays the way to do it deliberately. They sit in the
+ * bar rather than behind the disclosure, because the point of the handoff is to be offered without
+ * being looked for. Once a PR exists neither shows — the bar links the PR, and the interventions
+ * queue (#632) has picked it up by then.
  */
 export function HandoffActions({
   projectId,

--- a/packages/framework-dashboard/components/RunView.tsx
+++ b/packages/framework-dashboard/components/RunView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react'
 import type { FrameworkEvent } from '@gemstack/the-framework'
-import { runProgress, sessionInfo } from '@gemstack/the-framework/client'
+import { handoffState, runProgress, sessionInfo } from '@gemstack/the-framework/client'
 import { onRun, onRetainedWorktrees } from '../server/reads.telefunc.js'
 import { useLoaded } from '../lib/use-async.js'
 import { useRunHandoff } from '../lib/use-run-handoff.js'
@@ -11,7 +11,7 @@ import { RunFeed } from './RunFeed.js'
 import { ActionsRunNotice } from './ActionsRunNotice.js'
 import { RemoteRunNotice } from './RemoteRunNotice.js'
 import { ChangesSummary, RunChanges } from './RunChanges.js'
-import { HandoffActions, HandoffSummary, RunHandoffDetails, handoffExpandable } from './RunHandoff.js'
+import { HandoffActions, HandoffArm, HandoffSummary, RunHandoffDetails, handoffExpandable } from './RunHandoff.js'
 
 // One session's view, whether it is running or finished (#1026).
 //
@@ -96,6 +96,9 @@ export function RunView({
   const shown = live ? events : (archived ?? events)
   const session = sessionInfo(shown)
   const progress = runProgress(shown)
+  // What the session hands back when it ends (#1102), folded from its own events so the boxes read
+  // the same whether this tab watched the run start or was opened halfway through.
+  const armed = handoffState(shown)
   // Until the handoff has actually loaded, a just-stopped run keeps showing the file counts it
   // ended with (#1030): the summary swaps once, from the live counts to the handoff, instead of
   // blanking for the beat the handoff read takes. Same for the chevron, so it does not blink out.
@@ -116,6 +119,11 @@ export function RunView({
           showHandoff ? (
             <>
               <HandoffSummary handoff={handoff.handoff} />
+              {/* An automatic handoff that failed has to say so here (#1102): the buttons coming
+                  back is the offer to retry, but on its own it looks like nothing was tried. */}
+              {armed.result?.outcome === 'failed' && (
+                <span className="text-danger">auto-handoff failed: {armed.result.error}</span>
+              )}
               {handoff.error && <span className="text-danger">{handoff.error}</span>}
             </>
           ) : (
@@ -124,7 +132,15 @@ export function RunView({
         }
         expanded={open}
         {...(canExpand ? { onToggle: toggle } : {})}
-        actions={runId ? <HandoffActions projectId={projectId} runId={runId} state={handoff} /> : undefined}
+        actions={
+          runId ? (
+            live ? (
+              <HandoffArm projectId={projectId} runId={runId} state={armed} />
+            ) : (
+              <HandoffActions projectId={projectId} runId={runId} state={handoff} />
+            )
+          ) : undefined
+        }
       />
       {/* What the session has touched, behind the branch row's disclosure. While it runs that is
           its worktree; once it ends, the branch it left behind. The live read needs the run's id:

--- a/packages/framework-dashboard/lib/run-option-rows.ts
+++ b/packages/framework-dashboard/lib/run-option-rows.ts
@@ -1,5 +1,5 @@
 import type { Preferences } from '@gemstack/the-framework'
-import { AGENTS, AGENT_LABELS, autopilotEnabled, type AgentName } from '@gemstack/the-framework/client'
+import { AGENTS, AGENT_LABELS, autopilotEnabled, handoffFromPreferences, type AgentName } from '@gemstack/the-framework/client'
 
 // The Global options as one table (#314), and the rules between them.
 //
@@ -49,6 +49,9 @@ export function runOptionRows(preferences: Preferences): RunOptionRows {
   const ecoMaintenance = preferences.ecoMaintenance ?? false
   const onBeforeMergeableQuality = preferences.onBeforeMergeableQuality ?? false
   const browser = preferences.browser ?? false
+  // Default-on (#1102), so it reads through `handoffFromPreferences` rather than `?? false` like
+  // the rest — and that helper is also what makes PR imply push.
+  const handoff = handoffFromPreferences(preferences)
   const agent = preferences.agent ?? 'claude' // #650: which coding agent drives the run
   // The stored agent as a display name; an unknown stored value falls back to Claude Code.
   const agentLabel = AGENT_LABELS[AGENTS.includes(agent as AgentName) ? (agent as AgentName) : 'claude']
@@ -112,6 +115,23 @@ export function runOptionRows(preferences: Preferences): RunOptionRows {
       title: "When the session signals it's ready for merge, run maintainability, readability, and security-audit passes",
       checked: onBeforeMergeableQuality && !transparent,
       ...overriddenByTransparent(transparent),
+    },
+    // Where the two handoff boxes get their default (#1102). A session's own action bar can still
+    // untick them for that one run; this is what every new session starts from.
+    {
+      key: 'autoPushBranch',
+      label: 'Push branch',
+      description: 'Pushes the session branch to origin when it finishes.',
+      title: "Push the session's branch to origin when it finishes, so the work is never left only on this machine",
+      checked: handoff.push,
+      ...(handoff.pr ? { disabled: true, disabledReason: 'opening a PR already pushes the branch' } : {}),
+    },
+    {
+      key: 'autoOpenPr',
+      label: 'Open PR',
+      description: 'Opens a draft pull request when it finishes.',
+      title: 'Open a draft pull request when the session finishes. Draft, so it does not request review; it still shows on the needs-you queue',
+      checked: handoff.pr,
     },
     // Claude-only (#801): the browser is wired through Claude Code's MCP config, so another agent's
     // driver takes no MCP servers and the box would be checkable but inert.

--- a/packages/framework-dashboard/server/control.telefunc.ts
+++ b/packages/framework-dashboard/server/control.telefunc.ts
@@ -4,6 +4,6 @@
 // Imported then exported, not re-exported (#1014): telefunc's dev transform appends
 // `__decorateTelefunction(<name>, ...)` per export, which needs a local binding. An
 // `export ... from` creates none, so `pnpm dev` died with `<name> is not defined`.
-import { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendDeleteSession, sendPushBranch, sendOpenPullRequest, sendQueueTicket } from '@gemstack/the-framework/dashboard-rpc'
+import { sendStop, sendChoice, sendMessage, sendSetHandoff, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendDeleteSession, sendPushBranch, sendOpenPullRequest, sendQueueTicket } from '@gemstack/the-framework/dashboard-rpc'
 
-export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendDeleteSession, sendPushBranch, sendOpenPullRequest, sendQueueTicket }
+export { sendStop, sendChoice, sendMessage, sendSetHandoff, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendDeleteSession, sendPushBranch, sendOpenPullRequest, sendQueueTicket }

--- a/packages/the-framework/src/cli.test.ts
+++ b/packages/the-framework/src/cli.test.ts
@@ -87,6 +87,15 @@ test('parseArgs reads --browser (#452)', () => {
   assert.equal(parseArgs(['--browser', 'x']).browser, true)
 })
 
+test('the handoff flags default ON, which is what makes it zero-config (#1102)', () => {
+  // Unlike every other toggle here, saying nothing means yes: a plain run pushes its branch and
+  // opens a draft PR when it finishes.
+  assert.equal(parseArgs(['x']).autoPushBranch, true)
+  assert.equal(parseArgs(['x']).autoOpenPr, true)
+  assert.equal(parseArgs(['--no-auto-push-branch', 'x']).autoPushBranch, false)
+  assert.equal(parseArgs(['--no-auto-open-pr', 'x']).autoOpenPr, false)
+})
+
 test('parseArgs reads --resume-session to continue a finished run (#720)', () => {
   assert.equal(parseArgs(['x']).resumeSession, undefined)
   assert.equal(parseArgs(['prompt', 'keep going', '--resume-session', 'sess-42']).resumeSession, 'sess-42')

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -25,7 +25,8 @@ import { startRelay, relayPublisher, type RelayPublisher } from './relay.js'
 import { randomUUID } from 'node:crypto'
 import { formatFrameworkEvent } from './terminal.js'
 import { CLAUDE_CODE_SESSION_LINK } from './session-link.js'
-import { type ChoicePick, type ChoiceRequest, type FrameworkEvent, type OnBeforeMergeableSkip } from './events.js'
+import { type AutoHandoffSkip, type ChoicePick, type ChoiceRequest, type FrameworkEvent, type OnBeforeMergeableSkip } from './events.js'
+import { runAutoHandoff } from './dashboard/run-handoff.js'
 import {
   runFramework,
   type AppPreview,
@@ -52,7 +53,7 @@ import { appendLog, type LogEntry } from './logs.js'
 import { appendMessage, isSafeVia } from './conversations.js'
 import type { RecordMessage } from './await-gate.js'
 import { preflight } from './preflight.js'
-import { RunStore, currentBranch, nodeStoreFs, renameRunBranch, runBranchName, type StoreFs } from './store/index.js'
+import { RunStore, commitPendingWork, currentBranch, nodeStoreFs, renameRunBranch, runBranchName, type StoreFs } from './store/index.js'
 import { materializePresets } from './presets.js'
 import { daemonStatus, ensureDaemon, isLoopbackHost, registerHomeProject, runDaemon, stopDaemon, DEFAULT_DAEMON_HOST, DEFAULT_DAEMON_PORT } from './daemon.js'
 import { resetControl, watchControl, type ControlWatcher } from './control.js'
@@ -206,6 +207,11 @@ Options:
   --browser              Give the agent a real browser during the run via
                          chrome-devtools-mcp: navigate pages, read console + network,
                          inspect the DOM, and screenshot. Off by default (#452).
+  --no-auto-push-branch  Do not push this session's branch to origin when it finishes.
+                         Pushing is the default, so the work does not sit on a local
+                         branch nobody is told about (#1102).
+  --no-auto-open-pr      Do not open a draft PR when the session finishes. Opening one
+                         is the default; it implies the push above (#1102).
   --unattended           Nobody is watching: choice gates take the recommended option
                          instead of waiting for an answer. Stop still works (#846).
   --kind <name>          Build event kind the preset's review loop fires for, e.g.
@@ -314,6 +320,13 @@ export interface CliOptions {
   onBeforeMergeable: boolean
   /** `--browser`: give the agent a real browser via chrome-devtools-mcp (navigate, console, network, DOM, screenshot) during the run (#452). */
   browser: boolean
+  /**
+   * `--auto-push-branch` / `--no-auto-push-branch` (#1102): push this session's branch to `origin`
+   * when it finishes. On by default, which is what makes the handoff zero-config.
+   */
+  autoPushBranch: boolean
+  /** `--auto-open-pr` / `--no-auto-open-pr` (#1102): open a draft PR when the session finishes. On by default; implies {@link autoPushBranch}. */
+  autoOpenPr: boolean
   buildEvent?: string | undefined
   maxPasses?: number
   maxCost?: number
@@ -377,6 +390,10 @@ export function parseArgs(argv: string[]): CliOptions {
     context: [],
     onBeforeMergeable: false,
     browser: false,
+    // On unless said otherwise (#1102): the whole point is that a session left alone hands its
+    // work back by itself.
+    autoPushBranch: true,
+    autoOpenPr: true,
     dashboard: true,
     relayServe: false,
     skipPermissions: false,
@@ -450,6 +467,18 @@ export function parseArgs(argv: string[]): CliOptions {
         break
       case '--browser':
         opts.browser = true
+        break
+      case '--auto-push-branch':
+        opts.autoPushBranch = true
+        break
+      case '--no-auto-push-branch':
+        opts.autoPushBranch = false
+        break
+      case '--auto-open-pr':
+        opts.autoOpenPr = true
+        break
+      case '--no-auto-open-pr':
+        opts.autoOpenPr = false
         break
       case '--eco-auto-planning':
         opts.eco.autoPlanning = true
@@ -812,6 +841,8 @@ interface RunEpilogue {
   browserStream: BrowserStream | undefined
   clearInterrupt: () => void
   maybeFireOnBeforeMergeable: () => Promise<void>
+  /** Hand the session's work back (#1102): push its branch and open a draft PR, if still armed. */
+  maybeAutoHandoff: () => Promise<void>
   /** Write the run's `.the-framework/LOGS.md` entry (#898). Idempotent: called on every exit path. */
   finishLog: () => Promise<void>
   /** True once the run stopped cleanly (interrupt / budget cap) rather than failed. */
@@ -842,6 +873,10 @@ async function settleRun(
     // Before the close, not after (#835): close() archives the log into `runs/`, so an
     // outcome appended afterwards would miss the copy the dashboard's history reads.
     await ctx.maybeFireOnBeforeMergeable()
+    // After the quality step, so whatever it committed is in what gets pushed; before the close,
+    // for the same reason as above — `close()` archives the log, and an outcome appended after it
+    // would miss the copy the dashboard's history reads (#835).
+    await ctx.maybeAutoHandoff()
     await ctx.finishLog()
     await ctx.store?.close() // flush the event log; best-effort
     // Stay up while the dashboard and/or the app are live, then tear both down.
@@ -1375,6 +1410,15 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
   // file was the only thing wiring it); and present while unrelated to this run, so a headless run
   // parked in the #714 chat loop forever. The daemon passes --run-id when it spawns, which is a
   // fact about *this* run rather than about the machine, so that is the signal now.
+  // What this session hands back when it ends (#1102). Mutable: the action bar's checkboxes can
+  // disarm it at any point up to the moment it settles, which is the whole point of them being
+  // pre-commitments rather than buttons. Opening a PR implies pushing, so the pair is normalised
+  // wherever it is set.
+  const armedHandoff = { push: opts.autoPushBranch || opts.autoOpenPr, pr: opts.autoOpenPr }
+  // Assigned once the journal exists, which is after the control watcher is wired: a change that
+  // arrives before then still lands on `armedHandoff`, it just has no event to announce it yet.
+  let announceHandoff: ((push: boolean, pr: boolean) => void) | undefined
+
   let control: ControlWatcher | undefined
   if (isSteerable(opts, newDashboard, await daemonStatus() !== undefined)) {
     try {
@@ -1387,6 +1431,12 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
         if (entry.kind === 'message') {
           // Carry the origin the sender named (#917), so the turn is recorded where it happened.
           messages.push(entry.text, entry.via)
+          return
+        }
+        if (entry.kind === 'handoff') {
+          armedHandoff.push = entry.push || entry.pr
+          armedHandoff.pr = entry.pr
+          announceHandoff?.(armedHandoff.push, armedHandoff.pr)
           return
         }
         const resolve = pendingChoices.get(entry.id)
@@ -1459,6 +1509,12 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
   })
   const onEvent = journal.onEvent
 
+  // Put the armed state on the run's meta (#1102), and keep it there as the checkboxes change it.
+  // The control channel carries the instruction, but only an event reaches meta, and meta is the
+  // only thing a dashboard tab opened mid-run can read the boxes back from.
+  announceHandoff = (push, pr) => onEvent({ kind: 'handoff-armed', push, pr })
+  announceHandoff(armedHandoff.push, armedHandoff.pr)
+
   // Fire the #326 on-before-mergeable prompt once a --on-before-mergeable run has settled and the agent
   // signalled setReadyForMerge(). Skipped for a fake/offline run and when the run was stopped —
   // and every outcome, including each skip, is emitted as an event so the dashboard can show it (#835).
@@ -1490,6 +1546,42 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
       opts.eco,
     )
     onEvent({ kind: 'on-before-mergeable', outcome })
+  }
+
+  // Hand the session's work back (#1102): push the branch and open a draft PR for it, unless the
+  // action bar's checkboxes were unticked. Runs after the on-before-mergeable step above, so
+  // anything that step committed is part of what gets published rather than a commit left behind.
+  const maybeAutoHandoff = async (): Promise<void> => {
+    const armed = { ...armedHandoff }
+    const skip = (reason: AutoHandoffSkip) => onEvent({ kind: 'handoff', outcome: 'skipped', reason })
+    if (!armed.push && !armed.pr) return skip('not-armed')
+    // A stopped run is a session the user cut short; publishing what it happened to reach is the
+    // opposite of what stopping meant. Same call the on-before-mergeable step makes.
+    if (journal.stoppedCleanly()) return skip('run-stopped')
+    if (fake) return skip('fake-run')
+
+    // The daemon commits whatever the agent left uncommitted, but only after this process exits
+    // (`tearDownWorktree`), so at this point the tree can still hold real work. Pushing first
+    // would publish a branch missing the session's last edits. Its own checkout only: a plain
+    // `framework "..."` runs in the user's tree, where committing for them is not ours to do.
+    if (opts.runId) await commitPendingWork(cwd)
+
+    // The branch as it is now, not as it was named at start: #326 lets the agent rename it, and
+    // the rename is exactly what the PR should be opened against.
+    const branch = await currentBranch(cwd)
+    if (!branch) return skip('branch-gone')
+    const sessionName = journal.sessionName()
+    const run = {
+      id: opts.runId ?? '',
+      branch,
+      ...(sessionName ? { sessionName } : {}),
+      ...(intent ? { intent } : {}),
+    }
+    const outcome = await runAutoHandoff(cwd, run, armed)
+    onEvent({ kind: 'handoff', ...outcome })
+    if (outcome.outcome === 'failed') io.err(`✗ could not ${outcome.step === 'pr' ? 'open the PR' : 'push the branch'}: ${outcome.error}`)
+    else if (outcome.outcome === 'done' && outcome.url) io.out(`\n◆ Opened ${outcome.url}`)
+    else if (outcome.outcome === 'done') io.out(`\n◆ Pushed ${branch}.`)
   }
 
   // A mode/kind given with no preset in effect has nothing to act on: note it.
@@ -1594,6 +1686,7 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
     browserStream,
     clearInterrupt,
     maybeFireOnBeforeMergeable,
+    maybeAutoHandoff,
     finishLog: journal.finishLog,
     isStopped: () => controller.signal.aborted || journal.stoppedCleanly(),
     failLabel,

--- a/packages/the-framework/src/client.ts
+++ b/packages/the-framework/src/client.ts
@@ -12,10 +12,12 @@ export {
   sessionInfo,
   deployPlan,
   runProgress,
+  handoffState,
   type LoopStatus,
   type SessionInfo,
   type DeployPlan,
   type RunProgress,
+  type HandoffState,
 } from './run-view.js'
 // The Start-a-run presets (#433): pure prompt builders (no Node imports) the dashboard
 // prefills into the textarea, then runs verbatim as a `prompt` kind.
@@ -44,7 +46,7 @@ export { interventionKey, pickNewInterventions, activityKey, pickNewActivity } f
 export { PROJECT_PREFERENCE_KEYS, NOTIFICATION_DEFAULTS, MAX_SPEND_OFFSET, notificationEnabled, discordNotificationEnabled, type ProjectPreferences } from './preference-defaults.js'
 // The preferences -> run options mapping (#858), shared with the daemon so an unattended run
 // starts with the same settings a launcher-started one would. Pure field logic, no Node imports.
-export { runOptionsFromPreferences, autopilotEnabled, preferencesFromFileConfig } from './run-options.js'
+export { runOptionsFromPreferences, autopilotEnabled, handoffFromPreferences, preferencesFromFileConfig } from './run-options.js'
 // The Discord credential rules (#1095): the same precedence and validation the daemon enforces,
 // so the setup dialog rejects a malformed token before the round trip instead of guessing at it.
 export {

--- a/packages/the-framework/src/control.test.ts
+++ b/packages/the-framework/src/control.test.ts
@@ -133,3 +133,25 @@ test('a message carries the surface it came through, and a forged one is dropped
     await rm(cwd, { recursive: true, force: true })
   }
 })
+
+test('a handoff entry needs both booleans, so a half-written line cannot disarm a session (#1102)', async () => {
+  const dir = await tmpWorkspace()
+  try {
+    await resetControl(dir)
+    const seen: ControlEntry[] = []
+    const watcher = watchControl(dir, entry => seen.push(entry), 20)
+    try {
+      // Malformed first: a missing or non-boolean half must be dropped, not coerced. Getting this
+      // wrong would silently stop a session publishing its work.
+      await appendFile(controlPath(dir), JSON.stringify({ kind: 'handoff', push: true }) + '\n')
+      await appendFile(controlPath(dir), JSON.stringify({ kind: 'handoff', push: 'yes', pr: false }) + '\n')
+      await appendControl(dir, { kind: 'handoff', push: true, pr: false })
+      assert.ok(await until(() => seen.length > 0), 'the well-formed entry never arrived')
+      assert.deepEqual(seen, [{ kind: 'handoff', push: true, pr: false }])
+    } finally {
+      watcher.close()
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})

--- a/packages/the-framework/src/control.ts
+++ b/packages/the-framework/src/control.ts
@@ -31,6 +31,15 @@ export type ControlEntry =
    * and a run reading one falls back to its own surface exactly as before.
    */
   | { kind: 'message'; text: string; via?: string }
+  /**
+   * Re-arm or disarm the end-of-session handoff (#1102): whether this session pushes its branch
+   * and opens a draft PR when it finishes.
+   *
+   * Steering rather than an event because it is an instruction to the run, and it has to reach a
+   * run whose dashboard tab was opened after it started. The run echoes what it applied back as an
+   * event, which is what puts it on the meta the checkboxes read.
+   */
+  | { kind: 'handoff'; push: boolean; pr: boolean }
 
 /** The control log path for a workspace. */
 export function controlPath(cwd: string): string {
@@ -81,6 +90,9 @@ function isControlEntry(value: unknown): value is ControlEntry {
   if (!value || typeof value !== 'object') return false
   const v = value as Record<string, unknown>
   if (v['kind'] === 'stop') return true
+  // Both halves must be real booleans: a half-written entry would otherwise disarm by accident,
+  // and this decides whether the session's work reaches the remote at all.
+  if (v['kind'] === 'handoff') return typeof v['push'] === 'boolean' && typeof v['pr'] === 'boolean'
   // `via` is optional (older entries have none), but a present one must be a safe transport name:
   // it is written into a line-parsed conversation heading, and a surface names itself (#917).
   if (v['kind'] === 'message') {

--- a/packages/the-framework/src/daemon-runtime.ts
+++ b/packages/the-framework/src/daemon-runtime.ts
@@ -100,6 +100,10 @@ export function startOptionFlags(options: StartRunOptions): string[] {
     ['technical', '--technical'],
     ['vanilla', '--vanilla'],
     ['transparent', '--transparent'],
+    // Tri-state for a different reason (#1102): these two default ON, so `false` must be said out
+    // loud or the run would re-arm what the launcher just disarmed.
+    ['autoPushBranch', '--auto-push-branch'],
+    ['autoOpenPr', '--auto-open-pr'],
   ] as const) {
     const value = options[key]
     if (value === true) flags.push(flag)

--- a/packages/the-framework/src/daemon.test.ts
+++ b/packages/the-framework/src/daemon.test.ts
@@ -69,6 +69,20 @@ test('startOptionFlags maps only enabled Global options to CLI flags (#314)', ()
   assert.deepEqual(startOptionFlags({ transparent: true }), ['--transparent'])
 })
 
+test('a disarmed handoff travels as the --no-* form, since it defaults on (#1102)', () => {
+  // The mirror image of #842's reason: these two are ON unless told otherwise, so an unticked box
+  // that sent nothing would be re-armed by the run's own default and the session would publish
+  // itself anyway.
+  assert.deepEqual(startOptionFlags({ autoPushBranch: false, autoOpenPr: false }), [
+    '--no-auto-push-branch',
+    '--no-auto-open-pr',
+  ])
+  assert.deepEqual(startOptionFlags({ autoPushBranch: true, autoOpenPr: true }), [
+    '--auto-push-branch',
+    '--auto-open-pr',
+  ])
+})
+
 test('startOptionFlags spells an explicit off as the --no-* form (#842)', () => {
   // The launcher resolves the repo yml itself now, so a toggle it shows as off has to travel as
   // one: without --no-autopilot the file would turn it back on inside the run (#841).

--- a/packages/the-framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/the-framework/src/dashboard-rpc/control.telefunc.ts
@@ -52,6 +52,23 @@ export async function sendStop(projectId: string, runId?: string): Promise<void>
 }
 
 /**
+ * Arm or disarm a live session's end-of-session handoff (#1102): whether it pushes its branch and
+ * opens a draft PR when it finishes.
+ *
+ * Steering rather than a setting write, because it is about *this* session: the preference sets
+ * where the boxes start, and this is the user changing their mind for one run. The run echoes what
+ * it applied back as an event, so the boxes read from the run's meta rather than from local state
+ * that a reload would lose.
+ */
+export async function sendSetHandoff(projectId: string, runId: string, push: boolean, pr: boolean): Promise<void> {
+  return relayOr(runId, 'sendSetHandoff', [projectId, runId, push, pr], async () => {
+    // Opening a PR needs the branch on the remote, so the pair is normalised before it is stored
+    // rather than left for each reader to remember.
+    await appendControlFor(projectId, { kind: 'handoff', push: push || pr, pr }, runId)
+  }, undefined)
+}
+
+/**
  * Resolve the project's parked choice gate (#304/#332): `pick` is one option id for a
  * single-select, or the selected subset for a multi-select. `by` records who picked
  * (a human here, vs the autopilot countdown or a headless auto-accept).

--- a/packages/the-framework/src/dashboard-rpc/index.ts
+++ b/packages/the-framework/src/dashboard-rpc/index.ts
@@ -3,7 +3,7 @@
 // wiring) can reach the daemon's `startRun`; the framework-dashboard client imports
 // these through thin re-export shims so the baked RPC keys stay `/server/*.telefunc.ts`.
 export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent, onTickets, onRetainedWorktrees, onRunWorktree, onRunHandoff, onSystemPromptUser } from './reads.telefunc.js'
-export { sendStop, sendChoice, sendMessage, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendDeleteSession, sendPushBranch, sendOpenPullRequest, sendQueueTicket, type QueueTicketResult } from './control.telefunc.js'
+export { sendStop, sendChoice, sendMessage, sendSetHandoff, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendDeleteSession, sendPushBranch, sendOpenPullRequest, sendQueueTicket, type QueueTicketResult } from './control.telefunc.js'
 export { onEvents } from './events.telefunc.js'
 export { onProjects, sendAddProject, onOnboarding } from './projects.telefunc.js'
 export {

--- a/packages/the-framework/src/dashboard-rpc/relay-dispatch.test.ts
+++ b/packages/the-framework/src/dashboard-rpc/relay-dispatch.test.ts
@@ -11,7 +11,7 @@ test('RELAY_RPC_NAMES is the run-scoped read/steer/handoff surface and excludes 
   for (const name of [
     'onProjectFiles', 'onProjectFileStatus', 'onFileDiff', 'onRunChanges', 'onFileContent',
     'onGitStatus', 'onRunWorktree', 'onRunHandoff', 'onRun',
-    'sendStop', 'sendChoice', 'sendMessage', 'sendPushBranch', 'sendOpenPullRequest',
+    'sendStop', 'sendChoice', 'sendMessage', 'sendSetHandoff', 'sendPushBranch', 'sendOpenPullRequest',
   ]) {
     assert.ok(RELAY_RPC_NAMES.includes(name), `expected ${name} on the relay whitelist`)
   }

--- a/packages/the-framework/src/dashboard-rpc/relay-dispatch.ts
+++ b/packages/the-framework/src/dashboard-rpc/relay-dispatch.ts
@@ -1,5 +1,5 @@
 import { onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent, onGitStatus, onRunWorktree, onRunHandoff, onRun } from './reads.telefunc.js'
-import { sendStop, sendChoice, sendMessage, sendPushBranch, sendOpenPullRequest } from './control.telefunc.js'
+import { sendStop, sendChoice, sendMessage, sendSetHandoff, sendPushBranch, sendOpenPullRequest } from './control.telefunc.js'
 
 // The device side of the remote-run relay (#1067 slice 2). A daemon that relayed a run here asks this
 // to read/steer/hand off THAT run against THIS device's own checkout. Every entry is a run-scoped RPC
@@ -14,7 +14,7 @@ type RelayFn = (...args: unknown[]) => Promise<unknown>
 const RELAY_FNS = {
   onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent,
   onGitStatus, onRunWorktree, onRunHandoff, onRun,
-  sendStop, sendChoice, sendMessage, sendPushBranch, sendOpenPullRequest,
+  sendStop, sendChoice, sendMessage, sendSetHandoff, sendPushBranch, sendOpenPullRequest,
 } as unknown as Record<string, RelayFn>
 
 /** The names a relay caller may invoke. */

--- a/packages/the-framework/src/dashboard/gh.ts
+++ b/packages/the-framework/src/dashboard/gh.ts
@@ -102,14 +102,22 @@ export interface OpenPr {
   number: number
   title: string
   url: string
-  /** Draft PRs are not ready for review, so they are left off the queue. */
+  /**
+   * Draft PRs are generally left off the queue: a draft is not asking for review.
+   *
+   * The exception is a draft the framework opened for itself (#1102), which {@link headRefName}
+   * is what tells apart.
+   */
   isDraft: boolean
+  /** The branch the PR is from, so a session's own PR can be recognised as ours (#1102). */
+  headRefName?: string
   createdAt?: string
 }
 
 /** A checkout's open PRs; resolves `[]` when there is no remote or gh is unavailable. */
 export async function ghPrList(cwd: string): Promise<OpenPr[]> {
-  const args = ['pr', 'list', '--state', 'open', '--limit', '50', '--json', 'number,title,url,isDraft,createdAt']
+  const fields = 'number,title,url,isDraft,headRefName,createdAt'
+  const args = ['pr', 'list', '--state', 'open', '--limit', '50', '--json', fields]
   return ghJson<OpenPr[]>(args, cwd, [])
 }
 

--- a/packages/the-framework/src/dashboard/interventions.test.ts
+++ b/packages/the-framework/src/dashboard/interventions.test.ts
@@ -232,3 +232,22 @@ test('unpushed items key on the run, so each notifies once (#860)', () => {
     interventionKey({ ...base, kind: 'awaiting', awaitId: 'r1' }),
   )
 })
+
+test("a session's own draft PR still reaches the queue; a hand-made draft does not (#1102)", async () => {
+  // Auto-handoff opens a draft precisely so it does not ping reviewers. If the queue then dropped
+  // it too, nothing would tell anyone the work exists, which is #860 all over again.
+  const prs = async (): Promise<OpenPr[]> => [
+    { number: 9, title: 'session work', url: 'u9', isDraft: true, headRefName: 'the-framework/x', createdAt: '2026-07-16T00:00:00Z' },
+    { number: 10, title: 'my own wip', url: 'u10', isDraft: true, headRefName: 'feat/mine', createdAt: '2026-07-17T00:00:00Z' },
+  ]
+  const items = await buildInterventions([project('a', '/a')], { prs, liveRuns: noRuns, runs: async () => [] })
+  assert.deepEqual(items.map(i => i.number), [9])
+})
+
+test('a draft with no branch recorded is still treated as hand-made (#1102)', async () => {
+  // `headRefName` is new: an older gh, or a lookup that did not ask for it, must not turn every
+  // draft in the repo into a "needs you".
+  const prs = async (): Promise<OpenPr[]> => [{ number: 11, title: 'wip', url: 'u11', isDraft: true }]
+  const items = await buildInterventions([project('a', '/a')], { prs, liveRuns: noRuns, runs: async () => [] })
+  assert.deepEqual(items, [])
+})

--- a/packages/the-framework/src/dashboard/interventions.ts
+++ b/packages/the-framework/src/dashboard/interventions.ts
@@ -1,6 +1,6 @@
 import { listRuns, readLiveMetas, type LiveRun, type RunMeta } from '../store/index.js'
 import type { ProjectSummary } from './projects.js'
-import { readRunHandoff, runBranchFor, type RunHandoff } from './run-handoff.js'
+import { isSessionBranch, readRunHandoff, runBranchFor, type RunHandoff } from './run-handoff.js'
 import { ghPrList, type OpenPr, type PrLister } from './gh.js'
 import { interventionKey } from './keys.js'
 import { postDiscordWebhook } from './discord-webhook.js'
@@ -72,10 +72,11 @@ export interface InterventionsDeps {
 export const HANDOFF_LIMIT = 5
 
 /**
- * Build the cross-project interventions queue: every registered project's open, non-draft PRs,
- * plus any run currently paused on a choice gate (#636), newest first. Forgiving — a project
- * with no remote (or an unreadable one) simply contributes nothing. Draft PRs are excluded:
- * they are not yet asking for review.
+ * Build the cross-project interventions queue: every registered project's open PRs, plus any run
+ * currently paused on a choice gate (#636), newest first. Forgiving — a project with no remote
+ * (or an unreadable one) simply contributes nothing. Hand-opened draft PRs are excluded: they are
+ * not yet asking for review. A session's own draft is not (#1102), because that is how
+ * auto-handoff hands work back.
  */
 export async function buildInterventions(
   projects: ProjectSummary[],
@@ -87,7 +88,11 @@ export async function buildInterventions(
   for (const project of projects) {
     const open = await prs(project.path).catch(() => [])
     for (const pr of open) {
-      if (pr.isDraft) continue
+      // A draft opened by hand is not asking for review, so it stays off the queue. A draft the
+      // framework opened for a session is the opposite (#1102): auto-handoff opens it as a draft
+      // precisely so it does not ping reviewers, and if the queue then dropped it too, nothing
+      // would tell anyone the work exists — which is the whole of #860 again.
+      if (pr.isDraft && !isSessionBranch(pr.headRefName)) continue
       items.push({
         projectId: project.id,
         projectName: project.name,
@@ -120,8 +125,9 @@ export async function buildInterventions(
     // that committed real code and stopped produced neither, and nothing told anyone: the overview
     // drops it (it filters on `running`) and the handoff panel is behind clicking into that run.
     //
-    // Surfacing only. Pushing publishes the agent's work under the user's name, which stays their
-    // click (see `pushRunBranch`) — this just says there is a decision waiting.
+    // Surfacing only: this says there is a decision waiting, it does not take it. Since #1102 a
+    // session usually pushes itself, so what reaches here is the remainder — auto-handoff turned
+    // off for the project, or turned off for that session, or tried and failed.
     for (const item of await unpushedFor(project, deps).catch(() => [])) items.push(item)
   }
   items.sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''))

--- a/packages/the-framework/src/dashboard/run-handoff.test.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
-import { readRunHandoff, runBranchFor, pushRunBranch, openRunPullRequest, gitReason } from './run-handoff.js'
+import { readRunHandoff, runBranchFor, pushRunBranch, openRunPullRequest, gitReason, runAutoHandoff, isSessionBranch } from './run-handoff.js'
 import { nodeGitRunner, GIT_SLOW_TIMEOUT_MS, type GitRunner } from '../project.js'
 import { CliTimeoutError, isCliTimeout } from '../cli-exec.js'
 
@@ -255,4 +255,134 @@ test('a real repo: the branch outlives its worktree and still reports its work (
   } finally {
     await rm(dir, { recursive: true, force: true })
   }
+})
+
+// The end-of-session handoff that fires by itself (#1102).
+
+/** A branch with one commit, a remote, and no PR: the case a handoff should act on. */
+const READY = {
+  ...REPO,
+  'rev-parse --verify --quiet refs/heads/the-framework/x': 'abc123\n',
+  remote: 'origin\n',
+  'symbolic-ref': 'origin/main\n',
+  log: `abc123${SEP}abc${SEP}did the thing`,
+  diff: '1\t0\tsrc/app.ts',
+  'rev-parse --verify --quiet refs/remotes': '',
+  branch: '',
+}
+
+test('an armed session opens a DRAFT PR, and pushes on the way (#1102)', async () => {
+  const gh: string[][] = []
+  const { git } = fakeGit({ ...READY, push: '' })
+  const outcome = await runAutoHandoff(
+    '/repo',
+    { id: 'r1', branch: 'the-framework/x', sessionName: 'x', intent: 'build it' },
+    { push: true, pr: true },
+    {
+      git,
+      pr: async () => undefined,
+      gh: async args => {
+        gh.push(args)
+        return 'https://github.com/o/r/pull/9\n'
+      },
+    },
+  )
+  assert.deepEqual(outcome, { outcome: 'done', pushed: true, url: 'https://github.com/o/r/pull/9' })
+  // The draft flag is the whole reason this is safe to fire on every session: without it every
+  // finished run would put a review request in someone's inbox.
+  assert.ok(gh[0]?.includes('--draft'), `expected --draft in ${JSON.stringify(gh[0])}`)
+  assert.ok(gh[0]?.includes('the-framework/x'))
+})
+
+test('push armed alone pushes and opens nothing (#1102)', async () => {
+  const pushes: string[][] = []
+  const { git: read } = fakeGit(READY)
+  const outcome = await runAutoHandoff(
+    '/repo',
+    { id: 'r1', branch: 'the-framework/x' },
+    { push: true, pr: false },
+    {
+      git: async (args, cwd) => {
+        if (args[0] === 'push') {
+          pushes.push(args)
+          return ''
+        }
+        return read(args, cwd)
+      },
+      pr: async () => undefined,
+      gh: async () => assert.fail('no PR should be opened when only the push is armed'),
+    },
+  )
+  assert.deepEqual(outcome, { outcome: 'done', pushed: true })
+  assert.deepEqual(pushes, [['push', '--set-upstream', 'origin', 'the-framework/x']])
+})
+
+test('a disarmed session hands off nothing at all (#1102)', async () => {
+  const outcome = await runAutoHandoff(
+    '/repo',
+    { id: 'r1', branch: 'the-framework/x' },
+    { push: false, pr: false },
+    { git: async () => assert.fail('a disarmed handoff must not touch git'), gh: async () => assert.fail('nor gh') },
+  )
+  assert.deepEqual(outcome, { outcome: 'skipped', reason: 'not-armed' })
+})
+
+test('a branch that already has a PR is never given a second one (#1102)', async () => {
+  const { git } = fakeGit(READY)
+  const outcome = await runAutoHandoff(
+    '/repo',
+    { id: 'r1', branch: 'the-framework/x' },
+    { push: true, pr: true },
+    {
+      git,
+      pr: async () => ({ number: 4, url: 'https://github.com/o/r/pull/4', state: 'OPEN', title: 'already' }),
+      gh: async () => assert.fail('opening a second PR is the one mistake this must not make'),
+    },
+  )
+  assert.deepEqual(outcome, { outcome: 'skipped', reason: 'already-open' })
+})
+
+test('a session that committed nothing is not published (#1102)', async () => {
+  const { git } = fakeGit({ ...READY, log: '', diff: '' })
+  const outcome = await runAutoHandoff(
+    '/repo',
+    { id: 'r1', branch: 'the-framework/x' },
+    { push: true, pr: true },
+    { git, pr: async () => undefined, gh: async () => assert.fail('nothing to open a PR for') },
+  )
+  assert.deepEqual(outcome, { outcome: 'skipped', reason: 'no-commits' })
+})
+
+test('a repo with no remote is a skip, not a failure (#1102)', async () => {
+  const { git } = fakeGit({ ...READY, remote: '' })
+  const outcome = await runAutoHandoff(
+    '/repo',
+    { id: 'r1', branch: 'the-framework/x' },
+    { push: true, pr: true },
+    { git, pr: async () => undefined, gh: async () => assert.fail('nowhere to push to') },
+  )
+  assert.deepEqual(outcome, { outcome: 'skipped', reason: 'no-remote' })
+})
+
+test('a failed push is reported with git’s own reason, so the bar can offer the retry (#1102)', async () => {
+  const { git: read } = fakeGit(READY)
+  const outcome = await runAutoHandoff(
+    '/repo',
+    { id: 'r1', branch: 'the-framework/x' },
+    { push: true, pr: false },
+    {
+      git: async (args, cwd) => {
+        if (args[0] === 'push') throw new Error('Command failed: git push\nfatal: no write access\n')
+        return read(args, cwd)
+      },
+      pr: async () => undefined,
+    },
+  )
+  assert.deepEqual(outcome, { outcome: 'failed', step: 'push', error: 'fatal: no write access' })
+})
+
+test('a session branch is recognised by its prefix, a hand-made one is not (#1102)', () => {
+  assert.equal(isSessionBranch('the-framework/x'), true)
+  assert.equal(isSessionBranch('feat/mine'), false)
+  assert.equal(isSessionBranch(undefined), false)
 })

--- a/packages/the-framework/src/dashboard/run-handoff.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.ts
@@ -2,6 +2,7 @@ import { nodeGitRunner, type GitRunner } from '../project.js'
 import { cachedPrView, forgetPr, nodeGhRunner, type GhRunner, type LinkedPr, type BranchPrLookup } from './gh.js'
 import { parseNumstat } from './file-diff.js'
 import { errorMessage } from '../error-message.js'
+import type { AutoHandoffSkip } from '../events.js'
 import type { RunMeta } from '../store/index.js'
 
 // What a finished session produced, and what is left to do with it (#799).
@@ -80,7 +81,20 @@ export interface RunHandoffDeps {
  */
 export function runBranchFor(run: { id: string; branch?: string; sessionName?: string }): string {
   if (run.branch) return run.branch
-  return run.sessionName ? `the-framework/${run.sessionName}` : `the-framework/run-${run.id}`
+  return run.sessionName ? `${SESSION_BRANCH_PREFIX}${run.sessionName}` : `${SESSION_BRANCH_PREFIX}run-${run.id}`
+}
+
+/** What every branch a session creates for itself is named under. */
+export const SESSION_BRANCH_PREFIX = 'the-framework/'
+
+/**
+ * Whether a branch is one a session made, rather than one the user did.
+ *
+ * Only a naming convention, so it is a guess for the case #326 allows — the agent picking its own
+ * branch name. Every caller uses it to decide how loudly to surface something, never to act.
+ */
+export function isSessionBranch(branch: string | undefined): boolean {
+  return Boolean(branch?.startsWith(SESSION_BRANCH_PREFIX))
 }
 
 /** `git` that resolves to '' instead of rejecting, for reads where "no answer" is a fine answer. */
@@ -186,9 +200,10 @@ export type HandoffResult = { ok: true; url?: string } | { ok: false; error: str
 /**
  * Push a finished session's branch to `origin`.
  *
- * Deliberately a click, not something teardown does on its own: pushing publishes the agent's
- * work under the user's name to a shared remote, and that is the user's call to make, not a
- * side effect of a run ending. The dashboard offers it; the human takes it.
+ * Publishing the agent's work under the user's name is the user's call, but since #1102 that call
+ * is made once, up front, by a checkbox that is armed by default, rather than re-taken by hand at
+ * the end of every session. The click is still here for a session that opted out, and it is what
+ * a failed auto-push falls back to.
  */
 export async function pushRunBranch(
   cwd: string,
@@ -221,14 +236,21 @@ export interface PullRequestDraft {
   title: string
   body: string
   base?: string
+  /**
+   * Open it as a GitHub draft (#1102). What auto-handoff uses: opening a PR by itself at the end
+   * of every session should not put a review request in anyone's inbox.
+   *
+   * Safe to do only because the interventions queue was taught to keep listing a draft on a
+   * session branch. Left off, a draft would be invisible in both places at once.
+   */
+  draft?: boolean
 }
 
 /**
  * Open a PR for a finished session's branch, pushing it first when the remote does not have it.
  *
- * Opened ready rather than draft on purpose: the interventions queue (#632) lists open *non-draft*
- * PRs as "needs you", so a draft would open the loop back into the dashboard and then not appear
- * in it. The point of the handoff is that the work lands somewhere the human will see it again.
+ * The button opens it ready for review, because a PR a human asked for by name is asking for
+ * review. {@link PullRequestDraft.draft} is the auto-handoff case, which is not.
  */
 export async function openRunPullRequest(
   cwd: string,
@@ -245,6 +267,7 @@ export async function openRunPullRequest(
   try {
     const args = ['pr', 'create', '--head', branch, '--title', draft.title, '--body', draft.body]
     if (draft.base) args.push('--base', draft.base)
+    if (draft.draft) args.push('--draft')
     const out = (await gh(args, cwd)).trim()
     // The branch has a PR now, so the cached "no PR" must go or the bar would keep offering to
     // open one for the next minute (#1028).
@@ -265,7 +288,11 @@ export async function openRunPullRequest(
  * is the intent plus which session did it. This is the handoff decision the dashboard's
  * open-PR button offers; the RPC layer only resolves which run it is about.
  */
-export async function openSessionPullRequest(cwd: string, run: RunMeta): Promise<HandoffResult> {
+export async function openSessionPullRequest(
+  cwd: string,
+  run: RunMeta,
+  options: { draft?: boolean } = {},
+): Promise<HandoffResult> {
   const branch = runBranchFor(run)
   const handoff = await readRunHandoff(cwd, branch).catch(() => undefined)
   if (handoff && !handoff.exists) return { ok: false, error: `branch ${branch} no longer exists` }
@@ -276,11 +303,97 @@ export async function openSessionPullRequest(cwd: string, run: RunMeta): Promise
     title: run.sessionName ?? run.intent?.split('\n')[0]?.slice(0, 72) ?? `Session ${run.id}`,
     body: sessionPrBody(run),
     ...(handoff?.base ? { base: handoff.base } : {}),
+    ...(options.draft ? { draft: true } : {}),
   })
 }
 
+/**
+ * What a session was left armed to do when it ends (#1102).
+ *
+ * Both start true. The point of the feature is that the common case costs nothing: a session that
+ * is simply left alone puts its branch on the remote and opens a PR for it.
+ */
+export interface HandoffIntent {
+  push: boolean
+  pr: boolean
+}
+
+/** Both halves armed — the default a session starts from. */
+export const ARMED_HANDOFF: HandoffIntent = { push: true, pr: true }
+
+/**
+ * What auto-handoff did, so the run can say it as an event (#835).
+ *
+ * A dashboard-started run is spawned with `stdio: 'ignore'`, so anything printed here reaches
+ * nobody: the outcome has to travel as an event or it does not travel at all. Skips are reported
+ * for the same reason a skipped on-before-mergeable is — silence reads as "it ran and did nothing".
+ */
+export type AutoHandoffOutcome =
+  | { outcome: 'skipped'; reason: AutoHandoffSkip }
+  | { outcome: 'done'; pushed: boolean; url?: string }
+  | { outcome: 'failed'; step: 'push' | 'pr'; error: string }
+
+/**
+ * Do the end-of-session handoff a session was left armed for (#1102): push the branch, open a
+ * draft PR for it, or both.
+ *
+ * Reads the branch first and refuses on everything that is not a clean hand-off — a branch that is
+ * gone, a session that committed nothing, a repo with no remote, a branch that already has a PR.
+ * Those are the cases where doing it anyway would produce a confusing artefact rather than help.
+ *
+ * The PR is a draft on purpose. Opening one by itself at the end of every session must not put a
+ * review request in anyone's inbox, and the interventions queue keeps listing a session's draft
+ * so the work still comes back to the human.
+ */
+export async function runAutoHandoff(
+  cwd: string,
+  run: HandoffRun,
+  intent: HandoffIntent,
+  deps: RunHandoffDeps & { gh?: GhRunner } = {},
+): Promise<AutoHandoffOutcome> {
+  if (!intent.push && !intent.pr) return { outcome: 'skipped', reason: 'not-armed' }
+  const branch = runBranchFor(run)
+  const { gh, ...readDeps } = deps
+  const state = await readRunHandoff(cwd, branch, readDeps).catch(() => undefined)
+  if (!state || !state.exists) return { outcome: 'skipped', reason: 'branch-gone' }
+  if (state.empty) return { outcome: 'skipped', reason: 'no-commits' }
+  if (!state.hasRemote) return { outcome: 'skipped', reason: 'no-remote' }
+  // A PR already covers both halves: it means the branch is published and the human has a place
+  // to answer. Opening a second one is the one mistake this must never make.
+  if (state.pr) return { outcome: 'skipped', reason: 'already-open' }
+
+  if (intent.pr) {
+    // `openRunPullRequest` pushes first, so the PR half subsumes the push half.
+    const opened = await openRunPullRequest(
+      cwd,
+      branch,
+      {
+        title: run.sessionName ?? run.intent?.split('\n')[0]?.slice(0, 72) ?? `Session ${run.id}`,
+        body: sessionPrBody(run),
+        draft: true,
+        ...(state.base ? { base: state.base } : {}),
+      },
+      { ...(readDeps.git ? { git: readDeps.git } : {}), ...(gh ? { gh } : {}) },
+    )
+    if (!opened.ok) return { outcome: 'failed', step: 'pr', error: opened.error }
+    return { outcome: 'done', pushed: true, ...(opened.url ? { url: opened.url } : {}) }
+  }
+
+  if (state.pushed) return { outcome: 'skipped', reason: 'already-pushed' }
+  const pushed = await pushRunBranch(cwd, branch, readDeps.git)
+  if (!pushed.ok) return { outcome: 'failed', step: 'push', error: pushed.error }
+  return { outcome: 'done', pushed: true }
+}
+
+/**
+ * The little a handoff needs to know about the run it is for: which branch, and what to say on
+ * the PR. Narrower than {@link RunMeta} so the run process can call this before its meta is
+ * final, and so a caller cannot quietly start depending on the rest of the run's state.
+ */
+export type HandoffRun = Pick<RunMeta, 'id' | 'branch' | 'sessionName' | 'intent'>
+
 /** The PR body: what was asked for, and which session did it. */
-function sessionPrBody(run: RunMeta): string {
+function sessionPrBody(run: HandoffRun): string {
   const lines: string[] = []
   if (run.intent) lines.push(run.intent.trim(), '')
   lines.push(`Opened from The Framework session \`${run.sessionName ?? run.id}\`.`)

--- a/packages/the-framework/src/dashboard/types.ts
+++ b/packages/the-framework/src/dashboard/types.ts
@@ -53,6 +53,16 @@ export interface StartRunOptions {
   onBeforeMergeable?: boolean
   /** Give the agent a real browser via chrome-devtools-mcp during the run (#452); maps to `--browser`. */
   browser?: boolean
+  /**
+   * Push the session's branch to `origin` when it finishes (#1102); maps to `--auto-push-branch`.
+   *
+   * Tri-state like the four `the-framework.yml` toggles, and for the same reason: it defaults ON,
+   * so an explicit `false` has to travel as `--no-auto-push-branch` or the run's own default would
+   * turn back on what the launcher showed as off.
+   */
+  autoPushBranch?: boolean
+  /** Open a draft PR for the session's branch when it finishes (#1102); maps to `--auto-open-pr`. Implies {@link autoPushBranch}. */
+  autoOpenPr?: boolean
   /** The model to run the wrapped agent on (#628); maps to `--model`. Absent = the driver's own default. */
   model?: string
   /** Which coding agent drives the run (#650): `claude` or `codex`; maps to `--agent`. Absent = the default (`claude`). */

--- a/packages/the-framework/src/events.ts
+++ b/packages/the-framework/src/events.ts
@@ -65,6 +65,31 @@ export type OnBeforeMergeableSkip =
   /** `process.argv[1]` was empty, so there is no binary to spawn the follow-up with. */
   | 'no-bin-path'
 
+/**
+ * Why the end-of-session handoff (#1102) did nothing. Every one of these is a normal end rather
+ * than a fault, and each is reported so that "it was ticked and nothing happened" has an answer.
+ *
+ * Lives here beside {@link OnBeforeMergeableSkip} rather than with the handoff logic, because the
+ * event union is a leaf: the module that decides these imports the type, not the other way round.
+ */
+export type AutoHandoffSkip =
+  /** Neither box was ticked, so there was nothing to do. */
+  | 'not-armed'
+  /** The branch no longer exists (deleted, or never created). */
+  | 'branch-gone'
+  /** The session committed nothing the base branch does not already have. */
+  | 'no-commits'
+  /** The repo has no remote to push to. */
+  | 'no-remote'
+  /** The branch already has a PR: opening a second one is the one mistake this must not make. */
+  | 'already-open'
+  /** The branch is already on the remote at this commit, and only the push was asked for. */
+  | 'already-pushed'
+  /** The run was stopped (Stop button, Ctrl+C, budget cap) rather than finished. */
+  | 'run-stopped'
+  /** A fake/offline run: nothing real to publish. */
+  | 'fake-run'
+
 /** Who resolved a {@link ChoiceRequest}: a human, the autopilot countdown, or a headless auto-accept. */
 export type ChoiceBy = 'user' | 'autopilot' | 'auto'
 
@@ -156,6 +181,24 @@ export type FrameworkEvent =
    */
   | { kind: 'on-before-mergeable'; outcome: 'queued' | 'incomplete' }
   | { kind: 'on-before-mergeable'; outcome: 'skipped'; reason: OnBeforeMergeableSkip }
+  /**
+   * What the end-of-session handoff is armed to do (#1102), emitted at the start and again
+   * whenever the dashboard's checkboxes change it.
+   *
+   * This is what makes the boxes survive a reload: the control channel carries the instruction,
+   * but only an event reaches the run's meta, which is the one thing a tab opened later can read.
+   */
+  | { kind: 'handoff-armed'; push: boolean; pr: boolean }
+  /**
+   * What the end-of-session handoff actually did (#1102): pushed and/or opened a draft PR,
+   * declined for a reason that is not a fault, or failed at one of the two steps.
+   *
+   * Same reason as on-before-mergeable above: a dashboard-started run has no stdout anyone reads,
+   * so an outcome that is not an event is an outcome nobody learns.
+   */
+  | { kind: 'handoff'; outcome: 'skipped'; reason: AutoHandoffSkip }
+  | { kind: 'handoff'; outcome: 'done'; pushed: boolean; url?: string }
+  | { kind: 'handoff'; outcome: 'failed'; step: 'push' | 'pr'; error: string }
   /**
    * The work has settled and the run is parked on the user (#785): it stays open as a
    * conversation (#714), so its process is still alive and it still takes messages, but

--- a/packages/the-framework/src/index.ts
+++ b/packages/the-framework/src/index.ts
@@ -106,9 +106,11 @@ export {
   loopStatus,
   sessionInfo,
   runProgress,
+  handoffState,
   type LoopStatus,
   type SessionInfo,
   type RunProgress,
+  type HandoffState,
 } from './run-view.js'
 export {
   assessRepo,

--- a/packages/the-framework/src/preference-defaults.ts
+++ b/packages/the-framework/src/preference-defaults.ts
@@ -34,6 +34,11 @@ export const PROJECT_PREFERENCE_KEYS = [
   'ecoMaintenance',
   'onBeforeMergeableQuality',
   'browser',
+  // Per-project by nature (#1102): whether a session should publish itself is a fact about the
+  // repo, not about the machine. A scratch repo wants it on; someone else's repo you have push
+  // rights to may well not.
+  'autoPushBranch',
+  'autoOpenPr',
   'transparent',
   'model',
   'agent',

--- a/packages/the-framework/src/registry.test.ts
+++ b/packages/the-framework/src/registry.test.ts
@@ -227,6 +227,8 @@ test('every boolean preference survives a save; the sanitizer cannot silently dr
     ecoMaintenance: true,
     onBeforeMergeableQuality: true,
     browser: true,
+    autoPushBranch: true,
+    autoOpenPr: true,
     transparent: true,
     notifyBrowser: true,
     notifyDiscord: true,

--- a/packages/the-framework/src/registry.ts
+++ b/packages/the-framework/src/registry.ts
@@ -58,6 +58,16 @@ export interface Preferences {
   /** Give the agent a real browser via chrome-devtools-mcp during the run (#452); maps to `--browser`. */
   browser?: boolean
   /**
+   * Push a session's branch to `origin` when it finishes (#1102). Absent = on.
+   *
+   * Default-on, unlike most of this file, because it is what makes the handoff zero-config: the
+   * old behaviour was a button nobody was obliged to press, and work that stayed on a local
+   * branch nobody was told about (#860). A session can still opt out from its action bar.
+   */
+  autoPushBranch?: boolean
+  /** Open a draft PR for a session's branch when it finishes (#1102). Absent = on; implies {@link autoPushBranch}. */
+  autoOpenPr?: boolean
+  /**
    * Transparent mode (#625): run the wrapped agent raw — no framework system prompt, emit
    * protocols, consumption guard, dashboard, or TODO loop, so a run is identical to `claude -p`.
    * The coarse master off-switch ("only pick what you need"); maps to `--transparent`. Absent = off.
@@ -308,6 +318,8 @@ const BOOLEAN_PREFERENCES: Record<BooleanPreferenceKey, true> = {
   ecoMaintenance: true,
   onBeforeMergeableQuality: true,
   browser: true,
+  autoPushBranch: true,
+  autoOpenPr: true,
   transparent: true,
   notifyBrowser: true,
   notifyDiscord: true,

--- a/packages/the-framework/src/run-options.test.ts
+++ b/packages/the-framework/src/run-options.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { runOptionsFromPreferences, autopilotEnabled, preferencesFromFileConfig } from './run-options.js'
+import { runOptionsFromPreferences, autopilotEnabled, handoffFromPreferences, preferencesFromFileConfig } from './run-options.js'
 import { resolvePreferences } from './registry.js'
 
 test('autopilot defaults on when nothing is set (#858)', () => {
@@ -10,13 +10,32 @@ test('autopilot defaults on when nothing is set (#858)', () => {
 
 test('an empty preference set still starts a run in autopilot (#858)', () => {
   // The four yml-owned toggles travel explicitly since #842, so the run states the settled answer
-  // rather than letting the repo file fill the silence.
+  // rather than letting the repo file fill the silence. The two handoff flags travel explicitly
+  // for the mirror-image reason (#1102): they default ON, so silence would re-arm them.
   assert.deepEqual(runOptionsFromPreferences({}), {
     autopilot: true,
     technical: false,
     vanilla: false,
     transparent: false,
+    autoPushBranch: true,
+    autoOpenPr: true,
   })
+})
+
+test('the handoff defaults to armed, and opening a PR implies pushing (#1102)', () => {
+  assert.deepEqual(handoffFromPreferences({}), { push: true, pr: true })
+  // Unticking only the push half while the PR half stays on cannot disarm the push: `gh` will not
+  // open a PR for a branch the remote has never seen, so the pair is normalised rather than left
+  // to fail at the end of a session.
+  assert.deepEqual(handoffFromPreferences({ autoPushBranch: false }), { push: true, pr: true })
+  assert.deepEqual(handoffFromPreferences({ autoOpenPr: false }), { push: true, pr: false })
+  assert.deepEqual(handoffFromPreferences({ autoPushBranch: false, autoOpenPr: false }), { push: false, pr: false })
+})
+
+test('a disarmed handoff travels as an explicit false, so the run cannot re-arm it (#1102)', () => {
+  const off = runOptionsFromPreferences({ autoPushBranch: false, autoOpenPr: false })
+  assert.equal(off.autoPushBranch, false)
+  assert.equal(off.autoOpenPr, false)
 })
 
 test('the yml-owned toggles travel as explicit booleans (#842)', () => {

--- a/packages/the-framework/src/run-options.ts
+++ b/packages/the-framework/src/run-options.ts
@@ -41,6 +41,18 @@ export function autopilotEnabled(preferences: Preferences): boolean {
 }
 
 /**
+ * The end-of-session handoff a set of preferences arms (#1102). Both halves default on, which is
+ * what makes it zero-config: a session left alone pushes its branch and opens a draft PR.
+ *
+ * Opening a PR implies pushing — `gh` will not open one for a branch the remote has never seen —
+ * so the pair is normalised here rather than in the three places that read it.
+ */
+export function handoffFromPreferences(preferences: Preferences): { push: boolean; pr: boolean } {
+  const pr = preferences.autoOpenPr ?? true
+  return { push: pr || (preferences.autoPushBranch ?? true), pr }
+}
+
+/**
  * The run options a set of already-resolved preferences implies.
  *
  * Takes the merged view, not the two tiers: who wins between the global and the project setting is
@@ -54,6 +66,7 @@ export function runOptionsFromPreferences(preferences: Preferences, context: str
   const technical = preferences.technical ?? false
   const onBeforeMergeableQuality = preferences.onBeforeMergeableQuality ?? false
   const browser = preferences.browser ?? false
+  const handoff = handoffFromPreferences(preferences)
   const model = preferences.model ?? ''
   const agent = preferences.agent ?? 'claude'
   const target = preferences.target ?? 'local'
@@ -73,6 +86,10 @@ export function runOptionsFromPreferences(preferences: Preferences, context: str
     transparent,
     ...(eco && !vanilla && !transparent && Object.keys(ecoDrops).length ? { eco: ecoDrops } : {}),
     ...(onBeforeMergeableQuality ? { onBeforeMergeable: true } : {}),
+    // Stated explicitly, `false` included: these default ON (#1102), so sending nothing would let
+    // the run's own default turn back on what the launcher just showed as off.
+    autoPushBranch: handoff.push,
+    autoOpenPr: handoff.pr,
     // Claude-only (#801): another agent's driver takes no MCP servers, so sending it would only earn
     // the CLI's "no effect" notice. Matches the box being disabled off Claude Code.
     ...(browser && agent === 'claude' ? { browser: true } : {}),

--- a/packages/the-framework/src/run-view.test.ts
+++ b/packages/the-framework/src/run-view.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { loopStatus, sessionInfo, deployPlan, runProgress } from './run-view.js'
+import { loopStatus, sessionInfo, deployPlan, runProgress, handoffState } from './run-view.js'
 import type { FrameworkEvent } from './events.js'
 
 test('runProgress starts building with no name and flips to ready on setReadyForMerge (#326)', () => {
@@ -53,4 +53,33 @@ test('deployPlan returns the chosen deploy target from the deploy event; latest 
     boot({ type: 'deploy', plan: { render: 'ssr', target: 'dokploy', reason: 'per-request data' }, result: { deployed: true } }),
   ])
   assert.deepEqual(plan, { render: 'ssr', target: 'dokploy', reason: 'per-request data' })
+})
+
+test('a run with no handoff events reads as armed, matching what it will do (#1102)', () => {
+  // An older run emits no `handoff-armed`. Reading that as disarmed would show two unticked boxes
+  // for a session that is in fact going to push and open a PR.
+  assert.deepEqual(handoffState([]), { push: true, pr: true })
+})
+
+test('handoffState takes the latest arming, so unticking a box sticks (#1102)', () => {
+  const events: FrameworkEvent[] = [
+    { kind: 'handoff-armed', push: true, pr: true },
+    { kind: 'handoff-armed', push: true, pr: false },
+  ]
+  assert.deepEqual(handoffState(events), { push: true, pr: false })
+})
+
+test('handoffState carries the outcome once the handoff has run (#1102)', () => {
+  const done: FrameworkEvent[] = [
+    { kind: 'handoff-armed', push: true, pr: true },
+    { kind: 'handoff', outcome: 'done', pushed: true, url: 'https://github.com/o/r/pull/3' },
+  ]
+  assert.deepEqual(handoffState(done).result, { outcome: 'done', url: 'https://github.com/o/r/pull/3' })
+
+  // A failure has to survive into the projection: it is what the bar shows beside the retry button.
+  const failed: FrameworkEvent[] = [{ kind: 'handoff', outcome: 'failed', step: 'push', error: 'fatal: no write access' }]
+  assert.deepEqual(handoffState(failed).result, { outcome: 'failed', error: 'fatal: no write access' })
+
+  const skipped: FrameworkEvent[] = [{ kind: 'handoff', outcome: 'skipped', reason: 'no-remote' }]
+  assert.deepEqual(handoffState(skipped).result, { outcome: 'skipped', reason: 'no-remote' })
 })

--- a/packages/the-framework/src/run-view.ts
+++ b/packages/the-framework/src/run-view.ts
@@ -1,4 +1,4 @@
-import type { FrameworkEvent } from './events.js'
+import type { AutoHandoffSkip, FrameworkEvent } from './events.js'
 
 // Derived run state for the dashboard's overview cards (#431): the production-grade
 // loop status, the deploy plan, and the live session link — each a pure projection of
@@ -84,6 +84,41 @@ export function runProgress(events: readonly FrameworkEvent[]): RunProgress {
     else if (event.kind === 'ready-for-merge') progress.readyForMerge = true
   }
   return progress
+}
+
+/** What a session will do with its work when it ends (#1102), and what it did. */
+export interface HandoffState {
+  /** Push the branch to `origin` on finish. */
+  push: boolean
+  /** Open a draft PR on finish. Implies {@link push}. */
+  pr: boolean
+  /** How the handoff ended, once it has run. Absent while the session is still going. */
+  result?: { outcome: 'skipped'; reason: AutoHandoffSkip } | { outcome: 'done'; url?: string } | { outcome: 'failed'; error: string }
+}
+
+/**
+ * What the session is armed to hand back, folded from its own events (#1102).
+ *
+ * Both halves start armed, so a run from before this existed — which emits no `handoff-armed` —
+ * reads as armed, which is what it will actually do once it is running new code. Latest wins: the
+ * checkboxes re-emit on every change.
+ */
+export function handoffState(events: readonly FrameworkEvent[]): HandoffState {
+  const state: HandoffState = { push: true, pr: true }
+  for (const event of events) {
+    if (event.kind === 'handoff-armed') {
+      state.push = event.push
+      state.pr = event.pr
+    } else if (event.kind === 'handoff') {
+      state.result =
+        event.outcome === 'done'
+          ? { outcome: 'done', ...(event.url ? { url: event.url } : {}) }
+          : event.outcome === 'failed'
+            ? { outcome: 'failed', error: event.error }
+            : { outcome: 'skipped', reason: event.reason }
+    }
+  }
+  return state
 }
 
 /** The wrapped agent session (#431): its id and a deep link, when one is known. */

--- a/packages/the-framework/src/store/run-store.ts
+++ b/packages/the-framework/src/store/run-store.ts
@@ -109,6 +109,16 @@ export interface RunMeta {
   /** Whether the agent signalled `setReadyForMerge()` (#326): building (false/absent) vs ready (true). */
   readyForMerge?: boolean
   /**
+   * What this session's end-of-session handoff is armed to do (#1102): push its branch, and open
+   * a draft PR for it. Both start on.
+   *
+   * On the meta because the checkboxes that show it live in a different process from the run that
+   * obeys it, and a tab opened after the run started has no event history to fold — the same
+   * reason {@link browserStreamPort} is here. Absent means an older run, which the reader treats
+   * as armed, matching what that run will actually do.
+   */
+  handoff?: { push: boolean; pr: boolean }
+  /**
    * The choice gate the run is currently parked on (#636): set when a `choice` event fires and
    * cleared when its `choice-resolved` (or the run's `end`) arrives. Present means the run is
    * paused waiting for the user's answer — the second "needs you" source after open PRs (#624).
@@ -249,6 +259,9 @@ export function applyEventToMeta(meta: RunMeta, event: FrameworkEvent, at: strin
     }
     case 'browser-stream':
       next.browserStreamPort = event.port
+      break
+    case 'handoff-armed':
+      next.handoff = { push: event.push, pr: event.pr }
       break
     case 'settled':
       next.settledAt = at

--- a/packages/the-framework/src/terminal.ts
+++ b/packages/the-framework/src/terminal.ts
@@ -1,6 +1,6 @@
 import type { BootstrapEvent } from '@gemstack/ai-autopilot'
 import type { DriverEvent, DriverRateLimit } from './driver/index.js'
-import { pickedIds, type ChoiceOption, type FrameworkEvent, type OnBeforeMergeableSkip } from './events.js'
+import { pickedIds, type AutoHandoffSkip, type ChoiceOption, type FrameworkEvent, type OnBeforeMergeableSkip } from './events.js'
 
 // The terminal surface for the run's event stream: render one {@link FrameworkEvent} as one
 // human-readable line. This is the CLI's counterpart to the dashboard's read-model
@@ -40,6 +40,21 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
           return `  ! post-merge cleanup: queueing did not complete cleanly`
         case 'skipped':
           return `  ~ post-merge cleanup skipped: ${skipReason(event.reason)}`
+      }
+    case 'handoff-armed': {
+      // Said as what will happen, not as two flags: the line is read once, at a glance.
+      if (event.pr) return `  when this ends: push the branch and open a draft PR`
+      if (event.push) return `  when this ends: push the branch`
+      return `  when this ends: nothing — push and PR are both off`
+    }
+    case 'handoff':
+      switch (event.outcome) {
+        case 'done':
+          return event.url ? `✓ opened ${event.url}` : `✓ branch pushed`
+        case 'skipped':
+          return `  ~ handoff skipped: ${handoffSkipReason(event.reason)}`
+        case 'failed':
+          return `  ! could not ${event.step === 'pr' ? 'open the PR' : 'push the branch'}: ${event.error}`
       }
     case 'usage': {
       const turns = `over ${event.turns} turn${event.turns === 1 ? '' : 's'}`
@@ -85,6 +100,28 @@ function skipReason(reason: OnBeforeMergeableSkip): string {
       return 'the session never called setSessionName()'
     case 'no-bin-path':
       return 'the framework binary path is unknown'
+  }
+}
+
+/** Why the end-of-session handoff did nothing (#1102), as a reason rather than a code. */
+function handoffSkipReason(reason: AutoHandoffSkip): string {
+  switch (reason) {
+    case 'not-armed':
+      return 'push and PR are both off for this session'
+    case 'branch-gone':
+      return 'the branch no longer exists'
+    case 'no-commits':
+      return 'the session committed nothing'
+    case 'no-remote':
+      return 'this repo has no remote to push to'
+    case 'already-open':
+      return 'the branch already has a pull request'
+    case 'already-pushed':
+      return 'the branch is already on the remote'
+    case 'run-stopped':
+      return 'the run was stopped'
+    case 'fake-run':
+      return 'this was a fake run'
   }
 }
 


### PR DESCRIPTION
Closes #1102.

Push branch and Open PR become checkboxes in the session action bar, ticked by default, so the handoff needs no clicks.

## What changed

They are pre-commitments, not buttons: whatever is still ticked when the session settles fires by itself. Leave them alone and it is zero-config. Untick either one while the session runs and the old button comes back, so the deliberate path is never lost. A failure falls back to the button too, with git's or `gh`'s own reason beside it.

The two are not independent, because `gh` will not open a PR for a branch the remote has never seen. Ticking Open PR arms the push; unticking Push branch unticks the PR. That is decided per box rather than by normalising the resulting pair, because a shared rule cannot tell "ticked PR" from "unticked push" once it only has the pair to look at. The first version got this wrong and a test caught it.

New per-project preferences `autoPushBranch` and `autoOpenPr` set where the boxes start, both on. CLI: `--no-auto-push-branch` / `--no-auto-open-pr`, travelling as explicit `--no-*` flags for the mirror image of the #842 reason: these default on, so silence would re-arm them.

## The doctrine this reverses

Three comments said push and PR must never be automatic, on the grounds that publishing the agent's work under the user's name is the user's call. That call is still the user's, it is just made once instead of every session. The comments are updated rather than deleted, and the old buttons remain for the opted-out and failed cases. Worth a look, since this is a product decision and not just code.

## Draft PRs, and the queue

Firing on every session must not request review, so the PR is opened as a draft.

`interventions.ts` skipped every draft, because a draft is not asking for review. For a PR the framework opened for itself that reasoning inverts: nothing else would tell you the work exists, which is #860 again. The filter now lists a draft on a `the-framework/*` branch and still skips hand-opened ones. `ghPrList` asks for `headRefName` to tell them apart; a draft with no branch recorded is treated as hand-made, so an older `gh` cannot turn every WIP in the repo into a "needs you".

## Where it fires

In `settleRun`, beside `maybeFireOnBeforeMergeable` and after it, so anything the quality pass committed is in what gets published.

The trap worth naming: `commitPendingWork` normally runs in the **daemon**, in `tearDownWorktree`, *after* the run process exits. Pushing at settle time would therefore publish a branch missing the session's last edits. The hook commits first, gated on `opts.runId` so it only ever touches a checkout the framework owns; a plain `framework "..."` runs in the user's own tree, where committing for them is not ours to do. `commitPendingWork` returns early on a clean tree, so the daemon's later call is a no-op.

It declines, reporting a reason as an event, on: a stopped run, a fake run, a branch that is gone, a session that committed nothing, a repo with no remote, and a branch that already has a PR. Every outcome is an event because a dashboard-started run is spawned with `stdio: 'ignore'`, so anything printed reaches nobody.

The armed state rides the control channel (browser to run) and is echoed back as a `handoff-armed` event, which is what puts it on the run's meta. That is what makes the boxes survive a reload and read correctly in a tab opened halfway through a run. A run from before this exists emits no such event and reads as armed, which is what it will actually do.

## Verification

- framework **1242 tests, 1241 pass, 1 skipped, 0 fail** (1200 before)
- dashboard **419 pass** (414 before)
- `pnpm build` 12/12, both packages typecheck
- **3 mutation checks**, each failing exactly one test and nothing else: dropping `--draft`, restoring the unconditional draft exclusion, and removing the already-has-a-PR guard

## Not verified

No live end-to-end run: firing the real thing costs quota and would push a branch and open a PR on a real remote. The git and `gh` calls are exercised through the existing injected runners only.

## Not in scope

Auto-merge. This stops at "a PR exists and you have been told about it".
