### PR TITLE
Trigger routine now works while auto-run is off (#1210)

### DIFF
--- a/.changeset/trigger-routine-now.md
+++ b/.changeset/trigger-routine-now.md
@@ -2,4 +2,4 @@
 '@gemstack/the-framework': minor
 ---
 
-Adds `Trigger routine now` beside the Routine work card's `Auto-run` box, so a sweep can be fired on demand instead of waiting out the interval. The loop could always do this — it is what switching the preference on already triggers — but nothing could ask for it directly, so the only way to fast-forward was to tick the box off and on again. The button is disabled while auto-run is off, because a sweep re-reads the preference and stands straight back down.
+Adds `Trigger routine now` beside the Routine work card's `Auto-run` box, so a sweep can be fired on demand instead of waiting out the interval. The loop could always do this — it is what switching the preference on already triggers — but nothing could ask for it directly, so the only way to fast-forward was to tick the box off and on again. The button works with auto-run off too: that preference is consent to spend quota *unasked*, and clicking is asking, so the daemon runs one sweep — every other stand-down reason (live runs, cooldowns, the quota boundary, unticked routines) still in force — and the schedule stays off.

--- a/packages/framework-dashboard/components/RoutineWork.test.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.test.tsx
@@ -186,13 +186,15 @@ describe('RoutineWork (#1159)', () => {
     await waitFor(() => expect(sendAutoPmSweep).toHaveBeenCalledTimes(1))
   })
 
-  test('with auto-run off the trigger is disabled, since a sweep would just stand down (#1210)', async () => {
+  test('with auto-run off the trigger still sweeps once: the click is the ask (#1210)', async () => {
     prefs = { autoPm: false }
     render(<RoutineWork onRunStarted={() => {}} />)
-    const button = await screen.findByText('Trigger routine now')
-    expect(button.closest('button')!.disabled).toBe(true)
+    const button = (await screen.findByText('Trigger routine now')).closest('button')!
+    expect(button.disabled).toBe(false)
+    // The tooltip carries the one thing worth saying here: this is a one-shot, not an enrolment.
+    expect((await hoverTooltip(button)).textContent).toMatch(/Auto-run stays off/)
     fireEvent.click(button)
-    expect(sendAutoPmSweep).not.toHaveBeenCalled()
+    await waitFor(() => expect(sendAutoPmSweep).toHaveBeenCalledTimes(1))
   })
 
   test('a host with no sweep says so rather than looking like it worked (#1210)', async () => {

--- a/packages/framework-dashboard/components/RoutineWork.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.tsx
@@ -183,16 +183,16 @@ export function RoutineWork({
                 </Tooltip>
                 {/* The countdown's escape hatch (#1210): the sweep is on a long interval, so
                     without this the only way to fast-forward was to tick the box off and on
-                    again. Disabled while auto-run is off, because a sweep re-reads the
-                    preference and stands straight back down — a button that always did nothing
-                    would read as broken rather than as inapplicable. */}
+                    again. Live even while auto-run is off — that preference records consent to
+                    spend quota unasked, and clicking is asking — so the daemon sweeps once and
+                    the schedule stays off. */}
                 <Tooltip>
                   <TooltipTrigger
                     render={
                       <button
                         type="button"
                         onClick={sweepNow}
-                        disabled={!autoRun || sweeping}
+                        disabled={sweeping}
                         className="shrink-0 rounded border border-border px-2 py-1 text-xs text-foreground hover:bg-accent disabled:opacity-50"
                       />
                     }
@@ -202,7 +202,7 @@ export function RoutineWork({
                   <TooltipContent>
                     {autoRun
                       ? 'Run the scheduled sweep now instead of waiting for the countdown.'
-                      : 'Turn auto-run on first: a sweep checks the setting and stops when it is off.'}
+                      : 'Run the sweep once now. Auto-run stays off, so nothing further is scheduled.'}
                   </TooltipContent>
                 </Tooltip>
               </div>

--- a/packages/the-framework/src/auto-pm.test.ts
+++ b/packages/the-framework/src/auto-pm.test.ts
@@ -164,6 +164,25 @@ test('startAutoPm starts nothing while the preference is off (#685)', async () =
   assert.deepEqual(started, [])
 })
 
+test('an on-demand tick sweeps with the preference off: the click is the ask (#1210)', async () => {
+  const { loop, started } = harness({ enabled: async () => false })
+  await loop.tick({ onDemand: true })
+  loop.stop()
+  assert.deepEqual(started, ['p1'])
+  // The report still says where the box stood, beside what the asked-for sweep did.
+  const report = loop.report()
+  assert.equal(report.enabled, false)
+  assert.equal(report.outcomes[0]?.started, true)
+})
+
+test('on demand skips only the master switch: every other stand-down still holds (#1210)', async () => {
+  const { loop, started } = harness({ enabled: async () => false, activeRuns: () => 1 })
+  await loop.tick({ onDemand: true })
+  loop.stop()
+  assert.deepEqual(started, [])
+  assert.match(loop.report().outcomes[0]?.message ?? '', /already going/)
+})
+
 test('startAutoPm does not start a second run for the same project (#685)', async () => {
   // The cooldown is what stops a tick that lands before the spawn registers from doubling up.
   const { loop, started } = harness()

--- a/packages/the-framework/src/auto-pm.ts
+++ b/packages/the-framework/src/auto-pm.ts
@@ -352,8 +352,13 @@ export interface AutoPmLoop {
    * Run one sweep now, rather than waiting for the next tick. Called when the preference is
    * switched on (#1161) as well as from tests: the sweep re-reads it per tick, so without this
    * the box you just ticked does nothing at all for a whole interval.
+   *
+   * `onDemand` marks a sweep a person explicitly asked for (#1210's trigger button). The `autoPm`
+   * preference is consent to spend quota *unasked*, and a click is asking — so an on-demand sweep
+   * runs with the preference off, and the master switch is the only gate it skips: every other
+   * reason to stand down (live runs, cooldowns, the quota boundary, unticked routines) still holds.
    */
-  tick(): Promise<void>
+  tick(opts?: { onDemand?: boolean }): Promise<void>
   /** What the last sweep decided, for the dashboard to show (#1161). */
   report(): AutoPmReport
   stop(): void
@@ -385,7 +390,7 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
   let sweeping = false
   let stopped = false
 
-  const tick = async (): Promise<void> => {
+  const tick = async (opts?: { onDemand?: boolean }): Promise<void> => {
     if (stopped || sweeping) return
     sweeping = true
     let enabled = false
@@ -395,9 +400,11 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
       outcomes.push({ projectId: project.id, path: project.path, started, message })
     try {
       // The preference is the cheapest gate and the one the user flips most, so it is read
-      // once per sweep rather than per project.
+      // once per sweep rather than per project. An on-demand sweep outranks it — the click is
+      // the consent the preference exists to record — but still reads it, so the report says
+      // where the box stood.
       enabled = await deps.enabled().catch(() => false)
-      if (!enabled) return
+      if (!enabled && !opts?.onDemand) return
       const projects = await deps.projects().catch(() => [])
       if (!projects.length) return
       // Read beside the master switch and for the same reason (#1209): it is the same preference

--- a/packages/the-framework/src/daemon-services.ts
+++ b/packages/the-framework/src/daemon-services.ts
@@ -61,8 +61,11 @@ export interface BackgroundServices {
    * Sweep now instead of at the next tick (#1161), because the `autoPm` preference was just
    * switched on. The sweep re-reads the preference itself, so this only changes *when* it
    * notices — but a ten-minute wait with nothing on screen is what made the toggle read as dead.
+   *
+   * `onDemand` is the dashboard's trigger button (#1210): that sweep runs even while the
+   * preference is off, because the click itself is the ask the preference would otherwise record.
    */
-  wakeAutoPm: () => void
+  wakeAutoPm: (opts?: { onDemand?: boolean }) => void
   /** What the last auto-PM sweep decided, for the usage panel to show (#1161). */
   autoPmReport: () => AutoPmReport
 }
@@ -346,9 +349,10 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
     },
     flushConversations: () => conversationCommitter.flush().catch(() => 0),
     reloadDiscord,
-    // Not awaited, and safe to call when the preference went the other way: a sweep with the box
-    // unticked reads it, records "off", and starts nothing.
-    wakeAutoPm: () => void autoPm.tick().catch(() => {}),
+    // Not awaited. The plain wake is safe to call when the preference went the other way — the
+    // sweep re-reads the box, records "off", and starts nothing — while an on-demand one (#1210)
+    // runs regardless, because the click is the ask.
+    wakeAutoPm: opts => void autoPm.tick(opts).catch(() => {}),
     autoPmReport: () => autoPm.report(),
   }
 }

--- a/packages/the-framework/src/daemon.ts
+++ b/packages/the-framework/src/daemon.ts
@@ -412,9 +412,10 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     }),
     // Only the daemon runs the sweep, so only it can say what the sweep decided.
     autoPm: () => services?.autoPmReport(),
-    // ...and only it can be asked to sweep now (#1210), through the same wake the
-    // switched-on preference above uses.
-    autoPmSweep: () => services?.wakeAutoPm(),
+    // ...and only it can be asked to sweep now (#1210). On demand, not the plain wake the
+    // switched-on preference above uses: the button is an explicit ask, so the sweep runs even
+    // while auto-run is off — one sweep for the click, and the schedule stays off.
+    autoPmSweep: () => services?.wakeAutoPm({ onDemand: true }),
     ...(token ? { token } : {}),
     ...(clientBundleDir ? { clientBundleDir } : {}),
   })

--- a/packages/the-framework/src/dashboard-rpc/quota.telefunc.ts
+++ b/packages/the-framework/src/dashboard-rpc/quota.telefunc.ts
@@ -45,6 +45,10 @@ export async function onAutoPm(): Promise<AutoPmReport | undefined> {
  * write that switches the preference on triggers (#1167) — but until now nothing could ask for
  * it directly, so the only way to fast-forward was to tick the box off and on again.
  *
+ * The `autoPm` preference does not gate it: that preference is consent to spend quota *unasked*,
+ * and this call is asking. So with auto-run off the daemon still sweeps once — every other
+ * stand-down reason in force — and the schedule stays wherever the box says.
+ *
  * Returns whether a sweep was asked for, not what it decided: a sweep can start runs and take a
  * while, and `onAutoPm` is how the answer arrives. `false` on a host with no loop (the relay),
  * which the button reads as "nothing here to trigger".


### PR DESCRIPTION
"Turn auto-run on first: a sweep checks the setting and stops when it is off." — the report is right that this is the wrong design. The tooltip described the daemon truthfully (the sweep loop really does re-read the preference and stand down, so merely enabling the button would have produced a silent no-op click), but the design it described conflated two different consents:

- The `autoPm` preference is consent to spend quota **unasked**, on a schedule. That is how the feature documents itself, and it is why the quota boundary treats asked-for work differently from unasked work.
- Clicking **Trigger routine now** *is* asking. Gating an explicit ask on the unasked-spending switch made a one-shot impossible without enrolling in the standing schedule.

The old tooltip's advice was also circular in practice: ticking auto-run on is itself wired to fire a sweep immediately (#1167), so after following "turn auto-run on first" the sweep had already run and the freshly enabled button had nothing left to do.

## What changed

- **`auto-pm.ts`** — `tick()` takes an `onDemand` flag. It skips exactly one gate: the master switch. Every other reason to stand down (live runs, cooldowns, the quota boundary, unticked routines) still holds, and the report still records where the box stood, beside what the asked-for sweep did.
- **`daemon.ts` / `daemon-services.ts`** — the `autoPmSweep` RPC is the on-demand caller; the preference-flip wake stays a plain tick, so a box ticked on and straight back off still stands down.
- **`RoutineWork.tsx`** — the button is live regardless of auto-run. With auto-run off the tooltip now says what a click means: "Run the sweep once now. Auto-run stays off, so nothing further is scheduled."
- The pending changeset from #1210 is amended, since that feature is still unreleased.

The per-row **Run now** buttons already worked with auto-run off; the gap was only the sweep trigger.

## Tests

- `auto-pm.test.ts`: an on-demand tick sweeps with the preference off; on-demand skips *only* the master switch (a live run still stands it down).
- `RoutineWork.test.tsx`: the trigger is enabled with auto-run off, fires the sweep, and carries the one-shot tooltip.
- Both packages typecheck; full dashboard suite 589/589; the-framework suite green apart from 10 daemon integration failures that reproduce identically on the unmodified tree (sandbox limitation, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VYA1zicCbWjKp8KKmGrv1

---
_Generated by [Claude Code](https://claude.ai/code/session_013VYA1zicCbWjKp8KKmGrv1)_