### PR TITLE
fix(dashboard): cloud sessions read 'in cloud' with a cloud glyph, not 'done'

### DIFF
--- a/.changeset/cloud-session-rail.md
+++ b/.changeset/cloud-session-rail.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/the-framework": patch
+---
+
+The sessions rail is honest about cloud runs (#1263, #1264): a finished `Run on: Claude web` session reads "in cloud" instead of "done" (its local process ended at the hand-off; the cloud session keeps working and opens its own PR), rows carry a cloud glyph for web sessions, and a web run's row names its agent again (claude-web is still Claude).

--- a/packages/framework-dashboard/components/RunHistory.test.tsx
+++ b/packages/framework-dashboard/components/RunHistory.test.tsx
@@ -213,3 +213,53 @@ describe('RunHistory tickets nav (#1144)', () => {
     expect(screen.queryByText('Tickets')).toBeNull()
   })
 })
+
+describe('cloud sessions on the rail (#1263/#1264)', () => {
+  test('a finished web run reads as in cloud, not done: the session is still working over there', () => {
+    renderRail(
+      <RunHistory
+        projectId="p1"
+        runs={[run({ status: 'done', target: 'web', driver: 'claude-web' })]}
+        selectedRunId={null}
+        onSelect={() => {}}
+      />,
+    )
+    expect(screen.getByText('in cloud')).toBeTruthy()
+    expect(screen.queryByText('done')).toBeNull()
+  })
+
+  test('a web run stopped early is just stopped: nothing is working anywhere', () => {
+    renderRail(
+      <RunHistory
+        projectId="p1"
+        runs={[run({ status: 'stopped', target: 'web', driver: 'claude-web' })]}
+        selectedRunId={null}
+        onSelect={() => {}}
+      />,
+    )
+    expect(screen.getByText('stopped')).toBeTruthy()
+    expect(screen.queryByText('in cloud')).toBeNull()
+  })
+
+  test('a web run shows the cloud glyph and still names its agent (#1263)', () => {
+    renderRail(
+      <RunHistory
+        projectId="p1"
+        runs={[run({ status: 'done', target: 'web', driver: 'claude-web' })]}
+        selectedRunId={null}
+        onSelect={() => {}}
+      />,
+    )
+    expect(screen.getByLabelText('Runs as a Claude Code cloud session')).toBeTruthy()
+    // claude-web is still Claude: where it runs is the target, not the agent.
+    expect(screen.getByLabelText('Claude Code')).toBeTruthy()
+  })
+
+  test('a local finished run keeps its plain done badge and gets no cloud glyph', () => {
+    renderRail(
+      <RunHistory projectId="p1" runs={[run({ status: 'done', driver: 'claude-code' })]} selectedRunId={null} onSelect={() => {}} />,
+    )
+    expect(screen.getByText('done')).toBeTruthy()
+    expect(screen.queryByLabelText('Runs as a Claude Code cloud session')).toBeNull()
+  })
+})

--- a/packages/framework-dashboard/components/RunHistory.tsx
+++ b/packages/framework-dashboard/components/RunHistory.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Plus, ChevronDown, MonitorSmartphone, Settings, LayoutDashboard, FolderGit2, Ticket } from 'lucide-react'
+import { Plus, ChevronDown, Cloud, MonitorSmartphone, Settings, LayoutDashboard, FolderGit2, Ticket } from 'lucide-react'
 import type { RunMeta, RunStatus, RecentRun, ProjectSummary } from '@gemstack/the-framework'
 import { AGENT_LABELS, agentForDriver } from '@gemstack/the-framework/client'
 import { Button, buttonVariants } from './ui/button.js'
