### PR TITLE
fix: sweep when the roadmap toggle goes on, and say what the sweep decided

### DIFF
--- a/.changeset/auto-pm-visible.md
+++ b/.changeset/auto-pm-visible.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+Auto PM now sweeps as soon as "Spend what's left on the roadmap" is switched on, instead of up to ten minutes later, and the usage panel says what the last sweep decided. Every decision was already logged, but the log is the daemon's stdout and the toggle is in a browser, so a sweep standing down for a reason looked exactly like one quietly working.

--- a/packages/framework-dashboard/components/Quota.test.tsx
+++ b/packages/framework-dashboard/components/Quota.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import type { Preferences, QuotaView } from '@gemstack/the-framework'
+import type { AutoPmReport, Preferences, QuotaView } from '@gemstack/the-framework'
 
 const updatePreferences = vi.hoisted(() => vi.fn())
 let prefs: Preferences = {}
@@ -10,7 +10,8 @@ vi.mock('../lib/preferences.js', () => ({
 }))
 
 let view: QuotaView | undefined
-vi.mock('../lib/quota.js', () => ({ useQuota: () => view }))
+let autoPm: AutoPmReport | undefined
+vi.mock('../lib/quota.js', () => ({ useQuota: () => view, useAutoPm: () => autoPm }))
 
 const { Quota } = await import('./Quota.js')
 
@@ -37,6 +38,7 @@ function reading(percentUsed: number, limitOffset = 0): QuotaView {
 beforeEach(() => {
   prefs = {}
   view = undefined
+  autoPm = undefined
   updatePreferences.mockReset()
 })
 afterEach(cleanup)
@@ -129,3 +131,62 @@ describe('Quota (#960)', () => {
   })
 })
 
+
+describe('the auto-PM readout (#1161)', () => {
+  /** A sweep that considered one project, `minutesAgo` ago, with the next one an hour out. */
+  function swept(message: string, started = false, minutesAgo = 2): AutoPmReport {
+    return {
+      enabled: true,
+      sweptAt: Date.now() - minutesAgo * 60_000,
+      nextSweepAt: Date.now() + 60 * 60_000,
+      outcomes: [{ projectId: 'p1', path: '/Users/me/code/gemstack', started, message }],
+    }
+  }
+
+  test('says why nothing is running, rather than leaving the toggle to be guessed at', () => {
+    // The reason was always written — to the daemon's stdout, which the browser never shows.
+    view = reading(20)
+    autoPm = swept('4 runs are already going')
+    render(<Quota />)
+    expect(screen.getByText(/4 runs are already going/)).toBeTruthy()
+    expect(screen.getByText(/gemstack/)).toBeTruthy()
+  })
+
+  test('names the project by its directory, not its whole path', () => {
+    view = reading(20)
+    autoPm = swept('the quota could not be read')
+    render(<Quota />)
+    expect(screen.queryByText(/Users\/me\/code/)).toBeNull()
+  })
+
+  test('says when it last looked and when it will look again', () => {
+    view = reading(20)
+    autoPm = swept('draining the first open queue entry', true)
+    render(<Quota />)
+    expect(screen.getByText(/Last checked 2m ago/)).toBeTruthy()
+    expect(screen.getByText(/next in 1 hr/)).toBeTruthy()
+  })
+
+  test('stays quiet while the setting is off, since the box already says so', () => {
+    view = reading(20)
+    autoPm = { enabled: false, sweptAt: Date.now(), nextSweepAt: Date.now() + 60_000, outcomes: [] }
+    render(<Quota />)
+    expect(screen.queryByText(/Last checked/)).toBeNull()
+  })
+
+  test('a sweep that has not run yet reads as checking, never as an idle one', () => {
+    view = reading(20)
+    autoPm = { nextSweepAt: Date.now() + 60_000, outcomes: [] }
+    render(<Quota />)
+    expect(screen.getByText('Checking…')).toBeTruthy()
+    expect(screen.queryByText(/No projects/)).toBeNull()
+  })
+
+  test('says nothing at all on a host that runs no sweep', () => {
+    view = reading(20)
+    autoPm = undefined
+    render(<Quota />)
+    expect(screen.queryByText(/Last checked/)).toBeNull()
+    expect(screen.queryByText('Checking…')).toBeNull()
+  })
+})

--- a/packages/framework-dashboard/components/Quota.tsx
+++ b/packages/framework-dashboard/components/Quota.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
-import type { DriverQuotaWindow, QuotaBoundaryStatus, QuotaView } from '@gemstack/the-framework'
+import type { AutoPmReport, DriverQuotaWindow, QuotaBoundaryStatus, QuotaView } from '@gemstack/the-framework'
 import { MAX_SPEND_OFFSET } from '@gemstack/the-framework/client'
