### PR TITLE
fix: the AI Queue card reads entries the way the sweep drains them

### DIFF
--- a/.changeset/one-queue-parser.md
+++ b/.changeset/one-queue-parser.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+The AI Queue card now reads the queue with the same rules the sweep drains it by: every markdown list item is an entry, open unless its checkbox is checked. The card's old parser only accepted `- [ ]` checkbox lines, so a queue written in the link style (`- [Title](tickets/x.md) — ...`) showed "Nothing queued." while the sweep was happily draining the very same file.

--- a/packages/the-framework/src/dashboard/queue.test.ts
+++ b/packages/the-framework/src/dashboard/queue.test.ts
@@ -44,3 +44,46 @@ test('collectQueue skips a project whose docs read throws', async () => {
   const queues = await collectQueue([project('boom', '/boom'), project('ok', '/ok')], read)
   assert.deepEqual(queues.map(q => q.projectId), ['ok'])
 })
+
+test('link-style entries with no checkbox are open items, like the sweep reads them (#1296)', () => {
+  // The observed blocker: a triage-written queue in the #1164 link style read as "Nothing queued"
+  // while the sweep drained it happily.
+  const md = [
+    '# TODO_AGENTS',
+    '',
+    '## Priority 8',
+    '',
+    '- [Settle-moment UX: always offer Open PR](tickets/2026-07-25_unclear-ux.md) — offer the box',
+    '  and keep the push setting available.',
+    '- [Remove the babysitting paragraph](tickets/2026-07-26_remove-babysitting.md) — steps.ts:62',
+    '',
+    '## Priority 7',
+    '',
+    '- [x] already handled',
+    'prose that is not an entry',
+  ].join('\n')
+  const items = parseTodoItems(md)
+  assert.deepEqual(
+    items.map(i => [i.done, i.text.slice(0, 20)]),
+    [
+      [false, '[Settle-moment UX: a'],
+      [false, '[Remove the babysitt'],
+      [true, 'already handled'],
+    ],
+  )
+})
+
+test('parseTodoItems agrees with the sweep parser on which entries are open (#1296)', async () => {
+  const { parseTodoEntries } = await import('../todo-loop.js')
+  const md = [
+    '- [Link entry](tickets/a.md) — do the thing',
+    '- [ ] open checkbox entry',
+    '- [x] done entry',
+    '* starred plain entry',
+    '1. numbered entry',
+    '  continuation line, not an entry',
+    '## a heading',
+  ].join('\n')
+  const open = parseTodoItems(md).filter(i => !i.done).map(i => i.text)
+  assert.deepEqual(open, parseTodoEntries(md))
+})

--- a/packages/the-framework/src/dashboard/queue.ts
+++ b/packages/the-framework/src/dashboard/queue.ts
@@ -24,15 +24,31 @@ export interface ProjectQueue {
   items: QueueItem[]
 }
 
-// A GitHub-style task-list line: `- [ ] text` or `* [x] text` (any leading indent).
-const TASK_LINE = /^\s*[-*]\s+\[([ xX])\]\s+(.*\S)\s*$/
+// A markdown list item (`-`, `*`, or `1.`), any leading indent. Same rule as the sweep's
+// `parseTodoEntries` (todo-loop.ts), deliberately: the queue's readers must agree on what an
+// entry is, or the card says "Nothing queued" while the sweep drains the same file (#1296).
+const LIST_ITEM = /^\s*(?:[-*]|\d+\.)\s+(.*\S)\s*$/
+// A GitHub-style task checkbox at the start of an item's text: `[ ]` open, `[x]` done.
+const CHECKBOX = /^\[([ xX])\]\s*(.*)$/
 
-/** Parse the task-list entries out of a TODO doc; non-checklist lines are ignored. */
+/**
+ * Parse the queue entries out of a TODO doc; headings, prose and blank lines are ignored.
+ *
+ * Every list item is an entry, open unless its checkbox is checked — the sweep's semantics
+ * (#1296). Triage agents write the #1164 link style (`- [Title](tickets/x.md) — ...`) with no
+ * checkbox, and the old checkbox-only regex read that whole queue as empty.
+ */
 export function parseTodoItems(content: string): QueueItem[] {
   const items: QueueItem[] = []
   for (const line of content.split('\n')) {
-    const match = TASK_LINE.exec(line)
-    if (match) items.push({ text: match[2]!, done: match[1] !== ' ' })
+    const item = LIST_ITEM.exec(line)
+    if (!item) continue
+    const task = CHECKBOX.exec(item[1]!)
+    if (task) {
+      if (task[2]!.trim()) items.push({ text: task[2]!.trim(), done: task[1] !== ' ' })
+    } else {
+      items.push({ text: item[1]!, done: false })
+    }
   }
   return items
 }


### PR DESCRIPTION
Closes #1296

The blocker from tonight: the AI Queue card said "Nothing queued." while `cat TODO_AGENTS.md` showed a full queue and the sweep drained it fine.

Two parsers disagreed. The sweep reads entries with `parseTodoEntries` (any bullet is open, only `- [x]` is done); the card's `parseTodoItems` only matched `- [ ]` checkbox lines. Triage agents now write the #1164 link style with no checkboxes, so the card parsed zero items and `collectQueue` omitted the project entirely. Nothing regressed in code - the entry format drifted and the stricter parser silently went blind. (#1280's format-contract disease, third incarnation: writer vs sweep was #1280, sweep vs card is this.)

The fix gives the card the sweep's semantics: every list item (`-`, `*`, `1.`) is an entry, open unless its checkbox is checked; headings and prose are ignored. Checkbox behavior is unchanged, so existing checkbox queues read identically.

Tests: the observed link-style queue parses as open items; and a consistency pin asserting `parseTodoItems`' open entries equal `parseTodoEntries`' output for the same file, so the two readers cannot drift apart silently again. Framework 1490 tests / 0 fail, dashboard 619/619.