### PR TITLE
fix(dashboard): routine and preset runs start unattended so they finish and hand off

### DIFF
--- a/.changeset/unattended-routines.md
+++ b/.changeset/unattended-routines.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+Routine and preset runs fired from the dashboard now run unattended, exactly as the auto-PM sweep runs the same routines: choice gates take the recommended option, the run ends at settle, and its armed push+PR handoff fires. Previously a card-fired routine did its work and then parked forever in the stay-open chat loop as "running", its PR never opened and the queue never filled. The stay-open conversation is unchanged for hand-typed prompts, which is what it was built for.

--- a/packages/framework-dashboard/components/OnboardingChecklist.test.tsx
+++ b/packages/framework-dashboard/components/OnboardingChecklist.test.tsx
@@ -92,7 +92,8 @@ describe('the GitHub import lands on the session it starts (#1169)', () => {
     await clickImport()
 
     // The project travels with it: this surface has none selected, so an id alone cannot be routed.
-    expect(startRun.start).toHaveBeenCalledWith('p1', presets.importTickets.render(), 'prompt', {})
+    // Unattended (#1279): a checklist-fired routine ends at settle instead of parking in the chat loop.
+    expect(startRun.start).toHaveBeenCalledWith('p1', presets.importTickets.render(), 'prompt', { unattended: true })
     await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith('p1', presets.importTickets.render(), 'run-7'))
   })
 

