### PR TITLE
fix: release a pinned routine branch once its PR is closed, so triage fires again

### DIFF
--- a/.changeset/release-stale-triage-branch.md
+++ b/.changeset/release-stale-triage-branch.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/the-framework": patch
+---
+
+The triage routines no longer jam after their first run: a pinned branch (`the-framework/triage-quick`) whose PR was closed or merged is released before the routine fires, instead of tripping the prompt's "triage is already pending" abort forever. An open PR still keeps the branch, and a branch with no PR history is left alone.

--- a/packages/the-framework/src/auto-pm.test.ts
+++ b/packages/the-framework/src/auto-pm.test.ts
@@ -859,3 +859,58 @@ test('a drain-only sweep works the queue and never borrows the tick for the rota
   assert.equal(started.length, 0)
   assert.equal(empty.report().outcomes[0]?.message, 'the queue is empty, so there is nothing to drain')
 })
+
+test('a pinned job has its stale branch released before it fires (#1293)', async () => {
+  const order: string[] = []
+  const { loop } = harness({
+    jobs: [{ name: 'triage-quick', prompt: 'p', pinnedBranch: 'the-framework/triage-quick' }],
+    releasePinned: async (_project, branch) => {
+      order.push(`release:${branch}`)
+    },
+    start: async (_project, job) => {
+      order.push(`start:${job.name}`)
+      return 'run-1'
+    },
+  })
+  await loop.tick()
+  loop.stop()
+  assert.deepEqual(order, ['release:the-framework/triage-quick', 'start:triage-quick'])
+})
+
+test('an unpinned job never asks for a release, and a failing release does not stop the start (#1293)', async () => {
+  const releases: string[] = []
+  const unpinned = harness({
+    releasePinned: async (_project, branch) => {
+      releases.push(branch)
+    },
+  })
+  await unpinned.loop.tick()
+  unpinned.loop.stop()
+  assert.deepEqual(releases, [])
+  assert.deepEqual(unpinned.ran, ['first'])
+
+  // A release that could not happen leaves the routine exactly as jammed as it was; the job's own
+  // abort guard decides, exactly as before the seam existed.
+  const failing = harness({
+    jobs: [{ name: 'triage-quick', prompt: 'p', pinnedBranch: 'the-framework/triage-quick' }],
+    releasePinned: async () => {
+      throw new Error('gh is down')
+    },
+  })
+  await failing.loop.tick()
+  failing.loop.stop()
+  assert.deepEqual(failing.ran, ['triage-quick'])
+})
+
+test('the triage jobs declare exactly the branch their prompts pin (#1293)', () => {
+  const pinned = AUTO_PM_JOBS.filter(job => job.pinnedBranch !== undefined)
+  assert.deepEqual(pinned.map(job => job.name), ['triage-quick', 'triage-consensual'])
+  for (const job of pinned) {
+    // The release targets the branch the prompt's abort guard tests, so the two must not drift.
+    assert.equal(job.pinnedBranch, `the-framework/${job.name}`)
+    assert.ok(
+      job.prompt.includes(`Always set <SESSION_NAME> to ${job.name}`),
+      `${job.name} must pin the session name its release targets`,
+    )
+  }
+})

--- a/packages/the-framework/src/auto-pm.ts
+++ b/packages/the-framework/src/auto-pm.ts
@@ -174,6 +174,14 @@ export interface AutoPmJob {
    * since which entry is next is known only at the moment the sweep starts one.
    */
   entry?: string
+  /**
+   * The branch this job's prompt pins via its constant session name, when it does (#1293). The
+   * triage prompts abort when `the-framework/<SESSION_NAME>` already exists, so a leftover branch
+   * whose PR was closed or merged jams the routine forever. Declared as data on the job, like
+   * {@link AutoPmJob.drains}, so the sweep can release the stale name before firing without
+   * matching on {@link AutoPmJob.name} at the call site.
+   */
+  pinnedBranch?: string
 }
 
 /**
@@ -233,11 +241,13 @@ export const AUTO_PM_JOBS: readonly AutoPmJob[] = [
     name: presets.triageQuick.name,
     prompt: presets.triageQuick.render(),
     label: presets.triageQuick.label,
+    pinnedBranch: `the-framework/${presets.triageQuick.name}`,
   },
   {
     name: presets.triageConsensual.name,
     prompt: presets.triageConsensual.render(),
     label: presets.triageConsensual.label,
+    pinnedBranch: `the-framework/${presets.triageConsensual.name}`,
   },
   {
     name: presets.spikeAndPlan.name,
@@ -363,6 +373,13 @@ export interface AutoPmDeps {
   maintenanceJob?: AutoPmJob
   /** Start the PM run. Resolves the run's id, or undefined when the daemon refused. */
   start(project: AutoPmProject, job: AutoPmJob): Promise<string | undefined>
