### PR TITLE
fix(dashboard): the session menu's serve picker no longer crashes the view

### DIFF
--- a/.changeset/session-menu-group-crash.md
+++ b/.changeset/session-menu-group-crash.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/the-framework": patch
+---
+
+Fix the session view crashing (Base UI error #31) on multi-app repos once the preview URL clears, e.g. right after Stop session: the session menu's "Serve which app" submenu label was missing its menu-group wrapper.

--- a/packages/framework-dashboard/components/SessionActionsMenu.test.tsx
+++ b/packages/framework-dashboard/components/SessionActionsMenu.test.tsx
@@ -111,3 +111,23 @@ describe('SessionActionsMenu (#toolbar-menu)', () => {
     await waitFor(() => expect(sendDeleteSession).toHaveBeenCalledWith('p1', 'run-1'))
   })
 })
+
+describe('the Serve submenu on a multi-app repo (#toolbar-menu)', () => {
+  test('renders its picker without blowing up the view', async () => {
+    // The label inside the submenu is a Menu group part; unwrapped it throws Base UI's error #31
+    // and the page boundary swallows the whole session view. This is the branch a monorepo hits
+    // as soon as the preview URL clears (e.g. right after Stop session).
+    onServeTargets.mockResolvedValue([
+      { id: 'root', label: 'gemstack', script: 'dev' },
+      { id: 'docs', label: 'docs', script: 'dev' },
+    ])
+    render(<SessionActionsMenu projectId="p1" runId="run-1" events={[]} onDeleted={vi.fn()} />)
+    openMenu()
+    // The row only becomes a submenu trigger once the async target list lands with more than one.
+    await waitFor(() => expect(screen.getByText('Serve').closest('[aria-haspopup]')).toBeTruthy())
+    fireEvent.click(screen.getByText('Serve'))
+    await waitFor(() => expect(screen.getByText('Serve which app')).toBeTruthy())
+    expect(screen.getByText('docs')).toBeTruthy()
+    onServeTargets.mockResolvedValue([])
+  })
+})

--- a/packages/framework-dashboard/components/SessionActionsMenu.tsx
+++ b/packages/framework-dashboard/components/SessionActionsMenu.tsx
@@ -264,13 +264,17 @@ export function SessionActionsMenu({
                 <Play className="h-3.5 w-3.5 shrink-0" /> Serve
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent>
-                <DropdownMenuLabel>Serve which app</DropdownMenuLabel>
-                {targets.map(t => (
-                  <DropdownMenuItem key={t.id} disabled={busy} onClick={() => serve(t.id)}>
-                    <span className="truncate">{t.label}</span>
-                    <span className="ml-auto pl-3 text-xs text-muted-foreground">{t.script}</span>
-                  </DropdownMenuItem>
-                ))}
+                {/* Group parts need Menu.Group above them, or Base UI throws its error #31 and the
+                    boundary eats the whole view. Same list as PreviewBar's picker, same wrapper. */}
+                <DropdownMenuGroup>
+                  <DropdownMenuLabel>Serve which app</DropdownMenuLabel>
+                  {targets.map(t => (
+                    <DropdownMenuItem key={t.id} disabled={busy} onClick={() => serve(t.id)}>
+                      <span className="truncate">{t.label}</span>
+                      <span className="ml-auto pl-3 text-xs text-muted-foreground">{t.script}</span>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuGroup>
               </DropdownMenuSubContent>
             </DropdownMenuSub>
           ) : (


### PR DESCRIPTION
Found live while rehearsing the demo flow: on a multi-app repo, the session view dies to the error boundary with Base UI error #31 as soon as the preview URL clears (most visibly right after Stop session).

Base UI #31 is "Menu group parts must be used within Menu.Group". The session menu's Serve submenu renders "Serve which app" as a DropdownMenuLabel with no DropdownMenuGroup around it; while a preview URL exists the menu renders the Open/Stop branch instead, which is why the crash only appears once the preview stops. PreviewBar's identical picker has the wrapper; this copy dropped it.

Fix: same wrapper as PreviewBar. Regression test opens the submenu with two serve targets, and fails on the unfixed component (proved by revert). Dashboard suite 607/607.