### PR TITLE
Topics: start a run with no project, in a neutral cwd

### DIFF
--- a/.changeset/project-less-topic-runs.md
+++ b/.changeset/project-less-topic-runs.md
@@ -1,0 +1,9 @@
+---
+"@gemstack/the-framework": minor
+---
+
+Start a run with no project, in a neutral scratch directory.
+
+A "topic" run starts project-less: it spawns in a neutral scratch dir under the config home with no repo or worktree, so the agent has no code to touch. This is the "ask a question, plan, or draft a ticket without a repo" path. It still produces the normal run lifecycle (events.jsonl, run.json, settle) inside the scratch dir.
+
+A new `sendStartTopic` RPC starts one beside the project-scoped `sendStart`, keeping the home-default behavior untouched. The scratch dir is retained on failure or stop and removed on a clean finish, mirroring the worktree retention rule. The UI for it is tracked separately.

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -294,6 +294,11 @@ export interface CliOptions {
    * stays one row in the history.
    */
   continueRun?: boolean | undefined
+  /**
+   * `--topic` (#1120): this run is project-less. Set by the daemon when it spawns a topic run into a
+   * neutral scratch `--cwd`; recorded on the run's meta so a reader can tell it from a project run.
+   */
+  topic?: boolean | undefined
   model?: string | undefined
   /** `--resume-session <id>` (#720): continue a finished run's agent session — the prompt resumes that conversation (full prior context). Set by the dashboard when you message a run that has ended. */
   resumeSession?: string | undefined
@@ -547,6 +552,9 @@ export function parseArgs(argv: string[]): CliOptions {
         break
       case '--continue-run':
         opts.continueRun = true
+        break
+      case '--topic':
+        opts.topic = true
         break
       case '--model':
         opts.model = argv[++i]
@@ -1395,6 +1403,8 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
         ...(opts.continueRun ? { continueRun: true } : {}),
         // Where the run executes (#1053): the run view reads it to switch to the Actions affordance.
         ...(opts.target ? { target: opts.target } : {}),
+        // A project-less topic run (#1120): recorded so a reader can tell it from a project run.
+        ...(opts.topic ? { topic: true } : {}),
       })
     } catch (err) {
       io.err(`could not persist session state (${errorMessage(err)}); continuing without it`)

--- a/packages/the-framework/src/daemon-runtime.ts
+++ b/packages/the-framework/src/daemon-runtime.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { basename, join, resolve } from 'node:path'
-import { rm, stat } from 'node:fs/promises'
+import { mkdir, rm, stat } from 'node:fs/promises'
 import {
   runIdFromStartedAt,
   addWorktree,
@@ -17,6 +17,7 @@ import {
   removeWorktree,
   pruneWorktrees,
   readLiveMetas,
+  readLiveMeta,
   resolveRunCheckout,
   FRAMEWORK_DIR,
   EVENTS_FILE,
@@ -35,7 +36,7 @@ import { tailEvents } from './dashboard-rpc/events-tail.js'
 import { isSafeVia } from './conversations.js'
 import { createPreviewRuntime } from './preview-runtime.js'
 import { scopedKey, parseScopedKey, keyBelongsTo } from './runtime-keys.js'
-import { addProject, listProjects, projectId } from './registry.js'
+import { addProject, listProjects, projectId, topicScratchPath } from './registry.js'
 import { installProject, enumerateGitRepos } from './install.js'
 import { isGitRepo } from './project.js'
 import { isCliTimeout } from './cli-exec.js'
@@ -76,6 +77,20 @@ export function resolveSpawnBin(explicitBinPath: string | undefined): string {
 export async function cleanupTimedOutWorktree(repo: string, runId: string, err: unknown): Promise<void> {
   if (!isCliTimeout(err)) return
   await rm(worktreePath(repo, runId), { recursive: true, force: true }).catch(() => {})
+}
+
+/**
+ * Retire a finished topic run's scratch dir (#1120), by the same retention rule as a worktree
+ * ({@link createProjectRuntime}'s tearDownWorktree): a run that finished cleanly has nothing left to
+ * look at, so its scratch goes; a failed or stopped run keeps it, which is when you want to see what
+ * it died holding. The scratch is not a git checkout, so there is no branch to preserve and no work
+ * to commit — the run's own `run.json`/`events.jsonl` live inside it and go with it. Best-effort:
+ * this runs off a process-exit event with nothing to return to.
+ */
+export async function tearDownTopicScratch(scratchCwd: string): Promise<void> {
+  const meta = await readLiveMeta(scratchCwd).catch(() => undefined)
+  if (meta?.status !== 'done') return // failed / stopped / unreadable: keep it for inspection
+  await rm(scratchCwd, { recursive: true, force: true }).catch(() => {})
 }
 
 /** Spawn a detached, unref'd framework child (`node <binPath> <args...>`) that outlives us. */
@@ -222,6 +237,9 @@ export interface ProjectRuntime {
  */
 export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): ProjectRuntime {
   const homeId = projectId(resolve(cwd))
+  // The run-key namespace for project-less topic runs (#1120): `@`-prefixed so it can never equal a
+  // real project id (projectId always appends `-<hash>`), so a topic run belongs to no project.
+  const TOPIC_PROJECT_KEY = '@topic'
   // Live run pids, keyed per run rather than per project (#736) — see onStart for the key.
   const activeRuns = new Map<string, number>()
   const starting = new Set<string>() // reserved keys mid-spawn, to close the async gap
@@ -353,6 +371,64 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
     }
   }
 
+  /**
+   * Start a project-less "topic" run (#1120): no project, no repo, no worktree. The run spawns in a
+   * neutral scratch dir under the config home, so the agent has nothing to touch — the "ask a
+   * question / plan / draft a ticket without a repo" path. It still produces the normal lifecycle
+   * (`events.jsonl`, `run.json`, settle) inside that dir, so its files are readable exactly like a
+   * worktree run's. Its `--run-id` is unique per start, so the busy guard never trips; it is keyed
+   * off {@link TOPIC_PROJECT_KEY} so it belongs to no registered project.
+   */
+  const onStartTopic = async (
+    prompt: string,
+    kind: StartRunKind,
+    options: StartRunOptions,
+  ): Promise<StartRunResult> => {
+    let realBin: string
+    try {
+      realBin = resolveSpawnBin(binPath)
+    } catch (err) {
+      return { ok: false, error: errorMessage(err) }
+    }
+    const runId = runIdFromStartedAt(new Date().toISOString())
+    const scratchCwd = topicScratchPath(env, runId)
+    try {
+      await mkdir(scratchCwd, { recursive: true })
+    } catch (err) {
+      return { ok: false, error: `could not create a scratch directory for this topic run: ${errorMessage(err)}` }
+    }
+    const key = scopedKey(TOPIC_PROJECT_KEY, runId)
+    starting.add(key)
+    try {
+      const runArgs =
+        kind === 'research'
+          ? ['research', ...(prompt ? [prompt] : [])]
+          : kind === 'prompt'
+            ? ['prompt', prompt]
+            : [prompt]
+      const child = spawnDetached(realBin, [
+        ...runArgs,
+        ...startOptionFlags(options),
+        '--no-dashboard',
+        '--cwd',
+        scratchCwd,
+        '--run-id',
+        runId,
+        '--topic',
+      ])
+      const settle = (): void => {
+        activeRuns.delete(key)
+        void tearDownTopicScratch(scratchCwd)
+      }
+      child.once('error', settle)
+      child.once('exit', settle)
+      if (child.pid !== undefined) activeRuns.set(key, child.pid)
+      return { ok: true, runId }
+    } finally {
+      starting.delete(key)
+    }
+  }
+
   // Start-from-dashboard (#345): spawn `framework "<prompt>" --no-dashboard --cwd <checkout>`
   // as a detached child — the same spawn ensureDaemon uses for the daemon itself. The run
   // streams into the page via its tailed event log, and its gates + Stop steer through the
@@ -395,6 +471,9 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
       }
       return result
     }
+    // Project-less topic run (#1120): no project, no repo, no worktree — spawned into a neutral
+    // scratch dir instead. Kept a branch of its own rather than overloading "absent projectId = home".
+    if (options.topic) return onStartTopic(prompt, kind, options)
     const projectKey = targetProjectId ?? homeId
     const projectCwd = await resolveProject(targetProjectId)
     if (!projectCwd) return { ok: false, error: `unknown project: ${targetProjectId}` }

--- a/packages/the-framework/src/daemon-workspace.test.ts
+++ b/packages/the-framework/src/daemon-workspace.test.ts
@@ -3,9 +3,10 @@ import assert from 'node:assert/strict'
 import { mkdtemp, mkdir, writeFile, readFile, rm, stat, realpath } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { createProjectRuntime, cleanupTimedOutWorktree } from './daemon-runtime.js'
+import { createProjectRuntime, cleanupTimedOutWorktree, tearDownTopicScratch } from './daemon-runtime.js'
 import { CliTimeoutError } from './cli-exec.js'
-import { FRAMEWORK_DIR, WORKTREES_DIR, worktreePath } from './store/index.js'
+import { FRAMEWORK_DIR, WORKTREES_DIR, worktreePath, RUN_META_VERSION, type RunMeta } from './store/index.js'
+import { topicScratchPath } from './registry.js'
 import { nodeGitRunner } from './project.js'
 
 /**
@@ -103,6 +104,75 @@ test('a project that is not a git repo still falls back to the main checkout, an
     await runtime.dispose()
   } finally {
     await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+/** Write a run's live meta into a checkout, so a teardown/read has a status to act on. */
+async function writeRunMeta(checkout: string, status: RunMeta['status'], extra: Partial<RunMeta> = {}): Promise<void> {
+  const dir = join(checkout, FRAMEWORK_DIR)
+  await mkdir(dir, { recursive: true })
+  const meta: RunMeta = {
+    version: RUN_META_VERSION,
+    status,
+    id: 'run1',
+    startedAt: '2026-07-24T00:00:00.000Z',
+    updatedAt: '2026-07-24T00:00:00.000Z',
+    passes: 0,
+    ...extra,
+  }
+  await writeFile(join(dir, 'run.json'), JSON.stringify(meta))
+}
+
+test('a project-less topic run spawns in a neutral scratch dir with no worktree (#1120)', async () => {
+  const home = await realpath(await mkdtemp(join(tmpdir(), 'framework-topic-home-')))
+  const config = await realpath(await mkdtemp(join(tmpdir(), 'framework-topic-cfg-')))
+  try {
+    const log = join(home, 'started.log')
+    // XDG_CONFIG_HOME steers the scratch dir the same way it steers the registry file.
+    const env = { XDG_CONFIG_HOME: config }
+    const runtime = createProjectRuntime({ cwd: home, env, binPath: await writeStub(home, log) })
+    const result = (await runtime.onStart('draft a ticket', 'build', { topic: true })) as { ok: boolean; runId?: string }
+
+    assert.equal(result.ok, true, 'a topic run starts without a project')
+    assert.ok(result.runId, 'and reports its allocated run id')
+    const scratch = topicScratchPath(env, result.runId!)
+    const args = (await startedArgs(log, 1))[0]!
+    assert.equal(args[args.indexOf('--cwd') + 1], scratch, 'spawned into the config-home scratch dir')
+    assert.equal(args[args.indexOf('--run-id') + 1], result.runId, 'with its allocated run id')
+    assert.equal(args.includes('--topic'), true, 'flagged as a topic run so its meta records it')
+    // The whole point: no repo, so no worktree anywhere near the home checkout.
+    assert.equal(await stat(join(home, FRAMEWORK_DIR, WORKTREES_DIR)).then(() => true, () => false), false, 'no worktree allocated')
+    assert.equal(await stat(scratch).then(s => s.isDirectory(), () => false), true, 'the scratch dir exists')
+    await runtime.dispose()
+  } finally {
+    await rm(home, { recursive: true, force: true })
+    await rm(config, { recursive: true, force: true })
+  }
+})
+
+test('a topic scratch dir is removed on a clean finish and retained on failure or stop (#1120)', async () => {
+  const base = await realpath(await mkdtemp(join(tmpdir(), 'framework-topic-teardown-')))
+  const exists = async (dir: string): Promise<boolean> => stat(dir).then(() => true, () => false)
+  try {
+    const done = join(base, 'done')
+    await writeRunMeta(done, 'done')
+    await tearDownTopicScratch(done)
+    assert.equal(await exists(done), false, 'a run that finished cleanly loses its scratch dir')
+
+    for (const status of ['failed', 'stopped'] as const) {
+      const dir = join(base, status)
+      await writeRunMeta(dir, status)
+      await tearDownTopicScratch(dir)
+      assert.equal(await exists(dir), true, `a ${status} run keeps its scratch dir for inspection`)
+    }
+
+    // An unreadable / still-running scratch is kept: only a proven clean finish is removed.
+    const running = join(base, 'running')
+    await writeRunMeta(running, 'running')
+    await tearDownTopicScratch(running)
+    assert.equal(await exists(running), true, 'a run still going keeps its scratch dir')
+  } finally {
+    await rm(base, { recursive: true, force: true })
   }
 })
 

--- a/packages/the-framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/the-framework/src/dashboard-rpc/control.telefunc.ts
@@ -171,6 +171,25 @@ export async function sendStart(
 }
 
 /**
+ * Start a project-less "topic" run (#1120): the sibling of {@link sendStart} that takes no project.
+ * It spawns in a neutral scratch dir with no repo or worktree — the "ask a question / plan / draft a
+ * ticket without a repo" path. A separate RPC rather than an absent-projectId overload of `sendStart`,
+ * which keeps that call's home-default behavior untouched. The daemon takes the topic branch off the
+ * `topic` option; no `projectId` travels. Returns the same {@link StartRunResult} as `sendStart`.
+ */
+export async function sendStartTopic(
+  prompt: string,
+  kind: StartRunKind = 'build',
+  options: StartRunOptions = {},
+): Promise<StartRunResult> {
+  const { startRun } = getContext<DashboardContext>()
+  if (!startRun) return { ok: false, error: 'starting a session is not enabled on this server' }
+  const text = prompt.trim()
+  if (!text && kind !== 'research') return { ok: false, error: 'a non-empty prompt is required' }
+  return startRun(text, kind, { ...options, topic: true })
+}
+
+/**
  * Open a project's Preview (#475): serve its built result on demand and return the live URL.
  * The daemon provides the Preview handlers on the request context, so this runs in-process
  * (like `sendStart`). Idempotent — opening while a preview is up returns the running one.

--- a/packages/the-framework/src/dashboard-rpc/index.ts
+++ b/packages/the-framework/src/dashboard-rpc/index.ts
@@ -3,7 +3,7 @@
 // wiring) can reach the daemon's `startRun`; the framework-dashboard client imports
 // these through thin re-export shims so the baked RPC keys stay `/server/*.telefunc.ts`.
 export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onRecentRuns, onHotTickets, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent, onTickets, onRetainedWorktrees, onRunWorktree, onRunHandoff, onSystemPromptUser } from './reads.telefunc.js'
-export { sendStop, sendChoice, sendMessage, sendSetHandoff, sendStart, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendDeleteSession, sendPushBranch, sendOpenPullRequest, sendQueueTicket, type QueueTicketResult } from './control.telefunc.js'
+export { sendStop, sendChoice, sendMessage, sendSetHandoff, sendStart, sendStartTopic, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendDeleteSession, sendPushBranch, sendOpenPullRequest, sendQueueTicket, type QueueTicketResult } from './control.telefunc.js'
 export { onEvents } from './events.telefunc.js'
 export { onProjects, sendAddProject, onOnboarding } from './projects.telefunc.js'
 export {

--- a/packages/the-framework/src/dashboard/types.ts
+++ b/packages/the-framework/src/dashboard/types.ts
@@ -101,6 +101,13 @@ export interface StartRunOptions {
    * ordinary local run and does not relay onward.
    */
   remote?: { url: string; token: string; label?: string }
+  /**
+   * Start this run project-less (#1120): it spawns in a neutral scratch dir with no repo or worktree,
+   * so the agent has no code to touch — the "ask a question / plan / draft a ticket without a repo"
+   * path. Set only by {@link sendStartTopic}; a project run leaves it absent. No `projectId` travels
+   * with it, and it allocates no worktree.
+   */
+  topic?: true
 }
 
 /**

--- a/packages/the-framework/src/registry.ts
+++ b/packages/the-framework/src/registry.ts
@@ -248,6 +248,20 @@ export function registryPath(env: NodeJS.ProcessEnv): string {
   return join(env.HOME ?? '', '.' + REGISTRY_FILE)
 }
 
+/** The dotted basename topic scratch dirs live under, mirroring the registry file's. */
+const TOPICS_DIR = 'the-framework-topics'
+
+/**
+ * The neutral scratch directory a project-less "topic" run (#1120) executes in: `<runId>/`
+ * under a config-home folder, resolved exactly like {@link registryPath} so it never lands in a
+ * repo. It is deliberately NOT a git checkout, which is what makes a topic run repo-less — a run
+ * to ask a question, plan, or draft a ticket with no code for the agent to touch.
+ */
+export function topicScratchPath(env: NodeJS.ProcessEnv, runId: string): string {
+  const root = env.XDG_CONFIG_HOME ? join(env.XDG_CONFIG_HOME, TOPICS_DIR) : join(env.HOME ?? '', '.' + TOPICS_DIR)
+  return join(root, runId)
+}
+
 /** Minimal fs seam so the registry is unit-testable without touching disk. */
 export interface RegistryFs {
   /** Rejects when the file is absent. */

--- a/packages/the-framework/src/store/run-store.ts
+++ b/packages/the-framework/src/store/run-store.ts
@@ -147,6 +147,12 @@ export interface RunMeta {
   target?: 'local' | 'actions' | 'remote'
   /** The connected device a remote run (#1067) executes on, for the session list + notice after a reload. */
   remoteLabel?: string
+  /**
+   * A project-less "topic" run (#1120): started with no project, in a neutral scratch dir with no
+   * repo. Persisted so a reader can tell it from a project run without the daemon's memory (which a
+   * restart loses), and so teardown retains vs removes its scratch dir by the same policy as a worktree.
+   */
+  topic?: true
 }
 
 /**
@@ -215,6 +221,8 @@ export interface OpenStoreOptions {
   continueRun?: boolean
   /** Where this run executes (#1053): recorded on the meta so the run view can read it. */
   target?: 'local' | 'actions'
+  /** A project-less topic run (#1120): recorded on the meta so a reader can tell it from a project run. */
+  topic?: boolean
 }
 
 /**
@@ -291,7 +299,14 @@ export interface RunOwner {
 }
 
 /** The seed meta a run starts from, before any event is folded in. */
