### PR TITLE
Tidy the dashboard Overview's type scale and spacing (#1139)

### DIFF
--- a/.changeset/overview-type-and-spacing.md
+++ b/.changeset/overview-type-and-spacing.md
@@ -1,0 +1,7 @@
+---
+"@gemstack/the-framework": patch
+---
+
+Polish the dashboard Overview's typography and spacing.
+
+Every card now has a consistent 16px title with its one-line description dropped to a smaller muted tier, so each reads as a clear title → description → content hierarchy instead of a title and description at the same size. Row text is unified at one size — the Human Queue's item titles had been rendering larger than every other card's — the AI Queue's queued items are more legible, its per-project counts read as filled pills, and the Agents view's Current/Recent columns get a single ruled header row rather than two stacked muted lines. No behavioural change.

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -78,7 +78,7 @@ function HumanQueue({ items, onSelectProject }: { items: Intervention[]; onSelec
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="flex items-center gap-2">
+        <CardTitle className="flex items-center gap-2 text-base">
           <Inbox className="h-4 w-4 text-muted-foreground" />
           Human Queue
           {items.length > 0 && (
@@ -87,9 +87,9 @@ function HumanQueue({ items, onSelectProject }: { items: Intervention[]; onSelec
             </span>
           )}
         </CardTitle>
-        <p className="text-sm text-muted-foreground">Agents awaiting your approval, review, or input</p>
+        <p className="text-xs text-muted-foreground">Agents awaiting your approval, review, or input</p>
       </CardHeader>
-      <CardContent className="pt-0">
+      <CardContent>
         {items.length === 0 ? (
           <p className="py-2 text-sm text-muted-foreground">AI doesn&apos;t need you.</p>
         ) : (
@@ -100,24 +100,24 @@ function HumanQueue({ items, onSelectProject }: { items: Intervention[]; onSelec
                   <button
                     type="button"
                     onClick={() => onSelectProject(item.projectId)}
-                    className="flex w-full items-center gap-2 py-2 text-left hover:opacity-80"
+                    className="flex w-full items-center gap-2.5 py-2 text-left hover:opacity-80"
                     title="Open the session to answer"
                   >
                     <MessageCircleQuestion className="h-4 w-4 shrink-0 text-warning" />
                     <span className="shrink-0 text-xs font-medium text-warning">Awaiting</span>
-                    <span className="truncate font-medium">{item.title}</span>
+                    <span className="truncate text-sm font-medium">{item.title}</span>
                     <span className="ml-auto shrink-0 text-xs text-muted-foreground">{item.projectName}</span>
                   </button>
                 ) : item.kind === 'unpushed' ? (
                   <button
                     type="button"
                     onClick={() => onSelectProject(item.projectId)}
-                    className="flex w-full items-center gap-2 py-2 text-left hover:opacity-80"
+                    className="flex w-full items-center gap-2.5 py-2 text-left hover:opacity-80"
                     title={`Open the session: work on ${item.branch ?? ''} was never pushed`}
                   >
                     <GitBranch className="h-4 w-4 shrink-0 text-info" />
                     <span className="shrink-0 text-xs font-medium text-info">Unpushed</span>
-                    <span className="truncate font-medium">{item.title}</span>
+                    <span className="truncate text-sm font-medium">{item.title}</span>
                     {/* An unknown count says nothing rather than the contradictory "0 commits". */}
                     {item.commits !== undefined && item.commits > 0 && (
                       <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
@@ -131,12 +131,12 @@ function HumanQueue({ items, onSelectProject }: { items: Intervention[]; onSelec
                     href={item.url}
                     target="_blank"
                     rel="noreferrer"
-                    className="flex items-center gap-2 py-2 hover:opacity-80"
+                    className="flex items-center gap-2.5 py-2 hover:opacity-80"
                     title={`Open PR #${item.number} on GitHub`}
                   >
                     <GitPullRequest className="h-4 w-4 shrink-0 text-success" />
                     <span className="shrink-0 text-xs font-medium tabular-nums text-muted-foreground">#{item.number}</span>
-                    <span className="truncate font-medium">{item.title}</span>
+                    <span className="truncate text-sm font-medium">{item.title}</span>
                     <span className="ml-auto shrink-0 text-xs text-muted-foreground">{item.projectName}</span>
                   </a>
                 )}
@@ -165,19 +165,19 @@ function AiQueue({
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="flex items-center gap-2">
+        <CardTitle className="flex items-center gap-2 text-base">
           <ListTodo className="h-4 w-4 text-muted-foreground" />
           AI Queue
         </CardTitle>
-        <p className="text-sm text-muted-foreground">Tasks AI will work on next</p>
+        <p className="text-xs text-muted-foreground">Tasks AI will work on next</p>
       </CardHeader>
-      <CardContent className="pt-0">
+      <CardContent>
         {loading ? (
           <p className="py-2 text-sm text-muted-foreground">Loading…</p>
         ) : withOpen.length === 0 ? (
           <p className="py-2 text-sm text-muted-foreground">Nothing queued.</p>
         ) : (
-          <ul className="space-y-3">
+          <ul className="space-y-4">
             {withOpen.map(q => (
               <li key={q.projectId}>
                 <button
@@ -186,9 +186,9 @@ function AiQueue({
                   className="flex w-full items-center gap-2 text-left hover:opacity-80"
                 >
                   <span className="truncate text-sm font-medium">{q.projectName}</span>
-                  <span className="ml-auto shrink-0 rounded-full border border-border px-2 text-xs text-muted-foreground">{q.open}</span>
+                  <span className="ml-auto shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs tabular-nums text-muted-foreground">{q.open}</span>
                 </button>
-                <ul className="mt-1 space-y-0.5 pl-1">
+                <ul className="mt-1.5 space-y-1 pl-0.5">
                   {q.items
                     .filter(i => !i.done)
                     .map((item, i) => {
@@ -196,8 +196,8 @@ function AiQueue({
                       // so print the title rather than the source; the whole line stays in the tooltip.
                       const label = queueEntryLabel(item.text)
                       return (
-                        <li key={i} className="flex gap-1.5 text-xs text-muted-foreground">
-                          <span aria-hidden className="text-muted-foreground/60">•</span>
+                        <li key={i} className="flex gap-2 text-sm text-muted-foreground">
+                          <span aria-hidden className="text-muted-foreground/50">•</span>
                           <span className="truncate" title={item.text}>{label.text}</span>
                         </li>
                       )
@@ -255,13 +255,13 @@ function Agents({
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="flex items-center gap-2">
+        <CardTitle className="flex items-center gap-2 text-base">
           <Bot className="h-4 w-4 text-muted-foreground" />
           Agents
         </CardTitle>
       </CardHeader>
-      <CardContent className="pt-0">
-        <div className="grid gap-x-8 gap-y-6 sm:grid-cols-2">
+      <CardContent>
+        <div className="grid gap-x-10 gap-y-6 sm:grid-cols-2">
           <AgentColumn heading="Current" description="Agents currently working" rows={current} loading={loading} empty="No agents working right now." />
           <AgentColumn heading="Recent" description="Agents finished working" rows={recent} loading={loading} empty="No sessions yet." />
         </div>
@@ -285,14 +285,18 @@ function AgentColumn({
 }) {
   return (
     <div className="min-w-0">
-      <h4 className="text-xs font-semibold uppercase tracking-wide text-foreground/80">{heading}</h4>
-      <p className="text-xs text-muted-foreground">{description}</p>
+      {/* Eyebrow + one-line description on a single ruled row, so the column reads as a labelled
+          section rather than two stacked muted lines. */}
+      <div className="flex items-baseline gap-2 border-b border-border pb-1.5">
+        <h4 className="shrink-0 text-xs font-semibold uppercase tracking-wide text-foreground">{heading}</h4>
+        <p className="truncate text-xs text-muted-foreground">{description}</p>
+      </div>
       {loading ? (
         <p className="py-2 text-sm text-muted-foreground">Loading…</p>
       ) : rows.length === 0 ? (
         <p className="py-2 text-sm text-muted-foreground">{empty}</p>
       ) : (
-        <ul className="mt-2 space-y-0.5">
+        <ul className="mt-1.5 space-y-0.5">
           {rows.map(r => (
             <AgentRow key={r.key} label={r.label} at={r.at} projectName={r.projectName} onOpen={r.onOpen} />
           ))}
@@ -309,13 +313,13 @@ function AgentRow({ label, at, projectName, onOpen }: Omit<AgentRowData, 'key'>)
         type="button"
         onClick={onOpen}
         title="Open this session"
-        className="flex w-full items-baseline gap-2 rounded-md px-2 py-1 text-left hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
+        className="flex w-full items-baseline gap-2 rounded-md px-2 py-1.5 text-left hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
       >
-        <span aria-hidden className="shrink-0 text-muted-foreground/60">•</span>
+        <span aria-hidden className="shrink-0 text-muted-foreground/50">•</span>
         <span className="min-w-0 flex-1 truncate text-sm">{label}</span>
         <span className="shrink-0 text-xs text-muted-foreground">{projectName}</span>
         {at && (
-          <span className="shrink-0 text-xs tabular-nums text-muted-foreground" title={formatDateTime(at)}>
+          <span className="shrink-0 whitespace-nowrap text-xs tabular-nums text-muted-foreground/80" title={formatDateTime(at)}>
             {formatAge(at)}
           </span>
         )}

--- a/packages/framework-dashboard/components/HotTickets.tsx
+++ b/packages/framework-dashboard/components/HotTickets.tsx
@@ -50,7 +50,7 @@ export function HotTickets({
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="flex items-center gap-2">
+        <CardTitle className="flex items-center gap-2 text-base">
           <Flame className="h-4 w-4 text-muted-foreground" />
           Hot tickets
         </CardTitle>

--- a/packages/framework-dashboard/components/OnboardingChecklist.tsx
+++ b/packages/framework-dashboard/components/OnboardingChecklist.tsx
@@ -203,8 +203,8 @@ export function OnboardingChecklist({
     <Card>
       <CardHeader className="flex flex-row items-start justify-between gap-3">
         <div>
-          <CardTitle>Onboarding</CardTitle>
-          <p className="text-sm text-muted-foreground">
+          <CardTitle className="text-base">Onboarding</CardTitle>
+          <p className="text-xs text-muted-foreground">
             {doneCount} of {steps.length} set up.
           </p>
         </div>

--- a/packages/framework-dashboard/components/Quota.tsx
+++ b/packages/framework-dashboard/components/Quota.tsx
@@ -247,7 +247,7 @@ export function Quota() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Usage</CardTitle>
+        <CardTitle className="text-base">Usage</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         {!view && <p className="text-sm text-muted-foreground">Reading your usage…</p>}

--- a/packages/framework-dashboard/components/RoutineWork.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.tsx
@@ -60,7 +60,7 @@ export function RoutineWork({ onSelectProject }: { onSelectProject: (id: string)
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="flex items-center gap-2">
+        <CardTitle className="flex items-center gap-2 text-base">
           <CalendarClock className="h-4 w-4 text-muted-foreground" />
           Routine work
         </CardTitle>


### PR DESCRIPTION
A presentational pass over the whole Overview page — the "padding and font sizes" polish from #1139. No behaviour changes.

## The problem

The cards had a flat, slightly inconsistent type scale: titles and their descriptions were the same 14px size (weak hierarchy), and the Human Queue's row titles were rendering at the base 16px — visibly larger than every other card's rows.

## The pass

Established one scale across every card — **title 16px semibold › description 12px muted › row 14px › meta 12px** — and applied it consistently:

- **Card titles** (Usage, Human Queue, AI Queue, Routine work, Agents, Hot tickets, Onboarding) → 16px, so each card has a clear anchor.
- **Descriptions** → 12px muted, one tier below the title instead of matching it.
- **Rows** → unified at 14px; the oversized Human Queue titles are fixed, and the AI Queue's queued items go from 12px to a more legible 14px.
- **AI Queue counts** → filled muted pills rather than thin outlines.
- **Agents view** → the `Current` / `Recent` columns get a single ruled header row (eyebrow + description on one line) instead of two stacked muted lines, wider column gutter, and a touch more row height; the relative age no longer wraps.
- Restored the standard header→content gap on the queue and Agents cards (they were pinned flush with `pt-0`).

## How it was reviewed

Rendered the page from the app's own compiled stylesheet (Everforest tokens, IBM Plex) with representative data and screenshotted it in both light and dark themes, iterating on the type scale there before porting the exact classes back to the components.

## Verification

All three CI steps pass locally: `pnpm build` (incl. dashboard bundle), `pnpm typecheck` (22/22), `pnpm test` (21/21 — 475 dashboard tests). Changes are class-only; no test assertions touch the markup.

Refs #1139.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYHthQiuVfUoaEhc8mNtAL)_