### PR TITLE
fix(dashboard): let the right rail earn its tabs

### DIFF
--- a/.changeset/rail-earns-its-tabs.md
+++ b/.changeset/rail-earns-its-tabs.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+The right rail only shows what it has: a tab whose panel is empty (Docs, Tickets, Log) is no longer offered, and a rail with nothing in it is not rendered at all.

--- a/packages/framework-dashboard/components/DocsPanel.tsx
+++ b/packages/framework-dashboard/components/DocsPanel.tsx
@@ -1,19 +1,16 @@
 import { useState } from 'react'
 import type { WorkspaceDoc } from '@gemstack/the-framework'
-import { onDocs } from '../server/reads.telefunc.js'
 import { Button } from './ui/button.js'
 import { Markdown } from './Markdown.js'
-import { usePolled } from '../lib/use-async.js'
 import { cn } from '../lib/utils.js'
 import { ScrollArea } from './ui/scroll-area.js'
 
-// The surfaced documents (#319/#328): the PLAN/TODO the agent writes, rendered beside
-// the run. Telefunc RPC (server/reads.telefunc.ts), polled so edits mid-run show up.
-export function DocsPanel({ projectId }: { projectId: string | null }) {
-  const { value: docs, loaded } = usePolled<WorkspaceDoc[]>(projectId ? () => onDocs(projectId) : null, [], 4000, [projectId])
+// The surfaced documents (#319/#328): the PLAN/TODO the agent writes, rendered beside the run.
+// The read lives in the rail (#1146), which needs to know whether there are any docs before it
+// offers the tab; this renders what it is handed.
+export function DocsPanel({ docs, loaded }: { docs: WorkspaceDoc[]; loaded: boolean }) {
   const [active, setActive] = useState(0)
 
-  if (!projectId) return null
   // Loading and empty are different facts (#948): without the guard, a project with docs
   // flashed "No PLAN/TODO docs yet." on every open while the first read was still out.
   if (!loaded) return <p className="p-4 text-sm text-muted-foreground">Loading…</p>

--- a/packages/framework-dashboard/components/ProjectLogPanel.tsx
+++ b/packages/framework-dashboard/components/ProjectLogPanel.tsx
@@ -1,7 +1,5 @@
 import type { LogEntry } from '@gemstack/the-framework'
-import { onProjectLog } from '../server/reads.telefunc.js'
 import { Badge } from './ui/badge.js'
-import { usePolled } from '../lib/use-async.js'
 import { cn } from '../lib/utils.js'
 import { formatDateTime } from '../lib/format-date.js'
 import { STATUS_TONE } from '../lib/status-tone.js'
@@ -9,12 +7,9 @@ import { ScrollArea } from './ui/scroll-area.js'
 
 // The committed project log (#378/#379): `.the-framework/LOGS.md`, every finished
 // loop/prompt/build run newest-first, over a Telefunc RPC (server/reads.telefunc.ts).
-// Polled like the sibling rail panels, so an entry a run appends on finishing shows up
-// without a project switch.
-export function ProjectLogPanel({ projectId }: { projectId: string | null }) {
-  const { value: logs, loaded } = usePolled<LogEntry[]>(projectId ? () => onProjectLog(projectId) : null, [], 10_000, [projectId])
-
-  if (!projectId) return null
+// Read in the rail like its sibling panels (#1146), so an entry a run appends on finishing shows
+// up without a project switch, and an empty log costs no tab.
+export function ProjectLogPanel({ logs, loaded }: { logs: LogEntry[]; loaded: boolean }) {
   // Loading and empty are different facts (#948) — same guard as the Tickets panel.
   if (!loaded) return <p className="p-4 text-sm text-muted-foreground">Loading…</p>
   if (logs.length === 0) return <p className="p-4 text-sm text-muted-foreground">No committed log entries yet.</p>

--- a/packages/framework-dashboard/components/RightRail.test.tsx
+++ b/packages/framework-dashboard/components/RightRail.test.tsx
@@ -1,8 +1,16 @@
-import { afterEach, describe, expect, test, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import type { AgentView } from '../lib/live-state.js'
 
-// The rail's panels are Telefunc-backed; this is about the rail's own width, so stub them.
+// The rail reads the three content panels itself now (#1146), so it can tell an empty one from a
+// full one. Stub the reads: the default project has docs, tickets and a log, so every tab is
+// earned and the tests below are about what the rail does with them.
+const onDocs = vi.hoisted(() => vi.fn())
+const onTickets = vi.hoisted(() => vi.fn())
+const onProjectLog = vi.hoisted(() => vi.fn())
+vi.mock('../server/reads.telefunc.js', () => ({ onDocs, onTickets, onProjectLog }))
+
+// The panels themselves are rendered elsewhere; here they are stand-ins.
 vi.mock('./DocsPanel.js', () => ({ DocsPanel: () => <div>docs</div> }))
 vi.mock('./ProjectLogPanel.js', () => ({ ProjectLogPanel: () => <div>log</div> }))
 vi.mock('./FileTree.js', () => ({ FileTree: () => <div>files</div> }))
@@ -11,6 +19,12 @@ vi.mock('./ChoicesRail.js', () => ({ ChoicesRail: () => <div>choices</div> }))
 vi.mock('./TicketsPanel.js', () => ({ TicketsPanel: () => <div>tickets</div> }))
 
 const { RightRail } = await import('./RightRail.js')
+
+beforeEach(() => {
+  onDocs.mockReset().mockResolvedValue([{ name: 'PLAN.md', content: '# plan' }])
+  onTickets.mockReset().mockResolvedValue([{ file: 't.md', title: 'A ticket', summary: '', spiked: false, planned: false }])
+  onProjectLog.mockReset().mockResolvedValue([{ kind: 'prompt', status: 'done', at: '2026-07-25T00:00:00.000Z', intent: 'x' }])
+})
 
 afterEach(cleanup)
 
@@ -90,5 +104,66 @@ describe('RightRail loop status', () => {
     fireEvent.click(screen.getByRole('tab', { name: /log/i }))
     expect(screen.getByText('log')).toBeTruthy()
     expect(screen.getByText(/loop status/i)).toBeTruthy()
+  })
+})
+
+// Every tab is earned by its content (#1146): a panel that can only say "nothing yet" costs a tab
+// nobody wants, and when none of them has anything the rail itself is noise.
+describe('RightRail empty panels (#1146)', () => {
+  const settle = () => act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+
+  test('no docs, no Docs tab', async () => {
+    onDocs.mockResolvedValue([])
+    render(<RightRail {...baseProps} />)
+    await settle()
+    expect(screen.queryByRole('tab', { name: /docs/i })).toBeNull()
+    // The panels that do have something are untouched.
+    expect(screen.getByRole('tab', { name: /tickets/i })).toBeTruthy()
+    expect(screen.getByRole('tab', { name: /log/i })).toBeTruthy()
+  })
+
+  test('nothing anywhere means no rail at all', async () => {
+    onDocs.mockResolvedValue([])
+    onTickets.mockResolvedValue([])
+    onProjectLog.mockResolvedValue([])
+    const { container } = render(<RightRail {...baseProps} />)
+    await settle()
+    expect(container.querySelector('aside')).toBeNull()
+  })
+
+  test('a live surface keeps the rail even when every read comes back empty', async () => {
+    onDocs.mockResolvedValue([])
+    onTickets.mockResolvedValue([])
+    onProjectLog.mockResolvedValue([])
+    const { container } = render(<RightRail {...baseProps} views={[view]} />)
+    await settle()
+    expect(container.querySelector('aside')).toBeTruthy()
+    expect(screen.getByRole('tab', { name: /views/i })).toBeTruthy()
+  })
+
+  test('the tabs hold while the first read is still out, so switching projects does not blink', () => {
+    onDocs.mockReturnValue(new Promise(() => {}))
+    onTickets.mockReturnValue(new Promise(() => {}))
+    onProjectLog.mockReturnValue(new Promise(() => {}))
+    render(<RightRail {...baseProps} />)
+    // Not yet known to be empty is not the same as known to be empty.
+    expect(screen.getByRole('tab', { name: /docs/i })).toBeTruthy()
+  })
+
+  test('the open tab losing its content falls back to one that still has some', async () => {
+    const { rerender } = render(<RightRail {...baseProps} views={[view]} />)
+    await settle()
+    // Picked by hand, so nothing auto-defaults away from it; then the run ends and the views
+    // go with it, leaving the remembered tab pointing at something that is no longer there.
+    fireEvent.click(screen.getByRole('tab', { name: /views/i }))
+    expect(screen.getByRole('tab', { name: /views/i }).getAttribute('aria-selected')).toBe('true')
+    rerender(<RightRail {...baseProps} views={[]} />)
+    await settle()
+    expect(screen.queryByRole('tab', { name: /views/i })).toBeNull()
+    // Not an empty panel: the rail falls back to the first tab that still has content.
+    expect(screen.getByRole('tab', { name: /tickets/i }).getAttribute('aria-selected')).toBe('true')
   })
 })

--- a/packages/framework-dashboard/components/RightRail.tsx
+++ b/packages/framework-dashboard/components/RightRail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import type { ChoiceRequest } from '@gemstack/the-framework'
+import type { ChoiceRequest, LogEntry, WorkspaceDoc, WorkspaceTicket } from '@gemstack/the-framework'
 import type { LoopStatus } from '@gemstack/the-framework/client'
 import { LoopStatusCard } from './LoopStatusCard.js'
 import { DocsPanel } from './DocsPanel.js'
@@ -13,6 +13,8 @@ import type { AgentView } from '../lib/live-state.js'
 import { Badge } from './ui/badge.js'
 import { Button } from './ui/button.js'
 import { cn } from '../lib/utils.js'
+import { usePolled } from '../lib/use-async.js'
+import { onDocs, onProjectLog, onTickets } from '../server/reads.telefunc.js'
 
 type Tab = 'files' | 'choices' | 'views' | 'browser' | 'tickets' | 'docs' | 'log'
 
@@ -56,6 +58,18 @@ export function RightRail({
   /** Told when a panel starts a session (the tickets import, #948), so the shell shows it. */
   onRunStarted?: ((intent: string, runId?: string) => void) | undefined
 }) {
+  // The three content panels are read here rather than each polling for itself: the rail has to
+  // know whether they have anything before it can decide which tabs to offer, and whether to be
+  // there at all (#1146). One read each, passed down; the panels render what they are given.
+  const { value: docs, loaded: docsLoaded } = usePolled<WorkspaceDoc[]>(projectId ? () => onDocs(projectId) : null, [], 4000, [projectId])
+  const { value: tickets, loaded: ticketsLoaded } = usePolled<WorkspaceTicket[]>(projectId ? () => onTickets(projectId) : null, [], 10_000, [projectId])
+  const { value: logs, loaded: logsLoaded } = usePolled<LogEntry[]>(projectId ? () => onProjectLog(projectId) : null, [], 10_000, [projectId])
+  // Hidden only once we KNOW it is empty: while the first read is out, the tab stays, so switching
+  // projects does not blink the rail out and back in.
+  const hasDocs = !docsLoaded || docs.length > 0
+  const hasTickets = !ticketsLoaded || tickets.length > 0
+  const hasLog = !logsLoaded || logs.length > 0
+
   const [tab, setTab] = useState<Tab>('docs')
   // Once the user picks a tab, stop auto-defaulting (#695/U22) — only a genuinely new choice
   // gate or the first view may still pull focus after that.
@@ -89,16 +103,22 @@ export function RightRail({
   if (!projectId) return null
 
   // Files first (#492): the project peek surface, before the run's own choices/views/docs/log.
+  // Every tab is earned by content (#1146): a tab that can only say "nothing yet" is one the rail
+  // does not offer, and a rail with no tabs left is not shown at all.
   const tabs: Tab[] = [
     ...(hasFiles ? ['files' as const] : []),
     ...(hasChoices ? ['choices' as const] : []),
     ...(hasViews ? ['views' as const] : []),
     // Only when the run actually has one (#813) — a dead tab teaches people the preview is broken.
     ...(showBrowser && runId ? ['browser' as const] : []),
-    'tickets',
-    'docs',
-    'log',
+    ...(hasTickets ? ['tickets' as const] : []),
+    ...(hasDocs ? ['docs' as const] : []),
+    ...(hasLog ? ['log' as const] : []),
   ]
+  if (tabs.length === 0) return null
+  // The remembered tab may have just lost its content (the last doc deleted, a gate resolved), so
+  // fall back to the first one that still exists rather than rendering an empty panel.
+  const active: Tab = tabs.includes(tab) ? tab : tabs[0]!
   const label = (t: Tab) =>
     t === 'files'
       ? 'Files'
@@ -131,10 +151,10 @@ export function RightRail({
           <Button
             key={t}
             role="tab"
-            aria-selected={tab === t}
+            aria-selected={active === t}
             variant="ghost"
             size="sm"
-            className={cn('h-7 gap-1.5 text-xs', tab === t && 'bg-accent text-accent-foreground')}
+            className={cn('h-7 gap-1.5 text-xs', active === t && 'bg-accent text-accent-foreground')}
             onClick={() => pickTab(t)}
           >
             {label(t)}
@@ -147,20 +167,20 @@ export function RightRail({
           scroller once the content outgrows what is left. That is what puts the verdict below
           directly under the last row rather than at the foot of an empty column. */}
       <div className="flex min-h-0 flex-col overflow-hidden">
-        {tab === 'files' && hasFiles ? (
+        {active === 'files' && hasFiles ? (
           <FileTree projectId={projectId} runId={runId} files={files} selected={context} onToggle={toggleContext} />
-        ) : tab === 'choices' && hasChoices ? (
+        ) : active === 'choices' && hasChoices ? (
           <ChoicesRail projectId={projectId} runId={runId} choices={choices} />
-        ) : tab === 'views' && hasViews ? (
+        ) : active === 'views' && hasViews ? (
           <ViewsRail views={views} />
-        ) : tab === 'browser' && showBrowser && runId ? (
+        ) : active === 'browser' && showBrowser && runId ? (
           <BrowserPanel projectId={projectId} runId={runId} />
-        ) : tab === 'tickets' ? (
-          <TicketsPanel projectId={projectId} onRunStarted={onRunStarted} />
-        ) : tab === 'log' ? (
-          <ProjectLogPanel projectId={projectId} />
+        ) : active === 'tickets' ? (
+          <TicketsPanel projectId={projectId} tickets={tickets} loaded={ticketsLoaded} onRunStarted={onRunStarted} />
+        ) : active === 'log' ? (
+          <ProjectLogPanel logs={logs} loaded={logsLoaded} />
         ) : (
-          <DocsPanel projectId={projectId} />
+          <DocsPanel docs={docs} loaded={docsLoaded} />
         )}
       </div>
       {/* Straight under the panel's content, not one of the tabs and not pinned to the floor: the

--- a/packages/framework-dashboard/components/TicketsPanel.test.tsx
+++ b/packages/framework-dashboard/components/TicketsPanel.test.tsx
@@ -2,10 +2,8 @@ import { afterEach, describe, expect, test, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { WorkspaceTicket } from '@gemstack/the-framework'
 
-const onTickets = vi.hoisted(() => vi.fn())
 const sendQueueTicket = vi.hoisted(() => vi.fn())
 const sendStart = vi.hoisted(() => vi.fn())
-vi.mock('../server/reads.telefunc.js', () => ({ onTickets }))
 vi.mock('../server/control.telefunc.js', () => ({ sendQueueTicket, sendStart }))
 
 const { TicketsPanel } = await import('./TicketsPanel.js')
@@ -21,15 +19,13 @@ const ticket = (over: Partial<WorkspaceTicket> = {}): WorkspaceTicket => ({
 
 afterEach(() => {
   cleanup()
-  onTickets.mockReset()
   sendQueueTicket.mockReset()
   sendStart.mockReset()
 })
 
 describe('TicketsPanel (#697)', () => {
   test('lists the tickets with what has already been done to them', async () => {
-    onTickets.mockResolvedValue([ticket({ priority: 'high', planned: true })])
-    render(<TicketsPanel projectId="p1" />)
+    render(<TicketsPanel projectId="p1" tickets={[ticket({ priority: 'high', planned: true })]} loaded />)
     expect(await screen.findByText('Do the thing')).toBeTruthy()
     expect(screen.getByText('The thing is not done.')).toBeTruthy()
     expect(screen.getByText('high')).toBeTruthy()
@@ -37,9 +33,8 @@ describe('TicketsPanel (#697)', () => {
   })
 
   test('queueing a ticket writes it to the queue', async () => {
-    onTickets.mockResolvedValue([ticket()])
     sendQueueTicket.mockResolvedValue({ ok: true, file: 'TODO_AGENTS.md' })
-    render(<TicketsPanel projectId="p1" />)
+    render(<TicketsPanel projectId="p1" tickets={[ticket()]} loaded />)
     fireEvent.click(await screen.findByRole('button', { name: /queue/i }))
     await waitFor(() => expect(sendQueueTicket).toHaveBeenCalledWith('p1', 'Do the thing'))
   })
@@ -47,27 +42,24 @@ describe('TicketsPanel (#697)', () => {
   // The queue is a file, so a re-poll cannot tell us the row was queued: without remembering
   // the click the button would invite the same entry to be added twice.
   test('a queued ticket says so and cannot be queued twice', async () => {
-    onTickets.mockResolvedValue([ticket()])
     sendQueueTicket.mockResolvedValue({ ok: true, file: 'TODO_AGENTS.md' })
-    render(<TicketsPanel projectId="p1" />)
+    render(<TicketsPanel projectId="p1" tickets={[ticket()]} loaded />)
     fireEvent.click(await screen.findByRole('button', { name: /queue/i }))
     const queued = await screen.findByRole('button', { name: /queued/i })
     expect((queued as HTMLButtonElement).disabled).toBe(true)
   })
 
   test('a failed queue write surfaces and leaves the row addable', async () => {
-    onTickets.mockResolvedValue([ticket()])
     sendQueueTicket.mockResolvedValue({ ok: false, error: 'the queue could not be written' })
-    render(<TicketsPanel projectId="p1" />)
+    render(<TicketsPanel projectId="p1" tickets={[ticket()]} loaded />)
     fireEvent.click(await screen.findByRole('button', { name: /queue/i }))
     expect(await screen.findByText(/could not be written/i)).toBeTruthy()
     expect(screen.queryByRole('button', { name: /queued/i })).toBeNull()
   })
 
   test('an empty tickets/ offers the GitHub import instead of a dead end', async () => {
-    onTickets.mockResolvedValue([])
     sendStart.mockResolvedValue({ ok: true, runId: 'r1' })
-    render(<TicketsPanel projectId="p1" />)
+    render(<TicketsPanel projectId="p1" tickets={[]} loaded />)
     fireEvent.click(await screen.findByRole('button', { name: /import tickets from github/i }))
     await waitFor(() => expect(sendStart).toHaveBeenCalled())
     // A fixed prompt, so it takes the verbatim-text path rather than a build.
@@ -76,8 +68,7 @@ describe('TicketsPanel (#697)', () => {
   })
 
   test('no project renders nothing at all', () => {
-    const { container } = render(<TicketsPanel projectId={null} />)
+    const { container } = render(<TicketsPanel projectId={null} tickets={[]} loaded />)
     expect(container.textContent).toBe('')
-    expect(onTickets).not.toHaveBeenCalled()
   })
 })

--- a/packages/framework-dashboard/components/TicketsPanel.tsx
+++ b/packages/framework-dashboard/components/TicketsPanel.tsx
@@ -1,11 +1,9 @@
 import { useState } from 'react'
 import type { WorkspaceTicket } from '@gemstack/the-framework'
 import { ListPlus, Check } from 'lucide-react'
-import { onTickets } from '../server/reads.telefunc.js'
 import { sendQueueTicket, sendStart } from '../server/control.telefunc.js'
 import { Button } from './ui/button.js'
 import { Badge } from './ui/badge.js'
-import { usePolled } from '../lib/use-async.js'
 import { useAction } from '../lib/use-action.js'
 import { cn } from '../lib/utils.js'
 import { ScrollArea } from './ui/scroll-area.js'
@@ -31,19 +29,18 @@ const PRIORITY_TONE: Record<string, string> = {
 // `tickets/` offers to import the repo's GitHub issues instead of just saying "nothing here".
 export function TicketsPanel({
   projectId,
+  tickets,
+  loaded,
   onRunStarted,
 }: {
   projectId: string | null
+  /** Read in the rail (#1146), which needs the count to decide whether to offer the tab. */
+  tickets: WorkspaceTicket[]
+  loaded: boolean
   /** Told when the import session starts, so the shell can show it (#948) — the button used
    *  to flip "Starting…" and leave you staring at the still-empty panel. */
   onRunStarted?: ((intent: string, runId?: string) => void) | undefined
 }) {
-  const { value: tickets, loaded } = usePolled<WorkspaceTicket[]>(
-    projectId ? () => onTickets(projectId) : null,
-    [],
-    10_000,
-    [projectId],
-  )
   // Which tickets this session has queued. The queue is a file, not a field on the ticket, so
   // there is nothing on the ticket to re-read; remembering the click is what stops a row
   // reading as un-queued the moment the poll returns.


### PR DESCRIPTION
Closes #1146.

`Tickets`, `Docs` and `Log` were offered unconditionally, so a project with none of them got three tabs whose entire content was a sentence saying there was nothing — your screenshot.

Now each of the three appears only when its panel has something, and when nothing is left the rail is not rendered at all.

To decide that, the rail has to know what those panels hold, so the three reads moved up into it and the panels take their data as props. That also drops a duplicate poll per panel rather than adding one.

Two details that matter in use:
- A tab is hidden only once a read has actually come back empty. While the first read is out the tab stays, so switching projects does not blink the rail out and back in.
- A tab you picked that later loses its content falls back to one that still has some, instead of rendering an empty panel.

**The GitHub-issues import is not lost with the empty Tickets tab** — the same action is already on the Overview's onboarding row (`Populate tickets/` → `Import tickets from GitHub`), which is where someone with no tickets is looking anyway.

Driven in Chrome across three projects: a project with tickets/docs/log keeps `Files · Tickets · Docs · Log`; one with none of them shows just `Files`. In practice `Files` keeps the rail alive for most repos — the rail disappears entirely for a project with nothing at all, which is the case in your screenshot (no Files tab there either).

dashboard 434 tests (5 new for #1146), typecheck + build clean, patch changeset.