### PR TITLE
fix(website): drop the work-in-progress badge from Claude Code Web (#1218)

### DIFF
--- a/packages/the-framework.ai/pages/index/Features.tsx
+++ b/packages/the-framework.ai/pages/index/Features.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { cardStyle, SectionHead, sectionStyle, WipBadge } from './ui'
+import { cardStyle, SectionHead, sectionStyle } from './ui'
 
 const featureCardStyle = {
   ...cardStyle,
@@ -43,10 +43,7 @@ export function Features() {
         </div>
         <div style={{ ...featureCardStyle, gap: 12 }}>
           <h3 style={{ margin: 0, fontSize: 19, fontWeight: 600 }}>Claude Code Web</h3>
-          <FeatureText>
-            <WipBadge style={{ marginRight: 3, display: 'inline-block' }} /> Orchestrate agents via Claude Code Web for
-            0% local CPU usage.
-          </FeatureText>
+          <FeatureText>Orchestrate agents via Claude Code Web for 0% local CPU usage.</FeatureText>
         </div>
         <div style={{ ...featureCardStyle, gap: 12 }}>
           <h3 style={{ margin: 0, fontSize: 19, fontWeight: 600 }}>Swarm of local computers</h3>


### PR DESCRIPTION
Closes #1218

Removes the 🚧 Coming soon badge from the Claude Code Web feature card. The target shipped in #1207: it starts a real cloud session on the user's own account, at 0% local CPU, and the session opens its own pull request.

Card text is otherwise unchanged. `WipBadge` itself stays, still used by "Customize anything to fit your needs" in `YourFramework.tsx`; only the now-unused import in `Features.tsx` goes with it.

No changeset: `the-framework.ai` is a private package and ships nothing to npm. Typecheck clean.
