### PR TITLE
fix(dashboard): open a hot ticket into a launcher that knows which ticket

### DIFF
--- a/.changeset/hot-ticket-opens-prefilled.md
+++ b/.changeset/hot-ticket-opens-prefilled.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+Clicking a hot ticket that no run has picked up now opens its project's launcher with the ticket already in the composer, instead of an empty one. Also fixes an opening draft being dropped whenever the editor finished initialising after the composer mounted, which affected a draft carried from another device too.

--- a/packages/framework-dashboard/components/Agents.test.tsx
+++ b/packages/framework-dashboard/components/Agents.test.tsx
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { ActiveRun, RecentRun, RunMeta } from '@gemstack/the-framework'
+import { Agents } from './Agents.js'
+
+// The Overview's Agents card (#1139), which replaced Working now. Everything it renders arrives as
+// props, so there is no telefunc in its import graph and no mock to set up.
+//
+// What these pin is the click: #1189 made an Overview row open the session it names instead of
+// dropping the reader on the project launcher, and the tests that held that line went with
+// WorkingNow.tsx when #1190 deleted it.
+
+afterEach(cleanup)
+
+const active = (runId: string, over: Partial<ActiveRun> = {}): ActiveRun => ({
+  projectId: 'p1',
+  projectName: 'gemstack',
+  runId,
+  cwd: `/repos/gemstack/.the-framework/worktrees/${runId}`,
+  status: 'running',
+  updatedAt: '2026-07-25T10:00:00.000Z',
+  intent: `working on ${runId}`,
+  ...over,
+})
+
+const meta = (id: string): RunMeta => ({
+  version: 1,
+  status: 'done',
+  id,
+  startedAt: '2026-07-25T09:00:00.000Z',
+  updatedAt: '2026-07-25T09:30:00.000Z',
+  passes: 0,
+  intent: `did ${id}`,
+})
+
+const recent = (id: string): RecentRun => ({ projectId: 'p2', projectName: 'vike', run: meta(id) })
+
+describe('Agents (#1139)', () => {
+  test('splits sessions into Current and Recent', () => {
+    render(<Agents working={[active('r1')]} finished={[recent('r2')]} loading={false} onSelectRun={vi.fn()} />)
+    expect(screen.getByText('Current')).toBeTruthy()
+    expect(screen.getByText('Recent')).toBeTruthy()
+    expect(screen.getByText('working on r1')).toBeTruthy()
+  })
+
+  test('clicking a working agent opens that session', () => {
+    const onSelectRun = vi.fn()
+    render(<Agents working={[active('r1')]} finished={[]} loading={false} onSelectRun={onSelectRun} />)
+    fireEvent.click(screen.getByText('working on r1'))
+    // Project *and* run: a project alone would land on the launcher, which is the #1189 regression.
+    expect(onSelectRun).toHaveBeenCalledWith('p1', 'r1')
+  })
+
+  test('clicking a finished session opens it too', () => {
+    const onSelectRun = vi.fn()
+    render(<Agents working={[]} finished={[recent('r2')]} loading={false} onSelectRun={onSelectRun} />)
+    fireEvent.click(screen.getByText('did r2'))
+    // A finished run's row is the only way back into its transcript from the Overview.
+    expect(onSelectRun).toHaveBeenCalledWith('p2', 'r2')
+  })
+
+  test('each column says so when it is empty, rather than the card vanishing', () => {
+    render(<Agents working={[]} finished={[]} loading={false} onSelectRun={vi.fn()} />)
+    expect(screen.getByText('No agents working right now.')).toBeTruthy()
+    expect(screen.getByText('No finished sessions yet.')).toBeTruthy()
+  })
+
+  test('loading is not the same as empty', () => {
+    // The card polls, so "nothing yet" before the first read would read as "no agents ran".
+    render(<Agents working={[]} finished={[]} loading onSelectRun={vi.fn()} />)
+    expect(screen.queryByText('No agents working right now.')).toBeNull()
+    expect(screen.getAllByText('Loading…').length).toBe(2)
+  })
+
+  test('a working session with no intent still gets a label', () => {
+    // ActiveRun carries no branch or start time to fall back on, so an unlabelled row would be a
+    // blank line you cannot tell apart from its neighbours.
+    render(
+      <Agents
+        working={[active('r1', { intent: '   ', sessionName: 'oauth-work' })]}
+        finished={[]}
+        loading={false}
+        onSelectRun={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('oauth-work')).toBeTruthy()
+  })
+})

--- a/packages/framework-dashboard/components/Agents.tsx
+++ b/packages/framework-dashboard/components/Agents.tsx
@@ -1,0 +1,129 @@
+import type { ActiveRun, RecentRun } from '@gemstack/the-framework'
+import { Bot } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card.js'
+import { runLabel } from '../lib/run-label.js'
+import { formatAge, formatDateTime } from '../lib/format-date.js'
+
+// The Overview's Agents card (#1139): sessions working now (Current) and just finished (Recent),
+// side by side. Each row is the whole line, clickable straight into that session — its label is the
+// one-liner the sidebar shows (runLabel), and its age reads "22s ago" with the exact moment on
+// hover. This is what replaced the old "Working now" list.
+//
+// Its own file rather than inline in DashboardPage, like every other card on the Overview: opening
+// a session from here is the behaviour #1189 exists to protect, and DashboardPage has no test file
+// to pin it in.
+
+/** One row: a session, and what opening it does. */
+interface AgentRowData {
+  key: string
+  /** The session's one-liner, the same the sidebar shows. */
+  label: string
+  /** ISO: last activity for a working agent, finish time for a finished one. */
+  at: string | undefined
+  projectName: string
+  onOpen: () => void
+}
+
+export function Agents({
+  working,
+  finished,
+  loading,
+  onSelectRun,
+}: {
+  working: ActiveRun[]
+  finished: RecentRun[]
+  loading: boolean
+  onSelectRun: (projectId: string, runId: string) => void
+}) {
+  const current: AgentRowData[] = working.map(a => ({
+    key: `${a.projectId}:${a.runId}`,
+    label: activeLabel(a),
+    at: a.updatedAt,
+    projectName: a.projectName,
+    onOpen: () => onSelectRun(a.projectId, a.runId),
+  }))
+  const recent: AgentRowData[] = finished.map(f => ({
+    key: `${f.projectId}:${f.run.id}`,
+    label: runLabel(f.run),
+    at: f.run.updatedAt,
+    projectName: f.projectName,
+    onOpen: () => onSelectRun(f.projectId, f.run.id),
+  }))
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Bot className="h-4 w-4 text-muted-foreground" />
+          Agents
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <div className="grid gap-x-8 gap-y-6 sm:grid-cols-2">
+          <AgentColumn heading="Current" description="Agents currently working" rows={current} loading={loading} empty="No agents working right now." />
+          <AgentColumn heading="Recent" description="Agents finished working" rows={recent} loading={loading} empty="No finished sessions yet." />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function AgentColumn({
+  heading,
+  description,
+  rows,
+  loading,
+  empty,
+}: {
+  heading: string
+  description: string
+  rows: AgentRowData[]
+  loading: boolean
+  empty: string
+}) {
+  return (
+    <div className="min-w-0">
+      <h4 className="text-xs font-semibold uppercase tracking-wide text-foreground/80">{heading}</h4>
+      <p className="text-xs text-muted-foreground">{description}</p>
+      {loading ? (
+        <p className="py-2 text-sm text-muted-foreground">Loading…</p>
+      ) : rows.length === 0 ? (
+        <p className="py-2 text-sm text-muted-foreground">{empty}</p>
+      ) : (
+        <ul className="mt-2 space-y-0.5">
+          {rows.map(r => (
+            <AgentRow key={r.key} label={r.label} at={r.at} projectName={r.projectName} onOpen={r.onOpen} />
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function AgentRow({ label, at, projectName, onOpen }: Omit<AgentRowData, 'key'>) {
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onOpen}
+        title="Open this session"
+        className="flex w-full items-baseline gap-2 rounded-md px-2 py-1 text-left hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
+      >
+        <span aria-hidden className="shrink-0 text-muted-foreground/60">•</span>
+        <span className="min-w-0 flex-1 truncate text-sm">{label}</span>
+        <span className="shrink-0 text-xs text-muted-foreground">{projectName}</span>
+        {at && (
+          <span className="shrink-0 text-xs tabular-nums text-muted-foreground" title={formatDateTime(at)}>
+            {formatAge(at)}
+          </span>
+        )}
+      </button>
+    </li>
+  )
+}
+
+// A working session's one-liner: what the sidebar would show for it. ActiveRun carries no branch or
+// start time to fall back to, but a live session almost always has an intent or a chosen name; its
+// project is the last resort.
+function activeLabel(a: ActiveRun): string {
+  return a.intent?.trim() || a.sessionName?.trim() || a.scope?.trim() || a.projectName
+}

--- a/packages/framework-dashboard/components/Composer.test.tsx
+++ b/packages/framework-dashboard/components/Composer.test.tsx
@@ -32,21 +32,45 @@ vi.mock('../server/devices.telefunc.js', () => ({ checkDevices }))
 
 // Stub the Tiptap editor (it needs a real DOM/ProseMirror): a plain input driving onChange, a
 // "type-submit" button firing onSubmit, and a ref exposing the same handle the composer calls.
+//
+// The stub models one thing about the real editor deliberately: `loadTemplate` does NOTHING until
+// the editor has resolved. Tiptap runs with `immediatelyRender: false`, so on the first render the
+// handle is a no-op that returns false — and a stub that answered it synchronously is exactly why a
+// carried draft passed here while arriving as an empty composer in a browser. An opening draft
+// therefore has to travel as `initialText`, which the editor applies when it is ready.
+// It also holds and renders its own text, so a test can ask what is IN the box rather than only
+// what Start would send. The two used to be assertable only together, which hid this exact bug: the
+// composer's own `prompt` state was set alongside the editor call, so a dropped `loadTemplate` still
+// submitted the right text while the user looked at an empty box and had nothing to edit.
 vi.mock('./PromptEditor.js', async () => {
-  const { forwardRef, useImperativeHandle } = await import('react')
+  const { forwardRef, useEffect, useImperativeHandle, useRef, useState } = await import('react')
   const PromptEditor = forwardRef((props: any, ref: any) => {
+    const [ready, setReady] = useState(false)
+    const [held, setHeld] = useState('')
+    useEffect(() => setReady(true), []) // resolves a render late, like useEditor
+    const put = (text: string) => {
+      setHeld(text)
+      props.onChange(text)
+    }
     useImperativeHandle(ref, () => ({
-      clear: () => props.onChange(''),
+      clear: () => put(''),
       focus: () => {},
       // Loading a preset puts its text in the box, which is what makes a loaded preset submittable.
       loadTemplate: (text: string) => {
-        props.onChange(text)
+        if (!ready) return false
+        put(text)
         return false
       },
     }))
+    const seeded = useRef(false)
+    useEffect(() => {
+      if (!ready || seeded.current || !props.initialText) return
+      seeded.current = true
+      put(props.initialText)
+    }, [ready, props.initialText])
     return (
       <div>
-        <input aria-label="prompt" onChange={e => props.onChange(e.target.value)} disabled={props.disabled} />
+        <input aria-label="prompt" value={held} onChange={e => put(e.target.value)} disabled={props.disabled} />
         <button type="button" onClick={() => props.onSubmit()}>
           editor-submit
         </button>
@@ -55,6 +79,9 @@ vi.mock('./PromptEditor.js', async () => {
   })
   return { PromptEditor }
 })
+
+/** What the editor is actually holding, as opposed to what Start would submit. */
+const editorText = (): string => (screen.getByLabelText('prompt') as HTMLInputElement).value
 
 const { Composer } = await import('./Composer.js')
 
@@ -205,6 +232,17 @@ describe('Composer (#721)', () => {
     fireEvent.click(screen.getByRole('button', { name: /Start session/ }))
     expect(onSubmit).toHaveBeenCalledWith('carried from the studio box', 'build', { newSession: false })
     expect(sessionStorage.getItem('fw.pending-draft')).toBeNull() // taken once
+  })
+
+  test('a carried draft is IN the editor, not just in what Start would send (#1139)', () => {
+    // The regression the stub models: the draft is taken and cleared on the first render, while the
+    // editor is not there yet to receive it. Seeding it as `initialText` is what keeps those two
+    // facts from cancelling out. Asserted on the box rather than on submit, because submit was
+    // right the whole time this was broken — the user was the one looking at an empty composer.
+    const draft = 'Work on tickets/a.md. Do not start any other ticket.'
+    sessionStorage.setItem('fw.pending-draft', draft)
+    renderComposer({ submitLabel: 'Start session' })
+    expect(editorText()).toBe(draft)
   })
 
   test('an in-session composer does not rehydrate a carried draft (#1066)', () => {

--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -185,17 +185,21 @@ export const Composer = forwardRef<ComposerHandle, {
     focus: () => editorRef.current?.focus(),
   }))
 
-  // Rehydrate a draft carried from another device (#1066), launcher-only. stashDraftFromUrl is
-  // idempotent, so calling it here is race-safe even if the SPA-entry call has not run yet. A carried
-  // draft is still a 'build', so seed the editor without flipping kind.
+  // Rehydrate a draft carried in — from another device (#1066) or from the click that navigated
+  // here (#1139) — launcher-only. stashDraftFromUrl is idempotent, so calling it here is race-safe
+  // even if the SPA-entry call has not run yet. A carried draft is still a 'build', so it seeds the
+  // editor without flipping kind.
+  //
+  // Handed to the editor as `initialText` rather than pushed through the handle: the draft is taken
+  // once and cleared, while `loadTemplate` silently does nothing until Tiptap has resolved
+  // (`immediatelyRender: false`), so pushing it at mount dropped the draft and left an empty
+  // composer. `prompt` then arrives the normal way, through the editor's own onChange.
+  const [carriedDraft, setCarriedDraft] = useState<string | undefined>(undefined)
   useEffect(() => {
     if (compact || inSession) return
     stashDraftFromUrl()
     const carried = takePendingDraft()
-    if (carried) {
-      editorRef.current?.loadTemplate(carried)
-      setPrompt(carried)
-    }
+    if (carried) setCarriedDraft(carried)
   }, [compact, inSession])
 
   // A synchronous latch alongside the async `busy` prop (#948): two fast ⌘↵ presses both read
@@ -263,6 +267,7 @@ export const Composer = forwardRef<ComposerHandle, {
       {...(compact ? {} : { onNewPreset: () => setAddingPreset(true) })}
       disabled={busy}
       {...(placeholder ? { placeholder } : {})}
+      {...(carriedDraft ? { initialText: carriedDraft } : {})}
     />
   )
 

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -1,5 +1,5 @@
-import type { DashboardData, ActiveRun, ProjectQueue, RecentRun, Intervention } from '@gemstack/the-framework'
-import { Bot, GitBranch, GitPullRequest, Inbox, ListTodo, MessageCircleQuestion } from 'lucide-react'
+import type { DashboardData, ProjectQueue, Intervention } from '@gemstack/the-framework'
+import { GitBranch, GitPullRequest, Inbox, ListTodo, MessageCircleQuestion } from 'lucide-react'
 import { onDashboard } from '../server/reads.telefunc.js'
 import { interventionKey } from '@gemstack/the-framework/client'
 import { Quota } from './Quota.js'
@@ -9,9 +9,8 @@ import { usePreferences } from '../lib/preferences.js'
 import { OnboardingChecklist } from './OnboardingChecklist.js'
 import { HotTickets } from './HotTickets.js'
 import { RoutineWork } from './RoutineWork.js'
+import { Agents } from './Agents.js'
 import { queueEntryLabel } from '../lib/queue-entry.js'
-import { runLabel } from '../lib/run-label.js'
-import { formatAge, formatDateTime } from '../lib/format-date.js'
 import { ScrollArea } from './ui/scroll-area.js'
 
 // The Overview landing page (#1139): a focused at-a-glance board — usage first, then the two queues
@@ -210,123 +209,4 @@ function AiQueue({
       </CardContent>
     </Card>
   )
-}
-
-/** One agent row's data, shared by the Current and Recent columns. */
-interface AgentRowData {
-  key: string
-  /** The session's one-liner, the same the sidebar shows. */
-  label: string
-  /** ISO: last activity for a working agent, finish time for a finished one. */
-  at: string | undefined
-  projectName: string
-  onOpen: () => void
-}
-
-// The Agents view (#1139): sessions working now (Current) and just finished (Recent), side by side.
-// Each row is the whole line, clickable straight into that session — its label is the one-liner the
-// sidebar shows (runLabel), and its age reads "22s ago" with the exact moment on hover. This is what
-// replaced the old "Working now" list.
-function Agents({
-  working,
-  finished,
-  loading,
-  onSelectRun,
-}: {
-  working: ActiveRun[]
-  finished: RecentRun[]
-  loading: boolean
-  onSelectRun: (projectId: string, runId: string) => void
-}) {
-  const current: AgentRowData[] = working.map(a => ({
-    key: `${a.projectId}:${a.runId}`,
-    label: activeLabel(a),
-    at: a.updatedAt,
-    projectName: a.projectName,
-    onOpen: () => onSelectRun(a.projectId, a.runId),
-  }))
-  const recent: AgentRowData[] = finished.map(f => ({
-    key: `${f.projectId}:${f.run.id}`,
-    label: runLabel(f.run),
-    at: f.run.updatedAt,
-    projectName: f.projectName,
-    onOpen: () => onSelectRun(f.projectId, f.run.id),
-  }))
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Bot className="h-4 w-4 text-muted-foreground" />
-          Agents
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="pt-0">
-        <div className="grid gap-x-8 gap-y-6 sm:grid-cols-2">
-          <AgentColumn heading="Current" description="Agents currently working" rows={current} loading={loading} empty="No agents working right now." />
-          <AgentColumn heading="Recent" description="Agents finished working" rows={recent} loading={loading} empty="No finished sessions yet." />
-        </div>
-      </CardContent>
-    </Card>
-  )
-}
-
-function AgentColumn({
-  heading,
-  description,
-  rows,
-  loading,
-  empty,
-}: {
-  heading: string
-  description: string
-  rows: AgentRowData[]
-  loading: boolean
-  empty: string
-}) {
-  return (
-    <div className="min-w-0">
-      <h4 className="text-xs font-semibold uppercase tracking-wide text-foreground/80">{heading}</h4>
-      <p className="text-xs text-muted-foreground">{description}</p>
-      {loading ? (
-        <p className="py-2 text-sm text-muted-foreground">Loading…</p>
-      ) : rows.length === 0 ? (
-        <p className="py-2 text-sm text-muted-foreground">{empty}</p>
-      ) : (
-        <ul className="mt-2 space-y-0.5">
-          {rows.map(r => (
-            <AgentRow key={r.key} label={r.label} at={r.at} projectName={r.projectName} onOpen={r.onOpen} />
-          ))}
-        </ul>
-      )}
-    </div>
-  )
-}
-
-function AgentRow({ label, at, projectName, onOpen }: Omit<AgentRowData, 'key'>) {
-  return (
-    <li>
-      <button
-        type="button"
-        onClick={onOpen}
-        title="Open this session"
-        className="flex w-full items-baseline gap-2 rounded-md px-2 py-1 text-left hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
-      >
-        <span aria-hidden className="shrink-0 text-muted-foreground/60">•</span>
-        <span className="min-w-0 flex-1 truncate text-sm">{label}</span>
-        <span className="shrink-0 text-xs text-muted-foreground">{projectName}</span>
-        {at && (
-          <span className="shrink-0 text-xs tabular-nums text-muted-foreground" title={formatDateTime(at)}>
-            {formatAge(at)}
-          </span>
-        )}
-      </button>
-    </li>
-  )
-}
-
-// A working session's one-liner: what the sidebar would show for it. ActiveRun carries no branch or
-// start time to fall back to, but a live session almost always has an intent or a chosen name; its
-// project is the last resort.
-function activeLabel(a: ActiveRun): string {
-  return a.intent?.trim() || a.sessionName?.trim() || a.scope?.trim() || a.projectName
 }

--- a/packages/framework-dashboard/components/HotTickets.test.tsx
+++ b/packages/framework-dashboard/components/HotTickets.test.tsx
@@ -7,9 +7,14 @@ import type { HotTicket, HotBucket } from '@gemstack/the-framework'
 const onHotTickets = vi.hoisted(() => vi.fn())
 vi.mock('../server/reads.telefunc.js', () => ({ onHotTickets }))
 
-const { HotTickets } = await import('./HotTickets.js')
+const { HotTickets, workOnTicketDraft } = await import('./HotTickets.js')
+const { takePendingDraft } = await import('../lib/draft-handoff.js')
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  // The draft stash outlives a render, so a leftover would leak into the next test's assertion.
+  takePendingDraft()
+})
 
 const ht = (file: string, projectName: string, bucket: HotBucket, over: Record<string, unknown> = {}): HotTicket => ({
   projectId: projectName,
@@ -83,5 +88,30 @@ describe('a hot ticket that names a run opens that run', () => {
     fireEvent.click(await screen.findByText('b'))
     expect(onSelectProject).toHaveBeenCalledWith('beta')
     expect(onSelectRun).not.toHaveBeenCalled()
+  })
+})
+
+describe('a hot ticket with no run prefills the launcher it lands on', () => {
+  test('the click carries the ticket over as a composer draft', async () => {
+    onHotTickets.mockResolvedValue([ht('b.md', 'beta', 'ai-queue')])
+    render(<HotTickets onSelectProject={vi.fn()} onSelectRun={vi.fn()} />)
+    fireEvent.click(await screen.findByText('b'))
+    // Without this the row was a dead end: the launcher came up empty and the one fact the row
+    // carried — which ticket — was dropped. Composer takes this at mount (#1066).
+    expect(takePendingDraft()).toBe(workOnTicketDraft('b.md'))
+  })
+
+  test('the draft names the ticket file, not its title', async () => {
+    // The title is prose the agent would have to search for; the file is the ticket's identity.
+    expect(workOnTicketDraft('add-oauth.md')).toContain('tickets/add-oauth.md')
+  })
+
+  test('a ticket that opens a live session leaves no draft behind', async () => {
+    onHotTickets.mockResolvedValue([{ ...ht('a.md', 'alpha', 'in-progress'), runId: 'run-9' }])
+    render(<HotTickets onSelectProject={vi.fn()} onSelectRun={vi.fn()} />)
+    fireEvent.click(await screen.findByText('a'))
+    // That click goes to a session, not a launcher, so a draft stashed here would surface later
+    // on the next unrelated visit to one.
+    expect(takePendingDraft()).toBeNull()
   })
 })

--- a/packages/framework-dashboard/components/HotTickets.tsx
+++ b/packages/framework-dashboard/components/HotTickets.tsx
@@ -3,14 +3,38 @@ import { Flame } from 'lucide-react'
 import { onHotTickets } from '../server/reads.telefunc.js'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card.js'
 import { usePolled } from '../lib/use-async.js'
+import { stashPendingDraft } from '../lib/draft-handoff.js'
 import { cn } from '../lib/utils.js'
 
 // The Overview's "hot tickets" card (#1139): a cross-project glance at what the agent is working on
 // (in progress), what sits in the AI Queue, and what is flagged high priority — nothing else. A
 // projection of every project's `tickets/` + `TODO_AGENTS.md` over the `onHotTickets` read, polled
-// so it stays live. Selecting a ticket jumps into its project.
+// so it stays live. Selecting a ticket opens the session working it, or the launcher asking for it.
 
 const EMPTY: HotTicket[] = []
+
+/**
+ * The prompt a ticket row hands the launcher. Its vocabulary is the drain preset's ("work on … Do
+ * not start any other …"), narrowed to the one ticket the row names.
+ *
+ * Plain text rather than a preset: this is a draft the user reads and edits in the composer before
+ * sending, so there is no second, hidden version of the ask to drift from the button — which is
+ * what #1187 was about. Exported so the test asserts against this and not a copy.
+ */
+export function workOnTicketDraft(file: string): string {
+  return `Work on tickets/${file}. Do not start any other ticket.`
+}
+
+/**
+ * Open a ticket that no run is implementing (#1139). It has no session to jump to, so the click
+ * lands on its project's launcher — which used to arrive with an empty composer and the ticket
+ * forgotten, making the row a dead end. Stashing the draft first means the launcher rehydrates
+ * (#1066, launcher-only and taken once) prefilled with this ticket.
+ */
+function openTicket(ticket: HotTicket, onSelectProject: (id: string) => void): void {
+  stashPendingDraft(workOnTicketDraft(ticket.ticket.file))
+  onSelectProject(ticket.projectId)
+}
 
 // The three lanes the card shows (#1139): in progress, then the AI Queue, then high priority. Each
 // carries the dot colour that matches the rest of the status vocabulary (primary = active, warning =
@@ -91,8 +115,8 @@ function Lane({
               <button
                 type="button"
                 // A ticket being implemented names its run, and that session is what the row is
-                // reporting; one with no run yet has only its project to offer.
-                onClick={() => (t.runId ? onSelectRun(t.projectId, t.runId) : onSelectProject(t.projectId))}
+                // reporting; one with no run yet opens its project's launcher, asking for it.
+                onClick={() => (t.runId ? onSelectRun(t.projectId, t.runId) : openTicket(t, onSelectProject))}
                 title={t.ticket.summary || t.ticket.title}
                 className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
               >

--- a/packages/framework-dashboard/components/PromptEditor.tsx
+++ b/packages/framework-dashboard/components/PromptEditor.tsx
@@ -55,6 +55,15 @@ interface PromptEditorProps {
   onNewPreset?: () => void
   disabled?: boolean
   placeholder?: string
+  /**
+   * Text to open with, applied once as soon as the editor exists (#1066/#1139).
+   *
+   * A prop rather than a mount-time `loadTemplate` call, because `immediatelyRender: false` leaves
+   * `editor` null on the first render: the handle's loadTemplate returns false and does nothing,
+   * so a caller that had already taken its one-shot draft lost it silently. Seeding through a prop
+   * lets the editor apply it when it is ready instead of the caller guessing when that is.
+   */
+  initialText?: string | undefined
   /** A shorter surface for the navbar quick-launch (#723): starts one line tall instead of ~three. */
   compact?: boolean
 }
@@ -81,7 +90,7 @@ function applyTemplate(editor: Editor, text: string): void {
 }
 
 export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(function PromptEditor(
-  { onChange, onSubmit, onPreset, onMentionProject, onMentionFile, onMentionRemoved, projects, files = [], presets, customPresets = [], projectPresets = [], onNewPreset, disabled = false, placeholder = 'Describe what to build…  ( / commands · < tags · @ projects · # files )', compact = false },
+  { onChange, onSubmit, onPreset, onMentionProject, onMentionFile, onMentionRemoved, projects, files = [], presets, customPresets = [], projectPresets = [], onNewPreset, disabled = false, placeholder = 'Describe what to build…  ( / commands · < tags · @ projects · # files )', initialText, compact = false },
   ref,
 ) {
   const [isEmpty, setIsEmpty] = useState(true)
@@ -331,6 +340,16 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
   useEffect(() => {
     editor?.setEditable(!disabled)
   }, [editor, disabled])
+
+  // Seed {@link PromptEditorProps.initialText} the moment the editor exists, and only ever once:
+  // it is an opening draft, not a controlled value, so re-applying it would overwrite whatever the
+  // user has typed since. The ref (not state) because seeding must not itself cause a render.
+  const seeded = useRef(false)
+  useEffect(() => {
+    if (!editor || seeded.current || !initialText) return
+    seeded.current = true
+    loadTemplateInto(editor, initialText)
+  }, [editor, initialText])
 
   // The placeholder is absolutely positioned, so it must share the editor's padding to sit exactly
   // where the first typed character will (#721). The full composer breathes with more room; the

--- a/packages/framework-dashboard/lib/draft-handoff.ts
+++ b/packages/framework-dashboard/lib/draft-handoff.ts
@@ -27,6 +27,19 @@ export function stashDraftFromUrl(): void {
   window.history.replaceState(null, '', url.pathname + url.search + url.hash)
 }
 
+/**
+ * Carry a draft across an in-app navigation (#1139): the same stash the device hop uses, written
+ * directly rather than through the URL. For a click that knows what the next session should be
+ * about but lands on the launcher, where that knowledge would otherwise be dropped — a hot ticket
+ * with no run of its own.
+ *
+ * Deliberately not a `?draft=` param like the device hop: this navigation never leaves the tab, so
+ * there is nothing to hand another device and no reason to put the prompt in the address bar.
+ */
+export function stashPendingDraft(draft: string): void {
+  session()?.setItem(PENDING_DRAFT_KEY, draft)
+}
+
 /** The carried draft, if any, cleared as it is read so a reload does not re-seed it. */
 export function takePendingDraft(): string | null {
   const s = session()


### PR DESCRIPTION
## What

Clicking a hot ticket in the AI Queue or High priority lane was a dead end. Only the in-progress lane has a run to open (#1117), so every other row fell back to `onSelectProject`, the project rendered its launcher, and the ticket was dropped: empty composer, nothing started, nothing to say which ticket you had just clicked.

The row now stashes a draft naming the ticket, and the launcher comes up prefilled with it. `lib/draft-handoff.ts` already carried a composer draft through a navigation for the device hop (#1066), so this is the same stash written directly instead of through a `?draft=` param.

## The bug underneath it

The handoff was broken in a browser for every caller, including the device hop it was built for.

`PromptEditor` runs Tiptap with `immediatelyRender: false`, so on the composer's first render `editor` is still null and the handle's `loadTemplate` returns `false` and does nothing. The rehydrate effect had already taken the draft and cleared it, so it was gone.

It looked fine because the same effect also called `setPrompt(carried)`: the composer's own state held the text, so Start submitted the right thing and only the visible box was empty. The user saw a blank composer with nothing to read or edit.

Drafts now reach the editor as `initialText`, which it applies once it exists.

## Verified in a browser, not only in tests

Built output driven in real Chrome against the live daemon: clicked a real AI-Queue row and read the composer back.

- before: `composer: "\n"`, and the diagnostic showed both halves firing (`setItem` wrote the draft, `removeItem` consumed it) with an empty editor
- after: `composer: "Work on tickets/2026-07-21_readzip-leaks-onto-public-api.md. Do not start any other ticket."`

## Agents card

#1190 deleted `WorkingNow.tsx` and its three tests, replacing it with an `Agents` card inline in `DashboardPage.tsx`, which has no test file. That left nothing pinning the behaviour #1189 exists to protect: an Overview row opens the session it names rather than dropping you on the launcher. `Agents` moves into its own file, like every other card on the Overview, with tests.

## Note on the test that was passing

`Composer.test.tsx` stubbed `PromptEditor` with a `loadTemplate` that answered synchronously, so the stub was more capable than the real editor and the bug could not show. The stub now resolves a render late like `useEditor` does, and holds its own text so a test can ask what is *in* the box rather than only what Start would send. Proof-by-revert: the new assertion fails with the old code (`expected '' to be 'Work on tickets/a.md…'`) and the old submit-based assertions do not.

## Tests

dashboard 485 pass / 0 fail, framework 1327 pass / 0 fail / 1 skipped. Typecheck and build clean.