### PR TITLE
feat(dashboard): Agents card lists only working sessions, beside the queues

### DIFF
--- a/.changeset/agents-beside-the-queues.md
+++ b/.changeset/agents-beside-the-queues.md
@@ -1,0 +1,7 @@
+---
+"@gemstack/the-framework": minor
+---
+
+Rework the Overview's Agents card around the sessions working right now.
+
+The Recent column is gone — finished sessions already live in the sidebar's session list, so the card kept only the live half — and with it the per-column "Current" eyebrow: "Agents currently working" now reads as a one-liner right next to the card's title. The card also moves up from its slot below Routine work to sit beside the Human Queue, on top of the AI Queue, so what needs you, who is on it, and what the AI takes up next share one row. `DashboardData.recentAgents`, which existed only to feed the removed column, is dropped from the dashboard payload.

--- a/packages/framework-dashboard/components/Agents.test.tsx
+++ b/packages/framework-dashboard/components/Agents.test.tsx
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import type { ActiveRun, RecentRun, RunMeta } from '@gemstack/the-framework'
+import type { ActiveRun } from '@gemstack/the-framework'
 import { Agents } from './Agents.js'
 
-// The Overview's Agents card (#1139), which replaced Working now. Everything it renders arrives as
-// props, so there is no telefunc in its import graph and no mock to set up.
+// The Overview's Agents card (#1139), which replaced Working now — since trimmed to the sessions
+// working right now, the finished ones being the sidebar session list's job. Everything it renders
+// arrives as props, so there is no telefunc in its import graph and no mock to set up.
 //
 // What these pin is the click: #1189 made an Overview row open the session it names instead of
 // dropping the reader on the project launcher, and the tests that held that line went with
@@ -23,53 +24,35 @@ const active = (runId: string, over: Partial<ActiveRun> = {}): ActiveRun => ({
   ...over,
 })
 
