### PR TITLE
1. Look at all tickets and choose tickets to work on next

### DIFF
--- a/.the-framework/conversations/2026-07-27T14-13-07-977Z.md
+++ b/.the-framework/conversations/2026-07-27T14-13-07-977Z.md
@@ -1,0 +1,30 @@
+# Conversation 2026-07-27T14-13-07-977Z
+
+## 2026-07-27T14:13:09.100Z · user · dashboard
+
+1. Look at all tickets and choose tickets to work on next
+   - Only pick tickets that are quick-wins (quick to implement) and consensual (zero open questions, zero variability, e.g. a single fairly obvious plan)
+2. Add tickets to TODO_AGENTS.md
+
+Always set <SESSION_NAME> to triage-quick
+- If branch the-framework/<SESSION_NAME> already exists, abort and tell user that the branch already exists and that triage is already pending.
+
+## 2026-07-27T14:14:51.907Z · agent · dashboard
+
+```show-markdown
+\# Analysis result
+
+- Ambiguous prompt: NO — clear task (triage tickets for quick wins, add them to TODO_AGENTS.md, session name fixed to `triage-quick`).
+- Scope: small — triage only (read tickets, update TODO_AGENTS.md); no implementation work.
+- **ABORTED before any changes**: branch `the-framework/triage-quick` already exists on the remote and is not merged into `origin/main` — a triage is already pending.
+- No branch created, no commits made, TODO_AGENTS.md untouched.
+```
+
+**Aborted: the branch `the-framework/triage-quick` already exists, so a triage is already pending.** Per your instruction I stopped before making any changes.
+
+Details:
+
+- `origin/the-framework/triage-quick` exists on the remote (no local copy in this worktree) and is **not merged** into `origin/main`.
+- Its history shows a previous triage run from 2026-07-25: commit `ad81207` "[AI] Triage tickets: queue 4 consensual quick wins in TODO_AGENTS.md", followed by a revert of an "Uncommited changes" commit and an `rm` commit.
+
+Nothing was changed in this session — no new branch, no commits, and `TODO_AGENTS.md` was left untouched (it doesn't exist in this worktree's root, for what it's worth — worth checking whether the pending branch is the reason). If you want a fresh triage, merge or delete `origin/the-framework/triage-quick` first, then re-run this prompt.


### PR DESCRIPTION
1. Look at all tickets and choose tickets to work on next
   - Only pick tickets that are quick-wins (quick to implement) and consensual (zero open questions, zero variability, e.g. a single fairly obvious plan)
2. Add tickets to TODO_AGENTS.md

Always set <SESSION_NAME> to triage-quick
- If branch the-framework/<SESSION_NAME> already exists, abort and tell user that the branch already exists and that triage is already pending.

Opened from The Framework session `2026-07-27T14-13-07-977Z`.