### PR TITLE
Only the maintenance sweep describes itself in the routine list

### DIFF
--- a/.changeset/maintenance-detail-only.md
+++ b/.changeset/maintenance-detail-only.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/the-framework": patch
+---
+
+Only the maintenance sweep describes itself now, in the Overview's Routine work card and the daemon's log line alike, since "Maintenance" alone does not say what it does. The other routines' labels already read as what they do, so their rows lose the line that repeated the label in different words and their log lines say the label itself (`AutoPmJob.describe` is optional, carried only by the maintenance job).

--- a/packages/framework-dashboard/components/RoutineWork.test.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { AutoPmJob, AutoPmReport, Preferences, ProjectSummary } from '@gemstack/the-framework'
-import { AUTO_PM_ROUTINES, AUTO_PM_DRAIN_JOB } from '@gemstack/the-framework/client'
+import { AUTO_PM_ROUTINES, AUTO_PM_DRAIN_JOB, AUTO_PM_MAINTENANCE_JOB } from '@gemstack/the-framework/client'
 import { hoverTooltip } from '../test-utils.js'
 
 // Everything the card reads goes through a lib module, so the mocks stop short of telefunc: an
@@ -55,6 +55,18 @@ describe('RoutineWork (#1159)', () => {
     render(<RoutineWork onRunStarted={() => {}} />)
     await waitFor(() => expect(screen.getAllByText('Run now').length).toBe(AUTO_PM_ROUTINES.length))
     for (const job of AUTO_PM_ROUTINES) expect(screen.getByText(job.label ?? job.name)).toBeTruthy()
+  })
+
+  test('a routine that describes itself gets a line under its name; the rest are just their label', async () => {
+    render(<RoutineWork onRunStarted={() => {}} />)
+    await waitFor(() => expect(screen.getAllByText('Run now').length).toBe(AUTO_PM_ROUTINES.length))
+    // Today that is the maintenance sweep alone, whose label does not say what it does.
+    expect(screen.getByText(AUTO_PM_MAINTENANCE_JOB.describe!)).toBeTruthy()
+    // A row without one is a single line: nothing else stands in as a subtitle.
+    for (const job of AUTO_PM_ROUTINES) {
+      const title = screen.getByText(routineName(job))
+      expect(title.parentElement!.childElementCount).toBe(job.describe ? 2 : 1)
+    }
   })
 
   test('Run now starts the routine prompt verbatim and selects the run it started (#1191)', async () => {

--- a/packages/framework-dashboard/components/RoutineWork.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.tsx
@@ -146,7 +146,9 @@ export function RoutineWork({
                     />
                     <span className="min-w-0 flex-1">
                       <span className="block truncate text-sm font-medium">{job.label ?? job.name}</span>
-                      <span className="block truncate text-xs text-muted-foreground">{job.describe}</span>
+                      {job.describe && (
+                        <span className="block truncate text-xs text-muted-foreground">{job.describe}</span>
+                      )}
                     </span>
                   </label>
                   <Button

--- a/packages/the-framework/src/auto-pm.test.ts
+++ b/packages/the-framework/src/auto-pm.test.ts
@@ -546,10 +546,18 @@ test('AUTO_PM_ROUTINES is every job the sweep can fire, once each (#1159)', () =
 test('every routine carries its preset label and a rendered prompt, so a list of them is runnable (#1159)', () => {
   for (const job of AUTO_PM_ROUTINES) {
     assert.equal(job.label, presets[presetKey(job.name)].label, `${job.name} must be labelled by its preset`)
-    assert.ok(job.describe.length > 0, `${job.name} must say what it does`)
     assert.ok(job.prompt.trim().length > 0, `${job.name} must carry a prompt`)
     // The prompt travels to the browser and is started verbatim, so nothing may be left unrendered.
     assert.doesNotMatch(job.prompt, /\$\{\{/, `${job.name} must ship a rendered prompt`)
+  }
+})
+
+test('only the maintenance sweep describes itself; the rest are just their label', () => {
+  // "Maintenance" names the preset rather than the work, so its row and log line keep the
+  // sentence; the other routines' labels already say what they do.
+  assert.equal(AUTO_PM_MAINTENANCE_JOB.describe, 'sweeping the codebase for maintenance work')
+  for (const job of [AUTO_PM_DRAIN_JOB, ...AUTO_PM_JOBS]) {
+    assert.equal(job.describe, undefined, `${job.name} must not say its label twice`)
   }
 })
 

--- a/packages/the-framework/src/auto-pm.ts
+++ b/packages/the-framework/src/auto-pm.ts
@@ -130,12 +130,19 @@ export function autoPmDecision(input: AutoPmInputs): AutoPmDecision {
  * (#855), and the rotation resumes where it left off once the queue is empty again.
  */
 export interface AutoPmJob {
-  /** Stable id, used for the rotation and the log line. */
+  /** Stable id: the rotation and the opt-out list (#1209) key on it. */
   name: string
   /** The prompt to run, verbatim. */
   prompt: string
-  /** What it is doing, as the log line says it ("triaging quick-win tickets"). */
-  describe: string
+  /**
+   * A line saying what the job does, wherever its {@link label} does not already: under the label
+   * in the routines list, and as the log line's wording. Only the maintenance sweep carries one --
+   * "Maintenance" names its preset rather than the work -- while the other routines' labels read
+   * as what they do, so their rows stay one line and their log lines say the label itself rather
+   * than the same thing twice. Data on the job rather than a name matched in the dashboard, so a
+   * rename cannot quietly move the line around.
+   */
+  describe?: string
   /**
    * The user-facing name, for a surface that lists the routines (#1159). Read off the preset the
    * job fires rather than written again here, so a relabelled preset relabels its routine.
@@ -174,19 +181,16 @@ export const AUTO_PM_JOBS: readonly AutoPmJob[] = [
   {
     name: presets.triageQuick.name,
     prompt: presets.triageQuick.render(),
-    describe: 'triaging quick-win tickets',
     label: presets.triageQuick.label,
   },
   {
     name: presets.triageConsensual.name,
     prompt: presets.triageConsensual.render(),
-    describe: 'triaging consensual tickets',
     label: presets.triageConsensual.label,
   },
   {
     name: presets.spikeAndPlan.name,
     prompt: presets.spikeAndPlan.render(),
-    describe: 'spiking & planning tickets',
     label: presets.spikeAndPlan.label,
   },
 ]
@@ -199,7 +203,6 @@ export const AUTO_PM_JOBS: readonly AutoPmJob[] = [
 export const AUTO_PM_DRAIN_JOB: AutoPmJob = {
   name: presets.drainQueue.name,
   prompt: presets.drainQueue.render(),
-  describe: 'draining the first open queue entry',
   label: presets.drainQueue.label,
   drains: true,
 }
@@ -238,6 +241,9 @@ export const AUTO_PM_ROUTINES: readonly AutoPmJob[] = [
   ...AUTO_PM_JOBS,
   AUTO_PM_MAINTENANCE_JOB,
 ]
+
+/** The sentence a start is reported as: the log line and the outcome message say the same thing. */
+const doing = (job: AutoPmJob) => job.describe ?? job.label ?? job.name
 
 /**
  * What became of one attempt to land a run's queue (#852). The two flags are separate on purpose:
@@ -487,7 +493,7 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
         // Armed before the spawn, not after: starting is slow, and a tick that overlapped the
         // spawn would otherwise see no live run yet and start a second one.
         lastStart.set(project.id, now())
-        deps.log(`[framework] auto PM: ${job.describe} in ${project.path}`)
+        deps.log(`[framework] auto PM: ${doing(job)} in ${project.path}`)
         const runId = await deps.start(project, job).catch(() => undefined)
         if (runId) {
           // Advanced only on a start that took, so a refused job is retried rather than skipped.
@@ -502,7 +508,7 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
           else if (decision.mode === 'pm') nextJob.set(project.id, index + 1)
           // Its queue lives on the run's branch until a later tick promotes it.
           pending.set(project.id, [...(pending.get(project.id) ?? []), runId])
-          note(project, true, job.describe)
+          note(project, true, doing(job))
         } else {
           lastStart.delete(project.id)
           deps.log(`[framework] auto PM: could not start a run in ${project.path}`)


### PR DESCRIPTION
## Summary
- The "Routine work" card on the Overview subtitled every routine with its `describe` line, which mostly repeated the label in different words. Now only the maintenance sweep keeps its line — "sweeping the codebase for maintenance work" — since its label alone does not say what it does.
- `AutoPmJob.describe` is optional and removed from the other four jobs entirely (drain, triage quick, triage consensual, spike & plan). The card renders it when present; the daemon's log line and outcome message fall back to the label (`describe ?? label ?? name`), which for those routines already says the same thing.
- The decision is data on the job rather than a name match in the card, per the file's own `drains` rationale: a renamed routine cannot quietly gain or lose its line.
- Includes a changeset (patch).

## Test plan
- [x] New model test in `auto-pm.test.ts`: only the maintenance sweep carries a `describe`, pinned to the exact wording.
- [x] New card test in `RoutineWork.test.tsx`: a describing routine gets a second line, every other row renders exactly one. Full file: 19 passed.
- [x] `the-framework` suite: 1397 pass; failures are pre-existing on the base (triage-prompt assertions, see comment below), sandbox-only daemon-spawn tests, and one known `daemon-workspace` ENOTEMPTY flake — all identical with this diff removed.
- [x] `tsc --noEmit` clean on `framework-dashboard`; `turbo build` clean on `the-framework`.