### PR TITLE
fix(dashboard): land on the session the import started (#1169)

### DIFF
--- a/.changeset/import-tickets-lands-on-its-session.md
+++ b/.changeset/import-tickets-lands-on-its-session.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+"Import tickets from GitHub" now lands on the session it just started. From the onboarding checklist it started the run and then navigated by project alone, which is the project's launcher, so the import ran out of sight and the dashboard looked like it had lost track of its own work. A run started from a surface with nothing selected now carries the project it runs in along with its id, and a refused start leaves you where you are with the reason shown.

--- a/TODO_AGENTS.md
+++ b/TODO_AGENTS.md
@@ -8,7 +8,7 @@ The agent queue. Each unchecked entry is worked front to back, highest priority 
 
 ## Priority 5
 
-- [ ] [Make `Import tickets from GitHub` open the session it just started](tickets/2026-07-25_import-tickets-redirects-wrong-page.md) — `importTickets` in `packages/framework-dashboard/components/OnboardingChecklist.tsx:90-95` starts the run and then calls `onSelectProject(targetProjectId)`, which lands on the project instead of the run doing the import. `TicketsPanel.importFromGithub` (`TicketsPanel.tsx:67-72`) already does the right thing with the same preset — it passes `result.runId` to `onRunStarted` — so mirror that: take the run id back from `useStartRun().start` and navigate to the run.
+- [x] [Make `Import tickets from GitHub` open the session it just started](tickets/2026-07-25_import-tickets-redirects-wrong-page.md) — `importTickets` in `packages/framework-dashboard/components/OnboardingChecklist.tsx:90-95` starts the run and then calls `onSelectProject(targetProjectId)`, which lands on the project instead of the run doing the import. `TicketsPanel.importFromGithub` (`TicketsPanel.tsx:67-72`) already does the right thing with the same preset — it passes `result.runId` to `onRunStarted` — so mirror that: take the run id back from `useStartRun().start` and navigate to the run.
 
 ## Priority 2
 

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -23,9 +23,12 @@ import { ScrollArea } from './ui/scroll-area.js'
 // Selecting anything here jumps into that project. Shown by the shell when no project is picked.
 export function DashboardPage({
   onSelectProject,
+  onRunStarted,
   interventions,
 }: {
   onSelectProject: (id: string) => void
+  /** Where a session the onboarding checklist starts lands (#1169): on that session. */
+  onRunStarted: (projectId: string, intent: string, runId?: string) => void
   interventions: Intervention[]
 }) {
   const { value: data } = usePolled<DashboardData | null>(onDashboard, null, 5000, [])
@@ -40,7 +43,7 @@ export function DashboardPage({
           <h1 className="text-xl font-semibold">Overview</h1>
         </div>
 
-        {!onboardingDismissed && <OnboardingChecklist dismissible onSelectProject={onSelectProject} />}
+        {!onboardingDismissed && <OnboardingChecklist dismissible onRunStarted={onRunStarted} />}
 
         <NeedsYou items={interventions} onSelectProject={onSelectProject} />
 

--- a/packages/framework-dashboard/components/OnboardingChecklist.test.tsx
+++ b/packages/framework-dashboard/components/OnboardingChecklist.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { DashboardData } from '@gemstack/the-framework'
 
 // The checklist reads its state over several telefunc shims and hooks; stub them all so the import
@@ -18,11 +18,18 @@ vi.mock('../lib/preferences.js', () => ({
 }))
 vi.mock('../lib/notify-channels.js', () => ({ useNotifyChannels: () => null, reloadNotifyChannels: vi.fn() }))
 vi.mock('../lib/notification-permission.js', () => ({ useNotificationPermission: () => 'default' }))
-vi.mock('../lib/use-start-run.js', () => ({ useStartRun: () => ({ start: vi.fn(), busy: false, error: null }) }))
+// One stable object, so a test can steer the start and its error without a re-mock.
+const startRun = vi.hoisted(() => ({ start: vi.fn(), busy: false, error: null as string | null }))
+vi.mock('../lib/use-start-run.js', () => ({ useStartRun: () => startRun }))
 
 const { OnboardingChecklist } = await import('./OnboardingChecklist.js')
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  startRun.start.mockReset()
+  startRun.busy = false
+  startRun.error = null
+})
 
 /** A board with nothing set up: every row is open, which is when the marks have to be readable. */
 const EMPTY: DashboardData = {
@@ -34,11 +41,24 @@ const EMPTY: DashboardData = {
   runsByStatus: {},
 } as unknown as DashboardData
 
+/** One project registered, no tickets in it: the state the import step is offered in. */
+const WITH_PROJECT: DashboardData = {
+  ...EMPTY,
+  totals: { projects: 1, activeRuns: 0, openTodos: 0, totalRuns: 0 },
+  projects: [{ projectId: 'p1', hasTickets: false }],
+} as unknown as DashboardData
+
+/** Click the import step and wait for the start to have been attempted. */
+const clickImport = async () => {
+  fireEvent.click(await screen.findByRole('button', { name: /import tickets from github/i }))
+  await waitFor(() => expect(startRun.start).toHaveBeenCalled())
+}
+
 describe('OnboardingChecklist (#1139)', () => {
   test('the steps nothing breaks without are marked optional, and the two essentials are not', async () => {
     onDashboard.mockResolvedValue(EMPTY)
     onOnboarding.mockResolvedValue(null)
-    render(<OnboardingChecklist />)
+    render(<OnboardingChecklist onRunStarted={vi.fn()} />)
     await waitFor(() => expect(screen.getByText('Add a project')).toBeTruthy())
 
     // Four integrations/inputs are optional; adding a project and filling the queue are not.
@@ -53,10 +73,49 @@ describe('OnboardingChecklist (#1139)', () => {
   test('an unticked step is a checkbox, not a radio button', async () => {
     onDashboard.mockResolvedValue(EMPTY)
     onOnboarding.mockResolvedValue(null)
-    const { container } = render(<OnboardingChecklist />)
+    const { container } = render(<OnboardingChecklist onRunStarted={vi.fn()} />)
     await waitFor(() => expect(screen.getByText('Add a project')).toBeTruthy())
     // An outlined circle read as "pick one of these" when the rows are independent things to tick.
     expect(container.querySelector('circle')).toBeNull()
     expect(screen.getAllByLabelText('Not done').length).toBeGreaterThan(0)
+  })
+})
+
+describe('the GitHub import lands on the session it starts (#1169)', () => {
+  test('the started run id is handed up, with the project it runs in', async () => {
+    onDashboard.mockResolvedValue(WITH_PROJECT)
+    onOnboarding.mockResolvedValue(null)
+    startRun.start.mockResolvedValue({ runId: 'run-7' })
+    const onRunStarted = vi.fn()
+    render(<OnboardingChecklist onRunStarted={onRunStarted} />)
+    await clickImport()
+
+    // The project travels with it: this surface has none selected, so an id alone cannot be routed.
+    expect(startRun.start).toHaveBeenCalledWith('p1', 'Import tickets from GitHub', 'prompt', {})
+    await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('p1', 'Import tickets from GitHub', 'run-7'))
+  })
+
+  test('a project with no worktree hands up no id, so the shell can adopt the running one', async () => {
+    onDashboard.mockResolvedValue(WITH_PROJECT)
+    onOnboarding.mockResolvedValue(null)
+    startRun.start.mockResolvedValue({})
+    const onRunStarted = vi.fn()
+    render(<OnboardingChecklist onRunStarted={onRunStarted} />)
+    await clickImport()
+
+    await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('p1', 'Import tickets from GitHub', undefined))
+  })
+
+  test('a refused start says why and moves you nowhere', async () => {
+    onDashboard.mockResolvedValue(WITH_PROJECT)
+    onOnboarding.mockResolvedValue(null)
+    startRun.start.mockResolvedValue(undefined)
+    startRun.error = 'A session is already active for this project.'
+    const onRunStarted = vi.fn()
+    render(<OnboardingChecklist onRunStarted={onRunStarted} />)
+    await clickImport()
+
+    expect(await screen.findByText(/already active/i)).toBeTruthy()
+    expect(onRunStarted).not.toHaveBeenCalled()
   })
 })

--- a/packages/framework-dashboard/components/OnboardingChecklist.tsx
+++ b/packages/framework-dashboard/components/OnboardingChecklist.tsx
@@ -43,11 +43,16 @@ interface Step {
 
 export function OnboardingChecklist({
   dismissible = false,
-  onSelectProject,
+  onRunStarted,
 }: {
   /** The Overview offers to hide it; the settings page always shows it. */
   dismissible?: boolean
-  onSelectProject?: ((id: string) => void) | undefined
+  /**
+   * Told about the session a step started, so the shell can land on it (#1169). The project
+   * travels with it: this renders on the Overview and the settings page, neither of which has
+   * one selected. Required, so a new mounting surface cannot quietly drop the navigation.
+   */
+  onRunStarted: (projectId: string, intent: string, runId?: string) => void
 }) {
   // Slower than the Overview's own 5s poll: onboarding state changes at human speed, and this
   // read fans out over every project to answer the tickets question.
@@ -96,9 +101,11 @@ export function OnboardingChecklist({
 
   const importTickets = async () => {
     if (!targetProjectId) return
-    const started = await start(targetProjectId, presets.importTickets.render(), 'prompt', {})
-    // The import runs as a session; follow it, since that is where its output appears.
-    if (started) onSelectProject?.(targetProjectId)
+    const intent = presets.importTickets.render()
+    const started = await start(targetProjectId, intent, 'prompt', {})
+    // Land on the session doing the import, not the project's launcher (#1169): its id is what
+    // the shell needs to show the live output. A refusal keeps you here, with `startError` shown.
+    if (started) onRunStarted(targetProjectId, intent, started.runId)
   }
 
   const steps: Step[] = [

--- a/packages/framework-dashboard/components/ProjectHome.tsx
+++ b/packages/framework-dashboard/components/ProjectHome.tsx
@@ -19,7 +19,8 @@ export function ProjectHome({
 }: {
   projectId: string
   events: FrameworkEvent[]
-  onRunStarted?: ((intent: string) => void) | undefined
+  /** Carries the started run's id through to the shell — dropping it is what #1169 was. */
+  onRunStarted?: ((intent: string, runId?: string, runsOn?: string) => void) | undefined
   files: string[]
   context: Set<string>
   addContext: (path: string) => void

--- a/packages/framework-dashboard/components/ProjectHome.tsx
+++ b/packages/framework-dashboard/components/ProjectHome.tsx
@@ -19,7 +19,7 @@ export function ProjectHome({
 }: {
   projectId: string
   events: FrameworkEvent[]
-  /** Carries the started run's id through to the shell — dropping it is what #1169 was. */
+  /** Carries the started run's id through to the shell; dropping it is what #1169 was. */
   onRunStarted?: ((intent: string, runId?: string, runsOn?: string) => void) | undefined
   files: string[]
   context: Set<string>

--- a/packages/framework-dashboard/components/SettingsPage.tsx
+++ b/packages/framework-dashboard/components/SettingsPage.tsx
@@ -27,7 +27,13 @@ import { cn } from '../lib/utils.js'
 // is the default rather than one repo's override — which is what a settings page should mean. The
 // per-project overrides stay where the run is configured, in the launcher's gear.
 
-export function SettingsPage({ onSelectProject }: { onSelectProject?: ((id: string) => void) | undefined; onDone?: () => void }) {
+export function SettingsPage({
+  onRunStarted,
+}: {
+  /** Where a session the onboarding checklist starts lands (#1169): on that session. */
+  onRunStarted: (projectId: string, intent: string, runId?: string) => void
+  onDone?: () => void
+}) {
   const preferences = usePreferences()
   const editors = useDetectedEditors()
   const theme = themePreference(preferences)
@@ -55,7 +61,7 @@ export function SettingsPage({ onSelectProject }: { onSelectProject?: ((id: stri
           </p>
         </div>
 
-        <OnboardingChecklist onSelectProject={onSelectProject} />
+        <OnboardingChecklist onRunStarted={onRunStarted} />
 
         <Section title="Appearance">
           <SelectRow

--- a/packages/framework-dashboard/components/TicketsPanel.test.tsx
+++ b/packages/framework-dashboard/components/TicketsPanel.test.tsx
@@ -75,12 +75,24 @@ describe('TicketsPanel (#697)', () => {
 
   test('an empty tickets/ offers the GitHub import instead of a dead end', async () => {
     sendStart.mockResolvedValue({ ok: true, runId: 'r1' })
-    render(<TicketsPanel projectId="p1" tickets={[]} loaded />)
+    const onRunStarted = vi.fn()
+    render(<TicketsPanel projectId="p1" tickets={[]} loaded onRunStarted={onRunStarted} />)
     fireEvent.click(await screen.findByRole('button', { name: /import tickets from github/i }))
     await waitFor(() => expect(sendStart).toHaveBeenCalled())
     // A fixed prompt, so it takes the verbatim-text path rather than a build.
     expect(sendStart.mock.calls[0]?.[2]).toBe('prompt')
     expect(sendStart.mock.calls[0]?.[1]).toMatch(/GitHub issues into tickets\//i)
+    // The run id is what lands you on the import session rather than the project home (#1169).
+    await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith(expect.any(String), 'r1'))
+  })
+
+  test('a refused import says why and moves you nowhere (#1169)', async () => {
+    sendStart.mockResolvedValue({ ok: false, error: 'a session is already active' })
+    const onRunStarted = vi.fn()
+    render(<TicketsPanel projectId="p1" tickets={[]} loaded onRunStarted={onRunStarted} />)
+    fireEvent.click(await screen.findByRole('button', { name: /import tickets from github/i }))
+    expect(await screen.findByText(/already active/i)).toBeTruthy()
+    expect(onRunStarted).not.toHaveBeenCalled()
   })
 
   test('no project renders nothing at all', () => {

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -137,17 +137,24 @@ export default function Page() {
   // route — a selected project's own `runs` (above) carry its rail.
   const { value: recentRuns } = usePolled<RecentRun[]>(projectId === null ? onRecentRuns : null, EMPTY_RECENT, 10_000, [projectId])
 
-  const onRunStarted = (intent: string, startedId?: string, runsOn?: string) => {
+  // A run just started in `inProject`, which is not always the selected one: the onboarding
+  // checklist starts one from the Overview and the settings page, where nothing is selected (#1169).
+  const runStarted = (inProject: string | null, intent: string, startedId?: string, runsOn?: string) => {
     setRunStart(prev => ({ tick: prev.tick + 1, intent, id: startedId ?? null, ...(runsOn ? { runsOn } : {}) }))
     setAdopting(startedId === undefined)
     // The picked context went with that run; the next launch starts from a clean focus (#948).
     resetContext()
     // Go to the run we just started — a real history entry, so Back returns to where you launched
     // from. Its row does not exist yet; the main pane shows it live on the strength of the id.
-    if (startedId !== undefined) go({ projectId, runId: startedId })
+    // With no id yet, land on its project so the effect below can adopt the running one; `go`
+    // no-ops when that is already the URL.
+    go({ projectId: inProject, runId: startedId ?? null })
     // The new run just appends to the rail; reload so its real row shows up quickly.
     reload()
   }
+
+  /** The same, for the surfaces that start a run inside the selected project. */
+  const onRunStarted = (intent: string, startedId?: string, runsOn?: string) => runStarted(projectId, intent, startedId, runsOn)
 
   // The no-id fallback only: adopt the running run as the selection once the poll surfaces it.
   // A correction rather than a step, so it replaces the history entry.
@@ -232,8 +239,8 @@ export default function Page() {
   // run streams its own feed and is steered by its own id (#749).
   const selectedRun = runId ? runs.find(run => run.id === runId) : undefined
   const renderMain = () => {
-    if (view === 'settings') return <SettingsPage onSelectProject={selectProject} onDone={showDashboard} />
-    if (!projectId) return <DashboardPage onSelectProject={selectProject} interventions={interventions} />
+    if (view === 'settings') return <SettingsPage onRunStarted={runStarted} onDone={showDashboard} />
+    if (!projectId) return <DashboardPage onSelectProject={selectProject} onRunStarted={runStarted} interventions={interventions} />
     if (unknownProject)
       return (
         <NotFound


### PR DESCRIPTION
Closes #1169

## Root cause

Not a missing redirect: a redirect that could not carry a run id.

The onboarding checklist renders on the Overview and on `/settings`, and **neither has a project selected**. The shell's `onRunStarted(intent, runId)` closes over the selected project, so on those two surfaces it would have routed to `/null/<runId>`. The checklist therefore used the only project-aware callback it had, `onSelectProject(targetProjectId)`, which resolves to `go({ projectId, runId: null })`, the project's home/launcher. The run really started; the user was just sent to the launcher instead of to it.

## The fix

- The shell's handler is now `runStarted(inProject, intent, startedId, runsOn)`, with the old `onRunStarted` as its bound-to-the-selected-project form for the in-project surfaces. Nothing about those changes: `go` already no-ops when the URL is unchanged, so the previous `if (startedId !== undefined)` guard was only ever avoiding a navigation to where you already were.
- `OnboardingChecklist` hands back the id from `useStartRun().start` **plus** the project the run is in. `DashboardPage` and `SettingsPage` thread it.
- The prop is **required**, so a future surface that mounts the checklist cannot quietly drop the navigation again - the compiler asks for it.
- No id yet (a project with no git checkout gets no worktree, so `start` returns without one) lands on the project, which is what the existing adopt effect needs to pick up the running run and `replace` the history entry with it.
- A refused start already left you in place with `startError` rendered; that is now pinned by a test rather than incidental.

## Sibling actions from the same places

- **`TicketsPanel` ("Import tickets from GitHub" in the session rail's Tickets tab) was already correct**: it passes `result.runId` to `onRunStarted` and the shell's project is the right one there. Added a test pinning it, since it is the same button and the same trap.
- The other checklist rows (add project, Discord bot, browser notifications, Discord webhook) start no run, so they have nothing to navigate to.
- The preset menu paths (`StartRunForm`, `RunComposer`) already pass the started id.
- `ProjectHome` typed its `onRunStarted` as `(intent: string) => void`, dropping the run id from the type of the handler whose whole job is to carry it. Runtime was fine (it forwards the shell's function, which does receive all three arguments), but that is exactly the shape #1169 was, so the type is widened to match. One line.

## Not done here, on purpose

`TicketsPanel` sends its own hardcoded prompt ("Import this repo's open GitHub issues into `tickets/`…") while the checklist sends `presets.importTickets.render()`, which renders to the literal string "Import tickets from GitHub". Same button label, two different prompts to the agent. Unifying them changes what the agent is told, which is a behaviour change to the run rather than to the navigation, so it is left out of a redirect fix. Worth its own issue.

## Verification

- `pnpm typecheck` (root): 22/22 tasks successful.
- `pnpm build` (root): 12/12 tasks successful.
- `packages/framework-dashboard`: **63 files, 458 tests, all passing** (5 new).
- `packages/the-framework`: **1316 tests, 1315 pass, 0 fail, 1 skipped**.

New tests:
- `OnboardingChecklist.test.tsx`: the started run id is handed up with its project; no id hands up `undefined` so the shell can adopt; a refused start says why and calls nothing.
- `TicketsPanel.test.tsx`: the run id reaches `onRunStarted`; a refused import says why and navigates nowhere.

Also ticks the queue entry in `TODO_AGENTS.md` that describes this fix, so the agent does not pick it up again after merge.
