### PR TITLE
feat(the-framework): record the ticket a run is implementing (#1117)

### DIFF
--- a/.changeset/run-ticket-implementing.md
+++ b/.changeset/run-ticket-implementing.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/the-framework": minor
+---
+
+feat(the-framework): record the ticket a run is implementing (#1117): a draining run is started with the ticket its queue entry links back to (#1164), which it emits once and folds onto `RunMeta.ticket` — so the Overview's hot-tickets card can mark a ticket as `implementing` because a run says so, instead of inferring it from the plan or spike the work left behind.

--- a/packages/framework-dashboard/components/HotTickets.test.tsx
+++ b/packages/framework-dashboard/components/HotTickets.test.tsx
@@ -40,4 +40,24 @@ describe('HotTickets (#1112)', () => {
     fireEvent.click(screen.getByText('b'))
     expect(picked).toBe('beta')
   })
+
+  test('a ticket a run is implementing right now says so, over its plan/spike (#1117)', async () => {
+    onHotTickets.mockResolvedValue([
+      { ...ht('a.md', 'alpha', 'in-progress', { planned: true }), runId: 'run-7' },
+      ht('b.md', 'alpha', 'in-progress', { planned: true }),
+    ])
+    render(<HotTickets onSelectProject={() => {}} />)
+    await waitFor(() => expect(screen.getByText('a')).toBeTruthy())
+    // Live work outranks the mark older work left behind, so the same lane can say which is which.
+    expect(screen.getByText('implementing')).toBeTruthy()
+    expect(screen.getByText('planned')).toBeTruthy()
+  })
+
+  test('a ticket being implemented with no plan or spike still gets a tag (#1117)', async () => {
+    // The gap the run link opens up: in-progress used to imply planned-or-spiked, so a bare
+    // implementing ticket would have shown an unexplained row.
+    onHotTickets.mockResolvedValue([{ ...ht('a.md', 'alpha', 'in-progress'), runId: 'run-7' }])
+    render(<HotTickets onSelectProject={() => {}} />)
+    await waitFor(() => expect(screen.getByText('implementing')).toBeTruthy())
+  })
 })

--- a/packages/framework-dashboard/components/HotTickets.tsx
+++ b/packages/framework-dashboard/components/HotTickets.tsx
@@ -99,9 +99,21 @@ function Lane({
   )
 }
 
