### PR TITLE
fix(the-framework): hand off to one cloud session per run, not one per prompt

### DIFF
--- a/.changeset/cloud-one-session-per-run.md
+++ b/.changeset/cloud-one-session-per-run.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+A "Run on: Claude web" run now hands off to exactly one cloud session. A run is not a single prompt — the loop prompts again for each pass — and the driver was starting a fresh cloud session every time, so one run opened six of them, all racing on the same repo. The first prompt hands off; every later pass reports that hand-off instead of spending another session.

--- a/.the-framework/LOGS.md
+++ b/.the-framework/LOGS.md
@@ -5,3 +5,9 @@
 - status: done
 - session: [session_01Y8zE9xGtq65Row2JAeWdoi](https://claude.ai/code)
 - branch: fix/610-cloud-model-arg-order
+
+## 2026-07-26T00:17:18.785Z · prompt · Add a one-line comment to README.md explaining what this repo is.
+
+- status: done
+- session: [session_01EbowD3aYpnWJzWELap4Psr](https://claude.ai/code)
+- branch: fix/610-one-cloud-session-per-run

--- a/.the-framework/conversations/2026-07-26T00-17-08-771Z.md
+++ b/.the-framework/conversations/2026-07-26T00-17-08-771Z.md
@@ -1,0 +1,12 @@
+# Conversation 2026-07-26T00-17-08-771Z
+
+## 2026-07-26T00:17:08.789Z · user · dashboard
+
+Add a one-line comment to README.md explaining what this repo is.
+
+## 2026-07-26T00:17:18.783Z · agent · dashboard
+
+Handed off to Claude Code on the web.
+
+View the session: https://claude.ai/code/session_01EbowD3aYpnWJzWELap4Psr?from=cli&m=0
+Continue it here: claude --teleport session_01EbowD3aYpnWJzWELap4Psr

--- a/packages/the-framework/src/driver/cloud.test.ts
+++ b/packages/the-framework/src/driver/cloud.test.ts
@@ -149,13 +149,37 @@ test('a safe model id is passed through', async () => {
   assert.equal(calls[0]?.model, 'claude-opus-5')
 })
 
-test('each prompt creates its own cloud session, since one cannot be continued', async () => {
+test('a run hands off ONCE, however many times the loop prompts', async () => {
+  // The regression this exists for: a run is not one prompt. The loop prompts per pass, and
+  // spawning a session each time turned one run into six of them racing on the same repo.
   const calls: RunPtyOptions[] = []
   const session = await driverWith(CREATED, calls).start({ cwd: '/repo' })
-  await session.prompt('first')
-  await session.prompt('second')
-  assert.equal(calls.length, 2)
-  assert.equal(calls[1]?.prompt, 'second')
+  const first = await session.prompt('build the thing')
+  const second = await session.prompt('now review it')
+  const third = await session.prompt('and again')
+  assert.equal(calls.length, 1, 'only the first prompt may spend a cloud session')
+  assert.equal(second.sessionId, first.sessionId)
+  assert.equal(third.sessionId, first.sessionId)
+})
+
+test('a later pass says the work is already in the cloud, rather than repeating the hand-off', async () => {
+  const session = await driverWith(CREATED).start({ cwd: '/repo' })
+  const first = await session.prompt('build the thing')
+  const second = await session.prompt('now review it')
+  assert.match(first.text, /^Handed off to Claude Code on the web/)
+  assert.match(second.text, /already handed off/i)
+  assert.match(second.text, /nothing further to do here/i)
+  // Both still point at the same place, so the run view links through either way.
+  assert.match(second.text, new RegExp(SESSION))
+})
+
+test('the cloud link event fires once, so the run view shows one session', async () => {
+  const events: DriverEvent[] = []
+  const session = await driverWith(CREATED).start({ cwd: '/repo', onEvent: e => events.push(e) })
+  await session.prompt('build the thing')
+  await session.prompt('now review it')
+  const links = events.filter(e => e.type === 'action' && e.label.startsWith('cloud '))
+  assert.equal(links.length, 1)
 })
 
 test('session ids are unique per session, so two runs never collide', async () => {

--- a/packages/the-framework/src/driver/cloud.ts
+++ b/packages/the-framework/src/driver/cloud.ts
@@ -105,10 +105,17 @@ const TRUST_PROMPT = 'trustthisfolder'
 const SAFE_MODEL = /^[A-Za-z0-9._:-]+$/
 
 /**
- * One hand-off to Claude Code on the web. Each {@link prompt} creates its **own** cloud
- * session: the CLI can start a session and pull one back, but it cannot send a second
- * message to one, so there is no continuation to hold on to. A follow-up message therefore
- * starts a fresh cloud session rather than pretending to continue the first.
+ * One hand-off to Claude Code on the web — **exactly one, for the life of the session.**
+ *
+ * A run is not a single prompt. The loop prompts again for every pass (plan, build, review,
+ * the TODO backlog), so a driver that started a cloud session per prompt turned one run into
+ * six of them on the account. That is not a caveat, it is the wrong shape: the same task
+ * handed to six independent cloud VMs is six agents racing on one repo.
+ *
+ * So the first prompt hands off, and every later one reports the hand-off that already
+ * happened without spending another session. There is no continuation to offer either way —
+ * the CLI can start a cloud session and pull one back, but it cannot send a second message
+ * to one, so the honest answer to "keep going" is "this run is already over there".
  */
 export class CloudSession implements DriverSession {
   readonly id: string
@@ -117,6 +124,8 @@ export class CloudSession implements DriverSession {
   private readonly framing: string | undefined
   private readonly controllers = new Set<AbortController>()
   private disposed = false
+  /** The cloud session this run was handed to, once it exists. Set at most once. */
+  private handedOff: { url: string; sessionId: string } | undefined
 
   constructor(
     private readonly config: CloudDriverOptions,
@@ -133,6 +142,10 @@ export class CloudSession implements DriverSession {
     if (this.disposed) throw new Error('[framework] claude-web session disposed')
     const full = combineFraming(this.framing, opts.system, text)
     this.emit({ type: 'start', prompt: full })
+
+    // Already handed off: say so and spend nothing. This is the guard that keeps one run to
+    // one cloud session however many times the loop comes back round.
+    if (this.handedOff) return this.report(this.handedOff, 'again')
 
     const controller = new AbortController()
     this.controllers.add(controller)
@@ -193,17 +206,30 @@ export class CloudSession implements DriverSession {
 
     if (!found) throw new Error(`[framework] claude-web: no cloud session was created.\n${tail(output.replace(ANSI, ''))}`)
 
-    // `cloud <url>` mirrors the Actions driver's `run <url>`: the one event the run view
-    // reads to link through to where the work actually is.
-    this.emit({ type: 'action', label: `cloud ${found.url}` })
-    const summary = [
-      'Handed off to Claude Code on the web.',
-      '',
-      `View the session: ${found.url}`,
-      `Continue it here: claude --teleport ${found.sessionId}`,
-    ].join('\n')
-    this.emit({ type: 'result', text: summary, sessionId: found.sessionId })
-    return { text: summary, sessionId: found.sessionId }
+    this.handedOff = found
+    return this.report(found, 'first')
+  }
+
+  /**
+   * Report where this run went. The `first` hand-off emits the `cloud <url>` action the run
+   * view links through to — mirroring the Actions driver's `run <url>` — and a later pass
+   * says the work is already there, so a loop that keeps prompting cannot read the same turn
+   * as fresh progress and cannot spend a second session.
+   */
+  private report(session: { url: string; sessionId: string }, when: 'first' | 'again'): DriverTurn {
+    if (when === 'first') this.emit({ type: 'action', label: `cloud ${session.url}` })
+    const summary =
+      when === 'first'
+        ? ['Handed off to Claude Code on the web.', '', `View the session: ${session.url}`, `Continue it here: claude --teleport ${session.sessionId}`].join('\n')
+        : [
+            'This run was already handed off to Claude Code on the web, so there is nothing further to do here.',
+            'The work continues in that cloud session, which opens its own pull request.',
+            '',
+            `View the session: ${session.url}`,
+            `Continue it here: claude --teleport ${session.sessionId}`,
+          ].join('\n')
+    this.emit({ type: 'result', text: summary, sessionId: session.sessionId })
+    return { text: summary, sessionId: session.sessionId }
   }
 
   // No `readCode`: the cloud VM's workspace is not on this machine, and the branch it


### PR DESCRIPTION
Reported live: starting one `Run on: Claude web` session kept opening new sessions on claude.ai. Measured from the run's own event log — **one run, six cloud sessions**:

```
2026-07-25T23-53-35-230Z.jsonl cloud sessions: 6
```

**Cause.** A run is not a single prompt. The loop prompts again for every pass (plan, build, review, the TODO backlog), and `CloudSession.prompt()` started a fresh cloud session on each one. So the same task went to six independent cloud VMs, all working the same repo at once, each opening its own PR.

**Fix.** The first prompt hands off and records the session; every later pass reports that hand-off and spends nothing. There was never a continuation to offer anyway — the CLI can start a cloud session and pull one back, but cannot send a second message to one — so the honest answer to a later pass is "this run is already over there".

**Worth saying plainly: the old behaviour had a passing test asserting it** (`each prompt creates its own cloud session`). The test encoded my wrong assumption that a run is one prompt, so the suite confirmed the bug instead of catching it. It is replaced by a test that pins the opposite, plus one asserting the `cloud <url>` link event fires exactly once.

**Verified live against the compiled driver**, three prompts on one session:

```
prompt("Reply with only OK. ") -> session_0174FYxgujeFUdUEnWynZnUv
   Handed off to Claude Code on the web.
prompt("now review it")        -> session_0174FYxgujeFUdUEnWynZnUv
   This run was already handed off to Claude Code on the web, so there is nothing further to do here.
prompt("and again")            -> session_0174FYxgujeFUdUEnWynZnUv
distinct cloud sessions spent: 1
```

A full `--run-on web` run also completes with exactly one `cloud` event in its log.

Tests: framework 1368 pass / 0 fail / 1 skipped.

Part of #610.