+  /**
+   * Release a {@link AutoPmJob.pinnedBranch} its closed PR left behind (#1293), called right
+   * before such a job fires. Injected because the release reads `gh` and mutates git, and this
+   * module is pure policy. Omitted (or throwing) means the branch stays and the job's own abort
+   * guard decides, exactly as before the seam existed.
+   */
+  releasePinned?(project: AutoPmProject, branch: string): Promise<unknown>
   /**
    * Land a finished run's queue in the project checkout (#852). Called before the sweep decides
    * anything: a run's queue lives on its own worktree branch, so until it is promoted the checkout
@@ -627,6 +644,9 @@ export function startAutoPm(deps: AutoPmDeps): AutoPmLoop {
           // Re-checked per spawn, for the #983 reason above: a stop mid-batch must not spawn the rest.
           if (stopped) break
           deps.log(`[framework] auto PM: ${doing(item)} in ${project.path}`)
+          // A pinned-name job aborts itself when its branch already exists (#1293); a branch
+          // whose PR closed is not a pending triage, so it is released before the start.
+          if (item.pinnedBranch) await deps.releasePinned?.(project, item.pinnedBranch).catch(() => undefined)
           const runId = await deps.start(project, item).catch(() => undefined)
           if (!runId) {
             // The batch ends at the first refusal: whatever refused this start is not going to take

--- a/packages/the-framework/src/daemon-services.ts
+++ b/packages/the-framework/src/daemon-services.ts
@@ -10,6 +10,7 @@ import { startKeyedWatcher, type KeyedWatcher } from './dashboard/keyed-watcher.
 import { buildInterventions, interventionKey, postInterventionsDiscord } from './dashboard/interventions.js'
 import { buildActivity, activityKey, postActivityDiscord } from './dashboard/activity.js'
 import { startAutoPm, AUTO_PM_JOBS, type AutoPmReport } from './auto-pm.js'
+import { releaseStalePinnedBranch } from './stale-branch.js'
 import { maintenanceDue, readMaintenanceState, mergeMaintenanceState } from './maintenance.js'
 import { claimedQueueEntries, promoteQueue } from './queue-promote.js'
 import { findTodoBacklog, nextQueuedTicket, ticketFromQueueEntry } from './todo-loop.js'
@@ -152,6 +153,8 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
     // rebooted daily would otherwise sweep every morning and never reach its interval.
     maintenanceDue: async project => maintenanceDue(await readMaintenanceState(project.path), Date.now()),
     recordMaintenance: async project => mergeMaintenanceState(project.path, { sweptAt: new Date().toISOString() }),
+    // A pinned routine branch left behind by a closed PR blocks every later firing (#1293).
+    releasePinned: (project, branch) => releaseStalePinnedBranch(project.path, branch),
     start: async (project, job) => {
       // A draining run works one open queue entry, and since #1164 that entry links back to the
       // ticket it was queued from — so this is the one moment the framework knows what a run is

--- a/packages/the-framework/src/stale-branch.test.ts
+++ b/packages/the-framework/src/stale-branch.test.ts
@@ -1,0 +1,87 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { releaseStalePinnedBranch } from './stale-branch.js'
+import type { GitRunner } from './project.js'
+import type { LinkedPr } from './dashboard/gh.js'
+
+const BRANCH = 'the-framework/triage-quick'
+
+/** A {@link GitRunner} over canned branch state, recording every deletion it is asked for. */
+function fakeGit(state: { local?: boolean; remote?: boolean; refuseDeletes?: boolean }) {
+  const deleted: string[] = []
+  const run: GitRunner = async args => {
+    if (args[0] === 'show-ref') {
+      if (state.local) return `abc refs/heads/${BRANCH}\n`
+      throw new Error('not a valid ref')
+    }
+    if (args[0] === 'ls-remote') return state.remote ? `abc\trefs/heads/${BRANCH}\n` : ''
+    if (args[0] === 'push') {
+      if (state.refuseDeletes) throw new Error('remote hung up')
+      deleted.push('remote')
+      return ''
+    }
+    if (args[0] === 'branch') {
+      if (state.refuseDeletes) throw new Error('checked out in a worktree')
+      deleted.push('local')
+      return ''
+    }
+    throw new Error(`unexpected git ${args.join(' ')}`)
+  }
+  return { run, deleted }
+}
+
+const pr = (state: string): LinkedPr => ({ number: 1, url: 'https://x/1', state, title: 'triage' })
+
+test('a closed PR releases both copies of the pinned branch (#1293)', async () => {
+  const git = fakeGit({ local: true, remote: true })
+  const outcome = await releaseStalePinnedBranch('/repo', BRANCH, { git: git.run, prs: async () => [pr('CLOSED')] })
+  assert.equal(outcome, 'released')
+  assert.deepEqual(git.deleted, ['remote', 'local'])
+})
+
+test('a merged PR releases a remote-only leftover without touching local refs (#1293)', async () => {
+  const git = fakeGit({ remote: true })
+  const outcome = await releaseStalePinnedBranch('/repo', BRANCH, { git: git.run, prs: async () => [pr('MERGED')] })
+  assert.equal(outcome, 'released')
+  assert.deepEqual(git.deleted, ['remote'])
+})
+
+test('an open PR is a triage genuinely pending, so the branch is kept (#1293)', async () => {
+  const git = fakeGit({ local: true, remote: true })
+  const outcome = await releaseStalePinnedBranch('/repo', BRANCH, {
+    git: git.run,
+    prs: async () => [pr('CLOSED'), pr('OPEN')],
+  })
+  assert.equal(outcome, 'pending')
+  assert.deepEqual(git.deleted, [])
+})
+
+test('a branch with no PR history is unprovable, not stale: kept (#1293)', async () => {
+  // Either a run still working toward its handoff, or a gh that could not answer (ghPrsForBranch
+  // resolves [] on failure). Deleting on a hiccup would discard work, so neither is released.
+  const git = fakeGit({ local: true })
+  const outcome = await releaseStalePinnedBranch('/repo', BRANCH, { git: git.run, prs: async () => [] })
+  assert.equal(outcome, 'unproven')
+  assert.deepEqual(git.deleted, [])
+})
+
+test('no branch anywhere means no PR read at all (#1293)', async () => {
+  const git = fakeGit({})
+  let asked = 0
+  const outcome = await releaseStalePinnedBranch('/repo', BRANCH, {
+    git: git.run,
+    prs: async () => {
+      asked += 1
+      return []
+    },
+  })
+  assert.equal(outcome, 'absent')
+  assert.equal(asked, 0)
+})
+
+test('git refusing the deletes does not throw: the next tick retries (#1293)', async () => {
+  const git = fakeGit({ local: true, remote: true, refuseDeletes: true })
+  const outcome = await releaseStalePinnedBranch('/repo', BRANCH, { git: git.run, prs: async () => [pr('CLOSED')] })
+  assert.equal(outcome, 'released')
+  assert.deepEqual(git.deleted, [])
+})

