### PR TITLE
feat(framework): context fragment lists BUSINESS_LOGIC.md (#683)

### DIFF
--- a/.changeset/context-business-logic.md
+++ b/.changeset/context-business-logic.md
@@ -1,0 +1,7 @@
+---
+'@gemstack/the-framework': minor
+---
+
+feat(framework): context fragment lists BUSINESS_LOGIC.md (#683)
+
+The updated #683 OP adds `BUSINESS_LOGIC.md` (codebase business logic) to the project context files. `CONTEXT_DOCS` now lists it beside `GOAL.md`, so every run is told to read it. A read-only pointer, like `GOAL.md` and `tickets/`, so it stays out of the merge-update set: the on-before-mergeable prompt keeps naming exactly the three `knowledge-base/` writeback docs.

--- a/packages/the-framework/src/system-prompt.test.ts
+++ b/packages/the-framework/src/system-prompt.test.ts
@@ -29,6 +29,7 @@ test('CONTEXT_DOCS is the #683 fragment: business knowledge plus the roadmap/que
   assert.deepEqual(paths, [
     'knowledge-base/DECISIONS.md',
     'GOAL.md',
+    'BUSINESS_LOGIC.md',
     'knowledge-base/FACTS.md',
     'knowledge-base/INSIGHTS.md',
     'knowledge-base/MARKET_RESEARCH.md',
@@ -39,10 +40,10 @@ test('CONTEXT_DOCS is the #683 fragment: business knowledge plus the roadmap/que
   ])
   // The business-knowledge docs are a subset the agent also updates at merge.
   for (const doc of BUSINESS_KNOWLEDGE_DOCS) assert.ok(paths.includes(doc.path), `missing ${doc.path}`)
-  // GOAL / market research / tickets / conversations / TODO_AGENTS are read-only context, so they
-  // are not in the merge-update set.
+  // GOAL / business logic / market research / tickets / conversations / TODO_AGENTS are read-only
+  // context, so they are not in the merge-update set.
   const businessPaths = BUSINESS_KNOWLEDGE_DOCS.map(d => d.path)
-  for (const p of ['GOAL.md', 'knowledge-base/MARKET_RESEARCH.md', 'knowledge-base/**.md', 'tickets/**.md', '.the-framework/conversations/**.md', 'TODO_AGENTS.md']) {
+  for (const p of ['GOAL.md', 'BUSINESS_LOGIC.md', 'knowledge-base/MARKET_RESEARCH.md', 'knowledge-base/**.md', 'tickets/**.md', '.the-framework/conversations/**.md', 'TODO_AGENTS.md']) {
     assert.ok(!businessPaths.includes(p))
   }
   // The two format-bearing bullets name a section of this same channel (#1163), not a file to go

--- a/packages/the-framework/src/system-prompt.ts
+++ b/packages/the-framework/src/system-prompt.ts
@@ -182,9 +182,10 @@ const TODO_FORMAT_HEADING = 'TODO_AGENTS.md'
 /**
  * Everything the agent keeps in context at the start of a run (#683), which
  * {@link systemPromptBlock} renders as the `Context:` bullets. A superset of
- * {@link BUSINESS_KNOWLEDGE_DOCS}: it adds `GOAL.md` and the roadmap/queue/history pointers the
- * agent reads but does *not* fold knowledge back into — `tickets/**.md` (the potential work,
- * whose file shape is the `Ticket format` spec, #684/#674), the `TODO_AGENTS.md` task queue (whose
+ * {@link BUSINESS_KNOWLEDGE_DOCS}: it adds `GOAL.md`, `BUSINESS_LOGIC.md`, and the
+ * roadmap/queue/history pointers the agent reads but does *not* fold knowledge back into —
+ * `tickets/**.md` (the potential work, whose file shape is the `Ticket format` spec, #684/#674),
+ * the `TODO_AGENTS.md` task queue (whose
  * shape is the `TODO_AGENTS.md` spec, #880), and the committed conversations (#683/#908). Repo-root
  * paths, because that is the agent's cwd. README is left out: a repo's own `README.md` already
  * covers the overview.
@@ -197,6 +198,10 @@ const TODO_FORMAT_HEADING = 'TODO_AGENTS.md'
 export const CONTEXT_DOCS: readonly ContextDoc[] = [
   DECISIONS_DOC,
   { path: 'GOAL.md', comment: 'the goal of the project (long-term direction, scope, non-scope, ...)' },
+  // The codebase's business logic, documented (#683). Root-level beside GOAL.md, per the OP. A
+  // pointer the agent reads, not a doc it folds knowledge back into at merge, so it stays out of
+  // BUSINESS_KNOWLEDGE_DOCS.
+  { path: 'BUSINESS_LOGIC.md', comment: 'codebase business logic' },
   FACTS_DOC,
   INSIGHTS_DOC,
   // What the market looks like (#694): written by the [Market research] preset and read by the


### PR DESCRIPTION
The updated #683 OP adds `BUSINESS_LOGIC.md` (codebase business logic) to the project context files. `CONTEXT_DOCS` didn't have it — it was the one entry in the OP missing from the fragment (everything else was covered by the earlier syncs #687, #1042, #1048).

`CONTEXT_DOCS` now lists it beside `GOAL.md`, mirroring the OP's placement, so every run's `Context:` bullets include it:

```
- `BUSINESS_LOGIC.md` (codebase business logic)
```

A read-only pointer, like `GOAL.md` and `tickets/`, so it stays out of the merge-update set: the on-before-mergeable prompt's `## Business knowledge` section keeps naming exactly the three `knowledge-base/` writeback docs (that section is #537's spec, which the OP edit didn't touch). The pinned tests in `system-prompt.test.ts` are updated accordingly.

Verified: the two affected test files pass in full; the whole package suite shows the same 1210 pass / 19 fail as a clean checkout in this sandbox (the pre-existing daemon/dashboard env failures), so no regressions.

Refs #683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9mM5jiiYABhyrErUZQT8B

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9mM5jiiYABhyrErUZQT8B)_