### PR TITLE
feat(the-framework): re-home a bound topic run into its project (#1122)

### DIFF
--- a/.changeset/topic-rehome-on-bind.md
+++ b/.changeset/topic-rehome-on-bind.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/the-framework": minor
+---
+
+feat(the-framework): re-home a bound topic run into its project (#1122): the daemon watches for the recorded bind, allocates a worktree in the chosen project, resumes the same agent session there via continue-run, and tears down the scratch, so a bound topic run becomes an ordinary run living in the project's worktree

--- a/packages/the-framework/src/await-gate.ts
+++ b/packages/the-framework/src/await-gate.ts
@@ -149,7 +149,7 @@ export async function resolveAwaitGate(
     // is unreachable in practice. It stays as a safety net rather than an assumed-present lookup.
     const project = projects.find(p => p.id === picked)
     if (!project) return NO_PROJECTS_TO_BIND
-    // #1122 re-homes the run into the bound project's worktree; here the bind is only recorded.
+    // The gate only records the bind; the daemon watches for it and re-homes the run (#1122).
     deps.bind.recordBind(project.id)
     return `Bound this run to ${project.path}.`
   }
@@ -175,7 +175,7 @@ export async function resolveAwaitGate(
     // path declines back to the agent, so a bad path can never crash the run.
     const result = await deps.bind.addProject(gate.path)
     if (!result.ok) return `Could not register that project: ${result.error}. Continue without a project, or give an existing absolute repo path.`
-    // #1122 re-homes the run into the bound project's worktree; here the bind is only recorded.
+    // The gate only records the bind; the daemon watches for it and re-homes the run (#1122).
     deps.bind.recordBind(result.project.id)
     return result.created
       ? `Registered and bound this run to ${result.project.path}.`

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -1457,7 +1457,7 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
           return
         }
         if (entry.kind === 'bind') {
-          // #1122 re-homes the run into the bound project's worktree; here we only record it.
+          // Fold the bind onto meta + the event log; the daemon watches for it and re-homes (#1122).
           recordBind?.(entry.projectId)
           return
         }

--- a/packages/the-framework/src/daemon-runtime.ts
+++ b/packages/the-framework/src/daemon-runtime.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { basename, join, resolve } from 'node:path'
-import { mkdir, rm, stat } from 'node:fs/promises'
+import { appendFile, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import {
   runIdFromStartedAt,
   addWorktree,
@@ -21,6 +21,7 @@ import {
   resolveRunCheckout,
   FRAMEWORK_DIR,
   EVENTS_FILE,
+  META_FILE,
   RUN_META_VERSION,
   isPidAlive,
   writeSuspendedRuns,
@@ -91,6 +92,34 @@ export async function tearDownTopicScratch(scratchCwd: string): Promise<void> {
   const meta = await readLiveMeta(scratchCwd).catch(() => undefined)
   if (meta?.status !== 'done') return // failed / stopped / unreadable: keep it for inspection
   await rm(scratchCwd, { recursive: true, force: true }).catch(() => {})
+}
+
+/** Best-effort append of a `log` event to a run's live stream, so a daemon-side note (a #1122
+ * re-home failure) surfaces on a run whose own process wrote every other line. Never throws. */
+async function appendRunLog(cwd: string, message: string): Promise<void> {
+  const event: FrameworkEvent = { kind: 'log', message }
+  await appendFile(join(cwd, FRAMEWORK_DIR, EVENTS_FILE), JSON.stringify(event) + '\n').catch(() => {})
+}
+
+/**
+ * Move a bound topic run's history into its new worktree (#1122), so `--continue-run` reopens the
+ * same run row rather than starting empty. Copies the event log and the meta, with `topic` cleared
+ * and the bound project recorded, since the run is an ordinary project run from here on. A torn/
+ * missing meta is left behind, so continue-run falls back to a fresh row rather than writing junk.
+ */
+export async function moveTopicRunHistory(scratchCwd: string, worktreeCwd: string, boundProjectId: string): Promise<void> {
+  const from = join(scratchCwd, FRAMEWORK_DIR)
+  const to = join(worktreeCwd, FRAMEWORK_DIR)
+  await mkdir(to, { recursive: true })
+  await writeFile(join(to, EVENTS_FILE), await readFile(join(from, EVENTS_FILE), 'utf8').catch(() => ''))
+  const raw = await readFile(join(from, META_FILE), 'utf8').catch(() => '')
+  if (!raw) return
+  try {
+    const { topic: _topic, ...meta } = JSON.parse(raw) as RunMeta
+    await writeFile(join(to, META_FILE), JSON.stringify({ ...meta, boundProjectId }, null, 2) + '\n')
+  } catch {
+    // torn meta: leave it, so continue-run opens a fresh row instead of on a half-written one
+  }
 }
 
 /** Spawn a detached, unref'd framework child (`node <binPath> <args...>`) that outlives us. */
@@ -372,12 +401,88 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
   }
 
   /**
+   * Re-home a bound topic run into its project (#1122). A topic run (#1120) lives in a neutral
+   * scratch dir; binding it to a project (#1121) has to MOVE the conversation there. This reuses the
+   * continue-run machinery (#762) pointed at a newly chosen project: allocate a fresh worktree in the
+   * bound project, copy the run's history in, resume the SAME agent session in that worktree, and
+   * stop the scratch child. The one case #762 never hit is the target project having no prior
+   * worktree for this run, which is exactly {@link allocateWorkspace}'s job.
+   *
+   * Returns whether it re-homed. On failure (unknown project, or a worktree that could not be
+   * allocated) it retains the scratch and surfaces a log event, so the conversation is never lost
+   * and the run never points at a dead cwd, the same retain-on-failure direction as a worktree.
+   * `markRehomed` is called the instant re-home is committed (before the scratch child is stopped),
+   * so the child's own teardown leaves the scratch for this to remove rather than racing it.
+   */
+  const rehomeTopicRun = async (opts: {
+    scratchCwd: string
+    runId: string
+    boundProjectId: string
+    options: StartRunOptions
+    realBin: string
+    child: ChildProcess
+    markRehomed: () => void
+  }): Promise<boolean> => {
+    const { scratchCwd, runId, boundProjectId, options, realBin, child, markRehomed } = opts
+    const projectCwd = await resolveProject(boundProjectId)
+    if (!projectCwd) {
+      await appendRunLog(scratchCwd, `could not re-home this run: unknown project ${boundProjectId}`)
+      return false
+    }
+    // The resume handle, read before the scratch goes: without it the agent starts a fresh session.
+    const sessionId = (await readLiveMeta(scratchCwd).catch(() => undefined))?.sessionId
+    const allocated = await allocateWorkspace(projectCwd, runId)
+    if (!allocated.ok) {
+      await appendRunLog(scratchCwd, `could not re-home this run into ${basename(projectCwd)}: ${allocated.error}`)
+      return false
+    }
+    const workspace = allocated.workspace
+    // Committed now: stop the scratch child (its conversation lives in the resumed session, not in
+    // scratch), and take the scratch teardown away from its exit handler so this owns it.
+    markRehomed()
+    if (child.pid !== undefined) await terminate(child.pid, 5000)
+    await moveTopicRunHistory(scratchCwd, workspace.cwd, boundProjectId)
+    const key = scopedKey(boundProjectId, workspace.runId)
+    // A short continuation note in the spirit of continuationPrompt: the resumed session already
+    // carries the whole conversation, so this only tells it where it now is.
+    const note = `You have been moved into project ${basename(projectCwd)} and are now working in its checkout. Continue where you left off.`
+    const continued = spawnDetached(realBin, [
+      'prompt',
+      note,
+      ...startOptionFlags(options),
+      '--no-dashboard',
+      '--cwd',
+      workspace.cwd,
+      ...(workspace.runId ? ['--run-id', workspace.runId] : []),
+      // Reopen the moved run rather than truncating it, and resume the agent session so the
+      // conversation continues seamlessly. `--topic` is dropped: this is an ordinary project run now.
+      '--continue-run',
+      ...(sessionId ? ['--resume-session', sessionId] : []),
+    ])
+    const settle = (): void => {
+      activeRuns.delete(key)
+      if (workspace.runId) void tearDownWorktree(projectCwd, workspace.cwd, workspace.runId)
+    }
+    continued.once('error', settle)
+    continued.once('exit', settle)
+    if (continued.pid !== undefined) activeRuns.set(key, continued.pid)
+    // Re-home succeeded, so the scratch is spent: remove it outright. The retain-on-failure rule is
+    // for a run that ended in scratch, not one that moved on with its conversation intact.
+    await rm(scratchCwd, { recursive: true, force: true }).catch(() => {})
+    return true
+  }
+
+  /**
    * Start a project-less "topic" run (#1120): no project, no repo, no worktree. The run spawns in a
    * neutral scratch dir under the config home, so the agent has nothing to touch — the "ask a
    * question / plan / draft a ticket without a repo" path. It still produces the normal lifecycle
    * (`events.jsonl`, `run.json`, settle) inside that dir, so its files are readable exactly like a
    * worktree run's. Its `--run-id` is unique per start, so the busy guard never trips; it is keyed
    * off {@link TOPIC_PROJECT_KEY} so it belongs to no registered project.
+   *
+   * Once the run binds to a project (#1121) it re-homes into that project's worktree (#1122): the
+   * daemon tails the scratch run's own event log for the `bind` recorded there and hands the
+   * conversation to {@link rehomeTopicRun}, rather than adding a run<->daemon IPC path.
    */
   const onStartTopic = async (
     prompt: string,
@@ -393,7 +498,9 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
     const runId = runIdFromStartedAt(new Date().toISOString())
     const scratchCwd = topicScratchPath(env, runId)
     try {
-      await mkdir(scratchCwd, { recursive: true })
+      // The `.the-framework/` dir too, so the bind watcher's fs.watch attaches before the run's
+      // first write rather than relying on the poll backstop to notice the dir appear.
+      await mkdir(join(scratchCwd, FRAMEWORK_DIR), { recursive: true })
     } catch (err) {
       return { ok: false, error: `could not create a scratch directory for this topic run: ${errorMessage(err)}` }
     }
@@ -416,12 +523,29 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
         runId,
         '--topic',
       ])
+      // Re-home on bind (#1122): once, and only on a committed re-home. `rehomed` gates the scratch
+      // teardown below; `inFlight` stops a second bind racing a re-home already underway, but a bind
+      // that failed to re-home leaves the watcher armed so a later bind (to a good project) retries.
+      let rehomed = false
+      let inFlight = false
+      let stopBindWatch = (): void => {}
       const settle = (): void => {
         activeRuns.delete(key)
-        void tearDownTopicScratch(scratchCwd)
+        stopBindWatch()
+        // A committed re-home removes the scratch itself; otherwise fall back to the retain-on-fail rule.
+        if (!rehomed) void tearDownTopicScratch(scratchCwd)
       }
       child.once('error', settle)
       child.once('exit', settle)
+      stopBindWatch = tailEvents<FrameworkEvent>(join(scratchCwd, FRAMEWORK_DIR, EVENTS_FILE), event => {
+        if (rehomed || inFlight || event.kind !== 'bind') return
+        inFlight = true
+        void rehomeTopicRun({ scratchCwd, runId, boundProjectId: event.projectId, options, realBin, child, markRehomed: () => (rehomed = true) })
+          .then(ok => {
+            if (ok) stopBindWatch()
+          })
+          .finally(() => (inFlight = false))
+      })
       if (child.pid !== undefined) activeRuns.set(key, child.pid)
       return { ok: true, runId }
     } finally {

--- a/packages/the-framework/src/daemon-workspace.test.ts
+++ b/packages/the-framework/src/daemon-workspace.test.ts
@@ -3,10 +3,10 @@ import assert from 'node:assert/strict'
 import { mkdtemp, mkdir, writeFile, readFile, rm, stat, realpath } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { createProjectRuntime, cleanupTimedOutWorktree, tearDownTopicScratch } from './daemon-runtime.js'
+import { createProjectRuntime, cleanupTimedOutWorktree, tearDownTopicScratch, moveTopicRunHistory } from './daemon-runtime.js'
 import { CliTimeoutError } from './cli-exec.js'
-import { FRAMEWORK_DIR, WORKTREES_DIR, worktreePath, RUN_META_VERSION, type RunMeta } from './store/index.js'
-import { topicScratchPath } from './registry.js'
+import { FRAMEWORK_DIR, WORKTREES_DIR, EVENTS_FILE, META_FILE, worktreePath, runBranchName, RUN_META_VERSION, type RunMeta } from './store/index.js'
+import { topicScratchPath, addProject, projectId } from './registry.js'
 import { nodeGitRunner } from './project.js'
 
 /**
@@ -192,5 +192,189 @@ test('a SIGTERMed worktree add has its partial checkout removed, other failures 
     assert.equal(await exists(), false, 'a timeout kill takes its half-written checkout with it')
   } finally {
     await rm(repo, { recursive: true, force: true })
+  }
+})
+
+/** A committed git repo to re-home a run into, path realpath'd so it matches what git reports. */
+async function initRepo(prefix: string): Promise<string> {
+  const repo = await realpath(await mkdtemp(join(tmpdir(), prefix)))
+  const git = nodeGitRunner()
+  await git(['init'], repo)
+  await git(['config', 'user.email', 't@t'], repo)
+  await git(['config', 'user.name', 't'], repo)
+  await writeFile(join(repo, 'README.md'), '# t\n')
+  await git(['add', '-A'], repo)
+  await git(['commit', '-m', 'init'], repo)
+  return repo
+}
+
+/**
+ * A stub CLI that records its argv, then (for a topic run only) stays alive until the daemon
+ * terminates it on re-home (a real topic run parks in the chat loop the same way). The continued
+ * `prompt` run exits at once, so it never lingers past the test.
+ */
+async function writeTopicStub(dir: string, log: string): Promise<string> {
+  const stub = join(dir, 'topic-stub.cjs')
+  await writeFile(
+    stub,
+    `const fs = require('node:fs')\n` +
+      `const argv = process.argv.slice(2)\n` +
+      `fs.appendFileSync(${JSON.stringify(log)}, JSON.stringify(argv) + '\\n')\n` +
+      `if (argv.includes('--topic')) {\n` +
+      `  const t = setInterval(() => {}, 1000)\n` +
+      `  process.on('SIGTERM', () => { clearInterval(t); process.exit(0) })\n` +
+      `}\n`,
+  )
+  return stub
+}
+
+/** Write a topic run's scratch state (as its own process would), then record the bind that fires re-home. */
+async function seedBoundTopicRun(scratch: string, runId: string, projectId: string, sessionId: string): Promise<void> {
+  const dir = join(scratch, FRAMEWORK_DIR)
+  await mkdir(dir, { recursive: true })
+  const meta: RunMeta = {
+    version: RUN_META_VERSION,
+    status: 'running',
+    id: runId,
+    startedAt: '2026-07-24T00:00:00.000Z',
+    updatedAt: '2026-07-24T00:00:00.000Z',
+    passes: 0,
+    topic: true,
+    sessionId,
+  }
+  await writeFile(join(dir, META_FILE), JSON.stringify(meta))
+  // The bind the run recorded (#1121): the event the daemon tails for and re-homes on (#1122).
+  await writeFile(join(dir, EVENTS_FILE), JSON.stringify({ kind: 'bind', projectId }) + '\n')
+}
+
+/** Poll the stub's recorded starts until at least `expected` land, or time out. */
+async function waitForArgs(log: string, expected: number): Promise<string[][]> {
+  let lines: string[] = []
+  for (let i = 0; i < 300 && lines.length < expected; i++) {
+    await new Promise(r => setTimeout(r, 20))
+    lines = await readFile(log, 'utf8').then(s => s.split('\n').filter(Boolean), () => [])
+  }
+  return lines.map(line => JSON.parse(line) as string[])
+}
+
+test('binding a topic run re-homes it into the bound project: a worktree there, its session resumed, the scratch gone (#1122)', async () => {
+  const home = await realpath(await mkdtemp(join(tmpdir(), 'framework-rehome-home-')))
+  const config = await realpath(await mkdtemp(join(tmpdir(), 'framework-rehome-cfg-')))
+  const target = await initRepo('framework-rehome-target-')
+  const env = { XDG_CONFIG_HOME: config }
+  const runtime = createProjectRuntime({ cwd: home, env, binPath: await writeTopicStub(home, join(home, 'started.log')) })
+  try {
+    // The DIFFERENT, newly chosen project the run will move into: the #1122 delta over continue-run,
+    // which only ever re-homed a run into the project it already belonged to.
+    const record = await addProject(target, new Date().toISOString(), undefined, env)
+    const boundId = projectId(target)
+    assert.equal(record.id, boundId)
+
+    const started = (await runtime.onStart('draft a plan', 'build', { topic: true })) as { ok: boolean; runId?: string }
+    assert.equal(started.ok, true)
+    const runId = started.runId!
+    const scratch = topicScratchPath(env, runId)
+
+    // The run gets a session, then binds: exactly the state a real topic run reaches at its gate.
+    await seedBoundTopicRun(scratch, runId, boundId, 'sess-xyz')
+
+    const starts = await waitForArgs(join(home, 'started.log'), 2)
+    assert.equal(starts.length, 2, 'the scratch run started, then the daemon spawned the continued run')
+    const cont = starts[1]!
+    const worktree = worktreePath(target, runId)
+    assert.equal(cont[0], 'prompt', 'the run continues as a prompt run carrying the move note')
+    assert.equal(cont[cont.indexOf('--cwd') + 1], worktree, 'in a worktree under the BOUND project, not the scratch')
+    assert.equal(cont[cont.indexOf('--run-id') + 1], runId, 'reusing the topic run id, so it stays one run')
+    assert.equal(cont.includes('--continue-run'), true, 'reopening the moved run rather than starting fresh')
+    assert.equal(cont[cont.indexOf('--resume-session') + 1], 'sess-xyz', 'resuming the SAME agent session')
+    assert.equal(cont.includes('--topic'), false, 'it is an ordinary project run now')
+
+    // The re-home is structural: the run lives in a real worktree + branch under the target project.
+    assert.equal(await stat(worktree).then(s => s.isDirectory(), () => false), true, 'the worktree exists')
+    const branches = await nodeGitRunner()(['branch', '--list', runBranchName(runId)], target)
+    assert.match(branches, new RegExp(runBranchName(runId).replace('/', '\\/')), 'on its run branch')
+
+    // Its history moved with it, marked as a project run bound to the target.
+    const moved = JSON.parse(await readFile(join(worktree, FRAMEWORK_DIR, META_FILE), 'utf8')) as RunMeta
+    assert.equal(moved.id, runId)
+    assert.equal(moved.boundProjectId, boundId, 'the run records the project it bound to')
+    assert.equal(moved.topic, undefined, 'and no longer reads as a project-less topic run')
+
+    // The scratch it left is gone (not merely retained): the conversation moved on, it did not die there.
+    assert.equal(await stat(scratch).then(() => true, () => false), false, 'the scratch dir is removed')
+  } finally {
+    await runtime.suspendRuns().catch(() => {})
+    await runtime.dispose()
+    await rm(home, { recursive: true, force: true })
+    await rm(config, { recursive: true, force: true })
+    await rm(target, { recursive: true, force: true })
+  }
+})
+
+test('a bind to an unresolvable project retains the scratch and surfaces the failure, spawning nothing (#1122)', async () => {
+  const home = await realpath(await mkdtemp(join(tmpdir(), 'framework-rehome-fail-home-')))
+  const config = await realpath(await mkdtemp(join(tmpdir(), 'framework-rehome-fail-cfg-')))
+  const env = { XDG_CONFIG_HOME: config }
+  const log = join(home, 'started.log')
+  const runtime = createProjectRuntime({ cwd: home, env, binPath: await writeTopicStub(home, log) })
+  try {
+    const started = (await runtime.onStart('draft a plan', 'build', { topic: true })) as { ok: boolean; runId?: string }
+    const runId = started.runId!
+    const scratch = topicScratchPath(env, runId)
+
+    // Bind to a project id that was never registered: nothing to re-home into.
+    await seedBoundTopicRun(scratch, runId, 'ghost-project-000', 'sess-xyz')
+
+    // Wait for the daemon to see the bind and log its failure, rather than a second spawn.
+    let events = ''
+    for (let i = 0; i < 300 && !events.includes('could not re-home'); i++) {
+      await new Promise(r => setTimeout(r, 20))
+      events = await readFile(join(scratch, FRAMEWORK_DIR, EVENTS_FILE), 'utf8').catch(() => '')
+    }
+    assert.match(events, /could not re-home this run: unknown project ghost-project-000/, 'the failure is surfaced as an event')
+    // The topic run itself started; the re-home did not spawn anything on top of it.
+    const starts = await waitForArgs(log, 1)
+    assert.equal(starts.length, 1, 'only the topic run spawned; no continued run')
+    assert.equal(starts[0]!.includes('--topic'), true, 'and that one start is the topic run')
+    assert.equal(await stat(scratch).then(() => true, () => false), true, 'the scratch is retained so the conversation is not lost')
+  } finally {
+    await runtime.suspendRuns().catch(() => {})
+    await runtime.dispose()
+    await rm(home, { recursive: true, force: true })
+    await rm(config, { recursive: true, force: true })
+  }
+})
+
+test('moveTopicRunHistory copies the log and re-marks the meta as a bound project run (#1122)', async () => {
+  const base = await realpath(await mkdtemp(join(tmpdir(), 'framework-movehist-')))
+  try {
+    const scratch = join(base, 'scratch')
+    const worktree = join(base, 'worktree')
+    const dir = join(scratch, FRAMEWORK_DIR)
+    await mkdir(dir, { recursive: true })
+    const meta: RunMeta = {
+      version: RUN_META_VERSION,
+      status: 'running',
+      id: 'run1',
+      startedAt: '2026-07-24T00:00:00.000Z',
+      updatedAt: '2026-07-24T00:00:00.000Z',
+      passes: 0,
+      topic: true,
+      sessionId: 'sess-1',
+      intent: 'draft a plan',
+    }
+    await writeFile(join(dir, META_FILE), JSON.stringify(meta))
+    await writeFile(join(dir, EVENTS_FILE), JSON.stringify({ kind: 'log', message: 'hello' }) + '\n')
+
+    await moveTopicRunHistory(scratch, worktree, 'proj-abc')
+
+    const moved = JSON.parse(await readFile(join(worktree, FRAMEWORK_DIR, META_FILE), 'utf8')) as RunMeta
+    assert.equal(moved.topic, undefined, 'the topic flag is cleared')
+    assert.equal(moved.boundProjectId, 'proj-abc', 'the bound project is recorded')
+    assert.equal(moved.id, 'run1', 'the run id and its history are preserved')
+    assert.equal(moved.intent, 'draft a plan')
+    assert.match(await readFile(join(worktree, FRAMEWORK_DIR, EVENTS_FILE), 'utf8'), /hello/, 'the event log came along')
+  } finally {
+    await rm(base, { recursive: true, force: true })
   }
 })


### PR DESCRIPTION
## What

The keystone slice of Topics (#1115). A project-less topic run (#1120) that binds to a project (#1121) today only records `boundProjectId`; the run keeps living in the neutral scratch cwd. This makes the bind actually MOVE the run: it re-homes into a worktree in the bound project and continues the SAME agent conversation there, then tears down the scratch. After this, a bound topic run is a normal run living in the chosen project's worktree.

## How it works (reuses continue-run)

Re-home is the existing continue-run machinery (#762) pointed at a newly chosen project:

1. **Trigger.** The daemon tails the topic run's own `events.jsonl` for the `bind` recorded there (#1121), rather than adding a run<->daemon IPC path. The scratch's `.the-framework/` dir is pre-created so the watcher attaches before the run's first write.
2. **Re-home.** On a `bind` for a live topic run: resolve the bound project (`resolveProject`), read the run's `sessionId`, `allocateWorkspace(projectCwd, runId)` for a fresh worktree + branch in that project, move the run's history in (`moveTopicRunHistory`), then spawn the continue child: `prompt "<move note>" --cwd <worktree> --run-id <id> --continue-run --resume-session <sessionId>` (no `--topic`). Finally remove the scratch.
3. The continued run reopens the same run row (same id, same history) and resumes the agent session, so the conversation continues seamlessly inside the project.

## The delta over continue-run (and how it is proved)

Continue-run only ever re-homed a run into the project it already belonged to. Here the run continues into a DIFFERENT, newly chosen project that had no prior worktree for this run. That is exactly `allocateWorkspace`'s job. The real-git test `binding a topic run re-homes it into the bound project ...` registers a separate target repo, starts a topic run, records a bind to that repo, and asserts the continued run is spawned with `--cwd` under a worktree in the TARGET project, `--continue-run`, and `--resume-session <sessionId>`; that the worktree + run branch exist; that the moved meta records `boundProjectId` and no longer reads as a topic run; and that the scratch is gone.

## Scratch child: hand off, not finish

The bind gate is turn-ending but the run would otherwise keep working in the scratch it is about to lose. So the daemon hands off: the moment a re-home is committed it stops the scratch child (SIGTERM) rather than letting it do more work there. Nothing is lost, because the conversation lives in the resumed agent session (`RunMeta.sessionId`), not in anything left in scratch. A committed re-home removes the scratch outright (it moved on); the retain-on-failure rule stays for a run that actually ended in scratch.

## Failure handling

If the bound project cannot be resolved or the worktree cannot be allocated, the scratch is RETAINED (the conversation is not lost), a clear `could not re-home ...` log event is surfaced on the run, and nothing is spawned, so the run never points at a dead cwd. The bind watcher stays armed, so a later bind to a good project retries. Covered by the `bind to an unresolvable project ...` test.

## Deferred to #1124 (full Topics UI)

Re-addressing is kept minimal and structural: the run re-homes by now living in the bound project's worktree, so readers resolve it by project cwd + runId. The re-homed run's meta clears `topic` and keeps `boundProjectId`. Any dashboard re-addressing / navigation from the topic view to the now-project-homed run is left to #1124. No UI in this PR.

## Verification

- `pnpm --filter @gemstack/the-framework test`: 1277 pass, 1 skipped, 0 fail (baseline ~1274; adds 3 tests, two of which drive real git).
- `pnpm build`, root `pnpm typecheck`, and prompt-drift check all green.

Closes #1122