### PR TITLE
fix: continue a run its driver dropped mid-work instead of losing it

### DIFF
--- a/.changeset/retry-transient-deaths.md
+++ b/.changeset/retry-transient-deaths.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+A run whose driver dies to a transient transport error (connection closed mid-response, reset, timeout, overload, 5xx) is no longer lost: the daemon continues the same run in its retained worktree, on its recorded branch, up to twice with a short pause, using the same continue-run machinery that resumes runs after a daemon restart. The queue pin and agent session ride along, so a retried drain keeps its claim and its context. A run that fails on its own terms, or keeps dying after the retries, stays failed.

--- a/packages/the-framework/src/daemon-runtime.ts
+++ b/packages/the-framework/src/daemon-runtime.ts
@@ -14,6 +14,7 @@ import {
   attachWorktree,
   worktreePath,
   listRuns,
+  archivedRunPaths,
   commitPendingWork,
   currentBranch,
   removeWorktree,
@@ -189,6 +190,48 @@ export async function markFailedStart(cwd: string, runId: string, intent: string
 }
 
 /**
+ * Driver deaths worth one more try (#1281): the connection dropped or the API buckled mid-run —
+ * failures about the transport, not the work. Conservative on purpose: a run that failed for any
+ * reason this does not name stays failed, because retrying a real failure just re-runs it.
+ */
+const TRANSIENT_FAILURE =
+  /connection closed|connection reset|connection error|econnreset|etimedout|socket hang up|overloaded|rate.?limit|api error: 5\d\d|internal server error/i
+
+/** Whether a run's failure detail names a transient transport error (#1281). */
+export function isTransientRunFailure(detail: string | undefined): boolean {
+  return detail !== undefined && TRANSIENT_FAILURE.test(detail)
+}
+
+/**
+ * The detail the run's own `end` event failed with, off its archived event log (#1281), or
+ * undefined when the run did not fail by its own report. Only a child-written `end` counts: a
+ * boot death (#1261) never writes one, and retrying a run that cannot boot would just re-crash.
+ */
+export function lastRunFailureDetail(eventsJsonl: string): string | undefined {
+  let detail: string | undefined
+  for (const line of eventsJsonl.split('\n')) {
+    if (!line.trim()) continue
+    try {
+      const event = JSON.parse(line) as { kind?: string; ok?: boolean; detail?: string }
+      if (event.kind === 'end') detail = event.ok === false ? event.detail : undefined
+    } catch {
+      // A malformed line is not this reader's problem; the events around it still count.
+    }
+  }
+  return detail
+}
+
+/** How many times a transiently-dead run is continued before its failure stands (#1281). */
+export const MAX_TRANSIENT_RETRIES = 2
+
+/** The pause before a retry (#1281): long enough for a dropped connection to be worth re-trying. */
+export const TRANSIENT_RETRY_DELAY_MS = 15_000
+
+/** What the continued session is told (#1281), in the #923 resume prompt's shape. */
+export const RETRY_PROMPT =
+  'This session died to a transient connection error, not because anyone asked it to stop. Look at what you had already done, then carry on from there and finish the work.'
+
+/**
  * Translate the dashboard's Global options (#314) into CLI flags for the spawned
  * run. Only enabled toggles emit a flag, so a default (all-off) start is
  * byte-identical to before. `parseArgs` on the other side accepts every one.
@@ -292,6 +335,8 @@ export interface ProjectRuntimeOptions {
   env: NodeJS.ProcessEnv
   /** The CLI entry to spawn runs with (#345); undefined uses `process.argv[1]`. */
   binPath?: string | undefined
+  /** The pause before a transient-death retry (#1281); undefined uses {@link TRANSIENT_RETRY_DELAY_MS}. A test seam. */
+  retryDelayMs?: number | undefined
 }
 
 /** The per-project run + preview surface the dashboard drives, plus its teardown. */
