### PR TITLE
1. Look at all tickets and choose tickets to work on next

### DIFF
--- a/.changeset/routine-concurrent-agents.md
+++ b/.changeset/routine-concurrent-agents.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': minor
+---
+
+The routine can now keep several agents going at once (#1204). A "Concurrent agents" setting on the Routine work card (default 2, up to 10) drives how many runs the sweep keeps live per project, and a sweep tops a project up in one tick instead of one run per interval — so a standing queue fans out across parallel sessions, which is what makes ten Claude Code web sessions at once a single click. Concurrent drains are each pinned to their own queue entry so they never race for the first one, and landing a finished run's queue now merges its changes onto a checkout that moved in the meantime instead of overwriting it — the wholesale copy used to un-check entries a concurrent run had just retired and send the sweep off to redo them.

--- a/.the-framework/conversations/2026-07-26T20-24-32-577Z.md
+++ b/.the-framework/conversations/2026-07-26T20-24-32-577Z.md
@@ -1,0 +1,17 @@
+# Conversation 2026-07-26T20-24-32-577Z
+
+## 2026-07-26T20:24:33.387Z · user · cli
+
+1. Look at all tickets and choose tickets to work on next
+   - Only pick tickets that are quick-wins and consensual (zero open questions, zero variability, e.g. a single fairly obvious plan)
+2. Add tickets to TODO_AGENTS.md
+
+Always set <SESSION_NAME> to triage-quick
+- If branch the-framework/<SESSION_NAME> already exists, abort and do nothing
+
+## 2026-07-26T20:25:29.345Z · agent · cli
+
+Handed off to Claude Code on the web.
+
+View the session: https://claude.ai/code/session_01Q5kpUpxeA3sPyiLrLZC2Gy?from=cli&m=0
+Continue it here: claude --teleport session_01Q5kpUpxeA3sPyiLrLZC2Gy

--- a/packages/framework-dashboard/components/Quota.tsx
+++ b/packages/framework-dashboard/components/Quota.tsx
@@ -285,8 +285,9 @@ export function Quota() {
               <span className="font-medium text-foreground">Spend what's left on the roadmap</span>
             </label>
             <p className="text-xs text-muted-foreground">
-              When nothing is running, work the queue down and refill it rather than let the week's
-              allowance expire. Only while the account is still under the line above.
+              Work the queue down and refill it rather than let the week's allowance expire, up to
+              the Routine work card's concurrent-agent setting. Only while the account is still
+              under the line above.
             </p>
             {autoPm ? <AutoPmStatus report={autoPm} /> : null}
           </div>

--- a/packages/framework-dashboard/components/RoutineWork.test.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { AutoPmJob, AutoPmReport, Preferences, ProjectSummary } from '@gemstack/the-framework'
-import { AUTO_PM_ROUTINES, AUTO_PM_DRAIN_JOB } from '@gemstack/the-framework/client'
+import { AUTO_PM_ROUTINES, AUTO_PM_DRAIN_JOB, DEFAULT_AUTO_PM_CONCURRENCY, MAX_AUTO_PM_CONCURRENCY } from '@gemstack/the-framework/client'
 import { hoverTooltip } from '../test-utils.js'
 
 // Everything the card reads goes through a lib module, so the mocks stop short of telefunc: an
@@ -201,6 +201,37 @@ describe('RoutineWork (#1159)', () => {
     render(<RoutineWork onRunStarted={() => {}} />)
     fireEvent.click(await screen.findByText('Trigger routine now'))
     await waitFor(() => expect(screen.getByRole('status').textContent).toMatch(/not running the sweep/i))
+  })
+
+  test('the concurrent-agents field shows the default and writes the preference (#1204)', async () => {
+    render(<RoutineWork onRunStarted={() => {}} />)
+    const field = (await screen.findByLabelText('Concurrent agents')) as HTMLInputElement
+    // Unset shows the daemon's own default, so the number on screen is the number the sweep uses.
+    expect(field.value).toBe(String(DEFAULT_AUTO_PM_CONCURRENCY))
+    fireEvent.change(field, { target: { value: '10' } })
+    expect(updatePreferences).toHaveBeenCalledWith({ autoPmConcurrency: 10 })
+    // The fine print restates the cap, so the schedule's width is legible without the tooltip.
+    expect(screen.getByText(/Keeps up to 2 agents going at once/)).toBeTruthy()
+  })
+
+  test('the concurrent-agents field clamps what the control could not say (#1204)', async () => {
+    render(<RoutineWork onRunStarted={() => {}} />)
+    const field = await screen.findByLabelText('Concurrent agents')
+    fireEvent.change(field, { target: { value: '999' } })
+    expect(updatePreferences).toHaveBeenCalledWith({ autoPmConcurrency: MAX_AUTO_PM_CONCURRENCY })
+    fireEvent.change(field, { target: { value: '0' } })
+    expect(updatePreferences).toHaveBeenCalledWith({ autoPmConcurrency: 1 })
+    updatePreferences.mockClear()
+    fireEvent.change(field, { target: { value: '' } })
+    expect(updatePreferences).not.toHaveBeenCalled()
+  })
+
+  test('a saved concurrency shows, and the fine print follows it (#1204)', async () => {
+    prefs = { autoPmConcurrency: 1 }
+    render(<RoutineWork onRunStarted={() => {}} />)
+    const field = (await screen.findByLabelText('Concurrent agents')) as HTMLInputElement
+    expect(field.value).toBe('1')
+    expect(screen.getByText(/Keeps up to 1 agent going at once/)).toBeTruthy()
   })
 
   test('one project needs no picker', async () => {

--- a/packages/framework-dashboard/components/RoutineWork.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.tsx
@@ -1,6 +1,11 @@
 import { useState } from 'react'
 import type { AutoPmJob, ProjectSummary } from '@gemstack/the-framework'
-import { AUTO_PM_ROUTINES, runOptionsFromPreferences } from '@gemstack/the-framework/client'
+import {
+  AUTO_PM_ROUTINES,
+  DEFAULT_AUTO_PM_CONCURRENCY,
+  MAX_AUTO_PM_CONCURRENCY,
+  runOptionsFromPreferences,
+} from '@gemstack/the-framework/client'
 import { CalendarClock, Play } from 'lucide-react'
 import { onProjects } from '../server/projects.telefunc.js'
 import { sendAutoPmSweep } from '../server/quota.telefunc.js'
@@ -60,6 +65,14 @@ export function RoutineWork({
   const autoRun = preferences.autoPm ?? false
   // Absent = nothing opted out, which is also what the store saves an empty list back as.
   const optedOut = preferences.autoPmOptOut ?? []
+  // How many agents the sweep may keep going at once per project (#1204). The same default the
+  // daemon applies, so the number on screen is the number the sweep uses.
+  const concurrency = preferences.autoPmConcurrency ?? DEFAULT_AUTO_PM_CONCURRENCY
+  const setConcurrency = (raw: string) => {
+    const value = Number(raw)
+    if (raw.trim() === '' || !Number.isFinite(value)) return
+    updatePreferences({ autoPmConcurrency: Math.round(Math.min(Math.max(value, 1), MAX_AUTO_PM_CONCURRENCY)) })
+  }
   // Written as the whole list rather than a delta: `updatePreferences` patches by key, and this
   // key's value *is* the set.
   const setRoutine = (job: AutoPmJob, on: boolean) =>
@@ -205,8 +218,33 @@ export function RoutineWork({
                   </TooltipContent>
                 </Tooltip>
               </div>
+              {/* The concurrent-agent setting (#1204): how wide the schedule may fan out. Beside
+                  the auto-run switch because it parameterizes the same sweep — raising it is how
+                  a standing queue becomes parallel sessions instead of one at a time. */}
+              <div className="mt-2 flex items-center justify-between gap-2">
+                <Tooltip>
+                  <TooltipTrigger render={<label htmlFor="routine-concurrency" className="text-sm text-muted-foreground" />}>
+                    Concurrent agents
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    How many agents the routine may keep going at once per project.
+                  </TooltipContent>
+                </Tooltip>
+                <input
+                  id="routine-concurrency"
+                  type="number"
+                  inputMode="numeric"
+                  min={1}
+                  max={MAX_AUTO_PM_CONCURRENCY}
+                  step={1}
+                  value={concurrency}
+                  onChange={e => setConcurrency(e.target.value)}
+                  className="w-16 rounded-md border border-border bg-transparent px-2 py-1 text-sm"
+                />
+              </div>
               <p className="mt-1 text-xs text-muted-foreground">
-                Only while nothing else is running and the week&apos;s allowance is not already spent.
+                Keeps up to {concurrency} agent{concurrency === 1 ? '' : 's'} going at once, and only while the
+                week&apos;s allowance is not already spent.
               </p>
               {/* Auto-run on with every routine unticked is a schedule with nothing on it, and
                   from the countdown alone it looks like work is coming (#1209). */}

--- a/packages/the-framework/src/auto-pm.test.ts
+++ b/packages/the-framework/src/auto-pm.test.ts
@@ -4,6 +4,7 @@ import {
   autoPmDecision,
   quotaHeadroom,
   startAutoPm,
+  pinnedDrainJob,
   AUTO_PM_JOBS,
   AUTO_PM_DRAIN_JOB,
   AUTO_PM_MAINTENANCE_JOB,
@@ -41,11 +42,28 @@ test('autoPmDecision does nothing while the preference is off (#685)', () => {
   assert.equal(decision.start, false)
 })
 
-test('autoPmDecision leaves a busy project alone (#685)', () => {
-  // A live run is already spending the quota; a second one started unasked would race it.
-  const decision = autoPmDecision({ ...IDLE, activeRuns: 1 })
+test('autoPmDecision leaves a full single-agent project alone (#685/#1204)', () => {
+  // The pre-#1204 shape, spelled out: with one agent allowed, one live run is the cap.
+  const decision = autoPmDecision({ ...IDLE, activeRuns: 1, concurrency: 1 })
   assert.equal(decision.start, false)
   assert.match(decision.start === false ? decision.reason : '', /already going/)
+})
+
+test('autoPmDecision tops a project up to the concurrent-agent cap, default two (#1204)', () => {
+  // One live run no longer stands the sweep down: the default allows a second agent. At the cap
+  // the refusal names the number, so a moved setting reads as a setting rather than a bug (#960).
+  assert.deepEqual(autoPmDecision({ ...IDLE, activeRuns: 1 }), { start: true, mode: 'pm' })
+  const atCap = autoPmDecision({ ...IDLE, activeRuns: 2 })
+  assert.equal(atCap.start, false)
+  assert.match(atCap.start === false ? atCap.reason : '', /already going, and the routine keeps at most 2 at once/)
+})
+
+test('autoPmDecision honors a configured concurrency, floored at one (#1204)', () => {
+  assert.deepEqual(autoPmDecision({ ...IDLE, activeRuns: 9, concurrency: 10 }), { start: true, mode: 'pm' })
+  assert.equal(autoPmDecision({ ...IDLE, activeRuns: 10, concurrency: 10 }).start, false)
+  // Zero agents is not something the number can say — that is what `enabled: false` is for.
+  assert.deepEqual(autoPmDecision({ ...IDLE, activeRuns: 0, concurrency: 0 }), { start: true, mode: 'pm' })
+  assert.equal(autoPmDecision({ ...IDLE, activeRuns: 1, concurrency: 0 }).start, false)
 })
 
 test('autoPmDecision drains the queue before filling it again (#855)', () => {
@@ -107,7 +125,12 @@ const JOBS: readonly AutoPmJob[] = [
   { name: 'second', prompt: 'do the second thing', describe: 'doing the second thing' },
 ]
 
-/** A loop wired to one idle project, with every reading overridable per test. */
+/**
+ * A loop wired to one idle project, with every reading overridable per test.
+ *
+ * Pinned to one concurrent agent, the pre-#1204 shape, so the rotation and cooldown mechanics
+ * stay legible one start at a time; the batching tests below override `concurrency` explicitly.
+ */
 function harness(overrides: Partial<AutoPmDeps> = {}) {
   const project: AutoPmProject = { id: 'p1', path: '/repo' }
   const started: string[] = []
@@ -117,8 +140,9 @@ function harness(overrides: Partial<AutoPmDeps> = {}) {
     projects: async () => [project],
     jobs: JOBS,
     enabled: async () => true,
-    backlogEmpty: async () => true,
+    queue: async () => [],
     activeRuns: () => 0,
+    concurrency: async () => 1,
     quota: async () => status(1),
     start: async (p, job) => {
       started.push(p.id)
@@ -173,7 +197,7 @@ test('startAutoPm re-arms when the start was refused (#685)', async () => {
 
 test('startAutoPm survives a project whose backlog cannot be read (#685)', async () => {
   // An unreadable queue is not an empty one: it must not trigger a run, nor throw the sweep.
-  const { loop, started } = harness({ backlogEmpty: async () => Promise.reject(new Error('nope')) })
+  const { loop, started } = harness({ queue: async () => Promise.reject(new Error('nope')) })
   await loop.tick()
   loop.stop()
   assert.deepEqual(started, [])
@@ -289,7 +313,7 @@ test('startAutoPm drains a standing queue, then goes back to filling it (#855)',
   const ran: string[] = []
   const { loop } = harness({
     cooldownMs: 0,
-    backlogEmpty: async () => open === 0,
+    queue: async () => Array.from({ length: open }, (_, i) => `entry ${i + 1}`),
     // A drain run works one entry off; a PM run puts one there.
     start: async (_project, job) => {
       ran.push(job.name)
@@ -311,7 +335,7 @@ test('draining does not advance the PM rotation (#855)', async () => {
   const ran: string[] = []
   const { loop } = harness({
     cooldownMs: 0,
-    backlogEmpty: async () => open === 0,
+    queue: async () => Array.from({ length: open }, (_, i) => `entry ${i + 1}`),
     start: async (_project, job) => {
       ran.push(job.name)
       open += job.name === AUTO_PM_DRAIN_JOB.name ? -1 : 1
@@ -329,7 +353,7 @@ test('an unreadable queue starts nothing at all (#855)', async () => {
   const ran: string[] = []
   const { loop } = harness({
     cooldownMs: 0,
-    backlogEmpty: async () => {
+    queue: async () => {
       throw new Error('no such file')
     },
     start: async (_project, job) => {
@@ -400,7 +424,7 @@ test('a sweep is stamped only when the run actually started (#882)', async () =>
 
 test('a queue with work in it is drained rather than swept (#882)', async () => {
   // A repo with entries waiting has plenty to do; sweeping would only pile more on.
-  const { loop, ran } = harness({ cooldownMs: 0, backlogEmpty: async () => false, maintenanceDue: async () => true })
+  const { loop, ran } = harness({ cooldownMs: 0, queue: async () => ['an entry'], maintenanceDue: async () => true })
   await loop.tick()
   loop.stop()
   assert.deepEqual(ran, [AUTO_PM_DRAIN_JOB.name])
@@ -419,9 +443,9 @@ test('a sweep stopped mid-flight starts nothing (#983)', async () => {
   const h = harness({
     projects: async () => both,
     // The daemon shutting down while the sweep sits between its readings and the spawn.
-    backlogEmpty: async () => {
+    queue: async () => {
       loop.stop()
-      return true
+      return []
     },
   })
   loop = h.loop
@@ -553,7 +577,7 @@ test('an unticked drain routine stands the sweep down, it does not fall through 
   // is the opposite of what the checkbox asked for.
   const { loop, ran, logs } = harness({
     cooldownMs: 0,
-    backlogEmpty: async () => false,
+    queue: async () => ['an entry'],
     optedOut: async () => [AUTO_PM_DRAIN_JOB.name],
   })
   await loop.tick()
@@ -603,4 +627,144 @@ test('an unreadable opt-out list means none, never all (#1209)', async () => {
   await loop.tick()
   loop.stop()
   assert.deepEqual(ran, ['first'])
+})
+
+test('pinnedDrainJob names its entry and keeps the job recognizable (#1204)', () => {
+  const pinned = pinnedDrainJob(AUTO_PM_DRAIN_JOB, 'Fix the header [login](tickets/2026-07-26_login.md)')
+  assert.equal(pinned.name, AUTO_PM_DRAIN_JOB.name)
+  assert.equal(pinned.drains, true)
+  assert.equal(pinned.entry, 'Fix the header [login](tickets/2026-07-26_login.md)')
+  // The prompt is what keeps a batch of drains off each other's entry, so it must name this one
+  // and must not fall back to "the FIRST open entry".
+  assert.match(pinned.prompt, /Fix the header/)
+  assert.doesNotMatch(pinned.prompt, /FIRST open entry/)
+  // The assignment is a snapshot: an entry a human retired in between must stop the run, not
+  // send it hunting for a substitute.
+  assert.match(pinned.prompt, /stop and do nothing/)
+  assert.match(pinned.describe, /Fix the header/)
+})
+
+test('the sweep tops a project up with a fleet of pinned drains in one tick (#1204)', async () => {
+  // The demo case the setting exists for: a standing queue and the setting raised. One tick fans
+  // out one agent per entry up to the cap — not one agent per interval — each pinned to its own
+  // entry so none of them race for the first.
+  const startedJobs: AutoPmJob[] = []
+  const { loop } = harness({
+    concurrency: async () => 3,
+    queue: async () => ['entry a', 'entry b', 'entry c', 'entry d'],
+    start: async (_project, job) => {
+      startedJobs.push(job)
+      return `run-${startedJobs.length}`
+    },
+  })
+  await loop.tick()
+  loop.stop()
+  assert.deepEqual(startedJobs.map(job => job.entry), ['entry a', 'entry b', 'entry c'])
+  assert.ok(startedJobs.every(job => job.name === AUTO_PM_DRAIN_JOB.name))
+  assert.match(startedJobs[0]?.prompt ?? '', /entry a/)
+  assert.doesNotMatch(startedJobs[0]?.prompt ?? '', /entry b/)
+  const [outcome] = loop.report().outcomes
+  assert.equal(outcome?.started, true)
+  assert.match(outcome?.message ?? '', /started 3 agents/)
+})
+
+test('an entry assigned to a drain still in flight is not handed out again (#1204)', async () => {
+  // Concurrent drains fork the same checkout, so the checkout still shows an entry a live run is
+  // on. The sweep must offer the next entry instead — and with every entry taken, say so rather
+  // than double up.
+  const startedJobs: AutoPmJob[] = []
+  const { loop } = harness({
+    cooldownMs: 0,
+    concurrency: async () => 2,
+    queue: async () => ['entry a', 'entry b'],
+    promote: async () => ({ settled: false, promoted: false }), // nothing ever finishes
+    start: async (_project, job) => {
+      startedJobs.push(job)
+      return `run-${startedJobs.length}`
+    },
+  })
+  await loop.tick() // both entries go out
+  await loop.tick() // everything is assigned: nothing new to hand out
+  loop.stop()
+  assert.deepEqual(startedJobs.map(job => job.entry), ['entry a', 'entry b'])
+  assert.equal(loop.report().outcomes[0]?.message, 'every open queue entry is already being worked on')
+})
+
+test('the cap counts the runs already live (#1204)', async () => {
+  // One agent is going (a human's, or an earlier tick's): a cap of two leaves headroom for
+  // exactly one more, however long the queue is.
+  const { loop, started } = harness({
+    concurrency: async () => 2,
+    activeRuns: () => 1,
+    queue: async () => ['entry a', 'entry b', 'entry c'],
+  })
+  await loop.tick()
+  loop.stop()
+  assert.equal(started.length, 1)
+})
+
+test('a project at its cap stands down, and the reason names the cap (#1204)', async () => {
+  const { loop, started } = harness({ concurrency: async () => 2, activeRuns: () => 2 })
+  await loop.tick()
+  loop.stop()
+  assert.deepEqual(started, [])
+  assert.match(loop.report().outcomes[0]?.message ?? '', /keeps at most 2 at once/)
+})
+
+test('spare headroom fans the rotation out across distinct jobs, never doubling one (#1204)', async () => {
+  // A rotation of two with room for three: each distinct job goes out once. A doubled rotation
+  // job would spawn a run only for its own branch guard to no-op it.
+  const { loop, ran } = harness({ cooldownMs: 0, concurrency: async () => 3 })
+  await loop.tick()
+  loop.stop()
+  assert.deepEqual(ran, ['first', 'second'])
+})
+
+test('a batch advances the rotation only past starts that took (#1204)', async () => {
+  // The second start of a two-job batch is refused: the batch stops there, and that job is the
+  // next tick's first rather than skipped.
+  let attempts = 0
+  const ran: string[] = []
+  const { loop } = harness({
+    cooldownMs: 0,
+    concurrency: async () => 2,
+    start: async (_project, job) => {
+      attempts++
+      if (attempts === 2) return undefined
+      ran.push(job.name)
+      return `run-${attempts}`
+    },
+  })
+  await loop.tick() // 'first' lands, 'second' is refused
+  await loop.tick() // resumes at 'second'
+  loop.stop()
+  assert.deepEqual(ran, ['first', 'second', 'first'])
+})
+
+test('a due sweep and the rotation share a tick when there is headroom (#882/#1204)', async () => {
+  const stamped: string[] = []
+  const { loop, ran } = harness({
+    cooldownMs: 0,
+    concurrency: async () => 2,
+    maintenanceDue: async () => stamped.length === 0,
+    recordMaintenance: async project => {
+      stamped.push(project.id)
+    },
+  })
+  await loop.tick()
+  loop.stop()
+  assert.deepEqual(ran, [AUTO_PM_MAINTENANCE_JOB.name, 'first'])
+  assert.deepEqual(stamped, ['p1'])
+})
+
+test('an unreadable concurrency falls back to the default, not to zero (#1204)', async () => {
+  // The setting going unreadable must not stall the schedule; the default keeps it moving.
+  const { loop, started } = harness({
+    concurrency: async () => {
+      throw new Error('no registry')
+    },
+  })
+  await loop.tick()
+  loop.stop()
+  assert.equal(started.length > 0, true)
 })

--- a/packages/the-framework/src/auto-pm.ts
+++ b/packages/the-framework/src/auto-pm.ts
@@ -1,5 +1,6 @@
 import type { QuotaBoundaryStatus } from './quota-boundary.js'
 import { presets } from './preset-catalog.js'
+import { DEFAULT_AUTO_PM_CONCURRENCY } from './preference-defaults.js'
 
 /**
  * Auto PM (#685): spend leftover subscription quota on product management instead of
@@ -34,8 +35,15 @@ export interface AutoPmInputs {
    * since #855 both answers now *start* something and only "we could not tell" does not.
    */
   backlogEmpty: boolean | undefined
-  /** Live runs on this project. Any run at all means the user's quota is already being spent. */
+  /** Live runs on this project, measured against {@link AutoPmInputs.concurrency}. */
   activeRuns: number
+  /**
+   * How many agents the routine may keep running on this project at once (#1204);
+   * {@link DEFAULT_AUTO_PM_CONCURRENCY} when unset. The sweep tops the project up to this many
+   * concurrent runs instead of standing down the moment anything at all is going. Floored at
+   * one: zero concurrent agents is spelled `enabled: false`.
+   */
+  concurrency?: number
   /** Where the account stands against its quota boundary, or `undefined` when it could not be read. */
   quota: QuotaBoundaryStatus | undefined
   /** Milliseconds since this project was last auto-started, or `undefined` if it never was. */
@@ -101,8 +109,14 @@ export function quotaHeadroom(quota: QuotaBoundaryStatus | undefined): QuotaDeci
  */
 export function autoPmDecision(input: AutoPmInputs): AutoPmDecision {
   if (!input.enabled) return { start: false, reason: 'auto PM is off' }
-  if (input.activeRuns > 0) {
-    return { start: false, reason: `${input.activeRuns} run${input.activeRuns === 1 ? ' is' : 's are'} already going` }
+  const concurrency = Math.max(1, Math.floor(input.concurrency ?? DEFAULT_AUTO_PM_CONCURRENCY))
+  if (input.activeRuns >= concurrency) {
+    // Name the cap it stopped at, for the same reason the quota refusal names its line (#960):
+    // with the setting raised or lowered, "already going" alone reads as a bug, not a setting.
+    return {
+      start: false,
+      reason: `${input.activeRuns} run${input.activeRuns === 1 ? ' is' : 's are'} already going, and the routine keeps at most ${concurrency} at once`,
+    }
   }
   const cooldownMs = input.cooldownMs ?? DEFAULT_AUTO_PM_COOLDOWN_MS
   if (input.sinceLastStartMs !== undefined && input.sinceLastStartMs < cooldownMs) {
@@ -148,6 +162,45 @@ export interface AutoPmJob {
    * call site, so the job says what it does and a rename cannot quietly unhook it.
    */
   drains?: boolean
+  /**
+   * The queue entry a {@link AutoPmJob.drains} job is pinned to (#1204). Set only on the
+   * per-start variants {@link pinnedDrainJob} builds — the catalog's own jobs carry none, since
+   * which entry is next is only known at the moment the sweep starts one.
+   */
+  entry?: string
+}
+
+/**
+ * A drain job pinned to one named queue entry (#1204).
+ *
+ * With a single agent, the stock prompt ("work on the FIRST open entry") is exact. With several
+ * agents going at once it is a collision: every drain forks the same checkout, so every one of
+ * them would pick the same first entry and implement it as many times over. Naming the entry in
+ * the prompt is what lets a batch of drains work disjoint entries.
+ *
+ * The pinned prompt also tells the agent to stop when the entry is already checked off or gone:
+ * the assignment is a snapshot, and a human may retire the entry between the sweep's read and the
+ * run's own.
+ */
+export function pinnedDrainJob(job: AutoPmJob, entry: string): AutoPmJob {
+  return {
+    ...job,
+    entry,
+    prompt: [
+      'Open TODO_AGENTS.md and work on this one open entry only, then check it off:',
+      '',
+      `- ${entry}`,
+      '',
+      'Do not start any other entry. If that entry is already checked off or no longer there, stop and do nothing.',
+    ].join('\n'),
+    describe: `draining the queue entry "${entryPreview(entry)}"`,
+  }
+}
+
+/** An entry as a log line can carry it: one line, bounded. */
+function entryPreview(entry: string): string {
+  const flat = entry.replace(/\s+/g, ' ').trim()
+  return flat.length > 80 ? `${flat.slice(0, 80)}…` : flat
 }
 
 /**
@@ -278,10 +331,22 @@ export interface AutoPmDeps {
    * a preference that cannot be read must not silently switch the whole rotation off.
    */
   optedOut?(): Promise<readonly string[]>
-  /** Whether a project's agent queue has run dry. */
-  backlogEmpty(project: AutoPmProject): Promise<boolean>
+  /**
+   * The open entries of a project's agent queue, in file order. Empty = the queue has run dry; a
+   * rejection = it could not be read, which fails closed exactly as the old boolean did (#855).
+   * The entries themselves (not just emptiness) because a batch of drains is pinned one entry
+   * each (#1204), and the assignment has to come from the same read the decision was made on.
+   */
+  queue(project: AutoPmProject): Promise<readonly string[]>
   /** How many runs are live on a project. */
   activeRuns(project: AutoPmProject): number
+  /**
+   * How many agents the routine may keep running per project (#1204). Re-read per tick like
+   * {@link AutoPmDeps.enabled}, so the setting takes effect without a restart. Unset or
+   * unreadable falls back to {@link DEFAULT_AUTO_PM_CONCURRENCY} rather than to one: the
+   * setting's absence has never meant "less".
+   */
+  concurrency?(): Promise<number | undefined>
   /** Where the account stands against its boundary, or `undefined` when there is no reading. */
   quota(): Promise<QuotaBoundaryStatus | undefined>
   /** The jobs to rotate through, in cycle order. Used only while the queue is empty. */
@@ -368,7 +433,9 @@ export interface AutoPmLoop {
 
 /**
  * Start the auto-PM sweep (#685): every {@link DEFAULT_AUTO_PM_INTERVAL_MS}, ask
- * {@link autoPmDecision} for each project and start a run for the ones that say yes.
+ * {@link autoPmDecision} for each project and start runs for the ones that say yes — topping
+ * each up to its concurrent-agent allowance (#1204) rather than one at a time, so a raised
+ * setting shows up as a fleet in one tick instead of one run per interval.
  *
  * Ticks never overlap — a sweep reads a live-run map that its own `start` calls mutate,
  * so a second sweep running over the first would decide against a stale picture.
@@ -384,8 +451,10 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
   // start-up sweep below lands.
   let lastSweep: { enabled: boolean; sweptAt: number; outcomes: AutoPmOutcome[] } | undefined
   const lastStart = new Map<string, number>()
-  // Runs this loop started whose queue has not reached the checkout yet, oldest first.
-  const pending = new Map<string, string[]>()
+  // Runs this loop started whose queue has not reached the checkout yet, oldest first. A drain
+  // remembers the entry it was pinned to (#1204), so a later tick does not hand the same entry
+  // to a second agent while the first is still on it.
+  const pending = new Map<string, { runId: string; entry?: string }[]>()
   // Where each project is in the job cycle. Per project, not global: two repos idle at once
   // should each work through the rotation, not take alternate halves of it.
   const nextJob = new Map<string, number>()
@@ -415,6 +484,13 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
       // the cycle stays a cycle: with two of four off, the remaining two alternate instead of
       // every other tick landing on a job that cannot run.
       const rotation = deps.jobs.filter(job => !optedOut.has(job.name))
+      // How many agents each project may have going at once (#1204). Read beside the opt-outs
+      // and for the same reason: it is the same preference file, re-read so the setting takes
+      // effect mid-schedule. Floored at one — zero agents is the master switch's job.
+      const concurrency = Math.max(
+        1,
+        Math.floor((await deps.concurrency?.().catch(() => undefined)) ?? DEFAULT_AUTO_PM_CONCURRENCY),
+      )
       // One reading for the whole sweep: it is an account-wide meter, and re-reading it per
       // project would spend a rate-limited call to learn the same number.
       const quota = await deps.quota().catch(() => undefined)
@@ -423,12 +499,12 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
         // its entries are still on that run's branch, and the checkout cannot see them.
         const outstanding = pending.get(project.id) ?? []
         if (outstanding.length) {
-          const stillPending: string[] = []
+          const stillPending: { runId: string; entry?: string }[] = []
           let landed = 0
-          for (const runId of outstanding) {
-            const outcome = await deps.promote(project, runId).catch(() => ({ settled: false, promoted: false }))
+          for (const run of outstanding) {
+            const outcome = await deps.promote(project, run.runId).catch(() => ({ settled: false, promoted: false }))
             if (outcome.promoted) landed++
-            if (!outcome.settled) stillPending.push(runId)
+            if (!outcome.settled) stillPending.push(run)
           }
           if (stillPending.length) pending.set(project.id, stillPending)
           else pending.delete(project.id)
@@ -440,11 +516,14 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
             continue
           }
         }
+        const entries = await deps.queue(project).catch(() => undefined)
+        const activeRuns = deps.activeRuns(project)
         const since = lastStart.get(project.id)
         const decision = autoPmDecision({
           enabled: true,
-          backlogEmpty: await deps.backlogEmpty(project).catch(() => undefined),
-          activeRuns: deps.activeRuns(project),
+          backlogEmpty: entries === undefined ? undefined : entries.length === 0,
+          activeRuns,
+          concurrency,
           quota,
           ...(since !== undefined ? { sinceLastStartMs: now() - since } : {}),
           ...(deps.cooldownMs !== undefined ? { cooldownMs: deps.cooldownMs } : {}),
@@ -453,14 +532,6 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
           // Logged, so a wedged sweep is distinguishable from a healthy idle one (#855).
           deps.log(`[framework] auto PM: standing down for ${project.path} — ${decision.reason}`)
           note(project, false, decision.reason)
-          continue
-        }
-        // Switching the draining routine off (#1209) stands the sweep down rather than falling
-        // through to the rotation: the queue has work waiting, and answering "do not work it
-        // automatically" by inventing more work is the opposite of what was asked.
-        const drainJob = wanted(deps.drainJob ?? AUTO_PM_DRAIN_JOB)
-        if (decision.mode === 'drain' && !drainJob) {
-          note(project, false, 'the queue has work waiting and its routine is switched off')
           continue
         }
         const index = nextJob.get(project.id) ?? 0
@@ -472,47 +543,106 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
         // more importantly, leaves its calendar untouched: it must come due normally once it is
         // switched back on, rather than having been silently ticked past while it was off.
         const maintenanceJob = wanted(deps.maintenanceJob ?? AUTO_PM_MAINTENANCE_JOB)
-        const sweep =
+        const sweepJob =
           decision.mode === 'pm' &&
           maintenanceJob !== undefined &&
           (await deps.maintenanceDue?.(project).catch(() => false)) === true
-        const job = sweep ? maintenanceJob : decision.mode === 'drain' ? drainJob : rotation[index % rotation.length]
-        if (!job) {
-          // Told apart on purpose: a rotation emptied by the checkboxes is a setting the user can
-          // see and undo, and reads nothing like a daemon wired without jobs at all.
-          note(
-            project,
-            false,
-            deps.jobs.length ? 'every routine that makes new work is switched off' : 'there is no job to run',
+            ? maintenanceJob
+            : undefined
+        // The batch: what to start this tick, at most the project's headroom of them (#1204).
+        // Built up front so the spawn loop below is the same for both modes.
+        const headroom = concurrency - activeRuns
+        const batch: { job: AutoPmJob; kind: 'drain' | 'pm' | 'sweep' }[] = []
+        if (decision.mode === 'drain') {
+          // Switching the draining routine off (#1209) stands the sweep down rather than falling
+          // through to the rotation: the queue has work waiting, and answering "do not work it
+          // automatically" by inventing more work is the opposite of what was asked.
+          const drainJob = wanted(deps.drainJob ?? AUTO_PM_DRAIN_JOB)
+          if (!drainJob) {
+            note(project, false, 'the queue has work waiting and its routine is switched off')
+            continue
+          }
+          // One agent per open entry, each pinned to its own (#1204): concurrent drains all fork
+          // the same checkout, so unpinned they would all pick the same first entry. An entry
+          // already assigned to a run still in flight is not offered again.
+          const assigned = new Set(
+            (pending.get(project.id) ?? []).flatMap(run => (run.entry !== undefined ? [run.entry] : [])),
           )
-          continue
+          const open = (entries ?? []).filter(entry => !assigned.has(entry))
+          batch.push(...open.slice(0, headroom).map(entry => ({ job: pinnedDrainJob(drainJob, entry), kind: 'drain' as const })))
+          if (!batch.length) {
+            note(project, false, 'every open queue entry is already being worked on')
+            continue
+          }
+        } else {
+          if (sweepJob) batch.push({ job: sweepJob, kind: 'sweep' })
+          // The rotation fills what headroom is left, each job at most once per tick: a rotation
+          // job pins its own branch, so a doubled one would spawn a run only for it to no-op.
+          for (let ahead = 0; batch.length < headroom && ahead < rotation.length; ahead++) {
+            batch.push({ job: rotation[(index + ahead) % rotation.length]!, kind: 'pm' })
+          }
+          if (!batch.length) {
+            // Told apart on purpose: a rotation emptied by the checkboxes is a setting the user
+            // can see and undo, and reads nothing like a daemon wired without jobs at all.
+            note(
+              project,
+              false,
+              deps.jobs.length ? 'every routine that makes new work is switched off' : 'there is no job to run',
+            )
+            continue
+          }
         }
         // Re-checked here because everything above is awaited: a run spawned past a `stop()` is
         // missing from the live-run map the daemon has by then cleared, so nothing suspends or
         // terminates it (#983). Break, not continue: stopping is a verdict on the whole sweep.
         if (stopped) break
-        // Armed before the spawn, not after: starting is slow, and a tick that overlapped the
-        // spawn would otherwise see no live run yet and start a second one.
+        // Armed before the first spawn and once for the whole batch: starting is slow, and a
+        // tick that overlapped the spawns would otherwise see too few live runs and top up over
+        // the cap.
         lastStart.set(project.id, now())
-        deps.log(`[framework] auto PM: ${job.describe} in ${project.path}`)
-        const runId = await deps.start(project, job).catch(() => undefined)
-        if (runId) {
-          // Advanced only on a start that took, so a refused job is retried rather than skipped.
-          // Draining does not advance it: it is not part of the cycle, and a queue worked off
-          // over several ticks must not skip the rotation forward once per entry.
+        const started: AutoPmJob[] = []
+        let rotationStarted = 0
+        for (const item of batch) {
+          // Re-checked per spawn, for the #983 reason above: a stop mid-batch must not spawn the rest.
+          if (stopped) break
+          deps.log(`[framework] auto PM: ${item.job.describe} in ${project.path}`)
+          const runId = await deps.start(project, item.job).catch(() => undefined)
+          if (!runId) {
+            // The batch ends at the first refusal: whatever refused this start is not going to
+            // take the next one a moment later, and a refused rotation job must be retried next
+            // tick rather than advanced past.
+            deps.log(`[framework] auto PM: could not start a run in ${project.path}`)
+            break
+          }
+          started.push(item.job)
+          // The rotation advances only past starts that took, so a refused job is retried rather
+          // than skipped. Draining does not advance it: it is not part of the cycle, and a queue
+          // worked off over several ticks must not skip the rotation forward once per entry.
           //
           // A sweep does not advance it either, and stamps its own schedule instead: it is paced
           // by the calendar, not the cycle, so borrowing this tick must not cost the rotation its
           // turn. Stamped after the start took for the same reason the rotation is -- a sweep the
           // daemon refused should be retried next tick, not postponed a whole interval.
-          if (sweep) await deps.recordMaintenance?.(project).catch(() => {})
-          else if (decision.mode === 'pm') nextJob.set(project.id, index + 1)
+          if (item.kind === 'sweep') await deps.recordMaintenance?.(project).catch(() => {})
+          else if (item.kind === 'pm') {
+            rotationStarted++
+            nextJob.set(project.id, index + rotationStarted)
+          }
           // Its queue lives on the run's branch until a later tick promotes it.
-          pending.set(project.id, [...(pending.get(project.id) ?? []), runId])
-          note(project, true, job.describe)
-        } else {
+          pending.set(project.id, [
+            ...(pending.get(project.id) ?? []),
+            { runId, ...(item.job.entry !== undefined ? { entry: item.job.entry } : {}) },
+          ])
+        }
+        if (started.length) {
+          // One line per project however many agents went out, because that is the shape the
+          // report has always had; a single start keeps its old wording exactly.
+          const described = started.map(job => job.describe).join('; ')
+          note(project, true, started.length === 1 ? described : `started ${started.length} agents: ${described}`)
+        } else if (!stopped) {
+          // Nothing took, so the cooldown is re-armed: a refused batch spent nothing, and
+          // holding it would strand the project.
           lastStart.delete(project.id)
-          deps.log(`[framework] auto PM: could not start a run in ${project.path}`)
           note(project, false, 'the daemon could not start a run')
         }
       }

--- a/packages/the-framework/src/client.ts
+++ b/packages/the-framework/src/client.ts
@@ -47,7 +47,7 @@ export { AUTO_PM_ROUTINES, AUTO_PM_JOBS, AUTO_PM_DRAIN_JOB, AUTO_PM_MAINTENANCE_
 // The identity + diff both notifier paths run, and the preference defaults both sides read (#627).
 // Pure, so the dashboard shares them rather than keeping copies that drift silently.
 export { interventionKey, pickNewInterventions, activityKey, pickNewActivity } from './dashboard/keys.js'
-export { PROJECT_PREFERENCE_KEYS, NOTIFICATION_DEFAULTS, MAX_SPEND_OFFSET, notificationEnabled, discordNotificationEnabled, type ProjectPreferences } from './preference-defaults.js'
+export { PROJECT_PREFERENCE_KEYS, NOTIFICATION_DEFAULTS, MAX_SPEND_OFFSET, DEFAULT_AUTO_PM_CONCURRENCY, MAX_AUTO_PM_CONCURRENCY, notificationEnabled, discordNotificationEnabled, type ProjectPreferences } from './preference-defaults.js'
 // The preferences -> run options mapping (#858), shared with the daemon so an unattended run
 // starts with the same settings a launcher-started one would. Pure field logic, no Node imports.
 export { runOptionsFromPreferences, autopilotEnabled, handoffFromPreferences, preferencesFromFileConfig } from './run-options.js'

--- a/packages/the-framework/src/daemon-services.ts
+++ b/packages/the-framework/src/daemon-services.ts
@@ -12,7 +12,7 @@ import { buildActivity, activityKey, postActivityDiscord } from './dashboard/act
 import { startAutoPm, AUTO_PM_JOBS, type AutoPmReport } from './auto-pm.js'
 import { maintenanceDue, readMaintenanceState, mergeMaintenanceState } from './maintenance.js'
 import { promoteQueue } from './queue-promote.js'
-import { findTodoBacklog, nextQueuedTicket } from './todo-loop.js'
+import { findTodoBacklog, nextQueuedTicket, ticketFromQueueEntry } from './todo-loop.js'
 import { startConversationCommitter } from './conversation-commit.js'
 import { startMergedWorktreeSweep } from './merged-worktrees.js'
 import { readConversation } from './conversations.js'
@@ -134,8 +134,13 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
     // Which routines the user unticked (#1209). Global rather than per project, like the master
     // switch it sits under: the rotation is one schedule for the machine, not one per repo.
     optedOut: async () => (await prefs()).autoPmOptOut ?? [],
-    backlogEmpty: async project => (await findTodoBacklog(project.path)) === undefined,
+    // The queue's open entries rather than a bare emptiness bit: a batch of concurrent drains is
+    // pinned one entry each (#1204), so the sweep needs the entries the decision was made on.
+    queue: async project => (await findTodoBacklog(project.path))?.entries ?? [],
     activeRuns: project => deps.activeRunCount(project.id),
+    // How many agents the sweep may keep going per project (#1204). Global like the opt-outs;
+    // the sweep applies the default when it is unset.
+    concurrency: async () => (await prefs()).autoPmConcurrency,
     // The quota boundary is the gate (#879): auto PM has no budget notion of its own.
     quota: async () => (await deps.quota.read()).boundary,
     // The periodic codebase sweep (#882). The schedule is a file in the project checkout rather
@@ -144,11 +149,17 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
     maintenanceDue: async project => maintenanceDue(await readMaintenanceState(project.path), Date.now()),
     recordMaintenance: async project => mergeMaintenanceState(project.path, { sweptAt: new Date().toISOString() }),
     start: async (project, job) => {
-      // A draining run works the queue's first open entry, and since #1164 that entry links back to
-      // the ticket it was queued from — so this is the one moment the framework knows what a run is
-      // about to implement, and can say so on the run's meta (#1117). Every other job puts work on
-      // the queue rather than taking it off, so there is nothing to name.
-      const ticket = job.drains ? await nextQueuedTicket(project.path).catch(() => undefined) : undefined
+      // A draining run works one open queue entry, and since #1164 that entry links back to the
+      // ticket it was queued from — so this is the one moment the framework knows what a run is
+      // about to implement, and can say so on the run's meta (#1117). A sweep-built drain names
+      // its own pinned entry (#1204); the first-open-entry read is the fallback for a drain job
+      // wired without one. Every other job puts work on the queue rather than taking it off, so
+      // there is nothing to name.
+      const ticket = job.drains
+        ? job.entry !== undefined
+          ? ticketFromQueueEntry(job.entry)
+          : await nextQueuedTicket(project.path).catch(() => undefined)
+        : undefined
       const result = await startUnattended(project.id, job.prompt, ticket ? { ticket } : {})
       return result.ok ? result.runId : undefined
     },

--- a/packages/the-framework/src/preference-defaults.ts
+++ b/packages/the-framework/src/preference-defaults.ts
@@ -98,3 +98,19 @@ export function discordNotificationEnabled(
  * be one number both can import.
  */
 export const MAX_SPEND_OFFSET = 50
+
+/**
+ * How many agents the routine sweep keeps going at once when `autoPmConcurrency` is unset (#1204).
+ *
+ * Two, not one: the point of the setting is that the sweep may overlap work, and a default of one
+ * would make the feature invisible until someone finds the control. Two is the smallest number
+ * that does that while staying conservative about quota.
+ */
+export const DEFAULT_AUTO_PM_CONCURRENCY = 2
+
+/**
+ * The most agents the routine may be asked to keep going at once (#1204). Like
+ * {@link MAX_SPEND_OFFSET}, the control that writes the value is in the browser and the sanitizer
+ * that clamps it is in the daemon, so the bound has to be one number both can import.
+ */
+export const MAX_AUTO_PM_CONCURRENCY = 10

--- a/packages/the-framework/src/queue-merge.test.ts
+++ b/packages/the-framework/src/queue-merge.test.ts
@@ -1,0 +1,92 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { mergeQueueDocuments, parseTodoEntryLine } from './queue-merge.js'
+
+// The shape #1204 exists for: two agents fork the same checkout, each retires its own entry, and
+// the later promotion must not revert the earlier one.
+
+test('parseTodoEntryLine reads the queue grammar one line at a time', () => {
+  assert.deepEqual(parseTodoEntryLine('- [ ] fix login'), { text: 'fix login', checked: false })
+  assert.deepEqual(parseTodoEntryLine('  * [x] shipped'), { text: 'shipped', checked: true })
+  assert.deepEqual(parseTodoEntryLine('1. [X] also shipped'), { text: 'also shipped', checked: true })
+  assert.deepEqual(parseTodoEntryLine('- a bare item'), { text: 'a bare item', checked: undefined })
+  assert.equal(parseTodoEntryLine('## Priority 7'), undefined)
+  assert.equal(parseTodoEntryLine('plain prose'), undefined)
+  assert.equal(parseTodoEntryLine('- [ ]'), undefined)
+  assert.equal(parseTodoEntryLine(''), undefined)
+})
+
+const BASE = ['## Priority 7', '', '- [ ] entry a', '- [ ] entry b', '- [ ] entry c', ''].join('\n')
+
+test('concurrent check-offs compose instead of the later one reverting the earlier (#1204)', () => {
+  // Ours: a concurrent run already landed "entry a". Theirs: this run retired "entry b" off the
+  // same fork point. The wholesale copy would have re-opened "entry a"; the merge keeps both.
+  const ours = BASE.replace('- [ ] entry a', '- [x] entry a')
+  const theirs = BASE.replace('- [ ] entry b', '- [x] entry b')
+  const merged = mergeQueueDocuments(BASE, ours, theirs)
+  assert.match(merged, /- \[x\] entry a/)
+  assert.match(merged, /- \[x\] entry b/)
+  assert.match(merged, /- \[ \] entry c/)
+})
+
+test('entries queued on both sides survive each other (#1204)', () => {
+  // Two PM runs each appended their own pick. Promoting the second used to drop the first's.
+  const ours = BASE.replace('- [ ] entry c', '- [ ] entry c\n- [ ] ours queued this')
+  const theirs = BASE.replace('- [ ] entry c', '- [ ] entry c\n- [ ] theirs queued this')
+  const merged = mergeQueueDocuments(BASE, ours, theirs)
+  assert.match(merged, /- \[ \] ours queued this/)
+  assert.match(merged, /- \[ \] theirs queued this/)
+})
+
+test('an added entry keeps the priority section its run placed it under (#1204/#1164)', () => {
+  // Placement is not cosmetic: the drain works the file in order, so an entry demoted to the end
+  // would be worked last however its run ranked it.
+  const ours = BASE.replace('- [ ] entry a', '- [x] entry a')
+  const theirs = ['## Priority 9', '', '- [ ] urgent pick', '', BASE].join('\n')
+  const merged = mergeQueueDocuments(BASE, ours, theirs)
+  const urgent = merged.indexOf('urgent pick')
+  assert.ok(urgent !== -1, 'the added entry must survive')
+  assert.ok(urgent < merged.indexOf('entry b'), 'a Priority 9 pick outranks the Priority 7 section')
+  assert.match(merged, /- \[x\] entry a/, "ours' own check-off stays")
+})
+
+test('an entry the run removed outright goes, a reworded one is swapped (#1204)', () => {
+  const ours = BASE
+  const theirs = BASE.replace('- [ ] entry b\n', '').replace('- [ ] entry c', '- [ ] entry c, but reworded')
+  const merged = mergeQueueDocuments(BASE, ours, theirs)
+  assert.doesNotMatch(merged, /- \[ \] entry b/)
+  assert.doesNotMatch(merged, /entry c\n/)
+  assert.match(merged, /- \[ \] entry c, but reworded/)
+})
+
+test('a bare item is checked off in place, keeping its marker (#1204)', () => {
+  const base = '- entry a\n* entry b\n'
+  const theirs = '- [x] entry a\n* entry b\n'
+  const ours = '- entry a\n* entry b\n- [ ] added by ours\n'
+  const merged = mergeQueueDocuments(base, ours, theirs)
+  assert.match(merged, /- \[x\] entry a/)
+  assert.match(merged, /\* entry b/)
+  assert.match(merged, /- \[ \] added by ours/)
+})
+
+test('a run that changed nothing merges to ours exactly (#1204)', () => {
+  const ours = BASE.replace('- [ ] entry a', '- [x] entry a')
+  assert.equal(mergeQueueDocuments(BASE, ours, BASE), ours)
+})
+
+test("everything the run never saw — ours' prose, sections, checked history — stays verbatim (#1204)", () => {
+  const ours = ['# The queue', '', 'Some prose a human wrote.', '', BASE, '- [x] long done', ''].join('\n')
+  const theirs = BASE.replace('- [ ] entry a', '- [x] entry a')
+  const merged = mergeQueueDocuments(BASE, ours, theirs)
+  assert.match(merged, /Some prose a human wrote\./)
+  assert.match(merged, /- \[x\] long done/)
+  assert.match(merged, /- \[x\] entry a/)
+})
+
+test('an entry added already checked is kept, at the end, still checked (#1204)', () => {
+  // A run may queue a follow-up and complete it in the same session; losing the record would
+  // invite the sweep to queue it again.
+  const theirs = `${BASE}- [x] did a follow-up too\n`
+  const merged = mergeQueueDocuments(BASE, BASE, theirs)
+  assert.match(merged, /- \[x\] did a follow-up too/)
+})

--- a/packages/the-framework/src/queue-merge.ts
+++ b/packages/the-framework/src/queue-merge.ts
@@ -1,0 +1,186 @@
+/**
+ * The agent queue's line-level grammar, and the three-way merge built on it (#1204).
+ *
+ * A leaf module (no imports at all) on purpose: `todo-loop.ts` reads the grammar to drive the
+ * backlog, `queue-promote.ts` reads it to land a finished run's queue, and the two must agree on
+ * what an entry is. One parser here is what stops the drain loop and the promotion from ever
+ * reading the same line differently.
+ *
+ * The merge exists because runs may overlap (#1204): each runs in its own worktree and rewrites
+ * the whole queue file on its own branch, so with two agents going the second promotion used to
+ * overwrite the first — un-checking the entry the first had just retired, dropping the entries it
+ * had queued, and sending the sweep off to do the same work again. Entries are independent lines
+ * with a natural identity (their text), so the file merges the way a union-merged changelog does.
+ */
+
+/** One markdown list line, as the queue reads it. */
+export interface TodoEntryLine {
+  /** The entry text, without the marker or checkbox. */
+  text: string
+  /** `true` = checked off, `false` = an open checkbox, `undefined` = a bare item (open too). */
+  checked: boolean | undefined
+}
+
+/**
+ * Read one line as a queue entry: a markdown list item (`-`, `*`, or `1.`), where a task checkbox
+ * carries its state and a bare item counts as open. Headings, prose, and blank lines are not
+ * entries. The one grammar `parseTodoEntries` and the promotion merge both read.
+ */
+export function parseTodoEntryLine(line: string): TodoEntryLine | undefined {
+  const item = /^\s*(?:[-*]|\d+\.)\s+(.*)$/.exec(line)
+  if (!item) return undefined
+  const text = item[1]!.trim()
+  if (!text) return undefined
+  const task = /^\[([ xX])\]\s*(.*)$/.exec(text)
+  if (!task) return { text, checked: undefined }
+  const rest = task[2]!.trim()
+  if (!rest) return undefined
+  return { text: rest, checked: task[1] !== ' ' }
+}
+
+/** A `## Priority 7` heading, with whatever gloss the format's example puts after the number. */
+const PRIORITY_HEADING = /^##\s+priority\s+(\d{1,2})\b/i
+
+/** Any second-level heading, which is where a priority section ends. */
+const SECTION_HEADING = /^##\s+/
+
+/**
+ * Place an open entry in the backlog's priority section (`prompts/todo_format.md`), creating the
+ * section when the file has none, and return the new document.
+ *
+ * Pure, because the placement is the whole point and it is much easier to pin here than through
+ * the filesystem. The old behaviour was a plain append, which put a just-queued ticket at the
+ * *end* of the file — and since the drain preset works "the FIRST open entry" and
+ * `parseTodoEntries` reads in file order, queueing something meant it would be worked last,
+ * behind everything already there (#1164).
+ *
+ * Placement rules, in the order they are tried:
+ * - a section for this priority already exists: the entry joins the end of it, so a queue keeps
+ *   its arrival order within a priority
+ * - otherwise the section is created before the first *lower*-priority section, since the format
+ *   sorts high to low
+ * - with no priority sections at all, it goes above the first heading of any kind: the file's
+ *   own sections are then unranked, and burying a deliberate pick under them is the bug
+ */
+export function insertTodoEntry(md: string, entry: string, priority: number): string {
+  const item = `- [ ] ${entry}`
+  const lines = md.split('\n')
+  const headings = lines
+    .map((line, index) => ({ index, priority: Number(PRIORITY_HEADING.exec(line)?.[1]) }))
+    .filter(h => Number.isFinite(h.priority))
+
+  const existing = headings.find(h => h.priority === priority)
+  if (existing) {
+    // The end of that section: the last line before the next heading that is not blank, so the
+    // entry lands under the section's last item rather than after its trailing blank line.
+    let end = lines.findIndex((line, index) => index > existing.index && SECTION_HEADING.test(line))
+    if (end === -1) end = lines.length
+    while (end > existing.index + 1 && lines[end - 1]!.trim() === '') end--
+    lines.splice(end, 0, item)
+    return lines.join('\n')
+  }
+
+  const section = [`## Priority ${priority}`, '', item, '']
+  const lower = headings.find(h => h.priority < priority)
+  if (lower) {
+    lines.splice(lower.index, 0, ...section)
+    return lines.join('\n')
+  }
+  if (headings.length) {
+    // Every existing section outranks it, so it goes last -- but still as its own section.
+    const last = headings[headings.length - 1]!
+    let end = lines.findIndex((line, index) => index > last.index && SECTION_HEADING.test(line))
+    if (end === -1) end = lines.length
+    while (end > last.index + 1 && lines[end - 1]!.trim() === '') end--
+    lines.splice(end, 0, '', ...section.slice(0, 3))
+    return lines.join('\n')
+  }
+  const firstHeading = lines.findIndex(line => SECTION_HEADING.test(line))
+  if (firstHeading === -1) {
+    const separator = md === '' || md.endsWith('\n') ? '' : '\n'
+    return `${md}${separator}${section.slice(0, 3).join('\n')}\n`
+  }
+  lines.splice(firstHeading, 0, ...section)
+  return lines.join('\n')
+}
+
+/** The entry lines of a document, by text. First occurrence wins, as `parseTodoEntries` reads them. */
+function entryStates(md: string): Map<string, TodoEntryLine> {
+  const states = new Map<string, TodoEntryLine>()
+  for (const line of md.split('\n')) {
+    const entry = parseTodoEntryLine(line)
+    if (entry && !states.has(entry.text)) states.set(entry.text, entry)
+  }
+  return states
+}
+
+/** The line, checked off in place, whatever list marker it uses. */
+function checkLine(line: string): string {
+  const item = /^(\s*(?:[-*]|\d+\.)\s+)(.*)$/.exec(line)
+  if (!item) return line
+  const marker = item[1]!
+  const rest = item[2]!
+  return /^\[ \]/.test(rest) ? marker + rest.replace('[ ]', '[x]') : `${marker}[x] ${rest.trim()}`
+}
+
+/**
+ * Land a run's queue edits on a checkout that has moved since the run forked (#1204).
+ *
+ * A three-way merge at entry granularity, keyed on entry text: what the run did is read as
+ * `base -> theirs` (entries it checked off, removed, or added) and replayed onto `ours`, so two
+ * runs that worked different entries compose instead of the later promotion reverting the
+ * earlier one. The queue's operations are narrow — check off, remove, append — which is what
+ * makes text identity enough; a reworded entry is a removal plus an addition, exactly as a line
+ * merge would read it.
+ *
+ * Everything the run did not touch is `ours` verbatim: the checkout is the copy humans edit, and
+ * its formatting is not the promotion's to reflow. Added entries keep their priority section via
+ * {@link insertTodoEntry} when `theirs` placed them under one; anything else joins the end.
+ */
+export function mergeQueueDocuments(base: string, ours: string, theirs: string): string {
+  const atBase = entryStates(base)
+  const inTheirs = entryStates(theirs)
+
+  // What the run did: entries it retired (open at base, checked in its copy), entries it removed
+  // outright, and entries it wrote that the base never had.
+  const checkedOff = new Set(
+    [...inTheirs].filter(([text, entry]) => entry.checked === true && atBase.get(text)?.checked !== true).map(([text]) => text),
+  )
+  const removed = new Set([...atBase.keys()].filter(text => !inTheirs.has(text)))
+
+  // Replay onto ours, line by line: retire what the run retired, drop what it removed, keep the
+  // rest — including entries and prose the run never saw.
+  const merged: string[] = []
+  for (const line of ours.split('\n')) {
+    const entry = parseTodoEntryLine(line)
+    if (!entry || entry.checked === true) {
+      merged.push(line)
+      continue
+    }
+    if (removed.has(entry.text)) continue
+    merged.push(checkedOff.has(entry.text) ? checkLine(line) : line)
+  }
+
+  // The run's own additions, in its order. Present-in-ours (whatever the state) means both sides
+  // have it and ours' copy already won above.
+  const present = new Set([...entryStates(merged.join('\n')).keys()])
+  let result = merged.join('\n')
+  let priority: number | undefined
+  for (const line of theirs.split('\n')) {
+    const heading = PRIORITY_HEADING.exec(line)
+    if (heading) priority = Number(heading[1])
+    else if (SECTION_HEADING.test(line)) priority = undefined
+    const entry = parseTodoEntryLine(line)
+    if (!entry || atBase.has(entry.text) || present.has(entry.text)) continue
+    present.add(entry.text)
+    if (entry.checked !== true && priority !== undefined) {
+      result = insertTodoEntry(result, entry.text, priority)
+    } else {
+      // No section to aim for (or the run added it already checked): the end keeps it, and the
+      // end is also where an unranked queue reads last, which is the honest place for it.
+      const separator = result === '' || result.endsWith('\n') ? '' : '\n'
+      result = `${result}${separator}${line.trim()}\n`
+    }
+  }
+  return result
+}

--- a/packages/the-framework/src/queue-promote.test.ts
+++ b/packages/the-framework/src/queue-promote.test.ts
@@ -30,3 +30,85 @@ test('a run with no branch, or no queue file on it, is a final skip (no retry fl
   assert.equal(noFile.promoted, false)
   assert.ok(!('retry' in noFile && noFile.retry), 'no queue file is final')
 })
+
+/** A repo whose branch, checkout, and fork-point queues are given, recording what gets run. */
+function fakeRepo(files: { branch: string; checkout: string; base?: string }) {
+  const written: Record<string, string> = {}
+  const commands: string[][] = []
+  const git: GitRunner = async args => {
+    commands.push(args)
+    if (args[0] === 'show' && String(args[1]).startsWith('work:')) return files.branch
+    if (args[0] === 'show' && String(args[1]).startsWith('HEAD:')) return files.checkout
+    if (args[0] === 'show' && String(args[1]).startsWith('fork0000:')) {
+      if (files.base === undefined) throw new Error('path does not exist')
+      return files.base
+    }
+    if (args[0] === 'status') return ''
+    if (args[0] === 'merge-base') return 'fork0000\n'
+    if (args[0] === 'checkout' || args[0] === 'add' || args[0] === 'commit') return ''
+    throw new Error(`unexpected git ${args.join(' ')}`)
+  }
+  const write = async (path: string, content: string) => {
+    written[path] = content
+  }
+  const ran = (name: string) => commands.filter(args => args[0] === name)
+  return { git, write, written, ran }
+}
+
+test("a checkout that moved since the fork gets the run's changes merged on, not the wholesale copy (#1204)", async () => {
+  // Two agents forked the same queue; the other one's promotion landed "a" first. This run's
+  // wholesale copy would have re-opened it — the exact loop that made concurrent drains redo work.
+  const repo = fakeRepo({
+    base: '- [ ] a\n- [ ] b\n',
+    checkout: '- [x] a\n- [ ] b\n',
+    branch: '- [ ] a\n- [x] b\n',
+  })
+  const outcome = await promoteQueue('/repo', { id: 'r1', branch: 'work' }, repo.git, repo.write)
+  assert.deepEqual(outcome, { promoted: true, branch: 'work' })
+  assert.equal(repo.written['/repo/TODO_AGENTS.md'], '- [x] a\n- [x] b\n')
+  assert.equal(repo.ran('commit').length, 1)
+  assert.equal(repo.ran('checkout').length, 0, 'the merge path must not also copy the branch file over')
+})
+
+test('an unmoved checkout keeps the exact wholesale copy (#852)', async () => {
+  // The common serial case: nothing landed since the fork, so the run's file is strictly newer
+  // and `git checkout <branch> -- <file>` reproduces it byte for byte.
+  const repo = fakeRepo({
+    base: '- [ ] a\n',
+    checkout: '- [ ] a\n',
+    branch: '- [x] a\n',
+  })
+  const outcome = await promoteQueue('/repo', { id: 'r1', branch: 'work' }, repo.git, repo.write)
+  assert.deepEqual(outcome, { promoted: true, branch: 'work' })
+  assert.deepEqual(repo.written, {}, 'nothing is hand-written on the copy path')
+  assert.equal(repo.ran('checkout').length, 1)
+  assert.equal(repo.ran('commit').length, 1)
+})
+
+test('a fork point git cannot name falls back to the wholesale copy (#1204)', async () => {
+  const repo = fakeRepo({
+    checkout: '- [ ] a\n',
+    branch: '- [x] a\n',
+  })
+  const git: GitRunner = async args =>
+    args[0] === 'merge-base' ? Promise.reject(new Error('no common ancestor')) : repo.git(args, '/repo')
+  const outcome = await promoteQueue('/repo', { id: 'r1', branch: 'work' }, git, repo.write)
+  assert.deepEqual(outcome, { promoted: true, branch: 'work' })
+  assert.deepEqual(repo.written, {})
+  assert.equal(repo.ran('checkout').length, 1)
+})
+
+test('a run whose queue changes all landed already is a final skip (#1204)', async () => {
+  // The checkout moved past the run: everything it did is already in. Committing an identical
+  // file would fail; skipping quietly settles the run instead.
+  const repo = fakeRepo({
+    base: '- [ ] a\n',
+    checkout: '- [x] a\n- [ ] queued meanwhile\n',
+    branch: '- [x] a\n',
+  })
+  const outcome = await promoteQueue('/repo', { id: 'r1', branch: 'work' }, repo.git, repo.write)
+  assert.equal(outcome.promoted, false)
+  assert.ok(!('retry' in outcome && outcome.retry), 'nothing to land is final')
+  assert.deepEqual(repo.written, {})
+  assert.equal(repo.ran('commit').length, 0)
+})

--- a/packages/the-framework/src/queue-promote.ts
+++ b/packages/the-framework/src/queue-promote.ts
@@ -1,6 +1,9 @@
+import { writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
 import type { GitRunner } from './project.js'
 import { nodeGitRunner } from './project.js'
 import { FLAT_TODO_FILE } from './tickets.js'
+import { mergeQueueDocuments } from './queue-merge.js'
 import { errorMessage } from './error-message.js'
 
 /**
@@ -46,7 +49,7 @@ export function promotionMessage(runId: string): string {
 }
 
 /**
- * Copy `TODO_AGENTS.md` from a finished run's branch into the project checkout and commit it.
+ * Land `TODO_AGENTS.md` from a finished run's branch in the project checkout and commit it.
  *
  * Skips, rather than forcing, when:
  * - the run recorded no branch (nothing to read from)
@@ -54,12 +57,19 @@ export function promotionMessage(runId: string): string {
  * - the checkout has uncommitted changes to the queue file — a human is mid-edit, and their work
  *   outranks an unattended tidy-up
  *
+ * A checkout that has not moved since the run forked takes the run's file wholesale, as this
+ * always did. One that *has* moved — another agent's promotion landed first (#1204), or a human
+ * committed queue edits — gets the run's changes merged on instead: the wholesale copy used to
+ * revert whatever landed in between, un-checking entries a concurrent run had just retired, and
+ * the sweep would then start the same work over again.
+ *
  * Never throws: this runs on a background tick with nothing to catch it.
  */
 export async function promoteQueue(
   projectCwd: string,
   run: { id: string; branch?: string | undefined },
   git: GitRunner = nodeGitRunner(),
+  write: (path: string, content: string) => Promise<void> = (path, content) => writeFile(path, content, 'utf8'),
 ): Promise<QueuePromotion> {
   const branch = run.branch
   if (!branch) return { promoted: false, reason: 'the run recorded no branch' }
@@ -76,6 +86,24 @@ export async function promoteQueue(
     // tick will try again, and until then auto PM simply does not start more work.
     const dirty = (await git(['status', '--porcelain', '--', FLAT_TODO_FILE], projectCwd)).trim()
     if (dirty) return { promoted: false, reason: 'the checkout has uncommitted queue changes', retry: true }
+
+    // The queue as it stood where the run forked off, so its own changes can be told apart from
+    // the checkout's moves since. No merge base at all (a rewritten history, say) falls back to
+    // the wholesale copy this always was.
+    const mergeBase = (await git(['merge-base', branch, 'HEAD'], projectCwd).catch(() => '')).trim()
+    const atBase = mergeBase ? await git(['show', `${mergeBase}:${FLAT_TODO_FILE}`], projectCwd).catch(() => '') : undefined
+
+    if (atBase !== undefined && atBase !== inCheckout) {
+      // The checkout moved since the fork: land only what the run itself did (#1204).
+      const merged = mergeQueueDocuments(atBase, inCheckout, fromBranch)
+      if (merged === inCheckout) {
+        return { promoted: false, reason: 'every queue change the run made is already in the checkout' }
+      }
+      await write(join(projectCwd, FLAT_TODO_FILE), merged)
+      await git(['add', '--', FLAT_TODO_FILE], projectCwd)
+      await git(['commit', '-m', promotionMessage(run.id), '--', FLAT_TODO_FILE], projectCwd)
+      return { promoted: true, branch }
+    }
 
     // `checkout <branch> -- <path>` writes the file and stages it in one step, touching nothing
     // else in the tree. The commit is pathspec-scoped for the same reason: whatever else is

--- a/packages/the-framework/src/registry.test.ts
+++ b/packages/the-framework/src/registry.test.ts
@@ -23,6 +23,7 @@ import {
   REGISTRY_FILE,
   REGISTRY_FILE_MODE,
   MAX_SPEND_OFFSET,
+  MAX_AUTO_PM_CONCURRENCY,
   type Preferences,
   type ProjectRecord,
   type RegistryFs,
@@ -460,6 +461,27 @@ test('writePreferences round-trips and clamps the spend-limit slider (#960)', as
   await writePreferences({ autoSpendOffset: Number.NaN }, fs, ENV)
   assert.deepEqual(await readPreferences(fs, ENV), {})
   await writePreferences({ autoSpendOffset: '20' } as never, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), {})
+})
+
+test('writePreferences round-trips and clamps the routine concurrency (#1204)', async () => {
+  const fs = memFs({ [FILE]: JSON.stringify([APP_A]) })
+  await writePreferences({ autoPmConcurrency: 10 }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { autoPmConcurrency: 10 })
+
+  // The same guard the slider gets (#960): a hand-edited file must not be able to ask for a
+  // fleet the control could not, ask for zero agents, or land junk in the home file.
+  await writePreferences({ autoPmConcurrency: 9000 }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { autoPmConcurrency: MAX_AUTO_PM_CONCURRENCY })
+  await writePreferences({ autoPmConcurrency: 0 }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { autoPmConcurrency: 1 })
+  await writePreferences({ autoPmConcurrency: -3 }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { autoPmConcurrency: 1 })
+  await writePreferences({ autoPmConcurrency: 2.6 }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { autoPmConcurrency: 3 })
+  await writePreferences({ autoPmConcurrency: Number.NaN }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), {})
+  await writePreferences({ autoPmConcurrency: '4' } as never, fs, ENV)
   assert.deepEqual(await readPreferences(fs, ENV), {})
 })
 

--- a/packages/the-framework/src/registry.ts
+++ b/packages/the-framework/src/registry.ts
@@ -2,7 +2,7 @@ import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 import { randomBytes } from 'node:crypto'
 import { isAgentName } from './agent-names.js'
 import { nodeFs } from './node-fs.js'
-import { PROJECT_PREFERENCE_KEYS, MAX_SPEND_OFFSET, type ProjectPreferences } from './preference-defaults.js'
+import { PROJECT_PREFERENCE_KEYS, MAX_SPEND_OFFSET, MAX_AUTO_PM_CONCURRENCY, type ProjectPreferences } from './preference-defaults.js'
 
 /**
  * The multi-project registry (#390): the list of projects the user has
@@ -133,6 +133,13 @@ export interface Preferences {
    */
   autoPmOptOut?: string[]
   /**
+   * How many agents {@link autoPm} may keep running at once per project (#1204). Absent =
+   * `DEFAULT_AUTO_PM_CONCURRENCY` (2). Kept as a whole number between 1 and
+   * `MAX_AUTO_PM_CONCURRENCY`; the sweep tops a project up to this many concurrent runs instead
+   * of standing down the moment anything is going.
+   */
+  autoPmConcurrency?: number
+  /**
    * How far the automatic-consumption limit sits from the quota boundary, in percentage points
    * (#960). Absent or `0` puts it exactly on the boundary, which is the default policy of #879:
    * unattended work stops once the account has spent its share of the week.
@@ -176,7 +183,7 @@ export interface Preferences {
 // The key list lives in the leaf `preference-defaults.ts` so the dashboard reads the same one
 // (a second copy there erased the type link, see that module); re-exported so this stays the
 // import site for everything that already reads it beside `Preferences`.
-export { PROJECT_PREFERENCE_KEYS, MAX_SPEND_OFFSET, type ProjectPreferences } from './preference-defaults.js'
+export { PROJECT_PREFERENCE_KEYS, MAX_SPEND_OFFSET, DEFAULT_AUTO_PM_CONCURRENCY, MAX_AUTO_PM_CONCURRENCY, type ProjectPreferences } from './preference-defaults.js'
 
 /**
  * The credentials the daemon needs to reach a third party, set from the dashboard (#1095).
@@ -409,11 +416,15 @@ function sanitizePreferences(value: unknown): Preferences {
   // it gets its own branch like `theme`, constrained to the known set (anything else = default `local`).
   if (typeof input['target'] === 'string' && (KNOWN_RUN_TARGETS as readonly string[]).includes(input['target']))
     preferences.target = input['target'] as (typeof KNOWN_RUN_TARGETS)[number]
-  // `autoSpendOffset` (#960) is the one numeric preference: a slider position in percentage
-  // points, clamped so a hand-edited file cannot push the limit somewhere the slider could not.
+  // The numeric preferences, each clamped so a hand-edited file cannot push the value somewhere
+  // its control could not: `autoSpendOffset` (#960) is a slider position in percentage points,
+  // `autoPmConcurrency` (#1204) a whole number of agents.
   const offset = input['autoSpendOffset']
   if (typeof offset === 'number' && Number.isFinite(offset))
     preferences.autoSpendOffset = Math.round(Math.min(Math.max(offset, -MAX_SPEND_OFFSET), MAX_SPEND_OFFSET))
+  const concurrency = input['autoPmConcurrency']
+  if (typeof concurrency === 'number' && Number.isFinite(concurrency))
+    preferences.autoPmConcurrency = Math.round(Math.min(Math.max(concurrency, 1), MAX_AUTO_PM_CONCURRENCY))
   // `reposDirectory` (#1123) is a string, so like `target` the boolean-only loop would eat it. Kept
   // only as a non-empty absolute path; a relative or junk value is dropped rather than persisted.
   const reposDir = typeof input['reposDirectory'] === 'string' ? input['reposDirectory'].trim() : ''

--- a/packages/the-framework/src/todo-loop.ts
+++ b/packages/the-framework/src/todo-loop.ts
@@ -6,8 +6,13 @@ import { requestChoices, runAwaitRounds } from './await-gate.js'
 import { FLAT_TODO_FILE, findFlatTodo, ticketFromQueueEntry } from './tickets.js'
 import { drainsQueue } from './preset-catalog.js'
 import { createTurnSignalEmitter } from './turn-gate.js'
+import { insertTodoEntry, parseTodoEntryLine } from './queue-merge.js'
 
 export { FLAT_TODO_FILE, LEGACY_HYPHEN_TODO_FILE, LEGACY_TICKETS_TODO_FILE, LEGACY_TODO_FILE, TICKETS_DIR, ticketFromQueueEntry, todoPriorityForTicket } from './tickets.js'
+// The queue's line grammar and section placement live in the leaf `queue-merge.ts` so the
+// promotion merge (#1204) reads the same one; re-exported so this stays the import site for
+// everything that already reads them beside the loop.
+export { insertTodoEntry, parseTodoEntryLine, type TodoEntryLine } from './queue-merge.js'
 
 /**
  * The backlog loop (#323): once the main work settles, consume the agent's own
@@ -36,21 +41,14 @@ export interface TodoBacklog {
  * The open entries of a backlog document: markdown list items (`-`, `*`, or
  * `1.`), where a task checkbox counts only while unchecked (`- [ ]`); a checked
  * `- [x]` entry is done. Headings, prose, and blank lines are not entries.
+ * The grammar itself is `parseTodoEntryLine` (queue-merge.ts), shared with the
+ * promotion merge so the two can never read the same line differently (#1204).
  */
 export function parseTodoEntries(md: string): string[] {
   const entries: string[] = []
   for (const line of md.split('\n')) {
-    const item = /^\s*(?:[-*]|\d+\.)\s+(.*)$/.exec(line)
-    if (!item) continue
-    const text = item[1]!.trim()
-    if (!text) continue
-    const task = /^\[([ xX])\]\s*(.*)$/.exec(text)
-    if (task) {
-      if (task[1] !== ' ') continue // checked off = done
-      if (task[2]!.trim()) entries.push(task[2]!.trim())
-    } else {
-      entries.push(text)
-    }
+    const entry = parseTodoEntryLine(line)
+    if (entry && entry.checked !== true) entries.push(entry.text)
   }
   return entries
 }
@@ -114,72 +112,6 @@ export async function appendFlatTodoEntry(
   priority?: number,
 ): Promise<string | undefined> {
   return writeTodoEntry(cwd, (await findFlatTodo(cwd)) ?? FLAT_TODO_FILE, entry, priority)
-}
-
-/** A `## Priority 7` heading, with whatever gloss the format's example puts after the number. */
-const PRIORITY_HEADING = /^##\s+priority\s+(\d{1,2})\b/i
-
-/** Any second-level heading, which is where a priority section ends. */
-const SECTION_HEADING = /^##\s+/
-
-/**
- * Place an open entry in the backlog's priority section (`prompts/todo_format.md`), creating the
- * section when the file has none, and return the new document.
- *
- * Pure, because the placement is the whole point and it is much easier to pin here than through
- * the filesystem. The old behaviour was a plain append, which put a just-queued ticket at the
- * *end* of the file — and since the drain preset works "the FIRST open entry" and
- * {@link parseTodoEntries} reads in file order, queueing something meant it would be worked last,
- * behind everything already there (#1164).
- *
- * Placement rules, in the order they are tried:
- * - a section for this priority already exists: the entry joins the end of it, so a queue keeps
- *   its arrival order within a priority
- * - otherwise the section is created before the first *lower*-priority section, since the format
- *   sorts high to low
- * - with no priority sections at all, it goes above the first heading of any kind: the file's
- *   own sections are then unranked, and burying a deliberate pick under them is the bug
- */
-export function insertTodoEntry(md: string, entry: string, priority: number): string {
-  const item = `- [ ] ${entry}`
-  const lines = md.split('\n')
-  const headings = lines
-    .map((line, index) => ({ index, priority: Number(PRIORITY_HEADING.exec(line)?.[1]) }))
-    .filter(h => Number.isFinite(h.priority))
-
-  const existing = headings.find(h => h.priority === priority)
-  if (existing) {
-    // The end of that section: the last line before the next heading that is not blank, so the
-    // entry lands under the section's last item rather than after its trailing blank line.
-    let end = lines.findIndex((line, index) => index > existing.index && SECTION_HEADING.test(line))
-    if (end === -1) end = lines.length
-    while (end > existing.index + 1 && lines[end - 1]!.trim() === '') end--
-    lines.splice(end, 0, item)
-    return lines.join('\n')
-  }
-
-  const section = [`## Priority ${priority}`, '', item, '']
-  const lower = headings.find(h => h.priority < priority)
-  if (lower) {
-    lines.splice(lower.index, 0, ...section)
-    return lines.join('\n')
-  }
-  if (headings.length) {
-    // Every existing section outranks it, so it goes last -- but still as its own section.
-    const last = headings[headings.length - 1]!
-    let end = lines.findIndex((line, index) => index > last.index && SECTION_HEADING.test(line))
-    if (end === -1) end = lines.length
-    while (end > last.index + 1 && lines[end - 1]!.trim() === '') end--
-    lines.splice(end, 0, '', ...section.slice(0, 3))
-    return lines.join('\n')
-  }
-  const firstHeading = lines.findIndex(line => SECTION_HEADING.test(line))
-  if (firstHeading === -1) {
-    const separator = md === '' || md.endsWith('\n') ? '' : '\n'
-    return `${md}${separator}${section.slice(0, 3).join('\n')}\n`
-  }
-  lines.splice(firstHeading, 0, ...section)
-  return lines.join('\n')
 }
 
 /**


### PR DESCRIPTION
1. Look at all tickets and choose tickets to work on next
   - Only pick tickets that are quick-wins and consensual (zero open questions, zero variability, e.g. a single fairly obvious plan)
2. Add tickets to TODO_AGENTS.md

Always set <SESSION_NAME> to triage-quick
- If branch the-framework/<SESSION_NAME> already exists, abort and do nothing

Opened from The Framework session `2026-07-26T20-24-32-577Z`.