### PR TITLE
Add Status: open/closed to every ticket header

### DIFF
--- a/tickets/2026-06-25_design-imperative-agent-use-skill.md
+++ b/tickets/2026-06-25_design-imperative-agent-use-skill.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 2
 Topics: [enhancement]
 GitHub: [#13](https://github.com/gemstack-land/the-framework/issues/13)

--- a/tickets/2026-06-25_design-skill-scoped-tool-wrapper.md
+++ b/tickets/2026-06-25_design-skill-scoped-tool-wrapper.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 2
 Topics: [enhancement]
 GitHub: [#12](https://github.com/gemstack-land/the-framework/issues/12)

--- a/tickets/2026-06-25_design-ts-first-skill-authoring.md
+++ b/tickets/2026-06-25_design-ts-first-skill-authoring.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 2
 Topics: [enhancement]
 GitHub: [#11](https://github.com/gemstack-land/the-framework/issues/11)

--- a/tickets/2026-07-02_ai-autopilot-sandboxed-runner-adapters.md
+++ b/tickets/2026-07-02_ai-autopilot-sandboxed-runner-adapters.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 5
 Topics: [enhancement]
 GitHub: [#109](https://github.com/gemstack-land/the-framework/issues/109)

--- a/tickets/2026-07-07_background-jobs.md
+++ b/tickets/2026-07-07_background-jobs.md
@@ -1,3 +1,4 @@
+Status: open
 Topics: [the-framework]
 GitHub: [#298](https://github.com/gemstack-land/the-framework/issues/298)
 

--- a/tickets/2026-07-07_bootstrap-mode.md
+++ b/tickets/2026-07-07_bootstrap-mode.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 2
 Topics: [the-framework]
 GitHub: [#297](https://github.com/gemstack-land/the-framework/issues/297)

--- a/tickets/2026-07-10_cli.md
+++ b/tickets/2026-07-10_cli.md
@@ -1,3 +1,4 @@
+Status: open
 Topics: [the-framework]
 GitHub: [#312](https://github.com/gemstack-land/the-framework/issues/312)
 

--- a/tickets/2026-07-10_database.md
+++ b/tickets/2026-07-10_database.md
@@ -1,3 +1,4 @@
+Status: open
 Topics: [the-framework]
 GitHub: [#313](https://github.com/gemstack-land/the-framework/issues/313)
 

--- a/tickets/2026-07-10_system-prompt.md
+++ b/tickets/2026-07-10_system-prompt.md
@@ -1,3 +1,4 @@
+Status: open
 Topics: [the-framework]
 GitHub: [#326](https://github.com/gemstack-land/the-framework/issues/326)
 

--- a/tickets/2026-07-12_app-instead-of-localhost.md
+++ b/tickets/2026-07-12_app-instead-of-localhost.md
@@ -1,3 +1,4 @@
+Status: open
 GitHub: [#411](https://github.com/gemstack-land/the-framework/issues/411)
 
 # App instead of `localhost`?

--- a/tickets/2026-07-13_git-worktrees.md
+++ b/tickets/2026-07-13_git-worktrees.md
@@ -1,3 +1,4 @@
+Status: open
 Topics: [the-framework]
 GitHub: [#453](https://github.com/gemstack-land/the-framework/issues/453)
 

--- a/tickets/2026-07-13_syncing-ui-data.md
+++ b/tickets/2026-07-13_syncing-ui-data.md
@@ -1,3 +1,4 @@
+Status: open
 Topics: [the-framework]
 GitHub: [#454](https://github.com/gemstack-land/the-framework/issues/454)
 

--- a/tickets/2026-07-13_vike-error.md
+++ b/tickets/2026-07-13_vike-error.md
@@ -1,3 +1,4 @@
+Status: open
 Topics: [the-framework]
 GitHub: [#460](https://github.com/gemstack-land/the-framework/issues/460)
 

--- a/tickets/2026-07-14_browser-phase2-chromium-in-sandbox.md
+++ b/tickets/2026-07-14_browser-phase2-chromium-in-sandbox.md
@@ -1,3 +1,4 @@
+Status: open
 Topics: [the-framework]
 GitHub: [#469](https://github.com/gemstack-land/the-framework/issues/469)
 

--- a/tickets/2026-07-15_roadmap-mvp.md
+++ b/tickets/2026-07-15_roadmap-mvp.md
@@ -1,3 +1,4 @@
+Status: open
 Topics: [the-framework]
 GitHub: [#538](https://github.com/gemstack-land/the-framework/issues/538)
 

--- a/tickets/2026-07-16_drive-claude-code-on-the-web.md
+++ b/tickets/2026-07-16_drive-claude-code-on-the-web.md
@@ -1,3 +1,4 @@
+Status: closed
 Priority: 5
 Topics: [the-framework]
 GitHub: [#610](https://github.com/gemstack-land/the-framework/issues/610)

--- a/tickets/2026-07-16_epic-collaboration-layer.md
+++ b/tickets/2026-07-16_epic-collaboration-layer.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 2
 Topics: [the-framework]
 GitHub: [#606](https://github.com/gemstack-land/the-framework/issues/606)

--- a/tickets/2026-07-16_epic-daemon-gateway-split.md
+++ b/tickets/2026-07-16_epic-daemon-gateway-split.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 2
 Topics: [the-framework]
 GitHub: [#605](https://github.com/gemstack-land/the-framework/issues/605)

--- a/tickets/2026-07-16_epic-org-layer.md
+++ b/tickets/2026-07-16_epic-org-layer.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 2
 Topics: [the-framework]
 GitHub: [#607](https://github.com/gemstack-land/the-framework/issues/607)

--- a/tickets/2026-07-17_queue.md
+++ b/tickets/2026-07-17_queue.md
@@ -1,3 +1,4 @@
+Status: open
 Topics: [the-framework]
 GitHub: [#624](https://github.com/gemstack-land/the-framework/issues/624)
 

--- a/tickets/2026-07-18_combine-models.md
+++ b/tickets/2026-07-18_combine-models.md
@@ -1,3 +1,4 @@
+Status: open
 Topics: [the-framework]
 GitHub: [#681](https://github.com/gemstack-land/the-framework/issues/681)
 

--- a/tickets/2026-07-19_dogfooding-rom.md
+++ b/tickets/2026-07-19_dogfooding-rom.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 5
 GitHub: [#770](https://github.com/gemstack-land/the-framework/issues/770)
 

--- a/tickets/2026-07-19_epic-hosted-mode.md
+++ b/tickets/2026-07-19_epic-hosted-mode.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 2
 Topics: [the-framework]
 GitHub: [#806](https://github.com/gemstack-land/the-framework/issues/806)

--- a/tickets/2026-07-19_ui-project-dropdown-single-textarea.md
+++ b/tickets/2026-07-19_ui-project-dropdown-single-textarea.md
@@ -1,3 +1,4 @@
+Status: open
 Topics: [ux]
 GitHub: [#772](https://github.com/gemstack-land/the-framework/issues/772)
 

--- a/tickets/2026-07-20_git-as-database-all-in.md
+++ b/tickets/2026-07-20_git-as-database-all-in.md
@@ -1,3 +1,4 @@
+Status: open
 GitHub: [#857](https://github.com/gemstack-land/the-framework/issues/857)
 
 # Git as database — all in

--- a/tickets/2026-07-21_discord-chat-single-live-run.md
+++ b/tickets/2026-07-21_discord-chat-single-live-run.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 2
 GitHub: [#945](https://github.com/gemstack-land/the-framework/issues/945)
 

--- a/tickets/2026-07-21_dogfooding-tf-user-feedback.md
+++ b/tickets/2026-07-21_dogfooding-tf-user-feedback.md
@@ -1,3 +1,4 @@
+Status: open
 GitHub: [#936](https://github.com/gemstack-land/the-framework/issues/936)
 
 # Dogfooding: TF user feedback

--- a/tickets/2026-07-21_onboarding.md
+++ b/tickets/2026-07-21_onboarding.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 8
 GitHub: [#958](https://github.com/gemstack-land/the-framework/issues/958)
 

--- a/tickets/2026-07-21_quota-component.md
+++ b/tickets/2026-07-21_quota-component.md
@@ -1,3 +1,4 @@
+Status: open
 Topics: [the-framework, ux]
 GitHub: [#960](https://github.com/gemstack-land/the-framework/issues/960)
 

--- a/tickets/2026-07-21_readzip-leaks-onto-public-api.md
+++ b/tickets/2026-07-21_readzip-leaks-onto-public-api.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 2
 GitHub: [#947](https://github.com/gemstack-land/the-framework/issues/947)
 

--- a/tickets/2026-07-22_metafromevents-updatedat-replay.md
+++ b/tickets/2026-07-22_metafromevents-updatedat-replay.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 2
 Topics: [the-framework]
 GitHub: [#1039](https://github.com/gemstack-land/the-framework/issues/1039)

--- a/tickets/2026-07-24_interrupt-turn-steer-in-place.md
+++ b/tickets/2026-07-24_interrupt-turn-steer-in-place.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 5
 Topics: [enhancement, the-framework]
 GitHub: [#1132](https://github.com/gemstack-land/the-framework/issues/1132)

--- a/tickets/2026-07-24_record-ticket-run-starts-from.md
+++ b/tickets/2026-07-24_record-ticket-run-starts-from.md
@@ -1,3 +1,4 @@
+Status: closed
 Priority: 2
 Topics: [enhancement, the-framework]
 GitHub: [#1117](https://github.com/gemstack-land/the-framework/issues/1117)

--- a/tickets/2026-07-24_topics-dashboard-entry-point.md
+++ b/tickets/2026-07-24_topics-dashboard-entry-point.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 5
 Topics: [enhancement, the-framework, ux]
 GitHub: [#1124](https://github.com/gemstack-land/the-framework/issues/1124)

--- a/tickets/2026-07-24_topics-gate-for-bind-read-for-list.md
+++ b/tickets/2026-07-24_topics-gate-for-bind-read-for-list.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 5
 Topics: [question, the-framework]
 GitHub: [#1129](https://github.com/gemstack-land/the-framework/issues/1129)

--- a/tickets/2026-07-24_topics-project-less-conversations.md
+++ b/tickets/2026-07-24_topics-project-less-conversations.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 5
 Topics: [enhancement, the-framework, ux]
 GitHub: [#1115](https://github.com/gemstack-land/the-framework/issues/1115)

--- a/tickets/2026-07-25_bug-cannot-select-fable.md
+++ b/tickets/2026-07-25_bug-cannot-select-fable.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 2
 Topics: [bug]
 GitHub: [#1143](https://github.com/gemstack-land/the-framework/issues/1143)

--- a/tickets/2026-07-25_bug-files-missing.md
+++ b/tickets/2026-07-25_bug-files-missing.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 2
 Topics: [bug]
 GitHub: [#1142](https://github.com/gemstack-land/the-framework/issues/1142)

--- a/tickets/2026-07-25_dashboard-show-routine-work.md
+++ b/tickets/2026-07-25_dashboard-show-routine-work.md
@@ -1,3 +1,4 @@
+Status: closed
 GitHub: [#1159](https://github.com/gemstack-land/the-framework/issues/1159)
 
 # [Dashboard] Show routine work (i.e. cron jobs)

--- a/tickets/2026-07-25_global-store-one-file-or-folder.md
+++ b/tickets/2026-07-25_global-store-one-file-or-folder.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 2
 Topics: [question, the-framework]
 GitHub: [#1151](https://github.com/gemstack-land/the-framework/issues/1151)

--- a/tickets/2026-07-25_import-tickets-redirects-wrong-page.md
+++ b/tickets/2026-07-25_import-tickets-redirects-wrong-page.md
@@ -1,3 +1,4 @@
+Status: closed
 GitHub: [#1169](https://github.com/gemstack-land/the-framework/issues/1169)
 
 # Click `Import tickets from GitHub` => redirects to the wrong page (should redirect the running session)

--- a/tickets/2026-07-25_improve-add-project.md
+++ b/tickets/2026-07-25_improve-add-project.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 8
 GitHub: [#1150](https://github.com/gemstack-land/the-framework/issues/1150)
 

--- a/tickets/2026-07-25_improve-dashboard.md
+++ b/tickets/2026-07-25_improve-dashboard.md
@@ -1,3 +1,4 @@
+Status: closed
 Priority: 8
 GitHub: [#1139](https://github.com/gemstack-land/the-framework/issues/1139)
 

--- a/tickets/2026-07-25_improve-tooltip.md
+++ b/tickets/2026-07-25_improve-tooltip.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 8
 GitHub: [#1149](https://github.com/gemstack-land/the-framework/issues/1149)
 

--- a/tickets/2026-07-25_rehome-test-loses-bind-under-load.md
+++ b/tickets/2026-07-25_rehome-test-loses-bind-under-load.md
@@ -1,3 +1,4 @@
+Status: closed
 Priority: 5
 Topics: [bug, the-framework]
 GitHub: [#1165](https://github.com/gemstack-land/the-framework/issues/1165)

--- a/tickets/2026-07-25_removing-or-renaming-directory.md
+++ b/tickets/2026-07-25_removing-or-renaming-directory.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 2
 Topics: [bug]
 GitHub: [#1140](https://github.com/gemstack-land/the-framework/issues/1140)

--- a/tickets/2026-07-25_ticketing-format-not-respected.md
+++ b/tickets/2026-07-25_ticketing-format-not-respected.md
@@ -1,3 +1,4 @@
+Status: closed
 Priority: 2
 Topics: [bug]
 GitHub: [#1162](https://github.com/gemstack-land/the-framework/issues/1162)

--- a/tickets/2026-07-25_tickets-whole-page-instead-of-sidebar.md
+++ b/tickets/2026-07-25_tickets-whole-page-instead-of-sidebar.md
@@ -1,3 +1,4 @@
+Status: open
 GitHub: [#1144](https://github.com/gemstack-land/the-framework/issues/1144)
 
 # Show tickets as whole page instead of sidebar

--- a/tickets/2026-07-25_todo-agents-doesnt-respect-todo-format.md
+++ b/tickets/2026-07-25_todo-agents-doesnt-respect-todo-format.md
@@ -1,3 +1,4 @@
+Status: closed
 Priority: 8
 Topics: [bug]
 GitHub: [#1163](https://github.com/gemstack-land/the-framework/issues/1163)

--- a/tickets/2026-07-25_what-is-log.md
+++ b/tickets/2026-07-25_what-is-log.md
@@ -1,3 +1,4 @@
+Status: open
 Priority: 8
 GitHub: [#1145](https://github.com/gemstack-land/the-framework/issues/1145)
 

--- a/tickets/2026-07-25_what-is-spend-whats-left-on-roadmap.md
+++ b/tickets/2026-07-25_what-is-spend-whats-left-on-roadmap.md
@@ -1,3 +1,4 @@
+Status: closed
 Priority: 8
 GitHub: [#1138](https://github.com/gemstack-land/the-framework/issues/1138)
 


### PR DESCRIPTION
## Summary

Commit 06cd97c added a required `Status: open/closed` field to `packages/the-framework/prompts/ticketing_format.md`, ahead of `Priority:`/`Topics:`/`GitHub:`.

This PR sets that field on all 51 existing tickets under `tickets/`:
- Looked up each ticket's linked GitHub issue (via its `GitHub:` field, added in #1228) and set `Status:` from the issue's actual open/closed state
- 9 tickets are closed: `#610`, `#1117`, `#1138`, `#1139`, `#1159`, `#1162`, `#1163`, `#1165`, `#1169`
- The remaining 42 tickets are open

## Test plan
- [x] `git diff` reviewed: exactly one `Status:` line added per ticket, nothing else touched
- [x] `pnpm turbo run test --filter=@gemstack/the-framework` — the ticket-format spec test still passes; no new failures introduced


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vpo7oLDzRZJP4yzAvpRgZ9)_