### PR TITLE
fix(dashboard): put the light theme on a white canvas

### DIFF
--- a/.changeset/light-theme-white.md
+++ b/.changeset/light-theme-white.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+The light theme sits on a white canvas instead of Everforest's cream paper. The greens stay, darkened to stay readable on white.

--- a/packages/framework-dashboard/layouts/tailwind.css
+++ b/packages/framework-dashboard/layouts/tailwind.css
@@ -24,27 +24,32 @@
   /* Let the browser paint native theme-matched scrollbars + form controls (the shadcn way).
      `.dark` flips it below. */
   color-scheme: light;
-  /* Everforest Light (medium). Cards recede a shade below the canvas, mirroring the dark theme
-     where panels are darker than the background. */
-  --background: #fdf6e3;
-  --foreground: #5c6a72;
-  --card: #f4f0d9;
-  --card-foreground: #5c6a72;
-  --muted: #efebd4;
-  --muted-foreground: #829181;
-  --border: #ddd8be;
-  --primary: #8da101;
-  --primary-foreground: #fdf6e3;
-  --accent: #efebd4;
-  --accent-foreground: #5c6a72;
+  /* Everforest's greens on a white canvas (#1141). Everforest Light is paper-coloured (#fdf6e3),
+     which reads as orange next to any other app; the identity people recognise is the green, not
+     the paper, so the hues stay and the canvas goes white. Cards sit on white too and are told
+     apart by their border, the usual light-mode direction (the dark theme still recedes).
+     The greens are darkened from Everforest Light, which was mixed for cream: #8da101 is 2.9:1 on
+     white, below readable for the small text these tokens carry. */
+  --background: #ffffff;
+  --foreground: #3a4248;
+  --card: #ffffff;
+  --card-foreground: #3a4248;
+  --muted: #f3f5f2;
+  --muted-foreground: #66756c;
+  --border: #e3e7e1;
+  --primary: #6f7f00;
+  --primary-foreground: #ffffff;
+  --accent: #eef1ec;
+  --accent-foreground: #3a4248;
 
   /* Status. Every status colour used to be a raw palette value, so "good" was six different
      greens and `amber-500` meant both "stopped" and "building, fine". These four are the whole
-     vocabulary, now on the Everforest Light accents. */
-  --success: #8da101;
-  --warning: #dfa000;
-  --danger: #f85552;
-  --info: #3a94c5;
+     vocabulary: Everforest's four hues, each darkened to stay readable on white (the shipped
+     Light tones run 2.3-3.4:1 there, which is why they are not used verbatim). */
+  --success: #6f7f00;
+  --warning: #9a6b00;
+  --danger: #d1403d;
+  --info: #2b7ba5;
 
   /* The brand mark's six strands (#757), darkest first, exactly as the brand ships them.
      Kept as variables so the mark can be re-ramped for a dark canvas without touching the SVG. */


### PR DESCRIPTION
Closes #1141.

Everforest Light is paper-coloured (`#fdf6e3`) — that is the orange. The part of the identity people recognise is the green, not the paper, so the hues stay and the canvas goes white. **The dark theme is untouched.**

| token | was | now |
|---|---|---|
| background | `#fdf6e3` | `#ffffff` |
| card | `#f4f0d9` | `#ffffff` (told apart by its border, the usual light-mode direction) |
| muted / accent | `#efebd4` | `#f3f5f2` / `#eef1ec` |
| border | `#ddd8be` | `#e3e7e1` |
| foreground | `#5c6a72` | `#3a4248` |
| primary / success | `#8da101` | `#6f7f00` |
| warning / danger / info | `#dfa000` / `#f85552` / `#3a94c5` | `#9a6b00` / `#d1403d` / `#2b7ba5` |

The greens are darkened rather than copied: Everforest Light was mixed for cream, and on white those tones run 2.3–3.4:1, below readable for the small text these tokens carry (badges, statuses, links). Every text token now measures at least 4.4:1 against its own background.

Driven in Chrome on the Overview and a project page in Light: white throughout, green accents intact.

dashboard 429 tests, typecheck + build clean, patch changeset.