### PR TITLE
fix(dashboard): catch render errors instead of blanking the whole UI (#1194)

### DIFF
--- a/.changeset/dashboard-error-boundary.md
+++ b/.changeset/dashboard-error-boundary.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+The dashboard no longer goes to a blank white screen when a view hits a render error. It had no error boundary, so any uncaught error while drawing a view — a stray line off the live feed, a panel reading a field the daemon had not written yet — unmounted the whole React tree to the root and left nothing on screen and nothing to click. It read as random because it was data-driven: a particular event, a particular poll, a particular moment. A caught render error now shows a recoverable card on the themed shell — Try again, or Reload — and logs the stack to the console so the next occurrence leaves a trace, rather than taking the session with it.

--- a/packages/framework-dashboard/components/ErrorBoundary.test.tsx
+++ b/packages/framework-dashboard/components/ErrorBoundary.test.tsx
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { ErrorBoundary } from './ErrorBoundary.js'
+
+afterEach(cleanup)
+
+// React logs a caught render error to console.error (twice, plus the boundary's own log). That is
+// expected here and only clutters the run, so swallow it for these cases.
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+/** Throws on demand, so a test can flip it from crashing to healthy between renders. */
+function Boom({ crash }: { crash: boolean }) {
+  if (crash) throw new Error('kaboom')
+  return <div>healthy content</div>
+}
+
+describe('ErrorBoundary (#1194)', () => {
+  test('renders its children untouched when nothing throws', () => {
+    render(
+      <ErrorBoundary>
+        <Boom crash={false} />
+      </ErrorBoundary>,
+    )
+    expect(screen.getByText('healthy content')).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  test('shows a recoverable alert instead of a blank screen when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <Boom crash={true} />
+      </ErrorBoundary>,
+    )
+    // The whole point of #1194: a crash leaves something on screen, not nothing.
+    const alert = screen.getByRole('alert')
+    expect(alert).toBeTruthy()
+    expect(screen.getByText('Something went wrong')).toBeTruthy()
+    // The thrown message is surfaced so the crash is diagnosable rather than opaque.
+    expect(screen.getByText('kaboom')).toBeTruthy()
+    // And the offending subtree is gone, not still trying to render.
+    expect(screen.queryByText('healthy content')).toBeNull()
+  })
+
+  test('logs the error so a "random" crash leaves a trace in the console', () => {
+    const spy = vi.spyOn(console, 'error')
+    render(
+      <ErrorBoundary>
+        <Boom crash={true} />
+      </ErrorBoundary>,
+    )
+    expect(spy.mock.calls.some(call => call[0] === 'Dashboard render error:')).toBe(true)
+  })
+
+  test('"Try again" re-mounts the children, recovering once the cause is gone', () => {
+    const { rerender } = render(
+      <ErrorBoundary>
+        <Boom crash={true} />
+      </ErrorBoundary>,
+    )
+    expect(screen.getByRole('alert')).toBeTruthy()
+
+    // The next render would no longer throw (the transient cause passed); clearing the boundary
+    // then draws the healthy tree rather than the fallback.
+    rerender(
+      <ErrorBoundary>
+        <Boom crash={false} />
+      </ErrorBoundary>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Try again/ }))
+    expect(screen.getByText('healthy content')).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/packages/framework-dashboard/components/ErrorBoundary.tsx
+++ b/packages/framework-dashboard/components/ErrorBoundary.tsx
@@ -1,0 +1,66 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { Button } from './ui/button.js'
+
+// The white blank screen (#1194). When a render error escapes every boundary React unmounts the
+// whole tree to the root, and the dashboard had none — so one bad line off the live feed, or one
+// panel reading a field the daemon has not written yet, took the entire app with it: nothing on
+// screen, nothing to click, and (since ssr:false) not even an SSR error page to fall back to. It
+// looked random because it was data-driven — a particular event, a particular poll, a particular
+// moment. This is the net under all of it. A render error is caught here and shown as a recoverable
+// card on the themed shell, so a crash costs you a view and a click, not the session, and the stack
+// reaches the console for whoever hits it next.
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // The daemon never sees the browser console, and a blank page carries no trace on its own, so
+    // this is the one record of a "random" crash (#1194) — keep the stack for whoever debugs it.
+    console.error('Dashboard render error:', error, info.componentStack)
+  }
+
+  // Clearing the error re-mounts the children. A transient cause (a stream hiccup, a half-written
+  // read that the next poll completes) then renders through; a durable one throws straight back
+  // here, no worse than before, which is why Reload sits beside it as the sure way out.
+  private reset = (): void => this.setState({ error: null })
+
+  render(): ReactNode {
+    const { error } = this.state
+    if (!error) return this.props.children
+    return (
+      <div
+        role="alert"
+        className="flex min-h-screen flex-col items-center justify-center gap-3 bg-background p-8 text-center text-foreground"
+      >
+        <p className="text-base font-medium">Something went wrong</p>
+        <p className="max-w-md text-sm text-muted-foreground">
+          The dashboard hit an error and could not finish drawing this view. Your session is safe — the daemon keeps
+          running. Try again, or reload the page.
+        </p>
+        {error.message && (
+          <pre className="max-w-md overflow-x-auto rounded-md bg-muted px-3 py-2 text-left text-xs text-muted-foreground">
+            {error.message}
+          </pre>
+        )}
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={this.reset}>
+            Try again
+          </Button>
+          <Button onClick={() => window.location.reload()}>Reload</Button>
+        </div>
+      </div>
+    )
+  }
+}

--- a/packages/framework-dashboard/layouts/LayoutDefault.tsx
+++ b/packages/framework-dashboard/layouts/LayoutDefault.tsx
@@ -1,6 +1,7 @@
 import { useEffect, type ReactNode } from 'react'
 import './tailwind.css'
 import { usePreferences, themePreference, resolvedDark } from '../lib/preferences.js'
+import { ErrorBoundary } from '../components/ErrorBoundary.js'
 
 // The dashboard's color theme (#725): system (default, follow the OS), light, or dark. Client-only
 // (ssr:false), so toggling the `.dark` class in an effect is fine. Until the preferences load over
@@ -17,5 +18,12 @@ export default function LayoutDefault({ children }: { children: ReactNode }) {
     mql.addEventListener('change', apply)
     return () => mql.removeEventListener('change', apply)
   }, [theme])