--- a/packages/framework-dashboard/components/OnboardingChecklist.tsx
+++ b/packages/framework-dashboard/components/OnboardingChecklist.tsx
@@ -103,7 +103,8 @@ export function OnboardingChecklist({
   const importTickets = async () => {
     if (!targetProjectId) return
     const intent = presets.importTickets.render()
-    const started = await start(targetProjectId, intent, 'prompt', {})
+    // Unattended (#1279): a checklist-fired routine ends at settle instead of parking in the chat loop.
+    const started = await start(targetProjectId, intent, 'prompt', { unattended: true })
     // Land on the session doing the import, not the project's launcher (#1169): its id is what
     // the shell needs to show the live output. A refusal keeps you here, with `startError` shown.
     if (started) onRunStarted(targetProjectId, intent, started.runId)

--- a/packages/framework-dashboard/components/RoutineWork.test.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.test.tsx
@@ -85,10 +85,13 @@ describe('RoutineWork (#1159)', () => {
     await waitFor(() => expect(screen.getAllByText('Run now').length).toBeGreaterThan(0))
     fireEvent.click(screen.getAllByText('Run now')[1]!)
     await waitFor(() => expect(start).toHaveBeenCalled())
-    const [projectId, prompt, kind] = start.mock.calls[0]!
+    const [projectId, prompt, kind, options] = start.mock.calls[0]!
     expect(projectId).toBe('p1')
     expect(prompt).toBe(ROTATION_JOB.prompt)
     expect(kind).toBe('prompt')
+    // Unattended (#1279): a card-fired routine ends at settle and its handoff fires, like the
+    // sweep's own runs, instead of parking in the stay-open chat loop.
+    expect(options).toMatchObject({ unattended: true })
     // The run id is the whole point: without it the shell renders the launcher, so "Run now"
     // landed on an empty composer with its own session nowhere on screen (#1191).
     await waitFor(() => expect(started).toHaveLength(1))

--- a/packages/framework-dashboard/components/RoutineWork.tsx
+++ b/packages/framework-dashboard/components/RoutineWork.tsx
@@ -111,7 +111,10 @@ export function RoutineWork({
     setStarting(job.name)
     // The global options only: the Overview has no project open, so the per-project tier (#840) is
     // not resolved here and the run starts on the same defaults a fresh launcher would use.
-    const result = await start(projectId, job.prompt, 'prompt', runOptionsFromPreferences(preferences))
+    // Unattended (#1279): a routine fired by a card is the same work the sweep starts, so it runs
+    // the same way — gates auto-answer, the run ends at settle, and the armed handoff fires,
+    // instead of parking in the stay-open chat loop with its PR never opened.
+    const result = await start(projectId, job.prompt, 'prompt', { ...runOptionsFromPreferences(preferences), unattended: true })
     setStarting(null)
     // Go to the run itself, not merely to its project (#1191): selecting the project renders the
     // launcher, so the button that says "Run now" landed you on an empty composer and the session

--- a/packages/framework-dashboard/components/StartRunForm.test.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.test.tsx
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+// Everything the form reads goes through a lib module, so the mocks stop short of telefunc: an
+// unmocked `*.telefunc.js` in the import graph fails as an assertIsNotBrowser bug report.
+const onProjects = vi.hoisted(() => vi.fn())
+vi.mock('../server/projects.telefunc.js', () => ({ onProjects }))
+
+const onSystemPromptUser = vi.hoisted(() => vi.fn())
+vi.mock('../server/reads.telefunc.js', () => ({ onSystemPromptUser }))
+
+vi.mock('../lib/preferences.js', () => ({
+  usePreferences: () => ({}),
+  updatePreferences: vi.fn(),
+  autopilotEnabled: () => false,
+}))
+vi.mock('../lib/profiles.js', () => ({ useConnectionProfiles: () => [] }))
+vi.mock('../lib/remote-target.js', () => ({ useSelectedRemoteDeviceId: () => null }))
+
+const start = vi.hoisted(() => vi.fn())
+vi.mock('../lib/use-start-run.js', () => ({
+  useStartRun: () => ({ busy: false, error: null, reset: vi.fn(), start }),
+}))
+
+// The Composer is exercised by its own tests; here it only has to hand back the two submit
+// kinds its contract defines: 'build' for a typed prompt, 'prompt' once a preset was loaded.
+vi.mock('./Composer.js', async () => {
+  const { forwardRef } = await import('react')
+  const Composer = forwardRef((props: any, _ref: any) => (
+    <div>
+      <button type="button" onClick={() => props.onSubmit('do the thing', 'build', { newSession: false })}>
+        submit-typed
+      </button>
+      <button type="button" onClick={() => props.onSubmit('preset text', 'prompt', { newSession: false })}>
+        submit-preset
+      </button>
+    </div>
+  ))
+  return { Composer }
+})
+vi.mock('./ContextMenu.js', () => ({ ContextMenu: () => null }))
+vi.mock('./SystemPromptDisclosure.js', () => ({ SystemPromptDisclosure: () => null }))
+
+const { StartRunForm } = await import('./StartRunForm.js')
+
+afterEach(() => {
+  cleanup()
+  start.mockReset()
+})
+
+const props = {
+  projectId: 'p1',
+  files: [],
+  context: new Set<string>(),
+  addContext: () => {},
+  removeContext: () => {},
+  toggleContext: () => {},
+}
+
+describe('StartRunForm submit (#1279)', () => {
+  test('a preset run starts unattended, so it ends at settle and its handoff fires', async () => {
+    onProjects.mockResolvedValue([])
+    onSystemPromptUser.mockResolvedValue(null)
+    start.mockResolvedValue({ runId: 'r1' })
+    render(<StartRunForm {...props} />)
+    fireEvent.click(screen.getByText('submit-preset'))
+    await waitFor(() => expect(start).toHaveBeenCalled())
+    expect(start.mock.calls[0]![2]).toBe('prompt')
+    expect(start.mock.calls[0]![3]).toMatchObject({ unattended: true })
+  })
+
+  test('a typed prompt stays attended: the stay-open chat (#714) is for conversations', async () => {
+    onProjects.mockResolvedValue([])
+    onSystemPromptUser.mockResolvedValue(null)
+    start.mockResolvedValue({ runId: 'r1' })
+    render(<StartRunForm {...props} />)
+    fireEvent.click(screen.getByText('submit-typed'))
+    await waitFor(() => expect(start).toHaveBeenCalled())
+    expect(start.mock.calls[0]![2]).toBe('build')
+    expect(start.mock.calls[0]![3]).not.toHaveProperty('unattended')
+  })
+})

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -90,7 +90,10 @@ export function StartRunForm({
   const submit = async (text: string, submitKind: 'build' | 'prompt') => {
     if (busy) return
     setNote('Starting…')
-    const result = await start(projectId, text, submitKind, options)
+    // A preset run (`submitKind === 'prompt'`) is fired work, not a conversation: it runs
+    // unattended (#1279), ending at settle with its armed handoff firing, exactly as the same
+    // routine does when the auto-PM sweep starts it. A typed prompt keeps the stay-open chat.
+    const result = await start(projectId, text, submitKind, submitKind === 'prompt' ? { ...options, unattended: true } : options)
     setNote(null)
     if (result) {
       // Show the run in the Runs rail immediately (#405): the spawned process writes its run.json

--- a/packages/framework-dashboard/components/TicketsPanel.test.tsx
+++ b/packages/framework-dashboard/components/TicketsPanel.test.tsx
@@ -153,6 +153,8 @@ describe('TicketsPanel (#697/#1144)', () => {
     // And it is the preset's own text: the onboarding checklist offers this button under the same
     // label and sends `presets.importTickets`, so a second source here means one label, two asks.
     expect(sendStart.mock.calls[0]?.[1]).toBe(presets.importTickets.render())
+    // Unattended (#1279): a button-fired import ends at settle instead of parking in the chat loop.
+    expect(sendStart.mock.calls[0]?.[3]).toEqual({ unattended: true })
     // The run id is what lands you on the import session rather than the project home (#1169).
     await waitFor(() => expect(onRunStarted).toHaveBeenCalledWith(expect.any(String), 'r1'))
   })

--- a/packages/framework-dashboard/components/TicketsPanel.tsx
+++ b/packages/framework-dashboard/components/TicketsPanel.tsx
@@ -72,7 +72,9 @@ export function TicketsPanel({
   if (!loaded) return <p className="p-4 text-sm text-muted-foreground">Loading…</p>
 
   const startImport = async (prompt: string, failure: string) => {
-    const result = await run(() => sendStart(projectId, prompt, 'prompt'), failure)
+    // Unattended (#1279): an import fired by a button is routine work, not a conversation — it
+    // ends at settle and its armed handoff fires, as when the sweep starts the same routine.
+    const result = await run(() => sendStart(projectId, prompt, 'prompt', { unattended: true }), failure)
     // Jump to the session doing the work, so its progress is watchable instead of the panel
     // sitting on stale rows until files land.
     if (result?.ok) onRunStarted?.(prompt, result.runId)

--- a/packages/the-framework/src/dashboard/types.ts
+++ b/packages/the-framework/src/dashboard/types.ts
@@ -72,7 +72,9 @@ export interface StartRunOptions {
   /**
    * Nobody is watching this run (#846): its choice gates take the recommended option instead of
    * parking for an answer, which is the fallback a fully headless run already uses and the one
-   * autopilot would have clicked. Set by the work the daemon starts on its own (auto PM, #685).
+   * autopilot would have clicked. It also keeps the run out of the stay-open chat loop, so it
+   * ends at settle and its armed handoff fires. Set by the work the daemon starts on its own
+   * (auto PM, #685) and by dashboard surfaces that fire routine/preset work (#1279).
    * Stop still works — that aborts the run controller, not a gate.
    */
   unattended?: boolean


### PR DESCRIPTION
Closes #1279

Proved live in the #1279 drive: a routine fired from a dashboard card does its work, then parks forever in the stay-open chat loop — armed push+PR never fires (it fires at process end), so no PR and the queue never fills. The identical routine sweep-started ends by itself and hands off, because the sweep forces `unattended: true`.

The fix uses that existing lever, no new mechanism: dashboard surfaces that fire routine/preset work now pass `unattended: true` through `sendStart`, so those runs end at settle with gates auto-answered, exactly as when the sweep starts them.

Surfaces changed:
- RoutineWork "Run now" (non-drain rotation rows; the drain row already goes through the sweep)
- StartRunForm: preset submits only (`submitKind === 'prompt'`); a typed prompt keeps the stay-open chat, which is what #714 was built for
- OnboardingChecklist import step
- TicketsPanel GitHub import buttons

The finished-run continuation composer is untouched: it is the conversation surface.

Tests: new StartRunForm.test.tsx pins both directions (preset -> unattended, typed -> attended); RoutineWork / OnboardingChecklist / TicketsPanel assertions extended. Dashboard 619/619.