### PR TITLE
Fix CI: stale triage preset assertions + re-home teardown flake

### DIFF
--- a/packages/the-framework/src/daemon-workspace.test.ts
+++ b/packages/the-framework/src/daemon-workspace.test.ts
@@ -349,9 +349,13 @@ test('binding a topic run re-homes it into the bound project: a worktree there, 
   } finally {
     await runtime.suspendRuns().catch(() => {})
     await runtime.dispose()
-    await rm(home, { recursive: true, force: true })
-    await rm(config, { recursive: true, force: true })
-    await rm(target, { recursive: true, force: true })
+    // Retried: the continued run's daemon-side writes (meta, sessions, registry) can still be
+    // landing when this teardown starts, and a concurrent create inside a dir being removed fails
+    // the whole rm with ENOTEMPTY (#1165's teardown-race tail: the body passes, the cleanup flakes).
+    const retried = { recursive: true, force: true, maxRetries: 10, retryDelay: 100 } as const
+    await rm(home, retried)
+    await rm(config, retried)
+    await rm(target, retried)
   }
 })
 

--- a/packages/the-framework/src/preset-catalog.test.ts
+++ b/packages/the-framework/src/preset-catalog.test.ts
@@ -174,7 +174,7 @@ test('Suggest tickets to work on gates on a human, unlike the triage pair (#698)
 })
 
 test('the triage pair splits on cost and both append to the queue (#891/#892)', () => {
-  assert.match(presets.triageQuick.template, /Only pick tickets that are quick-wins and consensual/)
+  assert.match(presets.triageQuick.template, /Only pick tickets that are quick-wins \(quick to implement\) and consensual/)
   assert.match(presets.triageQuick.template, /Add tickets to TODO_AGENTS\.md/)
   assert.match(presets.triageConsensual.template, /Only pick tickets that are significant \(no quick-wins\) and consensual/)
   assert.match(presets.triageConsensual.template, /Add tickets to TODO_AGENTS\.md/)
@@ -182,11 +182,11 @@ test('the triage pair splits on cost and both append to the queue (#891/#892)', 
 
 test('each triage preset pins its own session name and aborts on a taken branch (#891/#892)', () => {
   // The collision guard is what makes these safe to fire on a schedule: a triage already in
-  // flight owns the branch, so the next firing must do nothing rather than triage twice.
+  // flight owns the branch, so the next firing must abort and say so rather than triage twice.
   for (const preset of [presets.triageQuick, presets.triageConsensual]) {
     const out = preset.render()
     assert.match(out, new RegExp(`Always set <SESSION_NAME> to ${preset.name}`))
-    assert.match(out, /If branch the-framework\/<SESSION_NAME> already exists, abort and do nothing/)
+    assert.match(out, /If branch the-framework\/<SESSION_NAME> already exists, abort and tell user that the branch already exists and that triage is already pending/)
   }
   // Distinct session names, or the two would collide with each other rather than with their own
   // in-flight run.


### PR DESCRIPTION
CI on `main` has been red since 847c041, for two independent reasons. This PR fixes both.

**1. Stale triage preset assertions (deterministic, red since the `wip` commit 4a38e4e)**

4a38e4e reworded the two triage preset prompts:
- `triage_quick.md`: "quick-wins" gained the parenthetical "(quick to implement)"
- both presets: the taken-branch guard changed from "abort and do nothing" to "abort and tell user that the branch already exists and that triage is already pending"

but two assertions in `packages/the-framework/src/preset-catalog.test.ts` still expected the old wording (e.g. the failed main run [30217752770](https://github.com/gemstack-land/the-framework/actions/runs/30217752770)). Commit 88d833c updates the two regexes (and the stale collision-guard comment) to match the prompts as they now are. Verified green in CI: run [30218198390](https://github.com/gemstack-land/the-framework/actions/runs/30218198390).

**2. The #1122 re-home test's teardown race (intermittent — #1165's tail)**

`binding a topic run re-homes it into the bound project` now passes its body (~400ms), but its `finally` teardown `rm(target, {recursive})` races the continued run's daemon-side writes into `<target>/.the-framework`: a concurrent create inside a directory being removed fails `fs.rm` with `ENOTEMPTY`. It hit main at 847c041 (run [30217699505](https://github.com/gemstack-land/the-framework/actions/runs/30217699505)) and this PR's first merge-ref run ([30218097685](https://github.com/gemstack-land/the-framework/actions/runs/30218097685)) — same error, different runs. Commit 56187d6 applies `fs.rm`'s built-in `maxRetries`/`retryDelay` (designed for exactly this error class) to the three teardown dirs.

Verified locally on top of `main` (3bcffa0): `pnpm install --frozen-lockfile && pnpm build && pnpm typecheck && pnpm test` — all 21 turbo tasks pass; the `daemon-workspace` suite passes 3/3 repeat runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J16FZuf2N3CSaPfdXCnZeP