### PR TITLE
fix: the drain's pin survives the daemon's suspend/resume cycle

### DIFF
--- a/.changeset/resume-keeps-pin.md
+++ b/.changeset/resume-keeps-pin.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/the-framework": patch
+---
+
+A daemon restart no longer risks double-assigning a queue entry (#1268): the drain's pin now rides the suspended-run record and is handed back on resume, so the resumed run re-emits its claim whether or not the meta replay kept it.

--- a/packages/the-framework/src/daemon-runtime.ts
+++ b/packages/the-framework/src/daemon-runtime.ts
@@ -747,6 +747,9 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
         runId,
         suspendedAt: new Date().toISOString(),
         ...(meta?.sessionId ? { sessionId: meta.sessionId } : {}),
+        // The drain's pin travels with the record (#1268): the resumed run re-emits it, so the
+        // sweep's claim on the entry (#1253) survives the restart even if the meta replay drops it.
+        ...(meta?.queueEntry ? { queueEntry: meta.queueEntry } : {}),
       }
       byProject.set(projectCwd, [...(byProject.get(projectCwd) ?? []), entry])
     }

--- a/packages/the-framework/src/daemon-services.test.ts
+++ b/packages/the-framework/src/daemon-services.test.ts
@@ -1,0 +1,45 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resumeSuspendedRuns } from './daemon-services.js'
+import { writeSuspendedRuns } from './store/index.js'
+import type { StartRunOptions, StartRunResult } from './dashboard/types.js'
+
+test("resume hands the drain's pin back, so the resumed run re-emits its claim (#1268)", async () => {
+  const config = await mkdtemp(join(tmpdir(), 'framework-resume-cfg-'))
+  const project = await mkdtemp(join(tmpdir(), 'framework-resume-proj-'))
+  try {
+    // A minimal registry naming the project, in an isolated XDG config.
+    await writeFile(
+      join(config, 'the-framework.json'),
+      JSON.stringify({ projects: [{ id: 'proj-1', path: project, addedAt: '2026-07-27T00:00:00.000Z' }] }),
+    )
+    await mkdir(join(project, '.the-framework'), { recursive: true })
+    await writeSuspendedRuns(project, [
+      { runId: 'run-pinned', suspendedAt: new Date().toISOString(), sessionId: 'sess-9', queueEntry: 'entry beta: fix the readme typo' },
+      { runId: 'run-plain', suspendedAt: new Date().toISOString() },
+    ])
+
+    const starts: { prompt: string; options: StartRunOptions }[] = []
+    const startRun = async (prompt: string, options: StartRunOptions): Promise<StartRunResult> => {
+      starts.push({ prompt, options })
+      return { ok: true, runId: options.continueRunId ?? 'r' }
+    }
+    await resumeSuspendedRuns({ XDG_CONFIG_HOME: config }, startRun, () => {})
+
+    assert.equal(starts.length, 2)
+    const pinned = starts.find(s => s.options.continueRunId === 'run-pinned')!
+    // The pin travels back verbatim; startOptionFlags turns it into --queue-entry, and the
+    // resumed process re-emits the queue-entry event whether or not the meta replay kept it.
+    assert.equal(pinned.options.queueEntry, 'entry beta: fix the readme typo')
+    assert.equal(pinned.options.resumeSession, 'sess-9')
+    // A run that was never pinned stays unpinned: no invented claim.
+    const plain = starts.find(s => s.options.continueRunId === 'run-plain')!
+    assert.equal(plain.options.queueEntry, undefined)
+  } finally {
+    await rm(config, { recursive: true, force: true })
+    await rm(project, { recursive: true, force: true })
+  }
+})

--- a/packages/the-framework/src/daemon-services.ts
+++ b/packages/the-framework/src/daemon-services.ts
@@ -409,7 +409,15 @@ export async function resumeSuspendedRuns(
       const options = await resolveProjectRunOptions(record.id, env)
       const result = await startRun(
         RESUME_PROMPT,
-        { ...options, unattended: true, continueRunId: run.runId, ...(run.sessionId ? { resumeSession: run.sessionId } : {}) },
+        {
+          ...options,
+          unattended: true,
+          continueRunId: run.runId,
+          ...(run.sessionId ? { resumeSession: run.sessionId } : {}),
+          // Hand the drain's pin back (#1268): the resumed process re-emits the queue-entry
+          // event, so the claim reaches the rebuilt meta whether or not the replay kept it.
+          ...(run.queueEntry ? { queueEntry: run.queueEntry } : {}),
+        },
         record.id,
       )
       log(

--- a/packages/the-framework/src/store/suspend.test.ts
+++ b/packages/the-framework/src/store/suspend.test.ts
@@ -63,3 +63,17 @@ test('resumableRuns keeps recent work and drops what has gone stale (#923)', () 
   )
   assert.deepEqual(resumableRuns([], NOW), [])
 })
+
+test("the drain's pin rides the record and survives the round-trip and the age filter (#1268)", async () => {
+  const cwd = await tmpWorkspace()
+  try {
+    const pinned: SuspendedRun[] = [{ runId: '2026-c', suspendedAt: AT, queueEntry: 'entry alpha: add a footer note' }]
+    await writeSuspendedRuns(cwd, pinned)
+    // Byte-for-byte: the claim (#1253) is matched against the queue text verbatim, so any
+    // normalization here would silently release the pin on resume.
+    assert.deepEqual(await readSuspendedRuns(cwd), pinned)
+    assert.deepEqual(resumableRuns(pinned, NOW), pinned)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})

--- a/packages/the-framework/src/store/suspend.ts
+++ b/packages/the-framework/src/store/suspend.ts
@@ -19,6 +19,13 @@ export interface SuspendedRun {
   sessionId?: string
   /** When the daemon stopped it, ISO. */
   suspendedAt: string
+  /**
+   * The queue entry a drain pinned the run to (#1268), carried across the restart so the resumed
+   * run re-emits it. Its meta is what keeps the entry off the sweep's market (#1253), and the
+   * meta rebuilt on `--continue-run` proved able to lose the fold — a released pin means a second
+   * agent on work the resumed one is still doing.
+   */
+  queueEntry?: string
 }
 
 function suspendedPath(cwd: string): string {


### PR DESCRIPTION
Closes #1268.

Found in the scripted rehearsal: the daemon suspends its runs at shutdown and resumes them at boot (#923), but the SuspendedRun record kept only runId/suspendedAt/sessionId. The resumed run's meta is rebuilt by replaying its log on --continue-run, and that replay proved able to drop RunMeta.queueEntry (1 of 3 in the rehearsal). A dropped pin silently releases the entry's durable claim (#1253) while the resumed agent still works it, so a below-capacity sweep can hand the same entry to a second agent; at capacity the concurrency cap masks it.

Fix, belt and braces: suspendRuns captures queueEntry from the live meta onto the record, and resumeSuspendedRuns passes it back through start options, so the resumed process re-emits the queue-entry event and the claim reaches the rebuilt meta regardless of what the replay kept. A run that was never pinned stays unpinned.

Tests: record round-trip keeps the pin verbatim (the claim matches queue text byte for byte), and a resume test against a real isolated registry asserts the pinned run's options carry the entry while the unpinned one stays clean. Daemon suites green.