-function freshMeta(startedAt: string, intent?: string, owner?: RunOwner, id?: string, target?: 'local' | 'actions'): RunMeta {
+function freshMeta(
+  startedAt: string,
+  intent?: string,
+  owner?: RunOwner,
+  id?: string,
+  target?: 'local' | 'actions',
+  topic?: boolean,
+): RunMeta {
   return {
     version: RUN_META_VERSION,
     status: 'running',
@@ -303,6 +318,8 @@ function freshMeta(startedAt: string, intent?: string, owner?: RunOwner, id?: st
     ...(intent ? { intent } : {}),
     // Only `actions` travels; `local` is the default every reader already assumes.
     ...(target === 'actions' ? { target } : {}),
+    // Only the topic flag travels; a project run is the default (absent).
+    ...(topic ? { topic: true } : {}),
   }
 }
 
@@ -402,7 +419,7 @@ export class RunStore {
     await fs.mkdir(dir)
     const owner = opts.owner ?? { pid: process.pid, host: hostname() }
     const clock = opts.clock ?? (() => new Date().toISOString())
-    const store = new RunStore(fs, dir, clock, freshMeta(now, opts.intent, owner, opts.id, opts.target))
+    const store = new RunStore(fs, dir, clock, freshMeta(now, opts.intent, owner, opts.id, opts.target, opts.topic))
     if (opts.continueRun) {
       // Reopen: the log stays, the row keeps its original intent, and this process takes ownership
       // so a liveness probe (#716) reads the run as alive rather than as an orphan.


### PR DESCRIPTION
## What

Adds a project-less "topic" run: a run that starts with no project, spawns in a neutral scratch directory with no repo or worktree, and still produces the normal run lifecycle (`events.jsonl`, `run.json`, settle). This delivers the "ask a question / plan / draft a ticket without a repo" use case, where the agent has no code to touch.

## How

- **New `sendStartTopic(prompt, kind, options)` RPC** beside `sendStart`, rather than overloading "absent projectId = home". It sets `options.topic` and passes no `projectId`, so the existing home-default behavior is untouched. Auto-registered on the telefunc surface the same way `sendStart` is (an export of `control.telefunc.ts`, re-exported from `dashboard-rpc/index.ts`).
- **Scratch-cwd design**: the daemon's `onStart` takes a topic branch that allocates a neutral scratch dir `<config-home>/.the-framework-topics/<runId>/` (resolved exactly like the registry file, `topicScratchPath` in `registry.ts`), creates it, and spawns the detached child with `--cwd <scratch> --run-id <runId> --topic`. No `allocateWorkspace`, no git worktree. The scratch is not a git repo, which is what makes the run repo-less. Topic runs are keyed off a reserved `@topic` run-key namespace so they belong to no registered project.
- **Teardown** (`tearDownTopicScratch`) mirrors the worktree retention rule: a clean finish (`status === 'done'`) removes the scratch dir; a failed or stopped run retains it for inspection.
- **`RunMeta.topic`** optional flag, threaded through the `--topic` CLI flag and `RunStore.open`, so a reader can tell a topic run from a project run without the daemon's in-memory state (which a restart loses).

## Tests

Added to `daemon-workspace.test.ts` (fake-spawn style): a topic run spawns into the config-home scratch dir with `--topic` and `--run-id` and no worktree; the scratch dir is removed on a clean finish and retained on failure / stop / still-running. Full suite: 1250 tests, 0 failures. `pnpm typecheck` green.

## Scope

UI addressing is deferred to #1124 (this PR is daemon / CLI / store plumbing only). Follow-on slices #1121 / #1122 build on the `RunMeta.topic` flag and the scratch layout established here.

Closes #1120