### PR TITLE
fix(dashboard): mark the optional onboarding steps and drop the radio-button look

### DIFF
--- a/.changeset/dashboard-onboarding-papercuts.md
+++ b/.changeset/dashboard-onboarding-papercuts.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+Onboarding steps now say which ones are optional, and their marks read as checkboxes rather than radio buttons: an outlined circle suggested one choice out of a set, when the rows are independent things to tick. The Overview also drops its subtitle, which restated what the page already showed.

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -37,7 +37,6 @@ export function DashboardPage({
       <div className="mx-auto max-w-6xl space-y-6 p-6">
         <div>
           <h1 className="text-xl font-semibold">Overview</h1>
-          <p className="text-sm text-muted-foreground">Everything the agent is doing, across every project.</p>
         </div>
 
         {!onboardingDismissed && <OnboardingChecklist dismissible onSelectProject={onSelectProject} />}

--- a/packages/framework-dashboard/components/OnboardingChecklist.test.tsx
+++ b/packages/framework-dashboard/components/OnboardingChecklist.test.tsx
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import type { DashboardData } from '@gemstack/the-framework'
+
+// The checklist reads its state over several telefunc shims and hooks; stub them all so the import
+// graph stays out of telefunc and each row's "done" comes from a fixture rather than a real daemon.
+const onDashboard = vi.hoisted(() => vi.fn())
+const onOnboarding = vi.hoisted(() => vi.fn())
+vi.mock('../server/reads.telefunc.js', () => ({ onDashboard }))
+vi.mock('../server/projects.telefunc.js', () => ({ onOnboarding, sendAddProject: vi.fn() }))
+vi.mock('../server/preferences.telefunc.js', () => ({ saveDiscordCredentials: vi.fn() }))
+vi.mock('../lib/preferences.js', () => ({
+  usePreferences: () => ({}),
+  updatePreferences: vi.fn(),
+  notificationsEnabled: () => false,
+  discordBotEnabled: () => false,
+  discordEnabled: () => false,
+}))
+vi.mock('../lib/notify-channels.js', () => ({ useNotifyChannels: () => null, reloadNotifyChannels: vi.fn() }))
+vi.mock('../lib/notification-permission.js', () => ({ useNotificationPermission: () => 'default' }))
+vi.mock('../lib/use-start-run.js', () => ({ useStartRun: () => ({ start: vi.fn(), busy: false, error: null }) }))
+
+const { OnboardingChecklist } = await import('./OnboardingChecklist.js')
+
+afterEach(cleanup)
+
+/** A board with nothing set up: every row is open, which is when the marks have to be readable. */
+const EMPTY: DashboardData = {
+  totals: { projects: 0, activeRuns: 0, openTodos: 0, totalRuns: 0 },
+  projects: [],
+  active: [],
+  queue: [],
+  activity: [],
+  runsByStatus: {},
+} as unknown as DashboardData
+
+describe('OnboardingChecklist (#1139)', () => {
+  test('the steps nothing breaks without are marked optional, and the two essentials are not', async () => {
+    onDashboard.mockResolvedValue(EMPTY)
+    onOnboarding.mockResolvedValue(null)
+    render(<OnboardingChecklist />)
+    await waitFor(() => expect(screen.getByText('Add a project')).toBeTruthy())
+
+    // Four integrations/inputs are optional; adding a project and filling the queue are not.
+    expect(screen.getAllByText('Optional')).toHaveLength(4)
+    const marked = (label: string) => screen.getByText(label).querySelector('span')?.textContent === 'Optional'
+    expect(marked('Add a project')).toBe(false)
+    expect(marked('Populate the queue of AI tasks')).toBe(false)
+    expect(marked('Populate tickets/')).toBe(true)
+    expect(marked('Add the Discord bot')).toBe(true)
+  })
+
+  test('an unticked step is a checkbox, not a radio button', async () => {
+    onDashboard.mockResolvedValue(EMPTY)
+    onOnboarding.mockResolvedValue(null)
+    const { container } = render(<OnboardingChecklist />)
+    await waitFor(() => expect(screen.getByText('Add a project')).toBeTruthy())
+    // An outlined circle read as "pick one of these" when the rows are independent things to tick.
+    expect(container.querySelector('circle')).toBeNull()
+    expect(screen.getAllByLabelText('Not done').length).toBeGreaterThan(0)
+  })
+})

--- a/packages/framework-dashboard/components/OnboardingChecklist.tsx
+++ b/packages/framework-dashboard/components/OnboardingChecklist.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import type { DashboardData, OnboardingSuggestion } from '@gemstack/the-framework'
 import { presets } from '@gemstack/the-framework/client'
-import { Check, Circle, X } from 'lucide-react'
+import { Square, SquareCheckBig, X } from 'lucide-react'
 import { onDashboard } from '../server/reads.telefunc.js'
 import { onOnboarding, sendAddProject } from '../server/projects.telefunc.js'
 import { usePolled } from '../lib/use-async.js'
@@ -30,6 +30,13 @@ interface Step {
   label: string
   description: string
   done: boolean
+  /**
+   * Nothing breaks if this one is never done (#1139).
+   *
+   * Marked per step rather than by position, so the list can be reordered without the promise
+   * moving with it. Only the two steps the agent cannot work without are left unmarked.
+   */
+  optional?: boolean
   /** The action(s) offered while it is not done. */
   action?: React.ReactNode
 }
@@ -129,6 +136,7 @@ export function OnboardingChecklist({
       description:
         'tickets/ holds the bigger things to work on, in the repo. The agent plans and spikes from them, and they are the input the queue is filled from.',
       done: hasTickets,
+      optional: true,
       action: (
         <div className="flex flex-col items-end gap-1">
           <Button size="sm" onClick={importTickets} disabled={!targetProjectId || starting}>
@@ -144,6 +152,7 @@ export function OnboardingChecklist({
       label: 'Add the Discord bot',
       description: DISCORD_BOT_DESCRIPTION,
       done: channels?.discordBot ?? false,
+      optional: true,
       action: (
         <Button size="sm" variant="outline" onClick={() => setDiscordBotOpen(true)}>
           Set up the bot
@@ -155,6 +164,7 @@ export function OnboardingChecklist({
       label: 'Add browser notifications',
       description: 'Desktop pings while the dashboard is open, so a session waiting on you does not sit unnoticed.',
       done: browserGranted,
+      optional: true,
       action:
         permission === 'denied' ? (
           <span className="text-xs text-muted-foreground">Blocked in your browser settings</span>
@@ -171,6 +181,7 @@ export function OnboardingChecklist({
       label: 'Add Discord notifications',
       description: DISCORD_WEBHOOK_DESCRIPTION,
       done: channels?.discordWebhook ?? false,
+      optional: true,
       action: (
         <Button size="sm" variant="outline" onClick={() => setDiscordWebhookOpen(true)}>
           Add the webhook
@@ -207,13 +218,22 @@ export function OnboardingChecklist({
           {steps.map(step => (
             <li key={step.key} className="flex items-start justify-between gap-4 py-3 first:pt-0 last:pb-0">
               <div className="flex min-w-0 items-start gap-3">
+                {/* A checkbox, not a circle: an outlined circle reads as a radio button, i.e. as
+                    one of a set you pick between, when these are independent things to tick (#1139). */}
                 {step.done ? (
-                  <Check className="mt-0.5 h-4 w-4 shrink-0 text-[var(--color-primary)]" aria-label="Done" />
+                  <SquareCheckBig className="mt-0.5 h-4 w-4 shrink-0 text-[var(--color-primary)]" aria-label="Done" />
                 ) : (
-                  <Circle className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-label="Not done" />
+                  <Square className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-label="Not done" />
                 )}
                 <div className="min-w-0">
-                  <p className={step.done ? 'text-sm text-muted-foreground line-through' : 'text-sm'}>{step.label}</p>
+                  <p className={step.done ? 'text-sm text-muted-foreground line-through' : 'text-sm'}>
+                    {step.label}
+                    {step.optional && (
+                      <span className="ml-2 rounded-full border border-border px-1.5 py-0.5 align-middle text-[10px] font-normal uppercase tracking-wide text-muted-foreground">
+                        Optional
+                      </span>
+                    )}
+                  </p>
                   <p className="text-xs text-muted-foreground">{step.description}</p>
                 </div>
               </div>


### PR DESCRIPTION
Part of #1139

Takes the three items from the issue that are pure implementation, so the two that need your words are not blocked behind them.

## Done here

**"Everything the agent is doing, across every project." is gone.** It restated what the page below it already showed.

**The onboarding marks are checkboxes, not circles.** An outlined circle reads as a radio button, i.e. as one choice out of a set, when the rows are independent things to tick. Done stays the primary colour.

**Optional steps say so.** Four rows carry an `Optional` tag: `tickets/`, the Discord bot, browser notifications and the Discord webhook. Two do not: "Add a project" and "Populate the queue of AI tasks".

That split is my proposal, not a fact from the code, so correct it if you draw the line elsewhere. My reasoning: nothing runs without a project, and an empty queue is what stops the agent carrying on by itself, while the other four are integrations or inputs a working install never needs. The flag sits on the step rather than on its position, so reordering the list cannot move the promise.

dashboard 448 tests (2 new), typecheck and build clean.

## Left for you

**The subtext rewrite.** You said the descriptions are a good idea but hard to understand and offered to help. Yours to word, mine to land after.

**The three redundancy questions** (what is strictly needed / what adds real value / what should be shown first), and "we should probably re-haul this whole view". That is direction, not a papercut.

**Clicking a project name.** You are right that it is weird: `selectProject` goes to `runId: null`, which renders `ProjectHome`, the launcher. So clicking a project really does land you on a new-session composer. The smallest honest fix is to open that project's most recent session instead, and fall back to the launcher only when it has none. I did not ship it because it changes what the project home is *for*, which is exactly the re-haul you flagged. Say the word and it is a few lines.
