### PR TITLE
fix(quota): recover from a usage readout the framework cannot parse

### DIFF
--- a/.changeset/quota-poller-recovers.md
+++ b/.changeset/quota-poller-recovers.md
@@ -1,0 +1,6 @@
+---
+'@gemstack/the-framework': patch
+'@gemstack/framework-dashboard': patch
+---
+
+The usage bar no longer disappears for the rest of the daemon's life after one usage readout the framework could not parse. A single unrecognized answer used to be treated as a statement about the account, which wiped the retained reading and stopped the poller permanently, so the panel fell back to a sentence and looked as though the bar had been reverted. An unparseable answer describes that one read, not the install, so it is now transient like a failed fetch: the reading is kept, the poller keeps asking, and the panel dates the numbers it is still showing rather than presenting them as current.

--- a/.changeset/quota-poller-recovers.md
+++ b/.changeset/quota-poller-recovers.md
@@ -1,6 +1,5 @@
 ---
 '@gemstack/the-framework': patch
-'@gemstack/framework-dashboard': patch
 ---
 
 The usage bar no longer disappears for the rest of the daemon's life after one usage readout the framework could not parse. A single unrecognized answer used to be treated as a statement about the account, which wiped the retained reading and stopped the poller permanently, so the panel fell back to a sentence and looked as though the bar had been reverted. An unparseable answer describes that one read, not the install, so it is now transient like a failed fetch: the reading is kept, the poller keeps asking, and the panel dates the numbers it is still showing rather than presenting them as current.

--- a/packages/framework-dashboard/components/Quota.test.tsx
+++ b/packages/framework-dashboard/components/Quota.test.tsx
@@ -105,6 +105,23 @@ describe('Quota (#960)', () => {
     expect(screen.queryByLabelText('Unattended work stops at')).toBeNull()
   })
 
+  test('a readout it could not parse keeps the bar and dates it, rather than replacing it (#960)', () => {
+    // The poller now survives an unrecognized answer, so the earlier reading is still on screen.
+    // It has to say how old it is: an undated bar claims to be current.
+    view = { ...reading(20), unavailable: 'unrecognized', readAt: Date.now() - 90 * 60 * 1000 }
+    render(<Quota />)
+    expect(screen.getByRole('img')).toBeTruthy()
+    expect(screen.getByText(/from the reading before it/)).toBeTruthy()
+    expect(screen.getByText(/Last read/)).toBeTruthy()
+  })
+
+  test('an unrecognized readout with nothing retained says it will try again (#960)', () => {
+    view = { windows: [], unavailable: 'unrecognized' }
+    render(<Quota />)
+    // It used to read as terminal ("the boundary is off"), which is what made this look reverted.
+    expect(screen.getByText(/Trying again shortly/)).toBeTruthy()
+  })
+
   // The bug this test exists for: the slider used to be bound straight to the polled value, which
   // only refreshes every 30s. Each keypress recomputed from the same stale number and the thumb
   // snapped back, so twenty presses of an arrow key moved the limit by one.

