### PR TITLE
feat(the-framework): let the routine keep several concurrent agents (#1204)

### DIFF
--- a/.changeset/routine-concurrent-agents.md
+++ b/.changeset/routine-concurrent-agents.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': minor
+---
+
+Routine work: a **Concurrent agents** setting (default 2, up to 10) for how many agents the routine keeps going at once. A sweep now tops a project up in one tick, so one click of "Trigger routine now" against a standing queue fans out that many sessions at once, each pinned to its own queue entry.

--- a/packages/framework-dashboard/components/RoutineWork.test.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.test.tsx
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { AutoPmJob, AutoPmReport, Preferences, ProjectSummary } from '@gemstack/the-framework'
-import { AUTO_PM_ROUTINES, AUTO_PM_DRAIN_JOB, AUTO_PM_MAINTENANCE_JOB } from '@gemstack/the-framework/client'
+import {
+  AUTO_PM_ROUTINES,
+  AUTO_PM_DRAIN_JOB,
+  AUTO_PM_MAINTENANCE_JOB,
+  DEFAULT_AUTO_PM_CONCURRENCY,
+  MAX_AUTO_PM_CONCURRENCY,
+} from '@gemstack/the-framework/client'
 import { hoverTooltip } from '../test-utils.js'
 
 // Everything the card reads goes through a lib module, so the mocks stop short of telefunc: an
@@ -228,6 +234,38 @@ describe('RoutineWork (#1159)', () => {
     render(<RoutineWork onRunStarted={() => {}} />)
     await waitFor(() => expect(screen.getByText('Add a project to run a routine.')).toBeTruthy())
     expect(screen.queryByText('Run now')).toBeNull()
+  })
+
+  // #1204: how many agents the routine keeps going at once.
+
+  test('the concurrent-agents box shows the daemon default until it is set', async () => {
+    render(<RoutineWork onRunStarted={() => {}} />)
+    const box = (await screen.findByLabelText('Concurrent agents')) as HTMLInputElement
+    // The default rather than 1, so the number on screen is the number the sweep would use.
+    expect(box.value).toBe(String(DEFAULT_AUTO_PM_CONCURRENCY))
+    expect(box.max).toBe(String(MAX_AUTO_PM_CONCURRENCY))
+  })
+
+  test('typing a concurrency writes it, clamped to the cap', async () => {
+    render(<RoutineWork onRunStarted={() => {}} />)
+    const box = await screen.findByLabelText('Concurrent agents')
+    fireEvent.change(box, { target: { value: '5' } })
+    expect(updatePreferences).toHaveBeenCalledWith({ autoPmConcurrency: 5 })
+    // The store clamps too, but a number input still hands back whatever was typed into it.
+    fireEvent.change(box, { target: { value: '999' } })
+    expect(updatePreferences).toHaveBeenCalledWith({ autoPmConcurrency: MAX_AUTO_PM_CONCURRENCY })
+    fireEvent.change(box, { target: { value: '0' } })
+    expect(updatePreferences).toHaveBeenCalledWith({ autoPmConcurrency: 1 })
+    // An emptied box is not a preference: it must not write NaN into the home file.
+    updatePreferences.mockClear()
+    fireEvent.change(box, { target: { value: '' } })
+    expect(updatePreferences).not.toHaveBeenCalled()
+  })
+
+  test('the fine print follows the setting rather than promising an idle machine', async () => {
+    prefs = { autoPmConcurrency: 4 }
+    render(<RoutineWork onRunStarted={() => {}} />)
+    await waitFor(() => expect(screen.getByText(/Keeps up to 4 agents going at once/)).toBeTruthy())
   })
 
   test('a start already in flight disables every Run now', async () => {

--- a/packages/framework-dashboard/components/RoutineWork.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.tsx
@@ -1,6 +1,11 @@
 import { useState } from 'react'
 import type { AutoPmJob, ProjectSummary } from '@gemstack/the-framework'
-import { AUTO_PM_ROUTINES, runOptionsFromPreferences } from '@gemstack/the-framework/client'
+import {
+  AUTO_PM_ROUTINES,
+  DEFAULT_AUTO_PM_CONCURRENCY,
+  MAX_AUTO_PM_CONCURRENCY,
+  runOptionsFromPreferences,
+} from '@gemstack/the-framework/client'
 import { CalendarClock, Play } from 'lucide-react'
 import { onProjects } from '../server/projects.telefunc.js'
 import { sendAutoPmSweep } from '../server/quota.telefunc.js'
@@ -66,6 +71,9 @@ export function RoutineWork({
     updatePreferences({
       autoPmOptOut: on ? optedOut.filter(name => name !== job.name) : [...optedOut, job.name],
     })
+  // How many agents the routine may keep going at once (#1204). Absent is the daemon's default
+  // rather than 1, so the number on screen is the number the sweep would use.
+  const concurrency = preferences.autoPmConcurrency ?? DEFAULT_AUTO_PM_CONCURRENCY
   // The countdown is the sweep's, and the sweep only reports once the daemon has run one. With
   // auto-run off, or before that first report, the box says what it does instead of when.
   const autoRunLabel =
@@ -208,8 +216,45 @@ export function RoutineWork({
                   </TooltipContent>
                 </Tooltip>
               </div>
+              {/* The concurrency setting (#1204). Beside the switch it qualifies, and worded as
+                  what it does rather than as a number: only draining fans out, because that is the
+                  routine that takes work off the queue one entry at a time. */}
+              <div className="mt-2 flex items-center justify-between gap-2">
+                <Tooltip>
+                  <TooltipTrigger
+                    render={<label htmlFor="auto-pm-concurrency" className="cursor-pointer text-sm text-foreground" />}
+                  >
+                    Concurrent agents
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    How many agents the routine keeps going at once while there is queued work.
+                  </TooltipContent>
+                </Tooltip>
+                <input
+                  id="auto-pm-concurrency"
+                  type="number"
+                  min={1}
+                  max={MAX_AUTO_PM_CONCURRENCY}
+                  step={1}
+                  value={concurrency}
+                  onChange={event => {
+                    // Clamped here as well as in the store, because a number input still hands
+                    // back whatever was typed. An emptied box is mid-edit rather than a setting:
+                    // it has to be caught by hand, since `Number('')` is 0, not NaN, and the clamp
+                    // below would turn a cleared field into a saved 1.
+                    const typed = event.target.value.trim()
+                    if (!typed) return
+                    const next = Math.round(Number(typed))
+                    if (!Number.isFinite(next)) return
+                    updatePreferences({ autoPmConcurrency: Math.min(Math.max(next, 1), MAX_AUTO_PM_CONCURRENCY) })
+                  }}
+                  className="w-16 rounded border border-border bg-background px-2 py-1 text-sm text-foreground"
+                />
+              </div>
               <p className="mt-1 text-xs text-muted-foreground">
-                Only while nothing else is running and the week&apos;s allowance is not already spent.
+                {concurrency === 1
+                  ? "Only while nothing else is running and the week's allowance is not already spent."
+                  : `Keeps up to ${concurrency} agents going at once on queued work, and only while the week's allowance is not already spent.`}
               </p>
               {/* Auto-run on with every routine unticked is a schedule with nothing on it, and
                   from the countdown alone it looks like work is coming (#1209). */}

--- a/packages/the-framework/src/auto-pm.test.ts
+++ b/packages/the-framework/src/auto-pm.test.ts
@@ -14,7 +14,7 @@ import {
   type AutoPmProject,
 } from './auto-pm.js'
 import { quotaBoundaryStatus, type QuotaBoundaryStatus } from './quota-boundary.js'
-import { DEFAULT_SPEND_OFFSET } from './preference-defaults.js'
+import { DEFAULT_SPEND_OFFSET, DEFAULT_AUTO_PM_CONCURRENCY } from './preference-defaults.js'
 import { presets, type PresetKey } from './preset-catalog.js'
 
 /** 2026-07-20T12:00:00Z. The week below resets in 4 days 19 hours, so ~31.5% has elapsed (#960 Edit). */
@@ -42,11 +42,30 @@ test('autoPmDecision does nothing while the preference is off (#685)', () => {
   assert.equal(decision.start, false)
 })
 
-test('autoPmDecision leaves a busy project alone (#685)', () => {
-  // A live run is already spending the quota; a second one started unasked would race it.
-  const decision = autoPmDecision({ ...IDLE, activeRuns: 1 })
+test('autoPmDecision leaves a project at its concurrency cap alone (#685/#1204)', () => {
+  // Live runs are already spending the quota; one more started unasked would race them. Before
+  // #1204 the cap was hardwired at one, which is what `concurrency: 1` still asks for here.
+  const decision = autoPmDecision({ ...IDLE, activeRuns: 1, concurrency: 1 })
   assert.equal(decision.start, false)
   assert.match(decision.start === false ? decision.reason : '', /already going/)
+})
+
+test('autoPmDecision tops a project up to its concurrency (#1204)', () => {
+  // The point of the setting: one run going is no longer a reason to stand down.
+  assert.deepEqual(autoPmDecision({ ...IDLE, activeRuns: 1, concurrency: 2 }), { start: true, mode: 'pm' })
+  // At the cap it refuses, and the refusal names the cap so a raised setting does not read as a bug.
+  const capped = autoPmDecision({ ...IDLE, activeRuns: 2, concurrency: 2 })
+  assert.equal(capped.start, false)
+  assert.match(capped.start === false ? capped.reason : '', /at most 2 at once/)
+})
+
+test('autoPmDecision defaults to the shipped concurrency, and floors it at one (#1204)', () => {
+  // Unset means the default, not one: the absence of the setting has never meant "less".
+  assert.equal(autoPmDecision({ ...IDLE, activeRuns: DEFAULT_AUTO_PM_CONCURRENCY - 1 }).start, true)
+  assert.equal(autoPmDecision({ ...IDLE, activeRuns: DEFAULT_AUTO_PM_CONCURRENCY }).start, false)
+  // Zero agents is what the master switch spells, so a hand-edited nought cannot wedge the routine.
+  assert.equal(autoPmDecision({ ...IDLE, activeRuns: 0, concurrency: 0 }).start, true)
+  assert.equal(autoPmDecision({ ...IDLE, activeRuns: 1, concurrency: 0 }).start, false)
 })
 
 test('autoPmDecision drains the queue before filling it again (#855)', () => {
@@ -134,7 +153,10 @@ function harness(overrides: Partial<AutoPmDeps> = {}) {
     projects: async () => [project],
     jobs: JOBS,
     enabled: async () => true,
-    backlogEmpty: async () => true,
+    queue: async () => [],
+    // Pinned at one so every test written before #1204 keeps asserting against the behaviour it
+    // was written for; the fan-out tests set it explicitly.
+    concurrency: async () => 1,
     activeRuns: () => 0,
     quota: async () => status(1),
     start: async (p, job) => {
@@ -209,7 +231,7 @@ test('startAutoPm re-arms when the start was refused (#685)', async () => {
 
 test('startAutoPm survives a project whose backlog cannot be read (#685)', async () => {
   // An unreadable queue is not an empty one: it must not trigger a run, nor throw the sweep.
-  const { loop, started } = harness({ backlogEmpty: async () => Promise.reject(new Error('nope')) })
+  const { loop, started } = harness({ queue: async () => Promise.reject(new Error('nope')) })
   await loop.tick()
   loop.stop()
   assert.deepEqual(started, [])
@@ -274,7 +296,7 @@ test('a promoted queue ends the tick, so the sweep re-reads it next time (#852)'
   const promoted: string[] = []
   const { loop, ran } = harness({
     cooldownMs: 0,
-    promote: async (_p, runId) => {
+    promote: async (_p, { runId }) => {
       promoted.push(runId)
       return { settled: true, promoted: true }
     },
@@ -291,7 +313,7 @@ test('a finished run that wrote no queue stops being retried (#852)', async () =
   const asked: string[] = []
   const { loop, ran } = harness({
     cooldownMs: 0,
-    promote: async (_p, runId) => {
+    promote: async (_p, { runId }) => {
       asked.push(runId)
       return { settled: true, promoted: false }
     },
@@ -323,7 +345,7 @@ test('startAutoPm drains a standing queue, then goes back to filling it (#855)',
   const ran: string[] = []
   const { loop } = harness({
     cooldownMs: 0,
-    backlogEmpty: async () => open === 0,
+    queue: async () => Array.from({ length: open }, (_, i) => `entry ${i + 1}`),
     // A drain run works one entry off; a PM run puts one there.
     start: async (_project, job) => {
       ran.push(job.name)
@@ -345,7 +367,7 @@ test('draining does not advance the PM rotation (#855)', async () => {
   const ran: string[] = []
   const { loop } = harness({
     cooldownMs: 0,
-    backlogEmpty: async () => open === 0,
+    queue: async () => Array.from({ length: open }, (_, i) => `entry ${i + 1}`),
     start: async (_project, job) => {
       ran.push(job.name)
       open += job.name === AUTO_PM_DRAIN_JOB.name ? -1 : 1
@@ -363,7 +385,7 @@ test('an unreadable queue starts nothing at all (#855)', async () => {
   const ran: string[] = []
   const { loop } = harness({
     cooldownMs: 0,
-    backlogEmpty: async () => {
+    queue: async () => {
       throw new Error('no such file')
     },
     start: async (_project, job) => {
@@ -434,7 +456,7 @@ test('a sweep is stamped only when the run actually started (#882)', async () =>
 
 test('a queue with work in it is drained rather than swept (#882)', async () => {
   // A repo with entries waiting has plenty to do; sweeping would only pile more on.
-  const { loop, ran } = harness({ cooldownMs: 0, backlogEmpty: async () => false, maintenanceDue: async () => true })
+  const { loop, ran } = harness({ cooldownMs: 0, queue: async () => ['entry a'], maintenanceDue: async () => true })
   await loop.tick()
   loop.stop()
   assert.deepEqual(ran, [AUTO_PM_DRAIN_JOB.name])
@@ -453,9 +475,9 @@ test('a sweep stopped mid-flight starts nothing (#983)', async () => {
   const h = harness({
     projects: async () => both,
     // The daemon shutting down while the sweep sits between its readings and the spawn.
-    backlogEmpty: async () => {
+    queue: async () => {
       loop.stop()
-      return true
+      return []
     },
   })
   loop = h.loop
@@ -595,7 +617,7 @@ test('an unticked drain routine stands the sweep down, it does not fall through 
   // is the opposite of what the checkbox asked for.
   const { loop, ran, logs } = harness({
     cooldownMs: 0,
-    backlogEmpty: async () => false,
+    queue: async () => ['entry a'],
     optedOut: async () => [AUTO_PM_DRAIN_JOB.name],
   })
   await loop.tick()
@@ -645,4 +667,123 @@ test('an unreadable opt-out list means none, never all (#1209)', async () => {
   await loop.tick()
   loop.stop()
   assert.deepEqual(ran, ['first'])
+})
+
+// #1204: the routine keeps several agents going at once. Only draining fans out — it is the one
+// routine that takes work *off* the queue, one entry per agent, so a batch of them does disjoint
+// work and lands disjoint edits.
+
+test('a standing queue fans out to the concurrency in one tick, one entry per agent (#1204)', async () => {
+  // The demo the issue asks for: one sweep, several sessions, each on its own entry. Fanning out
+  // over successive ticks instead would take a cooldown per agent.
+  const prompts: string[] = []
+  const { loop } = harness({
+    cooldownMs: 0,
+    concurrency: async () => 3,
+    queue: async () => ['entry a', 'entry b', 'entry c', 'entry d'],
+    start: async (_p, job) => {
+      prompts.push(job.prompt)
+      return `run-${prompts.length}`
+    },
+  })
+  await loop.tick()
+  loop.stop()
+  assert.equal(prompts.length, 3, 'the batch stops at the concurrency, not at the queue length')
+  // Pinned, and pinned to *different* entries: unpinned they would all fork the same checkout and
+  // read the same first entry.
+  assert.match(prompts[0]!, /entry a/)
+  assert.match(prompts[1]!, /entry b/)
+  assert.match(prompts[2]!, /entry c/)
+  assert.equal(new Set(prompts).size, 3)
+})
+
+test('an entry a live run was pinned to is not handed out twice (#1204)', async () => {
+  // The assignment outlives the tick that made it: the first run is still working entry a when
+  // the next sweep comes round, and its queue has not landed yet, so the checkout still shows the
+  // entry open. Handing it out again is exactly the duplicate work pinning exists to prevent.
+  const prompts: string[] = []
+  const { loop } = harness({
+    cooldownMs: 0,
+    concurrency: async () => 1,
+    queue: async () => ['entry a', 'entry b'],
+    promote: async () => ({ settled: false, promoted: false }), // still in flight
+    start: async (_p, job) => {
+      prompts.push(job.prompt)
+      return `run-${prompts.length}`
+    },
+  })
+  await loop.tick()
+  await loop.tick()
+  loop.stop()
+  assert.equal(prompts.length, 2)
+  assert.match(prompts[0]!, /entry a/)
+  assert.match(prompts[1]!, /entry b/)
+})
+
+test('a queue whose every entry is already being worked stands the sweep down (#1204)', async () => {
+  // With nothing left to assign, the sweep says so rather than starting a run with no entry to
+  // pin it to — which is what would send a second agent at work already in flight.
+  const { loop, started } = harness({
+    cooldownMs: 0,
+    concurrency: async () => 4,
+    queue: async () => ['entry a'],
+    promote: async () => ({ settled: false, promoted: false }),
+  })
+  await loop.tick()
+  await loop.tick()
+  loop.stop()
+  assert.equal(started.length, 1)
+  assert.equal(loop.report().outcomes[0]?.message, 'every open queue entry is already being worked on')
+})
+
+test('live runs count against the concurrency, so the sweep tops up rather than doubling (#1204)', async () => {
+  // Two already going under a cap of three leaves room for exactly one more.
+  const { loop, started } = harness({
+    cooldownMs: 0,
+    concurrency: async () => 3,
+    activeRuns: () => 2,
+    queue: async () => ['entry a', 'entry b', 'entry c'],
+  })
+  await loop.tick()
+  loop.stop()
+  assert.equal(started.length, 1)
+})
+
+test('the rotation stays one run per tick however high the concurrency (#1204)', async () => {
+  // Deliberate: every rotation job rewrites the whole queue file from the same fork point, so two
+  // at once would have the later promotion revert the earlier one's entries. Only draining, which
+  // takes one named entry off, is safe to run several of at a time.
+  const { loop, ran } = harness({ cooldownMs: 0, concurrency: async () => 5, queue: async () => [] })
+  await loop.tick()
+  loop.stop()
+  assert.deepEqual(ran, ['first'])
+})
+
+test('an unreadable concurrency falls back to the default rather than to one (#1204)', async () => {
+  // Same polarity as the opt-out list: one bad read must not quietly shrink the routine.
+  const { loop, started } = harness({
+    cooldownMs: 0,
+    concurrency: async () => Promise.reject(new Error('no registry')),
+    queue: async () => ['entry a', 'entry b', 'entry c'],
+  })
+  await loop.tick()
+  loop.stop()
+  assert.equal(started.length, DEFAULT_AUTO_PM_CONCURRENCY)
+})
+
+test('a refusal ends the batch, so the refused work is retried rather than skipped (#1204)', async () => {
+  // Whatever refused this start is not going to take the next one a moment later.
+  let attempts = 0
+  const { loop } = harness({
+    cooldownMs: 0,
+    concurrency: async () => 4,
+    queue: async () => ['entry a', 'entry b', 'entry c', 'entry d'],
+    start: async () => {
+      attempts++
+      return attempts === 1 ? 'run-1' : undefined
+    },
+  })
+  await loop.tick()
+  loop.stop()
+  assert.equal(attempts, 2, 'one start took, the second was refused, and the batch stopped there')
 })

--- a/packages/the-framework/src/auto-pm.ts
+++ b/packages/the-framework/src/auto-pm.ts
@@ -1,5 +1,6 @@
 import type { QuotaBoundaryStatus } from './quota-boundary.js'
 import { presets } from './preset-catalog.js'
+import { DEFAULT_AUTO_PM_CONCURRENCY } from './preference-defaults.js'
 
 /**
  * Auto PM (#685): spend leftover subscription quota on product management instead of
@@ -34,8 +35,14 @@ export interface AutoPmInputs {
    * since #855 both answers now *start* something and only "we could not tell" does not.
    */
   backlogEmpty: boolean | undefined
-  /** Live runs on this project. Any run at all means the user's quota is already being spent. */
+  /** Live runs on this project, measured against {@link AutoPmInputs.concurrency}. */
   activeRuns: number
+  /**
+   * How many agents the routine may keep going on this project at once (#1204);
+   * {@link DEFAULT_AUTO_PM_CONCURRENCY} when unset. Floored at one, because zero concurrent
+   * agents is what `enabled: false` already spells.
+   */
+  concurrency?: number
   /** Where the account stands against its quota boundary, or `undefined` when it could not be read. */
   quota: QuotaBoundaryStatus | undefined
   /** Milliseconds since this project was last auto-started, or `undefined` if it never was. */
@@ -104,8 +111,13 @@ export function quotaHeadroom(quota: QuotaBoundaryStatus | undefined): QuotaDeci
  */
 export function autoPmDecision(input: AutoPmInputs): AutoPmDecision {
   if (!input.enabled) return { start: false, reason: 'auto PM is off' }
-  if (input.activeRuns > 0) {
-    return { start: false, reason: `${input.activeRuns} run${input.activeRuns === 1 ? ' is' : 's are'} already going` }
+  const concurrency = Math.max(1, Math.floor(input.concurrency ?? DEFAULT_AUTO_PM_CONCURRENCY))
+  if (input.activeRuns >= concurrency) {
+    // The cap is named, for the same reason the quota refusal names its line (#960): with the
+    // setting raised or lowered, "already going" on its own reads as a bug rather than a setting.
+    // At one — what this was before #1204 — the old wording is kept exactly.
+    const going = `${input.activeRuns} run${input.activeRuns === 1 ? ' is' : 's are'} already going`
+    return { start: false, reason: concurrency === 1 ? going : `${going}, and the routine keeps at most ${concurrency} at once` }
   }
   const cooldownMs = input.cooldownMs ?? DEFAULT_AUTO_PM_COOLDOWN_MS
   if (input.sinceLastStartMs !== undefined && input.sinceLastStartMs < cooldownMs) {
@@ -156,6 +168,45 @@ export interface AutoPmJob {
    * call site, so the job says what it does and a rename cannot quietly unhook it.
    */
   drains?: boolean
+  /**
+   * The one queue entry a {@link AutoPmJob.drains} job is pinned to (#1204). Set only on the
+   * per-start variants {@link pinnedDrainJob} builds: the catalog's own drain job carries none,
+   * since which entry is next is known only at the moment the sweep starts one.
+   */
+  entry?: string
+}
+
+/**
+ * A drain job pinned to one named queue entry (#1204).
+ *
+ * With a single agent the stock prompt ("the FIRST open entry") is exact. With several going at
+ * once it is a collision: every drain forks the same checkout, so every one of them reads the same
+ * first entry and implements it as many times over. Naming the entry is what makes a batch of
+ * drains work on disjoint things.
+ *
+ * The prompt also tells the agent to stop when the entry is already checked off or gone: the
+ * assignment is a snapshot, and a human may retire the entry between the sweep's read and the
+ * run's own.
+ */
+export function pinnedDrainJob(job: AutoPmJob, entry: string): AutoPmJob {
+  return {
+    ...job,
+    entry,
+    prompt: [
+      'Open TODO_AGENTS.md and work on this one open entry only, then check it off:',
+      '',
+      `- ${entry}`,
+      '',
+      'Do not start any other entry. If that entry is already checked off or no longer there, stop and do nothing.',
+    ].join('\n'),
+    describe: `draining the queue entry "${entryPreview(entry)}"`,
+  }
+}
+
+/** An entry as a log line can carry it: one line, bounded. */
+function entryPreview(entry: string): string {
+  const flat = entry.replace(/\s+/g, ' ').trim()
+  return flat.length > 80 ? `${flat.slice(0, 80)}…` : flat
 }
 
 /**
@@ -277,10 +328,22 @@ export interface AutoPmDeps {
    * a preference that cannot be read must not silently switch the whole rotation off.
    */
   optedOut?(): Promise<readonly string[]>
-  /** Whether a project's agent queue has run dry. */
-  backlogEmpty(project: AutoPmProject): Promise<boolean>
+  /**
+   * The open entries of a project's agent queue, in file order. Empty = the queue has run dry, and
+   * a rejection = it could not be read, which fails closed exactly as the old boolean did (#855).
+   * The entries themselves rather than just emptiness, because a batch of drains is pinned one
+   * entry each (#1204) and the assignment has to come from the read the decision was made on.
+   */
+  queue(project: AutoPmProject): Promise<readonly string[]>
   /** How many runs are live on a project. */
   activeRuns(project: AutoPmProject): number
+  /**
+   * How many agents the routine may keep going per project (#1204). Re-read per tick like
+   * {@link AutoPmDeps.enabled}, so the setting takes effect without a restart. Unset or unreadable
+   * falls back to {@link DEFAULT_AUTO_PM_CONCURRENCY} rather than to one: the absence of the
+   * setting has never meant "less".
+   */
+  concurrency?(): Promise<number | undefined>
   /** Where the account stands against its boundary, or `undefined` when there is no reading. */
   quota(): Promise<QuotaBoundaryStatus | undefined>
   /** The jobs to rotate through, in cycle order. Used only while the queue is empty. */
@@ -305,7 +368,7 @@ export interface AutoPmDeps {
    * anything: a run's queue lives on its own worktree branch, so until it is promoted the checkout
    * still reads empty and the sweep would start the same work over again.
    */
-  promote(project: AutoPmProject, runId: string): Promise<PromoteOutcome>
+  promote(project: AutoPmProject, run: { runId: string; entry?: string }): Promise<PromoteOutcome>
   /** Progress line. */
   log(message: string): void
   /** Override the tick interval. */
@@ -388,8 +451,10 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
   // start-up sweep below lands.
   let lastSweep: { enabled: boolean; sweptAt: number; outcomes: AutoPmOutcome[] } | undefined
   const lastStart = new Map<string, number>()
-  // Runs this loop started whose queue has not reached the checkout yet, oldest first.
-  const pending = new Map<string, string[]>()
+  // Runs this loop started whose queue has not reached the checkout yet, oldest first. A drain
+  // remembers the entry it was pinned to (#1204), so while it is still in flight a later tick
+  // does not hand the same entry to a second agent.
+  const pending = new Map<string, { runId: string; entry?: string }[]>()
   // Where each project is in the job cycle. Per project, not global: two repos idle at once
   // should each work through the rotation, not take alternate halves of it.
   const nextJob = new Map<string, number>()
@@ -424,17 +489,24 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
       // One reading for the whole sweep: it is an account-wide meter, and re-reading it per
       // project would spend a rate-limited call to learn the same number.
       const quota = await deps.quota().catch(() => undefined)
+      // How many agents each project may keep going (#1204). Read beside the opt-outs and for the
+      // same reason: it is the same preference file, re-read so the setting takes effect
+      // mid-schedule. Floored at one, since zero agents is the master switch's job.
+      const concurrency = Math.max(
+        1,
+        Math.floor((await deps.concurrency?.().catch(() => undefined)) ?? DEFAULT_AUTO_PM_CONCURRENCY),
+      )
       for (const project of projects) {
         // Land anything a previous run produced before judging whether the queue is empty:
         // its entries are still on that run's branch, and the checkout cannot see them.
         const outstanding = pending.get(project.id) ?? []
         if (outstanding.length) {
-          const stillPending: string[] = []
+          const stillPending: { runId: string; entry?: string }[] = []
           let landed = 0
-          for (const runId of outstanding) {
-            const outcome = await deps.promote(project, runId).catch(() => ({ settled: false, promoted: false }))
+          for (const run of outstanding) {
+            const outcome = await deps.promote(project, run).catch(() => ({ settled: false, promoted: false }))
             if (outcome.promoted) landed++
-            if (!outcome.settled) stillPending.push(runId)
+            if (!outcome.settled) stillPending.push(run)
           }
           if (stillPending.length) pending.set(project.id, stillPending)
           else pending.delete(project.id)
@@ -446,11 +518,14 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
             continue
           }
         }
+        const entries = await deps.queue(project).catch(() => undefined)
+        const activeRuns = deps.activeRuns(project)
         const since = lastStart.get(project.id)
         const decision = autoPmDecision({
           enabled: true,
-          backlogEmpty: await deps.backlogEmpty(project).catch(() => undefined),
-          activeRuns: deps.activeRuns(project),
+          backlogEmpty: entries === undefined ? undefined : entries.length === 0,
+          activeRuns,
+          concurrency,
           quota,
           ...(since !== undefined ? { sinceLastStartMs: now() - since } : {}),
           ...(deps.cooldownMs !== undefined ? { cooldownMs: deps.cooldownMs } : {}),
@@ -493,16 +568,54 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
           )
           continue
         }
+        // What to start this tick (#1204). Only draining fans out, and the reason is what each
+        // mode does to the queue file: a drain takes one entry *off* it, so several agents pinned
+        // to different entries do disjoint work and land disjoint edits. Every other job puts
+        // entries *on* it, so two at once would each rewrite the whole file from the same fork
+        // point and the second promotion would revert the first. One per tick keeps that honest;
+        // fanning the rotation out needs the queue to stop being a single whole-file document,
+        // which is its own piece of work.
+        const batch: AutoPmJob[] = [job]
+        if (decision.mode === 'drain') {
+          // An entry a run still in flight was pinned to is not offered again.
+          const assigned = new Set(
+            (pending.get(project.id) ?? []).flatMap(run => (run.entry !== undefined ? [run.entry] : [])),
+          )
+          const open = (entries ?? []).filter(entry => !assigned.has(entry))
+          if (!open.length) {
+            note(project, false, 'every open queue entry is already being worked on')
+            continue
+          }
+          batch.length = 0
+          batch.push(...open.slice(0, concurrency - activeRuns).map(entry => pinnedDrainJob(job, entry)))
+        }
         // Re-checked here because everything above is awaited: a run spawned past a `stop()` is
         // missing from the live-run map the daemon has by then cleared, so nothing suspends or
         // terminates it (#983). Break, not continue: stopping is a verdict on the whole sweep.
         if (stopped) break
-        // Armed before the spawn, not after: starting is slow, and a tick that overlapped the
-        // spawn would otherwise see no live run yet and start a second one.
+        // Armed before the first spawn and once for the whole batch: starting is slow, and a tick
+        // that overlapped the spawns would otherwise see too few live runs and top up past the cap.
         lastStart.set(project.id, now())
-        deps.log(`[framework] auto PM: ${doing(job)} in ${project.path}`)
-        const runId = await deps.start(project, job).catch(() => undefined)
-        if (runId) {
+        const started: AutoPmJob[] = []
+        for (const item of batch) {
+          // Re-checked per spawn, for the #983 reason above: a stop mid-batch must not spawn the rest.
+          if (stopped) break
+          deps.log(`[framework] auto PM: ${doing(item)} in ${project.path}`)
+          const runId = await deps.start(project, item).catch(() => undefined)
+          if (!runId) {
+            // The batch ends at the first refusal: whatever refused this start is not going to take
+            // the next one a moment later, and a refused job must be retried rather than skipped.
+            deps.log(`[framework] auto PM: could not start a run in ${project.path}`)
+            break
+          }
+          started.push(item)
+          // Its queue lives on the run's branch until a later tick promotes it.
+          pending.set(project.id, [
+            ...(pending.get(project.id) ?? []),
+            { runId, ...(item.entry !== undefined ? { entry: item.entry } : {}) },
+          ])
+        }
+        if (started.length) {
           // Advanced only on a start that took, so a refused job is retried rather than skipped.
           // Draining does not advance it: it is not part of the cycle, and a queue worked off
           // over several ticks must not skip the rotation forward once per entry.
@@ -513,12 +626,14 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
           // daemon refused should be retried next tick, not postponed a whole interval.
           if (sweep) await deps.recordMaintenance?.(project).catch(() => {})
           else if (decision.mode === 'pm') nextJob.set(project.id, index + 1)
-          // Its queue lives on the run's branch until a later tick promotes it.
-          pending.set(project.id, [...(pending.get(project.id) ?? []), runId])
-          note(project, true, doing(job))
-        } else {
+          // One line per project however many agents went out, and a single start keeps the old
+          // wording exactly.
+          const described = started.map(item => doing(item)).join('; ')
+          note(project, true, started.length === 1 ? described : `started ${started.length} agents: ${described}`)
+        } else if (!stopped) {
+          // Nothing took, so the cooldown armed above is given back: a batch that started nothing
+          // spent nothing, and holding it would strand the project for a whole cooldown.
           lastStart.delete(project.id)
-          deps.log(`[framework] auto PM: could not start a run in ${project.path}`)
           note(project, false, 'the daemon could not start a run')
         }
       }

--- a/packages/the-framework/src/client.ts
+++ b/packages/the-framework/src/client.ts
@@ -47,7 +47,7 @@ export { AUTO_PM_ROUTINES, AUTO_PM_JOBS, AUTO_PM_DRAIN_JOB, AUTO_PM_MAINTENANCE_
 // The identity + diff both notifier paths run, and the preference defaults both sides read (#627).
 // Pure, so the dashboard shares them rather than keeping copies that drift silently.
 export { interventionKey, pickNewInterventions, activityKey, pickNewActivity } from './dashboard/keys.js'
-export { PROJECT_PREFERENCE_KEYS, NOTIFICATION_DEFAULTS, MAX_SPEND_OFFSET, DEFAULT_SPEND_OFFSET, notificationEnabled, discordNotificationEnabled, type ProjectPreferences } from './preference-defaults.js'
+export { PROJECT_PREFERENCE_KEYS, NOTIFICATION_DEFAULTS, MAX_SPEND_OFFSET, DEFAULT_SPEND_OFFSET, DEFAULT_AUTO_PM_CONCURRENCY, MAX_AUTO_PM_CONCURRENCY, notificationEnabled, discordNotificationEnabled, type ProjectPreferences } from './preference-defaults.js'
 // The preferences -> run options mapping (#858), shared with the daemon so an unattended run
 // starts with the same settings a launcher-started one would. Pure field logic, no Node imports.
 export { runOptionsFromPreferences, autopilotEnabled, handoffFromPreferences, preferencesFromFileConfig } from './run-options.js'

--- a/packages/the-framework/src/daemon-services.ts
+++ b/packages/the-framework/src/daemon-services.ts
@@ -12,7 +12,7 @@ import { buildActivity, activityKey, postActivityDiscord } from './dashboard/act
 import { startAutoPm, AUTO_PM_JOBS, type AutoPmReport } from './auto-pm.js'
 import { maintenanceDue, readMaintenanceState, mergeMaintenanceState } from './maintenance.js'
 import { promoteQueue } from './queue-promote.js'
-import { findTodoBacklog, nextQueuedTicket } from './todo-loop.js'
+import { findTodoBacklog, nextQueuedTicket, ticketFromQueueEntry } from './todo-loop.js'
 import { startConversationCommitter } from './conversation-commit.js'
 import { startMergedWorktreeSweep } from './merged-worktrees.js'
 import { readConversation } from './conversations.js'
@@ -137,8 +137,13 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
     // Which routines the user unticked (#1209). Global rather than per project, like the master
     // switch it sits under: the rotation is one schedule for the machine, not one per repo.
     optedOut: async () => (await prefs()).autoPmOptOut ?? [],
-    backlogEmpty: async project => (await findTodoBacklog(project.path)) === undefined,
+    // The queue's open entries rather than a bare emptiness bit: a batch of concurrent drains is
+    // pinned one entry each (#1204), so the sweep needs the entries the decision was made on.
+    queue: async project => (await findTodoBacklog(project.path))?.entries ?? [],
     activeRuns: project => deps.activeRunCount(project.id),
+    // How many agents the routine may keep going per project (#1204). Global like the opt-outs;
+    // the sweep applies the default when it is unset.
+    concurrency: async () => (await prefs()).autoPmConcurrency,
     // The quota boundary is the gate (#879): auto PM has no budget notion of its own.
     quota: async () => (await deps.quota.read()).boundary,
     // The periodic codebase sweep (#882). The schedule is a file in the project checkout rather
@@ -147,21 +152,29 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
     maintenanceDue: async project => maintenanceDue(await readMaintenanceState(project.path), Date.now()),
     recordMaintenance: async project => mergeMaintenanceState(project.path, { sweptAt: new Date().toISOString() }),
     start: async (project, job) => {
-      // A draining run works the queue's first open entry, and since #1164 that entry links back to
-      // the ticket it was queued from — so this is the one moment the framework knows what a run is
-      // about to implement, and can say so on the run's meta (#1117). Every other job puts work on
-      // the queue rather than taking it off, so there is nothing to name.
-      const ticket = job.drains ? await nextQueuedTicket(project.path).catch(() => undefined) : undefined
+      // A draining run works one open queue entry, and since #1164 that entry links back to the
+      // ticket it was queued from — so this is the one moment the framework knows what a run is
+      // about to implement, and can say so on the run's meta (#1117). A sweep-built drain names its
+      // own pinned entry (#1204), so the #1117 lane keeps working with several drains in flight;
+      // the first-open-entry read is the fallback for a drain job wired without one. Every other
+      // job puts work on the queue rather than taking it off, so there is nothing to name.
+      const ticket = job.drains
+        ? job.entry !== undefined
+          ? ticketFromQueueEntry(job.entry)
+          : await nextQueuedTicket(project.path).catch(() => undefined)
+        : undefined
       const result = await startUnattended(project.id, job.prompt, ticket ? { ticket } : {})
       return result.ok ? result.runId : undefined
     },
     // The daemon promotes the queue, never the agent (#852): the run stays sandboxed in its
     // worktree, and one known file is copied across once it has finished cleanly.
-    promote: async (project, runId) => {
+    promote: async (project, { runId, entry }) => {
       const run = (await listRuns(project.path).catch(() => [])).find(r => r.id === runId)
       // Unknown or still going: not settled, so it is tried again next tick.
       if (!run || run.status === 'running') return { settled: false, promoted: false }
-      const outcome = await promoteQueue(project.path, run)
+      // The entry it was pinned to travels with it (#1204), so the promotion lands that one entry
+      // rather than the run's whole view of the queue.
+      const outcome = await promoteQueue(project.path, { ...run, ...(entry !== undefined ? { entry } : {}) })
       if (!outcome.promoted) log(`[framework] auto PM: ${outcome.reason} (${runId})`)
       // A finished run is settled either way — one that wrote no queue is not going to start.
       // The exception (a checkout busy with the user's own queue edits) is the callee's to flag.

--- a/packages/the-framework/src/preference-defaults.ts
+++ b/packages/the-framework/src/preference-defaults.ts
@@ -108,3 +108,19 @@ export const MAX_SPEND_OFFSET = 50
  * cushion gives it room to breathe without meaningfully loosening the #879 policy.
  */
 export const DEFAULT_SPEND_OFFSET = 100 / (7 * 2)
+
+/**
+ * How many agents the routine keeps going at once when `autoPmConcurrency` is unset (#1204).
+ *
+ * Two, not one: the point of the setting is that the routine may overlap work, and a default of
+ * one would leave the feature invisible until someone finds the control. Two is the smallest
+ * number that shows it while staying conservative about quota.
+ */
+export const DEFAULT_AUTO_PM_CONCURRENCY = 2
+
+/**
+ * The most agents the routine may be asked to keep going at once (#1204). Like
+ * {@link MAX_SPEND_OFFSET}, the control that writes the value is in the browser and the sanitizer
+ * that clamps it is in the daemon, so the bound has to be one number both can import.
+ */
+export const MAX_AUTO_PM_CONCURRENCY = 10

--- a/packages/the-framework/src/queue-promote.test.ts
+++ b/packages/the-framework/src/queue-promote.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { promoteQueue } from './queue-promote.js'
+import { promoteQueue, landPinnedEntry } from './queue-promote.js'
 import type { GitRunner } from './project.js'
 
 // Pins the retry contract auto PM acts on: the callee flags the one retryable skip, so the
@@ -29,4 +29,97 @@ test('a run with no branch, or no queue file on it, is a final skip (no retry fl
   const noFile = await promoteQueue('/repo', { id: 'r1', branch: 'work' }, git)
   assert.equal(noFile.promoted, false)
   assert.ok(!('retry' in noFile && noFile.retry), 'no queue file is final')
+})
+
+// #1204: a drain pinned to one entry lands that entry, not its whole view of the queue. The
+// property that matters is that it is additive — it only ever ticks a box or appends a line — so
+// two drains landing in either order compose instead of reverting each other.
+
+const BASE = ['## Priority 7', '', '- [ ] entry a', '- [ ] entry b', ''].join('\n')
+
+test('landPinnedEntry retires its own entry and leaves the rest alone (#1204)', () => {
+  const out = landPinnedEntry(BASE, BASE, 'entry a', BASE)
+  assert.match(out, /- \[x\] entry a/)
+  assert.match(out, /- \[ \] entry b/)
+  assert.match(out, /## Priority 7/)
+})
+
+test('two concurrent drains compose whichever order they land in (#1204)', () => {
+  // The bug this exists for: run A retires entry a, run B forked before that and still shows it
+  // open. A wholesale copy of B's file would un-check entry a and send an agent to redo it.
+  const afterA = landPinnedEntry(BASE, BASE, 'entry a', BASE)
+  const afterBoth = landPinnedEntry(afterA, BASE, 'entry b', BASE)
+  assert.match(afterBoth, /- \[x\] entry a/, "the earlier run's check-off survives")
+  assert.match(afterBoth, /- \[x\] entry b/)
+})
+
+test('landPinnedEntry never resurrects an entry another run already retired (#1204)', () => {
+  // The run's branch still shows entry a open, because it forked before the other run landed.
+  // Absence, not openness, is what marks a follow-up, so the stale open line is not re-added.
+  const checkout = ['- [x] entry a', '- [ ] entry b', ''].join('\n')
+  const out = landPinnedEntry(checkout, BASE, 'entry b', BASE)
+  assert.equal(out.match(/entry a/g)?.length, 1)
+  assert.match(out, /- \[x\] entry a/)
+})
+
+test('landPinnedEntry keeps the follow-ups the run queued (#1204)', () => {
+  const branch = [BASE, '- [ ] a follow-up the run found', ''].join('\n')
+  const out = landPinnedEntry(BASE, branch, 'entry a', BASE)
+  assert.match(out, /- \[x\] entry a/)
+  assert.match(out, /- \[ \] a follow-up the run found/)
+})
+
+test('landPinnedEntry leaves prose and an already-retired entry untouched (#1204)', () => {
+  const checkout = ['# The queue', '', 'Some prose about it.', '', '- [x] entry a', ''].join('\n')
+  assert.equal(landPinnedEntry(checkout, checkout, 'entry a', checkout), checkout)
+  // An entry that is simply not there is not invented either.
+  assert.equal(landPinnedEntry(checkout, checkout, 'never queued', checkout), checkout)
+})
+
+test('a pinned run lands only its entry, and commits just the queue file (#1204)', async () => {
+  const calls: string[][] = []
+  const written: string[] = []
+  const git: GitRunner = async args => {
+    calls.push(args)
+    if (args[0] === 'merge-base') return 'abc123\n'
+    if (args[0] === 'show' && String(args[1]).startsWith('work:')) return BASE
+    if (args[0] === 'show' && String(args[1]).startsWith('abc123:')) return BASE
+    if (args[0] === 'show') return ['## Priority 7', '', '- [ ] entry a', '- [x] entry b', ''].join('\n')
+    if (args[0] === 'status') return ''
+    return ''
+  }
+  const outcome = await promoteQueue('/repo', { id: 'r1', branch: 'work', entry: 'entry a' }, git, async (_p, c) => {
+    written.push(c)
+  })
+  assert.deepEqual(outcome, { promoted: true, branch: 'work' })
+  // The other run's retired entry b is still retired: the run's own stale copy did not land.
+  assert.match(written[0]!, /- \[x\] entry a/)
+  assert.match(written[0]!, /- \[x\] entry b/)
+  assert.ok(!calls.some(args => args[0] === 'checkout'), 'a pinned run does not copy the branch file wholesale')
+  assert.ok(calls.some(args => args[0] === 'commit' && args.includes('TODO_AGENTS.md')))
+})
+
+test('a pinned run whose entry is already retired lands nothing (#1204)', async () => {
+  // Someone struck it off while the run worked. There is nothing left to do, and nothing on the
+  // branch that the fork point did not already have, so no empty commit is written.
+  const done = ['## Priority 7', '', '- [x] entry a', '- [ ] entry b', ''].join('\n')
+  const git: GitRunner = async args => {
+    if (args[0] === 'merge-base') return 'abc123\n'
+    if (args[0] === 'show' && String(args[1]).startsWith('work:')) return BASE
+    if (args[0] === 'show' && String(args[1]).startsWith('abc123:')) return BASE
+    if (args[0] === 'show') return done
+    if (args[0] === 'status') return ''
+    return ''
+  }
+  const outcome = await promoteQueue('/repo', { id: 'r1', branch: 'work', entry: 'entry a' }, git, async () => {})
+  assert.equal(outcome.promoted, false)
+})
+
+test('an entry removed by hand while the run worked is not resurrected (#1204)', () => {
+  // `todo_format.md` makes removal the ordinary way to retire an entry, so "on the branch, absent
+  // here" cannot mean "the run added it". Without the fork point this re-queued struck-off work.
+  const checkout = ['## Priority 7', '', '- [ ] entry a', ''].join('\n')
+  const out = landPinnedEntry(checkout, BASE, 'entry a', BASE)
+  assert.doesNotMatch(out, /entry b/)
+  assert.match(out, /- \[x\] entry a/)
 })

--- a/packages/the-framework/src/queue-promote.ts
+++ b/packages/the-framework/src/queue-promote.ts
@@ -1,3 +1,5 @@
+import { writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
 import type { GitRunner } from './project.js'
 import { nodeGitRunner } from './project.js'
 import { FLAT_TODO_FILE } from './tickets.js'
@@ -58,8 +60,9 @@ export function promotionMessage(runId: string): string {
  */
 export async function promoteQueue(
   projectCwd: string,
-  run: { id: string; branch?: string | undefined },
+  run: { id: string; branch?: string | undefined; entry?: string | undefined },
   git: GitRunner = nodeGitRunner(),
+  write: (path: string, content: string) => Promise<void> = (path, content) => writeFile(path, content, 'utf8'),
 ): Promise<QueuePromotion> {
   const branch = run.branch
   if (!branch) return { promoted: false, reason: 'the run recorded no branch' }
@@ -77,6 +80,27 @@ export async function promoteQueue(
     const dirty = (await git(['status', '--porcelain', '--', FLAT_TODO_FILE], projectCwd)).trim()
     if (dirty) return { promoted: false, reason: 'the checkout has uncommitted queue changes', retry: true }
 
+    // A run pinned to one entry (#1204) lands that entry, not its whole file: with several drains
+    // in flight the wholesale copy below would carry each run's stale view of every *other* entry,
+    // and the last promotion of the tick would un-check whatever the earlier ones had just retired.
+    if (run.entry !== undefined) {
+      // The queue where the run forked, so an entry it *added* can be told from one somebody
+      // *removed* while it worked. Both look alike from the branch alone — present there, absent
+      // here — and `todo_format.md` makes removal the way to retire an entry, so guessing wrong
+      // resurrects work a human deliberately struck off. No merge base (a rewritten history, say)
+      // means no additions land: the check-off is the part that must not be lost.
+      const mergeBase = (await git(['merge-base', branch, 'HEAD'], projectCwd).catch(() => '')).trim()
+      const atBase = mergeBase
+        ? await git(['show', `${mergeBase}:${FLAT_TODO_FILE}`], projectCwd).catch(() => undefined)
+        : undefined
+      const landed = landPinnedEntry(inCheckout, fromBranch, run.entry, atBase)
+      if (landed === inCheckout) return { promoted: false, reason: 'the run left nothing to land on the queue' }
+      await write(join(projectCwd, FLAT_TODO_FILE), landed)
+      await git(['add', '--', FLAT_TODO_FILE], projectCwd)
+      await git(['commit', '-m', promotionMessage(run.id), '--', FLAT_TODO_FILE], projectCwd)
+      return { promoted: true, branch }
+    }
+
     // `checkout <branch> -- <path>` writes the file and stages it in one step, touching nothing
     // else in the tree. The commit is pathspec-scoped for the same reason: whatever else is
     // staged in the user's checkout is theirs and must not ride along.
@@ -86,4 +110,55 @@ export async function promoteQueue(
   } catch (err) {
     return { promoted: false, reason: errorMessage(err) }
   }
+}
+
+/** One markdown list item, by the grammar `parseTodoEntries` reads. */
+const ENTRY_LINE = /^(\s*(?:[-*]|\d+\.)\s+)(?:\[([ xX])\]\s*)?(.*)$/
+
+/** Every entry the document names, checked or not, so a re-add can tell "new" from "already there". */
+function entryTexts(md: string): Set<string> {
+  const texts = new Set<string>()
+  for (const line of md.split('\n')) {
+    const text = ENTRY_LINE.exec(line)?.[3]?.trim()
+    if (text) texts.add(text)
+  }
+  return texts
+}
+
+/**
+ * Land what a drain run pinned to one entry actually did (#1204): retire that entry, and keep any
+ * follow-ups it queued.
+ *
+ * Additive by construction, which is what makes it safe to run concurrently: it only ever checks a
+ * box or appends a line. It never unchecks, never removes, and never reorders, so two drains
+ * landing in either order compose, and the worst a wrong guess can do is leave a duplicate line
+ * for a human to delete rather than silently send an agent to redo finished work.
+ *
+ * A follow-up is an entry the run's branch has that `atBase` did not: written during the run. The
+ * fork point is what tells that from an entry somebody *removed* meanwhile, which looks identical
+ * from the branch alone and which `todo_format.md` makes the ordinary way to retire an entry. With
+ * no fork point to compare against, nothing is added -- resurrecting struck-off work is worse than
+ * leaving a follow-up on the branch, and the check-off still lands either way.
+ */
+export function landPinnedEntry(
+  inCheckout: string,
+  fromBranch: string,
+  entry: string,
+  atBase: string | undefined,
+): string {
+  const lines = inCheckout.split('\n').map(line => {
+    const item = ENTRY_LINE.exec(line)
+    if (!item || item[3]?.trim() !== entry || item[2] === undefined || item[2] !== ' ') return line
+    return `${item[1]}[x] ${item[3]!.trim()}`
+  })
+
+  if (atBase === undefined) return lines.join('\n')
+  const known = entryTexts(inCheckout)
+  const base = entryTexts(atBase)
+  const added = [...entryTexts(fromBranch)].filter(text => !known.has(text) && !base.has(text))
+  if (!added.length) return lines.join('\n')
+
+  const body = lines.join('\n')
+  const separator = body === '' || body.endsWith('\n') ? '' : '\n'
+  return `${body}${separator}${added.map(text => `- [ ] ${text}`).join('\n')}\n`
 }

--- a/packages/the-framework/src/registry.test.ts
+++ b/packages/the-framework/src/registry.test.ts
@@ -23,6 +23,7 @@ import {
   REGISTRY_FILE,
   REGISTRY_FILE_MODE,
   MAX_SPEND_OFFSET,
+  MAX_AUTO_PM_CONCURRENCY,
   type Preferences,
   type ProjectRecord,
   type RegistryFs,
@@ -460,6 +461,29 @@ test('writePreferences round-trips and clamps the spend-limit slider (#960)', as
   await writePreferences({ autoSpendOffset: Number.NaN }, fs, ENV)
   assert.deepEqual(await readPreferences(fs, ENV), {})
   await writePreferences({ autoSpendOffset: '20' } as never, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), {})
+})
+
+test('writePreferences round-trips and clamps the concurrent-agents setting (#1204)', async () => {
+  const fs = memFs({ [FILE]: JSON.stringify([APP_A]) })
+  await writePreferences({ autoPmConcurrency: 4 }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { autoPmConcurrency: 4 })
+
+  // Clamped to the same bound the browser control offers, and floored at one: zero agents is what
+  // the `autoPm` switch already spells, and a hand-edited nought would wedge the routine with the
+  // switch still reading on.
+  await writePreferences({ autoPmConcurrency: 9000 }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { autoPmConcurrency: MAX_AUTO_PM_CONCURRENCY })
+  await writePreferences({ autoPmConcurrency: 0 }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { autoPmConcurrency: 1 })
+  await writePreferences({ autoPmConcurrency: -3 }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { autoPmConcurrency: 1 })
+  // A whole number of agents, and nothing but a number at all.
+  await writePreferences({ autoPmConcurrency: 2.6 }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), { autoPmConcurrency: 3 })
+  await writePreferences({ autoPmConcurrency: Number.NaN }, fs, ENV)
+  assert.deepEqual(await readPreferences(fs, ENV), {})
+  await writePreferences({ autoPmConcurrency: '5' } as never, fs, ENV)
   assert.deepEqual(await readPreferences(fs, ENV), {})
 })
 

--- a/packages/the-framework/src/registry.ts
+++ b/packages/the-framework/src/registry.ts
@@ -2,7 +2,13 @@ import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 import { randomBytes } from 'node:crypto'
 import { isAgentName } from './agent-names.js'
 import { nodeFs } from './node-fs.js'
-import { PROJECT_PREFERENCE_KEYS, MAX_SPEND_OFFSET, DEFAULT_SPEND_OFFSET, type ProjectPreferences } from './preference-defaults.js'
+import {
+  PROJECT_PREFERENCE_KEYS,
+  MAX_SPEND_OFFSET,
+  DEFAULT_SPEND_OFFSET,
+  MAX_AUTO_PM_CONCURRENCY,
+  type ProjectPreferences,
+} from './preference-defaults.js'
 
 /**
  * The multi-project registry (#390): the list of projects the user has
@@ -133,6 +139,15 @@ export interface Preferences {
    */
   autoPmOptOut?: string[]
   /**
+   * How many agents the routine may keep going at once on one project (#1204). Absent defaults to
+   * `DEFAULT_AUTO_PM_CONCURRENCY`, and the value is clamped to `MAX_AUTO_PM_CONCURRENCY`.
+   *
+   * Only the draining routine fans out: it takes work *off* the queue, one pinned entry per agent,
+   * so several at once do disjoint work. The rotation invents work and each of its jobs rewrites
+   * the queue file, so it stays one run per tick whatever this says.
+   */
+  autoPmConcurrency?: number
+  /**
    * How far the automatic-consumption limit sits from the quota boundary, in percentage points
    * (#960). Absent defaults to {@link DEFAULT_SPEND_OFFSET} — a half-day cushion ahead of the
    * boundary — rather than sitting exactly on it (#960 Edit).
@@ -176,7 +191,14 @@ export interface Preferences {
 // The key list lives in the leaf `preference-defaults.ts` so the dashboard reads the same one
 // (a second copy there erased the type link, see that module); re-exported so this stays the
 // import site for everything that already reads it beside `Preferences`.
-export { PROJECT_PREFERENCE_KEYS, MAX_SPEND_OFFSET, DEFAULT_SPEND_OFFSET, type ProjectPreferences } from './preference-defaults.js'
+export {
+  PROJECT_PREFERENCE_KEYS,
+  MAX_SPEND_OFFSET,
+  DEFAULT_SPEND_OFFSET,
+  DEFAULT_AUTO_PM_CONCURRENCY,
+  MAX_AUTO_PM_CONCURRENCY,
+  type ProjectPreferences,
+} from './preference-defaults.js'
 
 /**
  * The credentials the daemon needs to reach a third party, set from the dashboard (#1095).
@@ -426,6 +448,12 @@ function sanitizePreferences(value: unknown): Preferences {
   // is dropped like every other empty list — nothing opted out is exactly what absent means.
   const optOut = sanitizeNameList(input['autoPmOptOut'])
   if (optOut.length) preferences.autoPmOptOut = optOut
+  // `autoPmConcurrency` (#1204) is a count of agents, so it is clamped like `autoSpendOffset` and
+  // additionally floored at one: zero concurrent agents is what the `autoPm` switch already spells,
+  // and a hand-edited nought would otherwise wedge the routine with the switch still reading on.
+  const concurrency = input['autoPmConcurrency']
+  if (typeof concurrency === 'number' && Number.isFinite(concurrency))
+    preferences.autoPmConcurrency = Math.min(Math.max(Math.round(concurrency), 1), MAX_AUTO_PM_CONCURRENCY)
   return preferences
 }
 


### PR DESCRIPTION
Closes #1204. Supersedes the concurrency half of #1243.

A **Concurrent agents** setting (`autoPmConcurrency`, default **2**, up to **10**) for how many agents the routine keeps going at once per project, and a sweep that tops a project up **in one tick** rather than one run per interval. With a standing queue and the setting at 10, one click of "Trigger routine now" fans out ten sessions, which is the demo the issue asks for.

## What changed

**Setting** — `Preferences.autoPmConcurrency`, sanitized like the spend slider (whole number, clamped 1..`MAX_AUTO_PM_CONCURRENCY`) and floored at one, since zero agents is what the `autoPm` switch already spells. The default and the bound live in `preference-defaults.ts` so the browser control and the daemon sanitizer read the same numbers. The control sits on the Routine work card beside the Auto-run switch, and the fine print follows the value instead of promising an idle machine.

**Cap** — `autoPmDecision` refuses at `activeRuns >= concurrency` rather than at `activeRuns > 0`, and the refusal names the cap (per #960's lesson). At a concurrency of one the old wording is kept exactly.

**Fan-out, draining only** — a drain takes work *off* the queue, so a batch of them pinned one entry each does disjoint work and lands disjoint edits. Each is pinned by naming its entry in the prompt, and an entry a live run already holds is never handed out again. **The rotation deliberately stays one run per tick**: every rotation job rewrites the whole queue file from the same fork point, so two at once would have the later promotion revert the earlier one. Fanning that side out needs the queue to stop being a single whole-file document, which is its own piece of work.

**Promotion** — landing a finished run's `TODO_AGENTS.md` used to copy the whole file, so with two agents the later promotion reverted the earlier one: it un-checked the entry a concurrent run had just retired, and the sweep started that work over. A pinned drain now lands **only what it did** — its entry checked off, plus the follow-ups it queued. Additive by construction (it only ever ticks a box or appends a line), so two drains compose whichever order they land in. Additions are read against the run's own fork point, because "on the branch, absent here" otherwise resurrects an entry somebody struck off, and `todo_format.md` makes removal the ordinary way to retire one. An unpinned run keeps the exact wholesale copy it always had.

## Notes

- Behaviour at concurrency 1 is preserved exactly; the pre-#1204 sweep tests run under an explicit `concurrency: 1` harness. The new default of 2 is what the issue specifies.
- **Known gap, not addressed here and worth its own ticket:** for `target: web` the local run ends at the hand-off (#1225), so `activeRuns` falls back to 0 and the promotion settles without landing anything. The pin is released while the cloud session is still working, and a later sweep past the cooldown can hand the same entry out again. Within a tick the pinning still holds, and the 30 minute cooldown means it does not bite during a recording, but a routine left running on the web target will duplicate entries.
- The pins live in loop memory, so a daemon restart forgets them. Same ticket as above.

## Tests

- `registry` (+1): round-trip, clamping, the floor at one, rounding, and junk rejected.
- `auto-pm` (+10): the cap, the default, the floor, fan-out in one tick with distinct pinned prompts, no double assignment across ticks, standing down when every entry is taken, live runs counting against the cap, the rotation staying single, an unreadable setting falling back to the default rather than to one, and a refusal ending the batch.
- `queue-promote` (+8): the entry retired, two drains composing in either order, no resurrection of a retired or a hand-removed entry, follow-ups kept, prose untouched, the pinned path not copying wholesale, and nothing landed when there is nothing to land.
- `RoutineWork` (+3): the default shown, writing and clamping (including an emptied box, which must not save), and the fine print following the value.

`turbo run typecheck` passes for all 22 packages; `the-framework` **1432 pass / 0 fail / 1 skipped**; `framework-dashboard` **592/592**.

## Verified live

Against the built daemon, with an isolated `HOME`/`XDG_CONFIG_HOME`, a scratch repo holding a four-entry queue, and a stub agent on `PATH` that answers `/usage` and then exits — so runs really start and die at once, at zero token cost.

At `autoPmConcurrency: 3`, one sweep:

```
auto PM: draining the queue entry "first thing to do" in .../repo
auto PM: draining the queue entry "second thing to do" in .../repo
auto PM: draining the queue entry "third thing to do" in .../repo
```

Three agents in one tick, three *different* entries, and the fourth left for the next one. The same setup at `autoPmConcurrency: 1` starts exactly one, on the first entry, which is the pre-#1204 behaviour.
