### PR TITLE
fix(the-framework): pass the cloud prompt as --cloud's own value

### DIFF
--- a/.changeset/cloud-model-arg-order.md
+++ b/.changeset/cloud-model-arg-order.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+Fix "Run on: Claude web" failing with `--cloud requires a description` on any account that has a model preference set. The description is `--cloud`'s own value rather than a loose positional argument, so the `--model` flag was claiming the slot and the prompt never arrived. The prompt now sits directly after `--cloud`.

--- a/.the-framework/.gitignore
+++ b/.the-framework/.gitignore
@@ -1,0 +1,6 @@
+# The Framework: the committed project DB; session state is transient.
+*
+!.gitignore
+!LOGS.md
+!conversations/
+!conversations/**

--- a/.the-framework/LOGS.md
+++ b/.the-framework/LOGS.md
@@ -1,0 +1,7 @@
+# The Framework logs
+
+## 2026-07-25T23:36:17.500Z · prompt · Reply with only the word OK. Do not modify, create, commit, or push anything.
+
+- status: done
+- session: [session_01Y8zE9xGtq65Row2JAeWdoi](https://claude.ai/code)
+- branch: fix/610-cloud-model-arg-order

--- a/.the-framework/conversations/2026-07-25T23-36-02-890Z.md
+++ b/.the-framework/conversations/2026-07-25T23-36-02-890Z.md
@@ -1,0 +1,12 @@
+# Conversation 2026-07-25T23-36-02-890Z
+
+## 2026-07-25T23:36:02.905Z · user · dashboard
+
+Reply with only the word OK. Do not modify, create, commit, or push anything.
+
+## 2026-07-25T23:36:17.497Z · agent · dashboard
+
+Handed off to Claude Code on the web.
+
+View the session: https://claude.ai/code/session_01Y8zE9xGtq65Row2JAeWdoi?from=cli&m=0
+Continue it here: claude --teleport session_01Y8zE9xGtq65Row2JAeWdoi

--- a/packages/the-framework/src/driver/cloud.test.ts
+++ b/packages/the-framework/src/driver/cloud.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { CloudDriver, type RunPtyOptions } from './cloud.js'
+import { CLOUD_COMMAND, CloudDriver, type RunPtyOptions } from './cloud.js'
 import type { DriverEvent } from './types.js'
 
 /**
@@ -115,6 +115,24 @@ test('an untrusted workspace fails fast and says how to fix it, rather than hang
   const notice = events.find(e => e.type === 'notice')
   assert.ok(notice && /has not been trusted in \/repo/.test(notice.message))
   assert.ok(notice && /Run `claude` there once/.test(notice.message))
+})
+
+test('the prompt sits directly after --cloud, ahead of the model flag', () => {
+  // The description is `--cloud`'s own value, not a positional argument. With the model flag
+  // in between, every run on an account with a model preference died on "--cloud requires a
+  // description" while runs without one worked, which is what made it look unrelated to the
+  // model at first. Nothing else observes this order, so it is pinned here.
+  const promptAt = CLOUD_COMMAND.indexOf('"$FW_CLOUD_PROMPT"')
+  const modelAt = CLOUD_COMMAND.indexOf('FW_CLOUD_MODEL')
+  assert.ok(promptAt > 0 && modelAt > 0)
+  assert.ok(promptAt < modelAt, 'the prompt must be the argument to --cloud')
+  assert.match(CLOUD_COMMAND, /--cloud "\$FW_CLOUD_PROMPT"/)
+})
+
+test('the shell command never interpolates the prompt or the model as syntax', () => {
+  // Both arrive through the environment, so the hosted command stays a fixed literal.
+  assert.ok(!CLOUD_COMMAND.includes('${FW_CLOUD_PROMPT}'))
+  assert.match(CLOUD_COMMAND, /^exec "\$FW_CLOUD_BIN"/)
 })
 
 test('an unsafe model id never reaches the shell', async () => {

--- a/packages/the-framework/src/driver/cloud.ts
+++ b/packages/the-framework/src/driver/cloud.ts
@@ -226,8 +226,14 @@ function tail(text: string, max = 600): string {
  * The shell command `script` hosts. A **fixed literal**: the prompt and the model arrive
  * as environment variables, so nothing the user typed is ever parsed as shell syntax.
  * `${FW_CLOUD_MODEL:+...}` adds the model flag only when one was chosen.
+ *
+ * **The prompt has to come directly after `--cloud`.** The description is that flag's own
+ * value rather than a loose positional argument, so anything in between claims the slot and
+ * the CLI stops with "--cloud requires a description". That is why this failed on an account
+ * with a model preference and worked without one: the model flag was sitting in the slot.
+ * Exported so a test can pin the order, which is load-bearing and not otherwise observable.
  */
-const CLOUD_COMMAND = 'exec "$FW_CLOUD_BIN" --cloud ${FW_CLOUD_MODEL:+--model "$FW_CLOUD_MODEL"} "$FW_CLOUD_PROMPT"'
+export const CLOUD_COMMAND = 'exec "$FW_CLOUD_BIN" --cloud "$FW_CLOUD_PROMPT" ${FW_CLOUD_MODEL:+--model "$FW_CLOUD_MODEL"}'
 
 /**
  * Run the CLI under a pty supplied by `script`, streaming its terminal output.


### PR DESCRIPTION
A `Run on: Claude web` session failed with `Error: --cloud requires a description` whenever the account has a model preference set, which is every run started from the dashboard.

The description is `--cloud`'s **own value**, not a loose positional argument. The hosted command put the model flag first:

```
claude --cloud --model claude-fable-5 "<prompt>"   # -> --cloud requires a description
claude --cloud "<prompt>" --model claude-fable-5   # -> Created cloud session: ...
```

So `--model` claimed the slot and the prompt never arrived.

**Why #1207 looked fine.** Both live runs there were CLI runs with no `--model`, so the flag was absent and the order never mattered. The dashboard sends the account's model on every run, so that path failed every time. Found by @suleimansh testing on :4200; the run's own event log showed the driver was handed `prompt: 'hi'` correctly, which ruled out everything upstream and left the argument order.

**Verified live** on the exact failing shape, a web run with `--model claude-fable-5` and the full 8664-char system prompt:

```
    · cloud https://claude.ai/code/session_01Y8zE9xGtq65Row2JAeWdoi
  ‹ turn complete
✓ finished
```

The order is now pinned by a test, since nothing else observes it: the runner is injected in unit tests, so only a real invocation could have caught this the first time.

Tests: framework 1366 pass / 0 fail / 1 skipped.

Part of #610.