-import { useQuota } from '../lib/quota.js'
+import { useAutoPm, useQuota } from '../lib/quota.js'
+import { formatRelative } from '../lib/format-date.js'
 import { usePreferences, updatePreferences } from '../lib/preferences.js'
 import { weekTicks, quotaTone, limitPercent, TONE_NOTE, type QuotaTone } from '../lib/quota-bar.js'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card.js'
@@ -189,8 +190,54 @@ function useSpendOffset(serverOffset: number | undefined): [number, (offset: num
   ]
 }
 
+/** How long until `at`, as "in 4 min" / "in 1 hr". Past due reads as "any moment". */
+function untilText(at: number): string {
+  const minutes = Math.round((at - Date.now()) / 60_000)
+  if (minutes <= 0) return 'any moment'
+  if (minutes < 60) return `in ${minutes} min`
+  const hours = Math.round(minutes / 60)
+  return `in ${hours} hr`
+}
+
+/** The repo a line is about, by the name you would call it: its directory. */
+function projectName(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() ?? path
+}
+
+/**
+ * What the sweep last did (#1161). Without this the toggle was the only thing the panel could
+ * say, so "on, and standing down because the queue could not be read" looked exactly like "on,
+ * and quietly working" — and the reasons were already being written, to a log in a terminal the
+ * dashboard user never sees.
+ */
+function AutoPmStatus({ report }: { report: AutoPmReport }) {
+  // The box itself already says it is off, and a sweep's report on a preference it read as off
+  // says nothing more than that.
+  if (report.enabled === false) return null
+  if (report.sweptAt === undefined) return <p className="text-xs text-muted-foreground">Checking…</p>
+  return (
+    <div className="space-y-0.5 text-xs text-muted-foreground">
+      <p>
+        Last checked {formatRelative(new Date(report.sweptAt).toISOString())} · next {untilText(report.nextSweepAt)}
+      </p>
+      {report.outcomes.length === 0 ? (
+        <p>No projects to work on.</p>
+      ) : (
+        report.outcomes.map(outcome => (
+          <p key={outcome.projectId}>
+            <span className={cn(outcome.started && 'text-foreground')}>{projectName(outcome.path)}</span>
+            {' — '}
+            {outcome.message}
+          </p>
+        ))
+      )}
+    </div>
+  )
+}
+
 export function Quota() {
   const view = useQuota()
+  const autoPm = useAutoPm()
   const preferences = usePreferences()
   const [offset, setOffset] = useSpendOffset(view?.boundary?.limit.offset)
   const note = view ? unavailableNote(view) : undefined
@@ -232,6 +279,7 @@ export function Quota() {
               When nothing is running, work the queue down and refill it rather than let the week's
               allowance expire. Only while the account is still under the line above.
             </p>
+            {autoPm ? <AutoPmStatus report={autoPm} /> : null}
           </div>
         ) : null}
 

--- a/packages/framework-dashboard/lib/quota.ts
+++ b/packages/framework-dashboard/lib/quota.ts
@@ -1,5 +1,5 @@
-import type { QuotaView } from '@gemstack/the-framework'
-import { onQuota } from '../server/quota.telefunc.js'
+import type { AutoPmReport, QuotaView } from '@gemstack/the-framework'
+import { onQuota, onAutoPm } from '../server/quota.telefunc.js'
 import { usePolled } from './use-async.js'
 
 // The usage panel's data (#535). The daemon polls the agent for us and caches the answer,
@@ -17,4 +17,14 @@ const REFRESH_MS = 30_000
  */
 export function useQuota(): QuotaView | undefined {
   return usePolled<QuotaView | undefined>(onQuota, undefined, REFRESH_MS, []).value
+}
+
+/**
+ * What auto PM last decided (#1161), refreshed alongside the quota it spends against.
+ *
+ * Polled rather than read once: the sweep runs on the daemon's clock, not the browser's, so
+ * the panel finding out is a matter of asking again. `undefined` on a host with no sweep.
+ */
+export function useAutoPm(): AutoPmReport | undefined {
+  return usePolled<AutoPmReport | undefined>(onAutoPm, undefined, REFRESH_MS, []).value
 }

--- a/packages/framework-dashboard/server/quota.telefunc.ts
+++ b/packages/framework-dashboard/server/quota.telefunc.ts
@@ -5,6 +5,6 @@
 // Imported then exported, not re-exported (#1014): telefunc's dev transform appends
 // `__decorateTelefunction(<name>, ...)` per export, which needs a local binding. An
 // `export ... from` creates none, so `pnpm dev` died with `<name> is not defined`.
