### PR TITLE
Remove the [Quick wins] preset

### DIFF
--- a/.changeset/remove-quick-wins-preset.md
+++ b/.changeset/remove-quick-wins-preset.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/the-framework": minor
+---
+
+Remove the [Quick wins] preset (#773). It harvested `.plan.md` companions and appended the quick ones to `TODO_AGENTS.md`, a step the triage pair ([Do quick-win work] / [Do consensual work], #891/#892) already covers by reading `tickets/*.md` directly — so the auto-PM rotation now triages straight from tickets rather than harvesting an intermediate plan first, and the launcher no longer offers the button.

--- a/packages/the-framework/prompts/presets/quick_wins.md
+++ b/packages/the-framework/prompts/presets/quick_wins.md
@@ -1,1 +1,0 @@
-Look at all tickets/**.plan.md and add all quick-wins to TODO_AGENTS.md

--- a/packages/the-framework/src/auto-pm.test.ts
+++ b/packages/the-framework/src/auto-pm.test.ts
@@ -179,12 +179,10 @@ test('startAutoPm survives a project whose backlog cannot be read (#685)', async
   assert.deepEqual(started, [])
 })
 
-test('AUTO_PM_JOBS harvests, then triages, then plans (#773/#891/#892)', () => {
-  // Cheapest-and-readiest first: harvest existing plans, triage the cheap tickets, then the
-  // significant ones, and leave planning last — it is the priciest turn and the one whose
-  // output every earlier job consumes.
+test('AUTO_PM_JOBS triages, then plans (#773/#891/#892)', () => {
+  // Cheapest-and-readiest first: triage the cheap tickets, then the significant ones, and leave
+  // planning last — it is the priciest turn and the one whose output every earlier job consumes.
   assert.deepEqual(AUTO_PM_JOBS.map(j => j.name), [
-    'quick-wins',
     'triage-quick',
     'triage-consensual',
     'spike-and-plan',

--- a/packages/the-framework/src/auto-pm.ts
+++ b/packages/the-framework/src/auto-pm.ts
@@ -5,8 +5,8 @@ import { presets } from './preset-catalog.js'
  * Auto PM (#685): spend leftover subscription quota on product management instead of
  * letting it expire. While the account is still under its quota boundary (#879) and nobody
  * is at the keyboard, the daemon runs the cycle by itself: it works the agent queue down entry by entry (#855),
- * and once that is empty it refills it — harvesting quick-wins, then spiking and planning
- * the tickets that have neither yet.
+ * and once that is empty it refills it — triaging tickets, then spiking and planning
+ * the ones that have neither yet.
  *
  * The whole feature is one policy question ("is now a good time to spend tokens on our
  * own roadmap?"), so that question lives here as a pure function and the daemon only
@@ -122,18 +122,16 @@ export function autoPmDecision(input: AutoPmInputs): AutoPmDecision {
 /**
  * One thing auto PM knows how to do while the machine is idle (#773).
  *
- * The jobs form a cycle, and the order matters: [Quick wins] turns existing plans into queued
- * work, [Spike & plan] turns tickets into plans. Harvesting first means a machine that already
- * has plans starts *doing* rather than planning more. Once a job queues something the sweep
- * switches to draining it (#855), and the rotation resumes where it left off once the queue is
- * empty again.
+ * The jobs form a cycle, and the order matters: triage turns tickets into queued work, [Spike &
+ * plan] turns the rest into plans. Once a job queues something the sweep switches to draining it
+ * (#855), and the rotation resumes where it left off once the queue is empty again.
  */
 export interface AutoPmJob {
   /** Stable id, used for the rotation and the log line. */
   name: string
   /** The prompt to run, verbatim. */
   prompt: string
-  /** What it is doing, as the log line says it ("harvesting quick-wins"). */
+  /** What it is doing, as the log line says it ("triaging quick-win tickets"). */
   describe: string
   /**
    * The user-facing name, for a surface that lists the routines (#1159). Read off the preset the
@@ -151,11 +149,9 @@ export interface AutoPmJob {
 }
 
 /**
- * The default cycle, ordered cheapest-and-readiest first: harvest the plans we have (#773), triage
- * the quick tickets (#891), then the significant-but-agreed ones (#892), and only then make more
- * plans (#685). A machine sitting on work it has already thought through should start *doing*
- * rather than planning, and planning is both the most expensive turn and the one whose output the
- * earlier jobs consume.
+ * The default cycle, ordered cheapest-and-readiest first: triage the quick tickets (#891), then
+ * the significant-but-agreed ones (#892), and only then make more plans (#685). Planning is the
+ * most expensive turn and the one whose output the earlier jobs consume, so it runs last.
  *
  * This rotation is what #891/#892 mean by "with a cron job regularly firing this preset". No
  * separate scheduler is involved and none is needed: the rotation already fires on every idle tick
@@ -172,12 +168,6 @@ export interface AutoPmJob {
  * idle tick tries the next job instead of retrying a job that is already running.
  */
 export const AUTO_PM_JOBS: readonly AutoPmJob[] = [
-  {
-    name: presets.quickWins.name,
-    prompt: presets.quickWins.render(),
-    describe: 'harvesting quick-wins from the plans',
-    label: presets.quickWins.label,
-  },
   {
     name: presets.triageQuick.name,
     prompt: presets.triageQuick.render(),

--- a/packages/the-framework/src/daemon-services.ts
+++ b/packages/the-framework/src/daemon-services.ts
@@ -125,7 +125,7 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
     return deps.startRun(prompt, { ...options, ...extra, unattended: true }, projectId)
   }
 
-  // Auto PM (#685/#773): while the queue is dry and there is quota to spare, harvest quick-wins and
+  // Auto PM (#685/#773): while the queue is dry and there is quota to spare, triage and
   // spike & plan tickets rather than let the day's allowance expire unused.
   const autoPm = startAutoPm({
     projects,

--- a/packages/the-framework/src/preset-catalog.test.ts
+++ b/packages/the-framework/src/preset-catalog.test.ts
@@ -21,7 +21,6 @@ const PARAMETERIZED = [
 const PARAMLESS = [
   presets.marketResearch,
   presets.importTickets,
-  presets.quickWins,
   presets.spikeAndPlan,
   presets.suggestNewTickets,
   presets.suggestNewFeatures,
@@ -39,7 +38,7 @@ test('every preset keeps its exact run-kind name', () => {
     Object.values(presets).map(p => p.name).sort(),
     [
       'drain-queue', 'import-tickets', 'maintainability', 'maintenance', 'market-research',
-      'quick-wins', 'readability', 'research', 'security-audit', 'spike-and-plan',
+      'readability', 'research', 'security-audit', 'spike-and-plan',
       'suggest-new-features', 'suggest-new-tickets', 'suggest-tickets-to-work-on',
       'triage-consensual', 'triage-quick', 'update-tickets', 'ux',
     ],

--- a/packages/the-framework/src/preset-catalog.ts
+++ b/packages/the-framework/src/preset-catalog.ts
@@ -5,7 +5,6 @@ import {
   PRESETS_MAINTAINABILITY,
   PRESETS_MAINTENANCE,
   PRESETS_MARKET_RESEARCH,
-  PRESETS_QUICK_WINS,
   PRESETS_READABILITY,
   PRESETS_RESEARCH,
   PRESETS_SECURITY_AUDIT,
@@ -99,14 +98,6 @@ export const presets = {
    */
   updateTickets: definePreset({ name: 'update-tickets', template: PRESETS_UPDATE_TICKETS, label: 'Update from GitHub', newSession: true, tooltip: 'Bring `tickets/` up to date with the issues and comments changed since the last import.' }),
 
-  /**
-   * [Quick wins] (#773): harvest the cheap work out of the plans we already have. Reads the
-   * `.plan.md` companions the #684 format defines and appends the quick ones to `TODO_AGENTS.md`.
-   * This is the half of auto PM that closes the loop: [Spike & plan] turns tickets into plans,
-   * this turns plans into queued work, and the backlog loop drains the queue.
-   */
-  quickWins: definePreset({ name: 'quick-wins', template: PRESETS_QUICK_WINS, label: 'Quick wins' }),
-
   /** [Spike & plan] (#685): turn tickets into costed plans. */
   spikeAndPlan: definePreset({ name: 'spike-and-plan', template: PRESETS_SPIKE_AND_PLAN, label: 'Spike & plan' }),
 
@@ -149,7 +140,7 @@ export const presets = {
   triageConsensual: definePreset({ name: 'triage-consensual', template: PRESETS_TRIAGE_CONSENSUAL, label: 'Do consensual work', tooltip: 'Add `tickets/*.md` to queue (TODO_AGENTS.md), only significant (no quick-wins) and consensual tickets' }),
 } as const satisfies Record<string, PresetDef>
 
-/** The presets by key, e.g. `quickWins`. */
+/** The presets by key, e.g. `spikeAndPlan`. */
 export type PresetKey = keyof typeof presets
 
 /**
@@ -186,7 +177,6 @@ export const LAUNCHER_PRESETS: readonly PresetDef[] = [
   presets.suggestNewFeatures,
   presets.suggestTicketsToWorkOn,
   presets.spikeAndPlan,
-  presets.quickWins,
   presets.marketResearch,
   presets.importTickets,
   presets.updateTickets,

--- a/packages/the-framework/src/todo-loop.test.ts
+++ b/packages/the-framework/src/todo-loop.test.ts
@@ -513,7 +513,7 @@ test('ticketForPrompt names a ticket for a hand-fired drain, and for nothing els
     // Every other prompt implements whatever it likes; naming the queue's next entry for it would
     // put a ticket in the in-progress lane on the strength of an unrelated run.
     assert.equal(await ticketForPrompt('Work on the queue please', cwd), undefined)
-    assert.equal(await ticketForPrompt(presets.quickWins.render(), cwd), undefined)
+    assert.equal(await ticketForPrompt(presets.spikeAndPlan.render(), cwd), undefined)
     assert.equal(await ticketForPrompt('', cwd), undefined)
 
     // A read that throws is a lane label, not a run: it must never take the start down with it.


### PR DESCRIPTION
## Summary
- Drop `quickWins` from the preset catalog (`preset-catalog.ts`): removed the definition, its import of `PRESETS_QUICK_WINS`, and its entry in `LAUNCHER_PRESETS`
- Remove its source prompt file (`prompts/presets/quick_wins.md`), so the generated `PRESETS_QUICK_WINS` constant no longer exists
- Drop it from the auto-PM rotation (`AUTO_PM_JOBS` in `auto-pm.ts`) and reword the doc comments/log line that described it; the rotation now starts at triage rather than harvesting plans first
- Update the `daemon-services.ts` comment describing the rotation accordingly
- Update tests referencing the preset (`preset-catalog.test.ts`, `auto-pm.test.ts`, `todo-loop.test.ts`)
- Add a changeset

The triage pair ([Do quick-win work] / [Do consensual work], #891/#892) already picks quick-win tickets straight out of `tickets/*.md`, so harvesting `.plan.md` companions into `TODO_AGENTS.md` first was a redundant intermediate step.

## Test plan
- [x] `npm test` in `packages/the-framework` — same 10 pre-existing failures as on `main` (unrelated to this change, verified via `git stash` comparison), all preset/auto-PM/quick-wins-related tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWTutYzjrX8ZpqHtPVXgJD)_