### PR TITLE
feat(the-framework): repos-directory setting with opt-in auto-grant (#1123)

### DIFF
--- a/.changeset/repos-directory-setting.md
+++ b/.changeset/repos-directory-setting.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/the-framework": minor
+---
+
+Add a repos-directory preference with an opt-in auto-grant (#1123): a root directory the project-registration flow will default into, plus an off-by-default toggle that auto-adds every git repo directly inside it on daemon boot.

--- a/packages/the-framework/src/daemon.test.ts
+++ b/packages/the-framework/src/daemon.test.ts
@@ -17,11 +17,12 @@ import {
   startDaemonStateHeartbeat,
   startOptionFlags,
   registerHomeProject,
+  registerReposDirectory,
   isNestedWithin,
 } from './daemon.js'
 import { EVENTS_FILE, FRAMEWORK_DIR, addWorktree } from './store/index.js'
 import { controlPath } from './control.js'
-import { projectId, listProjects, addProject } from './registry.js'
+import { projectId, listProjects, addProject, writePreferences } from './registry.js'
 import { nodeGitRunner } from './project.js'
 
 // The new dashboard steers + starts over Telefunc (#405/#426), not the retired /api/* HTTP
@@ -864,5 +865,40 @@ test('registerHomeProject still adds an activated cwd that is not nested (#647)'
     assert.deepEqual(projects.map(p => p.path), [home])
   } finally {
     await rm(home, { recursive: true, force: true })
+  }
+})
+
+test('registerReposDirectory auto-adds the git repos when the opt-in is on (#1123)', async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), 'framework-repos-')))
+  const env = await configEnv(root)
+  try {
+    // Two git repos and one plain directory directly inside the repos dir.
+    await mkdir(join(root, 'app-a', '.git'), { recursive: true })
+    await mkdir(join(root, 'app-b', '.git'), { recursive: true })
+    await mkdir(join(root, 'not-a-repo'), { recursive: true })
+    await writePreferences({ reposDirectory: root, reposDirectoryAutoGrant: true }, undefined, env)
+
+    await registerReposDirectory(env)
+
+    const projects = (await listProjects(undefined, env)).map(p => p.path).sort()
+    assert.deepEqual(projects, [join(root, 'app-a'), join(root, 'app-b')])
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('registerReposDirectory adds nothing while the opt-in is off (#1123)', async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), 'framework-repos-off-')))
+  const env = await configEnv(root)
+  try {
+    await mkdir(join(root, 'app-a', '.git'), { recursive: true })
+    // reposDirectory is set, but the auto-grant is not: the default must stay hands-off.
+    await writePreferences({ reposDirectory: root }, undefined, env)
+
+    await registerReposDirectory(env)
+
+    assert.deepEqual(await listProjects(undefined, env), [])
+  } finally {
+    await rm(root, { recursive: true, force: true })
   }
 })

--- a/packages/the-framework/src/daemon.ts
+++ b/packages/the-framework/src/daemon.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, writeFile, rename, rm } from 'node:fs/promises'
-import { basename, dirname, join, relative, isAbsolute } from 'node:path'
+import { basename, dirname, join, relative, resolve, isAbsolute } from 'node:path'
 import type { FrameworkEvent } from './events.js'
 import { FRAMEWORK_DIR, isPidAlive, reconcileOrphanedRuns } from './store/index.js'
 import { startDashboard, type Dashboard, type StartRunOptions } from './dashboard/index.js'
@@ -9,7 +9,8 @@ import { defaultQuotaSource } from './dashboard/quota.js'
 import { startBackgroundServices, resumeSuspendedRuns, type BackgroundServices } from './daemon-services.js'
 import { resolveDashboardBundle } from './dashboard/bundle.js'
 import { isActivated } from './project.js'
-import { addProject, ensureDaemonToken, listProjects } from './registry.js'
+import { addProject, ensureDaemonToken, listProjects, readPreferences, type Preferences } from './registry.js'
+import { listReposInDirectory } from './repos-directory.js'
 import { registryDiscordCredentialsStore } from './discord-credentials-store.js'
 import { JsonlTailer } from './jsonl-tail.js'
 
