### PR TITLE
spike(the-framework): MCP-tools bind for topics (#1121)

### DIFF
--- a/packages/the-framework/package.json
+++ b/packages/the-framework/package.json
@@ -63,8 +63,10 @@
   },
   "dependencies": {
     "@gemstack/ai-autopilot": "workspace:^",
+    "@gemstack/mcp": "workspace:^",
     "telefunc": "^0.2.22",
-    "yaml": "^2.5.0"
+    "yaml": "^2.5.0",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/jsdom": "^28.0.3",

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -18,6 +18,7 @@ import { createRunDriver } from './run-driver.js'
 import { githubSlugFor } from './dashboard/github.js'
 import type { ActionsDriverOptions } from './driver/index.js'
 import { launchSharedBrowser, withBrowser, type SharedBrowser } from './browser.js'
+import { runProjectsMcp, withProjectsMcp, RUN_CWD_ENV } from './projects-mcp.js'
 import { connectCdp, startBrowserStream, type BrowserStream } from './browser-stream.js'
 import { hostExecutor } from './host-exec.js'
 import { startDashboard, singleProjectProvider, resolveDashboardBundle, type Dashboard } from './dashboard/index.js'
@@ -355,6 +356,8 @@ export interface CliOptions {
   host?: string | undefined
   dashboard: boolean
   relayServe: boolean
+  /** `mcp-projects` (#1121, spike): run the projects MCP stdio server. Internal — a topic run spawns it. */
+  mcpProjects?: boolean
   share?: string | undefined
   sessionLink?: string | undefined
   permissionMode?: PermissionMode | undefined
@@ -661,6 +664,9 @@ export function parseArgs(argv: string[]): CliOptions {
     words.shift()
   } else if (words[0] === 'relay') {
     opts.relayServe = true
+    words.shift()
+  } else if (words[0] === 'mcp-projects') {
+    opts.mcpProjects = true
     words.shift()
   } else if (words[0] === 'stop') {
     opts.stop = true
@@ -1219,6 +1225,13 @@ export async function runCli(argv: string[], io: CliIO = defaultIO): Promise<num
   // live (#230). It runs until interrupted; a run publishes to it with `--share`.
   if (opts.relayServe) return runRelayServer(opts, io)
 
+  // `mcp-projects` (#1121, spike): the projects MCP stdio server a topic run spawns so its agent can
+  // bind to a project by calling a tool. Reads the run's cwd from the env its parent handed it.
+  if (opts.mcpProjects) {
+    await runProjectsMcp({ runCwd: process.env[RUN_CWD_ENV] })
+    return 0
+  }
+
   // Resume a previous run's dashboard from its persisted log — the reload half of
   // #211. No agent runs; we just replay the saved events into a fresh stream so
   // the dashboard rehydrates exactly as it looked, then leave it up read-only.
@@ -1431,6 +1444,9 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
   // Assigned once the journal exists, which is after the control watcher is wired: a change that
   // arrives before then still lands on `armedHandoff`, it just has no event to announce it yet.
   let announceHandoff: ((push: boolean, pr: boolean) => void) | undefined
+  // Same deferral as announceHandoff: the projects MCP tool binds this topic run to a project
+  // (#1121, spike), and only an event puts that on the meta a later-opened tab can read.
+  let recordBind: ((projectId: string) => void) | undefined
 
   let control: ControlWatcher | undefined
   if (isSteerable(opts, newDashboard, await daemonStatus() !== undefined)) {
@@ -1450,6 +1466,11 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
           armedHandoff.push = entry.push || entry.pr
           armedHandoff.pr = entry.pr
           announceHandoff?.(armedHandoff.push, armedHandoff.pr)
+          return
+        }
+        if (entry.kind === 'bind') {
+          // #1122 re-homes the run into the bound project's worktree; here we only record it.
+          recordBind?.(entry.projectId)
           return
         }
         const resolve = pendingChoices.get(entry.id)
@@ -1527,6 +1548,8 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
   // only thing a dashboard tab opened mid-run can read the boxes back from.
   announceHandoff = (push, pr) => onEvent({ kind: 'handoff-armed', push, pr })
   announceHandoff(armedHandoff.push, armedHandoff.pr)
+  // Wired now the journal exists: a bind that arrives from the projects MCP tool folds to meta (#1121).
+  recordBind = projectId => onEvent({ kind: 'bind', projectId })
 
   // Fire the #326 on-before-mergeable prompt once a --on-before-mergeable run has settled and the agent
   // signalled setReadyForMerge(). Skipped for a fake/offline run and when the run was stopped —
@@ -1645,7 +1668,9 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
     ? fakeDriver()
     : createRunDriver({
         agent: opts.agent,
-        claudeOpts: withBrowser(claudeOpts, opts.browser, sharedBrowser?.browserUrl),
+        // A topic run (#1120) also gets the projects MCP server, so its agent can bind to a project
+        // by calling `create_project` (#1121, spike). Folded after the browser, same `mcpServers` map.
+        claudeOpts: withProjectsMcp(withBrowser(claudeOpts, opts.browser, sharedBrowser?.browserUrl), opts.topic, cwd),
         ...(opts.target ? { target: opts.target } : {}),
         ...(actionsConfig ? { actionsConfig } : {}),
       })

--- a/packages/the-framework/src/control.ts
+++ b/packages/the-framework/src/control.ts
@@ -40,6 +40,11 @@ export type ControlEntry =
    * event, which is what puts it on the meta the checkboxes read.
    */
   | { kind: 'handoff'; push: boolean; pr: boolean }
+  /**
+   * Bind a project-less topic run to a project (#1121): the projects MCP server appends this from the
+   * `create_project` tool, and the run folds `projectId` onto its meta. The worktree re-home is #1122.
+   */
+  | { kind: 'bind'; projectId: string }
 
 /** The control log path for a workspace. */
 export function controlPath(cwd: string): string {
@@ -93,6 +98,8 @@ function isControlEntry(value: unknown): value is ControlEntry {
   // Both halves must be real booleans: a half-written entry would otherwise disarm by accident,
   // and this decides whether the session's work reaches the remote at all.
   if (v['kind'] === 'handoff') return typeof v['push'] === 'boolean' && typeof v['pr'] === 'boolean'
+  // A bind needs a non-empty projectId; it decides which project the run re-homes into (#1121).
+  if (v['kind'] === 'bind') return typeof v['projectId'] === 'string' && v['projectId'].length > 0
   // `via` is optional (older entries have none), but a present one must be a safe transport name:
   // it is written into a line-parsed conversation heading, and a surface names itself (#917).
   if (v['kind'] === 'message') {

--- a/packages/the-framework/src/events.ts
+++ b/packages/the-framework/src/events.ts
@@ -210,6 +210,12 @@ export type FrameworkEvent =
    */
   | { kind: 'settled' }
   /**
+   * A project-less topic run (#1120) bound itself to a project (#1121): the agent called the
+   * `create_project` MCP tool, which signalled the bind over the control channel. Recorded so the
+   * run's meta names the project it re-homes into (#1122). Spike: the tools-based bind variant.
+   */
+  | { kind: 'bind'; projectId: string }
+  /**
    * Cumulative token + cost usage for the run so far (#322). Emitted after each
    * agent turn that reports usage; the dashboard renders a live spend readout and
    * the run stops itself once `costUsd` reaches the budget cap, if one is set.

--- a/packages/the-framework/src/projects-mcp.test.ts
+++ b/packages/the-framework/src/projects-mcp.test.ts
@@ -1,0 +1,117 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { McpTestClient } from '@gemstack/mcp/testing'
+import { makeProjectsServer, projectsMcpServers } from './projects-mcp.js'
+import { projectId, type RegistryFs } from './registry.js'
+import { watchControl, type ControlEntry } from './control.js'
+import { metaFromEvents } from './store/run-store.js'
+
+/** An in-memory {@link RegistryFs} so the registry round-trips without touching disk. */
+function memFs(): RegistryFs {
+  const files = new Map<string, string>()
+  return {
+    async read(path) {
+      const v = files.get(path)
+      if (v === undefined) throw new Error(`ENOENT: ${path}`)
+      return v
+    },
+    async write(path, contents) {
+      files.set(path, contents)
+    },
+    async mkdir() {},
+    async rename(from, to) {
+      files.set(to, files.get(from) ?? '')
+      files.delete(from)
+    },
+    async chmod() {},
+  }
+}
+
+/** Parse a tool result's single JSON text block. */
+function json(result: { content: Array<{ type: string; text?: string }> }): any {
+  const block = result.content[0]
+  assert.equal(block?.type, 'text')
+  return JSON.parse(block!.text!)
+}
+
+async function tmpRun(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'framework-projects-'))
+}
+
+/** Poll until the predicate holds or the timeout passes. */
+async function until(check: () => boolean, timeoutMs = 3000): Promise<boolean> {
+  for (let waited = 0; waited < timeoutMs; waited += 20) {
+    if (check()) return true
+    await new Promise(r => setTimeout(r, 20))
+  }
+  return check()
+}
+
+test('create_project registers a project, and list_projects reads it back (#1121)', async () => {
+  const fs = memFs()
+  const env = { XDG_CONFIG_HOME: '/cfg' }
+  const Server = makeProjectsServer({ fs, env, now: () => '2026-07-24T00:00:00.000Z' })
+  const client = new McpTestClient(Server)
+
+  // Both tools are advertised under their verbatim names.
+  const tools = (await client.listTools()).map(t => t.name).sort()
+  assert.deepEqual(tools, ['create_project', 'list_projects'])
+
+  assert.deepEqual(json(await client.callTool('list_projects')).projects, [])
+
+  const repo = resolve('/repos/my-app')
+  const created = json(await client.callTool('create_project', { path: repo }))
+  assert.equal(created.project.path, repo)
+  assert.equal(created.project.id, projectId(repo))
+
+  const listed = json(await client.callTool('list_projects')).projects
+  assert.equal(listed.length, 1)
+  assert.equal(listed[0].id, projectId(repo))
+})
+
+test('create_project signals the run over the control channel, and watchControl parses the bind (#1121)', async () => {
+  const cwd = await tmpRun()
+  const seen: ControlEntry[] = []
+  const watcher = watchControl(cwd, e => seen.push(e), 20)
+  try {
+    // Default appendControl, so this exercises the real tool -> control.jsonl -> watcher chain.
+    const Server = makeProjectsServer({ fs: memFs(), env: { XDG_CONFIG_HOME: '/cfg' }, runCwd: cwd })
+    const client = new McpTestClient(Server)
+
+    const repo = resolve('/repos/bind-me')
+    const created = json(await client.callTool('create_project', { path: repo }))
+    assert.equal(created.bound, true)
+
+    assert.ok(await until(() => seen.length === 1), `saw ${seen.length} entries`)
+    assert.deepEqual(seen[0], { kind: 'bind', projectId: projectId(repo) })
+  } finally {
+    watcher.close()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('without a run cwd, create_project registers but does not bind (#1121)', async () => {
+  const Server = makeProjectsServer({ fs: memFs(), env: { XDG_CONFIG_HOME: '/cfg' } })
+  const client = new McpTestClient(Server)
+  const created = json(await client.callTool('create_project', { path: resolve('/repos/unbound') }))
+  assert.equal(created.bound, false)
+})
+
+test('a bind event folds onto the run meta as boundProjectId (#1121)', () => {
+  const id = projectId(resolve('/repos/my-app'))
+  const meta = metaFromEvents([{ kind: 'bind', projectId: id }], '2026-07-24T00:00:00.000Z')
+  assert.equal(meta.boundProjectId, id)
+})
+
+test('projectsMcpServers spawns the framework bin and carries the run cwd + config home (#1121)', () => {
+  const spec = projectsMcpServers('/opt/the-framework/dist/bin.js', '/tmp/topic-run', {
+    XDG_CONFIG_HOME: '/cfg',
+    HOME: '/home/dev',
+  })
+  assert.deepEqual(spec.projects!.args, ['/opt/the-framework/dist/bin.js', 'mcp-projects'])
+  assert.equal(spec.projects!.env!.FRAMEWORK_RUN_CWD, '/tmp/topic-run')
+  assert.equal(spec.projects!.env!.XDG_CONFIG_HOME, '/cfg')
+})

--- a/packages/the-framework/src/projects-mcp.ts
+++ b/packages/the-framework/src/projects-mcp.ts
@@ -1,0 +1,143 @@
+import { z } from 'zod'
+import { McpServer, McpTool, McpResponse } from '@gemstack/mcp'
+import type { McpToolResult, McpServerOptions, ZodLikeObject } from '@gemstack/mcp'
+import { addProject, listProjects, nodeRegistryFs, type RegistryFs } from './registry.js'
+import { appendControl, type ControlEntry } from './control.js'
+import type { ClaudeCodeDriverOptions, McpServerSpec } from './driver/index.js'
+
+/**
+ * The projects MCP server (spike for #1121): the tools a project-less "topic" run (#1120) uses to
+ * bind itself to a project mid-run. Instead of a gate the run parks on, the agent calls a tool:
+ * `list_projects` to see what is registered, `create_project` to register one and bind this run to
+ * it. The bind is signalled back to the run over the same control channel the dashboard steers with.
+ *
+ * Authored on @gemstack/mcp directly rather than @gemstack/mcp-connectors because the connector
+ * layer namespaces + kebab-cases tool names (its ids reject `_`), and the agent-facing names here
+ * are `list_projects` / `create_project` verbatim.
+ */
+
+/** Env var carrying the topic run's cwd to the spawned server, so `create_project` can signal it. */
+export const RUN_CWD_ENV = 'FRAMEWORK_RUN_CWD'
+
+/** Injectable seams so the server is unit-testable without disk or a real registry. */
+export interface ProjectsMcpDeps {
+  /** Registry env (resolves the registry file path). Default `process.env`. */
+  env?: NodeJS.ProcessEnv
+  /** The topic run's cwd, where the bind control entry is appended. Absent = no signal. */
+  runCwd?: string | undefined
+  fs?: RegistryFs
+  /** Clock for a new project's `addedAt`. Default wall clock. */
+  now?: () => string
+  /** Append seam for the bind control entry. Default {@link appendControl}. */
+  append?: (cwd: string, entry: ControlEntry) => Promise<void>
+}
+
+interface ResolvedDeps {
+  env: NodeJS.ProcessEnv
+  runCwd: string | undefined
+  fs: RegistryFs
+  now: () => string
+  append: (cwd: string, entry: ControlEntry) => Promise<void>
+}
+
+function resolve(deps: ProjectsMcpDeps): ResolvedDeps {
+  return {
+    env: deps.env ?? process.env,
+    runCwd: deps.runCwd,
+    fs: deps.fs ?? nodeRegistryFs(),
+    now: deps.now ?? (() => new Date().toISOString()),
+    append: deps.append ?? appendControl,
+  }
+}
+
+function listProjectsTool(deps: ResolvedDeps): new () => McpTool {
+  return class extends McpTool {
+    override name(): string {
+      return 'list_projects'
+    }
+    override description(): string {
+      return 'List the projects registered with The Framework, so this run can bind to one.'
+    }
+    override schema(): ZodLikeObject {
+      return z.object({})
+    }
+    override async handle(): Promise<McpToolResult> {
+      return McpResponse.json({ projects: await listProjects(deps.fs, deps.env) })
+    }
+  }
+}
+
+function createProjectTool(deps: ResolvedDeps): new () => McpTool {
+  return class extends McpTool {
+    override name(): string {
+      return 'create_project'
+    }
+    override description(): string {
+      return 'Register a project by its absolute path and bind this run to it.'
+    }
+    override schema(): ZodLikeObject {
+      return z.object({ path: z.string().min(1) })
+    }
+    override async handle(input: Record<string, unknown>): Promise<McpToolResult> {
+      const path = String(input['path'] ?? '')
+      const project = await addProject(path, deps.now(), deps.fs, deps.env)
+      // Signal the run so the bind lands on its meta (#1121). The worktree re-home / respawn is
+      // #1122 — a bound run keeps executing in its scratch dir until that ships.
+      if (deps.runCwd) await deps.append(deps.runCwd, { kind: 'bind', projectId: project.id })
+      return McpResponse.json({ project, bound: deps.runCwd !== undefined })
+    }
+  }
+}
+
+/** The projects MCP server class, its tools closing over {@link deps}. */
+export function makeProjectsServer(deps: ProjectsMcpDeps = {}): new (o?: McpServerOptions) => McpServer {
+  const resolved = resolve(deps)
+  const tools = [listProjectsTool(resolved), createProjectTool(resolved)]
+  return class extends McpServer {
+    protected override tools = tools
+    override metadata() {
+      return {
+        name: 'the-framework-projects',
+        version: '1.0.0',
+        instructions: 'Bind this project-less run to a project: list_projects, then create_project.',
+      }
+    }
+  }
+}
+
+/** Run the projects server over stdio until the process exits (the `mcp-projects` subcommand). */
+export async function runProjectsMcp(deps: ProjectsMcpDeps = {}): Promise<void> {
+  // Dynamic import so the @modelcontextprotocol/sdk transport never enters the static graph of
+  // anything the client bundle can reach; only this subcommand pulls it.
+  const { startStdio } = await import('@gemstack/mcp/runtime')
+  const Server = makeProjectsServer(deps)
+  await startStdio(new Server())
+}
+
+/**
+ * The `mcpServers` spec that spawns this server for a run, mirroring {@link browserMcpServers}.
+ * The framework spawns itself (`node <bin> mcp-projects`) and hands the child the run's cwd plus the
+ * config-home vars, so the spawned server resolves the same registry file the daemon does.
+ */
+export function projectsMcpServers(
+  binPath: string,
+  runCwd: string,
+  env: NodeJS.ProcessEnv,
+): Record<string, McpServerSpec> {
+  const childEnv: Record<string, string> = { [RUN_CWD_ENV]: runCwd }
+  if (env.XDG_CONFIG_HOME) childEnv.XDG_CONFIG_HOME = env.XDG_CONFIG_HOME
+  if (env.HOME) childEnv.HOME = env.HOME
+  return { projects: { command: process.execPath, args: [binPath, 'mcp-projects'], env: childEnv } }
+}
+
+/** Fold the projects MCP server into driver options for a topic run (#1121). Non-topic runs skip it. */
+export function withProjectsMcp(
+  base: ClaudeCodeDriverOptions,
+  topic: boolean | undefined,
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+  binPath: string | undefined = process.argv[1],
+): ClaudeCodeDriverOptions {
+  if (!topic || !binPath) return base
+  return { ...base, mcpServers: { ...base.mcpServers, ...projectsMcpServers(binPath, cwd, env) } }
+}

--- a/packages/the-framework/src/store/run-store.ts
+++ b/packages/the-framework/src/store/run-store.ts
@@ -153,6 +153,12 @@ export interface RunMeta {
    * restart loses), and so teardown retains vs removes its scratch dir by the same policy as a worktree.
    */
   topic?: true
+  /**
+   * The project a topic run (#1120) bound itself to (#1121): set from a `bind` event when the agent
+   * calls `create_project`. Present means the run is no longer project-less; the worktree re-home it
+   * implies is #1122.
+   */
+  boundProjectId?: string
 }
 
 /**
@@ -273,6 +279,9 @@ export function applyEventToMeta(meta: RunMeta, event: FrameworkEvent, at: strin
       break
     case 'settled':
       next.settledAt = at
+      break
+    case 'bind':
+      next.boundProjectId = event.projectId
       break
     case 'driver':
       // Any new turn means the agent is working again, so the run is no longer parked (#785).

--- a/packages/the-framework/src/terminal.ts
+++ b/packages/the-framework/src/terminal.ts
@@ -32,6 +32,8 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
       return `✓ ready for merge`
     case 'settled':
       return `◆ done for now — waiting for your next message`
+    case 'bind':
+      return `◆ bound to project ${event.projectId}`
     case 'on-before-mergeable':
       switch (event.outcome) {
         case 'queued':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,12 +422,18 @@ importers:
       '@gemstack/ai-autopilot':
         specifier: workspace:^
         version: link:../ai-autopilot
+      '@gemstack/mcp':
+        specifier: workspace:^
+        version: link:../mcp
       telefunc:
         specifier: ^0.2.22
         version: 0.2.22(@babel/core@7.29.7)(@babel/parser@7.29.7)(@babel/types@7.29.7)(react-streaming@0.4.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(srvx@0.11.21)(vite@8.1.4(@types/node@20.19.43)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       yaml:
         specifier: ^2.5.0
         version: 2.9.0
+      zod:
+        specifier: ^4.0.0
+        version: 4.4.3
     devDependencies:
       '@types/jsdom':
         specifier: ^28.0.3


### PR DESCRIPTION
Spike for #1121, part of the #1129 decision. **Draft — not for merge.** Evaluates the MCP-tools variant of the topic-to-project bind against the await-gate variant (spiked separately).

## What it does

A project-less "topic" run (#1120) now gets two MCP tools, so its agent binds to a project by calling a tool instead of parking on a gate:

- `list_projects` — returns the registered projects (reads the registry).
- `create_project` — takes a path, registers it (`addProject`), and binds this run to it.

The bind is signalled back to the run over the existing control channel: `create_project` appends a new `{ kind: 'bind', projectId }` control entry to the run's `control.jsonl`, the run's watcher folds it to a `bind` event, and that lands on `RunMeta.boundProjectId`. Same file-is-the-seam design the dashboard already steers with, so there is no new run<->subprocess IPC.

The worktree re-home / respawn that a real bind implies is **out of scope — that is #1122**; a comment marks where it goes.

### Wiring

- `src/projects-mcp.ts` (new) — the server + tools (authored on `@gemstack/mcp` directly), `projectsMcpServers` spawn spec, and `withProjectsMcp` (mirrors `withBrowser`).
- `src/cli.ts` — hidden `mcp-projects` subcommand (the spawnable server, reads the run cwd from `FRAMEWORK_RUN_CWD`); folds the server into topic runs' `claudeOpts.mcpServers`; handles the `bind` control entry.
- `src/control.ts` / `src/events.ts` / `src/store/run-store.ts` / `src/terminal.ts` — the `bind` control entry, the `bind` event, `RunMeta.boundProjectId`, and the terminal line.

No prompt change was needed — MCP advertises the tools itself.

### Proof

- 5 new tests (in-memory registry + real control-channel round-trip + meta fold + spawn spec): green. Suite **1260 pass / 0 fail** (+1 skipped), root typecheck clean.
- Drove the real subprocess over stdio (`node dist/bin.js mcp-projects`): `tools/list` returns `list_projects, create_project`; `create_project` returns the record with `bound: true`; the run's `control.jsonl` gets `{"kind":"bind","projectId":"smoke-142xwjl"}`.

## How it felt (verdict)

**Clean:**
- The spawn side is a near-exact copy of the `--browser` precedent (`withBrowser` -> `withProjectsMcp`, one `mcpServers` entry). The MCP plumbing (`--mcp-config` temp file, merge-not-replace) already existed, so wiring a second server was trivial.
- No prompt edit. The tools are self-describing, which is the real ergonomic win over a gate: the agent discovers "I can make a project" without us scripting the moment.
- The bind signal reuses the control channel verbatim — one new entry kind, one new event, one meta field. It slotted in exactly where `handoff-armed` already lives.

**Awkward:**
- **Reuse hit a naming wall.** The obvious reuse (`@gemstack/mcp-connectors` `defineConnector`) kebab-cases and namespaces tool names, and its id regex rejects `_`, so it cannot produce `create_project` verbatim (best it does is `projects_create-project`). I dropped to `@gemstack/mcp` `McpTool` directly to honor the names, which costs a small factory-closure-per-tool. Worth flagging for the decision: if we accept `create-project`, connectors is even less code.
- **The cross-process callback is genuinely indirect.** The tool runs in a *separate spawned process* from the run; it cannot return anything to the run loop. The only way back is to write the control file and have the run tail it. It works and is consistent with the rest of the framework, but "the tool call updated the run" is two processes and a file, not a function return.
- **The respawn nuance bites, and it is the crux.** Binding will (in #1122) re-home the run into the project's worktree, which means killing and respawning the run process. So the agent's `create_project` call returns into a turn that is about to be torn down — there is nothing to continue into mid-turn. The tool's return value is effectively discarded; the *side effect* (the bind) is what matters. This is a slightly unnatural fit for "the agent calls a tool and uses the result": here the agent calls a tool and then its whole process is replaced. A gate that the orchestrator resolves by respawning models that reality more directly. The tools approach still works (the bind is recorded, #1122 picks it up on respawn), but the "tool returns a value the agent reasons about" mental model does not hold at the bind moment.

**Recommendation:** The MCP-tools path is clean to build and gives the nicest discovery story (no prompt, self-describing, list + create in one surface). Its weak spot is exactly the bind semantics: the respawn means the tool return is throwaway, so we get the ergonomics of "call a tool" without the payoff of "use its result." If the #1129 decision weights *agent-facing discoverability*, pick tools. If it weights *modeling the respawn honestly*, the gate is the more faithful shape. My lean: **tools for discovery, but only if we are fine treating create_project as fire-and-effect** (bind recorded, run respawned by #1122) rather than a value-returning call. Keep the tool return minimal (it will be discarded) and let #1122 own the respawn.

## Codex note (not wired here)

On Codex the same server would ride the driver's `extraArgs` hatch (`src/driver/codex.ts`): `codex exec` takes `-c` config overrides, so a topic run would append
`-c mcp_servers.projects.command=<node>` `-c mcp_servers.projects.args=["<bin>","mcp-projects"]` (plus the `FRAMEWORK_RUN_CWD` / `XDG_CONFIG_HOME` env). The server binary is agent-agnostic — only the "how the CLI is told about it" differs (Claude's `--mcp-config` file vs Codex's `-c mcp_servers.*`). Not built here to keep the spike to one driver.
