### PR TITLE
fix: resolve a session's PR from its own branches and start time

### DIFF
--- a/.changeset/run-pr-association.md
+++ b/.changeset/run-pr-association.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/the-framework": patch
+---
+
+Fix a session showing (and acting on) the wrong PR (#1251, #1255). A run's PR is now resolved from the run's own branch names and start time: an open PR on the branch counts, a closed one only when it was created after the run started. Previously the session header could show a predecessor's merged PR (a triage prompt pins its branch name, and `gh pr view` answers with the newest PR in any state), which also made auto-handoff skip opening the real PR; and once a finished run's worktree was gone, the PR link degraded to whatever branch the project root checkout was on, giving every finished run the same PR. Hands-off web runs are now found through their unique run-id branch, and a branch that no longer exists locally still reports its PR.

--- a/packages/the-framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/the-framework/src/dashboard-rpc/reads.telefunc.ts
@@ -11,7 +11,7 @@ import { buildActivity, type Activity } from '../dashboard/activity.js'
 import { buildDashboard, type DashboardData } from '../dashboard/dashboard.js'
 import { githubUrlFor } from '../dashboard/github.js'
 import { readGitStatus, type GitStatus } from '../dashboard/git-status.js'
-import { readRunHandoff, runBranchFor, type RunHandoff } from '../dashboard/run-handoff.js'
+import { readRunHandoff, resolveRunPr, runBranchFor, type RunHandoff } from '../dashboard/run-handoff.js'
 import type { RunWorktree } from '../dashboard/types.js'
 import { crawlRepoFiles } from '../project.js'
 import { readFileStatuses, type FileGitStatus } from '../dashboard/file-status.js'
@@ -132,17 +132,26 @@ export async function onRunWorktree(projectId: string, runId: string): Promise<R
     // poll, and `du` over a build directory mid-build is a cost with no answer worth having.
     const running = live.some(run => run.id === runId && run.status === 'running')
     const size = own && !running ? await worktreeSize(path) : undefined
+    // In the run's own worktree, the checkout's branch is the run's, so the status read's PR is
+    // right. Once the worktree is gone the checkout is the project root, and its current branch
+    // has nothing to do with this run (#1255) — resolve by the run's own branch names instead.
+    const run = own ? undefined : await findRun(root, runId).catch(() => undefined)
+    const pr = own
+      ? { value: status?.pr, pending: status?.prPending ?? false }
+      : run
+        ? await resolveRunPr(root, run).catch(() => ({ value: undefined, pending: false }))
+        : { value: undefined, pending: false }
     return {
       path,
       own,
       dirty: status?.dirty ?? false,
       ...(status?.branch ? { branch: status.branch } : {}),
       ...(size !== undefined ? { sizeBytes: size } : {}),
-      // The same read already looked the PR up (#809): a session's branch is exactly the thing
-      // that has one, so the session's bar can show it like the project's does.
-      ...(status?.pr ? { pr: status.pr } : {}),
+      // A session's branch is exactly the thing that has a PR (#809), so the bar can show it
+      // like the project's does.
+      ...(pr.value ? { pr: pr.value } : {}),
       // Still being looked up rather than absent (#1028), so the bar can ask again shortly.
-      ...(status?.prPending ? { prPending: true } : {}),
+      ...(pr.pending ? { prPending: true } : {}),
     }
   }, null)
 }
@@ -341,7 +350,7 @@ export async function onRunHandoff(projectId: string, runId: string): Promise<Ru
     // the agent edited. Only when that is a checkout of the session's own: per the note above,
     // `resolveRunPath` falls back to the project root, whose dirt belongs to the user.
     const checkout = await resolveRunPath(projectId, runId)
-    const deps = checkout && checkout !== cwd ? { checkout } : {}
+    const deps = { since: run.startedAt, ...(checkout && checkout !== cwd ? { checkout } : {}) }
     return (await readRunHandoff(cwd, runBranchFor(run), deps).catch(() => undefined)) ?? null
   }, null)
 }

