### PR TITLE
feat(the-framework): name the ticket a hand-fired drain implements (#1117)

### DIFF
--- a/.changeset/manual-drain-names-its-ticket.md
+++ b/.changeset/manual-drain-names-its-ticket.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/the-framework": patch
+---
+
+Tag the ticket a drain run implements when the drain is started by hand, not only when the daemon's sweep starts it. A drain fired from the dashboard worked the queue's next entry but recorded nothing about it, so the Overview's "in progress" lane stayed empty while the work was being done.

--- a/packages/the-framework/src/dashboard-rpc/control.telefunc.test.ts
+++ b/packages/the-framework/src/dashboard-rpc/control.telefunc.test.ts
@@ -1,0 +1,66 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { provideTelefuncContext } from 'telefunc'
+import { sendStart } from './control.telefunc.js'
+import { presets } from '../preset-catalog.js'
+import type { StartRunOptions } from '../dashboard/types.js'
+
+// A run started from the dashboard has to name the ticket it is about to implement, the same way
+// the sweep's own drain does (#1117). The daemon reads that off the `drains` flag on its job; a
+// click arrives with nothing but prompt text, so the resolution happens here.
+
+/** The options `startRun` was handed, plus a workspace with one queued ticket to resolve against. */
+async function harness(): Promise<{ cwd: string; started: () => StartRunOptions | undefined }> {
+  const cwd = await mkdtemp(join(tmpdir(), 'framework-start-'))
+  await writeFile(
+    join(cwd, 'TODO_AGENTS.md'),
+    ['## Priority 9', '', '- [ ] [Add a login page](tickets/2026-07-25_login.md)', ''].join('\n'),
+  )
+  let seen: StartRunOptions | undefined
+  provideTelefuncContext({
+    startRun: async (_text: string, _kind: string, options: StartRunOptions) => {
+      seen = options
+      return { ok: true, runId: 'r1' }
+    },
+    projects: { list: async () => [], resolvePath: async () => cwd },
+  } as never)
+  return { cwd, started: () => seen }
+}
+
+test('a drain started from the dashboard carries the ticket it is about to work (#1117)', async () => {
+  const { cwd, started } = await harness()
+  try {
+    const result = await sendStart('p1', presets.drainQueue.render())
+    assert.equal(result.ok, true)
+    // Without this the run implemented the ticket and the Overview's in-progress lane stayed empty,
+    // because only the daemon's own drain was tagging what it took off the queue.
+    assert.equal(started()?.ticket, 'tickets/2026-07-25_login.md')
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('any other prompt starts without a ticket, however busy the queue is (#1117)', async () => {
+  const { cwd, started } = await harness()
+  try {
+    await sendStart('p1', 'Have a look at the login page')
+    // Naming the queue's next entry here would show a ticket as being implemented on the strength
+    // of a run that never touched it.
+    assert.equal(started()?.ticket, undefined)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('a ticket named by the caller is not replaced by the guess (#1117)', async () => {
+  const { cwd, started } = await harness()
+  try {
+    await sendStart('p1', presets.drainQueue.render(), 'build', { ticket: 'tickets/2026-07-20_chosen.md' })
+    assert.equal(started()?.ticket, 'tickets/2026-07-20_chosen.md')
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})

--- a/packages/the-framework/src/dashboard-rpc/control.telefunc.ts
+++ b/packages/the-framework/src/dashboard-rpc/control.telefunc.ts
@@ -4,7 +4,7 @@ import { isSafeVia } from '../conversations.js'
 import { openInApp, type OpenTarget, type OpenResult } from '../dashboard/open-in-app.js'
 import { resolveProjectPath, resolveRunPath, contextPreferences, contextPreview } from './context.js'
 import { relayOr } from './relay-run.js'
-import { appendFlatTodoEntry } from '../todo-loop.js'
+import { appendFlatTodoEntry, ticketForPrompt } from '../todo-loop.js'
 import { TICKETS_DIR, todoPriorityForTicket } from '../tickets.js'
 import { findRun, isSafeRunId, type RunMeta } from '../store/index.js'
 import { removeProjectWorktree, deleteProjectRun } from '../worktrees.js'
@@ -168,7 +168,19 @@ export async function sendStart(
   if (!startRun) return { ok: false, error: 'starting a session is not enabled on this server' }
   const text = prompt.trim()
   if (!text && kind !== 'research') return { ok: false, error: 'a non-empty prompt is required' }
-  return startRun(text, kind, options, projectId)
+  // A drain fired by hand is the same work the sweep does, so it says the same thing about itself
+  // (#1117). Resolved here rather than sent by the caller: the value lands on the run's meta and is
+  // rendered, so it is read off the queue on this side instead of trusted from a browser. An
+  // explicit ticket on the options wins, since a caller that names one knows better than a guess.
+  const ticket = options.ticket ?? (await ticketForStart(projectId, text))
+  return startRun(text, kind, ticket ? { ...options, ticket } : options, projectId)
+}
+
+/** The queue entry a hand-fired drain is about to work, or undefined for any other prompt (#1117). */
+async function ticketForStart(projectId: string, prompt: string): Promise<string | undefined> {
+  const cwd = await resolveProjectPath(projectId)
+  if (!cwd) return undefined
+  return ticketForPrompt(prompt, cwd).catch(() => undefined)
 }
 
 /**

--- a/packages/the-framework/src/preset-catalog.ts
+++ b/packages/the-framework/src/preset-catalog.ts
@@ -140,6 +140,22 @@ export const presets = {
 export type PresetKey = keyof typeof presets
 
 /**
+ * Whether a prompt is the one that takes work OFF the queue (#1117).
+ *
+ * The daemon knows a drain by the `drains` flag on its job; a run started by hand arrives as bare
+ * prompt text with no such marking, so the text is all there is to recognise it by. Compared
+ * against the rendered preset rather than against a copy of its words, so rewording the preset
+ * cannot leave this behind — that drift would show up only as a lane on the Overview quietly
+ * staying empty, which is the kind of bug nobody reports.
+ *
+ * Deliberately exact: a prompt that merely mentions the queue is not a drain, and mistaking one
+ * for the other would name a ticket as being implemented by a run doing something else entirely.
+ */
+export function drainsQueue(prompt: string): boolean {
+  return prompt.trim() === presets.drainQueue.render().trim()
+}
+
+/**
  * The presets the launcher offers, in the order it shows them.
  *
  * One list rather than a `launcher: true` flag on each row: membership and order are the same

--- a/packages/the-framework/src/todo-loop.test.ts
+++ b/packages/the-framework/src/todo-loop.test.ts
@@ -6,7 +6,9 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { FakeDriver } from './driver/fake.js'
 import type { ChoicePick, ChoiceRequest, FrameworkEvent } from './events.js'
-import { appendTodoEntry, appendFlatTodoEntry, findTodoBacklog, insertTodoEntry, nextQueuedTicket, parseTodoEntries, runTodoLoop } from './todo-loop.js'
+import { appendTodoEntry, appendFlatTodoEntry, findTodoBacklog, insertTodoEntry, nextQueuedTicket, parseTodoEntries, runTodoLoop, ticketForPrompt } from './todo-loop.js'
+import { drainsQueue, presets } from './preset-catalog.js'
+import { AUTO_PM_DRAIN_JOB, AUTO_PM_JOBS } from './auto-pm.js'
 
 async function tmpWorkspace(): Promise<string> {
   return mkdtemp(join(tmpdir(), 'framework-todo-'))
@@ -493,4 +495,43 @@ test('nextQueuedTicket names the ticket the next drain run will pick up (#1117)'
   } finally {
     await rm(cwd, { recursive: true, force: true })
   }
+})
+
+test('ticketForPrompt names a ticket for a hand-fired drain, and for nothing else (#1117)', async () => {
+  const cwd = await tmpWorkspace()
+  try {
+    await writeFile(
+      join(cwd, 'TODO_AGENTS.md'),
+      ['## Priority 9', '', '- [ ] [Add a login page](tickets/2026-07-25_login.md)', ''].join('\n'),
+    )
+
+    // The drain preset, whatever its current wording: the sweep's own prompt, arriving by hand.
+    assert.equal(await ticketForPrompt(presets.drainQueue.render(), cwd), 'tickets/2026-07-25_login.md')
+    // Leading/trailing whitespace is what a textarea adds, not a different instruction.
+    assert.equal(await ticketForPrompt(`\n${presets.drainQueue.render()}  `, cwd), 'tickets/2026-07-25_login.md')
+
+    // Every other prompt implements whatever it likes; naming the queue's next entry for it would
+    // put a ticket in the in-progress lane on the strength of an unrelated run.
+    assert.equal(await ticketForPrompt('Work on the queue please', cwd), undefined)
+    assert.equal(await ticketForPrompt(presets.quickWins.render(), cwd), undefined)
+    assert.equal(await ticketForPrompt('', cwd), undefined)
+
+    // A read that throws is a lane label, not a run: it must never take the start down with it.
+    const boom = async () => {
+      throw new Error('unreadable queue')
+    }
+    assert.equal(await ticketForPrompt(presets.drainQueue.render(), cwd, boom), undefined)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('the drain the sweep fires and the drain a click fires are the same drain (#1117)', () => {
+  // The daemon recognises its drain by the `drains` flag on the job; a click has only the text.
+  // If those two ever name different prompts, a hand-fired drain silently stops tagging tickets,
+  // which shows up as an empty lane rather than as an error.
+  assert.equal(AUTO_PM_DRAIN_JOB.drains, true)
+  assert.equal(drainsQueue(AUTO_PM_DRAIN_JOB.prompt), true)
+  // And nothing that merely puts work ON the queue counts as taking it off.
+  for (const job of AUTO_PM_JOBS) assert.equal(drainsQueue(job.prompt), false, `${job.name} is not a drain`)
 })

--- a/packages/the-framework/src/todo-loop.ts
+++ b/packages/the-framework/src/todo-loop.ts
@@ -4,6 +4,7 @@ import type { DriverSession } from './driver/index.js'
 import type { ChoicePick, ChoiceRequest, FrameworkEvent } from './events.js'
 import { requestChoices, runAwaitRounds } from './await-gate.js'
 import { FLAT_TODO_FILE, findFlatTodo, ticketFromQueueEntry } from './tickets.js'
+import { drainsQueue } from './preset-catalog.js'
 import { createTurnSignalEmitter } from './turn-gate.js'
 
 export { FLAT_TODO_FILE, LEGACY_HYPHEN_TODO_FILE, LEGACY_TICKETS_TODO_FILE, LEGACY_TODO_FILE, TICKETS_DIR, ticketFromQueueEntry, todoPriorityForTicket } from './tickets.js'
@@ -244,6 +245,26 @@ export async function nextQueuedTicket(cwd: string): Promise<string | undefined>
   if (md === undefined) return undefined
   const first = parseTodoEntries(md)[0]
   return first ? ticketFromQueueEntry(first) : undefined
+}
+
+/**
+ * The ticket a run started by hand is about to implement, when that run is a drain (#1117).
+ *
+ * The daemon already does this for the sweep's own drain, off the `drains` flag on the job. A run
+ * fired from the dashboard reaches the same start with none of that context, so a hand-fired drain
+ * showed up working on nothing: the run implemented the ticket, and the lane it belonged in stayed
+ * empty. Same read as the sweep's, so both agree on which entry is next.
+ *
+ * Undefined for anything that is not a drain, and for a drain over an empty queue. The `read` seam
+ * is for tests; production always takes the default.
+ */
+export async function ticketForPrompt(
+  prompt: string,
+  cwd: string,
+  read: (cwd: string) => Promise<string | undefined> = nextQueuedTicket,
+): Promise<string | undefined> {
+  if (!drainsQueue(prompt)) return undefined
+  return read(cwd).catch(() => undefined)
 }
 
 /**


### PR DESCRIPTION
Part of #1117, and the last thing between the demo and its closing beat.

## The gap

#1176 made a drain run record the ticket it implements, which is what puts a ticket in the Overview's **in progress** lane. That link is made in one place: `daemon-services.ts`, from the `drains: true` flag on the auto-PM job.

A drain started from the dashboard reaches the same start with none of that context. It works the queue's first open entry exactly like the sweep does, and records nothing about it. So:

- the daemon's drain: ticket tagged, lane fills
- a drain you press: same work, lane stays at 0

That is visible on the Overview right now as `IN PROGRESS 0` while the queue has entries, and it is the exact thing the video needs to show moving. It also becomes reachable for the first time in #1186, which puts a **Run now** button on every routine, `Drain queue` included. Until now `drainQueue` was the one preset no human could fire, which is why the gap never showed.

## The fix

`sendStart` resolves the ticket itself, from the same `nextQueuedTicket` read the sweep uses:

```
const ticket = options.ticket ?? (await ticketForStart(projectId, text))
```

Three deliberate choices:

1. **Server-side, not a new RPC.** The value lands on the run's meta and is rendered, so it is read off the queue on the daemon side rather than accepted from a browser. `isTicketPath` still gates it at both ends, unchanged.
2. **Recognised by the rendered preset**, via `drainsQueue(prompt)`, not by a copy of its words. Reword or relabel `drainQueue` and this follows; a stale copy would have failed silently, as an empty lane rather than an error. A test asserts `drainsQueue(AUTO_PM_DRAIN_JOB.prompt)` so the sweep's drain and a clicked drain can never be different drains.
3. **An explicit `options.ticket` wins.** A caller that names one knows better than a read of the queue's head.

Exact match only: a prompt that merely mentions the queue is not a drain, and mistaking one for the other would show a ticket as being implemented by a run doing something else.

## Checks

- `pnpm typecheck` clean, 22/22.
- `packages/the-framework`: 1320 pass, 0 fail, 1 skipped (6 added).
- `packages/framework-dashboard`: 454 pass, 0 fail (untouched).
- The wiring itself is covered, not just the helper: `control.telefunc.test.ts` drives `sendStart` through `provideTelefuncContext` with a stub `startRun` and a temp workspace holding one queued ticket, and asserts what the start was actually handed in all three cases.

## Note for the reviewer

`LAUNCHER_PRESETS`'s comment says `drainQueue` is absent "because only the daemon fires it". #1186 changes that. The comment is still accurate about the launcher menu, so I left it, but the assumption behind it is no longer true.

Independent of the other open PRs: it branches off main and touches none of their files.