@@ -89,6 +90,25 @@ export async function registerHomeProject(cwd: string, env: NodeJS.ProcessEnv = 
   const existing = await listProjects(undefined, env).catch(() => [])
   if (existing.some(p => isNestedWithin(cwd, p.path))) return
   await addProject(cwd, new Date().toISOString(), undefined, env).catch(() => {})
+}
+
+/**
+ * Auto-register every git repo in the user's repos directory (#1123), when they turned the opt-in on.
+ *
+ * Off unless `reposDirectoryAutoGrant` is set: it grants the app filesystem access to a whole
+ * directory of repos at once, so it stays an explicit choice, and the blast radius is contained to
+ * that one directory. Idempotent (addProject dedupes by path); logs one line per newly added repo.
+ * Best-effort, so a bad path never blocks the daemon coming up.
+ */
+export async function registerReposDirectory(env: NodeJS.ProcessEnv = process.env): Promise<void> {
+  const { reposDirectory, reposDirectoryAutoGrant } = await readPreferences(undefined, env).catch((): Preferences => ({}))
+  if (!reposDirectoryAutoGrant || !reposDirectory) return
+  const known = new Set((await listProjects(undefined, env).catch(() => [])).map(p => resolve(p.path)))
+  for (const repo of await listReposInDirectory(reposDirectory).catch(() => [])) {
+    if (known.has(resolve(repo))) continue
+    await addProject(repo, new Date().toISOString(), undefined, env).catch(() => {})
+    console.log(`[framework] auto-added repo ${basename(repo)} from ${reposDirectory}`)
+  }
 }
 
 /**
@@ -338,6 +358,9 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
 
   // Multi-project (#392): make sure an activated home repo shows up in the Projects list.
   await registerHomeProject(cwd, env)
+
+  // Repos directory (#1123): when the opt-in is on, add every git repo in the user's repos dir.
+  await registerReposDirectory(env)
 
   // Crash recovery (#642): a fresh daemon drives no in-flight run, so any run a dead
   // process left marked `running` is orphaned — it would show as active forever with a

--- a/packages/the-framework/src/registry.test.ts
+++ b/packages/the-framework/src/registry.test.ts
@@ -237,6 +237,7 @@ test('every boolean preference survives a save; the sanitizer cannot silently dr
     notifyHumanIntervention: true,
     autoPm: true,
     onboardingDismissed: true,
+    reposDirectoryAutoGrant: true,
   }
   const fs = memFs()
   await writePreferences(allOn, fs, ENV)
@@ -251,6 +252,25 @@ test('sanitizePreferences keeps a valid run target and drops junk (#1050)', asyn
   assert.deepEqual(await readPreferences(fs, ENV), { target: 'actions' })
   await writePreferences({ target: 'moon' } as never, fs, ENV)
   assert.deepEqual(await readPreferences(fs, ENV), {})
+})
+
+test('sanitizePreferences keeps an absolute reposDirectory and drops junk (#1123)', async () => {
+  // Another string preference the boolean-only loop would eat: kept only as a non-empty absolute
+  // path, so a relative or blank value never lands in the file.
+  const fs = memFs()
+  await writePreferences({ reposDirectory: '/home/u/repos' }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { reposDirectory: '/home/u/repos' })
+  await writePreferences({ reposDirectory: 'relative/repos' }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), {})
+  await writePreferences({ reposDirectory: '   ' }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), {})
+})
+
+test('reposDirectoryAutoGrant is a boolean preference, off by default (#1123)', async () => {
+  const fs = memFs()
+  assert.equal((await readPreferences(fs, ENV)).reposDirectoryAutoGrant, undefined) // absent = off
+  await writePreferences({ reposDirectory: '/home/u/repos', reposDirectoryAutoGrant: true }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { reposDirectory: '/home/u/repos', reposDirectoryAutoGrant: true })
 })
 
 test('a project may override the run target (#1050)', async () => {

--- a/packages/the-framework/src/registry.ts
+++ b/packages/the-framework/src/registry.ts
@@ -1,4 +1,4 @@
-import { basename, dirname, join, resolve } from 'node:path'
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 import { randomBytes } from 'node:crypto'
 import { isAgentName } from './agent-names.js'
 import { nodeFs } from './node-fs.js'
@@ -140,6 +140,18 @@ export interface Preferences {
    * the same checklist stays available on the settings page.
    */
   onboardingDismissed?: boolean