--- a/packages/the-framework/src/dashboard/gh.ts
+++ b/packages/the-framework/src/dashboard/gh.ts
@@ -44,6 +44,8 @@ export interface LinkedPr {
   /** OPEN / MERGED / CLOSED (as gh reports it). */
   state: string
   title: string
+  /** ISO creation time, when the read included it: what tells one run's PR from a predecessor's. */
+  createdAt?: string
 }
 
 /**
@@ -95,6 +97,64 @@ export function forgetPr(cwd: string, branch?: string): void {
 
 function prCacheKey(cwd: string, branch?: string): string {
   return `pr\u0000${cwd}\u0000${branch ?? ''}`
+}
+
+/**
+ * Every PR a branch name has ever had, newest first (#1251).
+ *
+ * `gh pr view <branch>` answers with the newest PR for that head *in any state*, so a session
+ * whose prompt pins its branch name (`the-framework/triage-quick`) inherits a predecessor's
+ * merged PR as its own. The list form keeps the whole history so {@link pickRunPr} can decide
+ * which entry, if any, belongs to the run asking. Resolves `[]` when gh is missing/unauthed —
+ * indistinguishable from "no PRs", which is what every caller would do with a failure anyway.
+ */
+export async function ghPrsForBranch(cwd: string, branch: string): Promise<LinkedPr[]> {
+  const fields = 'number,url,state,title,createdAt'
+  const args = ['pr', 'list', '--head', branch, '--state', 'all', '--limit', '20', '--json', fields]
+  const prs = await ghJson<LinkedPr[]>(args, cwd, [])
+  return prs.map(pr => ({
+    number: pr.number,
+    url: pr.url,
+    state: pr.state,
+    title: pr.title,
+    ...(pr.createdAt ? { createdAt: pr.createdAt } : {}),
+  }))
+}
+
+/** The cached form of {@link ghPrsForBranch}, shared through the same read-through cache (#1028). */
+export async function cachedPrsForBranch(cwd: string, branch: string): Promise<Cached<LinkedPr[]>> {
+  return cachedRead(branchPrsCacheKey(cwd, branch), () => ghPrsForBranch(cwd, branch))
+}
+
+/** Forget a branch's PR history, after an action that changes it (opening one). */
+export function forgetBranchPrs(cwd: string, branch: string): void {
+  invalidate(branchPrsCacheKey(cwd, branch))
+}
+
+/** Same unprintable separator idea as `prCacheKey`, spelled so paths cannot collide with it. */
+const KEY_SEP = String.fromCharCode(0)
+
+function branchPrsCacheKey(cwd: string, branch: string): string {
+  return ['prs', cwd, branch].join(KEY_SEP)
+}
+
+/**
+ * The PR that belongs to a run, out of every PR its branch name has had (#1251/#1255).
+ *
+ * An OPEN PR always counts: GitHub allows one open PR per head branch, so whatever is open on the
+ * run's branch is where its pushed commits land. A closed one counts only when it was created
+ * after the run started (`since`, the run's `startedAt`) — the oldest such entry, which is the one
+ * this run's handoff opened. Anything older is a previous run's PR wearing the same branch name,
+ * which is exactly what showed a merged two-day-old PR as a fresh session's own. Without `since`
+ * only an open PR is trusted.
+ */
+export function pickRunPr(prs: LinkedPr[], since?: string): LinkedPr | undefined {
+  const open = prs.find(pr => pr.state === 'OPEN')
+  if (open) return open
+  if (!since) return undefined
+  return prs
+    .filter(pr => pr.createdAt && pr.createdAt >= since)
+    .sort((a, b) => ((a.createdAt ?? '') < (b.createdAt ?? '') ? -1 : 1))[0]
 }
 
 /** An open PR on the interventions queue (#632). */

