### PR TITLE
feat(dashboard): trigger a routine sweep on demand

### DIFF
--- a/.changeset/run-now-selects-the-run.md
+++ b/.changeset/run-now-selects-the-run.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+`Run now` on the Overview now opens the session it just started, instead of the project's launcher. It reported the project rather than the run, and selecting a project with no run renders the composer — so the button that starts a routine landed you on an empty "Describe what to build…" box with its own session nowhere on screen.

--- a/.changeset/trigger-routine-now.md
+++ b/.changeset/trigger-routine-now.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': minor
+---
+
+Adds `Trigger routine now` beside the Routine work card's `Auto-run` box, so a sweep can be fired on demand instead of waiting out the interval. The loop could always do this — it is what switching the preference on already triggers — but nothing could ask for it directly, so the only way to fast-forward was to tick the box off and on again. The button is disabled while auto-run is off, because a sweep re-reads the preference and stands straight back down.

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -59,7 +59,7 @@ export function DashboardPage({
 
         {/* Routine work sits below the AI Queue (#1139/#1159): the scheduled jobs and the button
             that fires one now. */}
-        <RoutineWork onSelectProject={onSelectProject} />
+        <RoutineWork onRunStarted={onRunStarted} />
 
         <Agents working={data?.active ?? []} finished={data?.recentAgents ?? []} loading={loading} onSelectRun={onSelectRun} />
 

--- a/packages/framework-dashboard/components/RoutineWork.test.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.test.tsx
@@ -41,14 +41,14 @@ afterEach(cleanup)
 
 describe('RoutineWork (#1159)', () => {
   test('lists every routine the sweep can fire, by its preset label', async () => {
-    render(<RoutineWork onSelectProject={() => {}} />)
+    render(<RoutineWork onRunStarted={() => {}} />)
     await waitFor(() => expect(screen.getAllByText('Run now').length).toBe(AUTO_PM_ROUTINES.length))
     for (const job of AUTO_PM_ROUTINES) expect(screen.getByText(job.label ?? job.name)).toBeTruthy()
   })
 
-  test('Run now starts the routine prompt verbatim and jumps into the project', async () => {
-    let picked: string | null = null
-    render(<RoutineWork onSelectProject={id => (picked = id)} />)
+  test('Run now starts the routine prompt verbatim and selects the run it started (#1191)', async () => {
+    const started: unknown[][] = []
+    render(<RoutineWork onRunStarted={(...args) => started.push(args)} />)
     await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
     fireEvent.click(screen.getAllByText('Run now')[0]!)
     // The drain job leads the list, and its prompt travels unchanged: this is the fast-forward.
@@ -57,18 +57,31 @@ describe('RoutineWork (#1159)', () => {
     expect(projectId).toBe('p1')
     expect(prompt).toBe(AUTO_PM_DRAIN_JOB.prompt)
     expect(kind).toBe('prompt')
-    await waitFor(() => expect(picked).toBe('p1'))
+    // The run id is the whole point: without it the shell renders the launcher, so "Run now"
+    // landed on an empty composer with its own session nowhere on screen (#1191).
+    await waitFor(() => expect(started).toHaveLength(1))
+    expect(started[0]).toEqual(['p1', AUTO_PM_DRAIN_JOB.prompt, 'run-1'])
+  })
+
+  test('a start that reports no run id still hands the project over, for the adopt fallback (#1191)', async () => {
+    start.mockResolvedValue({ ok: true })
+    const started: unknown[][] = []
+    render(<RoutineWork onRunStarted={(...args) => started.push(args)} />)
+    await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
+    fireEvent.click(screen.getAllByText('Run now')[0]!)
+    await waitFor(() => expect(started).toHaveLength(1))
+    expect(started[0]).toEqual(['p1', AUTO_PM_DRAIN_JOB.prompt, undefined])
   })
 
   test('a failed start neither navigates nor leaves the button stuck on Starting', async () => {
     start.mockResolvedValue(undefined)
     startError = 'A session is already active for this project.'
-    let picked: string | null = null
-    render(<RoutineWork onSelectProject={id => (picked = id)} />)
+    const started: unknown[][] = []
+    render(<RoutineWork onRunStarted={(...args) => started.push(args)} />)
     await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
     fireEvent.click(screen.getAllByText('Run now')[0]!)
     await waitFor(() => expect(start).toHaveBeenCalled())
-    expect(picked).toBeNull()
+    expect(started).toHaveLength(0)
     await waitFor(() => expect(screen.queryByText('Starting…')).toBeNull())
     expect(screen.getByRole('alert').textContent).toMatch(/already active/)
   })
@@ -76,23 +89,23 @@ describe('RoutineWork (#1159)', () => {
   test('with auto-run on and a reported sweep, the box says when it next runs', async () => {
     prefs = { autoPm: true }
     autoPm = { enabled: true, sweptAt: Date.now(), nextSweepAt: Date.now() + 2 * 60 * 60_000, outcomes: [] }
-    render(<RoutineWork onSelectProject={() => {}} />)
+    render(<RoutineWork onRunStarted={() => {}} />)
     await waitFor(() => expect(screen.getByText('Auto-runs in 2 hr')).toBeTruthy())
   })
 
   test('with auto-run off, or before the daemon has reported, it says only what it does', async () => {
     prefs = { autoPm: true }
     autoPm = undefined
-    const { rerender } = render(<RoutineWork onSelectProject={() => {}} />)
+    const { rerender } = render(<RoutineWork onRunStarted={() => {}} />)
     // On, but no sweep has reported yet: a countdown here would be invented.
     await waitFor(() => expect(screen.getByText('Auto-run')).toBeTruthy())
     prefs = {}
-    rerender(<RoutineWork onSelectProject={() => {}} />)
+    rerender(<RoutineWork onRunStarted={() => {}} />)
     expect(screen.getByText('Auto-run')).toBeTruthy()
   })
 
   test('the checkbox is the one global preference, and carries the tooltip', async () => {
-    render(<RoutineWork onSelectProject={() => {}} />)
+    render(<RoutineWork onRunStarted={() => {}} />)
     await waitFor(() => expect(screen.getByText('Auto-run')).toBeTruthy())
     // One box for the whole card (#1159): a per-routine box flipping a global switch would lie.
     expect(screen.getAllByRole('checkbox')).toHaveLength(1)
@@ -104,7 +117,7 @@ describe('RoutineWork (#1159)', () => {
 
   test('several projects get a picker, and Run now honours it', async () => {
     onProjects.mockResolvedValue([project('p1', 'gemstack'), project('p2', 'rudder')])
-    render(<RoutineWork onSelectProject={() => {}} />)
+    render(<RoutineWork onRunStarted={() => {}} />)
     const select = await screen.findByLabelText('Run in')
     fireEvent.change(select, { target: { value: 'p2' } })
     fireEvent.click(screen.getAllByText('Run now')[0]!)
@@ -113,21 +126,21 @@ describe('RoutineWork (#1159)', () => {
   })
 
   test('one project needs no picker', async () => {
-    render(<RoutineWork onSelectProject={() => {}} />)
+    render(<RoutineWork onRunStarted={() => {}} />)
     await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
     expect(screen.queryByLabelText('Run in')).toBeNull()
   })
 
   test('with no project there is nothing to run a routine in, and it says so', async () => {
     onProjects.mockResolvedValue([])
-    render(<RoutineWork onSelectProject={() => {}} />)
+    render(<RoutineWork onRunStarted={() => {}} />)
     await waitFor(() => expect(screen.getByText('Add a project to run a routine.')).toBeTruthy())
     expect(screen.queryByText('Run now')).toBeNull()
   })
 
   test('a start already in flight disables every Run now', async () => {
     busy = true
-    render(<RoutineWork onSelectProject={() => {}} />)
+    render(<RoutineWork onRunStarted={() => {}} />)
     await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
     for (const button of screen.getAllByText('Run now')) expect((button as HTMLButtonElement).disabled).toBe(true)
   })

--- a/packages/framework-dashboard/components/RoutineWork.test.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.test.tsx
@@ -9,6 +9,9 @@ import { hoverTooltip } from '../test-utils.js'
 const onProjects = vi.hoisted(() => vi.fn())
 vi.mock('../server/projects.telefunc.js', () => ({ onProjects }))
 
+const sendAutoPmSweep = vi.hoisted(() => vi.fn())
+vi.mock('../server/quota.telefunc.js', () => ({ sendAutoPmSweep }))
+
 const updatePreferences = vi.hoisted(() => vi.fn())
 let prefs: Preferences = {}
 vi.mock('../lib/preferences.js', () => ({ usePreferences: () => prefs, updatePreferences }))
@@ -36,6 +39,8 @@ beforeEach(() => {
   start.mockReset()
   start.mockResolvedValue({ ok: true, runId: 'run-1' })
   updatePreferences.mockReset()
+  sendAutoPmSweep.mockReset()
+  sendAutoPmSweep.mockResolvedValue({ ok: true })
 })
 afterEach(cleanup)
 
@@ -123,6 +128,31 @@ describe('RoutineWork (#1159)', () => {
     fireEvent.click(screen.getAllByText('Run now')[0]!)
     await waitFor(() => expect(start).toHaveBeenCalled())
     expect(start.mock.calls[0]![0]).toBe('p2')
+  })
+
+  test('Trigger routine now fires the sweep instead of waiting out the countdown (#1210)', async () => {
+    prefs = { autoPm: true }
+    render(<RoutineWork onRunStarted={() => {}} />)
+    const button = await screen.findByText('Trigger routine now')
+    fireEvent.click(button)
+    await waitFor(() => expect(sendAutoPmSweep).toHaveBeenCalledTimes(1))
+  })
+
+  test('with auto-run off the trigger is disabled, since a sweep would just stand down (#1210)', async () => {
+    prefs = { autoPm: false }
+    render(<RoutineWork onRunStarted={() => {}} />)
+    const button = await screen.findByText('Trigger routine now')
+    expect(button.closest('button')!.disabled).toBe(true)
+    fireEvent.click(button)
+    expect(sendAutoPmSweep).not.toHaveBeenCalled()
+  })
+
+  test('a host with no sweep says so rather than looking like it worked (#1210)', async () => {
+    prefs = { autoPm: true }
+    sendAutoPmSweep.mockResolvedValue({ ok: false })
+    render(<RoutineWork onRunStarted={() => {}} />)
+    fireEvent.click(await screen.findByText('Trigger routine now'))
+    await waitFor(() => expect(screen.getByRole('status').textContent).toMatch(/not running the sweep/i))
   })
 
   test('one project needs no picker', async () => {

--- a/packages/framework-dashboard/components/RoutineWork.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.tsx
@@ -3,6 +3,7 @@ import type { AutoPmJob, ProjectSummary } from '@gemstack/the-framework'
 import { AUTO_PM_ROUTINES, runOptionsFromPreferences } from '@gemstack/the-framework/client'
 import { CalendarClock, Play } from 'lucide-react'
 import { onProjects } from '../server/projects.telefunc.js'
+import { sendAutoPmSweep } from '../server/quota.telefunc.js'
 import { useAutoPm } from '../lib/quota.js'
 import { usePreferences, updatePreferences } from '../lib/preferences.js'
 import { useStartRun } from '../lib/use-start-run.js'
@@ -43,6 +44,9 @@ export function RoutineWork({
   const [picked, setPicked] = useState<string | null>(null)
   // Which routine is in flight, so only its own button says "Starting…".
   const [starting, setStarting] = useState<string | null>(null)
+  // The on-demand sweep (#1210): in flight, and anything worth saying about the last attempt.
+  const [sweeping, setSweeping] = useState(false)
+  const [sweepNote, setSweepNote] = useState<string | null>(null)
 
   // The list arrives after the first render, and a project can be removed under a stale pick, so
   // the selection is validated against what is actually there rather than trusted.
@@ -53,6 +57,20 @@ export function RoutineWork({
   // auto-run off, or before that first report, the box says what it does instead of when.
   const autoRunLabel =
     autoRun && report?.nextSweepAt !== undefined ? `Auto-runs ${formatUntil(report.nextSweepAt)}` : 'Auto-run'
+
+  // Firing the sweep on demand (#1210). The answer is not the click's to report: a sweep decides
+  // per project and can start runs, and `report` (polled) is where that shows up. So this only
+  // says whether the daemon took the request, and gets out of the way once it has.
+  const sweepNow = async () => {
+    if (sweeping) return
+    setSweeping(true)
+    setSweepNote(null)
+    const result = await sendAutoPmSweep().catch(() => ({ ok: false }))
+    setSweeping(false)
+    // A host with no loop is the honest failure here, and the only one: the relay serves this
+    // same dashboard, and there the button has nothing to fire.
+    if (!result.ok) setSweepNote('This dashboard is not running the sweep, so there is nothing to trigger here.')
+  }
 
   const runNow = async (job: AutoPmJob) => {
     if (!projectId || busy) return
@@ -132,16 +150,47 @@ export function RoutineWork({
             {/* The same `autoPm` preference the usage panel offers (#1161), which is the point: one
                 switch, shown where the schedule it governs is listed. */}
             <div className="border-t border-border pt-3">
-              <Tooltip>
-                <TooltipTrigger render={<label className="flex cursor-pointer items-center gap-1.5 text-sm" />}>
-                  <Checkbox checked={autoRun} onCheckedChange={checked => updatePreferences({ autoPm: checked })} />
-                  <span className="font-medium text-foreground">{autoRunLabel}</span>
-                </TooltipTrigger>
-                <TooltipContent>Automatically run this prompt on a regular schedule.</TooltipContent>
-              </Tooltip>
+              <div className="flex items-center justify-between gap-2">
+                <Tooltip>
+                  <TooltipTrigger render={<label className="flex cursor-pointer items-center gap-1.5 text-sm" />}>
+                    <Checkbox checked={autoRun} onCheckedChange={checked => updatePreferences({ autoPm: checked })} />
+                    <span className="font-medium text-foreground">{autoRunLabel}</span>
+                  </TooltipTrigger>
+                  <TooltipContent>Automatically run this prompt on a regular schedule.</TooltipContent>
+                </Tooltip>
+                {/* The countdown's escape hatch (#1210): the sweep is on a long interval, so
+                    without this the only way to fast-forward was to tick the box off and on
+                    again. Disabled while auto-run is off, because a sweep re-reads the
+                    preference and stands straight back down — a button that always did nothing
+                    would read as broken rather than as inapplicable. */}
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        type="button"
+                        onClick={sweepNow}
+                        disabled={!autoRun || sweeping}
+                        className="shrink-0 rounded border border-border px-2 py-1 text-xs text-foreground hover:bg-accent disabled:opacity-50"
+                      />
+                    }
+                  >
+                    {sweeping ? 'Triggering…' : 'Trigger routine now'}
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {autoRun
+                      ? 'Run the scheduled sweep now instead of waiting for the countdown.'
+                      : 'Turn auto-run on first: a sweep checks the setting and stops when it is off.'}
+                  </TooltipContent>
+                </Tooltip>
+              </div>
               <p className="mt-1 text-xs text-muted-foreground">
                 Only while nothing else is running and the week&apos;s allowance is not already spent.
               </p>
+              {sweepNote && (
+                <p role="status" className="mt-1 text-xs text-muted-foreground">
+                  {sweepNote}
+                </p>
+              )}
             </div>
           </>
         )}

--- a/packages/framework-dashboard/components/RoutineWork.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.tsx
@@ -27,7 +27,15 @@ import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip.js'
 /** Captured once: `useLoaded` treats a fresh `[]` literal as a new value on every render. */
 const NO_PROJECTS: ProjectSummary[] = []
 
-export function RoutineWork({ onSelectProject }: { onSelectProject: (id: string) => void }) {
+export function RoutineWork({
+  onRunStarted,
+}: {
+  /**
+   * Told which run the button just started (#1191). The project-carrying form, because the
+   * Overview has no project selected — each row picks one — so the shell cannot supply it.
+   */
+  onRunStarted: (projectId: string, intent: string, runId?: string) => void
+}) {
   const projects = useLoaded<ProjectSummary[]>(onProjects, NO_PROJECTS, [])
   const preferences = usePreferences()
   const report = useAutoPm()
@@ -53,9 +61,12 @@ export function RoutineWork({ onSelectProject }: { onSelectProject: (id: string)
     // not resolved here and the run starts on the same defaults a fresh launcher would use.
     const result = await start(projectId, job.prompt, 'prompt', runOptionsFromPreferences(preferences))
     setStarting(null)
-    // Jump into the project that is now working: the Overview has no view of a live run, and the
-    // point of the button is to watch what it started.
-    if (result) onSelectProject(projectId)
+    // Go to the run itself, not merely to its project (#1191): selecting the project renders the
+    // launcher, so the button that says "Run now" landed you on an empty composer and the session
+    // it had just started was nowhere on screen. Handing the id over is what makes it the
+    // selection; with no id yet the shell lands on the project and adopts the running run once the
+    // poll surfaces it, which is the same fallback every other start path uses.
+    if (result) onRunStarted(projectId, job.prompt, result.runId)
   }
 
   return (

--- a/packages/framework-dashboard/server/quota.telefunc.ts
+++ b/packages/framework-dashboard/server/quota.telefunc.ts
@@ -5,6 +5,6 @@
 // Imported then exported, not re-exported (#1014): telefunc's dev transform appends
 // `__decorateTelefunction(<name>, ...)` per export, which needs a local binding. An
 // `export ... from` creates none, so `pnpm dev` died with `<name> is not defined`.
-import { onQuota, onAutoPm } from '@gemstack/the-framework/dashboard-rpc'
+import { onQuota, onAutoPm, sendAutoPmSweep } from '@gemstack/the-framework/dashboard-rpc'
 
-export { onQuota, onAutoPm }
+export { onQuota, onAutoPm, sendAutoPmSweep }

--- a/packages/the-framework/src/daemon.ts
+++ b/packages/the-framework/src/daemon.ts
@@ -412,6 +412,9 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     }),
     // Only the daemon runs the sweep, so only it can say what the sweep decided.
     autoPm: () => services?.autoPmReport(),
+    // ...and only it can be asked to sweep now (#1210), through the same wake the
+    // switched-on preference above uses.
+    autoPmSweep: () => services?.wakeAutoPm(),
     ...(token ? { token } : {}),
     ...(clientBundleDir ? { clientBundleDir } : {}),
   })

--- a/packages/the-framework/src/dashboard-rpc/context.ts
+++ b/packages/the-framework/src/dashboard-rpc/context.ts
@@ -116,3 +116,11 @@ export function contextQuota(): QuotaSource | undefined {
 export function contextAutoPm(): AutoPmReporter | undefined {
   return fromContext(ctx => ctx.autoPm)
 }
+
+/**
+ * How a sweep is fired on demand (#1210), or undefined on a host that runs none. Same rule as
+ * {@link contextAutoPm}: only the daemon holds the loop, so only it can be asked to sweep.
+ */
+export function contextAutoPmSweep(): (() => void) | undefined {
+  return fromContext(ctx => ctx.autoPmSweep)
+}

--- a/packages/the-framework/src/dashboard-rpc/index.ts
+++ b/packages/the-framework/src/dashboard-rpc/index.ts
@@ -24,6 +24,6 @@ export {
 } from './preferences.telefunc.js'
 export type { CredentialSource, DiscordCredentialStatus, DiscordCredentialsPatch } from '../discord-credentials.js'
 export { type EditorInfo } from '../dashboard/open-in-app.js'
-export { onQuota, onAutoPm } from './quota.telefunc.js'
+export { onQuota, onAutoPm, sendAutoPmSweep } from './quota.telefunc.js'
 export { checkDevices, type DeviceCheck } from './devices.telefunc.js'
 export { registerDashboardTelefunctions, DASHBOARD_TELEFUNC_KEYS } from './register.js'

--- a/packages/the-framework/src/dashboard-rpc/quota.telefunc.ts
+++ b/packages/the-framework/src/dashboard-rpc/quota.telefunc.ts
@@ -1,4 +1,4 @@
-import { contextAutoPm, contextQuota } from './context.js'
+import { contextAutoPm, contextAutoPmSweep, contextQuota } from './context.js'
 import type { AutoPmReport } from '../auto-pm.js'
 import type { QuotaView } from '../dashboard/quota.js'
 
@@ -37,5 +37,25 @@ export async function onAutoPm(): Promise<AutoPmReport | undefined> {
     return report()
   } catch {
     return undefined
+  }
+}
+
+/**
+ * Sweep now rather than at the next interval (#1210). The loop already had this — it is what a
+ * write that switches the preference on triggers (#1167) — but until now nothing could ask for
+ * it directly, so the only way to fast-forward was to tick the box off and on again.
+ *
+ * Returns whether a sweep was asked for, not what it decided: a sweep can start runs and take a
+ * while, and `onAutoPm` is how the answer arrives. `false` on a host with no loop (the relay),
+ * which the button reads as "nothing here to trigger".
+ */
+export async function sendAutoPmSweep(): Promise<{ ok: boolean }> {
+  const sweep = contextAutoPmSweep()
+  if (!sweep) return { ok: false }
+  try {
+    sweep()
+    return { ok: true }
+  } catch {
+    return { ok: false }
   }
 }

--- a/packages/the-framework/src/dashboard/server.ts
+++ b/packages/the-framework/src/dashboard/server.ts
@@ -83,6 +83,11 @@ export interface DashboardOptions {
    */
   autoPm?: AutoPmReporter
   /**
+   * Fire an auto PM sweep now instead of waiting out the interval (#1210). Daemon-only for the
+   * same reason as {@link autoPm}: the loop runs in that process, so nowhere else has one.
+   */
+  autoPmSweep?: () => void
+  /**
    * Serve the new dashboard bundle (#405) from this directory — the prerendered Vike SPA
    * (`index.html` + `assets/**`). The daemon also mounts the dashboard's Telefunc surface
    * at `/_telefunc` (RPCs + the live-event Channel). Omit only for a broken install with
@@ -168,6 +173,7 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
     preferences: opts.preferences ?? registryPreferencesStore(),
     discord: opts.discord ?? registryDiscordCredentialsStore(),
     ...(opts.autoPm ? { autoPm: opts.autoPm } : {}),
+    ...(opts.autoPmSweep ? { autoPmSweep: opts.autoPmSweep } : {}),
     quota,
   })
 

--- a/packages/the-framework/src/dashboard/telefunc-serve.ts
+++ b/packages/the-framework/src/dashboard/telefunc-serve.ts
@@ -75,6 +75,13 @@ export interface DashboardContext {
   discord?: DiscordCredentialsStore
   /** What auto PM last decided (#1161). Only the daemon runs the sweep, so only it wires this. */
   autoPm?: AutoPmReporter
+  /**
+   * Run an auto PM sweep now rather than at the next interval (#1210). Same reason `autoPm` is
+   * daemon-only: the loop lives in that process, so nowhere else has one to fire. Returns
+   * immediately — a sweep can start runs and take a while, and the caller only needs to know it
+   * was asked for.
+   */
+  autoPmSweep?: () => void
 }
 
 let instance: Telefunc | undefined


### PR DESCRIPTION
`Trigger routine now`, beside the Routine work card's `Auto-run` box. Closes #1210.

> If I don't want to wait x minutes for auto-run to be triggered, I want to be able to click on a button.

**The loop could always do this.** `AutoPmLoop.tick()` is documented as "run one sweep now", and switching the preference on already fires it (#1167) — but nothing could *ask* for it directly, so the only fast-forward was ticking the box off and on again and relying on the side effect of the write. This threads `tick` out as `sendAutoPmSweep`, next to the `onAutoPm` report that already comes from the same loop.

Daemon-only, exactly like the report: the loop lives in that process, so any other host (the relay serves this same dashboard) answers that it has nothing to trigger rather than pretending it swept.

**Disabled while auto-run is off**, which is a deliberate call worth flagging: a sweep re-reads the preference and stands straight back down, so a button that fired a guaranteed no-op would read as broken rather than as inapplicable. The tooltip says which it is.

**Verified in the real UI** against an isolated daemon on a scratch repo with `claude` off `PATH`, so a sweep can run end to end with no chance of starting an agent:

```
button present: true
disabled with auto-run OFF: true
disabled with auto-run ON : false
```

and the daemon log shows the click producing a real sweep decision, not just a resolved promise:

```
[framework] auto PM: standing down for …/rw-repo — the quota could not be read, so there is no way to tell what is spare
```

(Two such lines: one from ticking the box on, one from the button.)

Tests: dashboard 508 pass, framework 1368 pass / 0 fail / 1 skipped. `PreviewBar` flaked once on the first run and passed on re-run — the known flake, untouched by this.

---

⚠️ **Stacked on #1214** (`fix/1191-run-now-selects-run`), because both change `RoutineWork`. Merge #1214 first and this retargets to main cleanly.