### PR TITLE
Fix Hot tickets misreading numeric priorities, leaving the card empty

### DIFF
--- a/.changeset/hot-tickets-priority-scale.md
+++ b/.changeset/hot-tickets-priority-scale.md
@@ -1,0 +1,7 @@
+---
+"@gemstack/the-framework": patch
+---
+
+Fix the Overview's "Hot tickets" card misreading numeric priorities, which left it empty ("No tickets yet.") over a backlog full of urgent tickets.
+
+The high-priority lane matched bare numbers `0`/`1` — the P0/P1 convention — while the ticket format's own scale runs 10-0 with 10 acting immediately, so a `Priority: 8` ticket never qualified. A bare number now reads on the format's scale, high from 7 up; `p0`/`p1` and the word labels (`high`, `urgent`, `critical`) still count. Closed tickets no longer surface as hot, and the card's empty state now says "Nothing in progress, queued, or high priority." instead of claiming no tickets exist.

--- a/packages/framework-dashboard/components/HotTickets.test.tsx
+++ b/packages/framework-dashboard/components/HotTickets.test.tsx
@@ -24,10 +24,10 @@ const ht = (file: string, projectName: string, bucket: HotBucket, over: Record<s
 })
 
 describe('HotTickets (#1112)', () => {
-  test('with no tickets it shows a hint', async () => {
+  test('with no hot tickets it names the empty lanes rather than claiming no tickets exist', async () => {
     onHotTickets.mockResolvedValue([])
     render(<HotTickets onSelectProject={() => {}} onSelectRun={vi.fn()} />)
-    await waitFor(() => expect(screen.getByText('No tickets yet.')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText('Nothing in progress, queued, or high priority.')).toBeTruthy())
   })
 
   test('groups tickets into the three lanes and selecting one jumps into its project', async () => {

--- a/packages/framework-dashboard/components/HotTickets.tsx
+++ b/packages/framework-dashboard/components/HotTickets.tsx
@@ -82,7 +82,9 @@ export function HotTickets({
       </CardHeader>
       <CardContent>
         {tickets.length === 0 ? (
-          <p className="py-2 text-sm text-muted-foreground">No tickets yet.</p>
+          // Named lanes, not "no tickets": the card is a shortlist, and its empty state must not
+          // claim the backlog is empty when merely nothing qualifies (the /tickets page may be full).
+          <p className="py-2 text-sm text-muted-foreground">Nothing in progress, queued, or high priority.</p>
         ) : (
           <div className="grid items-start gap-x-8 gap-y-5 sm:grid-cols-2">
             <div className="flex flex-col gap-5">{LEFT_LANES.map(renderLane)}</div>

--- a/packages/the-framework/src/dashboard/overview.test.ts
+++ b/packages/the-framework/src/dashboard/overview.test.ts
@@ -120,6 +120,24 @@ test('ticketBucket: in-progress > ai-queue > high-priority, else null (#1139)', 
   assert.equal(ticketBucket(ticket('j', { planned: true }), { queued: true }), 'in-progress')
 })
 
+test('ticketBucket: a bare number is the ticket format\'s 10-0 scale, high from 7 up', () => {
+  // ticketing_format.md: `Priority: 10-0 … 10: critical — act immediately, 0: only if capacity`.
+  for (const high of ['10', '9', '8', '7']) {
+    assert.equal(ticketBucket(ticket(high, { priority: high })), 'high-priority', `priority ${high}`)
+  }
+  // 0 and 1 are that scale's LOWEST rungs — the inverse P0/P1 reading only applies written `p0`/`p1`.
+  for (const low of ['6', '5', '2', '1', '0']) {
+    assert.equal(ticketBucket(ticket(low, { priority: low })), null, `priority ${low}`)
+  }
+})
+
+test('ticketBucket: a closed ticket is in no lane, whatever marks it left behind', () => {
+  assert.equal(ticketBucket(ticket('a', { status: 'closed', planned: true })), null)
+  assert.equal(ticketBucket(ticket('b', { status: 'closed', priority: '10' })), null)
+  assert.equal(ticketBucket(ticket('c', { status: 'closed' }), { queued: true }), null)
+  assert.equal(ticketBucket(ticket('d', { status: 'closed' }), { implementing: true }), null)
+})
+
 test('buildHotTickets pools every project, buckets each, drops the rest, and orders lane-first', async () => {
   const tickets: Record<string, WorkspaceTicket[]> = {
     '/a': [ticket('a1.md', { planned: true }), ticket('a2.md', { priority: 'high' })],

--- a/packages/the-framework/src/dashboard/overview.ts
+++ b/packages/the-framework/src/dashboard/overview.ts
@@ -133,8 +133,24 @@ export interface HotTicket {
   runId?: string
 }
 
-/** Priority values that read as "do this soon" — the "high priority" lane (#1139). */
-const HIGH_PRIORITY = new Set(['high', 'urgent', 'critical', 'p0', 'p1', '0', '1'])
+/** Priority labels that read as "do this soon" — the "high priority" lane (#1139). */
+const HIGH_PRIORITY_LABELS = new Set(['high', 'urgent', 'critical', 'p0', 'p1'])
+
+/** Where the ticket format's 10-0 scale starts reading as high. */
+const HIGH_PRIORITY_FLOOR = 7
+
+/**
+ * Whether a `priority:` value reads as "do this soon". A bare number is the ticket format's own
+ * scale (`ticketing_format.md`: `10-0 … 10: critical — act immediately, 0: only if capacity`), so
+ * 7 and up qualify — NOT the P0/P1 convention, whose low-numbers-first reading only applies when
+ * written `p0`/`p1`. Getting that backwards is what kept a backlog full of `Priority: 8` tickets
+ * off the card entirely.
+ */
+function isHighPriority(priority: string): boolean {
+  if (HIGH_PRIORITY_LABELS.has(priority)) return true
+  const n = Number.parseInt(priority, 10)
+  return !Number.isNaN(n) && n >= HIGH_PRIORITY_FLOOR
+}
 
 /**
  * A ticket's lane (#1139), or null when it is in none of the three the card shows:
@@ -145,7 +161,8 @@ const HIGH_PRIORITY = new Set(['high', 'urgent', 'critical', 'p0', 'p1', '0', '1
  * - high-priority: none of the above, but flagged high priority; what a human would likely queue next.
  *
  * Precedence follows that order: work already under way outranks a queued ticket, which outranks a
- * bare priority flag. Everything else is dropped — the card is a shortlist, not the whole backlog.
+ * bare priority flag. Everything else is dropped — the card is a shortlist, not the whole backlog —
+ * and a closed ticket is dropped before any of it, since finished work is not hot however marked.
  *
  * `implementing` is the only hard evidence and exists for a drain run only, so the plan/spike proxy
  * still carries every ticket someone is working by hand.
@@ -154,9 +171,13 @@ export function ticketBucket(
   ticket: WorkspaceTicket,
   opts: { implementing?: boolean; queued?: boolean } = {},
 ): HotBucket | null {
+  // A closed ticket is finished work: in no lane, whatever marks (plan/spike/priority/queue entry)
+  // it left behind — those say how it was worked, not that it still is. A run that is somehow
+  // still implementing one shows in "Working now" on the strength of the run itself.
+  if (ticket.status === 'closed') return null
   if (opts.implementing || ticket.planned || ticket.spiked) return 'in-progress'
   if (opts.queued) return 'ai-queue'
-  if (ticket.priority && HIGH_PRIORITY.has(ticket.priority)) return 'high-priority'
+  if (ticket.priority && isHighPriority(ticket.priority)) return 'high-priority'
   return null
 }
 


### PR DESCRIPTION
## Problem

The Overview's "Hot tickets" card showed **"No tickets yet."** even over a backlog of 50+ tickets (visible on `/tickets`).

The card's high-priority lane matched bare numeric priorities `0`/`1` — the P0/P1 convention where low numbers are urgent — but the ticket format's own scale (`prompts/ticketing_format.md`) runs `10-0` with **10 = critical, act immediately**. The dashboard's shared `priorityTone` helper already reads it that way (≥8 red, ≥5 amber). So a `Priority: 8` ticket rendered red on the tickets page yet never qualified as hot, and with no plan/spike siblings and no `TODO_AGENTS.md`, every lane came up empty.

## Changes

- `ticketBucket` now parses a bare numeric priority on the format's 10-0 scale and counts **7 and up** as high priority. The word labels (`high`, `urgent`, `critical`) and the explicit `p0`/`p1` forms still qualify; bare `0`/`1` no longer do.
- A `status: closed` ticket is never hot, whatever marks (plan/spike/priority/queue entry) it left behind — finished work doesn't belong on the card.
- The card's empty state now says **"Nothing in progress, queued, or high priority."** instead of claiming no tickets exist.
- Tests for the numeric scale boundaries (7 high, 6 not, 0/1 not) and the closed-ticket rule; updated the empty-state component test. Changeset included (patch).

## Test plan

- `packages/the-framework`: `pnpm test` — overview suite 16/16; full suite green except 2 pre-existing `preset-catalog` failures on `main` (triage prompt text drifted from its test, untouched here).
- `packages/framework-dashboard`: `vitest run components/HotTickets.test.tsx` — 9/9; `turbo run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ALZuHFRnS6KY9WA3BrZUky

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALZuHFRnS6KY9WA3BrZUky)_