### PR TITLE
fix(dashboard): Run now opens the session it started

### DIFF
--- a/.changeset/run-now-selects-the-run.md
+++ b/.changeset/run-now-selects-the-run.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+`Run now` on the Overview now opens the session it just started, instead of the project's launcher. It reported the project rather than the run, and selecting a project with no run renders the composer — so the button that starts a routine landed you on an empty "Describe what to build…" box with its own session nowhere on screen.

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -59,7 +59,7 @@ export function DashboardPage({
 
         {/* Routine work sits below the AI Queue (#1139/#1159): the scheduled jobs and the button
             that fires one now. */}
-        <RoutineWork onSelectProject={onSelectProject} />
+        <RoutineWork onRunStarted={onRunStarted} />
 
         <Agents working={data?.active ?? []} finished={data?.recentAgents ?? []} loading={loading} onSelectRun={onSelectRun} />
 

--- a/packages/framework-dashboard/components/RoutineWork.test.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.test.tsx
@@ -41,14 +41,14 @@ afterEach(cleanup)
 
 describe('RoutineWork (#1159)', () => {
   test('lists every routine the sweep can fire, by its preset label', async () => {
-    render(<RoutineWork onSelectProject={() => {}} />)
+    render(<RoutineWork onRunStarted={() => {}} />)
     await waitFor(() => expect(screen.getAllByText('Run now').length).toBe(AUTO_PM_ROUTINES.length))
     for (const job of AUTO_PM_ROUTINES) expect(screen.getByText(job.label ?? job.name)).toBeTruthy()
   })
 
-  test('Run now starts the routine prompt verbatim and jumps into the project', async () => {
-    let picked: string | null = null
-    render(<RoutineWork onSelectProject={id => (picked = id)} />)
+  test('Run now starts the routine prompt verbatim and selects the run it started (#1191)', async () => {
+    const started: unknown[][] = []
+    render(<RoutineWork onRunStarted={(...args) => started.push(args)} />)
     await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
     fireEvent.click(screen.getAllByText('Run now')[0]!)
     // The drain job leads the list, and its prompt travels unchanged: this is the fast-forward.
@@ -57,18 +57,31 @@ describe('RoutineWork (#1159)', () => {
     expect(projectId).toBe('p1')
     expect(prompt).toBe(AUTO_PM_DRAIN_JOB.prompt)
     expect(kind).toBe('prompt')
-    await waitFor(() => expect(picked).toBe('p1'))
+    // The run id is the whole point: without it the shell renders the launcher, so "Run now"
+    // landed on an empty composer with its own session nowhere on screen (#1191).
+    await waitFor(() => expect(started).toHaveLength(1))
+    expect(started[0]).toEqual(['p1', AUTO_PM_DRAIN_JOB.prompt, 'run-1'])
+  })
+
+  test('a start that reports no run id still hands the project over, for the adopt fallback (#1191)', async () => {
+    start.mockResolvedValue({ ok: true })
+    const started: unknown[][] = []
+    render(<RoutineWork onRunStarted={(...args) => started.push(args)} />)
+    await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
+    fireEvent.click(screen.getAllByText('Run now')[0]!)
+    await waitFor(() => expect(started).toHaveLength(1))
+    expect(started[0]).toEqual(['p1', AUTO_PM_DRAIN_JOB.prompt, undefined])
   })
 
   test('a failed start neither navigates nor leaves the button stuck on Starting', async () => {
     start.mockResolvedValue(undefined)
     startError = 'A session is already active for this project.'
-    let picked: string | null = null
-    render(<RoutineWork onSelectProject={id => (picked = id)} />)
+    const started: unknown[][] = []
+    render(<RoutineWork onRunStarted={(...args) => started.push(args)} />)
     await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
     fireEvent.click(screen.getAllByText('Run now')[0]!)
     await waitFor(() => expect(start).toHaveBeenCalled())
-    expect(picked).toBeNull()
+    expect(started).toHaveLength(0)
     await waitFor(() => expect(screen.queryByText('Starting…')).toBeNull())
     expect(screen.getByRole('alert').textContent).toMatch(/already active/)
   })
@@ -76,23 +89,23 @@ describe('RoutineWork (#1159)', () => {
   test('with auto-run on and a reported sweep, the box says when it next runs', async () => {
     prefs = { autoPm: true }
     autoPm = { enabled: true, sweptAt: Date.now(), nextSweepAt: Date.now() + 2 * 60 * 60_000, outcomes: [] }
-    render(<RoutineWork onSelectProject={() => {}} />)
+    render(<RoutineWork onRunStarted={() => {}} />)
     await waitFor(() => expect(screen.getByText('Auto-runs in 2 hr')).toBeTruthy())
   })
 
   test('with auto-run off, or before the daemon has reported, it says only what it does', async () => {
     prefs = { autoPm: true }
     autoPm = undefined
-    const { rerender } = render(<RoutineWork onSelectProject={() => {}} />)
+    const { rerender } = render(<RoutineWork onRunStarted={() => {}} />)
     // On, but no sweep has reported yet: a countdown here would be invented.
     await waitFor(() => expect(screen.getByText('Auto-run')).toBeTruthy())
     prefs = {}
-    rerender(<RoutineWork onSelectProject={() => {}} />)
+    rerender(<RoutineWork onRunStarted={() => {}} />)
     expect(screen.getByText('Auto-run')).toBeTruthy()
   })
 
   test('the checkbox is the one global preference, and carries the tooltip', async () => {
-    render(<RoutineWork onSelectProject={() => {}} />)
+    render(<RoutineWork onRunStarted={() => {}} />)
     await waitFor(() => expect(screen.getByText('Auto-run')).toBeTruthy())
     // One box for the whole card (#1159): a per-routine box flipping a global switch would lie.
     expect(screen.getAllByRole('checkbox')).toHaveLength(1)
@@ -104,7 +117,7 @@ describe('RoutineWork (#1159)', () => {
 
   test('several projects get a picker, and Run now honours it', async () => {
     onProjects.mockResolvedValue([project('p1', 'gemstack'), project('p2', 'rudder')])
-    render(<RoutineWork onSelectProject={() => {}} />)
+    render(<RoutineWork onRunStarted={() => {}} />)
     const select = await screen.findByLabelText('Run in')
     fireEvent.change(select, { target: { value: 'p2' } })
     fireEvent.click(screen.getAllByText('Run now')[0]!)
@@ -113,21 +126,21 @@ describe('RoutineWork (#1159)', () => {
   })
 
   test('one project needs no picker', async () => {
-    render(<RoutineWork onSelectProject={() => {}} />)
+    render(<RoutineWork onRunStarted={() => {}} />)
     await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
     expect(screen.queryByLabelText('Run in')).toBeNull()
   })
 
   test('with no project there is nothing to run a routine in, and it says so', async () => {
     onProjects.mockResolvedValue([])
-    render(<RoutineWork onSelectProject={() => {}} />)
+    render(<RoutineWork onRunStarted={() => {}} />)
     await waitFor(() => expect(screen.getByText('Add a project to run a routine.')).toBeTruthy())
     expect(screen.queryByText('Run now')).toBeNull()
   })
 
   test('a start already in flight disables every Run now', async () => {
     busy = true
-    render(<RoutineWork onSelectProject={() => {}} />)
+    render(<RoutineWork onRunStarted={() => {}} />)
     await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
     for (const button of screen.getAllByText('Run now')) expect((button as HTMLButtonElement).disabled).toBe(true)
   })

--- a/packages/framework-dashboard/components/RoutineWork.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.tsx
@@ -27,7 +27,15 @@ import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip.js'
 /** Captured once: `useLoaded` treats a fresh `[]` literal as a new value on every render. */
 const NO_PROJECTS: ProjectSummary[] = []
 
-export function RoutineWork({ onSelectProject }: { onSelectProject: (id: string) => void }) {
+export function RoutineWork({
+  onRunStarted,
+}: {
+  /**
+   * Told which run the button just started (#1191). The project-carrying form, because the
+   * Overview has no project selected — each row picks one — so the shell cannot supply it.
+   */
+  onRunStarted: (projectId: string, intent: string, runId?: string) => void
+}) {
   const projects = useLoaded<ProjectSummary[]>(onProjects, NO_PROJECTS, [])
   const preferences = usePreferences()
   const report = useAutoPm()
@@ -53,9 +61,12 @@ export function RoutineWork({ onSelectProject }: { onSelectProject: (id: string)
     // not resolved here and the run starts on the same defaults a fresh launcher would use.
     const result = await start(projectId, job.prompt, 'prompt', runOptionsFromPreferences(preferences))
     setStarting(null)
-    // Jump into the project that is now working: the Overview has no view of a live run, and the
-    // point of the button is to watch what it started.
-    if (result) onSelectProject(projectId)
+    // Go to the run itself, not merely to its project (#1191): selecting the project renders the
+    // launcher, so the button that says "Run now" landed you on an empty composer and the session
+    // it had just started was nowhere on screen. Handing the id over is what makes it the
+    // selection; with no id yet the shell lands on the project and adopts the running run once the
+    // poll surfaces it, which is the same fallback every other start path uses.
+    if (result) onRunStarted(projectId, job.prompt, result.runId)
   }
 
   return (


### PR DESCRIPTION
`Run now` on the Overview reported the **project**, not the run — and selecting a project with no run selected renders `ProjectHome`, which *is* the launcher. So the button that starts a routine landed you on an empty "Describe what to build…" composer, with the session it had just started nowhere on screen.

It now hands the run id to the same `runStarted` the launcher and the onboarding checklist already use. This is the same shape as #1169: a component that starts a run but has no callback able to carry a run id falls back to "select the project", which silently means the launcher.

```diff
-    if (result) onSelectProject(projectId)
+    if (result) onRunStarted(projectId, job.prompt, result.runId)
```

The project-carrying form of the callback, because the Overview has no project selected — each row picks its own.

**No-id fallback is preserved.** When a start reports no run id yet, `runStarted` lands on the project and adopts the running run once the poll surfaces it. That path is unchanged and now covered by a test.

**Verified in the real UI**, not just the mocks — this is a navigation bug, so a real click is the only honest proof. Isolated daemon on a scratch repo with `claude` off `PATH`, so the run starts and returns a run id without an agent doing any work:

```
url before: http://127.0.0.1:4397/
url after : http://127.0.0.1:4397/rw-repo-157u8rq/2026-07-26T02-26-41-960Z
landed on LAUNCHER (the bug): false
landed on the SESSION  (fixed): true
```

Tests: dashboard 505 pass. The old test asserted the old behaviour ("jumps into the project"), so it is replaced rather than added to, plus a new one for the no-id fallback.

Closes #1191.