--- a/packages/the-framework/src/stale-branch.ts
+++ b/packages/the-framework/src/stale-branch.ts
@@ -1,0 +1,65 @@
+import { nodeGitRunner, type GitRunner } from './project.js'
+import { ghPrsForBranch, type LinkedPr } from './dashboard/gh.js'
+
+// Release a pinned routine branch its closed PR left behind (#1293).
+//
+// The triage prompts pin their session name, so every firing wants the same branch
+// (`the-framework/triage-quick`) and aborts when it already exists: a triage still in flight owns
+// the branch, and the next firing must not triage twice. But nothing ever released the name. The
+// first triage PR that got closed or merged without its branch being deleted jammed the routine
+// forever: every later firing found the branch, followed the scripted abort, and reported a
+// pending triage that did not exist.
+//
+// A branch existing is not evidence of a pending triage; an open PR is. So the sweep asks the
+// branch's PR history before firing a pinned job and releases the leftover copies only when the
+// history proves the work is over: some PR existed and none is open. Deleting is safe exactly
+// then, because the closed PR itself preserves the diff on GitHub — the branch is a leftover
+// name, not the last copy of anything a human still needs.
+
+/** What became of one pinned branch: gone already, genuinely busy, unprovable, or released. */
+export type StaleBranchOutcome = 'absent' | 'pending' | 'unproven' | 'released'
+
+/** Injectable seams so the release is unit-testable off disk and off GitHub. */
+export interface StaleBranchDeps {
+  git?: GitRunner
+  /** The branch's full PR history (default {@link ghPrsForBranch}). */
+  prs?: (cwd: string, branch: string) => Promise<LinkedPr[]>
+}
+
+/**
+ * Delete a pinned routine branch whose PR is closed or merged, so the next firing proceeds.
+ *
+ * Deliberately conservative on the two unprovable cases: an open PR keeps the branch (that is a
+ * triage genuinely pending), and a branch with no PR history at all keeps it too — that is either
+ * a run still working toward its handoff or a `gh` that could not answer, and deleting on a
+ * hiccup would discard work. Never throws: a release that could not happen leaves the routine
+ * exactly as jammed as it was, which the next tick retries.
+ */
+export async function releaseStalePinnedBranch(
+  cwd: string,
+  branch: string,
+  deps: StaleBranchDeps = {},
+): Promise<StaleBranchOutcome> {
+  const git = deps.git ?? nodeGitRunner()
+  const prs = deps.prs ?? ghPrsForBranch
+
+  const local = await git(['show-ref', '--verify', `refs/heads/${branch}`], cwd).then(
+    () => true,
+    () => false,
+  )
+  const remote = await git(['ls-remote', '--heads', 'origin', branch], cwd).then(
+    out => out.trim() !== '',
+    () => false,
+  )
+  if (!local && !remote) return 'absent'
+
+  const history = await prs(cwd, branch).catch(() => [])
+  if (history.some(pr => pr.state === 'OPEN')) return 'pending'
+  if (history.length === 0) return 'unproven'
+
+  if (remote) await git(['push', 'origin', '--delete', branch], cwd).catch(() => undefined)
+  // -D, not -d: a squash merge leaves the branch unmerged in git's eyes. And git refusing because
+  // a worktree still has the branch checked out is the in-flight guard working, not a failure.
+  if (local) await git(['branch', '-D', branch], cwd).catch(() => undefined)
+  return 'released'
+}