-// The one fact that earns the lane: the plan/spike that made it in-progress, or the priority that
-// made it next. Queued rows carry nothing extra — the lane already says it.
+// The one fact that earns the lane: a run implementing it right now, else the plan/spike that made
+// it in-progress, else the priority that made it next. Queued rows carry nothing extra — the lane
+// already says it.
+//
+// `implementing` is coloured rather than muted like the others (#1117), because it is the only tag
+// that describes something happening as you read it: `planned` and `spiked` are marks work left
+// behind, and a lane holding both should not read as though they were the same claim.
 function TicketTag({ ticket: t }: { ticket: HotTicket }) {
+  if (t.runId) {
+    return (
+      <span className="shrink-0 rounded border border-primary/40 px-1 text-[10px] uppercase tracking-wide text-primary">
+        implementing
+      </span>
+    )
+  }
   const tag = t.bucket === 'in-progress' ? (t.ticket.planned ? 'planned' : t.ticket.spiked ? 'spiked' : null) : t.bucket === 'next' ? t.ticket.priority ?? null : null
   if (!tag) return null
   return (

--- a/packages/the-framework/src/auto-pm.test.ts
+++ b/packages/the-framework/src/auto-pm.test.ts
@@ -499,3 +499,11 @@ test('an out-of-band tick does not skew the next sweep (#1161)', async () => {
   loop.stop()
   assert.equal(loop.report().nextSweepAt, T0 + 60_000)
 })
+
+test('only the draining job says it works the queue rather than filling it (#1117)', () => {
+  // The marker is what tells the daemon which start can name a ticket. A rotation job that claimed
+  // it would name the entry it is about to *write*, which is not what it is doing.
+  assert.equal(AUTO_PM_DRAIN_JOB.drains, true)
+  for (const job of AUTO_PM_JOBS) assert.notEqual(job.drains, true, `${job.name} must not claim to drain`)
+  assert.notEqual(AUTO_PM_MAINTENANCE_JOB.drains, true)
+})

--- a/packages/the-framework/src/auto-pm.ts
+++ b/packages/the-framework/src/auto-pm.ts
@@ -135,6 +135,14 @@ export interface AutoPmJob {
   prompt: string
   /** What it is doing, as the log line says it ("harvesting quick-wins"). */
   describe: string
+  /**
+   * This job works an entry already on the queue, rather than putting entries on it (#1117).
+   *
+   * Only the draining job has a specific piece of work it is about to pick up, so only it can be
+   * told which ticket that is. Declared here rather than matched on {@link AutoPmJob.name} at the
+   * call site, so the job says what it does and a rename cannot quietly unhook it.
+   */
+  drains?: boolean
 }
 
 /**
@@ -178,6 +186,7 @@ export const AUTO_PM_DRAIN_JOB: AutoPmJob = {
   name: presets.drainQueue.name,
   prompt: presets.drainQueue.render(),
   describe: 'draining the first open queue entry',
+  drains: true,
 }
 
 /**

--- a/packages/the-framework/src/cli.test.ts
+++ b/packages/the-framework/src/cli.test.ts
@@ -969,3 +969,8 @@ test('an unreachable npm registry costs the footer nothing (#312)', async () => 
   assert.ok(out.includes(`The Framework v${frameworkVersion()}`))
   assert.ok(!out.some(l => l.includes('Up to date') || l.includes('Update available')))
 })
+
+test('parseArgs reads --ticket, the ticket the daemon says this run implements (#1117)', () => {
+  assert.equal(parseArgs(['--ticket', 'tickets/2026-07-25_login.md', 'x']).ticket, 'tickets/2026-07-25_login.md')
+  assert.equal(parseArgs(['x']).ticket, undefined)
+})

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -37,6 +37,7 @@ import {
 } from './run.js'
 import { FAKE_DEPLOY, FAKE_INTENT, FAKE_SIGNALS, fakeDriver } from './fake-script.js'
 import { readProjectSignals } from './project.js'
+import { isTicketPath } from './tickets.js'
 import { loadFrameworkConfig, type FrameworkFileConfig } from './config.js'
 import {
   describeResolvedConfig,
@@ -304,6 +305,8 @@ export interface CliOptions {
   resumeSession?: string | undefined
   /** `--via <surface>` (#917): the surface this run was started from, recorded on its conversation turns. Set by the daemon when a non-local surface (e.g. Discord) asked for the run. */
   via?: string | undefined
+  /** `--ticket <path>` (#1117): the `tickets/<file>.md` this run is implementing. Set by the daemon when it starts a drain run, from the ticket its queue entry links to; recorded on the run's meta. */
+  ticket?: string | undefined
   /** `--unattended`: no human is watching, so choice gates take the recommended option (#846). */
   unattended?: boolean
   scope: 'prototype' | 'full'
@@ -564,6 +567,9 @@ export function parseArgs(argv: string[]): CliOptions {
         break
       case '--via':
         opts.via = argv[++i]
+        break
+      case '--ticket':
+        opts.ticket = argv[++i]
         break
       case '--unattended':
         opts.unattended = true
@@ -1536,6 +1542,10 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
   // only thing a dashboard tab opened mid-run can read the boxes back from.
   announceHandoff = (push, pr) => onEvent({ kind: 'handoff-armed', push, pr })
   announceHandoff(armedHandoff.push, armedHandoff.pr)
+  // The ticket this run implements (#1117), if the daemon named one. Once, at start: it is a fact
+  // about why the run exists, not a state that changes, and folding it to meta is what lets the
+  // Overview mark that ticket as being implemented right now.
+  if (opts.ticket && isTicketPath(opts.ticket)) onEvent({ kind: 'ticket', path: opts.ticket })
   // Wired now the journal exists: a bind resolved from a topic run's gate folds to meta (#1121).
   recordBind = projectId => onEvent({ kind: 'bind', projectId })
 

--- a/packages/the-framework/src/daemon-runtime.ts
+++ b/packages/the-framework/src/daemon-runtime.ts
@@ -38,6 +38,7 @@ import { isSafeVia } from './conversations.js'
 import { createPreviewRuntime } from './preview-runtime.js'
 import { scopedKey, parseScopedKey, keyBelongsTo } from './runtime-keys.js'
 import { addProject, listProjects, projectId, topicScratchPath } from './registry.js'
+import { isTicketPath } from './tickets.js'
 import { installProject, enumerateGitRepos } from './install.js'
 import { isGitRepo } from './project.js'
 import { isCliTimeout } from './cli-exec.js'
@@ -166,6 +167,9 @@ export function startOptionFlags(options: StartRunOptions): string[] {
   }
   // Run target (#1050): only `actions` needs a flag; `local` is the default and emits nothing.
   if (options.target === 'actions') flags.push('--run-on', 'actions')
+  // The ticket this run implements (#1117): only ever a `tickets/<file>.md` the daemon read off
+  // the queue entry, and re-checked on the other side before it reaches the run's meta.
+  if (typeof options.ticket === 'string' && isTicketPath(options.ticket)) flags.push('--ticket', options.ticket)
   // Unattended (#846): nobody is at the keyboard, so gates take the recommended option
   // rather than park for an answer that is not coming.
   if (options.unattended) flags.push('--unattended')

--- a/packages/the-framework/src/daemon-services.ts
+++ b/packages/the-framework/src/daemon-services.ts
@@ -12,7 +12,7 @@ import { buildActivity, activityKey, postActivityDiscord } from './dashboard/act
 import { startAutoPm, AUTO_PM_JOBS, type AutoPmReport } from './auto-pm.js'
 import { maintenanceDue, readMaintenanceState, mergeMaintenanceState } from './maintenance.js'
 import { promoteQueue } from './queue-promote.js'
-import { findTodoBacklog } from './todo-loop.js'
+import { findTodoBacklog, nextQueuedTicket } from './todo-loop.js'
 import { startConversationCommitter } from './conversation-commit.js'
 import { startMergedWorktreeSweep } from './merged-worktrees.js'
 import { readConversation } from './conversations.js'
@@ -141,7 +141,12 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
     maintenanceDue: async project => maintenanceDue(await readMaintenanceState(project.path), Date.now()),
     recordMaintenance: async project => mergeMaintenanceState(project.path, { sweptAt: new Date().toISOString() }),
     start: async (project, job) => {
-      const result = await startUnattended(project.id, job.prompt)
+      // A draining run works the queue's first open entry, and since #1164 that entry links back to
+      // the ticket it was queued from — so this is the one moment the framework knows what a run is
+      // about to implement, and can say so on the run's meta (#1117). Every other job puts work on
+      // the queue rather than taking it off, so there is nothing to name.
+      const ticket = job.drains ? await nextQueuedTicket(project.path).catch(() => undefined) : undefined
+      const result = await startUnattended(project.id, job.prompt, ticket ? { ticket } : {})
       return result.ok ? result.runId : undefined
     },
     // The daemon promotes the queue, never the agent (#852): the run stays sandboxed in its

--- a/packages/the-framework/src/daemon.test.ts
+++ b/packages/the-framework/src/daemon.test.ts
@@ -902,3 +902,14 @@ test('registerReposDirectory adds nothing while the opt-in is off (#1123)', asyn
     await rm(root, { recursive: true, force: true })
   }
 })
+
+test('startOptionFlags passes the ticket a run implements, and only a real one (#1117)', () => {
+  assert.deepEqual(startOptionFlags({ ticket: 'tickets/2026-07-25_login.md' }), ['--ticket', 'tickets/2026-07-25_login.md'])
+  // Nothing said = the run implements no particular ticket, which is every hand-written prompt.
+  assert.deepEqual(startOptionFlags({}), [])
+  // The value comes off a queue file an agent writes, so it is checked here as well as on the way
+  // in: a path that is not a ticket never becomes a flag.
+  for (const bad of ['tickets/../etc/passwd', '/etc/passwd', 'TODO_AGENTS.md', '']) {
+    assert.deepEqual(startOptionFlags({ ticket: bad }), [], `expected ${bad} to be dropped`)
+  }
+})

--- a/packages/the-framework/src/dashboard/overview.test.ts
+++ b/packages/the-framework/src/dashboard/overview.test.ts
@@ -140,3 +140,56 @@ test('buildHotTickets tolerates a project whose tickets cannot be read', async (
   })
   assert.deepEqual(hot.map(h => h.ticket.file), ['x.md'])
 })
