### PR TITLE
fix(dashboard): align submenu rows with the rest of the menu

### DIFF
--- a/.changeset/submenu-trigger-alignment.md
+++ b/.changeset/submenu-trigger-alignment.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+Menu rows that open a submenu now line up with the rest of the menu. The row justified its contents to spread the chevron to the far end, which also spread everything before it, so a trigger whose label was plain text had that label pushed toward the middle while every ordinary row sat left. The chevron now moves itself to the end instead, which leaves the label where it belongs and makes the two ways of writing a trigger behave the same. Visible on "Open in editor" and, in a repo with several servable apps, "Serve".

--- a/packages/framework-dashboard/components/ui/dropdown-menu.tsx
+++ b/packages/framework-dashboard/components/ui/dropdown-menu.tsx
@@ -87,12 +87,16 @@ export function DropdownMenuCheckboxItem({
 
 export function DropdownMenuSubTrigger({ className, children, ...props }: ComponentProps<typeof Menu.SubmenuTrigger>) {
   return (
+    // The chevron is pushed to the end by its own `ml-auto`, not by `justify-between` on the row.
+    // Justifying the row spaces out *every* child, so a trigger whose label is plain text had it
+    // centred between the icon and the chevron while every ordinary item sat left, and the only
+    // way to sit straight was to remember a `flex-1` wrapper. Now both forms align the same.
     <Menu.SubmenuTrigger
-      className={cn(ITEM_CLASS, 'justify-between data-[popup-open]:bg-[var(--color-accent)]', className)}
+      className={cn(ITEM_CLASS, 'data-[popup-open]:bg-[var(--color-accent)]', className)}
       {...props}
     >
       {children}
-      <ChevronRight className="h-3.5 w-3.5 opacity-70" />
+      <ChevronRight className="ml-auto h-3.5 w-3.5 shrink-0 opacity-70" />
     </Menu.SubmenuTrigger>
   )
 }


### PR DESCRIPTION
## The bug

In the session ⋮ menu, `Open in editor` sat noticeably right of every other row.

`DropdownMenuSubTrigger` put `justify-between` on the row so the chevron would sit at the far end. But justifying the row spreads *every* child, not just the last one, so a trigger whose label is plain text had that label pushed toward the middle while ordinary items sat left against their icon.

The only way to sit straight was to remember a `flex-1` wrapper around the label. `AgentModelMenu` and `OptionsMenu` happen to do that; `SessionActionsMenu` does not, in two places.

## The fix

The chevron moves itself to the end with `ml-auto`, and the row keeps ordinary item layout. Both ways of writing a trigger now align identically, so the next call site cannot get it wrong.

## Measured, not eyeballed

Driven in real Chrome against the live dashboard, reading the left edge of each label's glyphs with a DOM Range (an element box would measure the row for a bare-text label and the wrapper for a wrapped one, which is not a comparison).

Before:

```
Open on GitHub          723
Open project folder     723
Open in editor          775.8   <-
Copy resume command     723
Serve                   723
Delete session          723
```

After: all six at `723`.

The second capture landed on a multi-package project, which also exercises the `Serve` trigger's submenu form. It aligns too.

## Tests

dashboard 495 pass / 0 fail, typecheck and build clean. No unit test: this is a layout property jsdom cannot observe, so the browser measurement above is the evidence.