--- a/packages/the-framework/src/dashboard/run-handoff.test.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.test.ts
@@ -5,7 +5,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
-import { readRunHandoff, runBranchFor, pushRunBranch, openRunPullRequest, gitReason, runAutoHandoff, isSessionBranch, prBaseName, commitSessionWork } from './run-handoff.js'
+import { readRunHandoff, resolveRunPr, runBranchFor, pushRunBranch, openRunPullRequest, gitReason, runAutoHandoff, isSessionBranch, prBaseName, commitSessionWork } from './run-handoff.js'
+import { pickRunPr } from './gh.js'
 import { nodeGitRunner, GIT_SLOW_TIMEOUT_MS, type GitRunner } from '../project.js'
 import { CliTimeoutError, isCliTimeout } from '../cli-exec.js'
 
@@ -539,4 +540,67 @@ test('a real repo: the finishing step commits what the agent left in its worktre
   } finally {
     await rm(dir, { recursive: true, force: true })
   }
+})
+
+test('pickRunPr trusts an open PR, and otherwise only one created after the run started (#1251)', () => {
+  const stale = { number: 1177, url: 'u1177', state: 'MERGED', title: 'old triage', createdAt: '2026-07-25T16:55:18Z' }
+  const own = { number: 1249, url: 'u1249', state: 'MERGED', title: 'this triage', createdAt: '2026-07-26T21:35:13Z' }
+  const later = { number: 1300, url: 'u1300', state: 'MERGED', title: 'even later', createdAt: '2026-07-26T23:00:00Z' }
+  const open = { number: 1301, url: 'u1301', state: 'OPEN', title: 'open one', createdAt: '2026-07-20T00:00:00Z' }
+  const since = '2026-07-26T21:17:39.507Z'
+
+  // The predecessor's merged PR is not this run's, however recently gh lists it.
+  assert.equal(pickRunPr([stale], since), undefined)
+  // The run's own PR still counts after it merges, and the oldest post-start entry is the one
+  // this run opened.
+  assert.equal(pickRunPr([later, own, stale], since)?.number, 1249)
+  // An open PR on the branch is where pushed commits land, whatever its age.
+  assert.equal(pickRunPr([stale, open], since)?.number, 1301)
+  // Without a start time only an open PR is trusted.
+  assert.equal(pickRunPr([stale, own, later]), undefined)
+  assert.equal(pickRunPr([stale, open])?.number, 1301)
+})
+
+test('a gone branch still reports its PR: it is a remote question (#1255)', async () => {
+  const { git } = fakeGit({ ...REPO, 'rev-parse --verify --quiet refs/heads/the-framework/run-r1': '', remote: 'origin\n' })
+  const handoff = await readRunHandoff('/repo', 'the-framework/run-r1', {
+    git,
+    pr: async () => ({ number: 1254, url: 'u1254', state: 'MERGED', title: 'web run', createdAt: '2026-07-26T21:52:58Z' }),
+  })
+  assert.equal(handoff?.exists, false)
+  assert.equal(handoff?.pr?.number, 1254)
+})
+
+test('resolveRunPr finds a web run through its run-id branch when the session-name branch is a reused pin (#1251)', async () => {
+  const asked: string[] = []
+  const stale = { number: 1177, url: 'u1177', state: 'MERGED', title: 'old triage', createdAt: '2026-07-25T16:55:18Z' }
+  const own = { number: 1249, url: 'u1249', state: 'OPEN', title: 'this triage', createdAt: '2026-07-26T21:35:13Z' }
+  const prs = async (_cwd: string, branch: string) => {
+    asked.push(branch)
+    if (branch === 'the-framework/triage-quick') return { value: [stale], pending: false }
+    if (branch === 'the-framework/run-2026-07-26T21-17-39-507Z') return { value: [own], pending: false }
+    return { value: [], pending: false }
+  }
+  const found = await resolveRunPr('/repo', { id: '2026-07-26T21-17-39-507Z', sessionName: 'triage-quick' }, prs)
+  assert.equal(found.value?.number, 1249)
+  assert.deepEqual(asked, ['the-framework/triage-quick', 'the-framework/run-2026-07-26T21-17-39-507Z'])
+})
+
+test('resolveRunPr prefers the recorded branch and stops at the first hit', async () => {
+  const asked: string[] = []
+  const prs = async (_cwd: string, branch: string) => {
+    asked.push(branch)
+    return { value: [{ number: 5, url: 'u5', state: 'OPEN', title: 'mine' }], pending: false }
+  }
+  const found = await resolveRunPr('/repo', { id: 'r1', branch: 'feat/mine', sessionName: 'named' }, prs)
+  assert.equal(found.value?.number, 5)
+  assert.deepEqual(asked, ['feat/mine'])
+})
+
+test('resolveRunPr reports pending only while nothing was found and a lookup is still running', async () => {
+  const prs = async (_cwd: string, branch: string) =>
+    branch === 'the-framework/run-r1' ? { value: undefined, pending: true } : { value: [], pending: false }
+  const found = await resolveRunPr('/repo', { id: 'r1', sessionName: 'named' }, prs)
+  assert.equal(found.value, undefined)
+  assert.equal(found.pending, true)
 })