+
+/** A live run meta carrying the ticket it is implementing (#1117). */
+const runOn = (id: string, ticket: string, status: RunMeta['status'] = 'running') =>
+  ({ version: 1, status, id, startedAt: 't', updatedAt: 't', passes: 0, ticket, cwd: '/w' }) as never
+
+test('ticketBucket: a run implementing it is in-progress, whatever the plan/spike says (#1117)', () => {
+  // The whole point of the link: a ticket nobody has planned yet, being coded right now, used to
+  // sit in `queued` because the only evidence the lane had was a plan/spike file.
+  assert.equal(ticketBucket(ticket('a'), true), 'in-progress')
+  assert.equal(ticketBucket(ticket('b', { priority: 'high' }), true), 'in-progress')
+  // Absent evidence, the #1112 inference is untouched.
+  assert.equal(ticketBucket(ticket('c', { planned: true }), false), 'in-progress')
+  assert.equal(ticketBucket(ticket('d'), false), 'queued')
+})
+
+test('buildHotTickets marks the ticket a live run is implementing, with its run id (#1117)', async () => {
+  const hot = await buildHotTickets([project('alpha', '/a')], {
+    tickets: async () => [ticket('2026-07-25_login.md'), ticket('2026-07-26_other.md')],
+    liveRuns: async () => [runOn('run-7', 'tickets/2026-07-25_login.md')],
+  })
+  const login = hot.find(h => h.ticket.file === '2026-07-25_login.md')
+  assert.equal(login?.bucket, 'in-progress', 'the ticket being coded is in progress')
+  assert.equal(login?.runId, 'run-7', 'and carries the run, so the card can link into it')
+  // The ticket nobody is on keeps its own lane and gains nothing.
+  const other = hot.find(h => h.ticket.file === '2026-07-26_other.md')
+  assert.equal(other?.bucket, 'queued')
+  assert.equal(other?.runId, undefined)
+})
+
+test('buildHotTickets ignores a finished run and another project\'s ticket (#1117)', async () => {
+  // A run that has ended is not implementing anything, however recently it stopped.
+  const finished = await buildHotTickets([project('alpha', '/a')], {
+    tickets: async () => [ticket('x.md')],
+    liveRuns: async () => [runOn('run-7', 'tickets/x.md', 'done')],
+  })
+  assert.equal(finished[0]?.runId, undefined)
+  assert.equal(finished[0]?.bucket, 'queued')
+
+  // A ticket path is only unique inside its own repo, so beta's run must not light up alpha's
+  // identically-named ticket.
+  const twoProjects = await buildHotTickets([project('alpha', '/a'), project('beta', '/b')], {
+    tickets: async () => [ticket('x.md')],
+    liveRuns: async cwd => (cwd === '/b' ? [runOn('run-9', 'tickets/x.md')] : []),
+  })
+  assert.deepEqual(
+    twoProjects.map(h => ({ p: h.projectName, run: h.runId })),
+    [
+      { p: 'beta', run: 'run-9' },
+      { p: 'alpha', run: undefined },
+    ],
+    'only beta reads as implementing, and it sorts into the in-progress lane first',
+  )
+})

