### PR TITLE
sync-tickets-2026-07-27

### DIFF
--- a/.the-framework/conversations/2026-07-27T14-21-36-276Z.md
+++ b/.the-framework/conversations/2026-07-27T14-21-36-276Z.md
@@ -1,0 +1,21 @@
+# Conversation 2026-07-27T14-21-36-276Z
+
+## 2026-07-27T14:21:37.346Z · user · dashboard
+
+Update `tickets/` from this repo's GitHub issues, bringing across what has changed since the last import rather than starting over.
+
+Note the current UTC time before you fetch anything, in ISO 8601. That is the timestamp you will record at the end, and taking it first is deliberate: an issue edited while you work is then picked up by the next update instead of being missed.
+
+Read `tickets/meta.json` for `lastImportedAt`.
+
+- With a timestamp, fetch only what changed since it: `gh issue list --state all --limit 500 --json number,title,body,state,labels,updatedAt --search "updated:>=<lastImportedAt>"`, and the discussion with `gh api --paginate "repos/{owner}/{repo}/issues/comments?since=<lastImportedAt>"`.
+- With no timestamp (or no file), treat it as a first import and bring every open issue across.
+
+Then reconcile, one ticket file per issue, following the ticket format:
+
+- An issue with no ticket yet gets one.
+- An issue that already has a ticket has that ticket updated in place. Keep its filename, and keep any `.spike.md` or `.plan.md` written against it: those are our work, not GitHub's, and re-importing must not discard them.
+- New comments are worth folding into the ticket only where they change what the work is. Do not paste the thread.
+- An issue that is now closed has its ticket removed, along with its spike and plan.
+
+Finish by writing `tickets/meta.json` as `{"lastImportedAt": "<the UTC time you noted at the start>"}`, and say in one line how many tickets you added, updated and removed.


### PR DESCRIPTION
Update `tickets/` from this repo's GitHub issues, bringing across what has changed since the last import rather than starting over.

Note the current UTC time before you fetch anything, in ISO 8601. That is the timestamp you will record at the end, and taking it first is deliberate: an issue edited while you work is then picked up by the next update instead of being missed.

Read `tickets/meta.json` for `lastImportedAt`.

- With a timestamp, fetch only what changed since it: `gh issue list --state all --limit 500 --json number,title,body,state,labels,updatedAt --search "updated:>=<lastImportedAt>"`, and the discussion with `gh api --paginate "repos/{owner}/{repo}/issues/comments?since=<lastImportedAt>"`.
- With no timestamp (or no file), treat it as a first import and bring every open issue across.

Then reconcile, one ticket file per issue, following the ticket format:

- An issue with no ticket yet gets one.
- An issue that already has a ticket has that ticket updated in place. Keep its filename, and keep any `.spike.md` or `.plan.md` written against it: those are our work, not GitHub's, and re-importing must not discard them.
- New comments are worth folding into the ticket only where they change what the work is. Do not paste the thread.
- An issue that is now closed has its ticket removed, along with its spike and plan.

Finish by writing `tickets/meta.json` as `{"lastImportedAt": "<the UTC time you noted at the start>"}`, and say in one line how many tickets you added, updated and removed.

Opened from The Framework session `sync-tickets-2026-07-27`.