-import { onQuota } from '@gemstack/the-framework/dashboard-rpc'
+import { onQuota, onAutoPm } from '@gemstack/the-framework/dashboard-rpc'
 
-export { onQuota }
+export { onQuota, onAutoPm }

--- a/packages/the-framework/src/auto-pm.test.ts
+++ b/packages/the-framework/src/auto-pm.test.ts
@@ -447,3 +447,55 @@ test('an unreadable sweep schedule falls back to the rotation (#882)', async () 
   loop.stop()
   assert.deepEqual(ran, ['first'])
 })
+
+test('the report names what a sweep started (#1161)', async () => {
+  const { loop } = harness()
+  await loop.tick()
+  loop.stop()
+  const report = loop.report()
+  assert.equal(report.enabled, true)
+  assert.equal(report.sweptAt, T0)
+  assert.deepEqual(report.outcomes, [
+    { projectId: 'p1', path: '/repo', started: true, message: 'doing the first thing' },
+  ])
+})
+
+test('the report carries the reason a sweep stood down (#1161)', async () => {
+  // The whole point: standing down for a reason must not look like quietly working. The reason
+  // was already logged, but the log is the daemon's stdout and the toggle is in a browser.
+  const { loop } = harness({ activeRuns: () => 2 })
+  await loop.tick()
+  loop.stop()
+  const [outcome] = loop.report().outcomes
+  assert.equal(outcome?.started, false)
+  assert.match(outcome?.message ?? '', /already going/)
+})
+
+test('the report says so when the preference is off (#1161)', async () => {
+  // Distinguishable from "on, and standing down": the panel hides the line entirely for off,
+  // and an off sweep considers no project, so it can have no per-project reason either.
+  const { loop } = harness({ enabled: async () => false })
+  await loop.tick()
+  loop.stop()
+  const report = loop.report()
+  assert.equal(report.enabled, false)
+  assert.deepEqual(report.outcomes, [])
+})
+
+test('the report offers a next sweep before the first one has run (#1161)', () => {
+  // The panel reads `sweptAt === undefined` as "checking…", so it must never read as an idle sweep.
+  const { loop } = harness({ intervalMs: 60_000 })
+  const report = loop.report()
+  loop.stop()
+  assert.equal(report.sweptAt, undefined)
+  assert.equal(report.enabled, undefined)
+  assert.equal(report.nextSweepAt, T0 + 60_000)
+})
+
+test('an out-of-band tick does not skew the next sweep (#1161)', async () => {
+  // Waking the loop when the box is ticked must not push the interval it is not driving.
+  const { loop } = harness({ intervalMs: 60_000 })
+  await loop.tick()
+  loop.stop()
+  assert.equal(loop.report().nextSweepAt, T0 + 60_000)
+})

--- a/packages/the-framework/src/auto-pm.ts
+++ b/packages/the-framework/src/auto-pm.ts
@@ -264,10 +264,52 @@ export interface AutoPmDeps {
   now?: () => number
 }
 
+/** What the last sweep decided about one project. */
+export interface AutoPmOutcome {
+  /** Registry id of the project considered. */
+  projectId: string
+  /** Its path, which is what the log line names and the panel shows. */
+  path: string
+  /** Whether a run was started for it. */
+  started: boolean
+  /** The sentence: what was started, or the reason for standing down. */
+  message: string
+}
+
+/**
+ * What auto PM has done lately (#1161).
+ *
+ * Every decision was already logged (#855), but the log is the daemon's stdout and the toggle
+ * lives in a browser, so from the dashboard a wedged sweep and a healthy idle one looked
+ * identical — the same failure #855 fixed one layer down.
+ */
+export interface AutoPmReport {
+  /** Whether the preference was on at the last sweep. `undefined` before the first one. */
+  enabled?: boolean
+  /** When the last sweep finished, epoch ms. `undefined` before the first one. */
+  sweptAt?: number
+  /** When the next sweep is due, epoch ms. */
+  nextSweepAt: number
+  /** One line per project the last sweep considered, in sweep order. */
+  outcomes: AutoPmOutcome[]
+}
+
+/**
+ * Where the dashboard reads {@link AutoPmReport} from. The daemon wires its live loop; a public
+ * host (the relay) leaves it unset, and one that has not finished starting answers `undefined`.
+ */
+export type AutoPmReporter = () => AutoPmReport | undefined
+
 /** A running sweep. */
 export interface AutoPmLoop {
-  /** Run one sweep now, rather than waiting for the next tick. Exposed for tests. */
+  /**
+   * Run one sweep now, rather than waiting for the next tick. Called when the preference is
+   * switched on (#1161) as well as from tests: the sweep re-reads it per tick, so without this
+   * the box you just ticked does nothing at all for a whole interval.
+   */
   tick(): Promise<void>
+  /** What the last sweep decided, for the dashboard to show (#1161). */
+  report(): AutoPmReport
   stop(): void
 }
 