### PR DESCRIPTION
The code-side half of #1293 (fix direction 2). The prompt half (dropping the manufactured pinned-branch abort) is #326 surface and stays open there.

The triage presets pin their session name, so every firing wants the same branch and aborts when it exists. Nothing ever released the name: the first closed triage PR left `the-framework/triage-quick` orphaned on the remote and every later firing reported "triage is already pending" forever (observed live, run 2026-07-27T14-38-59-032Z).

What this does:

- `AutoPmJob.pinnedBranch` declares, as data on the two triage jobs, the branch their prompts pin (a new test pins prompt and data together so they cannot drift).
- Before the sweep fires a pinned job, `releaseStalePinnedBranch` (new `stale-branch.ts`) asks the branch's PR history (`ghPrsForBranch`, the #1251 read): an OPEN PR keeps the branch (triage genuinely pending); no PR history keeps it too (in-flight run, or gh could not answer, and deleting on a hiccup would discard work); otherwise the leftover is deleted, remote and local. The closed PR itself preserves the diff on GitHub, so nothing readable is lost.
- Wired through a `releasePinned` dep seam in `startAutoPm` (pure policy stays pure), implemented in daemon-services. A failing release never stops the start; the job's own abort guard decides, as before.

Framework suite 1498 pass / 0 fail (9 new tests: 6 release semantics, 2 loop ordering/failure, 1 catalog pin).
