### PR TITLE
fix: mark a run failed when its child dies at boot (#1261)

### DIFF
--- a/.changeset/failed-start-marker.md
+++ b/.changeset/failed-start-marker.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+A run whose child dies at boot no longer shows "Waiting for the session to start" forever. Runs spawn detached with their stdio dropped, so a child that crashed before opening its run store (a dangling workspace link was the observed case) died invisibly: no run.json, no log line, a session page polling for a start that already failed. The daemon's exit handler now writes the minimal failed meta the page needs, dated by the run id, and the child's stderr is captured to a file in its checkout so the run log can quote the actual boot error. A child that wrote its own lifecycle is left alone, and the existing retention rules then keep the failed checkout for inspection.

--- a/packages/the-framework/src/daemon-runtime.ts
+++ b/packages/the-framework/src/daemon-runtime.ts
@@ -1,8 +1,10 @@
 import { spawn, type ChildProcess } from 'node:child_process'
-import { basename, join, resolve } from 'node:path'
+import { closeSync, mkdirSync, openSync } from 'node:fs'
+import { basename, dirname, join, resolve } from 'node:path'
 import { appendFile, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import {
   runIdFromStartedAt,
+  startedAtFromRunId,
   addWorktree,
   runBranchName,
   linkDependencies,
@@ -125,10 +127,64 @@ export async function moveTopicRunHistory(scratchCwd: string, worktreeCwd: strin
 }
 
 /** Spawn a detached, unref'd framework child (`node <binPath> <args...>`) that outlives us. */
-export function spawnDetached(binPath: string, args: string[]): ChildProcess {
-  const child = spawn(process.execPath, [binPath, ...args], { detached: true, stdio: 'ignore' })
+export function spawnDetached(binPath: string, args: string[], stderrFile?: string): ChildProcess {
+  // stderr goes to a file, never a pipe: a detached child must not block on a dead parent's pipe
+  // buffer, and the file is what makes a silent boot death diagnosable (#1261). Best-effort — a
+  // run must still start when the log cannot be opened.
+  let fd: number | undefined
+  if (stderrFile) {
+    try {
+      mkdirSync(dirname(stderrFile), { recursive: true })
+      fd = openSync(stderrFile, 'w')
+    } catch {}
+  }
+  const child = spawn(process.execPath, [binPath, ...args], { detached: true, stdio: ['ignore', 'ignore', fd ?? 'ignore'] })
+  if (fd !== undefined) closeSync(fd)
   child.unref()
   return child
+}
+
+/** Where a spawned run's stderr lands (#1261), so a child that dies at boot leaves a trace. */
+export function runStderrPath(cwd: string): string {
+  return join(cwd, FRAMEWORK_DIR, 'stderr.log')
+}
+
+/** One line saying how a child ended, for the failed-start marker (#1261). */
+function exitDetail(code: number | null, signal: NodeJS.Signals | null): string {
+  return code !== null
+    ? `its process exited with code ${code} before reporting anything`
+    : `its process was killed by ${signal ?? 'a signal'} before reporting anything`
+}
+
+/**
+ * Leave a `failed` marker behind a child that died before writing its own lifecycle (#1261).
+ *
+ * A healthy run's first act is opening its store (`run.json` + `events.jsonl`); a child that
+ * exited without one never booted — a module resolution error being the observed case — and with
+ * stdio detached the crash went nowhere, so the session page polled "Waiting for the session to
+ * start" forever. The daemon's exit handler is the one place that knows, so it writes the minimal
+ * meta the page needs and surfaces the child's stderr tail in the run log. A child that wrote its
+ * own meta is left alone: its lifecycle is its own to report.
+ */
+export async function markFailedStart(cwd: string, runId: string, intent: string, detail: string): Promise<boolean> {
+  const metaPath = join(cwd, FRAMEWORK_DIR, META_FILE)
+  if (await stat(metaPath).then(() => true, () => false)) return false
+  const now = new Date().toISOString()
+  const meta: RunMeta = {
+    version: RUN_META_VERSION,
+    status: 'failed',
+    id: runId,
+    startedAt: startedAtFromRunId(runId) ?? now,
+    updatedAt: now,
+    passes: 0,
+    ...(intent.trim() ? { intent } : {}),
+  }
+  const stderrTail = (await readFile(runStderrPath(cwd), 'utf8').catch(() => '')).trim().slice(-2000)
+  await mkdir(join(cwd, FRAMEWORK_DIR), { recursive: true }).catch(() => {})
+  await writeFile(metaPath, JSON.stringify(meta, null, 2) + '\n').catch(() => {})
+  await appendRunLog(cwd, `The session failed to start: ${detail}.` + (stderrTail ? `\n\n${stderrTail}` : ''))
+  console.log(`[framework] run ${runId} failed to start: ${detail}`)
+  return true
 }
 
 /**
@@ -459,25 +515,33 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
     // A short continuation note in the spirit of continuationPrompt: the resumed session already
     // carries the whole conversation, so this only tells it where it now is.
     const note = `You have been moved into project ${basename(projectCwd)} and are now working in its checkout. Continue where you left off.`
-    const continued = spawnDetached(realBin, [
-      'prompt',
-      note,
-      ...startOptionFlags(options),
-      '--no-dashboard',
-      '--cwd',
-      workspace.cwd,
-      ...(workspace.runId ? ['--run-id', workspace.runId] : []),
-      // Reopen the moved run rather than truncating it, and resume the agent session so the
-      // conversation continues seamlessly. `--topic` is dropped: this is an ordinary project run now.
-      '--continue-run',
-      ...(sessionId ? ['--resume-session', sessionId] : []),
-    ])
-    const settle = (): void => {
+    const continued = spawnDetached(
+      realBin,
+      [
+        'prompt',
+        note,
+        ...startOptionFlags(options),
+        '--no-dashboard',
+        '--cwd',
+        workspace.cwd,
+        ...(workspace.runId ? ['--run-id', workspace.runId] : []),
+        // Reopen the moved run rather than truncating it, and resume the agent session so the
+        // conversation continues seamlessly. `--topic` is dropped: this is an ordinary project run now.
+        '--continue-run',
+        ...(sessionId ? ['--resume-session', sessionId] : []),
+      ],
+      workspace.runId ? runStderrPath(workspace.cwd) : undefined,
+    )
+    const settle = (detail: string): void => {
       activeRuns.delete(key)
-      if (workspace.runId) void tearDownWorktree(projectCwd, workspace.cwd, workspace.runId)
+      const { cwd: checkout, runId: movedRunId } = workspace
+      if (!movedRunId) return
+      // The moved meta is normally already there, so the marker no-ops; it only writes when the
+      // copy was torn AND the resumed child died at boot (#1261) — the same hang either way.
+      void markFailedStart(checkout, movedRunId, '', detail).finally(() => void tearDownWorktree(projectCwd, checkout, movedRunId))
     }
-    continued.once('error', settle)
-    continued.once('exit', settle)
+    continued.once('error', err => settle(`its process could not be spawned (${errorMessage(err)})`))
+    continued.once('exit', (code, signal) => settle(exitDetail(code, signal)))
     if (continued.pid !== undefined) activeRuns.set(key, continued.pid)
     // Re-home succeeded, so the scratch is spent: remove it outright. The retain-on-failure rule is
     // for a run that ended in scratch, not one that moved on with its conversation intact.
@@ -526,30 +590,36 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
           : kind === 'prompt'
             ? ['prompt', prompt]
             : [prompt]
-      const child = spawnDetached(realBin, [
-        ...runArgs,
-        ...startOptionFlags(options),
-        '--no-dashboard',
-        '--cwd',
-        scratchCwd,
-        '--run-id',
-        runId,
-        '--topic',
-      ])
+      const child = spawnDetached(
+        realBin,
+        [
+          ...runArgs,
+          ...startOptionFlags(options),
+          '--no-dashboard',
+          '--cwd',
+          scratchCwd,
+          '--run-id',
+          runId,
+          '--topic',
+        ],
+        runStderrPath(scratchCwd),
+      )
       // Re-home on bind (#1122): once, and only on a committed re-home. `rehomed` gates the scratch
       // teardown below; `inFlight` stops a second bind racing a re-home already underway, but a bind
       // that failed to re-home leaves the watcher armed so a later bind (to a good project) retries.
       let rehomed = false
       let inFlight = false
       let stopBindWatch = (): void => {}
-      const settle = (): void => {
+      const settle = (detail: string): void => {
         activeRuns.delete(key)
         stopBindWatch()
-        // A committed re-home removes the scratch itself; otherwise fall back to the retain-on-fail rule.
-        if (!rehomed) void tearDownTopicScratch(scratchCwd)
+        if (rehomed) return // a committed re-home removes the scratch itself
+        // The failed marker lands before the teardown reads the meta (#1261), so a boot death is
+        // recorded and the retain-on-fail rule then keeps the scratch for inspection.
+        void markFailedStart(scratchCwd, runId, prompt, detail).finally(() => void tearDownTopicScratch(scratchCwd))
       }
-      child.once('error', settle)
-      child.once('exit', settle)
+      child.once('error', err => settle(`its process could not be spawned (${errorMessage(err)})`))
+      child.once('exit', (code, signal) => settle(exitDetail(code, signal)))
       stopBindWatch = tailEvents<FrameworkEvent>(join(scratchCwd, FRAMEWORK_DIR, EVENTS_FILE), event => {
         if (rehomed || inFlight || event.kind !== 'bind') return
         inFlight = true
@@ -651,24 +721,32 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
             : [prompt]
       // `--run-id` hands the run the id its worktree is named with, so the directory and the
       // run recorded inside it are one string — and tells it the framework owns its branch.
-      const child = spawnDetached(realBin, [
-        ...runArgs,
-        ...startOptionFlags(options),
-        '--no-dashboard',
-        '--cwd',
-        workspace.cwd,
-        ...(workspace.runId ? ['--run-id', workspace.runId] : []),
-        // Reopen the run's log instead of truncating it: the follow-up IS that run.
-        ...(continued ? ['--continue-run'] : []),
-      ])
+      const child = spawnDetached(
+        realBin,
+        [
+          ...runArgs,
+          ...startOptionFlags(options),
+          '--no-dashboard',
+          '--cwd',
+          workspace.cwd,
+          ...(workspace.runId ? ['--run-id', workspace.runId] : []),
+          // Reopen the run's log instead of truncating it: the follow-up IS that run.
+          ...(continued ? ['--continue-run'] : []),
+        ],
+        ...(workspace.runId ? [runStderrPath(workspace.cwd)] : []),
+      )
       // The run narrates itself through its own `.the-framework/events.jsonl`, which the
       // dashboard streams over a Telefunc Channel; the daemon just tracks liveness.
-      const settle = (): void => {
+      const settle = (detail: string): void => {
         activeRuns.delete(key)
-        if (workspace.runId) void tearDownWorktree(projectCwd, workspace.cwd, workspace.runId)
+        const { cwd: checkout, runId } = workspace
+        if (!runId) return
+        // The failed marker lands before the teardown reads the meta (#1261), so a boot death is
+        // archived as `failed` and the worktree is then kept for inspection, not removed.
+        void markFailedStart(checkout, runId, prompt, detail).finally(() => void tearDownWorktree(projectCwd, checkout, runId))
       }
-      child.once('error', settle)
-      child.once('exit', settle)
+      child.once('error', err => settle(`its process could not be spawned (${errorMessage(err)})`))
+      child.once('exit', (code, signal) => settle(exitDetail(code, signal)))
       if (child.pid !== undefined) activeRuns.set(key, child.pid)
       // Hand back the run's id (#761) so the dashboard can select this run rather than guess.
       return { ok: true, ...(workspace.runId ? { runId: workspace.runId } : {}) }

--- a/packages/the-framework/src/daemon-workspace.test.ts
+++ b/packages/the-framework/src/daemon-workspace.test.ts
@@ -3,9 +3,9 @@ import assert from 'node:assert/strict'
 import { mkdtemp, mkdir, writeFile, readFile, rm, stat, realpath } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { createProjectRuntime, cleanupTimedOutWorktree, tearDownTopicScratch, moveTopicRunHistory } from './daemon-runtime.js'
+import { createProjectRuntime, cleanupTimedOutWorktree, tearDownTopicScratch, moveTopicRunHistory, markFailedStart, runStderrPath } from './daemon-runtime.js'
 import { CliTimeoutError } from './cli-exec.js'
-import { FRAMEWORK_DIR, WORKTREES_DIR, EVENTS_FILE, META_FILE, worktreePath, runBranchName, RUN_META_VERSION, type RunMeta } from './store/index.js'
+import { FRAMEWORK_DIR, WORKTREES_DIR, EVENTS_FILE, META_FILE, worktreePath, runBranchName, RUN_META_VERSION, startedAtFromRunId, type RunMeta } from './store/index.js'
 import { topicScratchPath, addProject, projectId } from './registry.js'
 import { nodeGitRunner } from './project.js'
 
@@ -422,6 +422,101 @@ test('moveTopicRunHistory copies the log and re-marks the meta as a bound projec
     assert.equal(moved.id, 'run1', 'the run id and its history are preserved')
     assert.equal(moved.intent, 'draft a plan')
     assert.match(await readFile(join(worktree, FRAMEWORK_DIR, EVENTS_FILE), 'utf8'), /hello/, 'the event log came along')
+  } finally {
+    await rm(base, { recursive: true, force: true })
+  }
+})
+
+/** A stub CLI that prints a boot error to stderr and dies without ever opening its run store (#1261). */
+async function writeDyingStub(dir: string): Promise<string> {
+  const stub = join(dir, 'dying-stub.cjs')
+  await writeFile(
+    stub,
+    `process.stderr.write("Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'some-workspace-dep'\\n")\n` + `process.exit(1)\n`,
+  )
+  return stub
+}
+
+/** Poll a checkout until its `run.json` appears, or time out. */
+async function waitForMeta(cwd: string): Promise<RunMeta | undefined> {
+  for (let i = 0; i < POLL_ATTEMPTS; i++) {
+    const raw = await readFile(join(cwd, FRAMEWORK_DIR, META_FILE), 'utf8').catch(() => '')
+    if (raw) return JSON.parse(raw) as RunMeta
+    await new Promise(r => setTimeout(r, 20))
+  }
+  return undefined
+}
+
+/** Poll a checkout's event log until `pattern` shows up, and return what was read. */
+async function waitForLogLine(cwd: string, pattern: RegExp): Promise<string> {
+  let events = ''
+  for (let i = 0; i < POLL_ATTEMPTS && !pattern.test(events); i++) {
+    await new Promise(r => setTimeout(r, 20))
+    events = await readFile(join(cwd, FRAMEWORK_DIR, EVENTS_FILE), 'utf8').catch(() => '')
+  }
+  return events
+}
+
+test('a worktree run whose child dies at boot is marked failed instead of waiting forever (#1261)', async () => {
+  const cwd = await initRepo('framework-bootfail-')
+  const runtime = createProjectRuntime({ cwd, env: {}, binPath: await writeDyingStub(cwd) })
+  try {
+    const result = (await runtime.onStart('build a thing', 'build')) as { ok: boolean; runId?: string }
+    assert.equal(result.ok, true, 'the Start itself succeeds; the death is asynchronous')
+    const runId = result.runId!
+    const worktree = worktreePath(cwd, runId)
+
+    // The whole point: the child never wrote a lifecycle, so the daemon leaves one.
+    const meta = await waitForMeta(worktree)
+    assert.ok(meta, 'the daemon wrote a run.json for the dead child')
+    assert.equal(meta.status, 'failed', 'marked failed, so the page stops saying "Waiting for the session to start"')
+    assert.equal(meta.id, runId, 'under the run id the worktree is named with')
+    assert.equal(meta.startedAt, startedAtFromRunId(runId), 'dated by its run id, not by when the daemon noticed')
+    assert.equal(meta.intent, 'build a thing', 'carrying the prompt, so the run row is identifiable')
+
+    // The cause is visible: the child's stderr was captured and its tail is in the run log.
+    const events = await waitForLogLine(worktree, /failed to start/)
+    assert.match(events, /The session failed to start: its process exited with code 1/)
+    assert.match(events, /Cannot find package 'some-workspace-dep'/, 'the stderr tail names the actual boot error')
+    assert.match(await readFile(runStderrPath(worktree), 'utf8'), /ERR_MODULE_NOT_FOUND/, 'the full stderr file is kept')
+
+    // Failed, so the teardown's retention rule keeps the checkout for inspection.
+    assert.equal(await stat(worktree).then(s => s.isDirectory(), () => false), true, 'the worktree is retained')
+  } finally {
+    await runtime.dispose()
+    await rm(cwd, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+  }
+})
+
+test('a topic run whose child dies at boot is marked failed and its scratch retained (#1261)', async () => {
+  const home = await realpath(await mkdtemp(join(tmpdir(), 'framework-bootfail-topic-')))
+  const config = await realpath(await mkdtemp(join(tmpdir(), 'framework-bootfail-cfg-')))
+  const env = { XDG_CONFIG_HOME: config }
+  const runtime = createProjectRuntime({ cwd: home, env, binPath: await writeDyingStub(home) })
+  try {
+    const result = (await runtime.onStart('draft a ticket', 'build', { topic: true })) as { ok: boolean; runId?: string }
+    assert.equal(result.ok, true)
+    const scratch = topicScratchPath(env, result.runId!)
+
+    const meta = await waitForMeta(scratch)
+    assert.equal(meta?.status, 'failed', 'the scratch run is marked failed too')
+    await waitForLogLine(scratch, /failed to start/)
+    assert.equal(await stat(scratch).then(s => s.isDirectory(), () => false), true, 'the scratch is retained for inspection')
+  } finally {
+    await runtime.dispose()
+    await rm(home, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+    await rm(config, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+  }
+})
+
+test('a child that wrote its own lifecycle is left alone by the failed-start marker (#1261)', async () => {
+  const base = await realpath(await mkdtemp(join(tmpdir(), 'framework-bootfail-skip-')))
+  try {
+    await writeRunMeta(base, 'done')
+    assert.equal(await markFailedStart(base, 'run1', 'build a thing', 'its process exited with code 0'), false)
+    const meta = JSON.parse(await readFile(join(base, FRAMEWORK_DIR, META_FILE), 'utf8')) as RunMeta
+    assert.equal(meta.status, 'done', 'the run reported its own end; the marker does not rewrite history')
+    assert.equal(await stat(join(base, FRAMEWORK_DIR, EVENTS_FILE)).then(() => true, () => false), false, 'and no failure line is invented')
   } finally {
     await rm(base, { recursive: true, force: true })
   }


### PR DESCRIPTION
Closes #1261

## What happened

Runs spawn detached with stdio ignored. A child that crashed before opening its run store (the dangling `@gemstack/ai-autopilot` workspace link, #1262) died invisibly: no `run.json` was ever written, the daemon log said nothing, and the session page polled "Waiting for the session to start" forever.

## The fix

The daemon's exit handler is the one place that knows the child died, so it now leaves the record the page needs:

- `markFailedStart()`: if the child exited without writing its own lifecycle, write a minimal `run.json` (status `failed`, id the worktree is named with, `startedAt` derived from the run id, the prompt as `intent`) plus a run-log line saying how the process ended, and a daemon-log line. A child that wrote its own meta is left alone: its lifecycle is its own to report.
- stderr is no longer dropped: `spawnDetached` can point the child's stderr at `.the-framework/stderr.log` in its checkout (a file, never a pipe, so a detached child can never block on a dead parent). The run-log line quotes the tail, so the actual boot error is visible in the dashboard.
- The marker lands before the teardown reads the meta, so the existing retention rules do the rest: a `failed` worktree/scratch is kept for inspection, and the archive copies the failed meta.

All three spawn-site settles are wired: project runs, topic runs, and the re-homed continue-run child (there the meta normally already exists, so the marker no-ops).

## Proof

Three new tests in `daemon-workspace.test.ts` against a real git repo and a stub CLI that prints an `ERR_MODULE_NOT_FOUND` to stderr and exits 1: the worktree run gets a `failed` meta + the stderr tail in its log + a retained worktree; the topic run the same in its retained scratch; a run that wrote its own meta is untouched and no failure line is invented.

Full suite: 1479 pass, 0 fail.