@@ -283,6 +325,11 @@ export interface AutoPmLoop {
  */
 export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
   const now = deps.now ?? (() => Date.now())
+  const intervalMs = deps.intervalMs ?? DEFAULT_AUTO_PM_INTERVAL_MS
+  const startedAt = now()
+  // What the last sweep decided, for `report()`. Undefined only in the moment before the
+  // start-up sweep below lands.
+  let lastSweep: { enabled: boolean; sweptAt: number; outcomes: AutoPmOutcome[] } | undefined
   const lastStart = new Map<string, number>()
   // Runs this loop started whose queue has not reached the checkout yet, oldest first.
   const pending = new Map<string, string[]>()
@@ -295,10 +342,16 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
   const tick = async (): Promise<void> => {
     if (stopped || sweeping) return
     sweeping = true
+    let enabled = false
+    const outcomes: AutoPmOutcome[] = []
+    // Every branch that logs also records, so the panel says exactly what the log says.
+    const note = (project: AutoPmProject, started: boolean, message: string) =>
+      outcomes.push({ projectId: project.id, path: project.path, started, message })
     try {
       // The preference is the cheapest gate and the one the user flips most, so it is read
       // once per sweep rather than per project.
-      if (!(await deps.enabled().catch(() => false))) return
+      enabled = await deps.enabled().catch(() => false)
+      if (!enabled) return
       const projects = await deps.projects().catch(() => [])
       if (!projects.length) return
       // One reading for the whole sweep: it is an account-wide meter, and re-reading it per
@@ -322,6 +375,7 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
             // The queue the decision below reads was just filled, so that read is stale. Leave it
             // to the next tick, and let the backlog loop have the work in the meantime.
             deps.log(`[framework] auto PM: landed the queue from ${landed} run(s) in ${project.path}`)
+            note(project, false, `landed the queue from ${landed} finished run${landed === 1 ? '' : 's'}`)
             continue
           }
         }
@@ -337,6 +391,7 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
         if (!decision.start) {
           // Logged, so a wedged sweep is distinguishable from a healthy idle one (#855).
           deps.log(`[framework] auto PM: standing down for ${project.path} — ${decision.reason}`)
+          note(project, false, decision.reason)
           continue
         }
         const index = nextJob.get(project.id) ?? 0
@@ -349,7 +404,10 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
           : decision.mode === 'drain'
             ? (deps.drainJob ?? AUTO_PM_DRAIN_JOB)
             : deps.jobs[index % deps.jobs.length]
-        if (!job) continue
+        if (!job) {
+          note(project, false, 'there is no job to run')
+          continue
+        }
         // Re-checked here because everything above is awaited: a run spawned past a `stop()` is
         // missing from the live-run map the daemon has by then cleared, so nothing suspends or
         // terminates it (#983). Break, not continue: stopping is a verdict on the whole sweep.
@@ -372,20 +430,38 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
           else if (decision.mode === 'pm') nextJob.set(project.id, index + 1)
           // Its queue lives on the run's branch until a later tick promotes it.
           pending.set(project.id, [...(pending.get(project.id) ?? []), runId])
+          note(project, true, job.describe)
         } else {
           lastStart.delete(project.id)
           deps.log(`[framework] auto PM: could not start a run in ${project.path}`)
+          note(project, false, 'the daemon could not start a run')
         }
       }
     } finally {
       sweeping = false
+      // Recorded even when the sweep returned early, so "switched off" and "on, and standing
+      // down for a reason" are distinguishable from the dashboard (#1161).
+      lastSweep = { enabled, sweptAt: now(), outcomes }
     }
   }
 
-  const timer = setInterval(() => void tick(), deps.intervalMs ?? DEFAULT_AUTO_PM_INTERVAL_MS)
+  const timer = setInterval(() => void tick(), intervalMs)
   timer.unref?.() // a background sweep must never be the reason the process stays up
