### PR TITLE
fix(dashboard): stop offering a PR that cannot be opened, and make the queue readable (#1164, #1173)

### DIFF
--- a/.changeset/queue-label-and-empty-branch.md
+++ b/.changeset/queue-label-and-empty-branch.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+Three follow-ups from using the handoff for real. A session whose work is already in the base no longer offers an Open PR that GitHub can only refuse: the commit list was read with git's symmetric difference, so commits belonging to the base counted as the session's own. The launcher gear offers one Open PR row instead of a pair whose Push branch half was greyed out and explained away whenever Open PR was on, which is the default. And the Overview's queue card shows a queued ticket's title rather than the raw markdown link it is written as, with the agent's note moved to the tooltip.

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -12,6 +12,7 @@ import { usePreferences } from '../lib/preferences.js'
 import { OnboardingChecklist } from './OnboardingChecklist.js'
 import { HotTickets } from './HotTickets.js'
 import { cn } from '../lib/utils.js'
+import { queueEntryLabel } from '../lib/queue-entry.js'
 import { formatDateTime, formatRelative } from '../lib/format-date.js'
 import { ScrollArea } from './ui/scroll-area.js'
 
@@ -281,12 +282,18 @@ function Backlog({ queue, onSelectProject }: { queue: ProjectQueue[]; onSelectPr
             {q.items
               .filter(i => !i.done)
               .slice(0, 3)
-              .map((item, i) => (
-                <li key={i} className="flex gap-1.5 text-xs text-muted-foreground">
-                  <span aria-hidden className="text-muted-foreground/60">▢</span>
-                  <span className="truncate" title={item.text}>{item.text}</span>
-                </li>
-              ))}
+              .map((item, i) => {
+                // The line is markdown, and a queued ticket is written as a link to it (#1164), so
+                // print the title rather than the source. The whole line stays in the tooltip: the
+                // agent's note after the link is worth having, just not at the cost of the title.
+                const label = queueEntryLabel(item.text)
+                return (
+                  <li key={i} className="flex gap-1.5 text-xs text-muted-foreground">
+                    <span aria-hidden className="text-muted-foreground/60">▢</span>
+                    <span className="truncate" title={item.text}>{label.text}</span>
+                  </li>
+                )
+              })}
             {q.open > 3 && <li className="pl-5 text-xs text-muted-foreground">+{q.open - 3} more</li>}
           </ul>
         </li>

--- a/packages/framework-dashboard/lib/queue-entry.test.ts
+++ b/packages/framework-dashboard/lib/queue-entry.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest'
+import { queueEntryLabel } from './queue-entry.js'
+
+describe('queueEntryLabel (#1164)', () => {
+  test('a queued ticket reads as its title, not as markdown source', () => {
+    // What the Overview card actually showed: `[Improve tooltip: show it with no...`, truncated
+    // mid-source, which is why the queue looked like it had not worked.
+    const entry = '[Improve tooltip](tickets/2026-07-25_improve-tooltip.md)'
+    expect(queueEntryLabel(entry)).toEqual({ text: 'Improve tooltip', ticket: 'tickets/2026-07-25_improve-tooltip.md' })
+  })
+
+  test("the agent's note after the link is dropped from the label, not the title", () => {
+    // Agents append their findings to the entry. Keeping them inline pushed the title out of a
+    // one-line list entirely; the full text still goes in the tooltip.
+    const entry = '[Let Fable be picked](tickets/2026-07-25_fable.md) — the model menu filters it out in AgentModelMenu.tsx:65'
+    expect(queueEntryLabel(entry).text).toBe('Let Fable be picked')
+  })
+
+  test('a plain entry is left exactly as it is', () => {
+    expect(queueEntryLabel('Apply the maintainability preset')).toEqual({ text: 'Apply the maintainability preset' })
+    // A link mid-sentence is part of the sentence, not the name of the work.
+    const inline = 'read the [docs](README.md) first'
+    expect(queueEntryLabel(inline)).toEqual({ text: inline })
+  })
+})

--- a/packages/framework-dashboard/lib/queue-entry.ts
+++ b/packages/framework-dashboard/lib/queue-entry.ts
@@ -1,0 +1,32 @@
+// How a queue entry reads on screen (#1164).
+//
+// Entries are lines of `TODO_AGENTS.md`, so they are markdown, and since #1164 a ticket queued
+// from the dashboard is written as a link back to its ticket. The Overview's card printed the line
+// verbatim, so what the reader got was source: `[Improve tooltip: show it with no...`. Agents also
+// append their own notes after the link, which pushed the title out of a truncated single line
+// entirely — the queue looked broken because it was unreadable, not because it was empty.
+
+/** A queue entry split into what to show and where it points. */
+export interface QueueEntryLabel {
+  /** The human part: the link's text, else the line itself. */
+  text: string
+  /** The link target, when the entry is a link into `tickets/`. */
+  ticket?: string
+}
+
+/** `[title](target)` at the start of a line, with the title allowed to contain anything but `]`. */
+const LEADING_LINK = /^\s*\[([^\]]+)\]\(([^)\s]+)\)\s*/
+
+/**
+ * What one queue entry should read as.
+ *
+ * Only a link at the START of the entry counts as its title: that is where {@link sendQueueTicket}
+ * writes it, and a link further in is part of a sentence rather than the name of the work. Anything
+ * after the link is the agent's own note, which is detail — it belongs in the tooltip, not in a
+ * one-line list that would truncate the title away to show it.
+ */
+export function queueEntryLabel(entry: string): QueueEntryLabel {
+  const link = LEADING_LINK.exec(entry)
+  if (!link) return { text: entry.trim() }
+  return { text: link[1]!.trim(), ticket: link[2]! }
+}

