### PR TITLE
fix(website): open the dashboard with a real link, not a promised redirect

### DIFF
--- a/packages/the-framework.ai/pages/go-to-dashboard/+Page.tsx
+++ b/packages/the-framework.ai/pages/go-to-dashboard/+Page.tsx
@@ -102,6 +102,37 @@ function PmSnippet({ get }: { get: (pm: Pm) => string }) {
   )
 }
 
+/** The daemon's default bind (`DEFAULT_DAEMON_PORT`). */
+const DASHBOARD_URL = 'localhost:4200'
+
+// A link, not an auto-redirect: a public HTTPS page cannot probe loopback (Local Network Access),
+// so "is it running?" is unanswerable from here (#1135). New tab, so a miss keeps these steps.
+function OpenDashboard() {
+  return (
+    <a
+      href={'http://' + DASHBOARD_URL}
+      target="_blank"
+      rel="noreferrer"
+      className="nav-btn-primary"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        alignSelf: 'flex-start',
+        gap: 9,
+        marginTop: 4,
+        color: '#d3c6aa',
+        border: '1.5px solid #a7c080',
+        borderRadius: 8,
+        padding: '9px 15px',
+        fontWeight: 600,
+      }}
+    >
+      <img src="/assets/logo.svg" alt="" style={{ width: 16, height: 18, display: 'block' }} />
+      <span>Open dashboard</span>
+    </a>
+  )
+}
+
 function Step({ kicker, children }: { kicker: string; children: ReactNode }) {
   return (
     <section style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
@@ -130,9 +161,10 @@ export default function Page() {
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
           <h1 style={h2Style}>Go to dashboard</h1>
           <p style={pStyle}>The dashboard runs 100% locally — you open it from your terminal.</p>
+          <OpenDashboard />
           <Note>
-            When The Framework is running, refresh this page — you'll be redirected to the Dashboard (
-            <CodeChip fontSize={12}>the-framework.local</CodeChip>).
+            Opens <CodeChip fontSize={12}>{DASHBOARD_URL}</CodeChip> in a new tab. Nothing there? The Framework is not
+            running: start it below.
           </Note>
         </div>
         <Step kicker="Run">


### PR DESCRIPTION
Closes #1135.

`/go-to-dashboard` promised: *"When The Framework is running, refresh this page, you'll be redirected to the Dashboard (`the-framework.local`)."* Nothing implemented it, and it cannot be implemented silently.

## What I measured

Chrome 150, from the live page, daemon running on `127.0.0.1:4200`:

| probe from `https://the-framework.ai` | result |
| --- | --- |
| `fetch('http://127.0.0.1:4200/')`, cors and no-cors | blocked |
| same, against a local server sending `Access-Control-Allow-Private-Network: true` | blocked |
| `<img>` and `<script>` probe | error event |
| closed port (control) | identical failure |
| top level navigation to `http://127.0.0.1:4200/` | 200, dashboard loads |

Console on every blocked probe: `Permission was denied for this request to access the 'loopback' address space`. Chrome enforces Local Network Access now, so the old PNA header opt-in is no longer sufficient, and `local-network-access` is a `prompt` permission that needs a user gesture. A running daemon is therefore indistinguishable from a closed port.

`the-framework.local` would not have helped: a hosts entry still resolves to loopback, so it only makes the URL prettier, and it needs a sudo write (idea from #411).

## What this does

Top level navigation is unrestricted, so the promise is replaced with an action that works today:

- an "Open dashboard" link to `http://localhost:4200` (the daemon's `DEFAULT_DAEMON_PORT`), styled like the nav's primary button
- `target="_blank"`, so if the daemon is not running the install steps stay on screen
- the note now names the failure mode instead of promising a redirect

If the automatic redirect is still wanted, the upgrade path is a one time Local Network Access grant behind that same button (Chrome only). Option 3 in #1135.

## Verified

- `pnpm typecheck` and `pnpm build` clean
- built output driven in real Chrome: link renders once, `href="http://localhost:4200"`, clicking it opens the running dashboard (title "The Framework"), no console errors
- no horizontal overflow at 390px (`scrollWidth` 390 = `innerWidth` 390)
- `the-framework.local` and the redirect sentence are gone from the built HTML

No changeset: the site package is private.