+
+  /** When the interval next fires, counted from the anchor so an out-of-band {@link tick} cannot skew it. */
+  const nextSweepAt = () => startedAt + (Math.floor(Math.max(0, now() - startedAt) / intervalMs) + 1) * intervalMs
+
+  // The first sweep is the caller's to fire (see `startBackgroundServices`), not this
+  // constructor's: `tick` marks the loop busy synchronously, so a sweep started here would make
+  // the very next `tick()` a no-op — and every test that constructs a loop and ticks it would be
+  // asserting against a sweep it never awaited.
   return {
     tick,
+    report: () => ({
+      ...(lastSweep ? { enabled: lastSweep.enabled, sweptAt: lastSweep.sweptAt } : {}),
+      nextSweepAt: nextSweepAt(),
+      outcomes: lastSweep?.outcomes ?? [],
+    }),
     stop: () => {
       stopped = true
       clearInterval(timer)

--- a/packages/the-framework/src/daemon-services.ts
+++ b/packages/the-framework/src/daemon-services.ts
@@ -9,7 +9,7 @@ import { readSuspendedRuns, writeSuspendedRuns, resumableRuns, readLiveMetas, li
 import { startKeyedWatcher, type KeyedWatcher } from './dashboard/keyed-watcher.js'
 import { buildInterventions, interventionKey, postInterventionsDiscord } from './dashboard/interventions.js'
 import { buildActivity, activityKey, postActivityDiscord } from './dashboard/activity.js'
-import { startAutoPm, AUTO_PM_JOBS } from './auto-pm.js'
+import { startAutoPm, AUTO_PM_JOBS, type AutoPmReport } from './auto-pm.js'
 import { maintenanceDue, readMaintenanceState, mergeMaintenanceState } from './maintenance.js'
 import { promoteQueue } from './queue-promote.js'
 import { findTodoBacklog } from './todo-loop.js'
@@ -57,6 +57,14 @@ export interface BackgroundServices {
    * never replays the open backlog as new notifications.
    */
   reloadDiscord: () => Promise<void>
+  /**
+   * Sweep now instead of at the next tick (#1161), because the `autoPm` preference was just
+   * switched on. The sweep re-reads the preference itself, so this only changes *when* it
+   * notices — but a ten-minute wait with nothing on screen is what made the toggle read as dead.
+   */
+  wakeAutoPm: () => void
+  /** What the last auto-PM sweep decided, for the usage panel to show (#1161). */
+  autoPmReport: () => AutoPmReport
 }
 
 /** What {@link startBackgroundServices} needs from the daemon. */
@@ -151,6 +159,11 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
     },
     log,
   })
+
+  // Sweep once now rather than one interval from now (#1161): a daemon started with the setting
+  // already on would otherwise sit idle for ten minutes with quota going spare, which is exactly
+  // when it should be spending. Cheap and silent when the setting is off — it reads it and stops.
+  void autoPm.tick().catch(() => {})
 
   // Commit the conversations recorded on the main checkout (#912). A run's own worktree already
   // sweeps its transcript on teardown; nothing did the same for a chat held in the checkout itself,
@@ -325,6 +338,10 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
     },
     flushConversations: () => conversationCommitter.flush().catch(() => 0),
     reloadDiscord,
+    // Not awaited, and safe to call when the preference went the other way: a sweep with the box
+    // unticked reads it, records "off", and starts nothing.
+    wakeAutoPm: () => void autoPm.tick().catch(() => {}),
+    autoPmReport: () => autoPm.report(),
   }
 }
 

--- a/packages/the-framework/src/daemon.ts
+++ b/packages/the-framework/src/daemon.ts
@@ -9,7 +9,7 @@ import { defaultQuotaSource } from './dashboard/quota.js'
 import { startBackgroundServices, resumeSuspendedRuns, type BackgroundServices } from './daemon-services.js'
 import { resolveDashboardBundle } from './dashboard/bundle.js'
 import { isActivated } from './project.js'
-import { addProject, ensureDaemonToken, listProjects, readPreferences, type Preferences } from './registry.js'
+import { addProject, ensureDaemonToken, listProjects, nodeRegistryFs, readPreferences, registryPreferencesStore, type Preferences } from './registry.js'
 import { listReposInDirectory } from './repos-directory.js'
 import { registryDiscordCredentialsStore } from './discord-credentials-store.js'
 import { JsonlTailer } from './jsonl-tail.js'
@@ -403,6 +403,15 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     // finishable in-product: the credential is written to the registry, then this daemon's own
     // Discord services are rebuilt against it, so the bot connects without a restart.
     discord: registryDiscordCredentialsStore({ env, onChange: () => services?.reloadDiscord() }),