--- a/packages/framework-dashboard/lib/run-option-rows.test.ts
+++ b/packages/framework-dashboard/lib/run-option-rows.test.ts
@@ -10,6 +10,19 @@ const rows = (preferences: Preferences) => runOptionRows(preferences)
 const find = (list: OptionRow[], key: string) => list.find(r => r.key === key)!
 
 describe('runOptionRows', () => {
+  test('the handoff is one row, Open PR, not a pair with a greyed-out sibling (#1164/#1173)', () => {
+    // It used to offer `Push branch` beside it, disabled and explained away as "opening a PR
+    // already pushes the branch" whenever Open PR was on — which is the default, so the row was
+    // greyed out almost every time anyone opened the gear.
+    const main = rows({}).main
+    expect(main.filter(r => r.key === 'autoOpenPr')).toHaveLength(1)
+    expect(main.find(r => r.key === 'autoPushBranch')).toBeUndefined()
+    expect(find(main, 'autoOpenPr').checked).toBe(true)
+    // The preference itself is untouched: push-without-PR stays reachable from the-framework.yml
+    // and the CLI flag, it just no longer competes for attention in the menu.
+    expect(find(rows({ autoOpenPr: false }).main, 'autoOpenPr').checked).toBe(false)
+  })
+
   test('autopilot is on by default, and off only when explicitly turned off', () => {
     expect(find(rows({}).main, 'autopilot').checked).toBe(true)
     expect(find(rows({ autopilot: false }).main, 'autopilot').checked).toBe(false)

--- a/packages/framework-dashboard/lib/run-option-rows.ts
+++ b/packages/framework-dashboard/lib/run-option-rows.ts
@@ -116,21 +116,20 @@ export function runOptionRows(preferences: Preferences): RunOptionRows {
       checked: onBeforeMergeableQuality && !transparent,
       ...overriddenByTransparent(transparent),
     },
-    // Where the two handoff boxes get their default (#1102). A session's own action bar can still
-    // untick them for that one run; this is what every new session starts from.
-    {
-      key: 'autoPushBranch',
-      label: 'Push branch',
-      description: 'Pushes the session branch to origin when it finishes.',
-      title: "Push the session's branch to origin when it finishes, so the work is never left only on this machine",
-      checked: handoff.push,
-      ...(handoff.pr ? { disabled: true, disabledReason: 'opening a PR already pushes the branch' } : {}),
-    },
+    // Where the handoff gets its default (#1102). A session's own action bar can still untick it for
+    // that one run; this is what every new session starts from.
+    //
+    // One row, not the `Push branch` / `Open PR` pair this used to be (#1164/#1173). Opening a PR
+    // pushes the branch on the way, so `Push branch` was disabled and explained away as "opening a
+    // PR already pushes the branch" whenever `Open PR` was on, which is the default: a control that
+    // is greyed out almost always, and that nobody could say the purpose of when it was not.
+    // Push-without-PR stays reachable where someone deliberately wanting it would look: the
+    // `autoPushBranch` preference key, the `--auto-push-branch` flag, and `the-framework.yml`.
     {
       key: 'autoOpenPr',
       label: 'Open PR',
       description: 'Opens a draft pull request when it finishes.',
-      title: 'Open a draft pull request when the session finishes. Draft, so it does not request review; it still shows on the needs-you queue',
+      title: 'Open a draft pull request when the session finishes, pushing the branch on the way. Draft, so it does not request review; it still shows on the needs-you queue',
       checked: handoff.pr,
     },
     // Claude-only (#801): the browser is wired through Claude Code's MCP config, so another agent's

--- a/packages/the-framework/src/dashboard/run-handoff.test.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.test.ts
@@ -257,6 +257,38 @@ test('a real repo: the branch outlives its worktree and still reports its work (
   }
 })
 
+test('a real repo: a branch whose work is already in the base reports empty (#1164/#1173)', async () => {
+  // The bug this pins: the commit list used `base...branch`, git's SYMMETRIC difference, so a
+  // branch that had produced nothing of its own still reported the commits that were only on the
+  // base. `empty` stayed false, the dashboard offered Open PR, and GitHub refused it with
+  // "No commits between main and <branch>" — an action that could only ever fail.
+  const dir = await mkdtemp(join(tmpdir(), 'handoff-merged-'))
+  const git = nodeGitRunner()
+  try {
+    await exec('git', ['init', '-b', 'main', dir])
+    await exec('git', ['config', 'user.email', 'test@example.com'], { cwd: dir })
+    await exec('git', ['config', 'user.name', 'Test'], { cwd: dir })
+    await writeFile(join(dir, 'README.md'), 'base\n')
+    await exec('git', ['add', '-A'], { cwd: dir })
+    await exec('git', ['commit', '-m', 'base'], { cwd: dir })
+
+    // The session branches off and commits nothing: its edit was never committed, which is the
+    // shape a run that forgets to commit leaves behind.
+    await exec('git', ['branch', 'the-framework/demo'], { cwd: dir })
+    // Meanwhile the base moves on, which is the ordinary case on a repo anyone else is working in.
+    await writeFile(join(dir, 'README.md'), 'base, moved on\n')
+    await exec('git', ['commit', '-am', 'someone else landed this'], { cwd: dir })
+
+    const handoff = await readRunHandoff(dir, 'the-framework/demo', { git, pr: async () => undefined })
+    assert.equal(handoff?.exists, true)
+    assert.deepEqual(handoff?.commits, [], 'the base\'s own commits are not this session\'s work')
+    assert.equal(handoff?.empty, true, 'so there is nothing to open a PR for, and the bar says so')
+    assert.deepEqual(handoff?.files, [])
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
 // The end-of-session handoff that fires by itself (#1102).
 
 /** A branch with one commit, a remote, and no PR: the case a handoff should act on. */

--- a/packages/the-framework/src/dashboard/run-handoff.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.ts
@@ -156,13 +156,23 @@ export async function readRunHandoff(
   }
 
   const base = await detectBase(run)
-  // Compare against the branch point, not the base tip, so commits that merely landed on the base
-  // after this session started are not read as the session's work.
-  const range = base ? `${base}...${branch}` : undefined
+  // Two ranges, because git's two spellings mean opposite things here and only one is right for
+  // each question (#1164/#1173).
+  //
+  // `base..branch` is the branch's OWN commits, which is what "what did this session produce"
+  // asks. `base...branch` in `git log` is the SYMMETRIC difference, so it also lists commits that
+  // are only on the base — exactly the thing the comment below says not to count. A session whose
+  // work is already merged then reported commits it did not make, `empty` stayed false, and the
+  // dashboard offered an Open PR that GitHub refuses with "No commits between main and <branch>".
+  //
+  // For the diff the three-dot form IS the right one: it is the change since the branch point,
+  // rather than a comparison against a base that has moved on since.
+  const logRange = base ? `${base}..${branch}` : undefined
+  const diffRange = base ? `${base}...${branch}` : undefined
 
   const [commitsOut, numstatOut, remoteTip, mergedOut] = await Promise.all([
-    range ? run(['log', '--format=%H%x1f%s', range]) : Promise.resolve(''),
-    range ? run(['diff', '--numstat', range]) : Promise.resolve(''),
+    logRange ? run(['log', '--format=%H%x1f%s', logRange]) : Promise.resolve(''),
+    diffRange ? run(['diff', '--numstat', diffRange]) : Promise.resolve(''),
     hasRemote ? run(['rev-parse', '--verify', '--quiet', `refs/remotes/origin/${branch}`]) : Promise.resolve(''),
     base ? run(['branch', '--list', '--merged', base, branch]) : Promise.resolve(''),
   ])


### PR DESCRIPTION
Part of #1164, part of #1173. Three things that only showed up once the handoff was used on real sessions.

## 1. An Open PR that could only fail

A finished session offered **Open PR**, and pressing it returned:

```
GraphQL: No commits between main and the-framework/run-2026-07-25T17-18-10-650Z
```

The branch had produced nothing of its own. The commit list was read with `git log base...branch`, git's **symmetric** difference, so commits that were only on the *base* counted as the session's work. `empty` stayed false, and the bar offered an action GitHub can only refuse.

The comment above it already said what was meant ("commits that merely landed on the base after this session started are not read as the session's work") — that is `base..branch`. The diff keeps the three-dot form, where it is the correct one: the change since the branch point, not against a base that has moved on.

Measured on the session that hit it:

| | commits | empty |
|---|---|---|
| before | 2 (both belonging to `main`) | false → Open PR offered, fails |
| after | 0 | true → "Nothing committed — no PR to open." |

Pinned by a real-git test that fails on the old range.

## 2. The gear's greyed-out row

The launcher offered **Push branch** beside **Open PR**, disabled and explained as "opening a PR already pushes the branch" whenever Open PR was on. Since that is the default, the row was greyed out nearly every time anyone opened the gear, and when it was not greyed out nobody could say what it was for.

One row now. `autoPushBranch`, `--auto-push-branch` and the `the-framework.yml` key are all untouched, so push-without-PR stays reachable where someone deliberately wanting it would look. The session bar already labels itself "Push branch" for such a session rather than showing an unticked "Open PR" while pushing behind it.

## 3. The queue card printed markdown source

Since #1164 a queued ticket is written as a link back to its ticket, and the Overview's card rendered `{item.text}` verbatim. So the queue read as:

```
▢ [Improve tooltip: show it with no delay, and use it everywhere the browser's tooltip is...
```

Agents also append their findings after the link, which pushed the title out of the truncated line entirely. The card now shows the ticket's title and keeps the whole entry in the tooltip. `queueEntryLabel` only treats a link at the *start* of the entry as its title, since a link mid-sentence is part of a sentence rather than the name of the work.

## Checks

`pnpm typecheck` clean. `packages/the-framework` 1314 pass / 0 fail, `packages/framework-dashboard` 450 pass / 0 fail. The range fix was also re-read against the live session that failed, which now reports `empty: true`.
