### PR TITLE
fix(handoff): open the PR against a branch, and never against a cold cache

### DIFF
--- a/.changeset/handoff-pr-base.md
+++ b/.changeset/handoff-pr-base.md
@@ -1,0 +1,9 @@
+---
+"@gemstack/the-framework": patch
+---
+
+Fix two faults in opening a session's pull request, both found by driving the handoff against a real GitHub remote rather than a stubbed one.
+
+**The PR base was a tracking ref, so opening a PR failed outright.** `RunHandoff.base` holds what `detectBase` reads out of `refs/remotes/origin/HEAD`, which is `origin/main`. That is correct for the two things the field is otherwise used for, since the commit range and the merged check are both asking git about a remote-tracking ref. It is not a thing you can open a PR against: `gh pr create --base origin/main` is rejected with `Base ref must be a branch`. The name is now converted at the `gh` boundary, leaving the field as the git ref it is. This affected the manual **Open PR** button too, on any repo whose default branch is discovered through `origin/HEAD`.
+
+**The "this branch already has a PR" guard could be defeated by a cold cache.** The check read through the dashboard's cached PR lookup, which answers `prPending` rather than yes-or-no while it refreshes. "Not known yet" therefore read as "no PR", and a second handoff for the same branch went ahead and tried to open another one; only `gh` refusing the duplicate stopped it. The handoff now takes the uncached lookup and waits for a real answer. It runs once, at the end of a session, so it can afford to.

--- a/packages/the-framework/src/dashboard/run-handoff.test.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
-import { readRunHandoff, runBranchFor, pushRunBranch, openRunPullRequest, gitReason, runAutoHandoff, isSessionBranch } from './run-handoff.js'
+import { readRunHandoff, runBranchFor, pushRunBranch, openRunPullRequest, gitReason, runAutoHandoff, isSessionBranch, prBaseName } from './run-handoff.js'
 import { nodeGitRunner, GIT_SLOW_TIMEOUT_MS, type GitRunner } from '../project.js'
 import { CliTimeoutError, isCliTimeout } from '../cli-exec.js'
 
@@ -385,4 +385,31 @@ test('a session branch is recognised by its prefix, a hand-made one is not (#110
   assert.equal(isSessionBranch('the-framework/x'), true)
   assert.equal(isSessionBranch('feat/mine'), false)
   assert.equal(isSessionBranch(undefined), false)
+})
+
+test('the PR base is the remote branch name, not the tracking ref (#1102)', async () => {
+  // Found by driving this against a real GitHub remote: `base` is `origin/main`, because that is
+  // what the log range and the merged check need, but `gh pr create --base origin/main` is
+  // rejected with "Base ref must be a branch". Pre-existing in #799's Open PR button; auto-handoff
+  // made it fire on every session.
+  assert.equal(prBaseName('origin/main'), 'main')
+  assert.equal(prBaseName('main'), 'main') // the no-remote fallback is already a branch name
+  assert.equal(prBaseName('origin/release/2.x'), 'release/2.x')
+
+  const ghCalls: string[][] = []
+  await openRunPullRequest(
+    '/repo',
+    'the-framework/x',
+    { title: 't', body: 'b', base: 'origin/main' },
+    {
+      git: async () => '',
+      gh: async args => {
+        ghCalls.push(args)
+        return 'https://github.com/o/r/pull/1\n'
+      },
+    },
+  )
+  const at = ghCalls[0]?.indexOf('--base') ?? -1
+  assert.notEqual(at, -1, 'the base should still be passed')
+  assert.equal(ghCalls[0]?.[at + 1], 'main')
 })

--- a/packages/the-framework/src/dashboard/run-handoff.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.ts
@@ -1,5 +1,5 @@
 import { nodeGitRunner, type GitRunner } from '../project.js'
-import { cachedPrView, forgetPr, nodeGhRunner, type GhRunner, type LinkedPr, type BranchPrLookup } from './gh.js'
+import { cachedPrView, forgetPr, ghPrView, nodeGhRunner, type GhRunner, type LinkedPr, type BranchPrLookup } from './gh.js'
 import { parseNumstat } from './file-diff.js'
 import { errorMessage } from '../error-message.js'
 import type { AutoHandoffSkip } from '../events.js'