-const meta = (id: string): RunMeta => ({
-  version: 1,
-  status: 'done',
-  id,
-  startedAt: '2026-07-25T09:00:00.000Z',
-  updatedAt: '2026-07-25T09:30:00.000Z',
-  passes: 0,
-  intent: `did ${id}`,
-})
-
-const recent = (id: string): RecentRun => ({ projectId: 'p2', projectName: 'vike', run: meta(id) })
-
 describe('Agents (#1139)', () => {
-  test('splits sessions into Current and Recent', () => {
-    render(<Agents working={[active('r1')]} finished={[recent('r2')]} loading={false} onSelectRun={vi.fn()} />)
-    expect(screen.getByText('Current')).toBeTruthy()
-    expect(screen.getByText('Recent')).toBeTruthy()
+  test('lists the working sessions under the "currently working" description, with no Current/Recent split', () => {
+    render(<Agents working={[active('r1')]} loading={false} onSelectRun={vi.fn()} />)
+    expect(screen.getByText('Agents currently working')).toBeTruthy()
     expect(screen.getByText('working on r1')).toBeTruthy()
+    // The columns are gone: no "Current" eyebrow, and no "Recent" list — the sidebar's session
+    // list already carries the finished sessions.
+    expect(screen.queryByText('Current')).toBeNull()
+    expect(screen.queryByText('Recent')).toBeNull()
   })
 
   test('clicking a working agent opens that session', () => {
     const onSelectRun = vi.fn()
-    render(<Agents working={[active('r1')]} finished={[]} loading={false} onSelectRun={onSelectRun} />)
+    render(<Agents working={[active('r1')]} loading={false} onSelectRun={onSelectRun} />)
     fireEvent.click(screen.getByText('working on r1'))
     // Project *and* run: a project alone would land on the launcher, which is the #1189 regression.
     expect(onSelectRun).toHaveBeenCalledWith('p1', 'r1')
   })
 
-  test('clicking a finished session opens it too', () => {
-    const onSelectRun = vi.fn()
-    render(<Agents working={[]} finished={[recent('r2')]} loading={false} onSelectRun={onSelectRun} />)
-    fireEvent.click(screen.getByText('did r2'))
-    // A finished run's row is the only way back into its transcript from the Overview.
-    expect(onSelectRun).toHaveBeenCalledWith('p2', 'r2')
-  })
-
-  test('each column says so when it is empty, rather than the card vanishing', () => {
-    render(<Agents working={[]} finished={[]} loading={false} onSelectRun={vi.fn()} />)
+  test('says so when nothing is working, rather than the card vanishing', () => {
+    render(<Agents working={[]} loading={false} onSelectRun={vi.fn()} />)
     expect(screen.getByText('No agents working right now.')).toBeTruthy()
-    expect(screen.getByText('No sessions yet.')).toBeTruthy()
   })
 
   test('loading is not the same as empty', () => {
-    // The card polls, so "nothing yet" before the first read would read as "no agents ran".
-    render(<Agents working={[]} finished={[]} loading onSelectRun={vi.fn()} />)
+    // The card polls, so "nothing yet" before the first read would read as "no agents working".
+    render(<Agents working={[]} loading onSelectRun={vi.fn()} />)
     expect(screen.queryByText('No agents working right now.')).toBeNull()
-    expect(screen.getAllByText('Loading…').length).toBe(2)
+    expect(screen.getByText('Loading…')).toBeTruthy()
   })
 
   test('a working session with no intent still gets a label', () => {
@@ -78,7 +61,6 @@ describe('Agents (#1139)', () => {
     render(
       <Agents
         working={[active('r1', { intent: '   ', sessionName: 'oauth-work' })]}
-        finished={[]}
         loading={false}
         onSelectRun={vi.fn()}
       />,

--- a/packages/framework-dashboard/components/Agents.tsx
+++ b/packages/framework-dashboard/components/Agents.tsx
@@ -1,110 +1,77 @@
-import type { ActiveRun, RecentRun } from '@gemstack/the-framework'
+import type { ActiveRun } from '@gemstack/the-framework'
 import { Bot } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card.js'
 import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip.js'
-import { runLabel } from '../lib/run-label.js'
 import { formatAge, formatDateTime } from '../lib/format-date.js'
 
-// The Overview's Agents card (#1139): sessions working now (Current) and just finished (Recent),
-// side by side. Each row is the whole line, clickable straight into that session — its label is the
-// one-liner the sidebar shows (runLabel), and its age reads "22s ago" with the exact moment on
-// hover. This is what replaced the old "Working now" list.
+// The Overview's Agents card (#1139): the sessions working right now. Each row is the whole line,
+// clickable straight into that session — its label is the one-liner the sidebar shows, and its age
+// reads "22s ago" with the exact moment on hover. This is what replaced the old "Working now" list.
+// The Recent column the card launched with is gone: finished sessions already live in the sidebar's
+// session list, so a second copy here said nothing new.
 //
 // Its own file rather than inline in DashboardPage, like every other card on the Overview: opening
 // a session from here is the behaviour #1189 exists to protect, and DashboardPage has no test file
 // to pin it in.
 
-/** One row: a session, and what opening it does. */
-interface AgentRowData {
-  key: string
-  /** The session's one-liner, the same the sidebar shows. */
-  label: string
-  /** ISO: last activity for a working agent, finish time for a finished one. */
-  at: string | undefined
-  projectName: string
-  onOpen: () => void
-}
-
 export function Agents({
   working,
-  finished,
   loading,
   onSelectRun,
 }: {
   working: ActiveRun[]
-  finished: RecentRun[]
   loading: boolean
   onSelectRun: (projectId: string, runId: string) => void
 }) {
-  const current: AgentRowData[] = working.map(a => ({
-    key: `${a.projectId}:${a.runId}`,
-    label: activeLabel(a),
-    at: a.updatedAt,
-    projectName: a.projectName,
-    onOpen: () => onSelectRun(a.projectId, a.runId),
-  }))
-  const recent: AgentRowData[] = finished.map(f => ({
-    key: `${f.projectId}:${f.run.id}`,
-    label: runLabel(f.run),
-    at: f.run.updatedAt,
-    projectName: f.projectName,
-    onOpen: () => onSelectRun(f.projectId, f.run.id),
-  }))
   return (
     <Card>
       <CardHeader>
+        {/* The one-line description sits beside the title rather than under a "Current" eyebrow of
+            its own: with the Recent column gone there is nothing left for column headers to tell
+            apart. */}
         <CardTitle className="flex items-center gap-2 text-base">
-          <Bot className="h-4 w-4 text-muted-foreground" />
+          <Bot className="h-4 w-4 shrink-0 text-muted-foreground" />
           Agents
+          <span className="truncate text-xs font-normal text-muted-foreground">Agents currently working</span>
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="grid gap-x-10 gap-y-6 sm:grid-cols-2">
-          <AgentColumn heading="Current" description="Agents currently working" rows={current} loading={loading} empty="No agents working right now." />
-          <AgentColumn heading="Recent" description="Agents finished working" rows={recent} loading={loading} empty="No sessions yet." />
-        </div>
+        {loading ? (
+          <p className="py-2 text-sm text-muted-foreground">Loading…</p>
+        ) : working.length === 0 ? (
+          <p className="py-2 text-sm text-muted-foreground">No agents working right now.</p>
+        ) : (
+          <ul className="space-y-0.5">
+            {working.map(a => (
+              <AgentRow
+                key={`${a.projectId}:${a.runId}`}
+                label={activeLabel(a)}
+                at={a.updatedAt}
+                projectName={a.projectName}
+                onOpen={() => onSelectRun(a.projectId, a.runId)}
+              />
+            ))}
+          </ul>
+        )}
       </CardContent>
     </Card>
   )
 }
 
-function AgentColumn({
-  heading,
-  description,
-  rows,
-  loading,
-  empty,
+function AgentRow({
+  label,
+  at,
+  projectName,
+  onOpen,
 }: {
-  heading: string
-  description: string
-  rows: AgentRowData[]
-  loading: boolean
-  empty: string
+  /** The session's one-liner, the same the sidebar shows. */
+  label: string
+  /** ISO: the session's last activity. */
+  at: string | undefined
+  projectName: string
+  /** Open the session — project and run both, never just the launcher (#1189). */
+  onOpen: () => void
 }) {
-  return (
-    <div className="min-w-0">
-      {/* Eyebrow + one-line description on a single ruled row, so the column reads as a labelled
-          section rather than two stacked muted lines. */}
-      <div className="flex items-baseline gap-2 border-b border-border pb-1.5">
-        <h4 className="shrink-0 text-xs font-semibold uppercase tracking-wide text-foreground">{heading}</h4>
-        <p className="truncate text-xs text-muted-foreground">{description}</p>
-      </div>
-      {loading ? (
-        <p className="py-2 text-sm text-muted-foreground">Loading…</p>
-      ) : rows.length === 0 ? (
-        <p className="py-2 text-sm text-muted-foreground">{empty}</p>
-      ) : (
-        <ul className="mt-1.5 space-y-0.5">
-          {rows.map(r => (
-            <AgentRow key={r.key} label={r.label} at={r.at} projectName={r.projectName} onOpen={r.onOpen} />
-          ))}
-        </ul>
-      )}
-    </div>
-  )
-}
-
-function AgentRow({ label, at, projectName, onOpen }: Omit<AgentRowData, 'key'>) {
   return (
     <li>
       {/* No hint on the row itself: that a session row opens the session is the one thing this card

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -14,10 +14,10 @@ import { Agents } from './Agents.js'
 import { queueEntryLabel } from '../lib/queue-entry.js'
 import { ScrollArea } from './ui/scroll-area.js'
 
-// The Overview landing page (#1139): a focused at-a-glance board — usage first, then the two queues
-// (what needs a human, what the AI takes up next) side by side, the routine jobs, the agents working
-// now and just finished, and the hot tickets across every project. Each section is a projection of
-// the same .the-framework files over the `onDashboard` Telefunc read, polled so it stays live;
+// The Overview landing page (#1139): a focused at-a-glance board — usage first, then what needs a
+// human (Human Queue) beside the agents working now stacked on what the AI takes up next (AI
+// Queue), the routine jobs, and the hot tickets across every project. Each section is a projection
+// of the same .the-framework files over the `onDashboard` Telefunc read, polled so it stays live;
 // selecting a row jumps into its project or straight into a session. Shown by the shell when no
 // project is picked.
 //
@@ -51,17 +51,20 @@ export function DashboardPage({
         {/* Usage first (#1139): the one figure that governs everything the agent may do next. */}
         <Quota />
 
-        {/* The two queues side by side (#1139): what needs you, and what the AI takes up next. */}
+        {/* The two queues side by side (#1139), with the agents working now sitting to the Human
+            Queue's right on top of the AI Queue: what needs you, who is on it, and what the AI
+            takes up next. */}
         <div className="grid items-start gap-4 lg:grid-cols-2">
           <HumanQueue items={interventions} onSelectProject={onSelectProject} onSelectRun={onSelectRun} />
-          <AiQueue queue={data?.queue ?? []} loading={loading} />
+          <div className="space-y-4">
+            <Agents working={data?.active ?? []} loading={loading} onSelectRun={onSelectRun} />
+            <AiQueue queue={data?.queue ?? []} loading={loading} />
+          </div>
         </div>
 
         {/* Routine work sits below the AI Queue (#1139/#1159): the scheduled jobs and the button
             that fires one now. */}
         <RoutineWork onRunStarted={onRunStarted} />
-
-        <Agents working={data?.active ?? []} finished={data?.recentAgents ?? []} loading={loading} onSelectRun={onSelectRun} />
 
         <HotTickets onSelectProject={onSelectProject} onSelectRun={onSelectRun} />
       </div>

--- a/packages/the-framework/src/dashboard/dashboard.test.ts
+++ b/packages/the-framework/src/dashboard/dashboard.test.ts
@@ -44,17 +44,6 @@ test('buildDashboard rolls up totals, run-status, and per-project counts', async
   assert.equal(a.openTodos, 2)
   assert.equal(a.running, true)
   assert.equal(data.projects.find(p => p.projectId === 'b')!.running, false)
-
-  // Finished sessions feed the Agents view's "Recent" column, newest-finished first (#1139); the
-  // live running run is not one of them.
-  assert.deepEqual(
-    data.recentAgents.map(r => ({ p: r.projectName, id: r.run.id })),
-    [
-      { p: 'a', id: '2026-07-14T09:00:00Z' },
-      { p: 'a', id: '2026-07-13T09:00:00Z' },
-      { p: 'b', id: '2026-07-12T09:00:00Z' },
-    ],
-  )
 })
 
 test('buildDashboard buckets run activity across a 14-day window, oldest-first', async () => {

--- a/packages/the-framework/src/dashboard/dashboard.ts
+++ b/packages/the-framework/src/dashboard/dashboard.ts
@@ -2,7 +2,7 @@ import { listRuns, type RunMeta, type RunStatus } from '../store/index.js'
 import type { ProjectSummary } from './projects.js'
 import { collectQueue, type ProjectQueue } from './queue.js'
 import { hasTickets } from './tickets.js'
-import { buildOverview, type ActiveRun, type RecentProject, type RecentRun, type OverviewDeps } from './overview.js'
+import { buildOverview, type ActiveRun, type RecentProject, type OverviewDeps } from './overview.js'
 
 // The Overview dashboard page (#471): the cross-project rollup that used to live cramped in
 // the first sidebar, promoted to a real at-a-glance page. It reuses buildOverview for the
@@ -49,11 +49,6 @@ export interface DashboardData {
   activity: ActivityDay[]
   /** Runs going right now, most-recently-updated first (from {@link buildOverview}). */
   active: ActiveRun[]
-  /**
-   * Finished sessions across every project, most-recently-finished first (capped), for the Agents
-   * view's "Recent" column (#1139). The "Current" column reads {@link active}.
-   */
-  recentAgents: RecentRun[]
   /** The most recently active projects (capped). */
   recent: RecentProject[]
   /** Every registered project with its run/TODO rollup, most-recently-active first. */
@@ -64,9 +59,6 @@ export interface DashboardData {
 
 /** How many days of run activity the chart covers. */
 const ACTIVITY_DAYS = 14
-
-/** How many finished sessions the Agents view's "Recent" column pools across every project (#1139). */
-const RECENT_AGENTS_LIMIT = 20
 
 /** Injectable readers/clock so {@link buildDashboard} is unit-testable off disk. */
 export interface DashboardDeps extends OverviewDeps {
@@ -115,9 +107,6 @@ export async function buildDashboard(projects: ProjectSummary[], deps: Dashboard
 
   const runsByStatus: Record<RunStatus, number> = { running: 0, done: 0, stopped: 0, failed: 0 }
   const projectStats: ProjectStat[] = []
-  // Finished sessions across every project, for the Agents view's "Recent" column (#1139). Read
-  // off the same archived-runs pass that counts them, so it costs no extra disk.
-  const recentAgents: RecentRun[] = []
   let totalRuns = 0
   for (const project of projects) {
     const runs = await listRunsFor(project.path)
@@ -126,9 +115,6 @@ export async function buildDashboard(projects: ProjectSummary[], deps: Dashboard
       runsByStatus[run.status] += 1
       const key = localDateKey(new Date(run.startedAt))
       if (buckets.has(key)) buckets.set(key, buckets.get(key)! + 1)
-      // Archived runs are finished by definition; the guard is belt-and-braces against a
-      // just-self-healed row (#716) still reading as running.
-      if (run.status !== 'running') recentAgents.push({ projectId: project.id, projectName: project.name, run })
     }
     projectStats.push({
       projectId: project.id,
@@ -142,8 +128,6 @@ export async function buildDashboard(projects: ProjectSummary[], deps: Dashboard
     })
   }
   projectStats.sort((a, b) => (b.lastActivityAt ?? '').localeCompare(a.lastActivityAt ?? ''))
-  // Newest-finished first: a finished run's `updatedAt` is its last event, i.e. when it ended.
-  recentAgents.sort((a, b) => (b.run.updatedAt ?? '').localeCompare(a.run.updatedAt ?? ''))
 
   return {
     totals: {
@@ -155,7 +139,6 @@ export async function buildDashboard(projects: ProjectSummary[], deps: Dashboard
     runsByStatus,
     activity: dayKeys.map(date => ({ date, count: buckets.get(date) ?? 0 })),
     active: overview.active,
-    recentAgents: recentAgents.slice(0, RECENT_AGENTS_LIMIT),
     recent: overview.recent,
     projects: projectStats,
     queue,


### PR DESCRIPTION
Rework the Overview's Agents section per the layout feedback:

- **Recent column removed.** Finished sessions already live in the sidebar's session list, so the "Recent — Agents finished working" half of the card said nothing new; the card now keeps only the live sessions.
- **"Current" eyebrow removed.** With a single list there is nothing left for per-column headers to tell apart — "Agents currently working" now reads as a one-liner right next to the card's `🤖 Agents` title.
- **Card moved up beside the queues.** The Agents card leaves its old slot below Routine work and now sits to the Human Queue's right, stacked on top of the AI Queue, so what needs you, who is on it, and what the AI takes up next share one row.
- **`DashboardData.recentAgents` dropped.** It existed only to feed the removed column (the sidebar's recents come from the separate `onRecentRuns` read), so `buildDashboard` no longer computes or ships it.

Tests: `Agents.test.tsx` updated for the single-list card (the #1189 open-the-session click stays pinned), the `recentAgents` assertion removed from `dashboard.test.ts`. Both packages' `test` and `typecheck` pass; a changeset is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtUvHQk2VydRo6znrdJm2R

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtUvHQk2VydRo6znrdJm2R)_