+    // Same idea for "Spend what's left on the roadmap" (#1161): the sweep re-reads the preference
+    // per tick, so without this the box you just ticked sits there doing nothing for up to ten
+    // minutes and reads as broken. Only on the write that switches it *on* — an unrelated setting
+    // saved while it happens to be on is not a reason to go spend quota.
+    preferences: registryPreferencesStore(nodeRegistryFs(), env, written => {
+      if (written.autoPm === true) services?.wakeAutoPm()
+    }),
+    // Only the daemon runs the sweep, so only it can say what the sweep decided.
+    autoPm: () => services?.autoPmReport(),
     ...(token ? { token } : {}),
     ...(clientBundleDir ? { clientBundleDir } : {}),
   })

--- a/packages/the-framework/src/dashboard-rpc/context.ts
+++ b/packages/the-framework/src/dashboard-rpc/context.ts
@@ -5,6 +5,7 @@ import type { DashboardContext, EventsSource, RemoteRuns } from '../dashboard/te
 import type { PreferencesStore } from '../registry.js'
 import type { DiscordCredentialsStore } from '../discord-credentials.js'
 import type { QuotaSource } from '../dashboard/quota.js'
+import type { AutoPmReporter } from '../auto-pm.js'
 
 /**
  * Read one field off the Telefunc request context, or undefined when it is unset. Every
@@ -105,4 +106,13 @@ export function contextDiscord(): DiscordCredentialsStore | undefined {
  */
 export function contextQuota(): QuotaSource | undefined {
   return fromContext(ctx => ctx.quota)
+}
+
+/**
+ * Where auto PM's last decision is read from (#1161), or undefined on a host that runs no
+ * sweep. Only the daemon has one: the loop lives in its process, and a report from anywhere
+ * else would be describing a sweep nobody is running.
+ */
+export function contextAutoPm(): AutoPmReporter | undefined {
+  return fromContext(ctx => ctx.autoPm)
 }

--- a/packages/the-framework/src/dashboard-rpc/index.ts
+++ b/packages/the-framework/src/dashboard-rpc/index.ts
@@ -24,6 +24,6 @@ export {
 } from './preferences.telefunc.js'
 export type { CredentialSource, DiscordCredentialStatus, DiscordCredentialsPatch } from '../discord-credentials.js'
 export { type EditorInfo } from '../dashboard/open-in-app.js'
-export { onQuota } from './quota.telefunc.js'
+export { onQuota, onAutoPm } from './quota.telefunc.js'
 export { checkDevices, type DeviceCheck } from './devices.telefunc.js'
 export { registerDashboardTelefunctions, DASHBOARD_TELEFUNC_KEYS } from './register.js'

--- a/packages/the-framework/src/dashboard-rpc/quota.telefunc.ts
+++ b/packages/the-framework/src/dashboard-rpc/quota.telefunc.ts
@@ -1,4 +1,5 @@
-import { contextQuota } from './context.js'
+import { contextAutoPm, contextQuota } from './context.js'
+import type { AutoPmReport } from '../auto-pm.js'
 import type { QuotaView } from '../dashboard/quota.js'
 
 // The usage panel's read surface (#533): where the account's subscription quota stands,
@@ -19,4 +20,22 @@ export async function onQuota(): Promise<QuotaView> {
   const source = contextQuota()
   if (!source) return noReading()
   return source.read().catch(() => noReading())
+}
+
+/**
+ * What auto PM last decided (#1161), for the line under the panel's toggle. It sits beside
+ * `onQuota` because it is the same panel and the same gate: auto PM spends against exactly the
+ * boundary drawn above it.
+ *
+ * `undefined` on a host with no sweep (the relay), which the panel reads as "nothing to say"
+ * rather than as an idle sweep — the distinction this whole read exists to make.
+ */
+export async function onAutoPm(): Promise<AutoPmReport | undefined> {
+  const report = contextAutoPm()
+  if (!report) return undefined
+  try {
+    return report()
+  } catch {
+    return undefined
+  }
 }

--- a/packages/the-framework/src/dashboard/server.ts
+++ b/packages/the-framework/src/dashboard/server.ts
@@ -6,6 +6,7 @@ import { registryPreferencesStore, type PreferencesStore } from '../registry.js'
 import { registryDiscordCredentialsStore } from '../discord-credentials-store.js'
 import type { DiscordCredentialsStore } from '../discord-credentials.js'
 import { defaultQuotaSource, type QuotaSource } from './quota.js'
+import type { AutoPmReporter } from '../auto-pm.js'
 import { serveClientBundle } from './static.js'
 import { BROWSER_PROXY_PREFIX, handleBrowserProxy } from './browser-proxy.js'
 import { makeTelefuncMount } from './telefunc-serve.js'
