### PR TITLE
fix(the-framework): end a Claude web run at the hand-off (#1225)

### DIFF
--- a/.changeset/cloud-run-ends-at-handoff.md
+++ b/.changeset/cloud-run-ends-at-handoff.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+A run on Claude Code on the web now ends at the hand-off, instead of carrying on locally as if the agent had answered. It had not: a cloud session's replies stay in the cloud, so every phase after the first prompt was reading the driver's own "handed off to <url>" note as the agent's reply. The production-grade checklist found no verdict in it and reported the app un-reviewable, and the backlog gate then asked "Start the next backlog item?" about work that was no longer on this machine, which is why the same question turned up on every cloud run before the session had even replied. The review passes, the backlog loop and the stay-open composer are dropped for this target, and the run view says the session asks its questions and opens its pull request over there.

--- a/packages/framework-dashboard/components/CloudRunNotice.test.tsx
+++ b/packages/framework-dashboard/components/CloudRunNotice.test.tsx
@@ -30,6 +30,11 @@ describe('CloudRunNotice (#610)', () => {
     expect(screen.getByRole('status').textContent).toMatch(/opens its own pull request/i)
   })
 
+  test('says the session asks its questions over there, since none can be answered here (#1225)', () => {
+    render(<CloudRunNotice target="web" events={[handOff()]} />)
+    expect(screen.getByRole('status').textContent).toMatch(/asks its questions.*over there, not here/i)
+  })
+
   test('renders nothing for the other targets', () => {
     for (const target of ['local', 'actions', 'remote'] as const) {
       const { container } = render(<CloudRunNotice target={target} events={[handOff()]} />)

--- a/packages/framework-dashboard/components/CloudRunNotice.tsx
+++ b/packages/framework-dashboard/components/CloudRunNotice.tsx
@@ -7,6 +7,8 @@ import { CopyButton } from './ui/copy-button.js'
 // streamed run: the session runs on Anthropic's infrastructure, does its own worktree and opens
 // its own PR, and there is no read-back API to follow it with — so the honest thing to show is
 // where the work went and how to reach it, rather than an empty feed that looks stalled.
+// That includes the questions it asks (#1225): a choice raised in the cloud session is answered
+// in the cloud session, because nothing carries it here and nothing could carry an answer back.
 // Renders nothing for any other target, so the run view can mount it unconditionally.
 export function CloudRunNotice({
   target,
@@ -22,7 +24,7 @@ export function CloudRunNotice({
       <Cloud className="h-3.5 w-3.5 shrink-0" aria-hidden />
       <span className="min-w-0 flex-1">
         {session
-          ? 'Running as a Claude Code cloud session. It opens its own pull request when it is done.'
+          ? 'Running as a Claude Code cloud session. It asks its questions and opens its own pull request over there, not here.'
           : 'Starting a Claude Code cloud session…'}
       </span>
       {session && (

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -1869,9 +1869,13 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
 
   return settleRun(epilogue('session'), async () => {
     const { result, preview } = await runFramework(runOpts)
-    const successLine = result.productionGrade
-      ? `\n✓ production-grade in ${result.passes} pass(es).`
-      : `\n• prototype ready${result.stoppedEarly ? ` (stopped with ${result.blockers.length} blocker(s))` : ''}.`
+    // A hand-off ran no review passes by design (#1225), so neither of the build lines fits:
+    // "prototype ready" would claim this machine built something it never saw.
+    const successLine = driver.handsOff
+      ? '\n✓ handed off. The session continues where it was sent, and opens its own pull request.'
+      : result.productionGrade
+        ? `\n✓ production-grade in ${result.passes} pass(es).`
+        : `\n• prototype ready${result.stoppedEarly ? ` (stopped with ${result.blockers.length} blocker(s))` : ''}.`
     return { successLine, ...(preview ? { preview } : {}) }
   })
 }

--- a/packages/the-framework/src/driver/cloud.test.ts
+++ b/packages/the-framework/src/driver/cloud.test.ts
@@ -208,3 +208,9 @@ test('there is no readCode: the workspace lives in a cloud VM', async () => {
   const session = await driverWith(CREATED).start({ cwd: '/repo' })
   assert.equal(session.readCode, undefined)
 })
+
+test('the driver declares itself a hand-off, so a run ends at the first prompt (#1225)', () => {
+  // Load-bearing rather than descriptive: this flag is what stops the run reviewing,
+  // improving and asking about work that left this machine with the first prompt.
+  assert.equal(driverWith(CREATED).handsOff, true)
+})

--- a/packages/the-framework/src/driver/cloud.ts
+++ b/packages/the-framework/src/driver/cloud.ts
@@ -37,6 +37,14 @@ import type { Driver, DriverEvent, DriverPromptOptions, DriverSession, DriverSta
  */
 export class CloudDriver implements Driver {
   readonly name = 'claude-web'
+  /**
+   * The run ends at the hand-off (#1225). A cloud session's replies stay in the cloud, so
+   * every later phase would be reading this driver's own summary of where the work went and
+   * treating it as the agent's answer: the checklist found no verdict in it and reported the
+   * app un-reviewable, and the backlog gate then asked the user which item to start next —
+   * a question from this machine about work that is no longer on it.
+   */
+  readonly handsOff = true
   constructor(private readonly opts: CloudDriverOptions = {}) {}
 
   start(opts: DriverStartOptions): Promise<DriverSession> {

--- a/packages/the-framework/src/driver/types.ts
+++ b/packages/the-framework/src/driver/types.ts
@@ -34,6 +34,16 @@ export interface Driver {
    * way {@link DriverRateLimit} is omitted by drivers that can't emit it.
    */
   readQuota?(opts?: { signal?: AbortSignal }): Promise<DriverQuota>
+  /**
+   * This driver hands the task somewhere this machine cannot follow, so the first prompt is
+   * the whole run (#1225). Everything a run would do after that prompt — review the reply,
+   * improve against blockers, work the backlog, stay open for messages — reads a reply the
+   * agent never wrote, and asks the user questions the agent never asked.
+   *
+   * Optional and false by default: a driver that streams its agent's own replies (local,
+   * Actions, a device) omits it.
+   */
+  readonly handsOff?: boolean
 }
 
 /** How to boot a {@link DriverSession}. */

--- a/packages/the-framework/src/run.test.ts
+++ b/packages/the-framework/src/run.test.ts
@@ -939,3 +939,80 @@ test('runAwaitRounds does not report exhausted when a chat phase follows the ope
   assert.equal(result.exhausted, false)
   assert.equal(result.declined, false)
 })
+
+/**
+ * A driver whose every reply is the same note about where the work went (#1225) — the shape
+ * of a hand-off, whatever it hands off to. Named 'fake' so the workspace-verify stays off,
+ * which keeps these unit tests off the filesystem.
+ */
+function handsOffDriver(): { driver: Driver; prompts: () => readonly string[] } {
+  const prompts: string[] = []
+  const inner = new FakeDriver({
+    respond: (prompt: string) => {
+      prompts.push(prompt)
+      return 'Handed off. View the session: https://claude.ai/code/session_01ABC'
+    },
+    sessionId: 'session_01ABC',
+  })
+  return { driver: { name: 'fake', handsOff: true, start: opts => inner.start(opts) }, prompts: () => prompts }
+}
+
+test('a hand-off run ends at the hand-off: no review passes, no backlog gate (#1225)', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'framework-handsoff-'))
+  await writeFile(join(cwd, 'TODO.md'), '- [ ] leftover task\n')
+  try {
+    const events: FrameworkEvent[] = []
+    const asked: ChoiceRequest[] = []
+    const { driver, prompts } = handsOffDriver()
+    const { result, todo } = await runFramework({
+      intent: FAKE_INTENT,
+      driver,
+      cwd,
+      signals: FAKE_SIGNALS,
+      // Explicit, so this proves the hand-off outranks an opt-in rather than merely
+      // sharing a default with it.
+      todoLoop: true,
+      requestChoice: async req => {
+        asked.push(req)
+        return { picked: req.options[0]!.id, by: 'user' }
+      },
+      onEvent: e => events.push(e),
+    })
+
+    // The build prompt was the whole run: no checklist pass followed it, so nothing read the
+    // hand-off note as a reply and reported a missing verdict.
+    assert.equal(prompts().length, 1)
+    assert.ok(!prompts().some(p => /production-grade checklist/.test(p)))
+    assert.equal(result.passes, 0)
+    assert.deepEqual(result.blockers, [])
+    assert.equal(result.stoppedEarly, false)
+    // The backlog is still there and still unasked about: this machine has no standing to
+    // ask which item to start next when the work is somewhere it cannot see.
+    assert.equal(todo, undefined)
+    assert.deepEqual(asked, [])
+    assert.ok(!events.some(e => e.kind === 'choice'))
+    assert.match(await readFile(join(cwd, 'TODO.md'), 'utf8'), /leftover task/)
+    // And it says why it stopped, before the end.
+    const handed = events.findIndex(e => e.kind === 'log' && /^Handed off:/.test(e.message))
+    assert.ok(handed !== -1 && handed < events.findIndex(e => e.kind === 'end'))
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('a hand-off run does not stay open for messages (#1225)', async () => {
+  const { driver } = handsOffDriver()
+  // Left open on purpose: a run that still waited on it would never resolve, since the
+  // composer it waits for cannot reach the session it handed to.
+  const messages = new RunMessageQueue()
+  const run = runFramework({
+    intent: FAKE_INTENT,
+    driver,
+    cwd: '/tmp/ws',
+    signals: FAKE_SIGNALS,
+    messages,
+    onEvent: () => {},
+  })
+  const timer = new Promise<'waited'>(resolve => setTimeout(() => resolve('waited'), 2000).unref())
+  assert.notEqual(await Promise.race([run.then(() => 'ended' as const), timer]), 'waited')
+})

--- a/packages/the-framework/src/run.ts
+++ b/packages/the-framework/src/run.ts
@@ -396,6 +396,15 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     // Topic runs only (#1121): resolves an await-bind-project / await-create-project gate.
     ...(opts.bind ? { bind: opts.bind } : {}),
   }
+  // A hand-off driver (#1225): the prompt leaves this machine and the reply never comes back,
+  // so the build prompt is the entire run. Every phase after it — the production-grade
+  // checklist, improving against its blockers, the backlog gate, live chat — would be reading
+  // the driver's own "handed off to <url>" summary as if the agent had written it. That is
+  // what put a `{ blockers }` verdict is missing complaint and an unanswerable "Start the next
+  // backlog item?" call on a dashboard whose agent was somewhere else entirely. So the phases
+  // are dropped rather than fed: Bootstrap skips its whole loop when no `checklist` step is
+  // given, which leaves scope -> build and nothing after it.
+  const handsOff = opts.driver.handsOff === true
   let preview: AppPreview | undefined
   try {
     const bootstrap = new Bootstrap({
@@ -405,8 +414,7 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
       steps: {
         scope: () => ({ scope: opts.scope ?? 'full', intent: opts.intent }),
         build: agentAwaitGate(driverBuild(session, workspaceOpt), session, gateDeps),
-        checklist,
-        improve: driverImprove(session, workspaceOpt),
+        ...(handsOff ? {} : { checklist, improve: driverImprove(session, workspaceOpt) }),
         ...(opts.deploy
           ? {
               deploy: opts.deployTarget
@@ -423,7 +431,7 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     // its reused tmp workspace could also carry stale files). The run signal
     // (Stop / budget cap #322) and the item cap bound it for unattended runs.
     let todo: TodoLoopResult | undefined
-    if (opts.todoLoop ?? opts.driver.name !== 'fake') {
+    if (!handsOff && (opts.todoLoop ?? opts.driver.name !== 'fake')) {
       todo = await runTodoLoop({
         session,
         cwd: opts.cwd,
@@ -441,7 +449,10 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     if (runner && s?.keepAlive) preview = await startAppPreview(runner, s, emit)
     // Live chat (#714): with the build settled, stay open for the user's own messages,
     // each continuing the same session. Ends on Stop / budget cap (next -> undefined).
-    if (opts.messages) {
+    // A hand-off run has no session here to continue: the CLI can start a cloud session and
+    // pull one back, but it cannot send a second message to one, so staying open would offer
+    // a composer whose every message answers itself. The run ends instead, with the link.
+    if (opts.messages && !handsOff) {
       await runChatPhase(session, opts.messages, { text: '' }, {
         ...(opts.requestChoice ? { requestChoice: opts.requestChoice } : {}),
         emit,
@@ -450,6 +461,9 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
         ...(opts.recordMessage ? { recordMessage: opts.recordMessage } : {}),
       })
     }
+    // Say why the run stops here, so a finished hand-off does not read as a run that gave up
+    // one phase in. The link itself is already on the driver's `cloud <url>` action.
+    if (handsOff) emit({ kind: 'log', message: 'Handed off: the rest of this run happens in its own session, which opens its own pull request.' })
     emit({ kind: 'end', ok: true })
     return { result, detection, events, ...(preview ? { preview } : {}), ...(loop ? { loop } : {}), ...(todo ? { todo } : {}) }
   } catch (err) {


### PR DESCRIPTION
Closes #1225

## What you saw

Two different things, and neither came from the cloud session:

1. **The choice.** "Start the next backlog item? (1 open)" is not the agent's. It is the framework's own backlog gate (`todo-loop.ts`), raised on this machine. That is why it was the same choice all three times: it is the first open entry in the backlog, not anything the session said. It appeared before the session replied because it never depended on a reply.
2. **"ended early — the `{ blockers }` verdict was missing."** The production-grade checklist prompted, got back the driver's own `Handed off to Claude Code on the web. View the session: ...` note, found no fenced verdict in it, and failed closed. Correctly, for a reply the agent never wrote.

The real choice, the one in your second screenshot, was asked inside the cloud session. Nothing carries it here and nothing could carry an answer back: a cloud session exposes no read-back API, and the CLI cannot send a second message to one.

## The cause

The run loop was never told the run had left. `CloudSession.prompt()` answers every later prompt with the same hand-off note (#1213 stopped it spending a *session* per prompt, but the loop kept coming back), so review, improve, backlog and live chat all ran against a canned string.

## The fix

`Driver` gains `handsOff`, and `CloudDriver` sets it. For a hand-off driver the run is scope -> build and nothing after:

- **No checklist, no improve.** Bootstrap already skips its entire loop when given no `checklist` step, so this is a step omitted rather than a branch added. `passes: 0`, no blockers, `stoppedEarly: false`.
- **No backlog loop.** This machine has no standing to ask which item to start next when the work is somewhere it cannot see. Skipped even when `todoLoop: true` is explicit.
- **No stay-open composer.** This is the judgement call, flag it if you disagree: leaving it open is not harmless, since every message would be answered by "this run was already handed off". The run ends instead, with the link and the teleport command.
- The CLI's closing line and a new `Handed off:` log say why it stopped, so a finished hand-off does not read as a run that gave up one phase in.
- `CloudRunNotice` now says the session asks its questions and opens its PR over there, not here. That is the only honest answer to the title of this issue: the choices cannot be relayed, so the UI should stop implying they might be.

## Verification

- `the-framework` 1381 pass / 0 fail / 1 skipped, `framework-dashboard` 517 pass, typecheck clean.
- Proof-by-revert: with the guard forced to `false`, exactly the two new `run.test.ts` tests fail, and the messages one hangs its full 2s budget, which is the stay-open composer being real rather than assumed.

## Not in this PR

A `--run-on web` run with handoff armed still opens a PR for the branch it is sitting on, off a local worktree the cloud session never touched. Separate from the choices, so it is not folded in here.