--- a/packages/the-framework/src/dashboard/run-handoff.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.ts
@@ -1,9 +1,20 @@
 import { nodeGitRunner, type GitRunner } from '../project.js'
-import { cachedPrView, forgetPr, ghPrView, nodeGhRunner, type GhRunner, type LinkedPr, type BranchPrLookup } from './gh.js'
+import {
+  cachedPrsForBranch,
+  forgetBranchPrs,
+  forgetPr,
+  ghPrsForBranch,
+  nodeGhRunner,
+  pickRunPr,
+  type GhRunner,
+  type LinkedPr,
+  type BranchPrLookup,
+} from './gh.js'
+import type { Cached } from './cache.js'
 import { parseNumstat } from './file-diff.js'
 import { errorMessage } from '../error-message.js'
 import type { AutoHandoffSkip } from '../events.js'
-import { commitPendingWork, currentBranch, type RunMeta } from '../store/index.js'
+import { commitPendingWork, currentBranch, startedAtFromRunId, type RunMeta } from '../store/index.js'
 
 // What a finished session produced, and what is left to do with it (#799).
 //
@@ -84,6 +95,11 @@ export interface RunHandoffDeps {
    * read from there; uncommitted work does not, it sits in the tree the agent actually edited.
    */
   checkout?: string
+  /**
+   * When the run started (ISO), so the PR lookup can tell the run's own PR from an earlier run's
+   * on the same branch name (#1251). Without it, only an open PR is trusted.
+   */
+  since?: string
 }
 
 /**
@@ -100,6 +116,61 @@ export function runBranchFor(run: { id: string; branch?: string; sessionName?: s
 
 /** What every branch a session creates for itself is named under. */
 export const SESSION_BRANCH_PREFIX = 'the-framework/'
