### PR TITLE
fix(website): drop the Dashboard button until opening it actually works

### DIFF
--- a/packages/the-framework.ai/pages/go-to-dashboard/+Page.tsx
+++ b/packages/the-framework.ai/pages/go-to-dashboard/+Page.tsx
@@ -2,11 +2,10 @@ import '../index/styles.css'
 import type { CSSProperties, ReactNode } from 'react'
 import { TopNav } from '../index/TopNav'
 import { Footer } from '../index/Footer'
-import { CodeChip } from '../index/ui'
 import { useCopy } from '../index/copy'
 import { currentPm, pickPm, PMS } from '../index/Hero'
 import type { Pm } from '../index/Hero'
-import { h2Style, kickerStyle, mono, Note } from '../index/ui'
+import { h2Style, kickerStyle, mono } from '../index/ui'
 
 const tipStyle: CSSProperties = {
   position: 'absolute',
@@ -102,37 +101,6 @@ function PmSnippet({ get }: { get: (pm: Pm) => string }) {
   )
 }
 
-/** The daemon's default bind (`DEFAULT_DAEMON_PORT`). */
-const DASHBOARD_URL = 'localhost:4200'
-
-// A link, not an auto-redirect: a public HTTPS page cannot probe loopback (Local Network Access),
-// so "is it running?" is unanswerable from here (#1135). New tab, so a miss keeps these steps.
-function OpenDashboard() {
-  return (
-    <a
-      href={'http://' + DASHBOARD_URL}
-      target="_blank"
-      rel="noreferrer"
-      className="nav-btn-primary"
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        alignSelf: 'flex-start',
-        gap: 9,
-        marginTop: 4,
-        color: '#d3c6aa',
-        border: '1.5px solid #a7c080',
-        borderRadius: 8,
-        padding: '9px 15px',
-        fontWeight: 600,
-      }}
-    >
-      <img src="/assets/logo.svg" alt="" style={{ width: 16, height: 18, display: 'block' }} />
-      <span>Open dashboard</span>
-    </a>
-  )
-}
-
 function Step({ kicker, children }: { kicker: string; children: ReactNode }) {
   return (
     <section style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
@@ -161,11 +129,6 @@ export default function Page() {
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
           <h1 style={h2Style}>Go to dashboard</h1>
           <p style={pStyle}>The dashboard runs 100% locally — you open it from your terminal.</p>
-          <OpenDashboard />
-          <Note>
-            Opens <CodeChip fontSize={12}>{DASHBOARD_URL}</CodeChip> in a new tab. Nothing there? The Framework is not
-            running: start it below.
-          </Note>
         </div>
         <Step kicker="Run">
           <p style={pStyle}>If The Framework is installed, run it:</p>

--- a/packages/the-framework.ai/pages/index/TopNav.tsx
+++ b/packages/the-framework.ai/pages/index/TopNav.tsx
@@ -66,21 +66,8 @@ export function TopNav() {
           fontSize: 14.5,
         }}
       >
-        {/* Primary via green border, not fill — the multicolor logo drowns on a green background. */}
-        <a
-          href="/go-to-dashboard"
-          className="nav-btn-primary"
-          style={{
-            ...navBtnStyle,
-            // 1.5px border with compensated padding: same outer box as the secondaries.
-            border: '1.5px solid #a7c080',
-            padding: '7px 13.5px',
-            fontWeight: 600,
-          }}
-        >
-          <img src="/assets/logo.svg" alt="" style={{ width: 16, height: 18, display: 'block' }} />
-          <span>Dashboard</span>
-        </a>
+        {/* No Dashboard button until opening it from here actually works (#1137): the dashboard is
+            a local daemon, and a public page cannot reach or detect one (#1135). */}
         <a href={DISCORD_URL} className="nav-btn" style={navBtnStyle}>
           <DiscordIcon width={16} height={13} />
           <span>Discord</span>


### PR DESCRIPTION
Closes #1137.

Removes the `Dashboard` button from the top nav and the "Open dashboard" button + note from `/go-to-dashboard` — the part of #1136 in your screenshot.

**What I did not do: restore the old note.** It said refreshing the page would redirect you to `the-framework.local`, which cannot work — a public HTTPS page is denied the loopback address space outright (Chrome's Local Network Access), and a running daemon is indistinguishable from a closed port, so the page cannot even branch its copy on it (#1135). Putting that sentence back would re-promise the thing this reverts to. The page now just says the dashboard runs locally, then shows run + install steps.

The page stays reachable by URL, only unlinked. When the real redirect lands, the button comes back with it.

Site typecheck + build clean, driven in Chrome: nav is `The Framework | Discord | GitHub`, and `/go-to-dashboard` has no open-dashboard link.

Private package, so no changeset.