### PR TITLE
fix: a drain's pin on a queue entry survives the daemon and the web hand-off

### DIFF
--- a/.changeset/drain-run-now-fans-out.md
+++ b/.changeset/drain-run-now-fans-out.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/the-framework": patch
+---
+
+"Spin up agents working on the AI queue" now does what it says (#1204): the drain routine's Run now fires a drain-only sweep, which fans out to the concurrency setting, one agent per open queue entry, instead of starting a single agent on the first entry. An empty queue is reported on the card rather than the click being borrowed for a rotation job.

--- a/.changeset/durable-queue-pins.md
+++ b/.changeset/durable-queue-pins.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/the-framework": patch
+---
+
+Fix a pinned queue entry being handed out to a second agent (#1253). The routine's drain pins lived only in the daemon's memory, so a hands-off web run (whose local process ends at the hand-off while the cloud session still works the entry) and a daemon restart both put the entry back on the market, fanning it out again and opening duplicate PRs. The pinned entry now travels to the run's meta (`--queue-entry`, like `--ticket`), and the sweep derives durable claims from the metas: a live run holds its entry, a finished one holds it while its PR is open, and failed/stopped runs release it.

--- a/packages/framework-dashboard/components/RoutineWork.test.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.test.tsx
@@ -75,21 +75,46 @@ describe('RoutineWork (#1159)', () => {
     }
   })
 
+  // The drain leads the list, and since #1204 its Run now goes to the sweep, so the plain-start
+  // tests click the first *rotation* row instead.
+  const ROTATION_JOB = AUTO_PM_ROUTINES[1]!
+
   test('Run now starts the routine prompt verbatim and selects the run it started (#1191)', async () => {
     const started: unknown[][] = []
     render(<RoutineWork onRunStarted={(...args) => started.push(args)} />)
     await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
-    fireEvent.click(screen.getAllByText('Run now')[0]!)
-    // The drain job leads the list, and its prompt travels unchanged: this is the fast-forward.
+    fireEvent.click(screen.getAllByText('Run now')[1]!)
     await waitFor(() => expect(start).toHaveBeenCalled())
     const [projectId, prompt, kind] = start.mock.calls[0]!
     expect(projectId).toBe('p1')
-    expect(prompt).toBe(AUTO_PM_DRAIN_JOB.prompt)
+    expect(prompt).toBe(ROTATION_JOB.prompt)
     expect(kind).toBe('prompt')
     // The run id is the whole point: without it the shell renders the launcher, so "Run now"
     // landed on an empty composer with its own session nowhere on screen (#1191).
     await waitFor(() => expect(started).toHaveLength(1))
-    expect(started[0]).toEqual(['p1', AUTO_PM_DRAIN_JOB.prompt, 'run-1'])
+    expect(started[0]).toEqual(['p1', ROTATION_JOB.prompt, 'run-1'])
+  })
+
+  test("the drain's Run now fires a drain-only sweep, the only thing that can fan out (#1204)", async () => {
+    // Rom's demo click: "Spin up agents working on the AI queue" must spin up to the concurrency,
+    // one agent per entry. A plain start could only ever be one agent on the first entry.
+    sendAutoPmSweep.mockResolvedValue({ ok: true })
+    const started: unknown[][] = []
+    render(<RoutineWork onRunStarted={(...args) => started.push(args)} />)
+    await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
+    fireEvent.click(screen.getAllByText('Run now')[0]!)
+    await waitFor(() => expect(sendAutoPmSweep).toHaveBeenCalledWith({ drainOnly: true }))
+    expect(start).not.toHaveBeenCalled()
+    // No navigation: the batch lands in the Agents card, not one session's page.
+    expect(started).toHaveLength(0)
+  })
+
+  test("the drain's Run now on a host with no sweep says so instead of failing silently (#1204)", async () => {
+    sendAutoPmSweep.mockResolvedValue({ ok: false })
+    render(<RoutineWork onRunStarted={() => {}} />)
+    await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
+    fireEvent.click(screen.getAllByText('Run now')[0]!)
+    await waitFor(() => expect(screen.getByText(/not running the sweep/).textContent).toMatch(/nothing to trigger/))
   })
 
   test('a start that reports no run id still hands the project over, for the adopt fallback (#1191)', async () => {
@@ -97,9 +122,9 @@ describe('RoutineWork (#1159)', () => {
     const started: unknown[][] = []
     render(<RoutineWork onRunStarted={(...args) => started.push(args)} />)
     await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
-    fireEvent.click(screen.getAllByText('Run now')[0]!)
+    fireEvent.click(screen.getAllByText('Run now')[1]!)
     await waitFor(() => expect(started).toHaveLength(1))
-    expect(started[0]).toEqual(['p1', AUTO_PM_DRAIN_JOB.prompt, undefined])
+    expect(started[0]).toEqual(['p1', ROTATION_JOB.prompt, undefined])
   })
 
   test('a failed start neither navigates nor leaves the button stuck on Starting', async () => {
@@ -108,7 +133,7 @@ describe('RoutineWork (#1159)', () => {
     const started: unknown[][] = []
     render(<RoutineWork onRunStarted={(...args) => started.push(args)} />)
     await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
-    fireEvent.click(screen.getAllByText('Run now')[0]!)
+    fireEvent.click(screen.getAllByText('Run now')[1]!)
     await waitFor(() => expect(start).toHaveBeenCalled())
     expect(started).toHaveLength(0)
     await waitFor(() => expect(screen.queryByText('Starting…')).toBeNull())
@@ -169,9 +194,9 @@ describe('RoutineWork (#1159)', () => {
     render(<RoutineWork onRunStarted={() => {}} />)
     await waitFor(() => expect(screen.getAllByText('Run now').length).toBe(AUTO_PM_ROUTINES.length))
     for (const button of screen.getAllByText('Run now')) expect((button as HTMLButtonElement).disabled).toBe(false)
-    fireEvent.click(screen.getAllByText('Run now')[0]!)
+    fireEvent.click(screen.getAllByText('Run now')[1]!)
     await waitFor(() => expect(start).toHaveBeenCalled())
-    expect(start.mock.calls[0]![1]).toBe(AUTO_PM_DRAIN_JOB.prompt)
+    expect(start.mock.calls[0]![1]).toBe(ROTATION_JOB.prompt)
   })
 
   test('auto-run on with nothing ticked says so, rather than counting down to nothing (#1209)', async () => {
@@ -191,7 +216,7 @@ describe('RoutineWork (#1159)', () => {
     render(<RoutineWork onRunStarted={() => {}} />)
     const select = await screen.findByLabelText('Run in')
     fireEvent.change(select, { target: { value: 'p2' } })
-    fireEvent.click(screen.getAllByText('Run now')[0]!)
+    fireEvent.click(screen.getAllByText('Run now')[1]!)
     await waitFor(() => expect(start).toHaveBeenCalled())
     expect(start.mock.calls[0]![0]).toBe('p2')
   })

--- a/packages/framework-dashboard/components/RoutineWork.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.tsx
@@ -95,6 +95,19 @@ export function RoutineWork({
 
   const runNow = async (job: AutoPmJob) => {
     if (!projectId || busy) return
+    // The drain's Run now means "spin agents up on the queue" (#1204), and only the sweep can fan
+    // out — one agent per entry, up to the concurrency. A plain start could only ever be one
+    // agent reading the first entry. Drain-only, so an empty queue is reported on the card
+    // rather than the click quietly borrowing a rotation job. No navigation on purpose: the
+    // agents land in the Agents card, which is where a batch is watchable.
+    if (job.drains) {
+      setStarting(job.name)
+      setSweepNote(null)
+      const result = await sendAutoPmSweep({ drainOnly: true }).catch(() => ({ ok: false }))
+      setStarting(null)
+      if (!result.ok) setSweepNote('This dashboard is not running the sweep, so there is nothing to trigger here.')
+      return
+    }
     setStarting(job.name)
     // The global options only: the Overview has no project open, so the per-project tier (#840) is
     // not resolved here and the run starts on the same defaults a fresh launcher would use.

--- a/packages/the-framework/src/auto-pm.test.ts
+++ b/packages/the-framework/src/auto-pm.test.ts
@@ -835,3 +835,27 @@ test('an unreadable claim list means none: the in-memory pins still guard the co
   loop.stop()
   assert.equal(started.length, 1, 'a gh hiccup must not stall a healthy queue')
 })
+
+test('a drain-only sweep works the queue and never borrows the tick for the rotation (#1204)', async () => {
+  // The drain row's Run now: with entries waiting it fans out like any drain sweep...
+  const prompts: string[] = []
+  const { loop } = harness({
+    cooldownMs: 0,
+    concurrency: async () => 2,
+    queue: async () => ['entry a', 'entry b'],
+    start: async (_p, job) => {
+      prompts.push(job.prompt)
+      return `run-${prompts.length}`
+    },
+  })
+  await loop.tick({ onDemand: true, drainOnly: true })
+  loop.stop()
+  assert.equal(prompts.length, 2)
+
+  // ...and with an empty queue it says so instead of starting a rotation job.
+  const { loop: empty, started } = harness({ cooldownMs: 0, queue: async () => [] })
+  await empty.tick({ onDemand: true, drainOnly: true })
+  empty.stop()
+  assert.equal(started.length, 0)
+  assert.equal(empty.report().outcomes[0]?.message, 'the queue is empty, so there is nothing to drain')
+})

--- a/packages/the-framework/src/auto-pm.test.ts
+++ b/packages/the-framework/src/auto-pm.test.ts
@@ -787,3 +787,51 @@ test('a refusal ends the batch, so the refused work is retried rather than skipp
   loop.stop()
   assert.equal(attempts, 2, 'one start took, the second was refused, and the batch stopped there')
 })
+
+test('a durably claimed entry is not re-fanned: the web hand-off and restart case (#1253)', async () => {
+  // The pin on entry a lives in a run meta (a hands-off web run, or one from before a daemon
+  // restart), not in this loop's memory. The sweep must treat it exactly like an in-flight pin.
+  const prompts: string[] = []
+  const { loop } = harness({
+    cooldownMs: 0,
+    concurrency: async () => 2,
+    queue: async () => ['entry a', 'entry b', 'entry c'],
+    claimedEntries: async (_p, candidates) => candidates.filter(entry => entry === 'entry a'),
+    start: async (_p, job) => {
+      prompts.push(job.prompt)
+      return `run-${prompts.length}`
+    },
+  })
+  await loop.tick()
+  loop.stop()
+  assert.equal(prompts.length, 2)
+  assert.match(prompts[0]!, /entry b/)
+  assert.match(prompts[1]!, /entry c/)
+  assert.ok(!prompts.some(prompt => prompt.includes('entry a')), 'the claimed entry stays off the market')
+})
+
+test('a queue whose every entry is durably claimed stands the sweep down (#1253)', async () => {
+  const { loop, started } = harness({
+    cooldownMs: 0,
+    concurrency: async () => 4,
+    queue: async () => ['entry a'],
+    claimedEntries: async () => ['entry a'],
+  })
+  await loop.tick()
+  loop.stop()
+  assert.equal(started.length, 0)
+  assert.equal(loop.report().outcomes[0]?.message, 'every open queue entry is already being worked on')
+})
+
+test('an unreadable claim list means none: the in-memory pins still guard the common case (#1253)', async () => {
+  const { loop, started } = harness({
+    cooldownMs: 0,
+    queue: async () => ['entry a'],
+    claimedEntries: async () => {
+      throw new Error('gh is down')
+    },
+  })
+  await loop.tick()
+  loop.stop()
+  assert.equal(started.length, 1, 'a gh hiccup must not stall a healthy queue')
+})

--- a/packages/the-framework/src/auto-pm.ts
+++ b/packages/the-framework/src/auto-pm.ts
@@ -369,6 +369,15 @@ export interface AutoPmDeps {
    * still reads empty and the sweep would start the same work over again.
    */
   promote(project: AutoPmProject, run: { runId: string; entry?: string }): Promise<PromoteOutcome>
+  /**
+   * Which of `candidates` are claimed by a run outside this loop's memory (#1253): pinned to a
+   * run that is still live, or to a finished one whose PR is still open. The in-memory pin dies
+   * with the daemon, and a hands-off web run's local process ends at the hand-off while the cloud
+   * session still works the entry — both would otherwise put the same entry back on the market
+   * and fan it out to a second agent. Unreadable means unclaimed: the in-memory pins still guard
+   * the common case, and refusing the whole sweep over a `gh` hiccup would stall a healthy queue.
+   */
+  claimedEntries?(project: AutoPmProject, candidates: readonly string[]): Promise<readonly string[]>
   /** Progress line. */
   log(message: string): void
   /** Override the tick interval. */
@@ -581,7 +590,14 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
           const assigned = new Set(
             (pending.get(project.id) ?? []).flatMap(run => (run.entry !== undefined ? [run.entry] : [])),
           )
-          const open = (entries ?? []).filter(entry => !assigned.has(entry))
+          const unassigned = (entries ?? []).filter(entry => !assigned.has(entry))
+          // The durable claims (#1253), asked only about entries the memory above did not already
+          // rule out: a run this loop never started (or has forgotten across a restart), or one
+          // whose local process ended at the web hand-off, may still own an entry via its meta.
+          const claimed = new Set(
+            unassigned.length ? await deps.claimedEntries?.(project, unassigned).catch(() => []) ?? [] : [],
+          )
+          const open = unassigned.filter(entry => !claimed.has(entry))
           if (!open.length) {
             note(project, false, 'every open queue entry is already being worked on')
             continue

--- a/packages/the-framework/src/auto-pm.ts
+++ b/packages/the-framework/src/auto-pm.ts
@@ -435,8 +435,12 @@ export interface AutoPmLoop {
    * preference is consent to spend quota *unasked*, and a click is asking — so an on-demand sweep
    * runs with the preference off, and the master switch is the only gate it skips: every other
    * reason to stand down (live runs, cooldowns, the quota boundary, unticked routines) still holds.
+   *
+   * `drainOnly` narrows the sweep to working the queue (#1204): the drain row's Run now means
+   * "spin agents up on the queue", so a tick that would fall through to a rotation job (the queue
+   * is empty) says so instead of borrowing the click for work nobody asked for.
    */
-  tick(opts?: { onDemand?: boolean }): Promise<void>
+  tick(opts?: { onDemand?: boolean; drainOnly?: boolean }): Promise<void>
   /** What the last sweep decided, for the dashboard to show (#1161). */
   report(): AutoPmReport
   stop(): void
@@ -470,7 +474,7 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
   let sweeping = false
   let stopped = false
 
-  const tick = async (opts?: { onDemand?: boolean }): Promise<void> => {
+  const tick = async (opts?: { onDemand?: boolean; drainOnly?: boolean }): Promise<void> => {
     if (stopped || sweeping) return
     sweeping = true
     let enabled = false
@@ -543,6 +547,12 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
           // Logged, so a wedged sweep is distinguishable from a healthy idle one (#855).
           deps.log(`[framework] auto PM: standing down for ${project.path} — ${decision.reason}`)
           note(project, false, decision.reason)
+          continue
+        }
+        // A drain-only sweep (#1204) works the queue or says why not — it never borrows the
+        // click for a rotation job the user did not ask for.
+        if (opts?.drainOnly && decision.mode !== 'drain') {
+          note(project, false, 'the queue is empty, so there is nothing to drain')
           continue
         }
         // Switching the draining routine off (#1209) stands the sweep down rather than falling

--- a/packages/the-framework/src/cli.test.ts
+++ b/packages/the-framework/src/cli.test.ts
@@ -974,3 +974,7 @@ test('parseArgs reads --ticket, the ticket the daemon says this run implements (
   assert.equal(parseArgs(['--ticket', 'tickets/2026-07-25_login.md', 'x']).ticket, 'tickets/2026-07-25_login.md')
   assert.equal(parseArgs(['x']).ticket, undefined)
 })
+
+test('parseArgs reads --queue-entry, the queue entry a drain pinned this run to (#1253)', () => {
+  assert.equal(parseArgs(['--queue-entry', 'Fix the flaky teardown test', 'x']).queueEntry, 'Fix the flaky teardown test')
+})

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -311,6 +311,8 @@ export interface CliOptions {
   via?: string | undefined
   /** `--ticket <path>` (#1117): the `tickets/<file>.md` this run is implementing. Set by the daemon when it starts a drain run, from the ticket its queue entry links to; recorded on the run's meta. */
   ticket?: string | undefined
+  /** `--queue-entry <text>` (#1253): the one queue entry a routine drain pinned this run to; recorded on the run's meta so the sweep's claim outlives the daemon and the local process. */
+  queueEntry?: string | undefined
   /** `--unattended`: no human is watching, so choice gates take the recommended option (#846). */
   unattended?: boolean
   scope: 'prototype' | 'full'
@@ -574,6 +576,9 @@ export function parseArgs(argv: string[]): CliOptions {
         break
       case '--ticket':
         opts.ticket = argv[++i]
+        break
+      case '--queue-entry':
+        opts.queueEntry = argv[++i]
         break
       case '--unattended':
         opts.unattended = true
@@ -1550,6 +1555,9 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
   // about why the run exists, not a state that changes, and folding it to meta is what lets the
   // Overview mark that ticket as being implemented right now.
   if (opts.ticket && isTicketPath(opts.ticket)) onEvent({ kind: 'ticket', path: opts.ticket })
+  // The queue entry a routine drain pinned this run to (#1253), same shape as the ticket above:
+  // once, at start, folded to meta — the durable half of the sweep's claim on the entry.
+  if (opts.queueEntry?.trim()) onEvent({ kind: 'queue-entry', entry: opts.queueEntry })
   // Wired now the journal exists: a bind resolved from a topic run's gate folds to meta (#1121).
   recordBind = projectId => onEvent({ kind: 'bind', projectId })
 

--- a/packages/the-framework/src/daemon-runtime.ts
+++ b/packages/the-framework/src/daemon-runtime.ts
@@ -172,6 +172,9 @@ export function startOptionFlags(options: StartRunOptions): string[] {
   // The ticket this run implements (#1117): only ever a `tickets/<file>.md` the daemon read off
   // the queue entry, and re-checked on the other side before it reaches the run's meta.
   if (typeof options.ticket === 'string' && isTicketPath(options.ticket)) flags.push('--ticket', options.ticket)
+  // The pinned queue entry (#1253): one line of agent-written queue text, passed verbatim (argv,
+  // never a shell) so the meta's claim matches the queue read byte for byte.
+  if (typeof options.queueEntry === 'string' && options.queueEntry.trim()) flags.push('--queue-entry', options.queueEntry)
   // Unattended (#846): nobody is at the keyboard, so gates take the recommended option
   // rather than park for an answer that is not coming.
   if (options.unattended) flags.push('--unattended')

--- a/packages/the-framework/src/daemon-services.ts
+++ b/packages/the-framework/src/daemon-services.ts
@@ -11,10 +11,11 @@ import { buildInterventions, interventionKey, postInterventionsDiscord } from '.
 import { buildActivity, activityKey, postActivityDiscord } from './dashboard/activity.js'
 import { startAutoPm, AUTO_PM_JOBS, type AutoPmReport } from './auto-pm.js'
 import { maintenanceDue, readMaintenanceState, mergeMaintenanceState } from './maintenance.js'
-import { promoteQueue } from './queue-promote.js'
+import { claimedQueueEntries, promoteQueue } from './queue-promote.js'
 import { findTodoBacklog, nextQueuedTicket, ticketFromQueueEntry } from './todo-loop.js'
 import { startConversationCommitter } from './conversation-commit.js'
 import { startMergedWorktreeSweep } from './merged-worktrees.js'
+import { resolveRunPr } from './dashboard/run-handoff.js'
 import { readConversation } from './conversations.js'
 import { startDiscordBot, DISCORD_VIA } from './discord/bot.js'
 import { startDiscordReplyMirror } from './discord/reply-mirror.js'
@@ -163,9 +164,19 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
           ? ticketFromQueueEntry(job.entry)
           : await nextQueuedTicket(project.path).catch(() => undefined)
         : undefined
-      const result = await startUnattended(project.id, job.prompt, ticket ? { ticket } : {})
+      // The pinned entry itself also rides along (#1253), so the claim on it reaches the run's
+      // meta and outlives both this process's memory and the run's local process.
+      const result = await startUnattended(project.id, job.prompt, {
+        ...(ticket ? { ticket } : {}),
+        ...(job.entry !== undefined ? { queueEntry: job.entry } : {}),
+      })
       return result.ok ? result.runId : undefined
     },
+    // The durable half of the drain pins (#1253): entries claimed by run metas rather than this
+    // process's memory. The PR lookup rides the #1257 cache, so a sweep costs at most one `gh`
+    // read per open entry per TTL.
+    claimedEntries: async (project, candidates) =>
+      claimedQueueEntries(project.path, candidates, { runs: listRuns, pr: resolveRunPr }),
     // The daemon promotes the queue, never the agent (#852): the run stays sandboxed in its
     // worktree, and one known file is copied across once it has finished cleanly.
     promote: async (project, { runId, entry }) => {

--- a/packages/the-framework/src/daemon-services.ts
+++ b/packages/the-framework/src/daemon-services.ts
@@ -66,7 +66,7 @@ export interface BackgroundServices {
    * `onDemand` is the dashboard's trigger button (#1210): that sweep runs even while the
    * preference is off, because the click itself is the ask the preference would otherwise record.
    */
-  wakeAutoPm: (opts?: { onDemand?: boolean }) => void
+  wakeAutoPm: (opts?: { onDemand?: boolean; drainOnly?: boolean }) => void
   /** What the last auto-PM sweep decided, for the usage panel to show (#1161). */
   autoPmReport: () => AutoPmReport
 }

--- a/packages/the-framework/src/daemon.test.ts
+++ b/packages/the-framework/src/daemon.test.ts
@@ -918,3 +918,11 @@ test('startOptionFlags passes the ticket a run implements, and only a real one (
     assert.deepEqual(startOptionFlags({ ticket: bad }), [], `expected ${bad} to be dropped`)
   }
 })
+
+test('startOptionFlags forwards the pinned queue entry verbatim, and drops a blank one (#1253)', () => {
+  assert.deepEqual(startOptionFlags({ queueEntry: 'Fix the flaky teardown test' }), [
+    '--queue-entry',
+    'Fix the flaky teardown test',
+  ])
+  assert.deepEqual(startOptionFlags({ queueEntry: '   ' }), [])
+})

--- a/packages/the-framework/src/daemon.ts
+++ b/packages/the-framework/src/daemon.ts
@@ -426,7 +426,7 @@ export async function runDaemon(cwd: string, opts: RunDaemonOptions = {}): Promi
     // ...and only it can be asked to sweep now (#1210). On demand, not the plain wake the
     // switched-on preference above uses: the button is an explicit ask, so the sweep runs even
     // while auto-run is off — one sweep for the click, and the schedule stays off.
-    autoPmSweep: () => services?.wakeAutoPm({ onDemand: true }),
+    autoPmSweep: opts => services?.wakeAutoPm({ onDemand: true, ...opts }),
     ...(token ? { token } : {}),
     ...(clientBundleDir ? { clientBundleDir } : {}),
   })

--- a/packages/the-framework/src/dashboard-rpc/context.ts
+++ b/packages/the-framework/src/dashboard-rpc/context.ts
@@ -121,6 +121,6 @@ export function contextAutoPm(): AutoPmReporter | undefined {
  * How a sweep is fired on demand (#1210), or undefined on a host that runs none. Same rule as
  * {@link contextAutoPm}: only the daemon holds the loop, so only it can be asked to sweep.
  */
-export function contextAutoPmSweep(): (() => void) | undefined {
+export function contextAutoPmSweep(): ((opts?: { drainOnly?: boolean }) => void) | undefined {
   return fromContext(ctx => ctx.autoPmSweep)
 }

--- a/packages/the-framework/src/dashboard-rpc/quota.telefunc.ts
+++ b/packages/the-framework/src/dashboard-rpc/quota.telefunc.ts
@@ -52,12 +52,16 @@ export async function onAutoPm(): Promise<AutoPmReport | undefined> {
  * Returns whether a sweep was asked for, not what it decided: a sweep can start runs and take a
  * while, and `onAutoPm` is how the answer arrives. `false` on a host with no loop (the relay),
  * which the button reads as "nothing here to trigger".
+ *
+ * `drainOnly` narrows the sweep to working the queue (#1204): the drain routine's Run now spins
+ * agents up on the queue's entries — the fan-out only the sweep can do — and an empty queue is
+ * reported rather than borrowed for a rotation job.
  */
-export async function sendAutoPmSweep(): Promise<{ ok: boolean }> {
+export async function sendAutoPmSweep(opts?: { drainOnly?: boolean }): Promise<{ ok: boolean }> {
   const sweep = contextAutoPmSweep()
   if (!sweep) return { ok: false }
   try {
-    sweep()
+    sweep(opts?.drainOnly ? { drainOnly: true } : undefined)
     return { ok: true }
   } catch {
     return { ok: false }

--- a/packages/the-framework/src/dashboard/server.ts
+++ b/packages/the-framework/src/dashboard/server.ts
@@ -88,7 +88,7 @@ export interface DashboardOptions {
    * Fire an auto PM sweep now instead of waiting out the interval (#1210). Daemon-only for the
    * same reason as {@link autoPm}: the loop runs in that process, so nowhere else has one.
    */
-  autoPmSweep?: () => void
+  autoPmSweep?: (opts?: { drainOnly?: boolean }) => void
   /**
    * Serve the new dashboard bundle (#405) from this directory — the prerendered Vike SPA
    * (`index.html` + `assets/**`). The daemon also mounts the dashboard's Telefunc surface

--- a/packages/the-framework/src/dashboard/telefunc-serve.ts
+++ b/packages/the-framework/src/dashboard/telefunc-serve.ts
@@ -81,7 +81,7 @@ export interface DashboardContext {
    * immediately — a sweep can start runs and take a while, and the caller only needs to know it
    * was asked for.
    */
-  autoPmSweep?: () => void
+  autoPmSweep?: (opts?: { drainOnly?: boolean }) => void
 }
 
 let instance: Telefunc | undefined

--- a/packages/the-framework/src/dashboard/types.ts
+++ b/packages/the-framework/src/dashboard/types.ts
@@ -83,6 +83,13 @@ export interface StartRunOptions {
    */
   ticket?: string
   /**
+   * The one queue entry a routine drain pinned this run to (#1253), verbatim; maps to
+   * `--queue-entry`. Recorded on the run's meta so the sweep's claim on the entry outlives both
+   * the daemon (a restart forgets its in-memory pins) and the run's local process (a hands-off
+   * web run ends at the hand-off while the cloud session still works the entry).
+   */
+  queueEntry?: string
+  /**
    * The surface this run was asked for from (#917), e.g. `discord`; maps to `--via`. Recorded on
    * the session's conversation turns so a run started from a chat surface is not filed under the
    * dashboard. Absent = the local surface, exactly as before.

--- a/packages/the-framework/src/events.ts
+++ b/packages/the-framework/src/events.ts
@@ -200,6 +200,13 @@ export type FrameworkEvent =
    */
   | { kind: 'ticket'; path: string }
   /**
+   * The one queue entry this run was pinned to by the routine's drain (#1253). An event for the
+   * same reason `ticket` is: only an event reaches the run's meta, and the meta is what outlives
+   * the sweep's memory — the claim must survive a daemon restart, and a hands-off run whose local
+   * process ends at the hand-off while the cloud session still works the entry.
+   */
+  | { kind: 'queue-entry'; entry: string }
+  /**
    * What the end-of-session handoff actually did (#1102): pushed and/or opened a draft PR,
    * declined for a reason that is not a fault, or failed at one of the two steps.
    *

--- a/packages/the-framework/src/queue-promote.test.ts
+++ b/packages/the-framework/src/queue-promote.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { promoteQueue, landPinnedEntry } from './queue-promote.js'
+import { claimedQueueEntries, promoteQueue, landPinnedEntry } from './queue-promote.js'
 import type { GitRunner } from './project.js'
 
 // Pins the retry contract auto PM acts on: the callee flags the one retryable skip, so the
@@ -122,4 +122,50 @@ test('an entry removed by hand while the run worked is not resurrected (#1204)',
   const out = landPinnedEntry(checkout, BASE, 'entry a', BASE)
   assert.doesNotMatch(out, /entry b/)
   assert.match(out, /- \[x\] entry a/)
+})
+
+test('claimedQueueEntries: live and open-PR runs hold their entries, abandoned ones release them (#1253)', async () => {
+  const runs = [
+    { id: 'r1', status: 'running', queueEntry: 'entry a' },
+    { id: 'r2', status: 'done', queueEntry: 'entry b' }, // PR open: the web hand-off case
+    { id: 'r3', status: 'done', queueEntry: 'entry c' }, // PR closed unmerged: abandoned
+    { id: 'r4', status: 'failed', queueEntry: 'entry d' },
+    { id: 'r5', status: 'done', queueEntry: 'entry e' }, // no PR at all
+    { id: 'r6', status: 'done' }, // never pinned
+  ]
+  const claimed = await claimedQueueEntries('/repo', ['entry a', 'entry b', 'entry c', 'entry d', 'entry e'], {
+    runs: async () => runs,
+    pr: async (_path, run) => {
+      if (run.id === 'r2') return { value: { state: 'OPEN' }, pending: false }
+      if (run.id === 'r3') return { value: { state: 'CLOSED' }, pending: false }
+      return { value: undefined, pending: false }
+    },
+  })
+  assert.deepEqual(claimed.sort(), ['entry a', 'entry b'])
+})
+
+test('claimedQueueEntries: a PR lookup still warming counts as claimed, and only candidates are asked about (#1253)', async () => {
+  const asked: string[] = []
+  const claimed = await claimedQueueEntries('/repo', ['entry a'], {
+    runs: async () => [
+      { id: 'r1', status: 'done', queueEntry: 'entry a' },
+      { id: 'r2', status: 'done', queueEntry: 'entry z' }, // not a candidate: never looked up
+    ],
+    pr: async (_path, run) => {
+      asked.push(run.id)
+      return { value: undefined, pending: true }
+    },
+  })
+  assert.deepEqual(claimed, ['entry a'], 'slow answer = claimed, never handed out on a guess')
+  assert.deepEqual(asked, ['r1'])
+})
+
+test('claimedQueueEntries: an unreadable run list claims nothing rather than stalling the sweep (#1253)', async () => {
+  const claimed = await claimedQueueEntries('/repo', ['entry a'], {
+    runs: async () => {
+      throw new Error('no store')
+    },
+    pr: async () => ({ value: undefined, pending: false }),
+  })
+  assert.deepEqual(claimed, [])
 })

--- a/packages/the-framework/src/queue-promote.ts
+++ b/packages/the-framework/src/queue-promote.ts
@@ -162,3 +162,54 @@ export function landPinnedEntry(
   const separator = body === '' || body.endsWith('\n') ? '' : '\n'
   return `${body}${separator}${added.map(text => `- [ ] ${text}`).join('\n')}\n`
 }
+
+/** The little {@link claimedQueueEntries} needs to know about a run. Structurally a `RunMeta`. */
+export interface QueueClaimRun {
+  id: string
+  status: string
+  startedAt?: string
+  branch?: string
+  sessionName?: string
+  queueEntry?: string
+}
+
+/** Injectable seams for {@link claimedQueueEntries}: the runs on disk, and a run's PR. */
+export interface QueueClaimDeps {
+  runs(path: string): Promise<readonly QueueClaimRun[]>
+  pr(path: string, run: QueueClaimRun): Promise<{ value?: { state: string } | undefined; pending: boolean }>
+}
+
+/**
+ * Which of `candidates` are claimed by a run's meta rather than the sweep's memory (#1253).
+ *
+ * The in-memory pin dies with the daemon, and a hands-off web run's local process ends at the
+ * hand-off while the cloud session still works its entry — both put the entry back on the market
+ * and fan it out to a second agent. The meta is what survives: a live run claims its entry
+ * outright, and a finished one keeps the claim while its PR is open, because the work (including
+ * the entry's own check-off) travels in that PR and the merge is what closes the entry. A
+ * closed-unmerged PR releases the claim, as do failed and stopped runs: that work was abandoned,
+ * and the entry should be offered again. A PR lookup still warming counts as claimed — handing
+ * the entry out because the answer was slow is the exact double-assignment this prevents, and the
+ * next tick knows.
+ */
+export async function claimedQueueEntries(
+  path: string,
+  candidates: readonly string[],
+  deps: QueueClaimDeps,
+): Promise<string[]> {
+  const wanted = new Set(candidates)
+  const runs = (await deps.runs(path).catch((): QueueClaimRun[] => [])).filter(
+    run => run.queueEntry !== undefined && wanted.has(run.queueEntry),
+  )
+  const claimed = new Set<string>()
+  for (const run of runs) {
+    const entry = run.queueEntry
+    if (entry === undefined || claimed.has(entry)) continue
+    if (run.status === 'running') claimed.add(entry)
+    else if (run.status === 'done') {
+      const pr = await deps.pr(path, run).catch(() => ({ value: undefined, pending: false }))
+      if (pr.pending || pr.value?.state === 'OPEN') claimed.add(entry)
+    }
+  }
+  return [...claimed]
+}

--- a/packages/the-framework/src/store/run-store.test.ts
+++ b/packages/the-framework/src/store/run-store.test.ts
@@ -652,3 +652,14 @@ test('startedAtFromRunId inverts runIdFromStartedAt, and refuses foreign ids (#1
   assert.equal(startedAtFromRunId('not-a-run-id'), undefined)
   assert.equal(startedAtFromRunId(''), undefined)
 })
+
+test('applyEventToMeta records the queue entry a drain pinned the run to (#1253)', () => {
+  const base = metaFromEvents(RUN.slice(0, 4), AT)
+  assert.equal(base.queueEntry, undefined, 'a run no drain pinned says nothing')
+  const on = applyEventToMeta(base, { kind: 'queue-entry', entry: 'Fix the flaky teardown test' }, AT)
+  assert.equal(on.queueEntry, 'Fix the flaky teardown test')
+  // The claim must outlive the run: a finished web run's meta is what keeps the entry off the
+  // market while its PR is open.
+  const ended = applyEventToMeta(on, { kind: 'end', ok: true }, AT)
+  assert.equal(ended.queueEntry, 'Fix the flaky teardown test')
+})

--- a/packages/the-framework/src/store/run-store.ts
+++ b/packages/the-framework/src/store/run-store.ts
@@ -136,6 +136,14 @@ export interface RunMeta {
    * behind. Absent on every run nobody linked to a ticket.
    */
   ticket?: string
+  /**
+   * The queue entry this run was pinned to by the routine's drain (#1253), verbatim.
+   *
+   * The durable half of the sweep's pin: the in-memory pin dies with the daemon, and a hands-off
+   * web run's local process ends at the hand-off, but the meta stays — so the sweep can keep an
+   * entry off the market while any run that names it is live or has an open PR.
+   */
+  queueEntry?: string
   /** Whether the agent signalled `setReadyForMerge()` (#326): building (false/absent) vs ready (true). */
   readyForMerge?: boolean
   /**
@@ -310,6 +318,9 @@ export function applyEventToMeta(meta: RunMeta, event: FrameworkEvent, at: strin
       break
     case 'ticket':
       next.ticket = event.path
+      break
+    case 'queue-entry':
+      next.queueEntry = event.entry
       break
     case 'settled':
       next.settledAt = at

--- a/packages/the-framework/src/terminal.ts
+++ b/packages/the-framework/src/terminal.ts
@@ -36,6 +36,8 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
       return `◆ bound to project ${event.projectId}`
     case 'ticket':
       return `  implementing ${event.path}`
+    case 'queue-entry':
+      return `  working the queue entry: ${event.entry}`
     case 'on-before-mergeable':
       switch (event.outcome) {
         case 'queued':


### PR DESCRIPTION
Closes #1253. Also finishes the #1204 ask that "Run now" on the queue leads to max concurrent agents.

**Commit 1: durable queue pins (#1253).** The drain's pin on a queue entry lived only in the sweep's in-memory map, released as soon as the run settled locally. Two ways that hands the same entry to a second agent: a `target: web` run ends its local process at the hand-off while the cloud session is still working the entry (each duplicate opens its own PR; this is the 10-CC-web demo scenario), and a daemon restart forgets every pin.

The fix derives claims from durable state. The pinned entry rides to the run's meta (`StartRunOptions.queueEntry` -> `--queue-entry` -> `queue-entry` event -> `RunMeta.queueEntry`, the #1117 ticket lane). New `claimedQueueEntries`: a candidate entry is claimed while a run naming it is `running`, or `done` with an open PR on its branch (per-run resolution via #1257's `resolveRunPr`, cached). The merge closes the entry; a closed-unmerged PR or a failed/stopped run releases the claim; a lookup still warming counts as claimed rather than guessing. The sweep only asks about entries its in-memory pins did not already rule out, and an unreadable claim list means "none" so a `gh` hiccup cannot stall a healthy queue.

Residual, stated on purpose: a restart still forgets promotion bookkeeping for local runs, but that now self-heals through the same lane, since the run's draft PR holds the claim until the merge lands the check-off.

**Commit 2: the demo click (#1204).** The drain preset's label is literally "Spin up agents working on the AI queue", but its Run now used `sendStart`: one agent, on the first entry. Only the sweep can fan out, so the drain row's Run now is now a drain-only sweep: up to the concurrency, one agent per entry, and an empty queue is reported on the card instead of the click quietly borrowing a rotation job. `sendAutoPmSweep` takes an optional `{ drainOnly }`, threaded to `tick`.

Tests: derivation cases, sweep-seam cases, meta fold, flag round-trip, drain-only guard (framework 162/162 on touched suites); RoutineWork rewired incl. the two new drain-click cases (dashboard 606/606).