+  /**
+   * Absolute path to the directory the user keeps their repos in (#1123): the default the
+   * create-project flow (#1121) offers, and the root {@link reposDirectoryAutoGrant} scans.
+   * Absent = no default. Kept only as a non-empty absolute path.
+   */
+  reposDirectory?: string
+  /**
+   * Auto-add and grant every git repo directly inside {@link reposDirectory} on daemon boot (#1123).
+   * **Absent = off**: it hands the app filesystem access to a whole directory of repos at once, so it
+   * is an explicit opt-in, and the blast radius is contained to that one directory.
+   */
+  reposDirectoryAutoGrant?: boolean
 }
 
 /**
@@ -328,6 +340,7 @@ const BOOLEAN_PREFERENCES: Record<BooleanPreferenceKey, true> = {
   notifyHumanIntervention: true,
   autoPm: true,
   onboardingDismissed: true,
+  reposDirectoryAutoGrant: true,
 }
 
 const PREFERENCE_KEYS = Object.keys(BOOLEAN_PREFERENCES) as BooleanPreferenceKey[]
@@ -369,6 +382,10 @@ function sanitizePreferences(value: unknown): Preferences {
   const offset = input['autoSpendOffset']
   if (typeof offset === 'number' && Number.isFinite(offset))
     preferences.autoSpendOffset = Math.round(Math.min(Math.max(offset, -MAX_SPEND_OFFSET), MAX_SPEND_OFFSET))
+  // `reposDirectory` (#1123) is a string, so like `target` the boolean-only loop would eat it. Kept
+  // only as a non-empty absolute path; a relative or junk value is dropped rather than persisted.
+  const reposDir = typeof input['reposDirectory'] === 'string' ? input['reposDirectory'].trim() : ''
+  if (reposDir && isAbsolute(reposDir)) preferences.reposDirectory = reposDir
   const customPresets = sanitizeCustomPresets(input['customPresets'])
   if (customPresets.length) preferences.customPresets = customPresets
   return preferences

--- a/packages/the-framework/src/repos-directory.test.ts
+++ b/packages/the-framework/src/repos-directory.test.ts
@@ -1,0 +1,54 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { join } from 'node:path'
+import { listReposInDirectory, type ReposDirectoryFs } from './repos-directory.js'
+
+/**
+ * A fake fs modelling a directory tree as a set of file paths and a set of directory paths, so the
+ * scan is tested without touching disk. A `.git` listed under `files` models a worktree/submodule
+ * pointer file; one listed under `dirs` models a normal clone.
+ */
+function fakeFs(tree: { dirs?: string[]; files?: string[] }): ReposDirectoryFs {
+  const dirs = new Set(tree.dirs ?? [])
+  const files = new Set(tree.files ?? [])
+  return {
+    async readdir(path) {
+      const prefix = path.endsWith('/') ? path : path + '/'
+      const names = new Set<string>()
+      for (const entry of [...dirs, ...files]) {
+        if (!entry.startsWith(prefix)) continue
+        const rest = entry.slice(prefix.length)
+        if (!rest.includes('/')) names.add(rest)
+      }
+      return [...names]
+    },
+    async isDirectory(path) {
+      return dirs.has(path)
+    },
+    async exists(path) {
+      return files.has(path)
+    },
+  }
+}
+
+test('listReposInDirectory returns only the child dirs holding a .git (#1123)', async () => {
+  const root = '/home/u/repos'
+  const fs = fakeFs({
+    dirs: [
+      root,
+      join(root, 'app-a'),
+      join(root, 'app-a', '.git'), // normal clone: .git is a directory
+      join(root, 'app-b'),
+      join(root, 'not-a-repo'), // a plain directory, no .git
+    ],
+    files: [
+      join(root, 'app-b', '.git'), // worktree/submodule: .git is a file
+      join(root, 'README.md'), // a loose file, not a directory
+    ],
+  })
+  assert.deepEqual(await listReposInDirectory(root, fs), [join(root, 'app-a'), join(root, 'app-b')])
+})
+
+test('listReposInDirectory yields [] for a missing directory (#1123)', async () => {
+  assert.deepEqual(await listReposInDirectory('/nope', fakeFs({})), [])
+})