@@ -219,6 +219,22 @@ export async function pushRunBranch(
 }
 
 /**
+ * {@link RunHandoff.base} as a base a PR can actually be opened against.
+ *
+ * The field holds a git ref, because that is what every other use of it needs: `detectBase` reads
+ * `refs/remotes/origin/HEAD`, so it is `origin/main`, and the log range and merged check are both
+ * asking git a question about a remote-tracking ref. `gh pr create --base` is asking GitHub for a
+ * *branch on the remote*, and rejects `origin/main` with "Base ref must be a branch".
+ *
+ * So the conversion belongs at the `gh` boundary rather than in the field. Stripping `origin/`
+ * matches what the rest of this module already assumes: the remote is `origin` (`pushRunBranch`
+ * pushes there, `detectBase` reads its HEAD).
+ */
+export function prBaseName(base: string): string {
+  return base.startsWith('origin/') ? base.slice('origin/'.length) : base
+}
+
+/**
  * The line of a failed git invocation worth showing.
  *
  * `execFile` rejects with "Command failed: git push ..." and buries git's own `fatal:` line
@@ -266,7 +282,7 @@ export async function openRunPullRequest(
   if (!pushed.ok) return pushed
   try {
     const args = ['pr', 'create', '--head', branch, '--title', draft.title, '--body', draft.body]
-    if (draft.base) args.push('--base', draft.base)
+    if (draft.base) args.push('--base', prBaseName(draft.base))
     if (draft.draft) args.push('--draft')
     const out = (await gh(args, cwd)).trim()
     // The branch has a PR now, so the cached "no PR" must go or the bar would keep offering to
@@ -354,7 +370,12 @@ export async function runAutoHandoff(
   if (!intent.push && !intent.pr) return { outcome: 'skipped', reason: 'not-armed' }
   const branch = runBranchFor(run)
   const { gh, ...readDeps } = deps
-  const state = await readRunHandoff(cwd, branch, readDeps).catch(() => undefined)
+  // The UNcached PR lookup, deliberately. The dashboard's cache answers `prPending` rather than
+  // yes-or-no (#1028), which is right for a panel repainting every 15s and wrong here: "not known
+  // yet" would read as "no PR" and this would open a second one. Proved against a real remote —
+  // only `gh` refusing the duplicate stopped it. This runs once, at the end of a session, so it
+  // can afford to wait for a real answer.
+  const state = await readRunHandoff(cwd, branch, { pr: ghPrView, ...readDeps }).catch(() => undefined)
   if (!state || !state.exists) return { outcome: 'skipped', reason: 'branch-gone' }
   if (state.empty) return { outcome: 'skipped', reason: 'no-commits' }
   if (!state.hasRemote) return { outcome: 'skipped', reason: 'no-remote' }


### PR DESCRIPTION
Part of #1102. Follow-up to #1105, which I merged before driving it against a real remote.

I flagged in #1105 that the git and `gh` calls were only exercised through injected fake runners. Driving them for real found two faults. Neither was reachable from a stub, because both are about what a *real* GitHub says back.

## 1. The PR base was a tracking ref, so opening a PR failed outright

`RunHandoff.base` holds what `detectBase` reads out of `refs/remotes/origin/HEAD`, so it is `origin/main`. That is right for the two things the field is otherwise for: the commit range (`git log origin/main...branch`) and the merged check are both asking git about a remote-tracking ref.

It is not a thing you can open a PR against:

```
gh pr create --base origin/main
  -> GraphQL: Base ref must be a branch (createPullRequest)
```

Converted at the `gh` boundary, so the field stays the git ref it is. **This affected the manual Open PR button too**, on any repo whose default branch is discovered through `origin/HEAD`, which is essentially every cloned repo. It predates #1102; auto-handoff just made it fire on every session instead of on a click.

## 2. The already-has-a-PR guard could be defeated by a cold cache

The check read through the dashboard's *cached* PR lookup, which answers `prPending` rather than yes-or-no while it refreshes (#1028). "Not known yet" therefore read as "no PR", so a second handoff for the same branch went ahead and tried to open another one. Only `gh` refusing the duplicate stopped it.

This is the guard I mutation-tested in #1105, and the test passed because it injects a resolved `pr`. The stub hid exactly the failure mode. The handoff now takes the uncached lookup and waits for a real answer; it runs once, at the end of a session, so it can afford the ~600ms.

## How it was verified

A throwaway private repo, a session-shaped branch with a commit, and a hand-made draft PR as the control. `runAutoHandoff` driven from the built `dist` with real git and real `gh`. **No agent and no quota** — the agent is irrelevant to the surface that was unproven.

Before the fix:

```
{ "outcome": "failed", "step": "pr",
  "error": "... Base ref must be a branch (createPullRequest)" }
```

After:

```
firing runAutoHandoff({push:true, pr:true})
  { "outcome": "done", "pushed": true, "url": ".../pull/2" }
firing a second time
  { "outcome": "skipped", "reason": "already-open" }

gh pr list
  #2 draft=true head=the-framework/verify-session base=main
  #1 draft=true head=feat/by-hand            base=main

interventions queue
  [ { "kind": "pr", "number": 2, "title": "verify-session" } ]
```

So, confirmed end to end against a real remote: the branch reaches `origin`; the PR is opened as a **draft**; its base is `main`, not `origin/main`; the session's own draft **is** on the needs-you queue and the hand-made draft is **not**; and a second fire opens nothing.

The push-only arm separately: `done` -> `already-pushed` -> `not-armed`, with the PR count unchanged at 2.

## Verification

- framework **1243 tests, 1242 pass, 1 skipped, 0 fail** (1242 before this branch)
- dashboard **419 pass**, `pnpm build` 12/12, both packages typecheck
- new regression test asserts `--base` receives `main` when the handoff says `origin/main`

The scratch repo was deleted from disk; removing the GitHub repo itself needs the `delete_repo` scope, which this token does not have.
