### PR TITLE
fix: record the run branch from the start instead of guessing (#1277)

### DIFF
--- a/.changeset/one-branch-name.md
+++ b/.changeset/one-branch-name.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+A run's branch is recorded on its meta from the start, and updated when the framework renames the run-id branch after the agent names the session, instead of being stamped only at teardown. Continuing a run re-attaches the recorded branch, so a run whose agent created its own branch is no longer continued on a branch without its previous commits.

--- a/packages/the-framework/src/cli.test.ts
+++ b/packages/the-framework/src/cli.test.ts
@@ -13,6 +13,7 @@ import {
   chooseSessionLink,
   claudeDriverOptions,
   CLAUDE_CODE_SESSION_LIST,
+  createRunJournal,
   ecoOptions,
   frameworkVersion,
   mergeRunConfig,
@@ -977,4 +978,38 @@ test('parseArgs reads --ticket, the ticket the daemon says this run implements (
 
 test('parseArgs reads --queue-entry, the queue entry a drain pinned this run to (#1253)', () => {
   assert.equal(parseArgs(['--queue-entry', 'Fix the flaky teardown test', 'x']).queueEntry, 'Fix the flaky teardown test')
+})
+
+test('naming the session renames the run-id branch and records it as a branch event (#1277)', async t => {
+  const { execFileSync } = await import('node:child_process')
+  const repo = await mkdtemp(join(tmpdir(), 'fw-journal-'))
+  t.after(() => rm(repo, { recursive: true, force: true }))
+  const git = (...args: string[]): string => execFileSync('git', args, { cwd: repo, encoding: 'utf8' })
+  git('init', '-q')
+  git('config', 'user.email', 'test@example.com')
+  git('config', 'user.name', 'Test')
+  git('commit', '--allow-empty', '-q', '-m', 'seed')
+  // The state allocateWorkspace leaves a run in: checked out on its run-id branch (#736).
+  git('checkout', '-q', '-b', 'the-framework/run-r1')
+  const { io, out } = capture()
+  const journal = createRunJournal({
+    io,
+    cwd: repo,
+    store: undefined,
+    publisher: undefined,
+    runId: 'r1',
+    kind: 'prompt',
+    title: 'a run',
+    beforeLog: async () => {},
+  })
+  journal.onEvent({ kind: 'session-name', name: 'cool-name' })
+  // The rename runs off the event asynchronously; wait for the recorded branch to come through.
+  for (let i = 0; i < 200 && !out.some(line => line.includes('branch: the-framework/cool-name')); i++) {
+    await new Promise(res => setTimeout(res, 10))
+  }
+  assert.ok(
+    out.some(line => line.includes('branch: the-framework/cool-name')),
+    `expected a branch event, got: ${out.join('; ')}`,
+  )
+  assert.equal(git('rev-parse', '--abbrev-ref', 'HEAD').trim(), 'the-framework/cool-name')
 })

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -1090,7 +1090,7 @@ function conversationRecorder(deps: {
 }
 
 /** What the run journal exposes to the epilogue. See {@link createRunJournal}. */
-interface RunJournal {
+export interface RunJournal {
   onEvent: (event: FrameworkEvent) => void
   /** The session name the agent chose via setSessionName() (#326), once it has. */
   sessionName: () => string | undefined
@@ -1111,9 +1111,9 @@ interface RunJournal {
  * branch once the agent names its session (#736), and re-emits a held browser-stream port
  * right after `session` so it lands in the slice the dashboard renders (#829). These jobs sat
  * inline in runCli across six mutable locals; the journal is their one owner, and runCli reads
- * the getters.
+ * the getters. Exported for the rename-records-the-branch test (#1277).
  */
-function createRunJournal(deps: {
+export function createRunJournal(deps: {
   io: CliIO
   cwd: string
   store: RunStore | undefined
@@ -1149,8 +1149,15 @@ function createRunJournal(deps: {
     if (event.kind === 'session-name') {
       sessionName = event.name
       // The framework-owned checkout (#736) was branched as `the-framework/run-<id>` before a
-      // name existed; put the readable name on it now. No-ops when the agent branched itself.
-      if (deps.runId) void renameRunBranch(cwd, runBranchName(deps.runId), `the-framework/${event.name}`)
+      // name existed; put the readable name on it now. No-ops when the agent branched itself,
+      // and only a rename that happened is recorded (#1277) — a guessed name on the meta is
+      // exactly what the branch event exists to end.
+      if (deps.runId) {
+        const renamed = `the-framework/${event.name}`
+        void renameRunBranch(cwd, runBranchName(deps.runId), renamed).then(didRename => {
+          if (didRename) onEvent({ kind: 'branch', branch: renamed })
+        })
+      }
     }
     if (event.kind === 'end') {
       if (event.stopped) stoppedCleanly = true
@@ -1558,6 +1565,11 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
   // The queue entry a routine drain pinned this run to (#1253), same shape as the ticket above:
   // once, at start, folded to meta — the durable half of the sweep's claim on the entry.
   if (opts.queueEntry?.trim()) onEvent({ kind: 'queue-entry', entry: opts.queueEntry })
+  // The branch this run actually starts on (#1277): recorded, not guessed, so surfaces reading
+  // the meta mid-run resolve the same name teardown will later confirm. Undefined outside a git
+  // checkout (a non-repo project), and then nothing is recorded.
+  const startBranch = await currentBranch(cwd)
+  if (startBranch) onEvent({ kind: 'branch', branch: startBranch })
   // Wired now the journal exists: a bind resolved from a topic run's gate folds to meta (#1121).
   recordBind = projectId => onEvent({ kind: 'bind', projectId })
 

--- a/packages/the-framework/src/daemon-runtime.ts
+++ b/packages/the-framework/src/daemon-runtime.ts
@@ -34,6 +34,7 @@ import type { FrameworkEvent } from './events.js'
 import type { StartRunKind, StartRunOptions, StartRunResult, AddProjectResult } from './dashboard/index.js'
 import type { EventsSource, PreviewHandlers, RemoteRuns } from './dashboard/telefunc-serve.js'
 import { RelayedRuns, startRemoteRun } from './dashboard/remote-run.js'
+import { runBranchFor } from './dashboard/run-handoff.js'
 import { dispatchRelayRpc } from './dashboard-rpc/relay-dispatch.js'
 import { tailEvents } from './dashboard-rpc/events-tail.js'
 import { isSafeVia } from './conversations.js'
@@ -375,7 +376,10 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
       const existing = await stat(path).then(s => s.isDirectory()).catch(() => false)
       if (!existing) {
         const archived = (await listRuns(projectCwd).catch(() => [])).find(run => run.id === runId)
-        const branch = archived?.sessionName ? `the-framework/${archived.sessionName}` : runBranchName(runId)
+        // The recorded branch first (#1277): an agent that branched itself (#326 allows it) has
+        // its work there, and re-attaching by the session-name guess would continue the run on a
+        // branch without its previous commits.
+        const branch = runBranchFor(archived ?? { id: runId })
         await attachWorktree(projectCwd, { runId, branch })
         await linkDependencies(projectCwd, path).catch(() => [])
       }

--- a/packages/the-framework/src/events.ts
+++ b/packages/the-framework/src/events.ts
@@ -207,6 +207,14 @@ export type FrameworkEvent =
    */
   | { kind: 'queue-entry'; entry: string }
   /**
+   * The branch the run's work is on (#1277), observed off the checkout rather than guessed:
+   * emitted at start with the branch the run actually begins on, and again when the framework
+   * renames the run-id branch after the agent names the session. Folded to `RunMeta.branch`,
+   * which every surface resolves first — before this event the branch was stamped only at
+   * teardown (#799), so any read before that guessed between three naming schemes.
+   */
+  | { kind: 'branch'; branch: string }
+  /**
    * What the end-of-session handoff actually did (#1102): pushed and/or opened a draft PR,
    * declined for a reason that is not a fault, or failed at one of the two steps.
    *

--- a/packages/the-framework/src/store/run-store.test.ts
+++ b/packages/the-framework/src/store/run-store.test.ts
@@ -663,3 +663,12 @@ test('applyEventToMeta records the queue entry a drain pinned the run to (#1253)
   const ended = applyEventToMeta(on, { kind: 'end', ok: true }, AT)
   assert.equal(ended.queueEntry, 'Fix the flaky teardown test')
 })
+
+test('applyEventToMeta records the branch a branch event names (#1277)', () => {
+  const base = metaFromEvents(RUN.slice(0, 4), AT)
+  const on = applyEventToMeta(base, { kind: 'branch', branch: 'the-framework/run-r1' }, AT)
+  assert.equal(on.branch, 'the-framework/run-r1')
+  // A rename mid-run replaces it: the meta always names the branch the work is on now.
+  const renamed = applyEventToMeta(on, { kind: 'branch', branch: 'the-framework/cool-name' }, AT)
+  assert.equal(renamed.branch, 'the-framework/cool-name')
+})

--- a/packages/the-framework/src/store/run-store.ts
+++ b/packages/the-framework/src/store/run-store.ts
@@ -121,11 +121,12 @@ export interface RunMeta {
   /** The session name the agent chose (#326), also its `the-framework/<name>` branch. */
   sessionName?: string
   /**
-   * The branch the run's work landed on, recorded while its worktree still exists (#799).
+   * The branch the run's work is on: folded from `branch` events as the run observes it (#1277),
+   * and corrected at teardown while the worktree still exists (#799).
    *
-   * Not reliably derivable afterwards: a clean run loses its checkout, and the #326 prompt lets
-   * the agent create its own branch, so neither `the-framework/<sessionName>` nor the run-id
-   * branch is guaranteed to be the one holding the commits.
+   * Not reliably derivable instead of recorded: a clean run loses its checkout, and the #326
+   * prompt lets the agent create its own branch, so neither `the-framework/<sessionName>` nor
+   * the run-id branch is guaranteed to be the one holding the commits.
    */
   branch?: string
   /**
@@ -321,6 +322,9 @@ export function applyEventToMeta(meta: RunMeta, event: FrameworkEvent, at: strin
       break
     case 'queue-entry':
       next.queueEntry = event.entry
+      break
+    case 'branch':
+      next.branch = event.branch
       break
     case 'settled':
       next.settledAt = at

--- a/packages/the-framework/src/terminal.ts
+++ b/packages/the-framework/src/terminal.ts
@@ -38,6 +38,8 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
       return `  implementing ${event.path}`
     case 'queue-entry':
       return `  working the queue entry: ${event.entry}`
+    case 'branch':
+      return `  branch: ${event.branch}`
     case 'on-before-mergeable':
       switch (event.outcome) {
         case 'queued':


### PR DESCRIPTION
Closes #1277

A run's branch had four competing sources and was only recorded at teardown; every earlier read guessed between naming schemes, and continue-run guessed too.

What this does, code-side only (no prompt changes):

- New `branch` event: emitted once at run start with the branch the checkout is actually on, and again when the framework's rename to `the-framework/<sessionName>` succeeds. Only a rename that happened is recorded.
- The store folds it into `RunMeta.branch`, so mid-run reads resolve the same name teardown later confirms. The teardown stamp stays as the final correction (covers an agent that branched itself, #326 allows it).
- Continue-run now resolves through `runBranchFor` (recorded branch first) instead of the session-name guess, so a run whose agent named its own branch is no longer continued on a branch without its previous commits.
- Terminal prints the event; the dashboard's badge labeling already falls back generically.

Tests: fold test in run-store.test.ts; a real-repo test that naming the session renames the run-id branch and records the branch event (createRunJournal exported for it). Framework suite 1482 tests 0 fail, dashboard 617/617.