--- a/packages/the-framework/src/dashboard/overview.ts
+++ b/packages/the-framework/src/dashboard/overview.ts
@@ -2,6 +2,7 @@ import { readAllRuns, readLiveMetas, type LiveRun, type RunMeta, type RunStatus 
 import type { ProjectSummary } from './projects.js'
 import { collectQueue, type ProjectQueue } from './queue.js'
 import { readTickets, type WorkspaceTicket } from './tickets.js'
+import { TICKETS_DIR } from '../tickets.js'
 
 // The first-sidebar Overview (#437, part of #314): a cross-project glance at what the agent
 // is working on right now, the size of the backlog, and the recently active projects. It
@@ -91,6 +92,14 @@ export interface HotTicket {
   projectName: string
   bucket: HotBucket
   ticket: WorkspaceTicket
+  /**
+   * A run is implementing this ticket right now (#1117): its id, for the card to link into.
+   *
+   * The difference between "someone planned this at some point" and "this is being coded as you
+   * look at it", which the plan/spike proxy could not tell apart. Only set for a ticket a live run
+   * actually recorded (`RunMeta.ticket`), so absent still means the lane was inferred.
+   */
+  runId?: string
 }
 
 /** Priority values that read as "do this soon" — the "likely next" lane (#1112). */
@@ -98,13 +107,17 @@ const HIGH_PRIORITY = new Set(['high', 'urgent', 'critical', 'p0', 'p1', '0', '1
 
 /**
  * A ticket's lane (#1112):
- * - in-progress: the agent has planned or spiked it, i.e. work is under way. (There is no run↔ticket
- *   link, so a ticket being *implemented* right now is only visible through the plan/spike it left.)
+ * - in-progress: a run is implementing it right now (#1117), or failing that the agent has planned
+ *   or spiked it, so work is under way in the older, inferred sense.
  * - next: no plan/spike yet, but flagged high priority — likely the next thing picked up.
  * - queued: everything else open, the backlog waiting its turn.
+ *
+ * `implementing` outranks the plan/spike proxy rather than replacing it: a live run is the only
+ * hard evidence, and it exists for a drain run only, so the inference still carries every ticket
+ * someone is working by hand.
  */
-export function ticketBucket(ticket: WorkspaceTicket): HotBucket {
-  if (ticket.planned || ticket.spiked) return 'in-progress'
+export function ticketBucket(ticket: WorkspaceTicket, implementing = false): HotBucket {
+  if (implementing || ticket.planned || ticket.spiked) return 'in-progress'
   if (ticket.priority && HIGH_PRIORITY.has(ticket.priority)) return 'next'
   return 'queued'
 }
@@ -112,9 +125,11 @@ export function ticketBucket(ticket: WorkspaceTicket): HotBucket {
 /** How many hot tickets the Overview pools before the card trims per lane. */
 const HOT_TICKETS_LIMIT = 60
 
-/** Injectable reader so {@link buildHotTickets} is unit-testable off disk. */
+/** Injectable readers so {@link buildHotTickets} is unit-testable off disk. */
 export interface HotTicketsDeps {
   tickets?: (cwd: string) => Promise<WorkspaceTicket[]>
+  /** The project's live runs, read for the ticket each one recorded (#1117). */
+  liveRuns?: (cwd: string) => Promise<LiveRun[]>
 }
 
 /**
@@ -125,10 +140,25 @@ export interface HotTicketsDeps {
  */
 export async function buildHotTickets(projects: ProjectSummary[], deps: HotTicketsDeps = {}): Promise<HotTicket[]> {
   const readT = deps.tickets ?? readTickets
+  const readRuns = deps.liveRuns ?? readLiveMetas
   const all: HotTicket[] = []
   for (const project of projects) {
+    // Which of this project's tickets are being implemented right now, by run id (#1117). Built
+    // per project because a ticket path is only unique within its own repo.
+    const implementing = new Map<string, string>()
+    for (const meta of await readRuns(project.path).catch(() => [])) {
+      if (meta.status !== 'running' || !meta.ticket) continue
+      implementing.set(meta.ticket, meta.id)
+    }
     for (const ticket of await readT(project.path).catch(() => [])) {
-      all.push({ projectId: project.id, projectName: project.name, bucket: ticketBucket(ticket), ticket })
+      const runId = implementing.get(`${TICKETS_DIR}/${ticket.file}`)
+      all.push({
+        projectId: project.id,
+        projectName: project.name,
+        bucket: ticketBucket(ticket, runId !== undefined),
+        ticket,
+        ...(runId ? { runId } : {}),
+      })
     }
   }
   const lane: Record<HotBucket, number> = { 'in-progress': 0, next: 1, queued: 2 }

--- a/packages/the-framework/src/dashboard/types.ts
+++ b/packages/the-framework/src/dashboard/types.ts
@@ -77,6 +77,12 @@ export interface StartRunOptions {
    */
   unattended?: boolean
   /**
+   * The `tickets/<file>.md` this run implements (#1117); maps to `--ticket`. Set by the daemon
+   * when it starts a drain run and the queue entry it will work links back to a ticket, so the
+   * Overview can show that ticket as being implemented rather than guessing from its plan/spike.
+   */
+  ticket?: string
+  /**
    * The surface this run was asked for from (#917), e.g. `discord`; maps to `--via`. Recorded on
    * the session's conversation turns so a run started from a chat surface is not filed under the
    * dashboard. Absent = the local surface, exactly as before.

--- a/packages/the-framework/src/events.ts
+++ b/packages/the-framework/src/events.ts
@@ -190,6 +190,16 @@ export type FrameworkEvent =
    */
   | { kind: 'handoff-armed'; push: boolean; pr: boolean }
   /**
+   * The ticket this run was started to implement (#1117), as a repo-relative `tickets/<file>.md`.
+   *
+   * Emitted once at start, and only when the framework itself chose the ticket — today that is the
+   * [Drain queue] run, whose queue entry links back to the ticket it was queued from (#1164). An
+   * event rather than a start argument for the usual reason: only an event reaches the run's meta,
+   * and the meta is what a dashboard tab opened mid-run reads. Absent means nobody knows what this
+   * run is implementing, which is every hand-written prompt.
+   */
+  | { kind: 'ticket'; path: string }
+  /**
    * What the end-of-session handoff actually did (#1102): pushed and/or opened a draft PR,
    * declined for a reason that is not a fault, or failed at one of the two steps.
    *

--- a/packages/the-framework/src/store/run-store.test.ts
+++ b/packages/the-framework/src/store/run-store.test.ts
@@ -208,6 +208,17 @@ test('applyEventToMeta records the session name + ready-for-merge lifecycle sign
   assert.equal(ready.sessionName, 'add-comments') // ready doesn't clobber the name
 })
 
+test('applyEventToMeta records the ticket a run is implementing (#1117)', () => {
+  const base = metaFromEvents(RUN.slice(0, 4), AT)
+  assert.equal(base.ticket, undefined, 'a run nobody linked to a ticket says nothing')
+  const on = applyEventToMeta(base, { kind: 'ticket', path: 'tickets/2026-07-25_login.md' }, AT)
+  assert.equal(on.ticket, 'tickets/2026-07-25_login.md')
+  // It is a fact about why the run exists, so it outlives the work: a reader looking at a finished
+  // run still gets to see which ticket it was.
+  const ended = applyEventToMeta(on, { kind: 'end', ok: true }, AT)
+  assert.equal(ended.ticket, 'tickets/2026-07-25_login.md')
+})
+
 test('applyEventToMeta tracks the pending choice gate a run is parked on (#636)', () => {
   const base = metaFromEvents(RUN.slice(0, 4), AT)
   assert.equal(base.pendingChoice, undefined)

--- a/packages/the-framework/src/store/run-store.ts
+++ b/packages/the-framework/src/store/run-store.ts
@@ -106,6 +106,14 @@ export interface RunMeta {
    * branch is guaranteed to be the one holding the commits.
    */
   branch?: string
+  /**
+   * The ticket this run is implementing (#1117), repo-relative (`tickets/<file>.md`).
+   *
+   * Set only when the framework picked the ticket itself, so the Overview can show a ticket that is
+   * being coded right now as `implementing` instead of inferring it from the plan/spike it left
+   * behind. Absent on every run nobody linked to a ticket.
+   */
+  ticket?: string
   /** Whether the agent signalled `setReadyForMerge()` (#326): building (false/absent) vs ready (true). */
   readyForMerge?: boolean
   /**
@@ -276,6 +284,9 @@ export function applyEventToMeta(meta: RunMeta, event: FrameworkEvent, at: strin
       break
     case 'handoff-armed':
       next.handoff = { push: event.push, pr: event.pr }
+      break
+    case 'ticket':
+      next.ticket = event.path
       break
     case 'settled':
       next.settledAt = at

--- a/packages/the-framework/src/terminal.ts
+++ b/packages/the-framework/src/terminal.ts
@@ -34,6 +34,8 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
       return `◆ done for now — waiting for your next message`
     case 'bind':
       return `◆ bound to project ${event.projectId}`
+    case 'ticket':
+      return `  implementing ${event.path}`
     case 'on-before-mergeable':
       switch (event.outcome) {
         case 'queued':

--- a/packages/the-framework/src/tickets.test.ts
+++ b/packages/the-framework/src/tickets.test.ts
@@ -10,6 +10,8 @@ import {
   LEGACY_TODO_FILE,
   TICKETS_DIR,
   findFlatTodo,
+  isTicketPath,
+  ticketFromQueueEntry,
   todoPriorityForTicket,
 } from './tickets.js'
 import { TICKETING_FORMAT, TODO_FORMAT } from './prompts.generated.js'
@@ -92,4 +94,32 @@ test('a ticket priority maps onto the backlog format\'s numbered sections (#1164
   // 10 is reserved for critical production bugs and 0 for "only if capacity"; neither is
   // something a click on Queue should be able to claim.
   assert.equal(todoPriorityForTicket('critical'), 5)
+})
+
+test('ticketFromQueueEntry reads the ticket a queued entry links back to (#1117/#1164)', () => {
+  // The write side (#1164) queues a ticket as a markdown link, so the identity is on the line.
+  assert.equal(ticketFromQueueEntry('[Add a login page](tickets/2026-07-25_login.md)'), 'tickets/2026-07-25_login.md')
+  // An entry that is just text is exactly what it used to be: work with no ticket behind it.
+  assert.equal(ticketFromQueueEntry('Apply the maintainability preset'), undefined)
+  assert.equal(ticketFromQueueEntry('see the [docs](README.md)'), undefined)
+})
+
+test('only a plain file inside tickets/ counts as a ticket path (#1117)', () => {
+  assert.equal(isTicketPath('tickets/2026-07-25_login.md'), true)
+  // The result is a path a reader opens and the dashboard renders, so nothing may point out of
+  // tickets/, deeper than it, or at something that is not a ticket.
+  for (const bad of [
+    'tickets/../secrets.md',
+    'tickets/nested/deep.md',
+    'tickets/.hidden.md',
+    'tickets/notes.txt',
+    '/etc/passwd',
+    'https://example.com/x.md',
+    'TODO_AGENTS.md',
+    'tickets/',
+  ]) {
+    assert.equal(isTicketPath(bad), false, `expected ${bad} to be rejected`)
+  }
+  // A traversal dressed as a link is refused at the same gate.
+  assert.equal(ticketFromQueueEntry('[sneaky](tickets/../../etc/passwd)'), undefined)
 })

--- a/packages/the-framework/src/tickets.ts
+++ b/packages/the-framework/src/tickets.ts
@@ -52,6 +52,35 @@ export function todoPriorityForTicket(priority?: string): number {
   }
 }
 
+/**
+ * The ticket a queue entry came from, or `undefined` for an entry that is just text (#1117).
+ *
+ * Queueing a ticket writes the entry as a markdown link back to it (#1164), so the identity the
+ * queue used to drop is already on the line — this is the read side of that write. Only a link
+ * into {@link TICKETS_DIR} counts, and only one whose target stays inside it: the result names a
+ * file a reader will go and open, so an entry linking anywhere else is treated as plain text
+ * rather than followed. A relative segment, an absolute path, a URL, or a nested directory all
+ * fail that test.
+ */
+export function ticketFromQueueEntry(entry: string): string | undefined {
+  const target = /\]\(([^)\s]+)\)/.exec(entry)?.[1]
+  return target && isTicketPath(target) ? target : undefined
+}
+
+/**
+ * Whether a string names a ticket file: `tickets/<name>.md`, and nothing else (#1117).
+ *
+ * The one gate for both ends of the link — what a queue entry is read as, and what the `--ticket`
+ * flag is allowed to record — because the result is a path the dashboard renders and a reader
+ * opens. A relative segment, an absolute path, a URL, a dotfile, or anything nested deeper all
+ * fail it, so no caller has to think about the difference.
+ */
+export function isTicketPath(path: string): boolean {
+  if (!path.startsWith(`${TICKETS_DIR}/`)) return false
+  const file = path.slice(TICKETS_DIR.length + 1)
+  return file.endsWith('.md') && !file.includes('/') && !file.startsWith('.')
+}
+
 /** The brief hyphen spelling from #682, read as a fallback after #674 settled on the underscore. */
 export const LEGACY_HYPHEN_TODO_FILE = 'TODO-AGENTS.md'
 

--- a/packages/the-framework/src/todo-loop.test.ts
+++ b/packages/the-framework/src/todo-loop.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { FakeDriver } from './driver/fake.js'
 import type { ChoicePick, ChoiceRequest, FrameworkEvent } from './events.js'
-import { appendTodoEntry, appendFlatTodoEntry, findTodoBacklog, insertTodoEntry, parseTodoEntries, runTodoLoop } from './todo-loop.js'
+import { appendTodoEntry, appendFlatTodoEntry, findTodoBacklog, insertTodoEntry, nextQueuedTicket, parseTodoEntries, runTodoLoop } from './todo-loop.js'
 
 async function tmpWorkspace(): Promise<string> {
   return mkdtemp(join(tmpdir(), 'framework-todo-'))
@@ -459,5 +459,38 @@ test('appendFlatTodoEntry places by priority when given one, and appends when no
     assert.deepEqual(parseTodoEntries(md), ['ranked', 'old', 'unranked'])
   } finally {
     await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('nextQueuedTicket names the ticket the next drain run will pick up (#1117)', async () => {
+  const cwd = await tmpWorkspace()
+  try {
+    // Nothing queued at all: nothing to name.
+    assert.equal(await nextQueuedTicket(cwd), undefined)
+
+    // The drain preset works "the FIRST open entry only", so that is the entry this reads --
+    // priority order is already the file order the queue is written in (#1164).
+    await writeFile(
+      join(cwd, 'TODO_AGENTS.md'),
+      [
+        '## Priority 9',
+        '',
+        '- [x] [Already done](tickets/2026-07-01_done.md)',
+        '- [ ] [Add a login page](tickets/2026-07-25_login.md)',
+        '',
+        '## Priority 5',
+        '',
+        '- [ ] [Later](tickets/2026-07-26_later.md)',
+        '',
+      ].join('\n'),
+    )
+    assert.equal(await nextQueuedTicket(cwd), 'tickets/2026-07-25_login.md')
+
+    // A queue whose first open entry is plain text: a drain run there implements no ticket, and
+    // saying "the one below it" would label the wrong ticket as being worked.
+    await writeFile(join(cwd, 'TODO_AGENTS.md'), '- [ ] tidy the README\n- [ ] [Login](tickets/2026-07-25_login.md)\n')
+    assert.equal(await nextQueuedTicket(cwd), undefined)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
   }
 })

--- a/packages/the-framework/src/todo-loop.ts
+++ b/packages/the-framework/src/todo-loop.ts
@@ -3,10 +3,10 @@ import { dirname, join } from 'node:path'
 import type { DriverSession } from './driver/index.js'
 import type { ChoicePick, ChoiceRequest, FrameworkEvent } from './events.js'
 import { requestChoices, runAwaitRounds } from './await-gate.js'
-import { FLAT_TODO_FILE, findFlatTodo } from './tickets.js'
+import { FLAT_TODO_FILE, findFlatTodo, ticketFromQueueEntry } from './tickets.js'
 import { createTurnSignalEmitter } from './turn-gate.js'
 
-export { FLAT_TODO_FILE, LEGACY_HYPHEN_TODO_FILE, LEGACY_TICKETS_TODO_FILE, LEGACY_TODO_FILE, TICKETS_DIR, todoPriorityForTicket } from './tickets.js'
+export { FLAT_TODO_FILE, LEGACY_HYPHEN_TODO_FILE, LEGACY_TICKETS_TODO_FILE, LEGACY_TODO_FILE, TICKETS_DIR, ticketFromQueueEntry, todoPriorityForTicket } from './tickets.js'
 
 /**
  * The backlog loop (#323): once the main work settles, consume the agent's own
@@ -222,6 +222,28 @@ export async function findTodoBacklog(cwd: string): Promise<TodoBacklog | undefi
     if (entries.length) return { name, entries }
   }
   return undefined
+}
+
+/**
+ * The ticket the next drain run will pick up, or `undefined` when there is none (#1117).
+ *
+ * "Next" is the first open entry of the flat backlog, because that is what the [Drain queue]
+ * preset says to work ("the FIRST open entry only") and {@link parseTodoEntries} returns entries
+ * in file order. Read from the project checkout, the same copy the sweep already consults when it
+ * decides whether there is anything to drain, so the entry this names is the entry that decision
+ * was made on.
+ *
+ * A best guess by construction: the run reads its own worktree a moment later, and an entry
+ * checked off in between would move it on. Being wrong here costs a mislabelled lane on the
+ * Overview and nothing else — no run is started or steered by this.
+ */
+export async function nextQueuedTicket(cwd: string): Promise<string | undefined> {
+  const name = await findFlatTodo(cwd)
+  if (!name) return undefined
+  const md = await readFile(join(cwd, name), 'utf8').catch(() => undefined)
+  if (md === undefined) return undefined
+  const first = parseTodoEntries(md)[0]
+  return first ? ticketFromQueueEntry(first) : undefined
 }
 
 /**


### PR DESCRIPTION
Closes #1117.

## What was missing

The Overview's **In progress** lane (#1112) worked out that a ticket was being worked from the `.plan`/`.spike` sitting beside it, because nothing linked a run to a ticket. Two things fell out of that: a ticket being coded *right now* showed up wherever its sibling files happened to put it, and a ticket nobody had planned yet sat in **Queued** while an agent was writing it.

#1164 had already closed the other half: queueing a ticket writes the entry as a markdown link back to it, so the ticket's identity survives the trip through the plain-text queue. This picks that link back up.

## Where the link is made

At the one moment the framework actually knows what a run is about to implement: the auto-PM **drain** start. That preset works "the FIRST open entry only", and `parseTodoEntries` reads in file order, so the entry the daemon reads is the entry the run will take. Every other job puts work *on* the queue rather than taking it off, so there is nothing for them to name — which is why `AutoPmJob` gained a `drains` marker rather than the call site matching on a preset name.

From there it takes the path every other durable run fact takes:

```
queue entry  ──#1164 link──►  daemon (drain start)  ──--ticket──►  run
                                                                    │
                                        RunMeta.ticket  ◄──event────┘
                                                │
                              buildHotTickets ──┴──►  "implementing"
```

An event rather than a start argument, because only an event reaches the meta, and the meta is what a dashboard tab opened mid-run reads.

The lane prefers hard evidence and keeps the old inference behind it: a live run's ticket is `in-progress` because a run said so, and everything else buckets exactly as before, so a ticket someone is working by hand still shows up. The card tags it `implementing` in the primary colour rather than muted — `planned` and `spiked` are marks work left behind, and a lane holding all three should not read as though they were the same claim. (That tag also fixes a row that would otherwise show nothing: `in-progress` used to imply planned-or-spiked.)

## Verified end to end, not just in units

Drove the real binary against a temp repo whose queue holds one linked ticket. The event is the first line of the run log:

```
{"kind":"ticket","path":"tickets/2026-07-25_login.md"}
```

and it lands in the meta. Then `buildHotTickets` with its **real** disk readers, against that run:

```
{"file":"2026-07-25_login.md","title":"Add a login page","bucket":"in-progress","runId":"2026-07-25T16-31-00-176Z"}
```

With the same run finished, the same ticket falls back to `{"bucket":"next"}` — that ticket is `priority: high` with no plan or spike, so it is exactly the case the old inference got wrong.

## Safety

A ticket path comes off a file an agent writes and ends up rendered in the dashboard and opened by a reader, so `isTicketPath` gates both ends — the queue read and the `--ticket` flag. Only `tickets/<name>.md` travels; traversal, absolute paths, URLs, dotfiles and nested paths are all refused, pinned by a test.

## Scope

The wrinkle in the issue is real and unfixed by design: this is a best guess about which entry the run will take, since it reads the checkout a moment before the run reads its worktree. Being wrong costs a mislabelled lane, never a wrong run — nothing acts on it but the display. A run started from a hand-written prompt records no ticket, as before.

`pnpm typecheck` clean; `packages/the-framework` 1313 pass / 0 fail, `packages/framework-dashboard` 443 pass / 0 fail.
