### PR TITLE
fix: a bookkeeping-only branch is empty, so it is never pushed or PR'd

### DIFF
--- a/.changeset/bookkeeping-not-work.md
+++ b/.changeset/bookkeeping-not-work.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+A run that produced nothing beyond the framework's own bookkeeping no longer pushes a branch or opens a PR. Every run's branch carries the framework's paper trail (the conversation record swept in by the pre-work commit), and that one commit used to defeat the handoff's emptiness check, so a run that did no work still published a PR of pure bookkeeping. The changed files now decide: a branch whose every change is under `.the-framework/` is empty, so the auto-handoff skips it, the Open PR button refuses it, and the panel says the session produced nothing. The bookkeeping itself stays committed; it just no longer counts as work.

--- a/packages/the-framework/src/dashboard/run-handoff.test.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.test.ts
@@ -386,6 +386,35 @@ test('a session that committed nothing is not published (#1102)', async () => {
   assert.deepEqual(outcome, { outcome: 'skipped', reason: 'no-commits' })
 })
 
+test('a branch of pure framework bookkeeping is empty, and is not published (#1291)', async () => {
+  // The observed junk PR: one "[The Framework] Uncommited changes" commit sweeping in the
+  // conversation record the daemon wrote at start, and nothing else on the branch.
+  const bookkeeping = {
+    ...READY,
+    log: `abc123${SEP}[The Framework] Uncommited changes`,
+    diff: '21\t0\t.the-framework/conversations/2026-07-27T14-21-36-276Z.md\n2\t0\t.the-framework/LOGS.md',
+  }
+  const { git } = fakeGit(bookkeeping)
+  const handoff = await readRunHandoff('/repo', 'the-framework/x', { git, pr: async () => undefined })
+  assert.equal(handoff?.empty, true, 'paper trail is provenance, not work')
+  const outcome = await runAutoHandoff(
+    '/repo',
+    { id: 'r1', branch: 'the-framework/x' },
+    { push: true, pr: true },
+    { git: fakeGit(bookkeeping).git, pr: async () => undefined, gh: async () => assert.fail('nothing to publish') },
+  )
+  assert.deepEqual(outcome, { outcome: 'skipped', reason: 'no-commits' })
+})
+
+test('bookkeeping alongside real work does not make a branch empty (#1291)', async () => {
+  const { git } = fakeGit({
+    ...READY,
+    diff: '21\t0\t.the-framework/conversations/r1.md\n3\t1\tsrc/app.ts',
+  })
+  const handoff = await readRunHandoff('/repo', 'the-framework/x', { git, pr: async () => undefined })
+  assert.equal(handoff?.empty, false)
+})
+
 test('a repo with no remote is a skip, not a failure (#1102)', async () => {
   const { git } = fakeGit({ ...READY, remote: '' })
   const outcome = await runAutoHandoff(

--- a/packages/the-framework/src/dashboard/run-handoff.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.ts
@@ -14,7 +14,7 @@ import type { Cached } from './cache.js'
 import { parseNumstat } from './file-diff.js'
 import { errorMessage } from '../error-message.js'
 import type { AutoHandoffSkip } from '../events.js'
-import { commitPendingWork, currentBranch, startedAtFromRunId, type RunMeta } from '../store/index.js'
+import { commitPendingWork, currentBranch, startedAtFromRunId, FRAMEWORK_DIR, type RunMeta } from '../store/index.js'
 
 // What a finished session produced, and what is left to do with it (#799).
 //
@@ -62,7 +62,9 @@ export interface RunHandoff {
   deletions: number
   /**
    * The session produced nothing to hand off: the branch exists but carries no commit the base
-   * does not already have. Said out loud, rather than shown as an empty branch.
+   * does not already have — or nothing beyond the framework's own bookkeeping (#1291), which is
+   * committed for provenance, never as publishable work. Said out loud, rather than shown as an
+   * empty branch.
    */
   empty: boolean
   /** The repo has a remote to push to at all. */
@@ -216,6 +218,11 @@ function parseHandoffFiles(out: string): HandoffFile[] {
   return parseNumstat(out).map(({ path, added, removed, binary }) => ({ path, insertions: added, deletions: removed, binary }))
 }
 
+/** The framework's own paper trail (#1291): conversation records, LOGS, session archives. */
+function isBookkeepingPath(path: string): boolean {
+  return path === FRAMEWORK_DIR || path.startsWith(`${FRAMEWORK_DIR}/`)
+}
+
 /**
  * Read what a finished session left behind, from the project repo, for `branch`.
  *
@@ -296,8 +303,12 @@ export async function readRunHandoff(
     insertions: files.reduce((sum, f) => sum + f.insertions, 0),
     deletions: files.reduce((sum, f) => sum + f.deletions, 0),
     // A session that changed nothing is a real outcome, not an error: it gets said, not shown as
-    // an empty branch with buttons that would push nothing.
-    empty: commits.length === 0,
+    // an empty branch with buttons that would push nothing. Bookkeeping-only counts as nothing
+    // (#1291): every run's branch carries the framework's own records — the #326 pre-work commit
+    // sweeps in the conversation file the daemon just wrote — and publishing those alone produced
+    // junk PRs of pure paper trail. The files decide, not the commits: a branch of bookkeeping
+    // sweeps has commits and still nothing to hand off.
+    empty: commits.length === 0 || files.every(file => isBookkeepingPath(file.path)),
     hasRemote,
     pushed: remoteTip.trim() === tip,
     merged: mergedOut.trim().length > 0,


### PR DESCRIPTION
Closes #1291

Diagnosed from PR #1287 ("it pushes too early"): a sync-tickets run whose only commit was "[The Framework] Uncommited changes" sweeping in the conversation record the daemon had just written. The handoff's emptiness gate was `commits.length === 0`, so that one bookkeeping commit made the branch look publishable and the run pushed + opened a PR of pure paper trail. Every retry minted another junk PR.

The fix: `readRunHandoff` already computes the branch's changed files; `empty` is now also true when every changed file is under `.the-framework/`. One predicate fixes every consumer at once: `runAutoHandoff` skips with `no-commits`, `openSessionPullRequest` refuses the same way it does for a truly empty branch, and the dashboard panel reports the session produced nothing instead of offering to publish bookkeeping. The paper trail stays committed (provenance, #908/#1179); it just no longer counts as work.

Also verified while diagnosing (no change needed): the failed-run path never calls the handoff, and stopped runs are skipped explicitly - the junk PRs came from runs that ended cleanly having produced nothing.

Tests: the observed junk-PR shape (bookkeeping-only commit + files) is empty and skips the handoff; bookkeeping alongside real work stays publishable. Framework suite 1484 tests, 0 fail.