### PR TITLE
Update tickets/ to new ticketing_format.md header

### DIFF
--- a/packages/the-framework/src/tickets.test.ts
+++ b/packages/the-framework/src/tickets.test.ts
@@ -30,8 +30,9 @@ test('the ticket-format spec ships in the package (not materialized), with prior
   // The spec teaches both file shapes and the revised #684 optional priority/topics fields.
   assert.ok(TICKETING_FORMAT.includes('tickets/<DATE>_<SLUG>.md'))
   assert.ok(TICKETING_FORMAT.includes('tickets/<DATE>_<SLUG>.spike.md'))
-  assert.ok(TICKETING_FORMAT.includes('priority: low/medium/high/urgent'))
-  assert.ok(TICKETING_FORMAT.includes('topics:'))
+  assert.ok(TICKETING_FORMAT.includes('Priority: 10-0'))
+  assert.ok(TICKETING_FORMAT.includes('Topics:'))
+  assert.ok(TICKETING_FORMAT.includes('GitHub:'))
 })
 
 test('the backlog-format spec ships in the package and teaches the priority sections (#880)', () => {

--- a/tickets/2026-06-25_design-imperative-agent-use-skill.md
+++ b/tickets/2026-06-25_design-imperative-agent-use-skill.md
@@ -1,5 +1,6 @@
-priority: low
-topics: [enhancement]
+Priority: 2
+Topics: [enhancement]
+GitHub: [#13](https://github.com/gemstack-land/the-framework/issues/13)
 
 # Design: optional imperative agent.use(skill) runtime composition
 

--- a/tickets/2026-06-25_design-skill-scoped-tool-wrapper.md
+++ b/tickets/2026-06-25_design-skill-scoped-tool-wrapper.md
@@ -1,5 +1,6 @@
-priority: low
-topics: [enhancement]
+Priority: 2
+Topics: [enhancement]
+GitHub: [#12](https://github.com/gemstack-land/the-framework/issues/12)
 
 # Design: optional skill-scoped tool wrapper (skillTool) over tool()
 

--- a/tickets/2026-06-25_design-ts-first-skill-authoring.md
+++ b/tickets/2026-06-25_design-ts-first-skill-authoring.md
@@ -1,5 +1,6 @@
-priority: low
-topics: [enhancement]
+Priority: 2
+Topics: [enhancement]
+GitHub: [#11](https://github.com/gemstack-land/the-framework/issues/11)
 
 # Design: optional TS-first skill authoring (defineSkill) alongside SKILL.md
 

--- a/tickets/2026-07-02_ai-autopilot-sandboxed-runner-adapters.md
+++ b/tickets/2026-07-02_ai-autopilot-sandboxed-runner-adapters.md
@@ -1,5 +1,6 @@
-priority: medium
-topics: [enhancement]
+Priority: 5
+Topics: [enhancement]
+GitHub: [#109](https://github.com/gemstack-land/the-framework/issues/109)
 
 # ai-autopilot: sandboxed runner adapters (Docker / WebContainer / Flue)
 

--- a/tickets/2026-07-07_background-jobs.md
+++ b/tickets/2026-07-07_background-jobs.md
@@ -1,4 +1,5 @@
-topics: [the-framework]
+Topics: [the-framework]
+GitHub: [#298](https://github.com/gemstack-land/the-framework/issues/298)
 
 # [The Framework] Background jobs
 

--- a/tickets/2026-07-07_bootstrap-mode.md
+++ b/tickets/2026-07-07_bootstrap-mode.md
@@ -1,5 +1,6 @@
-priority: low
-topics: [the-framework]
+Priority: 2
+Topics: [the-framework]
+GitHub: [#297](https://github.com/gemstack-land/the-framework/issues/297)
 
 # [The Framework] Bootstrap mode
 

--- a/tickets/2026-07-10_cli.md
+++ b/tickets/2026-07-10_cli.md
@@ -1,4 +1,5 @@
-topics: [the-framework]
+Topics: [the-framework]
+GitHub: [#312](https://github.com/gemstack-land/the-framework/issues/312)
 
 # CLI
 

--- a/tickets/2026-07-10_database.md
+++ b/tickets/2026-07-10_database.md
@@ -1,4 +1,5 @@
-topics: [the-framework]
+Topics: [the-framework]
+GitHub: [#313](https://github.com/gemstack-land/the-framework/issues/313)
 
 # Database
 

--- a/tickets/2026-07-10_system-prompt.md
+++ b/tickets/2026-07-10_system-prompt.md
@@ -1,4 +1,5 @@
-topics: [the-framework]
+Topics: [the-framework]
+GitHub: [#326](https://github.com/gemstack-land/the-framework/issues/326)
 
 # System prompt
 

--- a/tickets/2026-07-12_app-instead-of-localhost.md
+++ b/tickets/2026-07-12_app-instead-of-localhost.md
@@ -1,3 +1,5 @@
+GitHub: [#411](https://github.com/gemstack-land/the-framework/issues/411)
+
 # App instead of `localhost`?
 
 ## TLDR

--- a/tickets/2026-07-13_git-worktrees.md
+++ b/tickets/2026-07-13_git-worktrees.md
@@ -1,4 +1,5 @@
-topics: [the-framework]
+Topics: [the-framework]
+GitHub: [#453](https://github.com/gemstack-land/the-framework/issues/453)
 
 # Git worktrees
 

--- a/tickets/2026-07-13_syncing-ui-data.md
+++ b/tickets/2026-07-13_syncing-ui-data.md
@@ -1,4 +1,5 @@
-topics: [the-framework]
+Topics: [the-framework]
+GitHub: [#454](https://github.com/gemstack-land/the-framework/issues/454)
 
 # Syncing UI<->data
 

--- a/tickets/2026-07-13_vike-error.md
+++ b/tickets/2026-07-13_vike-error.md
@@ -1,4 +1,5 @@
-topics: [the-framework]
+Topics: [the-framework]
+GitHub: [#460](https://github.com/gemstack-land/the-framework/issues/460)
 
 # Vike error
 

--- a/tickets/2026-07-14_browser-phase2-chromium-in-sandbox.md
+++ b/tickets/2026-07-14_browser-phase2-chromium-in-sandbox.md
@@ -1,4 +1,5 @@
-topics: [the-framework]
+Topics: [the-framework]
+GitHub: [#469](https://github.com/gemstack-land/the-framework/issues/469)
 
 # Browser Phase 2: bundle Chromium into the sandbox runner image
 

--- a/tickets/2026-07-15_roadmap-mvp.md
+++ b/tickets/2026-07-15_roadmap-mvp.md
@@ -1,4 +1,5 @@
-topics: [the-framework]
+Topics: [the-framework]
+GitHub: [#538](https://github.com/gemstack-land/the-framework/issues/538)
 
 # Roadmap (MVP) 🚀
 

--- a/tickets/2026-07-16_drive-claude-code-on-the-web.md
+++ b/tickets/2026-07-16_drive-claude-code-on-the-web.md
@@ -1,5 +1,6 @@
-priority: medium
-topics: [the-framework]
+Priority: 5
+Topics: [the-framework]
+GitHub: [#610](https://github.com/gemstack-land/the-framework/issues/610)
 
 # Drive Claude Code on the web instead of the CLI (MVP shortcut: free worktrees + PR, 0% local CPU)
 

--- a/tickets/2026-07-16_epic-collaboration-layer.md
+++ b/tickets/2026-07-16_epic-collaboration-layer.md
@@ -1,5 +1,6 @@
-priority: low
-topics: [the-framework]
+Priority: 2
+Topics: [the-framework]
+GitHub: [#606](https://github.com/gemstack-land/the-framework/issues/606)
 
 # Epic: Collaboration layer — agents as teammates in the comms layer
 

--- a/tickets/2026-07-16_epic-daemon-gateway-split.md
+++ b/tickets/2026-07-16_epic-daemon-gateway-split.md
@@ -1,5 +1,6 @@
-priority: low
-topics: [the-framework]
+Priority: 2
+Topics: [the-framework]
+GitHub: [#605](https://github.com/gemstack-land/the-framework/issues/605)
 
 # Epic: Daemon + gateway split — headless 24/7 runtime, composable frontend
 

--- a/tickets/2026-07-16_epic-org-layer.md
+++ b/tickets/2026-07-16_epic-org-layer.md
@@ -1,5 +1,6 @@
-priority: low
-topics: [the-framework]
+Priority: 2
+Topics: [the-framework]
+GitHub: [#607](https://github.com/gemstack-land/the-framework/issues/607)
 
 # Epic: Org layer — company / department / project scopes
 

--- a/tickets/2026-07-17_queue.md
+++ b/tickets/2026-07-17_queue.md
@@ -1,4 +1,5 @@
-topics: [the-framework]
+Topics: [the-framework]
+GitHub: [#624](https://github.com/gemstack-land/the-framework/issues/624)
 
 # Queue
 

--- a/tickets/2026-07-18_combine-models.md
+++ b/tickets/2026-07-18_combine-models.md
@@ -1,4 +1,5 @@
-topics: [the-framework]
+Topics: [the-framework]
+GitHub: [#681](https://github.com/gemstack-land/the-framework/issues/681)
 
 # Combine models
 

--- a/tickets/2026-07-19_dogfooding-rom.md
+++ b/tickets/2026-07-19_dogfooding-rom.md
@@ -1,4 +1,5 @@
-priority: medium
+Priority: 5
+GitHub: [#770](https://github.com/gemstack-land/the-framework/issues/770)
 
 # Dogfooding: Rom
 

--- a/tickets/2026-07-19_epic-hosted-mode.md
+++ b/tickets/2026-07-19_epic-hosted-mode.md
@@ -1,5 +1,6 @@
-priority: low
-topics: [the-framework]
+Priority: 2
+Topics: [the-framework]
+GitHub: [#806](https://github.com/gemstack-land/the-framework/issues/806)
 
 # Epic: Hosted mode. Run the agent on a server instead of the laptop / local machine
 

--- a/tickets/2026-07-19_ui-project-dropdown-single-textarea.md
+++ b/tickets/2026-07-19_ui-project-dropdown-single-textarea.md
@@ -1,4 +1,5 @@
-topics: [ux]
+Topics: [ux]
+GitHub: [#772](https://github.com/gemstack-land/the-framework/issues/772)
 
 # UI: remove project list + every page includes a single textarea
 

--- a/tickets/2026-07-20_git-as-database-all-in.md
+++ b/tickets/2026-07-20_git-as-database-all-in.md
@@ -1,3 +1,5 @@
+GitHub: [#857](https://github.com/gemstack-land/the-framework/issues/857)
+
 # Git as database — all in
 
 ## TLDR

--- a/tickets/2026-07-21_discord-chat-single-live-run.md
+++ b/tickets/2026-07-21_discord-chat-single-live-run.md
@@ -1,4 +1,5 @@
-priority: low
+Priority: 2
+GitHub: [#945](https://github.com/gemstack-land/the-framework/issues/945)
 
 # Discord chat assumes one live run per project
 

--- a/tickets/2026-07-21_dogfooding-tf-user-feedback.md
+++ b/tickets/2026-07-21_dogfooding-tf-user-feedback.md
@@ -1,3 +1,5 @@
+GitHub: [#936](https://github.com/gemstack-land/the-framework/issues/936)
+
 # Dogfooding: TF user feedback
 
 ## TLDR

--- a/tickets/2026-07-21_onboarding.md
+++ b/tickets/2026-07-21_onboarding.md
@@ -1,4 +1,5 @@
-priority: high
+Priority: 8
+GitHub: [#958](https://github.com/gemstack-land/the-framework/issues/958)
 
 # Onboarding
 

--- a/tickets/2026-07-21_quota-component.md
+++ b/tickets/2026-07-21_quota-component.md
@@ -1,4 +1,5 @@
-topics: [the-framework, ux]
+Topics: [the-framework, ux]
+GitHub: [#960](https://github.com/gemstack-land/the-framework/issues/960)
 
 # <Quota> component
 

--- a/tickets/2026-07-21_readzip-leaks-onto-public-api.md
+++ b/tickets/2026-07-21_readzip-leaks-onto-public-api.md
@@ -1,4 +1,5 @@
-priority: low
+Priority: 2
+GitHub: [#947](https://github.com/gemstack-land/the-framework/issues/947)
 
 # readZip/ZipEntry leak onto the public API via the driver barrel
 

--- a/tickets/2026-07-22_metafromevents-updatedat-replay.md
+++ b/tickets/2026-07-22_metafromevents-updatedat-replay.md
@@ -1,5 +1,6 @@
-priority: low
-topics: [the-framework]
+Priority: 2
+Topics: [the-framework]
+GitHub: [#1039](https://github.com/gemstack-land/the-framework/issues/1039)
 
 # metaFromEvents anchors updatedAt to startedAt on replay
 

--- a/tickets/2026-07-24_interrupt-turn-steer-in-place.md
+++ b/tickets/2026-07-24_interrupt-turn-steer-in-place.md
@@ -1,5 +1,6 @@
-priority: medium
-topics: [enhancement, the-framework]
+Priority: 5
+Topics: [enhancement, the-framework]
+GitHub: [#1132](https://github.com/gemstack-land/the-framework/issues/1132)
 
 # Interrupt the current turn (steer in place), not only a hard Stop
 

--- a/tickets/2026-07-24_record-ticket-run-starts-from.md
+++ b/tickets/2026-07-24_record-ticket-run-starts-from.md
@@ -1,5 +1,6 @@
-priority: low
-topics: [enhancement, the-framework]
+Priority: 2
+Topics: [enhancement, the-framework]
+GitHub: [#1117](https://github.com/gemstack-land/the-framework/issues/1117)
 
 # Record the ticket a run starts from, for a true 'implementing' status
 

--- a/tickets/2026-07-24_topics-dashboard-entry-point.md
+++ b/tickets/2026-07-24_topics-dashboard-entry-point.md
@@ -1,5 +1,6 @@
-priority: medium
-topics: [enhancement, the-framework, ux]
+Priority: 5
+Topics: [enhancement, the-framework, ux]
+GitHub: [#1124](https://github.com/gemstack-land/the-framework/issues/1124)
 
 # Topics: dashboard entry point and project-less addressing
 

--- a/tickets/2026-07-24_topics-gate-for-bind-read-for-list.md
+++ b/tickets/2026-07-24_topics-gate-for-bind-read-for-list.md
@@ -1,5 +1,6 @@
-priority: medium
-topics: [question, the-framework]
+Priority: 5
+Topics: [question, the-framework]
+GitHub: [#1129](https://github.com/gemstack-land/the-framework/issues/1129)
 
 # Topics: recommend gate for bind + read for list (#1121 mechanism)
 

--- a/tickets/2026-07-24_topics-project-less-conversations.md
+++ b/tickets/2026-07-24_topics-project-less-conversations.md
@@ -1,5 +1,6 @@
-priority: medium
-topics: [enhancement, the-framework, ux]
+Priority: 5
+Topics: [enhancement, the-framework, ux]
+GitHub: [#1115](https://github.com/gemstack-land/the-framework/issues/1115)
 
 # Topics: start a conversation without a project, bind to one lazily
 

--- a/tickets/2026-07-25_bug-cannot-select-fable.md
+++ b/tickets/2026-07-25_bug-cannot-select-fable.md
@@ -1,5 +1,6 @@
-priority: low
-topics: [bug]
+Priority: 2
+Topics: [bug]
+GitHub: [#1143](https://github.com/gemstack-land/the-framework/issues/1143)
 
 # Bug: cannot select Fable
 

--- a/tickets/2026-07-25_bug-files-missing.md
+++ b/tickets/2026-07-25_bug-files-missing.md
@@ -1,5 +1,6 @@
-priority: low
-topics: [bug]
+Priority: 2
+Topics: [bug]
+GitHub: [#1142](https://github.com/gemstack-land/the-framework/issues/1142)
 
 # Bug: `Files` missing
 

--- a/tickets/2026-07-25_dashboard-show-routine-work.md
+++ b/tickets/2026-07-25_dashboard-show-routine-work.md
@@ -1,3 +1,5 @@
+GitHub: [#1159](https://github.com/gemstack-land/the-framework/issues/1159)
+
 # [Dashboard] Show routine work (i.e. cron jobs)
 
 ## TLDR

--- a/tickets/2026-07-25_global-store-one-file-or-folder.md
+++ b/tickets/2026-07-25_global-store-one-file-or-folder.md
@@ -1,5 +1,6 @@
-priority: low
-topics: [question, the-framework]
+Priority: 2
+Topics: [question, the-framework]
+GitHub: [#1151](https://github.com/gemstack-land/the-framework/issues/1151)
 
 # Global store: one file or a folder?
 

--- a/tickets/2026-07-25_import-tickets-redirects-wrong-page.md
+++ b/tickets/2026-07-25_import-tickets-redirects-wrong-page.md
@@ -1,3 +1,5 @@
+GitHub: [#1169](https://github.com/gemstack-land/the-framework/issues/1169)
+
 # Click `Import tickets from GitHub` => redirects to the wrong page (should redirect the running session)
 
 ## TLDR

--- a/tickets/2026-07-25_improve-add-project.md
+++ b/tickets/2026-07-25_improve-add-project.md
@@ -1,4 +1,5 @@
-priority: high
+Priority: 8
+GitHub: [#1150](https://github.com/gemstack-land/the-framework/issues/1150)
 
 # Improve "Add project"
 

--- a/tickets/2026-07-25_improve-dashboard.md
+++ b/tickets/2026-07-25_improve-dashboard.md
@@ -1,4 +1,5 @@
-priority: high
+Priority: 8
+GitHub: [#1139](https://github.com/gemstack-land/the-framework/issues/1139)
 
 # Improve dashboard
 

--- a/tickets/2026-07-25_improve-tooltip.md
+++ b/tickets/2026-07-25_improve-tooltip.md
@@ -1,4 +1,5 @@
-priority: high
+Priority: 8
+GitHub: [#1149](https://github.com/gemstack-land/the-framework/issues/1149)
 
 # Improve tooltip
 

--- a/tickets/2026-07-25_rehome-test-loses-bind-under-load.md
+++ b/tickets/2026-07-25_rehome-test-loses-bind-under-load.md
@@ -1,5 +1,6 @@
-priority: medium
-topics: [bug, the-framework]
+Priority: 5
+Topics: [bug, the-framework]
+GitHub: [#1165](https://github.com/gemstack-land/the-framework/issues/1165)
 
 # test: the #1122 re-home test loses the bind under load (not a poll budget)
 

--- a/tickets/2026-07-25_removing-or-renaming-directory.md
+++ b/tickets/2026-07-25_removing-or-renaming-directory.md
@@ -1,5 +1,6 @@
-priority: low
-topics: [bug]
+Priority: 2
+Topics: [bug]
+GitHub: [#1140](https://github.com/gemstack-land/the-framework/issues/1140)
 
 # What happens when removing (or renaming) a directory
 

--- a/tickets/2026-07-25_ticketing-format-not-respected.md
+++ b/tickets/2026-07-25_ticketing-format-not-respected.md
@@ -1,5 +1,6 @@
-priority: low
-topics: [bug]
+Priority: 2
+Topics: [bug]
+GitHub: [#1162](https://github.com/gemstack-land/the-framework/issues/1162)
 
 # `ticketing_format.md` not respected?
 

--- a/tickets/2026-07-25_tickets-whole-page-instead-of-sidebar.md
+++ b/tickets/2026-07-25_tickets-whole-page-instead-of-sidebar.md
@@ -1,3 +1,5 @@
+GitHub: [#1144](https://github.com/gemstack-land/the-framework/issues/1144)
+
 # Show tickets as whole page instead of sidebar
 
 ## TLDR

--- a/tickets/2026-07-25_todo-agents-doesnt-respect-todo-format.md
+++ b/tickets/2026-07-25_todo-agents-doesnt-respect-todo-format.md
@@ -1,5 +1,6 @@
-priority: high
-topics: [bug]
+Priority: 8
+Topics: [bug]
+GitHub: [#1163](https://github.com/gemstack-land/the-framework/issues/1163)
 
 # `TODO_AGENTS.md` doesn't respect `todo_format.md`
 

--- a/tickets/2026-07-25_what-is-log.md
+++ b/tickets/2026-07-25_what-is-log.md
@@ -1,4 +1,5 @@
-priority: high
+Priority: 8
+GitHub: [#1145](https://github.com/gemstack-land/the-framework/issues/1145)
 
 # What is "Log"?
 

--- a/tickets/2026-07-25_what-is-spend-whats-left-on-roadmap.md
+++ b/tickets/2026-07-25_what-is-spend-whats-left-on-roadmap.md
@@ -1,4 +1,5 @@
-priority: high
+Priority: 8
+GitHub: [#1138](https://github.com/gemstack-land/the-framework/issues/1138)
 
 # What is "Spend what's left on the roadmap"?
 


### PR DESCRIPTION
## Summary

Commit 07999f6 changed `packages/the-framework/prompts/ticketing_format.md`:
- `priority: low/medium/high/urgent` → `Priority: 10-0` (numeric scale)
- `topics:` → `Topics:` (capitalized)
- added an optional `GitHub: [#42](url)` field

This PR applies that new header format to all 51 existing tickets under `tickets/`:
- Capitalized `priority:`/`topics:` → `Priority:`/`Topics:`
- Mapped old word priorities to the new 0-10 scale: `high` → 8, `medium` → 5, `low` → 2 (no `urgent` tickets existed)
- Added a `GitHub:` link field to every ticket, sourced from its existing "Imported from GitHub issue" reference in the body

## Test plan
- [x] `git diff` reviewed: only header lines (`Priority:`/`Topics:`/`GitHub:`) were added/changed; no other ticket content touched


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vpo7oLDzRZJP4yzAvpRgZ9)_