@@ -76,6 +77,11 @@ export interface DashboardOptions {
    * own poller; the relay passes nothing and mounts no panel.
    */
   quota?: QuotaSource
+  /**
+   * What auto PM last decided (#1161), for the line under the panel's toggle. Only the daemon
+   * runs the sweep, so every other host leaves it unset and the panel says nothing about it.
+   */
+  autoPm?: AutoPmReporter
   /**
    * Serve the new dashboard bundle (#405) from this directory — the prerendered Vike SPA
    * (`index.html` + `assets/**`). The daemon also mounts the dashboard's Telefunc surface
@@ -161,6 +167,7 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
     ...(opts.remote ? { remote: opts.remote } : {}),
     preferences: opts.preferences ?? registryPreferencesStore(),
     discord: opts.discord ?? registryDiscordCredentialsStore(),
+    ...(opts.autoPm ? { autoPm: opts.autoPm } : {}),
     quota,
   })
 

--- a/packages/the-framework/src/dashboard/telefunc-serve.ts
+++ b/packages/the-framework/src/dashboard/telefunc-serve.ts
@@ -7,6 +7,7 @@ import type { FrameworkEvent } from '../events.js'
 import type { PreferencesStore } from '../registry.js'
 import type { DiscordCredentialsStore } from '../discord-credentials.js'
 import type { QuotaSource } from './quota.js'
+import type { AutoPmReporter } from '../auto-pm.js'
 import type { AddProjectResult, PreviewResult, PreviewStatus, StartRunKind, StartRunOptions, StartRunResult } from './types.js'
 import type { ServeTarget } from '../preview.js'
 import type { RunMeta } from '../store/index.js'
@@ -72,6 +73,8 @@ export interface DashboardContext {
   /** The Discord credentials store (#1095). The daemon wires one that also reloads its Discord
    * services on a save; a public host leaves it unset, so nothing there is configurable. */
   discord?: DiscordCredentialsStore
+  /** What auto PM last decided (#1161). Only the daemon runs the sweep, so only it wires this. */
+  autoPm?: AutoPmReporter
 }
 
 let instance: Telefunc | undefined

