### PR TITLE
test(the-framework): keep the re-home poll under the suite's per-test timeout

### DIFF
--- a/packages/the-framework/src/daemon-workspace.test.ts
+++ b/packages/the-framework/src/daemon-workspace.test.ts
@@ -26,8 +26,13 @@ async function writeStub(dir: string, log: string): Promise<string> {
   return stub
 }
 
-/** 20ms apart, so 1500 attempts is a 30s ceiling — long enough for a slow runner (#1153). */
-const POLL_ATTEMPTS = 1500
+/**
+ * 20ms apart, so 750 attempts is a 15s ceiling: long enough for a slow runner (#1153), and short
+ * enough that the two polls a single re-home test runs still fit inside the suite's 60s per-test
+ * timeout (`--test-timeout` in scripts/run-tests.mjs) with the real git work between them. A 30s
+ * ceiling did not — two waits alone reached the cap, turning a slow test into a file timeout.
+ */
+const POLL_ATTEMPTS = 750
 
 /** The stub's recorded starts, waited for (a start spawns detached). */
 async function startedArgs(log: string, expected: number): Promise<string[][]> {


### PR DESCRIPTION
Follows #1153 / #1154.

I raised that poll ceiling to 30s, which fixed the 6s timeout and introduced a worse one: a single re-home test runs **two** of those polls, so two slow waits alone hit the suite's 60s `--test-timeout` and the whole `daemon-workspace.test.js` file timed out instead (seen on #1156).

15s each clears the 6.5s the original failing run needed, with the real git work between them still inside the cap.

1286 tests green locally. Test-only, no changeset.