--- a/packages/framework-dashboard/components/Quota.tsx
+++ b/packages/framework-dashboard/components/Quota.tsx
@@ -152,7 +152,11 @@ function unavailableNote(view: QuotaView): string | undefined {
     case 'agent-not-found':
       return 'Claude Code was not found, so usage cannot be read.'
     case 'unrecognized':
-      return 'Claude Code reported its usage in a way this version does not recognize, so the boundary is off.'
+      // The poller no longer gives up on this (#960), so where a reading survives, say it is
+      // behind rather than that the boundary is off, which read as terminal.
+      return view.windows.length
+        ? "Claude Code's latest usage readout wasn't one this version recognizes, so these numbers are from the reading before it."
+        : 'Claude Code reported its usage in a way this version does not recognize. Trying again shortly.'
     default:
       return view.windows.length
         ? "Couldn't refresh just now, so these numbers may be a little behind."
@@ -241,6 +245,9 @@ export function Quota() {
   const preferences = usePreferences()
   const [offset, setOffset] = useSpendOffset(view?.boundary?.limit.offset)
   const note = view ? unavailableNote(view) : undefined
+  // When the newest attempt failed but earlier numbers are still on screen, say how old they are.
+  // A retained reading can now outlive several failures (#960), and an undated bar claims to be now.
+  const staleAt = view?.unavailable !== undefined && view.windows.length > 0 ? view.readAt : undefined
   const week = view ? weekWindow(view.windows) : undefined
   // Everything else: the session window, and a model's own week. Never the account week, which
   // the bar above already is.
@@ -264,7 +271,12 @@ export function Quota() {
 
         {others.length ? <div className="space-y-1 border-t border-border pt-3">{others.map(w => <OtherWindow key={w.label} window={w} />)}</div> : null}
 
-        {note ? <p className="text-sm text-muted-foreground">{note}</p> : null}
+        {note ? (
+          <p className="text-sm text-muted-foreground">
+            {note}
+            {staleAt !== undefined ? ` Last read ${formatRelative(new Date(staleAt).toISOString())}.` : ''}
+          </p>
+        ) : null}
 
         {view ? (
           <div className="space-y-1 border-t border-border pt-3">

--- a/packages/the-framework/src/driver/claude-code-quota.test.ts
+++ b/packages/the-framework/src/driver/claude-code-quota.test.ts
@@ -91,9 +91,10 @@ test('parseQuotaReadout never reports an empty reading as zero use (#521)', () =
 test('isTransientQuotaReason splits this-attempt failures from setup failures', () => {
   assert.equal(isTransientQuotaReason('fetch-failed'), true)
   assert.equal(isTransientQuotaReason('timeout'), true)
+  // One answer we could not read, not a statement about the install (#960).
+  assert.equal(isTransientQuotaReason('unrecognized'), true)
   assert.equal(isTransientQuotaReason('no-subscription'), false)
   assert.equal(isTransientQuotaReason('agent-not-found'), false)
-  assert.equal(isTransientQuotaReason('unrecognized'), false)
 })
 
 /** A fake process that emits `stdout` then closes with `code`. */

--- a/packages/the-framework/src/driver/types.ts
+++ b/packages/the-framework/src/driver/types.ts
@@ -207,11 +207,12 @@ export interface DriverQuotaWindow {
 /**
  * Why a quota read came back empty.
  *
- * The split that matters is transient vs authoritative. `fetch-failed` and
- * `timeout` describe *this attempt* (the agent's own usage fetch can be refused
- * upstream, with a penalty window), so a recent reading is still worth showing.
- * Every other reason describes the account or the install and is a statement
- * about the setup, so a retained reading must not outlive it.
+ * The split that matters is transient vs authoritative. `fetch-failed`,
+ * `timeout` and `unrecognized` describe *this attempt* (the agent's own usage
+ * fetch can be refused upstream, with a penalty window), so a recent reading is
+ * still worth showing and asking again may work. The remaining reasons describe
+ * the account or the install and are a statement about the setup, so a retained
+ * reading must not outlive them.
  */
 export type DriverQuotaUnavailableReason =
   /** The agent's own usage fetch failed, e.g. refused upstream. Transient. */
@@ -222,12 +223,19 @@ export type DriverQuotaUnavailableReason =
   | 'agent-not-found'
   /** The account has no subscription quota to report (e.g. API-key auth). */
   | 'no-subscription'
-  /** The agent answered, but not in a shape we recognize (it reworded the readout). */
+  /**
+   * The agent answered, but not in a shape we recognize (it reworded the readout).
+   *
+   * Transient, because it describes one answer rather than the install: an
+   * update notice printed ahead of the JSON, or empty stdout while the CLI
+   * swaps itself under a long-lived daemon, both land here and both are gone by
+   * the next read (#960).
+   */
   | 'unrecognized'
 
 /** Whether a {@link DriverQuotaUnavailableReason} describes this attempt rather than the setup. */
 export function isTransientQuotaReason(reason: DriverQuotaUnavailableReason): boolean {
-  return reason === 'fetch-failed' || reason === 'timeout'
+  return reason === 'fetch-failed' || reason === 'timeout' || reason === 'unrecognized'
 }
 
 /**

--- a/packages/the-framework/src/quota-poller.test.ts
+++ b/packages/the-framework/src/quota-poller.test.ts
@@ -85,11 +85,26 @@ test('QuotaPoller gives up when the agent is missing (#525)', async () => {
   assert.equal(poller.isStopped, true)
 })
 
-test('QuotaPoller treats a reworded readout as authoritative and stops (#525)', async () => {
-  const { poller } = pollerOf([{ available: false, reason: 'unrecognized' }])
+test('QuotaPoller keeps polling after a readout it did not recognize (#960)', async () => {
+  const { poller, advance } = pollerOf([goodAt(10), { available: false, reason: 'unrecognized' }])
   await poller.poll()
-  // Polling on wouldn't reword it back; this needs a code change, not a retry.
-  assert.equal(poller.isStopped, true)
+  advance(1000)
+  await poller.poll()
+  // One unhandled answer is not a verdict on the account: an update notice ahead
+  // of the JSON reads exactly like this and is gone by the next read.
+  assert.equal(poller.isStopped, false)
+  assert.ok(poller.current().lastGood?.available)
+})
+
+test('QuotaPoller recovers once the readout is recognized again (#960)', async () => {
+  const { poller } = pollerOf([{ available: false, reason: 'unrecognized' }, goodAt(42)])
+  await poller.poll()
+  await poller.poll()
+  // The bug this pins: a single bad first read used to stop the poller for the
+  // daemon's whole life, so the usage bar never came back and looked reverted.
+  assert.equal(poller.isStopped, false)
+  assert.equal(poller.current().lastGood?.windows.find(w => w.kind === 'week')?.percentUsed, 42)
+  assert.equal(poller.intervalMs, DEFAULT_POLL_MS)
 })
 
 test('QuotaPoller survives a driver that throws (#525)', async () => {


### PR DESCRIPTION
Closes #960

## What was wrong

The `<Quota>` component was not reverted. It is all still on main: the week track, the day ticks, the boundary `|`, the tone colours and the bonus slider. What broke is the reading behind it.

`parseQuotaResponse` returns `unrecognized` for any stdout that is not clean JSON: empty stdout, an update notice printed ahead of the JSON, or the subscription header with no `X: N% used` lines. That reason sat on the authoritative side of `isTransientQuotaReason`, so `QuotaPoller.onBad` wiped `lastGood` and called `stop()`. That stop is permanent: `start()` early-returns once `stopped` is set, and `defaultQuotaSource` builds the poller once at daemon boot.

So one bad read killed the usage panel for the daemon's entire life, and it degraded to a single sentence. Restarting the daemon was the only way back. The likely trigger is the Claude CLI auto-updating under a long-lived daemon: a poll landing in the swap gets non-JSON.

## The fix

`unrecognized` describes one answer, not the account or the install, so it moves to the transient side alongside `fetch-failed` and `timeout`. The retained reading survives, the poller keeps asking, and backoff already caps the retries at 30 minutes.

`no-subscription` and `agent-not-found` stay authoritative, which is what that branch was written for.

Because a reading can now outlive several failed attempts, the panel had to stop presenting it as current. `QuotaView.readAt` was already plumbed through and unused by the UI; it now renders as "Last read ..." whenever the newest attempt failed but earlier numbers are still on screen. The `unrecognized` copy also stopped reading as terminal.

## Proof

Against the built `dist`, a poller fed one `unrecognized` then four good readings:

```
reads attempted: 5
isStopped: false
lastGood week %: 42
```

Previously that exact script attempted **1** read, with `isStopped: true` and `lastGood: undefined`.

framework 1315 tests, dashboard 448. Typecheck and build clean.

## Open question

Should an authoritative stop retry occasionally too? `agent-not-found` self-heals as well (a reinstall, or a PATH fix), and today it also stops the poller for the daemon's life. Left out of this PR to keep it to the reported bug, happy to follow up.
