### PR TITLE
fix(the-framework): commit the work a session left behind before handing it off (#1173)

### DIFF
--- a/.changeset/handoff-commits-settled-work.md
+++ b/.changeset/handoff-commits-settled-work.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/the-framework": patch
+---
+
+Commit what a session left in its checkout when its work is handed off, so a settled agent that never committed no longer dead-ends at "No commits between main and the-framework/...". The finishing step also stops calling an empty branch a dead end while the work is sitting uncommitted next to it.

--- a/packages/framework-dashboard/components/RunHandoff.test.tsx
+++ b/packages/framework-dashboard/components/RunHandoff.test.tsx
@@ -88,6 +88,16 @@ describe('run handoff (#799)', () => {
     expect(screen.getByText('Nothing committed — no PR to open.')).toBeTruthy()
   })
 
+  test('an empty branch with work waiting in the tree is offered, not called a dead end (#1173)', async () => {
+    onRunHandoff.mockResolvedValue({ ...worked, commits: [], files: [], insertions: 0, deletions: 0, empty: true, pending: 2 })
+    render(<Harness />)
+    // The agent commits what it found and nothing it wrote, so a settled session holding its whole
+    // output in the tree is the ordinary case, not a session that did nothing. Opening the PR
+    // commits what is waiting, so the button is offered.
+    await waitFor(() => expect(screen.getByText('Open PR')).toBeTruthy())
+    expect(screen.queryByText('Nothing committed — no PR to open.')).toBeNull()
+  })
+
   test('a branch that is gone is reported, not shown as work', async () => {
     onRunHandoff.mockResolvedValue({ ...worked, exists: false, commits: [], files: [], empty: true })
     render(<Harness />)

--- a/packages/framework-dashboard/components/RunHandoff.tsx
+++ b/packages/framework-dashboard/components/RunHandoff.tsx
@@ -166,13 +166,16 @@ export function HandoffActions({
   // From here every branch says something. A session that has finished and shows no control at all
   // is #1173: the reason there is nothing to press is exactly what the reader came for.
   if (!handoff.exists) return <Reason>Branch gone — nothing to open a PR from.</Reason>
-  // The case Rom hit: the agent wrote files and never committed, so the branch holds nothing to
-  // propose. Said plainly, because the tree reads "dirty" right beside it and the two together
-  // are the whole story.
-  if (handoff.empty) return <Reason>Nothing committed — no PR to open.</Reason>
+  // A branch with no commits and nothing waiting in the tree: the session genuinely produced
+  // nothing. Said plainly, rather than shown as a button that could only fail (#1173).
+  //
+  // Uncommitted work is the other half of that case and is not a dead end: the agent commits what
+  // it found before it starts and nothing at the end, so its whole output routinely sits in the
+  // tree. Opening the PR commits it first, so the button is offered rather than explained away.
+  if (handoff.empty && !handoff.pending) return <Reason>Nothing committed — no PR to open.</Reason>
   if (!handoff.hasRemote) return <Reason>No remote to push to.</Reason>
   // One button, not two (#1173). "Push branch" and "Open PR" sat side by side as equals, and
-  // neither Rom nor Suleiman could say what pushing without a PR was for — a control nobody can
+  // nobody could say what pushing without a PR was for — a control nobody can
   // explain is a control nobody should have to read. Opening a PR pushes the branch on the way,
   // so the one that names the outcome is the one that stays. Pushing alone is still reachable as
   // a session setting for anyone who wants it, it just no longer competes here.

--- a/packages/the-framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/the-framework/src/dashboard-rpc/control.telefunc.ts
@@ -8,7 +8,7 @@ import { appendFlatTodoEntry } from '../todo-loop.js'
 import { TICKETS_DIR, todoPriorityForTicket } from '../tickets.js'
 import { findRun, isSafeRunId, type RunMeta } from '../store/index.js'
 import { removeProjectWorktree, deleteProjectRun } from '../worktrees.js'
-import { openSessionPullRequest, pushRunBranch, runBranchFor, type HandoffResult } from '../dashboard/run-handoff.js'
+import { commitSessionWork, openSessionPullRequest, pushRunBranch, runBranchFor, type HandoffResult } from '../dashboard/run-handoff.js'
 import type { ChoiceBy } from '../events.js'
 import type {
   DeleteSessionResult,
@@ -249,11 +249,17 @@ export async function sendOpenInApp(projectId: string, target: OpenTarget, runId
  * The session's own branch, or undefined when the run/project is unknown. Shared by the two
  * handoff actions so they address exactly what {@link onRunHandoff} reports on.
  */
-async function handoffTargetFor(projectId: string, runId: string): Promise<{ cwd: string; run: RunMeta } | undefined> {
+async function handoffTargetFor(
+  projectId: string,
+  runId: string,
+): Promise<{ cwd: string; run: RunMeta; checkout: string } | undefined> {
   const cwd = await resolveProjectPath(projectId)
   if (!cwd || !isSafeRunId(runId)) return undefined
   const run = await findRun(cwd, runId).catch(() => undefined)
-  return run ? { cwd, run } : undefined
+  // The branch is read from the project repo; the tree the agent edited is its own checkout (#453),
+  // and for a session that has not committed, that is the only place its work exists.
+  const checkout = (await resolveRunPath(projectId, runId)) ?? cwd
+  return run ? { cwd, run, checkout } : undefined
 }
 
 /**
@@ -266,7 +272,11 @@ export async function sendPushBranch(projectId: string, runId: string): Promise<
   return relayOr(runId, 'sendPushBranch', [projectId, runId], async () => {
     const target = await handoffTargetFor(projectId, runId)
     if (!target) return { ok: false, error: 'unknown session' }
-    return pushRunBranch(target.cwd, runBranchFor(target.run))
+    const branch = runBranchFor(target.run)
+    if (!(await commitSessionWork(target.checkout, target.cwd, branch))) {
+      return { ok: false, error: 'could not commit the work this session left uncommitted' }
+    }
+    return pushRunBranch(target.cwd, branch)
   }, { ok: false, error: 'could not reach the device' })
 }
 
@@ -281,6 +291,9 @@ export async function sendOpenPullRequest(projectId: string, runId: string): Pro
   return relayOr(runId, 'sendOpenPullRequest', [projectId, runId], async () => {
     const target = await handoffTargetFor(projectId, runId)
     if (!target) return { ok: false, error: 'unknown session' }
+    if (!(await commitSessionWork(target.checkout, target.cwd, runBranchFor(target.run)))) {
+      return { ok: false, error: 'could not commit the work this session left uncommitted' }
+    }
     return openSessionPullRequest(target.cwd, target.run)
   }, { ok: false, error: 'could not reach the device' })
 }

--- a/packages/the-framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/the-framework/src/dashboard-rpc/reads.telefunc.ts
@@ -318,7 +318,12 @@ export async function onRunHandoff(projectId: string, runId: string): Promise<Ru
     if (!cwd || !isSafeRunId(runId)) return null
     const run = await findRun(cwd, runId).catch(() => undefined)
     if (!run) return null
-    return (await readRunHandoff(cwd, runBranchFor(run)).catch(() => undefined)) ?? null
+    // Uncommitted work is the one thing the branch cannot answer (#1173), and it lives in the tree
+    // the agent edited. Only when that is a checkout of the session's own: per the note above,
+    // `resolveRunPath` falls back to the project root, whose dirt belongs to the user.
+    const checkout = await resolveRunPath(projectId, runId)
+    const deps = checkout && checkout !== cwd ? { checkout } : {}
+    return (await readRunHandoff(cwd, runBranchFor(run), deps).catch(() => undefined)) ?? null
   }, null)
 }
 

--- a/packages/the-framework/src/dashboard/run-handoff.test.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
-import { readRunHandoff, runBranchFor, pushRunBranch, openRunPullRequest, gitReason, runAutoHandoff, isSessionBranch, prBaseName } from './run-handoff.js'
+import { readRunHandoff, runBranchFor, pushRunBranch, openRunPullRequest, gitReason, runAutoHandoff, isSessionBranch, prBaseName, commitSessionWork } from './run-handoff.js'
 import { nodeGitRunner, GIT_SLOW_TIMEOUT_MS, type GitRunner } from '../project.js'
 import { CliTimeoutError, isCliTimeout } from '../cli-exec.js'
 
@@ -444,4 +444,99 @@ test('the PR base is the remote branch name, not the tracking ref (#1102)', asyn
   const at = ghCalls[0]?.indexOf('--base') ?? -1
   assert.notEqual(at, -1, 'the base should still be passed')
   assert.equal(ghCalls[0]?.[at + 1], 'main')
+})
+
+test('uncommitted work is counted from the session checkout, not the project (#1173)', async () => {
+  const { git, calls } = fakeGit({
+    ...REPO,
+    'rev-parse --verify --quiet refs/heads/the-framework/dirty': 'abc123\n',
+    remote: 'origin\n',
+    'symbolic-ref': 'origin/main\n',
+    log: '',
+    diff: '',
+    'rev-parse --verify --quiet refs/remotes': '',
+    branch: '',
+    status: ' M src/app.ts\n?? src/new.ts\n',
+  })
+  const handoff = await readRunHandoff('/repo', 'the-framework/dirty', {
+    git,
+    pr: async () => undefined,
+    checkout: '/repo/.the-framework/worktrees/r1',
+  })
+  // The branch really is empty; the work is real and sitting next to it. Both are true at once,
+  // which is the whole of #1173.
+  assert.equal(handoff?.empty, true)
+  assert.equal(handoff?.pending, 2)
+  assert.ok(calls.some(args => args[0] === 'status'), 'the checkout should have been asked')
+})
+
+test('pending is absent, not zero, when no session checkout was given (#1173)', async () => {
+  const { git, calls } = fakeGit({
+    ...REPO,
+    'rev-parse --verify --quiet refs/heads/the-framework/quiet': 'abc123\n',
+    remote: 'origin\n',
+    'symbolic-ref': 'origin/main\n',
+    log: '',
+    diff: '',
+    'rev-parse --verify --quiet refs/remotes': '',
+    branch: '',
+  })
+  const handoff = await readRunHandoff('/repo', 'the-framework/quiet', { git, pr: async () => undefined })
+  // "Nobody asked" must not read as "asked, tree clean": only the second may be shown as a dead end.
+  assert.equal(handoff?.pending, undefined)
+  assert.ok(!calls.some(args => args[0] === 'status'), 'no checkout means no status read')
+})
+
+test('commitSessionWork leaves the project checkout and other branches alone (#1173)', async () => {
+  const onBranch = fakeGit({ 'rev-parse --abbrev-ref HEAD': 'main\n' })
+  // The checkout IS the project root: the dirt there is the user's, whatever branch it is on. This
+  // is what `resolveRunCheckout` falls back to once a session's worktree is gone.
+  assert.equal(await commitSessionWork('/repo', '/repo', 'the-framework/x', onBranch.git), true)
+  assert.equal(onBranch.calls.length, 0, 'the project root should not even be inspected')
+
+  // Its own checkout, but parked on another branch: not this session's work to commit.
+  const elsewhere = fakeGit({ 'rev-parse --abbrev-ref HEAD': 'main\n' })
+  assert.equal(await commitSessionWork('/wt', '/repo', 'the-framework/x', elsewhere.git), true)
+  assert.ok(!elsewhere.calls.some(args => args[0] === 'commit'), 'nothing should be committed')
+})
+
+test('a real repo: the finishing step commits what the agent left in its worktree (#1173)', async () => {
+  // Rom's dead-end session, reproduced end to end: the agent edited a file, never committed, and
+  // the branch was 0 commits ahead, so `gh pr create` could only answer "No commits between main
+  // and the-framework/run-r1".
+  const dir = await mkdtemp(join(tmpdir(), 'handoff-settle-'))
+  const git = nodeGitRunner()
+  const branch = 'the-framework/run-r1'
+  try {
+    await exec('git', ['init', '-b', 'main', dir])
+    await exec('git', ['config', 'user.email', 'test@example.com'], { cwd: dir })
+    await exec('git', ['config', 'user.name', 'Test'], { cwd: dir })
+    await writeFile(join(dir, 'README.md'), 'base\n')
+    await exec('git', ['add', '-A'], { cwd: dir })
+    await exec('git', ['commit', '-m', 'base'], { cwd: dir })
+
+    // The session's own checkout, as #453 allocates it.
+    const checkout = join(dir, '.the-framework', 'worktrees', 'r1')
+    await exec('git', ['worktree', 'add', '-b', branch, checkout], { cwd: dir })
+    await writeFile(join(checkout, 'index.html'), '<h1>hi</h1>\n')
+
+    const before = await readRunHandoff(dir, branch, { git, pr: async () => undefined, checkout })
+    assert.equal(before?.empty, true, 'the branch carries nothing yet')
+    assert.equal(before?.pending, 1, 'and the work is sitting in the checkout')
+
+    assert.equal(await commitSessionWork(checkout, dir, branch, git), true)
+
+    const after = await readRunHandoff(dir, branch, { git, pr: async () => undefined, checkout })
+    assert.equal(after?.empty, false, 'the work is on the branch now, so a PR has something to say')
+    assert.equal(after?.pending, 0)
+    assert.deepEqual(after?.commits.map(c => c.subject), ['[The Framework] uncommitted changes'])
+    assert.deepEqual(after?.files.map(f => f.path), ['index.html'])
+
+    // Idempotent: pressing the button twice must not make an empty commit.
+    assert.equal(await commitSessionWork(checkout, dir, branch, git), true)
+    const again = await readRunHandoff(dir, branch, { git, pr: async () => undefined, checkout })
+    assert.equal(again?.commits.length, 1)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
 })

--- a/packages/the-framework/src/dashboard/run-handoff.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.ts
@@ -3,7 +3,7 @@ import { cachedPrView, forgetPr, ghPrView, nodeGhRunner, type GhRunner, type Lin
 import { parseNumstat } from './file-diff.js'
 import { errorMessage } from '../error-message.js'
 import type { AutoHandoffSkip } from '../events.js'
-import type { RunMeta } from '../store/index.js'
+import { commitPendingWork, currentBranch, type RunMeta } from '../store/index.js'
 
 // What a finished session produced, and what is left to do with it (#799).
 //
@@ -64,12 +64,26 @@ export interface RunHandoff {
   pr?: LinkedPr
   /** The PR is not known yet, rather than absent (#1028): the lookup is still running. */
   prPending?: boolean
+  /**
+   * Files the session changed and never committed, counted in its own checkout (#1173).
+   *
+   * The agent is instructed to commit what it *found*, never what it *wrote*, so a settled session
+   * can hold its whole output in an uncommitted tree. That work is not on the branch yet, so it is
+   * not in {@link commits} and it does not make {@link empty} false. Absent when the caller did not
+   * say which checkout the session worked in.
+   */
+  pending?: number
 }
 
-/** Injectable seams so the reader is unit-testable off disk. */
+/** Injectable seams so the reader is unit-testable off disk, plus the checkout the session worked in. */
 export interface RunHandoffDeps {
   git?: GitRunner
   pr?: BranchPrLookup
+  /**
+   * The session's own checkout (#453), when it has one. The branch lives in the project repo and is
+   * read from there; uncommitted work does not, it sits in the tree the agent actually edited.
+   */
+  checkout?: string
 }
 
 /**
@@ -151,8 +165,9 @@ export async function readRunHandoff(
 
   const tip = (await run(['rev-parse', '--verify', '--quiet', `refs/heads/${branch}`])).trim()
   const hasRemote = (await run(['remote'])).trim().length > 0
+  const pending = await countPendingWork(git, deps.checkout)
   if (!tip) {
-    return { branch, exists: false, commits: [], files: [], insertions: 0, deletions: 0, empty: true, hasRemote, pushed: false, merged: false }
+    return { branch, exists: false, commits: [], files: [], insertions: 0, deletions: 0, empty: true, hasRemote, pushed: false, merged: false, ...pending }
   }
 
   const base = await detectBase(run)
@@ -201,7 +216,51 @@ export async function readRunHandoff(
     merged: mergedOut.trim().length > 0,
     ...(pr.value ? { pr: pr.value } : {}),
     ...(pr.pending ? { prPending: true } : {}),
+    ...pending,
   }
+}
+
+/**
+ * How many files the session left uncommitted in its own checkout, as a spreadable field.
+ *
+ * Absent rather than 0 when no checkout was given: "nobody asked" and "asked, nothing pending" are
+ * different answers, and only the second one may be shown as a clean tree.
+ */
+async function countPendingWork(git: GitRunner, checkout: string | undefined): Promise<{ pending?: number }> {
+  if (!checkout) return {}
+  const status = await git(['status', '--porcelain'], checkout).catch(() => undefined)
+  if (status === undefined) return {}
+  const lines = status.split('\n').filter(line => line.trim().length > 0)
+  return { pending: lines.length }
+}
+
+/**
+ * Commit what a session left uncommitted, so what it did is what gets handed off (#1173).
+ *
+ * The agent is instructed to commit what it *found* before it starts, and nothing at the end, so a
+ * settled session routinely holds its whole output in an uncommitted tree: the branch carries no
+ * commit and a button offering to publish it can only fail with GitHub's "No commits between ...".
+ * The automatic handoff already commits this on the run's way out, but that happens when the run
+ * process exits, and the finishing step is offered as soon as the agent settles (#1178), which for
+ * a session left open for another turn is much earlier. Pressing the button is the same instruction
+ * given by hand, so it does the same thing rather than reporting a dead end.
+ *
+ * Two guards, because both failure modes end with the user's own work committed for them: the
+ * checkout has to be the session's own (#453) rather than the project root that `resolveRunCheckout`
+ * falls back to once a worktree is gone, and it has to be sitting on the session's branch.
+ *
+ * Returns whether the handoff may go ahead: true when there was nothing to do, when the guards say
+ * this is not ours to commit, or when the commit succeeded.
+ */
+export async function commitSessionWork(
+  checkout: string,
+  projectCwd: string,
+  branch: string,
+  git: GitRunner = nodeGitRunner(),
+): Promise<boolean> {
+  if (checkout === projectCwd) return true
+  if ((await currentBranch(checkout, git)) !== branch) return true
+  return commitPendingWork(checkout, git)
 }
 
 /** The outcome of a handoff action, in the `{ ok }` shape the dashboard's `useAction` understands. */


### PR DESCRIPTION
Part of #1173 (follow-up 1 and 2 of the three left on the issue).

## The dead end

A session finished, offered **Open PR**, and pressing it returned:

```
GraphQL: No commits between main and the-framework/run-2026-07-25T17-18-10-650Z
```

#1181 fixed the *button* so it stops offering a PR for a branch with no commits. This fixes the *cause*: the work was never committed at all.

The agent is instructed to commit what it **found** before it starts (`prompts/system_prompt.md`, "If the repository has uncommitted changes, create a commit"), and nothing at the end. `store/worktree.ts` already says so out loud: "the system prompt has it commit *pre-existing* changes before it starts, never its own work at the end." So a settled session routinely holds its entire output in an uncommitted tree.

The framework does commit that work, in two places, and neither one covers the click:

| path | when | covers the click? |
|---|---|---|
| `maybeAutoHandoff` (`cli.ts`) | when the run **process exits** | no: the finishing step is offered as soon as the agent **settles** (#1178), and a session left open for another turn has not exited |
| `tearDownWorktree` (`daemon-runtime.ts`) | when the worktree is retired | no: same, and it only runs for `status: done` |

`sendOpenPullRequest` / `sendPushBranch` did neither. They also addressed the **project** checkout, while the uncommitted work is in the session's own checkout (#453).

## The fix

`commitSessionWork(checkout, projectCwd, branch, git)` in `dashboard/run-handoff.ts`, called by both handoff RPCs before they push or open. Pressing the button is the same instruction the automatic handoff carries out, so it now does the same thing.

Two guards, because both failure modes end with the user's own work committed for them:

1. the checkout has to be the session's own, not the project root that `resolveRunCheckout` falls back to once a worktree is gone (the hazard `onRunHandoff` already documents),
2. and it has to be sitting on the session's branch.

Either guard failing means "not ours to commit", and the handoff proceeds untouched rather than erroring.

## The reader stops lying too

`RunHandoff` gains `pending`: files the session changed and never committed, counted in its own checkout. It is `undefined` when the caller did not say which checkout the session used, because "nobody asked" and "asked, tree clean" are different answers and only the second may be drawn as a dead end.

So the bar no longer prints `Nothing committed - no PR to open.` over a tree holding the whole session. That message is now reserved for a branch with no commits **and** nothing waiting.

## What is deliberately not here

Item 2 on the issue asks that the agent **ask in the chat** whether to commit, before it settles. That half is not in this PR, for two reasons worth a decision on the issue:

- it lives in `prompts/system_prompt.md`, which `check-prompt-drift.mjs` holds byte-for-byte against the `md` block in #326, so it has to be changed there first;
- asking would **deadlock an unattended run**. The autonomous queue drain has nobody to answer, so for the routine work the answer has to be "commit", which is what this PR does. If the ask is added, it should be for interactive sessions only.

Item 3 (one row in the launcher gear) already shipped in #1181.

## Checks

- `pnpm typecheck`: clean, 22/22 tasks.
- `packages/the-framework`: 1319 pass, 0 fail, 1 skipped.
- `packages/framework-dashboard`: 455 pass, 0 fail.
- New: a real-git test that builds a project repo plus a real `git worktree`, writes a file without committing, and asserts the branch reads `empty: true, pending: 1`, then reads `empty: false` with the work on it after the handoff commits, and that pressing twice does not make an empty commit. Plus both guards, and the reader's absent-vs-zero distinction.
- One unrelated flake seen once in `PreviewControls` (`sendPreview` with 'p2') and not again in two further full runs.

Also removed two personal names from a code comment in `RunHandoff.tsx`. There are around ten more elsewhere in `packages/the-framework/src`; a mechanical sweep for those does not belong in this PR.

Closes #1173
