### PR TITLE
feat(preset): add a "Suggest new features" preset

### DIFF
--- a/.changeset/suggest-new-features.md
+++ b/.changeset/suggest-new-features.md
@@ -1,0 +1,9 @@
+---
+"@gemstack/the-framework": patch
+---
+
+Add a "Suggest new features" preset.
+
+The Agentic-PM presets covered proposing work items you describe (Suggest new tickets), researching the outside market (Market research), and choosing among tickets that already exist (Suggest tickets to work on) — but not proposing net-new features from the product itself. This fills that corner: it studies what the product does today and proposes features it should have next, writing each as a ticket under `tickets/` for the normal triage pipeline to pick up.
+
+Autonomous rather than gated, like the other suggest-class presets: a proposal is a reviewable ticket, so the human triages later instead of approving mid-run, which also keeps it usable on a schedule. Paramless — it scopes itself to the whole product, so there is no blank to fill.

--- a/packages/the-framework/prompts/presets/suggest_new_features.md
+++ b/packages/the-framework/prompts/presets/suggest_new_features.md
@@ -1,0 +1,7 @@
+1. Study what this product does today: skim the README, the docs, and the main user-facing surfaces, plus the existing `tickets/`
+2. Think like a product manager and propose net-new features the product should have next
+   - Net-new capabilities a user would want, not bugs, refactors, or chores
+   - Skip anything an existing ticket already covers, and anything already built
+   - Favour features that fit the product's direction and are worth building
+3. Write each proposed feature as a new ticket under `tickets/`, following the ticket format
+4. Show a short summary of what you proposed via `showMarkdown()`

--- a/packages/the-framework/src/preset-catalog.test.ts
+++ b/packages/the-framework/src/preset-catalog.test.ts
@@ -24,6 +24,7 @@ const PARAMLESS = [
   presets.quickWins,
   presets.spikeAndPlan,
   presets.suggestNewTickets,
+  presets.suggestNewFeatures,
   presets.suggestTicketsToWorkOn,
   presets.drainQueue,
   presets.triageQuick,
@@ -38,8 +39,8 @@ test('every preset keeps its exact run-kind name', () => {
     [
       'drain-queue', 'import-tickets', 'maintainability', 'maintenance', 'market-research',
       'quick-wins', 'readability', 'research', 'security-audit', 'spike-and-plan',
-      'suggest-new-tickets', 'suggest-tickets-to-work-on', 'triage-consensual', 'triage-quick',
-      'ux',
+      'suggest-new-features', 'suggest-new-tickets', 'suggest-tickets-to-work-on',
+      'triage-consensual', 'triage-quick', 'ux',
     ],
   )
 })

--- a/packages/the-framework/src/preset-catalog.ts
+++ b/packages/the-framework/src/preset-catalog.ts
@@ -10,6 +10,7 @@ import {
   PRESETS_RESEARCH,
   PRESETS_SECURITY_AUDIT,
   PRESETS_SPIKE_AND_PLAN,
+  PRESETS_SUGGEST_NEW_FEATURES,
   PRESETS_SUGGEST_NEW_TICKETS,
   PRESETS_SUGGEST_TICKETS_TO_WORK_ON,
   PRESETS_TRIAGE_CONSENSUAL,
@@ -100,6 +101,16 @@ export const presets = {
   suggestNewTickets: definePreset({ name: 'suggest-new-tickets', template: PRESETS_SUGGEST_NEW_TICKETS, label: 'Suggest new tickets' }),
 
   /**
+   * [Suggest new features] (#1109): the product-inward, generative corner of the PM cluster. It
+   * studies what the product does today and proposes net-new features as tickets in `tickets/`.
+   * Distinct from its neighbours: `suggestNewTickets` echoes a line the human types,
+   * `marketResearch` looks outward at the market, and `suggestTicketsToWorkOn` picks from tickets
+   * that already exist. Autonomous rather than gated — a proposal is a reviewable ticket, so the
+   * human triages later instead of approving mid-run, which also keeps it usable unattended.
+   */
+  suggestNewFeatures: definePreset({ name: 'suggest-new-features', template: PRESETS_SUGGEST_NEW_FEATURES, label: 'Suggest new features', tooltip: 'Propose net-new features as tickets in `tickets/`' }),
+
+  /**
    * [Suggest tickets to work on] (#698): the gated sibling of the triage pair. It ends in
    * `<AWAIT>`, so it is deliberately kept out of {@link AUTO_PM_JOBS} — firing it unattended
    * would wedge a run against a human who is not there.
@@ -143,6 +154,7 @@ export const LAUNCHER_PRESETS: readonly PresetDef[] = [
   presets.securityAudit,
   presets.ux,
   presets.suggestNewTickets,
+  presets.suggestNewFeatures,
   presets.suggestTicketsToWorkOn,
   presets.spikeAndPlan,
   presets.quickWins,


### PR DESCRIPTION
Closes #1109. The last unchecked leaf under Agentic PM on the roadmap (#538).

Adds an autonomous **"Suggest new features"** preset: it studies what the product does today and proposes net-new features it should have, writing each as a ticket under `tickets/` for the normal triage pipeline.

## Why it is a new preset and not one we already have

The Agentic-PM cluster is dense, so I checked the overlap before building. It fills the one missing corner:

| preset | direction | mode |
|---|---|---|
| Suggest new tickets | you type the line, agent expands it | interactive echo |
| Market research | outward (external market) → tickets | autonomous |
| Suggest tickets to work on | picks from **existing** tickets | gated on approval |
| **Suggest new features** | **inward (this product) → new features as tickets** | **autonomous, generative** |

Autonomous rather than gated on purpose: a proposal is a reviewable ticket, so the human triages later instead of approving mid-run, which also keeps it usable on a schedule. Paramless — it scopes itself to the whole product.

## The prompt (first draft — preset wording is yours to tune)

```
1. Study what this product does today: skim the README, the docs, and the main user-facing surfaces, plus the existing `tickets/`
2. Think like a product manager and propose net-new features the product should have next
   - Net-new capabilities a user would want, not bugs, refactors, or chores
   - Skip anything an existing ticket already covers, and anything already built
   - Favour features that fit the product's direction and are worth building
3. Write each proposed feature as a new ticket under `tickets/`, following the ticket format
4. Show a short summary of what you proposed via `showMarkdown()`
```

## Recipe

The per-preset module pattern is gone — a preset is now one catalog row. So: new `prompts/presets/suggest_new_features.md`, one `definePreset` row + import + `LAUNCHER_PRESETS` entry in `preset-catalog.ts`, and the pinned name-list + `PARAMLESS` entries in `preset-catalog.test.ts`. The index/client re-exports and the launcher button all derive from the catalog — no edit. Not added to `PRESET_STEMS` (suggest-class presets do not materialize to `.the-framework/presets/`).

## Verified

- framework **1243 tests, 1242 pass, 1 skipped, 0 fail**; dashboard **420 pass**; typecheck clean.
- rendered the preset from the built `dist`: paramless, in `LAUNCHER_PRESETS`, template renders verbatim.
- **drove the real dashboard**: `/suggest-new-features` "Suggest new features" shows in the `/` preset menu, positioned between "Suggest new tickets" and "Suggest tickets to work on" (screenshot in the commit history of my session).