-  return <div className="min-h-screen bg-background text-foreground">{children}</div>
+  // Everything dynamic renders below here — the live feed, the polled panels, the markdown — so the
+  // error boundary (#1194) sits inside the themed shell: a caught crash shows its recoverable card on
+  // the app's own background rather than the browser's blank white.
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <ErrorBoundary>{children}</ErrorBoundary>
+    </div>
+  )
 }


### PR DESCRIPTION
Fixes #1194.

## The bug

The dashboard sometimes went to a blank white screen, seemingly at random.

## Diagnosis

The dashboard had **no error boundary anywhere**. In React, an uncaught error thrown during render propagates to the root and unmounts the entire tree — a blank page. With `ssr:false` (per #405) there isn't even an SSR error page to fall back to, so the whole app just vanishes with nothing on screen and nothing to click.

It looked random because it was data-driven. The dashboard is a projection of a live event stream and a fistful of polls, and it renders that data across many panels (the feed, markdown views, the rails, the overview cards). A single value the code didn't expect — a stray line off `events.jsonl`, a field the daemon hasn't written yet, an unusual shape from a poll — throws during render on the one render that hits it, and takes everything with it. The data hooks are already defensive (`usePolled` keeps the last value on a rejected read, `format-date` handles unparseable timestamps), but there was no net for a render-time throw.

## The fix

Add a small `ErrorBoundary` and place it inside `LayoutDefault`, wrapping the page tree but sitting within the themed `bg-background text-foreground` shell. Now a caught render error shows a **recoverable card** — *Try again* / *Reload* — on the app's own background instead of the browser's blank white, and logs the error + component stack to the console so the next occurrence leaves a trace to debug (the daemon never sees the browser console; a blank page carried none).

- **Try again** clears the boundary and re-mounts the subtree — a transient cause (a stream hiccup, a half-written read the next poll completes) renders straight through.
- **Reload** is the sure way out for a durable cause.

This is the net under all of it: a render crash now costs you a view and a click, not the session.

## Changes

- `components/ErrorBoundary.tsx` — new class-based error boundary with a themed, recoverable fallback.
- `layouts/LayoutDefault.tsx` — wrap the page tree in `<ErrorBoundary>` inside the themed shell.
- `components/ErrorBoundary.test.tsx` — renders children normally; shows the alert (not a blank) on a throw; surfaces the message; logs the error; recovers on *Try again* once the cause is gone.
- Changeset (`@gemstack/the-framework: patch`).

## Verification

- `pnpm test` — 65 files, **479 tests pass** (4 new).
- `pnpm typecheck` — clean.
- `pnpm build` (turbo build + `bundle:dashboard`) — green.

## Note / possible follow-up

This is an app-wide safety net: a crash anywhere in the page replaces the whole page with the fallback. A natural follow-up would be a second, finer-grained boundary around just the main pane so the sidebar and rails survive a main-pane crash and navigation stays usable — deliberately left out here to keep the fix focused on the reported symptom (never a blank screen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5PHAJ2sXPqwdbPZJsvYyx)_