+
+/**
+ * The branch's PR as it applies to *this* run: the injected seam when the caller gave one, else
+ * the cached history filtered through {@link pickRunPr} with the run's start time (#1251).
+ */
+async function lookupRunPr(cwd: string, branch: string, deps: RunHandoffDeps): Promise<Cached<LinkedPr | undefined>> {
+  if (deps.pr) return { value: await deps.pr(cwd, branch).catch(() => undefined), pending: false }
+  const prs = await cachedPrsForBranch(cwd, branch).catch(() => ({ value: undefined, pending: false }))
+  return { value: prs.value ? pickRunPr(prs.value, deps.since) : undefined, pending: prs.pending }
+}
+
+/** What {@link resolveRunPr} needs to know about a run: structurally satisfied by {@link RunMeta}. */
+export interface RunPrRun {
+  id: string
+  startedAt?: string
+  branch?: string
+  sessionName?: string
+}
+
+/** The injectable lookup seam for {@link resolveRunPr}: a branch's cached PR history. */
+export type BranchPrsLookup = (cwd: string, branch: string) => Promise<Cached<LinkedPr[]>>
+
+/**
+ * The PR that belongs to a run, tried across every branch name the run may have worked under
+ * (#1251/#1255): the recorded branch, the session-name branch, then the run-id branch.
+ *
+ * The ladder is what makes a hands-off web run resolvable: its local worktree is torn down (or
+ * never existed), its meta may carry only a session name whose branch is a reused pin, but the
+ * cloud session pushed the run-id branch, which no other run can ever have. Each candidate is
+ * filtered through {@link pickRunPr} with the run's start time, so a predecessor's PR on a shared
+ * branch name is never the answer. `pending` only when nothing was found and a lookup is still
+ * running, so the caller can ask again rather than render "no PR".
+ */
+export async function resolveRunPr(
+  cwd: string,
+  run: RunPrRun,
+  prs: BranchPrsLookup = cachedPrsForBranch,
+): Promise<Cached<LinkedPr | undefined>> {
+  const since = run.startedAt ?? startedAtFromRunId(run.id)
+  const candidates = [
+    ...new Set([
+      ...(run.branch ? [run.branch] : []),
+      ...(run.sessionName ? [`${SESSION_BRANCH_PREFIX}${run.sessionName}`] : []),
+      `${SESSION_BRANCH_PREFIX}run-${run.id}`,
+    ]),
+  ]
+  let pending = false
+  for (const branch of candidates) {
+    const read = await prs(cwd, branch).catch((): Cached<LinkedPr[]> => ({ value: undefined, pending: false }))
+    if (read.pending) pending = true
+    const pr = read.value ? pickRunPr(read.value, since) : undefined
+    if (pr) return { value: pr, pending: false }
+  }
+  return { value: undefined, pending }
+}
 
 /**
  * Whether a branch is one a session made, rather than one the user did.
@@ -167,7 +238,25 @@ export async function readRunHandoff(
   const hasRemote = (await run(['remote'])).trim().length > 0
   const pending = await countPendingWork(git, deps.checkout)
   if (!tip) {
-    return { branch, exists: false, commits: [], files: [], insertions: 0, deletions: 0, empty: true, hasRemote, pushed: false, merged: false, ...pending }
+    // The branch being gone locally does not mean the work is: a hands-off web run pushes its
+    // branch and opens its PR remotely, and a merged branch gets deleted. The PR is a remote
+    // question, so it is still answerable — and it is the one thing left worth showing (#1255).
+    const pr = await lookupRunPr(cwd, branch, deps)
+    return {
+      branch,
+      exists: false,
+      commits: [],
+      files: [],
+      insertions: 0,
+      deletions: 0,
+      empty: true,
+      hasRemote,
+      pushed: false,
+      merged: false,
+      ...(pr.value ? { pr: pr.value } : {}),
+      ...(pr.pending ? { prPending: true } : {}),
+      ...pending,
+    }
   }
 
   const base = await detectBase(run)
@@ -196,9 +285,7 @@ export async function readRunHandoff(
   const files = parseHandoffFiles(numstatOut)
   // Read through the cache and allowed to arrive late (#1028): the commits, the files and
   // whether the branch is pushed are all local git, and none of them should wait on `gh`.
-  const pr = deps.pr
-    ? { value: await deps.pr(cwd, branch).catch(() => undefined), pending: false }
-    : await cachedPrView(cwd, branch).catch(() => ({ value: undefined, pending: false }))
+  const pr = await lookupRunPr(cwd, branch, deps)
 
   return {
     branch,
@@ -355,8 +442,9 @@ export async function openRunPullRequest(
     if (draft.draft) args.push('--draft')
     const out = (await gh(args, cwd)).trim()
     // The branch has a PR now, so the cached "no PR" must go or the bar would keep offering to
-    // open one for the next minute (#1028).
+    // open one for the next minute (#1028). Both caches: the single-PR view and the history.
     forgetPr(cwd, branch)
+    forgetBranchPrs(cwd, branch)
     // gh prints the new PR's URL as its last line.
     const url = out.split('\n').filter(Boolean).at(-1)
     return url ? { ok: true, url } : { ok: true }
@@ -379,11 +467,13 @@ export async function openSessionPullRequest(
   options: { draft?: boolean } = {},
 ): Promise<HandoffResult> {
   const branch = runBranchFor(run)
-  const handoff = await readRunHandoff(cwd, branch).catch(() => undefined)
+  const handoff = await readRunHandoff(cwd, branch, { since: run.startedAt }).catch(() => undefined)
+  // The run's PR first, even when its branch is gone locally: a hands-off web run's branch only
+  // ever existed on the remote, and its PR is the answer the button exists to give (#1255).
+  if (handoff?.pr) return { ok: true, url: handoff.pr.url }
   if (handoff && !handoff.exists) return { ok: false, error: `branch ${branch} no longer exists` }
   // Refuse rather than open an empty PR: a session that changed nothing has nothing to hand off.
   if (handoff?.empty) return { ok: false, error: 'this session produced no commits to open a PR for' }
-  if (handoff?.pr) return { ok: true, url: handoff.pr.url }
   return openRunPullRequest(cwd, branch, {
     title: run.sessionName ?? run.intent?.split('\n')[0]?.slice(0, 72) ?? `Session ${run.id}`,
     body: sessionPrBody(run),
@@ -438,13 +528,16 @@ export async function runAutoHandoff(
 ): Promise<AutoHandoffOutcome> {
   if (!intent.push && !intent.pr) return { outcome: 'skipped', reason: 'not-armed' }
   const branch = runBranchFor(run)
+  const since = run.startedAt ?? startedAtFromRunId(run.id)
   const { gh, ...readDeps } = deps
   // The UNcached PR lookup, deliberately. The dashboard's cache answers `prPending` rather than
   // yes-or-no (#1028), which is right for a panel repainting every 15s and wrong here: "not known
   // yet" would read as "no PR" and this would open a second one. Proved against a real remote —
   // only `gh` refusing the duplicate stopped it. This runs once, at the end of a session, so it
-  // can afford to wait for a real answer.
-  const state = await readRunHandoff(cwd, branch, { pr: ghPrView, ...readDeps }).catch(() => undefined)
+  // can afford to wait for a real answer. Filtered by the run's start time (#1251): a merged PR
+  // from an earlier run on the same branch name must not stop this run from opening its own.
+  const runPr: BranchPrLookup = async (c, b) => pickRunPr(await ghPrsForBranch(c, b), since)
+  const state = await readRunHandoff(cwd, branch, { pr: runPr, ...readDeps }).catch(() => undefined)
   if (!state || !state.exists) return { outcome: 'skipped', reason: 'branch-gone' }
   if (state.empty) return { outcome: 'skipped', reason: 'no-commits' }
   if (!state.hasRemote) return { outcome: 'skipped', reason: 'no-remote' }
@@ -480,7 +573,7 @@ export async function runAutoHandoff(
  * the PR. Narrower than {@link RunMeta} so the run process can call this before its meta is
  * final, and so a caller cannot quietly start depending on the rest of the run's state.
  */
