### PR TITLE
feat(dashboard): show a session's agent id and copy the command that reopens it

### DIFF
--- a/.changeset/session-id-resume-command.md
+++ b/.changeset/session-id-resume-command.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/the-framework': minor
+---
+
+A session's agent id is now visible, and clicking it copies the command that reopens that session in a terminal. The id was recorded all along and shown nowhere, so a conversation you wanted to continue outside the dashboard could not be named. The id on its own is not enough either: the CLI matches a session by the directory it ran in, and that directory is usually gone by then, because a run that finishes cleanly has its worktree removed. The copied command recreates the path first, which is what makes the resume actually find the session.
+
+The same menu's folder item is now named for what it opens. Once a session's worktree is gone the item resolves to the project root, and calling that "the session's folder" was a lie the user had no way to see.

--- a/packages/framework-dashboard/components/SessionActionsMenu.test.tsx
+++ b/packages/framework-dashboard/components/SessionActionsMenu.test.tsx
@@ -41,17 +41,62 @@ describe('SessionActionsMenu (#toolbar-menu)', () => {
     render(<SessionActionsMenu projectId="p1" runId="run-1" events={[]} label="my session" onDeleted={vi.fn()} />)
     openMenu()
     await waitFor(() => expect(screen.getByText('Open on GitHub')).toBeTruthy())
-    expect(screen.getByText("Open session's folder")).toBeTruthy()
+    // No retained worktree here, so the folder item names the project root it will actually open.
+    expect(screen.getByText('Open project folder')).toBeTruthy()
     expect(screen.getByText('Open in editor')).toBeTruthy()
     expect(screen.getByText('Serve')).toBeTruthy()
     expect(screen.getByText('Delete session')).toBeTruthy()
   })
 