@@ -238,6 +238,7 @@ export function RunHistory({
                       active={row.active}
                       waiting={row.run.settledAt !== undefined}
                       remote={row.run.target === 'remote'}
+                      cloud={row.run.target === 'web'}
                       {...(row.run.remoteLabel ? { remoteLabel: row.run.remoteLabel } : {})}
                       onClick={row.onClick}
                     />
@@ -496,6 +497,7 @@ function RunRow({
   dim = false,
   waiting = false,
   remote = false,
+  cloud = false,
   remoteLabel,
 }: {
   status: RunStatus
@@ -510,12 +512,18 @@ function RunRow({
   waiting?: boolean
   /** Runs on a connected device (#1067): the row gets a device glyph next to the agent logo. */
   remote?: boolean
+  /** A Claude Code cloud session (#1263): the row gets a cloud glyph beside the agent logo. */
+  cloud?: boolean
   /** The device's label, for the glyph's tooltip. */
   remoteLabel?: string | undefined
 }) {
   // Only a live run can be waiting on you; a finished one is just finished.
   const parked = waiting && status === 'running'
   const agent = agentForDriver(driver)
+  // A web run's local process ends at the hand-off by design, so its `done` is about this
+  // machine, not the session (#1264): the cloud side keeps working and opens its own PR. Saying
+  // "done" under ten working cloud agents is the lie the demo would put on camera.
+  const inCloud = cloud && status === 'done'
   // The title only fades + marquees when it actually overflows the fixed-width rail; a short one
   // shows plainly. Measured here since CSS cannot tell. The rail width is fixed, so intent is the
   // only thing that changes the answer.
@@ -543,14 +551,15 @@ function RunRow({
         {status === 'running' && (
           <span className={cn('inline-block h-2 w-2 shrink-0 rounded-full', parked ? 'bg-muted-foreground' : 'animate-pulse bg-primary')} />
         )}
-        <Badge className={cn('shrink-0 border-transparent px-0 text-[10px] uppercase', parked ? 'text-muted-foreground' : STATUS_TONE[status])}>
-          {parked ? 'waiting' : status}
+        <Badge className={cn('shrink-0 border-transparent px-0 text-[10px] uppercase', parked ? 'text-muted-foreground' : inCloud ? 'text-primary' : STATUS_TONE[status])}>
+          {parked ? 'waiting' : inCloud ? 'in cloud' : status}
         </Badge>
         <span className="truncate text-xs font-normal text-muted-foreground">{subtitle}</span>
         {/* Right cluster: a device glyph when the run is relayed to a connected device (#1067),
-            then the agent logo. The logo is the only thing naming the agent on this row, so it
-            carries a title rather than being decorative. */}
-        {(remote || agent) && (
+            a cloud glyph for a Claude Code cloud session (#1263), then the agent logo. The logo
+            is the only thing naming the agent on this row, so it carries a title rather than
+            being decorative. */}
+        {(remote || cloud || agent) && (
           <span className="ml-auto flex shrink-0 items-center gap-1.5">
             {remote && (
               <Tooltip>
@@ -558,6 +567,14 @@ function RunRow({
                   <MonitorSmartphone className="h-3 w-3 text-muted-foreground" aria-label={remoteLabel ? `Runs on ${remoteLabel}` : 'Runs on a connected device'} />
                 </TooltipTrigger>
                 <TooltipContent>{remoteLabel ? `Runs on ${remoteLabel}` : 'Runs on a connected device'}</TooltipContent>
+              </Tooltip>
+            )}
+            {cloud && (
+              <Tooltip>
+                <TooltipTrigger render={<span className="flex items-center" />}>
+                  <Cloud className="h-3 w-3 text-muted-foreground" aria-label="Runs as a Claude Code cloud session" />
+                </TooltipTrigger>
+                <TooltipContent>Runs as a Claude Code cloud session; it works and opens its PR over there.</TooltipContent>
               </Tooltip>
             )}
             {agent && (

--- a/packages/the-framework/src/agent-names.ts
+++ b/packages/the-framework/src/agent-names.ts
@@ -31,6 +31,8 @@ export const AGENT_LABELS: Record<AgentName, string> = {
  * name differs from its own needs a case here, like claude's does.
  */
 export function agentForDriver(driver: string | undefined): AgentName | undefined {
-  if (driver === 'claude-code') return 'claude'
+  // Every surface Claude runs on is still Claude (#1263): the local CLI, the cloud session, and
+  // the Actions runner. Where it runs is the run's `target`, not its agent.
+  if (driver === 'claude-code' || driver === 'claude-web' || driver === 'github-actions') return 'claude'
   return isAgentName(driver) ? driver : undefined
 }


### PR DESCRIPTION
Closes #1263, closes #1264.

A web run's local process ends at the hand-off by design, so its recorded status is done. But the session is not done: the cloud side keeps working and opens its own PR. The sidebar captioned ten working cloud agents DONE, which is exactly what the demo would put on camera.

- The rail's badge shows "in cloud" (primary tone) for a web run whose status is done. A web run stopped early stays "stopped": nothing is working anywhere.
- Web rows get a cloud glyph beside the agent logo (mirroring the #1067 device glyph), with a tooltip saying the session works and opens its PR over there.
- agentForDriver now maps claude-web and github-actions to Claude, so a web run's row names its agent again. Where it runs is the target, not the agent.

Display-level only; no daemon changes. Settling "in cloud" back to done once the run's PR merges is possible per run via #1257 but costs a gh read per row, so it is deliberately left out of the list surface for now.

Tests: 4 new RunHistory cases; dashboard suite 611/611.