--- a/packages/the-framework/src/index.ts
+++ b/packages/the-framework/src/index.ts
@@ -361,6 +361,9 @@ export {
   type AutoPmLoop,
   type AutoPmProject,
   type AutoPmJob,
+  type AutoPmReport,
+  type AutoPmOutcome,
+  type AutoPmReporter,
 } from './auto-pm.js'
 export {
   PRESETS,

--- a/packages/the-framework/src/registry.test.ts
+++ b/packages/the-framework/src/registry.test.ts
@@ -550,6 +550,29 @@ test('registryPreferencesStore round-trips through the same file', async () => {
   assert.deepEqual(await store.read(), { vanilla: true })
 })
 
+test('registryPreferencesStore tells its listener which keys were written (#1161)', async () => {
+  // The daemon wakes auto PM only on the write that switched it on, so it needs the caller's own
+  // keys — the merged result would say "on" every time anything else was saved while it was on.
+  const fs = memFs()
+  const written: Preferences[] = []
+  const store = registryPreferencesStore(fs, ENV, patch => written.push(patch))
+  await store.save({ autoPm: true })
+  await store.patch?.({ vanilla: true })
+  assert.deepEqual(written, [{ autoPm: true }, { vanilla: true }])
+  // The patch still merged, so the listener's narrower view is not the stored one.
+  assert.deepEqual(await store.read(), { autoPm: true, vanilla: true })
+})
+
+test('a preferences listener that throws does not fail the write (#1161)', async () => {
+  // The write already landed; a listener must not be able to report otherwise.
+  const fs = memFs()
+  const store = registryPreferencesStore(fs, ENV, () => {
+    throw new Error('the daemon is mid-shutdown')
+  })
+  await store.save({ autoPm: true })
+  assert.deepEqual(await store.read(), { autoPm: true })
+})
+
 test('the registry file is never written in place, only renamed over (#991)', async () => {
   const fs = memFs({ [FILE]: JSON.stringify({ projects: [APP_A], preferences: {} }) })
   await writePreferences({ vanilla: true }, fs, ENV)

--- a/packages/the-framework/src/registry.ts
+++ b/packages/the-framework/src/registry.ts
@@ -827,15 +827,32 @@ export async function readDaemonToken(
 }
 
 /** A {@link PreferencesStore} bound to the real registry file, wired by the daemon so the
- * dashboard's preferences RPCs read/write the user's home file. */
+ * dashboard's preferences RPCs read/write the user's home file.
+ *
+ * `onChange` is handed **the keys the caller wrote**, not the merged result, so a listener can
+ * tell "this write switched the setting on" from "it was already on and something else changed"
+ * (#1161). It runs after the write has landed, and its failure is swallowed: the save succeeded,
+ * and a listener must not be able to report otherwise. Same shape as the Discord store's
+ * `onChange` (#1095), for the same reason — a setting saved in the browser has to reach the
+ * daemon's own services without a restart.
+ */
 export function registryPreferencesStore(
   fs: RegistryFs = nodeRegistryFs(),
   env: NodeJS.ProcessEnv = process.env,
+  onChange?: (written: Preferences) => void,
 ): PreferencesStore {
+  const changed = <T>(written: Preferences, result: T): T => {
+    try {
+      onChange?.(written)
+    } catch {
+      // The write landed; a listener that throws is not the writer's problem.
+    }
+    return result
+  }
   return {
     read: () => readPreferences(fs, env),
-    save: preferences => writePreferences(preferences, fs, env),
-    patch: patch => patchPreferences(patch, fs, env),
+    save: async preferences => changed(preferences, await writePreferences(preferences, fs, env)),
+    patch: async patch => changed(patch, await patchPreferences(patch, fs, env)),
     readProject: projectId => readProjectPreferences(projectId, fs, env),
     saveProject: (projectId, preferences) => writeProjectPreferences(projectId, preferences, fs, env),
     patchProject: (projectId, patch) => patchProjectPreferences(projectId, patch, fs, env),


### PR DESCRIPTION
Closes #1161

The queue was full, the box was there to tick, and nothing happened, with nothing on screen to say why.

## What was wrong

**The toggle did nothing for up to ten minutes.** Auto PM only ever swept from its 10 minute `setInterval`; there was no non-test caller of `tick()` anywhere. The `autoPm` preference is re-read per tick, so ticking the box was correct but invisible until the next interval came round. That is indistinguishable from a broken switch.

**Nothing said why it was standing down.** Since #855 every decision is logged, including refusals. But the log is the daemon's stdout and the toggle lives in a browser, so from the dashboard a sweep standing down ("the quota could not be read", "4 runs are already going") looked exactly like one quietly working. That is the same failure #855 fixed one layer down.

## What this does

A preference write that switches auto PM **on** now wakes the sweep, via a new optional `onChange` on `registryPreferencesStore`. It is the same seam a pasted Discord token already uses to reach the daemon's services without a restart (#1095). The daemon also sweeps once at startup, so a daemon that comes up with the setting already on does not idle for ten minutes with quota going spare.

The listener is handed **the keys the caller wrote**, not the merged result, so an unrelated setting saved while auto PM happens to be on is not a reason to go spend quota. A listener that throws cannot fail the write: the write already landed.

The loop keeps its last verdict (`report()`), and the usage panel shows it under the toggle: when it last looked, when it looks next, and per project what it started or why it stood down. Hidden entirely while the setting is off, since the box already says that.

## Notes

- The start-up sweep is fired by `startBackgroundServices`, not by `startAutoPm` itself. `tick` marks the loop busy synchronously, so a sweep started inside the constructor would make the very next `tick()` a no-op and every test that constructs a loop and ticks it would be asserting against a sweep it never awaited.
- An out-of-band wake does not skew the interval it is not driving: `nextSweepAt` is counted from a fixed anchor. Pinned by a test.
- `onAutoPm` sits in the existing `quota.telefunc.ts` rather than a new telefunc file: same panel, same gate, and no new RPC key or shim file. Only the daemon wires the reporter, so the relay reports nothing rather than an idle sweep.

## Verified

Framework 1293 pass / 0 fail (7 new), dashboard 440 pass (6 new), root typecheck and build clean.

Live, against a real daemon on an isolated `XDG_CONFIG_HOME` with no agent on `PATH`, so the quota reads `agent-not-found` and the gate fails closed with no chance of spawning a run:

- boot: `sweptAt` set within seconds, `enabled: false`, next sweep 10 min out
- ticking the box through the real `patchPreferences` RPC: swept **0.5s later**, not ten minutes
- the panel's reason came back over the wire as `the quota could not be read, so there is no way to tell what is spare`, matching the daemon log line exactly
- `nextSweepAt` unchanged by the out-of-band wake, and no run started, no branch created

## Out of scope, worth knowing

While reading this path: the quota poller stops permanently on one non-transient bad read (`quota-poller.ts`), and auto PM fails closed on an unreadable quota. That combination silently disables auto PM for the daemon's whole life. Before this PR there was no way to see it from the dashboard; now the reason at least shows up. The poller's own behaviour is untouched here.