-  test("opening the folder targets this session's worktree", async () => {
+  test('opening the folder addresses this session, whichever checkout it resolves to', async () => {
     render(<SessionActionsMenu projectId="p1" runId="run-1" events={[]} onDeleted={vi.fn()} />)
     openMenu()
-    fireEvent.click(await screen.findByText("Open session's folder"))
+    fireEvent.click(await screen.findByText('Open project folder'))
     await waitFor(() => expect(sendOpenInApp).toHaveBeenCalledWith('p1', 'files', 'run-1'))
+  })
+
+  test("names the folder item for what it opens once the session's worktree is gone (#1195)", async () => {
+    // A finished, non-retained run has no checkout of its own, so the item resolves to the project
+    // root. Promising "the session's folder" there was a lie the user could not see.
+    render(<SessionActionsMenu projectId="p1" runId="run-1" events={[]} onDeleted={vi.fn()} />)
+    openMenu()
+    expect(await screen.findByText('Open project folder')).toBeTruthy()
+    expect(screen.queryByText("Open session's folder")).toBeNull()
+    cleanup()
+
+    // A retained worktree still exists, so the session wording is honest again.
+    render(<SessionActionsMenu projectId="p1" runId="run-1" events={[]} retainedWorktree onDeleted={vi.fn()} />)
+    openMenu()
+    expect(await screen.findByText("Open session's folder")).toBeTruthy()
+  })
+
+  test('copies the command that reopens the session in a terminal (#1195)', async () => {
+    const writeText = vi.fn(async () => {})
+    Object.assign(navigator, { clipboard: { writeText } })
+    const events = [
+      { kind: 'session', driver: 'claude', workspace: '/repo/.the-framework/worktrees/run-1', fake: false },
+      { kind: 'session-update', sessionId: '45015d11-755b-423c-ae71-8dbfd54f7cce' },
+    ] as never
+    render(<SessionActionsMenu projectId="p1" runId="run-1" events={events} onDeleted={vi.fn()} />)
+    openMenu()
+    // The id is visible in its own right: it is the only handle on the conversation off-dashboard.
+    expect(await screen.findByText('45015d11')).toBeTruthy()
+    fireEvent.click(screen.getByText('Copy resume command'))
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        'mkdir -p /repo/.the-framework/worktrees/run-1 && cd /repo/.the-framework/worktrees/run-1 && claude --resume 45015d11-755b-423c-ae71-8dbfd54f7cce',
+      ),
+    )
+    // And it says so, since a click that only fills the clipboard shows nothing otherwise.
+    await waitFor(() => expect(screen.getByText('Copied')).toBeTruthy())
+  })
+
+  test('offers nothing to copy for a run that never reported a session', async () => {
+    render(<SessionActionsMenu projectId="p1" runId="run-1" events={[]} onDeleted={vi.fn()} />)
+    openMenu()
+    await waitFor(() => expect(screen.getByText('Open in editor')).toBeTruthy())
+    expect(screen.queryByText('Copy resume command')).toBeNull()
+    expect(screen.queryByText('Copy session id')).toBeNull()
   })
 
   test('Delete asks to confirm before deleting', async () => {

--- a/packages/framework-dashboard/components/SessionActionsMenu.tsx
+++ b/packages/framework-dashboard/components/SessionActionsMenu.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { FrameworkEvent, ServeTarget } from '@gemstack/the-framework'
 import { sessionInfo } from '@gemstack/the-framework/client'
-import { MoreVertical, Github, FolderOpen, Code, Check, Play, ExternalLink, Square, FolderX, Trash2 } from 'lucide-react'
+import { MoreVertical, Github, FolderOpen, Code, Check, Play, ExternalLink, Square, FolderX, Trash2, Copy } from 'lucide-react'
 import { onGithubUrl } from '../server/reads.telefunc.js'
 import {
   sendOpenInApp,
@@ -20,6 +20,7 @@ import { usePreferences, updatePreferences } from '../lib/preferences.js'
 import { useDetectedEditors } from '../lib/editors.js'
 import { isRunActive } from '../lib/live-state.js'
 import { describeSessionLink } from '../lib/session-link.js'
+import { buildResumeCommand } from '../lib/resume-command.js'
 import { cn } from '../lib/utils.js'
 import { buttonVariants } from './ui/button.js'
 import { OptionLabel } from './ui/option-label.js'
@@ -62,7 +63,33 @@ export function SessionActionsMenu({
   onDeleted?: (() => void) | undefined
 }) {
   const active = isRunActive(events)
-  const session = describeSessionLink(sessionInfo(events))
+  const info = sessionInfo(events)
+  const session = describeSessionLink(info)
+
+  // Whether this session still has a checkout of its own. A live run is working in one, and a
+  // finished run only keeps one when it was retained (#737) — a clean run has had it removed by
+  // teardown. Without this the folder item promised the session's folder and silently opened the
+  // project root instead, because `resolveRunCheckout` falls back there once the worktree is gone.
+  const hasOwnFolder = active || retainedWorktree
+
+  // What to put on the clipboard to pick this session back up in a terminal (#1195). `mkdir -p`
+  // leads because the directory is usually gone by the time you want it: the CLI finds a session
+  // by the cwd it ran in, so the path has to exist again before `--resume` can see it. Recreating
+  // it empty is enough to read the conversation back.
+  const resumeCommand = buildResumeCommand(info)
+  // Flash a confirmation for a beat, the same feedback the CopyButton gives, since a click that
+  // only fills the clipboard has nothing else to show for itself.
+  const [copied, setCopied] = useState(false)
+  const copiedTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  useEffect(() => () => clearTimeout(copiedTimer.current), [])
+  const copyResume = () => {
+    if (!resumeCommand) return
+    void navigator.clipboard?.writeText(resumeCommand).then(() => {
+      setCopied(true)
+      clearTimeout(copiedTimer.current)
+      copiedTimer.current = setTimeout(() => setCopied(false), 1500)
+    })
+  }
   // keepPrevious: hold the last repo URL while a new project's loads, so the item does not flicker.
   const githubUrl = useLoaded<string | null>(() => onGithubUrl(projectId), null, [projectId], true)
 
@@ -141,8 +168,16 @@ export function SessionActionsMenu({
               <Github className="h-3.5 w-3.5 shrink-0" /> Open on GitHub
             </DropdownMenuItem>
           )}
-          <DropdownMenuItem disabled={busy} onClick={() => void openApp('files')}>
-            <FolderOpen className="h-3.5 w-3.5 shrink-0" /> {runId ? "Open session's folder" : 'Open folder'}
+          {/* Named for what it actually opens (#1195): once a session's worktree is gone this
+              resolves to the project root, and calling that "the session's folder" was a lie the
+              user could not see. */}
+          <DropdownMenuItem
+            disabled={busy}
+            onClick={() => void openApp('files')}
+            title={runId && !hasOwnFolder ? 'This session no longer has its own checkout' : undefined}
+          >
+            <FolderOpen className="h-3.5 w-3.5 shrink-0" />{' '}
+            {runId ? (hasOwnFolder ? "Open session's folder" : 'Open project folder') : 'Open folder'}
           </DropdownMenuItem>
           <DropdownMenuSub>
             <DropdownMenuSubTrigger disabled={busy}>
@@ -182,6 +217,25 @@ export function SessionActionsMenu({
           {session && (
             <DropdownMenuItem render={<a href={session.href} target="_blank" rel="noreferrer" />}>
               <ExternalLink className="h-3.5 w-3.5 shrink-0" /> {session.label.replace(' ↗', '')}
+            </DropdownMenuItem>
+          )}
+          {/* The agent's session id (#1195), shown because it is the only handle on the
+              conversation once you leave the dashboard, and clickable because on its own an id is
+              not actionable: the click copies the command that reopens it in a terminal. Stays
+              open on click so the confirmation is visible. */}
+          {resumeCommand && info?.sessionId && (
+            <DropdownMenuItem closeOnClick={false} onClick={copyResume} title={resumeCommand}>
+              {copied ? (
+                <Check className="h-3.5 w-3.5 shrink-0 text-success" />
+              ) : (
+                <Copy className="h-3.5 w-3.5 shrink-0" />
+              )}
+              <span className="flex-1">
+                {copied ? 'Copied' : info.workspace ? 'Copy resume command' : 'Copy session id'}
+              </span>
+              <span className="ml-auto pl-3 font-mono text-[10px] text-muted-foreground">
+                {info.sessionId.slice(0, 8)}
+              </span>
             </DropdownMenuItem>
           )}
 

--- a/packages/framework-dashboard/lib/resume-command.test.ts
+++ b/packages/framework-dashboard/lib/resume-command.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest'
+import { buildResumeCommand } from './resume-command.js'
+
+describe('buildResumeCommand (#1195)', () => {
+  test('recreates the directory before resuming, since the worktree is usually gone', () => {
+    const cmd = buildResumeCommand({ sessionId: 'sess-1', workspace: '/repo/.the-framework/worktrees/run-1' })
+    // The mkdir is the load-bearing part: the CLI matches a session by the cwd it ran in, so
+    // without the path existing again `--resume` cannot find it.
+    expect(cmd).toBe(
+      'mkdir -p /repo/.the-framework/worktrees/run-1 && cd /repo/.the-framework/worktrees/run-1 && claude --resume sess-1',
+    )
+  })
+
+  test('falls back to the bare id when no workspace was recorded', () => {
+    // An older run, or one that never opened a session: the id is still worth handing over.
+    expect(buildResumeCommand({ sessionId: 'sess-1' })).toBe('sess-1')
+  })
+
+  test('has nothing to offer without a session id', () => {
+    expect(buildResumeCommand({ workspace: '/repo' })).toBeNull()
+    expect(buildResumeCommand(null)).toBeNull()
+    expect(buildResumeCommand(undefined)).toBeNull()
+  })
+})

--- a/packages/framework-dashboard/lib/resume-command.ts
+++ b/packages/framework-dashboard/lib/resume-command.ts
@@ -1,0 +1,25 @@
+import type { SessionInfo } from '@gemstack/the-framework'
+
+// The shell one-liner that picks a session back up in a terminal (#1195).
+//
+// The dashboard knew the agent's session id and never showed it, so a session you wanted to
+// continue outside the dashboard was unreachable: the conversation was on disk and you had no way
+// to name it. The id alone is not enough either — the CLI finds a session by the directory it ran
+// in, and that directory is usually gone by the time you want it, since a run that finishes
+// cleanly has its worktree removed. So the command recreates the path first; an empty directory
+// is enough for the CLI to match the session and read the conversation back.
+//
+// Deliberately no permission-mode flag: this lands in someone's terminal, and what an agent is
+// allowed to do once it reopens is that person's call to make at the prompt, not ours to preset.
+//
+// With no directory recorded (an older run, or one that never opened a session) the id is still
+// worth handing over on its own, so the caller can say which of the two it copied.
+export function buildResumeCommand(
+  session: Pick<SessionInfo, 'sessionId' | 'workspace'> | null | undefined,
+): string | null {
+  const id = session?.sessionId
+  if (!id) return null
+  const dir = session.workspace
+  if (!dir) return id
+  return `mkdir -p ${dir} && cd ${dir} && claude --resume ${id}`
+}

--- a/packages/the-framework/src/run-view.test.ts
+++ b/packages/the-framework/src/run-view.test.ts
@@ -45,6 +45,17 @@ test('sessionInfo merges the opening session with the latest session-update link
   assert.equal(sessionInfo([{ kind: 'log', message: 'x' }]), null)
 })
 
+test('sessionInfo keeps the workspace the run used, so a removed worktree is still nameable (#1195)', () => {
+  const events: FrameworkEvent[] = [
+    { kind: 'session', driver: 'claude', workspace: '/repo/.the-framework/worktrees/run-1', fake: false },
+    { kind: 'session-update', sessionId: 'sess-1' },
+  ]
+  // The later session-update must not drop it: the id arrives after the workspace, and it is the
+  // pair together that reopens the session in a terminal.
+  assert.equal(sessionInfo(events)?.workspace, '/repo/.the-framework/worktrees/run-1')
+  assert.equal(sessionInfo(events)?.sessionId, 'sess-1')
+})
+
 test('deployPlan returns the chosen deploy target from the deploy event; latest wins (#433)', () => {
   const boot = (event: Record<string, unknown>): FrameworkEvent => ({ kind: 'bootstrap', event: event as never })
   assert.equal(deployPlan([{ kind: 'log', message: 'x' }]), null) // no deploy yet

--- a/packages/the-framework/src/run-view.ts
+++ b/packages/the-framework/src/run-view.ts
@@ -127,6 +127,14 @@ export interface SessionInfo {
   fake?: boolean
   sessionId?: string
   sessionLink?: string
+  /**
+   * The directory the agent ran in (#1195), from the opening `session` event.
+   *
+   * Taken from the event rather than the filesystem on purpose: a run that finishes cleanly has
+   * its worktree removed (`tearDownWorktree`), so the event is the only surviving record of where
+   * the session lived — and that path is exactly what `claude --resume` needs to find it again.
+   */
+  workspace?: string
 }
 
 /**
@@ -138,7 +146,12 @@ export function sessionInfo(events: readonly FrameworkEvent[]): SessionInfo | nu
   let info: SessionInfo | null = null
   for (const event of events) {
     if (event.kind === 'session') {
-      info = { driver: event.driver, fake: event.fake, ...(event.sessionLink ? { sessionLink: event.sessionLink } : {}) }
+      info = {
+        driver: event.driver,
+        fake: event.fake,
+        workspace: event.workspace,
+        ...(event.sessionLink ? { sessionLink: event.sessionLink } : {}),
+      }
     } else if (event.kind === 'session-update') {
       info = { ...(info ?? {}), sessionId: event.sessionId, ...(event.sessionLink ? { sessionLink: event.sessionLink } : {}) }
     }


### PR DESCRIPTION
Closes #1195.

## What

A session's agent id is now shown in the ⋮ menu, and clicking it copies the command that reopens that session in a terminal.

The id was recorded on every run and surfaced nowhere. Both of tonight's "my work is lost" incidents were really this: the conversation was on disk and there was no way to name it. The second one ended with "I have the ID ... but I don't know what directory".

## The directory is the load-bearing part

The id on its own does not resume anything. The CLI matches a session by the directory it ran in, and that directory is usually gone by the time you want it: a run that finishes cleanly has its worktree removed by `tearDownWorktree`. So the copied command recreates the path first:

```
mkdir -p <workspace> && cd <workspace> && claude --resume <sessionId>
```

Verified by hand against a real session whose worktree had been deleted: recreate the empty directory, resume, and the conversation comes back.

The path comes from the opening `session` event rather than the filesystem, since that event is the only surviving record once the worktree is gone. `SessionInfo` gains `workspace` for it.

## The folder item was lying

Same menu, same root cause. `resolveRunCheckout` falls back to the project root once a session's worktree is gone, so `Open session's folder` quietly opened the project instead, for every successful run, with no `git clean` involved. It now reads `Open project folder` in that case, with a tooltip saying why. A live or retained run keeps the session wording, because there the folder really is the session's.

## Note for @brillout

The issue asked for `--dangerously-skip-permissions` on the copied command and it is deliberately not there. This string lands in someone's terminal, and what the agent is allowed to do when it reopens felt like their call to make at the prompt rather than ours to preset. One word to add if you disagree.

## Tests

- `buildResumeCommand` extracted to `lib/resume-command.ts` and unit tested: the mkdir form, the bare-id fallback when no workspace was recorded, and null with no session.
- `sessionInfo` keeps the workspace across a later `session-update` (the id arrives after the path, and it is the pair that reopens the session).
- Menu: the id renders, the click copies the full command and confirms, the label flips with `retainedWorktree`, and a run with no session offers nothing to copy.

dashboard 495 pass / 0 fail, framework 1347 pass / 0 fail / 1 skipped. Typecheck and build clean.

The framework suite failed once on `binding a topic run re-homes it (#1122)` and passed on re-run, this time with an `ENOTEMPTY` on the scratch dir rather than the usual timeout. That is the known flake and it is worth reopening #1165: the branch already contains its fix (`a9c86ba`) and it still fires.