@@ -330,7 +375,7 @@ export interface ProjectRuntime {
  * with no project id (or the home id) resolves to it without a registry lookup. Split out of
  * {@link runDaemon} so the daemon body reads as lifecycle and this reads as business logic.
  */
-export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOptions): ProjectRuntime {
+export function createProjectRuntime({ cwd, env, binPath, retryDelayMs }: ProjectRuntimeOptions): ProjectRuntime {
   const homeId = projectId(resolve(cwd))
   // The run-key namespace for project-less topic runs (#1120): `@`-prefixed so it can never equal a
   // real project id (projectId always appends `-<hash>`), so a topic run belongs to no project.
@@ -471,6 +516,54 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
     } catch {
       // A worktree we could not retire is a worktree left on disk, which is the safe direction.
     }
+  }
+
+  // One more try for a run the API dropped mid-work (#1281): the failure is about the transport,
+  // not the work, and the continue-run machinery (#762/#923) reopens the retained checkout on its
+  // recorded branch (#1278). Counted in memory on purpose: a daemon restart already re-resumes
+  // runs (#923), and a lost count only ever grants one extra attempt.
+  const runRetries = new Map<string, number>()
+  const retryTransientDeath = async (
+    projectCwd: string,
+    targetProjectId: string | undefined,
+    runId: string,
+    options: StartRunOptions,
+  ): Promise<void> => {
+    const attempts = runRetries.get(runId) ?? 0
+    if (attempts >= MAX_TRANSIENT_RETRIES) return
+    const meta = (await listRuns(projectCwd).catch((): RunMeta[] => [])).find(run => run.id === runId)
+    // Only a run that failed by its own report, and only a local one: a web/actions run's
+    // lifecycle lives elsewhere and is not this daemon's to replay. A stopped run stays stopped.
+    if (meta?.status !== 'failed') return
+    if (meta.target !== undefined && meta.target !== 'local') return
+    const jsonl = (await archivedRunPaths(projectCwd, runId).catch((): string[] => [])).find(path => path.endsWith('.jsonl'))
+    const detail = jsonl ? lastRunFailureDetail(await readFile(jsonl, 'utf8').catch(() => '')) : undefined
+    if (!isTransientRunFailure(detail)) return
+    runRetries.set(runId, attempts + 1)
+    console.log(
+      `[framework] session ${runId} died to a transient error (${detail}); continuing it in ${(retryDelayMs ?? TRANSIENT_RETRY_DELAY_MS) / 1000}s, attempt ${attempts + 1} of ${MAX_TRANSIENT_RETRIES}`,
+    )
+    // Unref'd: a pending retry must never hold the daemon open, and a daemon that exits first
+    // simply does not retry — #923's resume owns the restart case.
+    const timer = setTimeout(() => {
+      void onStart(
+        RETRY_PROMPT,
+        'build',
+        {
+          ...options,
+          // Unattended like #923's resume: nobody is watching a retry, and the run must end.
+          unattended: true,
+          continueRunId: runId,
+          ...(meta.sessionId ? { resumeSession: meta.sessionId } : {}),
+          // The drain's pin rides along (#1268), so the claim survives onto the continued meta.
+          ...(meta.queueEntry ? { queueEntry: meta.queueEntry } : {}),
+        },
+        targetProjectId,
+      ).then(result => {
+        if (!result.ok) console.log(`[framework] could not continue session ${runId} after its transient death: ${result.error}`)
+      })
+    }, retryDelayMs ?? TRANSIENT_RETRY_DELAY_MS)
+    timer.unref?.()
   }
 
   /**
@@ -746,8 +839,13 @@ export function createProjectRuntime({ cwd, env, binPath }: ProjectRuntimeOption
         const { cwd: checkout, runId } = workspace
         if (!runId) return
         // The failed marker lands before the teardown reads the meta (#1261), so a boot death is
-        // archived as `failed` and the worktree is then kept for inspection, not removed.
-        void markFailedStart(checkout, runId, prompt, detail).finally(() => void tearDownWorktree(projectCwd, checkout, runId))
+        // archived as `failed` and the worktree is then kept for inspection, not removed. After
+        // teardown the archive is readable, which is when a transient death earns a retry (#1281).
+        void markFailedStart(checkout, runId, prompt, detail).finally(() =>
+          void tearDownWorktree(projectCwd, checkout, runId).finally(() =>
+            void retryTransientDeath(projectCwd, targetProjectId, runId, options),
+          ),
+        )
       }
       child.once('error', err => settle(`its process could not be spawned (${errorMessage(err)})`))
       child.once('exit', (code, signal) => settle(exitDetail(code, signal)))

--- a/packages/the-framework/src/daemon-workspace.test.ts
+++ b/packages/the-framework/src/daemon-workspace.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtemp, mkdir, writeFile, readFile, rm, stat, realpath } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { createProjectRuntime, cleanupTimedOutWorktree, tearDownTopicScratch, moveTopicRunHistory, markFailedStart, runStderrPath } from './daemon-runtime.js'
+import { createProjectRuntime, cleanupTimedOutWorktree, tearDownTopicScratch, moveTopicRunHistory, markFailedStart, runStderrPath, isTransientRunFailure, lastRunFailureDetail, MAX_TRANSIENT_RETRIES } from './daemon-runtime.js'
 import { CliTimeoutError } from './cli-exec.js'
 import { FRAMEWORK_DIR, WORKTREES_DIR, EVENTS_FILE, META_FILE, worktreePath, runBranchName, RUN_META_VERSION, startedAtFromRunId, type RunMeta } from './store/index.js'
 import { topicScratchPath, addProject, projectId } from './registry.js'
@@ -519,5 +519,111 @@ test('a child that wrote its own lifecycle is left alone by the failed-start mar
     assert.equal(await stat(join(base, FRAMEWORK_DIR, EVENTS_FILE)).then(() => true, () => false), false, 'and no failure line is invented')
   } finally {
     await rm(base, { recursive: true, force: true })
+  }
+})
+
+test('isTransientRunFailure names transport deaths, not work failures (#1281)', () => {
+  assert.equal(
+    isTransientRunFailure('[framework] claude-code exited (1): API Error: Connection closed mid-response. The response above may be incomplete.'),
+    true,
+  )
+  assert.equal(isTransientRunFailure('read ECONNRESET'), true)
+  assert.equal(isTransientRunFailure('API Error: 529 overloaded'), true)
+  // A boot death (#1261) or a real failure is not a retry candidate.
+  assert.equal(isTransientRunFailure('its process exited with code 1 before reporting anything'), false)
+  assert.equal(isTransientRunFailure('AssertionError: expected 2 to equal 3'), false)
+  assert.equal(isTransientRunFailure(undefined), false)
+})
+
+test('lastRunFailureDetail reads the child-written end, and only a failed one (#1281)', () => {
+  const line = (event: object) => JSON.stringify(event) + '\n'
+  assert.equal(lastRunFailureDetail(line({ kind: 'session' }) + line({ kind: 'end', ok: false, detail: 'boom' })), 'boom')
+  assert.equal(lastRunFailureDetail(line({ kind: 'end', ok: true })), undefined)
+  assert.equal(lastRunFailureDetail('not json\n' + line({ kind: 'end', ok: false, detail: 'boom' })), 'boom')
+  assert.equal(lastRunFailureDetail(''), undefined)
+  // A continued log whose last end succeeded: the earlier failure no longer counts.
+  assert.equal(lastRunFailureDetail(line({ kind: 'end', ok: false, detail: 'boom' }) + line({ kind: 'end', ok: true })), undefined)
+})
+
+/**
+ * A stub CLI that behaves like a run whose driver died mid-work: it writes its own lifecycle
+ * (run.json + a failed `end` carrying `detail`), records each spawn, and exits 1.
+ */
+async function writeFailingRunStub(dir: string, detail: string): Promise<string> {
+  const stub = join(dir, 'failing-run-stub.cjs')
+  await writeFile(
+    stub,
+    `const fs = require('node:fs')
+const path = require('node:path')
+const args = process.argv.slice(2)
+const cwd = args[args.indexOf('--cwd') + 1]
+const runId = args[args.indexOf('--run-id') + 1]
+fs.appendFileSync(path.join(cwd, 'spawned.log'), (args.includes('--continue-run') ? 'continue' : 'start') + '\\n')
+const dir = path.join(cwd, '.the-framework')
+fs.mkdirSync(dir, { recursive: true })
+const now = new Date().toISOString()
+fs.writeFileSync(
+  path.join(dir, 'run.json'),
+  JSON.stringify({ version: ${RUN_META_VERSION}, status: 'failed', id: runId, startedAt: now, updatedAt: now, passes: 0, driver: 'claude-code' }),
+)
+fs.appendFileSync(path.join(dir, 'events.jsonl'), JSON.stringify({ kind: 'end', ok: false, detail: ${JSON.stringify(detail)} }) + '\\n')
+process.exit(1)
+`,
+  )
+  return stub
+}
+
+/** Poll the worktree's spawn record until `expected` lines show up, or time out. */
+async function waitForSpawns(worktree: string, expected: number): Promise<string[]> {
+  let lines: string[] = []
+  for (let i = 0; i < POLL_ATTEMPTS && lines.length < expected; i++) {
+    await new Promise(r => setTimeout(r, 20))
+    lines = (await readFile(join(worktree, 'spawned.log'), 'utf8').catch(() => '')).trim().split('\n').filter(Boolean)
+  }
+  return lines
+}
+
+test('a run that dies to a transient API error is continued, at most twice (#1281)', async () => {
+  const cwd = await initRepo('framework-transient-')
+  const detail = '[framework] claude-code exited (1): API Error: Connection closed mid-response. The response above may be incomplete.'
+  const runtime = createProjectRuntime({ cwd, env: {}, binPath: await writeFailingRunStub(cwd, detail), retryDelayMs: 25 })
+  try {
+    const result = (await runtime.onStart('build a thing', 'build')) as { ok: boolean; runId?: string }
+    assert.equal(result.ok, true)
+    const worktree = worktreePath(cwd, result.runId!)
+    // The retry continues the SAME run in its retained checkout, rather than starting a new one.
+    const lines = await waitForSpawns(worktree, 1 + MAX_TRANSIENT_RETRIES)
+    assert.deepEqual(lines, ['start', 'continue', 'continue'])
+    // And the cap holds: a run that keeps dying transiently stays failed.
+    await new Promise(r => setTimeout(r, 400))
+    const after = (await readFile(join(worktree, 'spawned.log'), 'utf8')).trim().split('\n').filter(Boolean)
+    assert.equal(after.length, 1 + MAX_TRANSIENT_RETRIES)
+  } finally {
+    await runtime.dispose()
+    await rm(cwd, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+  }
+})
+
+test('a run that fails on its own terms is not retried (#1281)', async () => {
+  const cwd = await initRepo('framework-nontransient-')
+  const runtime = createProjectRuntime({
+    cwd,
+    env: {},
+    binPath: await writeFailingRunStub(cwd, 'AssertionError: expected 2 to equal 3'),
+    retryDelayMs: 25,
+  })
+  try {
+    const result = (await runtime.onStart('build a thing', 'build')) as { ok: boolean; runId?: string }
+    assert.equal(result.ok, true)
+    const worktree = worktreePath(cwd, result.runId!)
+    const lines = await waitForSpawns(worktree, 1)
+    assert.deepEqual(lines, ['start'])
+    // Give a wrong retry every chance to fire before declaring it absent.
+    await new Promise(r => setTimeout(r, 400))
+    const after = (await readFile(join(worktree, 'spawned.log'), 'utf8')).trim().split('\n').filter(Boolean)
+    assert.deepEqual(after, ['start'], 'a real failure stands; only transport deaths earn a retry')
+  } finally {
+    await runtime.dispose()
+    await rm(cwd, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
   }
 })


### PR DESCRIPTION
Closes #1281

In the #1279 drive, 2 of 7 real runs died to "API Error: Connection closed mid-response" and were simply lost: recorded failed, claim released, work gone. One entry happened to be re-picked by a later sweep tick and completed on the retry, proving the failures were transient.

The daemon now retries those deaths itself, with the machinery that already exists:

- After teardown archives a failed run, the settle path reads the run's own `end` detail off the archived event log. Only a child-written failed `end` counts, so a boot death (#1261) is never retried (it would just re-crash).
- If the detail names a transport error (connection closed/reset, timeout, socket hang up, overloaded, rate limit, API 5xx) the run is continued after a 15s pause: same run id, retained worktree, recorded branch (#1278), resumed agent session, queue pin carried (#1268), unattended like the #923 resume, with the resume-style prompt to carry on and finish.
- Two attempts at most, counted in memory (a daemon restart already re-resumes runs, so a lost count only grants one extra attempt). Web/actions runs and stopped runs are excluded.

Tests: pure pins for the signature matcher and the end-detail reader, plus two integration tests against a real runtime with a stub CLI that writes its own failed lifecycle: a transient death spawns `start, continue, continue` and stops at the cap; an assertion-style failure spawns once and stands. Framework suite 1486 tests, 0 fail.