-export type HandoffRun = Pick<RunMeta, 'id' | 'branch' | 'sessionName' | 'intent'>
+export type HandoffRun = Pick<RunMeta, 'id' | 'branch' | 'sessionName' | 'intent'> & Partial<Pick<RunMeta, 'startedAt'>>
 
 /** The PR body: what was asked for, and which session did it. */
 function sessionPrBody(run: HandoffRun): string {

--- a/packages/the-framework/src/store/index.ts
+++ b/packages/the-framework/src/store/index.ts
@@ -17,6 +17,7 @@ export {
   restoreArchivedRun,
   listWorktreeDirs,
   runIdFromStartedAt,
+  startedAtFromRunId,
   isSafeRunId,
   FRAMEWORK_DIR,
   WORKTREES_DIR,

--- a/packages/the-framework/src/store/run-store.test.ts
+++ b/packages/the-framework/src/store/run-store.test.ts
@@ -15,6 +15,7 @@ import {
   reconcileOrphanedRuns,
   loadRunEvents,
   runIdFromStartedAt,
+  startedAtFromRunId,
   RUN_META_VERSION,
   type StoreFs,
   type RunMeta,
@@ -643,4 +644,11 @@ test('updatedAt tracks the last event, not the run start (settledAt likewise)', 
   await store.append({ kind: 'log', message: 'second' })
   assert.equal(store.snapshot().updatedAt, ticks[1], 'each event advances it')
   assert.equal(store.snapshot().startedAt, AT, 'the start is still the start')
+})
+
+test('startedAtFromRunId inverts runIdFromStartedAt, and refuses foreign ids (#1251)', () => {
+  const startedAt = '2026-07-26T21:17:39.507Z'
+  assert.equal(startedAtFromRunId(runIdFromStartedAt(startedAt)), startedAt)
+  assert.equal(startedAtFromRunId('not-a-run-id'), undefined)
+  assert.equal(startedAtFromRunId(''), undefined)
 })

--- a/packages/the-framework/src/store/run-store.ts
+++ b/packages/the-framework/src/store/run-store.ts
@@ -68,6 +68,16 @@ export function isSafeRunId(id: string): boolean {
   return /^[A-Za-z0-9_-]+$/.test(id)
 }
 
+/**
+ * The inverse of {@link runIdFromStartedAt}, for a caller that has the id but not the meta
+ * (#1251): the CLI's end-of-run handoff needs the start time to tell the run's own PR from a
+ * predecessor's on the same branch name. Undefined for an id that is not one of ours.
+ */
+export function startedAtFromRunId(id: string): string | undefined {
+  const match = /^(\d{4}-\d{2}-\d{2}T\d{2})-(\d{2})-(\d{2})-(\d{3})Z$/.exec(id)
+  return match ? `${match[1]}:${match[2]}:${match[3]}.${match[4]}Z` : undefined
+}
+
 /** Bumped when the on-disk shape changes, so a reader can detect an old file. */
 export const RUN_META_VERSION = 1
 


### PR DESCRIPTION
Closes #1251, closes #1255. Both are the same defect: no PR is ever recorded against a run, so every surface re-guessed the association, two ways, both wrong.

**What was happening**

1. The handoff resolves the PR with `gh pr view <branch>`, and the branch falls back to `the-framework/<sessionName>`. The triage prompt pins its session name, so every triage run guesses `the-framework/triage-quick`, and `gh pr view` answers with the newest PR for that head *in any state*: merged #1177 from two days ago. The "already-open" guard has no state check, so it also skipped opening the real PR, and the Open PR button returned #1177's URL as success. That is the #1251 screenshot.
2. Once a finished run's worktree is torn down, `resolveRunCheckout` falls back to the project root and the session's PR badge becomes `gh pr view` on whatever branch the root checkout is on: one shared, cached answer for every finished run. That is how the update-tickets run pointed at #1249 instead of #1254.

**The fix**

A run's PR is resolved from the run's own identity:

- `pickRunPr`: an OPEN PR on the branch always counts (GitHub allows one open PR per head, so that is where pushed commits land); a closed one counts only when created after the run started, oldest first. A predecessor's PR on a reused branch name is never the answer.
- `resolveRunPr`: tries the recorded branch, then the session-name branch, then the run-id branch. The run-id branch is unique per run, which is what makes a hands-off web run resolvable after its local worktree is gone.
- `onRunWorktree` no longer attaches the root checkout's branchless PR to a run.
- A branch that no longer exists locally still reports its PR (it is a remote question), and the Open PR action answers with the run's PR before declaring the branch gone.
- Auto-handoff filters by run start time, so a merged predecessor PR no longer blocks a fresh run from opening its own.

**Proof against the live repo** (the exact runs from the issues):

```
OLD ghPrView(triage-quick)      -> #1177 MERGED   (the bug)
NEW resolveRunPr(triage run)    -> #1249 OPEN
NEW resolveRunPr(update run)    -> #1254 OPEN
NEW pickRunPr(triage-quick)     -> none           (stale pin filtered)
```

Tests: 5 new cases in run-handoff.test.ts, a round-trip test for `startedAtFromRunId`; dashboard + dashboard-rpc suites 301/301.