--- a/packages/the-framework/src/repos-directory.ts
+++ b/packages/the-framework/src/repos-directory.ts
@@ -1,0 +1,31 @@
+import { join } from 'node:path'
+import { nodeFs, type NodeFs } from './node-fs.js'
+
+/**
+ * The repos-directory helper (#1123): find the git repos directly inside a directory the user
+ * pointed The Framework at, so the daemon can auto-register them when the opt-in is on.
+ *
+ * The fs is a seam so this is unit-testable without touching disk, matching the rest of the package.
+ */
+
+/** The narrow fs the scan needs: list a directory and test its entries. {@link nodeFs} satisfies it. */
+export type ReposDirectoryFs = Pick<NodeFs, 'readdir' | 'isDirectory' | 'exists'>
+
+/**
+ * The immediate subdirectories of `dir` that are git repos: a child directory holding a `.git`
+ * (a directory in a normal clone, a file in a worktree or submodule). Returns absolute paths, sorted.
+ *
+ * Only one level deep on purpose (#1123): the auto-grant's blast radius is "this directory of repos",
+ * not the whole tree beneath it. A missing `dir` yields `[]` (readdir already swallows that), so it
+ * never throws on boot.
+ */
+export async function listReposInDirectory(dir: string, fs: ReposDirectoryFs = nodeFs()): Promise<string[]> {
+  const repos: string[] = []
+  for (const name of (await fs.readdir(dir)).sort()) {
+    const child = join(dir, name)
+    if (!(await fs.isDirectory(child))) continue
+    const git = join(child, '.git')
+    if ((await fs.exists(git)) || (await fs.isDirectory(git))) repos.push(child)
+  }
+  return repos
+}


### PR DESCRIPTION
## What this does (#1123)

Adds a "directory of repos" preference plus a dangerous, off-by-default opt-in:

- Two new keys on `Preferences`: `reposDirectory` (absolute path to the root dir of repos) and `reposDirectoryAutoGrant` (boolean, **off by default**).
- `listReposInDirectory(dir, fs)` in a new `repos-directory.ts` module: the immediate subdirectories of `dir` that are git repos (a `.git` directory in a normal clone, or a `.git` file in a worktree/submodule). Seam-injected fs so it is unit-testable, one level deep on purpose.
- `registerReposDirectory(env)` on daemon boot, right after `registerHomeProject`: when the opt-in is on and a dir is set, `addProject` each repo found. Idempotent (addProject dedupes by resolved path), one log line per newly added repo. When the opt-in is off it does nothing.

## The string-sanitizer gotcha

The registry preference sanitizer is boolean-only (`PROJECT_PREFERENCE_KEYS` / `BOOLEAN_PREFERENCES`), so a new *string* preference would be silently dropped on every save. `reposDirectory` gets its own sanitizer branch (like the `target` string and `autoSpendOffset` number before it), kept only as a non-empty **absolute** path; a relative or blank value is dropped. `reposDirectoryAutoGrant` is a plain boolean and joins the boolean table.

## Safety framing

Off by default. The auto-grant hands the app filesystem access to a whole directory of repos at once, so it stays an explicit opt-in, and the blast radius is contained to that one directory rather than "the app suddenly has fs access outside known projects."

## Tests

- string-preference sanitize: valid absolute path kept, relative/blank dropped, boolean list unaffected (the `#944` round-trip test now covers the new boolean too).
- `listReposInDirectory`: only git-repo subdirs returned (`.git` as dir or file), missing dir yields `[]`.
- auto-register path: opt-in on adds the repos, opt-in off adds nothing.

## Deferred

- Dashboard settings UI row for the two keys deferred to #1124.
- The create-project flow consuming `reposDirectory` as its default is #1121.

Closes #1123
