### PR TITLE
feat(dashboard): show routine work and let it be run now (#1159)

### DIFF
--- a/.changeset/routine-work-run-now.md
+++ b/.changeset/routine-work-run-now.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/the-framework": minor
+---
+
+Show the routine work on the Overview: the jobs the idle sweep fires (drain the queue, harvest quick-wins, triage, spike & plan, the maintenance sweep), each with a "Run now" button that starts it against a project immediately, plus the single auto-run checkbox that says when the next sweep is due. The list is the daemon's own job table rather than a copy, so the two cannot drift.

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -11,6 +11,7 @@ import { usePolled } from '../lib/use-async.js'
 import { usePreferences } from '../lib/preferences.js'
 import { OnboardingChecklist } from './OnboardingChecklist.js'
 import { HotTickets } from './HotTickets.js'
+import { RoutineWork } from './RoutineWork.js'
 import { cn } from '../lib/utils.js'
 import { queueEntryLabel } from '../lib/queue-entry.js'
 import { formatDateTime, formatRelative } from '../lib/format-date.js'
@@ -45,6 +46,10 @@ export function DashboardPage({
         <NeedsYou items={interventions} onSelectProject={onSelectProject} />
 
         <HotTickets onSelectProject={onSelectProject} />
+
+        {/* The scheduled jobs, and the button that fires one now (#1159). Above the tiles: it is
+            something to do, and the rest of the page is something to read. */}
+        <RoutineWork onSelectProject={onSelectProject} />
 
         {data === null ? (
           <p className="text-sm text-muted-foreground">Loading…</p>

--- a/packages/framework-dashboard/components/Quota.tsx
+++ b/packages/framework-dashboard/components/Quota.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import type { AutoPmReport, DriverQuotaWindow, QuotaBoundaryStatus, QuotaView } from '@gemstack/the-framework'
 import { MAX_SPEND_OFFSET } from '@gemstack/the-framework/client'
 import { useAutoPm, useQuota } from '../lib/quota.js'
-import { formatRelative } from '../lib/format-date.js'
+import { formatRelative, formatUntil } from '../lib/format-date.js'
 import { usePreferences, updatePreferences } from '../lib/preferences.js'
 import { weekTicks, quotaTone, limitPercent, TONE_NOTE, type QuotaTone } from '../lib/quota-bar.js'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card.js'
@@ -194,15 +194,6 @@ function useSpendOffset(serverOffset: number | undefined): [number, (offset: num
   ]
 }
 
-/** How long until `at`, as "in 4 min" / "in 1 hr". Past due reads as "any moment". */
-function untilText(at: number): string {
-  const minutes = Math.round((at - Date.now()) / 60_000)
-  if (minutes <= 0) return 'any moment'
-  if (minutes < 60) return `in ${minutes} min`
-  const hours = Math.round(minutes / 60)
-  return `in ${hours} hr`
-}
-
 /** The repo a line is about, by the name you would call it: its directory. */
 function projectName(path: string): string {
   return path.split(/[\\/]/).filter(Boolean).pop() ?? path
@@ -222,7 +213,7 @@ function AutoPmStatus({ report }: { report: AutoPmReport }) {
   return (
     <div className="space-y-0.5 text-xs text-muted-foreground">
       <p>
-        Last checked {formatRelative(new Date(report.sweptAt).toISOString())} · next {untilText(report.nextSweepAt)}
+        Last checked {formatRelative(new Date(report.sweptAt).toISOString())} · next {formatUntil(report.nextSweepAt)}
       </p>
       {report.outcomes.length === 0 ? (
         <p>No projects to work on.</p>

--- a/packages/framework-dashboard/components/RoutineWork.test.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.test.tsx
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { AutoPmReport, Preferences, ProjectSummary } from '@gemstack/the-framework'
+import { AUTO_PM_ROUTINES, AUTO_PM_DRAIN_JOB } from '@gemstack/the-framework/client'
+
+// Everything the card reads goes through a lib module, so the mocks stop short of telefunc: an
+// unmocked `*.telefunc.js` in the import graph fails as an assertIsNotBrowser bug report.
+const onProjects = vi.hoisted(() => vi.fn())
+vi.mock('../server/projects.telefunc.js', () => ({ onProjects }))
+
+const updatePreferences = vi.hoisted(() => vi.fn())
+let prefs: Preferences = {}
+vi.mock('../lib/preferences.js', () => ({ usePreferences: () => prefs, updatePreferences }))
+
+let autoPm: AutoPmReport | undefined
+vi.mock('../lib/quota.js', () => ({ useAutoPm: () => autoPm, useQuota: () => undefined }))
+
+const start = vi.hoisted(() => vi.fn())
+let busy = false
+let startError: string | null = null
+vi.mock('../lib/use-start-run.js', () => ({
+  useStartRun: () => ({ busy, error: startError, reset: () => {}, start }),
+}))
+
+const { RoutineWork } = await import('./RoutineWork.js')
+
+const project = (id: string, name: string): ProjectSummary => ({ id, path: `/repos/${name}`, name, activated: true })
+
+beforeEach(() => {
+  prefs = {}
+  autoPm = undefined
+  busy = false
+  startError = null
+  onProjects.mockResolvedValue([project('p1', 'gemstack')])
+  start.mockReset()
+  start.mockResolvedValue({ ok: true, runId: 'run-1' })
+  updatePreferences.mockReset()
+})
+afterEach(cleanup)
+
+describe('RoutineWork (#1159)', () => {
+  test('lists every routine the sweep can fire, by its preset label', async () => {
+    render(<RoutineWork onSelectProject={() => {}} />)
+    await waitFor(() => expect(screen.getAllByText('Run now').length).toBe(AUTO_PM_ROUTINES.length))
+    for (const job of AUTO_PM_ROUTINES) expect(screen.getByText(job.label ?? job.name)).toBeTruthy()
+  })
+
+  test('Run now starts the routine prompt verbatim and jumps into the project', async () => {
+    let picked: string | null = null
+    render(<RoutineWork onSelectProject={id => (picked = id)} />)
+    await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
+    fireEvent.click(screen.getAllByText('Run now')[0]!)
+    // The drain job leads the list, and its prompt travels unchanged: this is the fast-forward.
+    await waitFor(() => expect(start).toHaveBeenCalled())
+    const [projectId, prompt, kind] = start.mock.calls[0]!
+    expect(projectId).toBe('p1')
+    expect(prompt).toBe(AUTO_PM_DRAIN_JOB.prompt)
+    expect(kind).toBe('prompt')
+    await waitFor(() => expect(picked).toBe('p1'))
+  })
+
+  test('a failed start neither navigates nor leaves the button stuck on Starting', async () => {
+    start.mockResolvedValue(undefined)
+    startError = 'A session is already active for this project.'
+    let picked: string | null = null
+    render(<RoutineWork onSelectProject={id => (picked = id)} />)
+    await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
+    fireEvent.click(screen.getAllByText('Run now')[0]!)
+    await waitFor(() => expect(start).toHaveBeenCalled())
+    expect(picked).toBeNull()
+    await waitFor(() => expect(screen.queryByText('Starting…')).toBeNull())
+    expect(screen.getByRole('alert').textContent).toMatch(/already active/)
+  })
+
+  test('with auto-run on and a reported sweep, the box says when it next runs', async () => {
+    prefs = { autoPm: true }
+    autoPm = { enabled: true, sweptAt: Date.now(), nextSweepAt: Date.now() + 2 * 60 * 60_000, outcomes: [] }
+    render(<RoutineWork onSelectProject={() => {}} />)
+    await waitFor(() => expect(screen.getByText('Auto-runs in 2 hr')).toBeTruthy())
+  })
+
+  test('with auto-run off, or before the daemon has reported, it says only what it does', async () => {
+    prefs = { autoPm: true }
+    autoPm = undefined
+    const { rerender } = render(<RoutineWork onSelectProject={() => {}} />)
+    // On, but no sweep has reported yet: a countdown here would be invented.
+    await waitFor(() => expect(screen.getByText('Auto-run')).toBeTruthy())
+    prefs = {}
+    rerender(<RoutineWork onSelectProject={() => {}} />)
+    expect(screen.getByText('Auto-run')).toBeTruthy()
+  })
+
+  test('the checkbox is the one global preference, and carries the tooltip', async () => {
+    render(<RoutineWork onSelectProject={() => {}} />)
+    await waitFor(() => expect(screen.getByText('Auto-run')).toBeTruthy())
+    // One box for the whole card (#1159): a per-routine box flipping a global switch would lie.
+    expect(screen.getAllByRole('checkbox')).toHaveLength(1)
+    fireEvent.click(screen.getByText('Auto-run'))
+    expect(updatePreferences).toHaveBeenCalledWith({ autoPm: true })
+    expect(screen.getByTitle('Automatically run this prompt on a regular schedule.')).toBeTruthy()
+  })
+
+  test('several projects get a picker, and Run now honours it', async () => {
+    onProjects.mockResolvedValue([project('p1', 'gemstack'), project('p2', 'rudder')])
+    render(<RoutineWork onSelectProject={() => {}} />)
+    const select = await screen.findByLabelText('Run in')
+    fireEvent.change(select, { target: { value: 'p2' } })
+    fireEvent.click(screen.getAllByText('Run now')[0]!)
+    await waitFor(() => expect(start).toHaveBeenCalled())
+    expect(start.mock.calls[0]![0]).toBe('p2')
+  })
+
+  test('one project needs no picker', async () => {
+    render(<RoutineWork onSelectProject={() => {}} />)
+    await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
+    expect(screen.queryByLabelText('Run in')).toBeNull()
+  })
+
+  test('with no project there is nothing to run a routine in, and it says so', async () => {
+    onProjects.mockResolvedValue([])
+    render(<RoutineWork onSelectProject={() => {}} />)
+    await waitFor(() => expect(screen.getByText('Add a project to run a routine.')).toBeTruthy())
+    expect(screen.queryByText('Run now')).toBeNull()
+  })
+
+  test('a start already in flight disables every Run now', async () => {
+    busy = true
+    render(<RoutineWork onSelectProject={() => {}} />)
+    await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
+    for (const button of screen.getAllByText('Run now')) expect((button as HTMLButtonElement).disabled).toBe(true)
+  })
+})

--- a/packages/framework-dashboard/components/RoutineWork.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react'
+import type { AutoPmJob, ProjectSummary } from '@gemstack/the-framework'
+import { AUTO_PM_ROUTINES, runOptionsFromPreferences } from '@gemstack/the-framework/client'
+import { CalendarClock, Play } from 'lucide-react'
+import { onProjects } from '../server/projects.telefunc.js'
+import { useAutoPm } from '../lib/quota.js'
+import { usePreferences, updatePreferences } from '../lib/preferences.js'
+import { useStartRun } from '../lib/use-start-run.js'
+import { useLoaded } from '../lib/use-async.js'
+import { formatUntil } from '../lib/format-date.js'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card.js'
+import { Button } from './ui/button.js'
+import { Checkbox } from './ui/checkbox.js'
+
+// The Overview's "Routine work" card (#1159): the jobs the idle sweep fires on a schedule, each with
+// a Run now button that starts it against a project immediately.
+//
+// The list is `AUTO_PM_ROUTINES` itself, straight off the browser-safe client entry, so what is on
+// screen is what the daemon runs rather than a second copy of it: no read of its own, and no way
+// for the two to drift. Run now takes the same path the launcher does (`sendStart` with the job's
+// prompt verbatim), so it starts the work now instead of asking the sweep to come round sooner.
+//
+// One auto-run checkbox for the whole card, not one per row: there is a single `autoPm` preference
+// (#685), and a per-row box that flipped a global switch would be a lie about what it controls.
+
+/** Captured once: `useLoaded` treats a fresh `[]` literal as a new value on every render. */
+const NO_PROJECTS: ProjectSummary[] = []
+
+export function RoutineWork({ onSelectProject }: { onSelectProject: (id: string) => void }) {
+  const projects = useLoaded<ProjectSummary[]>(onProjects, NO_PROJECTS, [])
+  const preferences = usePreferences()
+  const report = useAutoPm()
+  const { busy, error, start } = useStartRun()
+  const [picked, setPicked] = useState<string | null>(null)
+  // Which routine is in flight, so only its own button says "Starting…".
+  const [starting, setStarting] = useState<string | null>(null)
+
+  // The list arrives after the first render, and a project can be removed under a stale pick, so
+  // the selection is validated against what is actually there rather than trusted.
+  const projectId = (picked !== null && projects.some(p => p.id === picked) ? picked : projects[0]?.id) ?? null
+
+  const autoRun = preferences.autoPm ?? false
+  // The countdown is the sweep's, and the sweep only reports once the daemon has run one. With
+  // auto-run off, or before that first report, the box says what it does instead of when.
+  const autoRunLabel =
+    autoRun && report?.nextSweepAt !== undefined ? `Auto-runs ${formatUntil(report.nextSweepAt)}` : 'Auto-run'
+
+  const runNow = async (job: AutoPmJob) => {
+    if (!projectId || busy) return
+    setStarting(job.name)
+    // The global options only: the Overview has no project open, so the per-project tier (#840) is
+    // not resolved here and the run starts on the same defaults a fresh launcher would use.
+    const result = await start(projectId, job.prompt, 'prompt', runOptionsFromPreferences(preferences))
+    setStarting(null)
+    // Jump into the project that is now working: the Overview has no view of a live run, and the
+    // point of the button is to watch what it started.
+    if (result) onSelectProject(projectId)
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <CalendarClock className="h-4 w-4 text-muted-foreground" />
+          Routine work
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {projects.length === 0 ? (
+          <p className="py-2 text-sm text-muted-foreground">Add a project to run a routine.</p>
+        ) : (
+          <>
+            {projects.length > 1 && (
+              <div className="flex items-center gap-2 text-sm">
+                <label htmlFor="routine-project" className="text-muted-foreground">
+                  Run in
+                </label>
+                <select
+                  id="routine-project"
+                  className="min-w-0 flex-1 rounded-md border border-border bg-transparent px-2 py-1 text-sm"
+                  value={projectId ?? ''}
+                  onChange={e => setPicked(e.target.value)}
+                >
+                  {projects.map(p => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            <ul className="divide-y divide-border">
+              {AUTO_PM_ROUTINES.map(job => (
+                <li key={job.name} className="flex items-center gap-3 py-2 first:pt-0">
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium">{job.label ?? job.name}</span>
+                    <span className="block truncate text-xs text-muted-foreground">{job.describe}</span>
+                  </span>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="xs"
+                    disabled={busy || !projectId}
+                    onClick={() => void runNow(job)}
+                  >
+                    <Play className="h-3 w-3" aria-hidden />
+                    {starting === job.name ? 'Starting…' : 'Run now'}
+                  </Button>
+                </li>
+              ))}
+            </ul>
+
+            {error && (
+              <p role="alert" className="text-xs text-danger">
+                {error}
+              </p>
+            )}
+
+            {/* The same `autoPm` preference the usage panel offers (#1161), which is the point: one
+                switch, shown where the schedule it governs is listed. */}
+            <div className="border-t border-border pt-3">
+              <label
+                className="flex cursor-pointer items-center gap-1.5 text-sm"
+                title="Automatically run this prompt on a regular schedule."
+              >
+                <Checkbox checked={autoRun} onCheckedChange={checked => updatePreferences({ autoPm: checked })} />
+                <span className="font-medium text-foreground">{autoRunLabel}</span>
+              </label>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Only while nothing else is running and the week&apos;s allowance is not already spent.
+              </p>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/packages/framework-dashboard/lib/format-date.test.ts
+++ b/packages/framework-dashboard/lib/format-date.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { formatDate, formatDateTime } from './format-date.js'
+import { formatDate, formatDateTime, formatUntil } from './format-date.js'
 
 describe('format-date (#759)', () => {
   test('formats a real timestamp', () => {
@@ -23,5 +23,18 @@ describe('format-date (#759)', () => {
   test('the caller can word the fallback', () => {
     expect(formatDateTime(undefined, 'no activity yet')).toBe('no activity yet')
     expect(formatDateTime('nonsense', 'no activity yet')).toBe('no activity yet')
+  })
+})
+
+describe('formatUntil (#1161/#1159)', () => {
+  test('counts down in minutes, then in hours', () => {
+    expect(formatUntil(Date.now() + 4 * 60_000)).toBe('in 4 min')
+    expect(formatUntil(Date.now() + 2 * 60 * 60_000)).toBe('in 2 hr')
+  })
+
+  test('a schedule already due reads as imminent, not as late', () => {
+    // The daemon ticks on its own clock, so "past due" here only ever means "about to happen".
+    expect(formatUntil(Date.now() - 60_000)).toBe('any moment')
+    expect(formatUntil(Date.now())).toBe('any moment')
   })
 })

--- a/packages/framework-dashboard/lib/format-date.ts
+++ b/packages/framework-dashboard/lib/format-date.ts
@@ -36,6 +36,19 @@ export function formatDate(value: string | undefined, fallback = '—'): string 
 }
 
 /**
+ * How long until `at` (epoch ms), as "in 4 min" / "in 1 hr". Past due reads as "any moment": a
+ * schedule the daemon has not reached yet is imminent, not late. Shared by the usage panel's
+ * next-sweep line (#1161) and the routines card's auto-run label (#1159).
+ */
+export function formatUntil(at: number): string {
+  const minutes = Math.round((at - Date.now()) / 60_000)
+  if (minutes <= 0) return 'any moment'
+  if (minutes < 60) return `in ${minutes} min`
+  const hours = Math.round(minutes / 60)
+  return `in ${hours} hr`
+}
+
+/**
  * A timestamp as freshness (#948): "just now" / "12m ago" / "3h ago" / "2d ago", falling back
  * to the local date past a week. An at-a-glance board wants "2m ago", not today's date.
  */

--- a/packages/the-framework/src/auto-pm.test.ts
+++ b/packages/the-framework/src/auto-pm.test.ts
@@ -7,12 +7,14 @@ import {
   AUTO_PM_JOBS,
   AUTO_PM_DRAIN_JOB,
   AUTO_PM_MAINTENANCE_JOB,
+  AUTO_PM_ROUTINES,
   type AutoPmDeps,
   type AutoPmJob,
   type AutoPmLoop,
   type AutoPmProject,
 } from './auto-pm.js'
 import { quotaBoundaryStatus, type QuotaBoundaryStatus } from './quota-boundary.js'
+import { presets, type PresetKey } from './preset-catalog.js'
 
 /** 2026-07-20T12:00:00Z. The week below resets in 5 days, so this is day 3 of 7 (42.8% allowed). */
 const T0 = Date.UTC(2026, 6, 20, 12, 0, 0)
@@ -506,4 +508,32 @@ test('only the draining job says it works the queue rather than filling it (#111
   assert.equal(AUTO_PM_DRAIN_JOB.drains, true)
   for (const job of AUTO_PM_JOBS) assert.notEqual(job.drains, true, `${job.name} must not claim to drain`)
   assert.notEqual(AUTO_PM_MAINTENANCE_JOB.drains, true)
+})
+
+/** The catalog key whose preset a routine fires, found by that preset's run-kind name. */
+function presetKey(name: string): PresetKey {
+  const key = (Object.keys(presets) as PresetKey[]).find(k => presets[k].name === name)
+  if (!key) throw new Error(`no preset is named ${name}`)
+  return key
+}
+
+test('AUTO_PM_ROUTINES is every job the sweep can fire, once each (#1159)', () => {
+  // The dashboard lists this rather than a copy of it, so a job added to the rotation reaches the
+  // screen without anyone remembering to put it there too.
+  const expected = [AUTO_PM_DRAIN_JOB, ...AUTO_PM_JOBS, AUTO_PM_MAINTENANCE_JOB]
+  assert.deepEqual(AUTO_PM_ROUTINES.map(j => j.name), expected.map(j => j.name))
+  assert.equal(new Set(AUTO_PM_ROUTINES.map(j => j.name)).size, AUTO_PM_ROUTINES.length)
+  // Draining leads: it is what the sweep does whenever there is queued work, and the only routine
+  // that turns a queue entry into commits.
+  assert.equal(AUTO_PM_ROUTINES[0]?.name, AUTO_PM_DRAIN_JOB.name)
+})
+
+test('every routine carries its preset label and a rendered prompt, so a list of them is runnable (#1159)', () => {
+  for (const job of AUTO_PM_ROUTINES) {
+    assert.equal(job.label, presets[presetKey(job.name)].label, `${job.name} must be labelled by its preset`)
+    assert.ok(job.describe.length > 0, `${job.name} must say what it does`)
+    assert.ok(job.prompt.trim().length > 0, `${job.name} must carry a prompt`)
+    // The prompt travels to the browser and is started verbatim, so nothing may be left unrendered.
+    assert.doesNotMatch(job.prompt, /\$\{\{/, `${job.name} must ship a rendered prompt`)
+  }
 })

--- a/packages/the-framework/src/auto-pm.ts
+++ b/packages/the-framework/src/auto-pm.ts
@@ -136,6 +136,11 @@ export interface AutoPmJob {
   /** What it is doing, as the log line says it ("harvesting quick-wins"). */
   describe: string
   /**
+   * The user-facing name, for a surface that lists the routines (#1159). Read off the preset the
+   * job fires rather than written again here, so a relabelled preset relabels its routine.
+   */
+  label?: string
+  /**
    * This job works an entry already on the queue, rather than putting entries on it (#1117).
    *
    * Only the draining job has a specific piece of work it is about to pick up, so only it can be
@@ -167,14 +172,30 @@ export interface AutoPmJob {
  * idle tick tries the next job instead of retrying a job that is already running.
  */
 export const AUTO_PM_JOBS: readonly AutoPmJob[] = [
-  { name: presets.quickWins.name, prompt: presets.quickWins.render(), describe: 'harvesting quick-wins from the plans' },
-  { name: presets.triageQuick.name, prompt: presets.triageQuick.render(), describe: 'triaging quick-win tickets' },
+  {
+    name: presets.quickWins.name,
+    prompt: presets.quickWins.render(),
+    describe: 'harvesting quick-wins from the plans',
+    label: presets.quickWins.label,
+  },
+  {
+    name: presets.triageQuick.name,
+    prompt: presets.triageQuick.render(),
+    describe: 'triaging quick-win tickets',
+    label: presets.triageQuick.label,
+  },
   {
     name: presets.triageConsensual.name,
     prompt: presets.triageConsensual.render(),
     describe: 'triaging consensual tickets',
+    label: presets.triageConsensual.label,
   },
-  { name: presets.spikeAndPlan.name, prompt: presets.spikeAndPlan.render(), describe: 'spiking & planning tickets' },
+  {
+    name: presets.spikeAndPlan.name,
+    prompt: presets.spikeAndPlan.render(),
+    describe: 'spiking & planning tickets',
+    label: presets.spikeAndPlan.label,
+  },
 ]
 
 /**
@@ -186,6 +207,7 @@ export const AUTO_PM_DRAIN_JOB: AutoPmJob = {
   name: presets.drainQueue.name,
   prompt: presets.drainQueue.render(),
   describe: 'draining the first open queue entry',
+  label: presets.drainQueue.label,
   drains: true,
 }
 
@@ -206,7 +228,23 @@ export const AUTO_PM_MAINTENANCE_JOB: AutoPmJob = {
   name: presets.maintenance.name,
   prompt: presets.maintenance.render(),
   describe: 'sweeping the codebase for maintenance work',
+  label: presets.maintenance.label,
 }
+
+/**
+ * Every routine the sweep can fire, in the order a surface should list them (#1159).
+ *
+ * Derived from the three constants above rather than written out again, so the list the dashboard
+ * shows and the jobs the daemon actually runs cannot drift. The order is the sweep's own precedence
+ * (#855/#882 read the other way round): draining comes first because it is what happens whenever
+ * there is queued work, the rotation is what happens when there is not, and the calendar-paced
+ * maintenance sweep is the exception outside both.
+ */
+export const AUTO_PM_ROUTINES: readonly AutoPmJob[] = [
+  AUTO_PM_DRAIN_JOB,
+  ...AUTO_PM_JOBS,
+  AUTO_PM_MAINTENANCE_JOB,
+]
 
 /**
  * What became of one attempt to land a run's queue (#852). The two flags are separate on purpose:

--- a/packages/the-framework/src/client.ts
+++ b/packages/the-framework/src/client.ts
@@ -40,6 +40,10 @@ export {
 // the session it was launched from. Pure string work, like the renderers below.
 export { defaultWhat, DEFAULT_WHAT, type PresetRenderContext } from './preset-prompt.js'
 export { presets, LAUNCHER_PRESETS, type PresetKey } from './preset-catalog.js'
+// The routines the idle sweep fires (#1159), so the dashboard can list them and run one on demand.
+// The jobs are built from the presets above and carry their prompt verbatim, so this needs no
+// backend of its own, and the list on screen is the list the daemon runs rather than a copy of it.
+export { AUTO_PM_ROUTINES, AUTO_PM_JOBS, AUTO_PM_DRAIN_JOB, AUTO_PM_MAINTENANCE_JOB, type AutoPmJob } from './auto-pm.js'
 // The identity + diff both notifier paths run, and the preference defaults both sides read (#627).
 // Pure, so the dashboard shares them rather than keeping copies that drift silently.
 export { interventionKey, pickNewInterventions, activityKey, pickNewActivity } from './dashboard/keys.js'

--- a/packages/the-framework/src/index.ts
+++ b/packages/the-framework/src/index.ts
@@ -350,7 +350,9 @@ export { runOptionsFromPreferences, autopilotEnabled, preferencesFromFileConfig 
 export {
   startAutoPm,
   AUTO_PM_JOBS,
+  AUTO_PM_DRAIN_JOB,
   AUTO_PM_MAINTENANCE_JOB,
+  AUTO_PM_ROUTINES,
   autoPmDecision,
   quotaHeadroom,
   DEFAULT_AUTO_PM_INTERVAL_MS,


### PR DESCRIPTION
Closes #1159

## What this adds

A **Routine work** card on the Overview. It lists the jobs the idle sweep can fire, in the sweep's own precedence order, each with a **Run now** button:

| Routine | What it does |
|---|---|
| Drain queue | draining the first open queue entry |
| Quick wins | harvesting quick-wins from the plans |
| Do quick-win work | triaging quick-win tickets |
| Do consensual work | triaging consensual tickets |
| Spike & plan | spiking & planning tickets |
| Maintenance | sweeping the codebase for maintenance work |

Under the list, one **Auto-run** checkbox with the issue's tooltip ("Automatically run this prompt on a regular schedule."). With auto-run on and the daemon having reported a sweep, its label carries the countdown: **"Auto-runs in 2 hr"**.

Until now nothing in the dashboard or the daemon could fast-forward anything: auto PM only fired from its 10 minute `setInterval`. These buttons are that transport.

## Design calls

1. **One global auto-run box, not one per routine.** There is a single `autoPm` preference (#685). A per-row checkbox that actually flipped a global switch would be a lie about what it controls, so the box governs the whole card and says so.
2. **Run now starts the routine's prompt immediately**, over the existing `useStartRun` -> `sendStart` path with `kind: 'prompt'` and the job's prompt verbatim. It does not ask the sweep to come round sooner. On success it selects the project, because the Overview has no view of a live run and the point of the button is to watch what it started.
3. **The list is `AUTO_PM_ROUTINES` itself**, a new constant derived from `AUTO_PM_DRAIN_JOB` + `AUTO_PM_JOBS` + `AUTO_PM_MAINTENANCE_JOB`, re-exported from the browser-safe `@gemstack/the-framework/client`. No new telefunc file, no new RPC, no new preference, and no second copy of the job table to drift. Each job now carries the `label` of the preset it fires, read off the preset rather than written again.
4. **Additive and self-contained.** One new component plus one line in `DashboardPage.tsx`, so the coming re-haul of that view has one place to move rather than a diff spread across it. The card fetches its own project list, so nothing had to be threaded through.

## Deliberately left out

- **Per-routine schedules / per-routine enable.** That would need a new preference shape; the issue's checkbox is served by the one switch that already exists.
- **A "force a sweep now" button.** Run now starts the work; asking the sweep to tick early would be a different (and weaker) button.
- **Naming the ticket a manual drain is about.** The daemon tags a draining run with `nextQueuedTicket` (#1117); that is a disk read, and doing it here would need a new RPC. A hand-fired drain simply carries no ticket on its meta.
- **Per-project run options.** The Overview has no project open, so the start resolves the global tier only (#840), same as a fresh launcher.

## Note for the designer's pass

`autoPm` now has two checkboxes on the Overview: this one and "Spend what's left on the roadmap" in the Usage panel (#1161). They share the preference store, so they stay in lockstep, but whoever re-hauls the view may want to keep only one.

## Verification

- `pnpm typecheck` at the root: 22 tasks successful, clean.
- `pnpm build` at the root: 12 tasks successful, clean.
- `packages/the-framework`: **1318 tests, 1317 pass, 0 fail, 1 skipped** (2 added).
- `packages/framework-dashboard`: **64 files, 466 tests, 466 pass** (12 added: 10 for the card, 2 for the extracted `formatUntil`).

New tests cover: the list is every sweep job once, in order, each with its preset's label and a fully rendered prompt; Run now sends the drain job's prompt verbatim as `kind: 'prompt'` and jumps into the project; a failed start neither navigates nor sticks on "Starting"; the countdown appears only with auto-run on and a reported sweep; there is exactly one checkbox and it writes `{ autoPm: true }`; the project picker appears only with more than one project and Run now honours it; the empty and busy states.