### PR TITLE
fix: since-filter a run's status-read PR, so a reused pinned branch cannot flash a predecessor's badge

### DIFF
--- a/.changeset/run-badge-own-pr.md
+++ b/.changeset/run-badge-own-pr.md
@@ -1,0 +1,5 @@
+---
+"@gemstack/the-framework": patch
+---
+
+A running session's PR badge no longer flashes a predecessor's merged PR: run-scoped git-status reads pick the PR from the branch's history with the run's own start as the cutoff, instead of trusting the newest PR in any state. A reused pinned branch (`the-framework/triage-quick`) previously dressed every new run in the last closed PR's badge.

--- a/packages/the-framework/src/dashboard-rpc/reads.telefunc.ts
+++ b/packages/the-framework/src/dashboard-rpc/reads.telefunc.ts
@@ -1,4 +1,4 @@
-import { findRun, readLiveMetas, readAllRuns, loadRunEvents, worktreeSize, isSafeRunId, type RunMeta } from '../store/index.js'
+import { findRun, readLiveMetas, readAllRuns, loadRunEvents, worktreeSize, isSafeRunId, startedAtFromRunId, type RunMeta } from '../store/index.js'
 import { loadUserSystemPrompt } from '../system-prompt-file.js'
 import { listProjectWorktrees } from '../worktrees.js'
 import { readLogs, type LogEntry } from '../logs.js'
@@ -124,17 +124,21 @@ export async function onRunWorktree(projectId: string, runId: string): Promise<R
     const path = await resolveRunPath(projectId, runId)
     if (!path) return null
     const own = path !== root
+    // Since-filtered like every run-scoped PR read (#1255): in the run's own worktree the
+    // checkout's branch is the run's, but a reused pinned branch has a predecessor's PR history.
+    const since = startedAtFromRunId(runId)
     const [status, live] = await Promise.all([
-      readGitStatus(path).catch(() => undefined),
+      readGitStatus(path, since !== undefined ? { since } : {}).catch(() => undefined),
       readLiveMetas(root).catch(() => []),
     ])
     // Size is only read for a checkout nothing is writing to: a live run's tree changes under the
     // poll, and `du` over a build directory mid-build is a cost with no answer worth having.
     const running = live.some(run => run.id === runId && run.status === 'running')
     const size = own && !running ? await worktreeSize(path) : undefined
-    // In the run's own worktree, the checkout's branch is the run's, so the status read's PR is
-    // right. Once the worktree is gone the checkout is the project root, and its current branch
-    // has nothing to do with this run (#1255) — resolve by the run's own branch names instead.
+    // In the run's own worktree, the checkout's branch is the run's, so the (since-filtered)
+    // status read's PR is right. Once the worktree is gone the checkout is the project root, and
+    // its current branch has nothing to do with this run (#1255) — resolve by the run's own
+    // branch names instead.
     const run = own ? undefined : await findRun(root, runId).catch(() => undefined)
     const pr = own
       ? { value: status?.pr, pending: status?.prPending ?? false }
@@ -320,13 +324,15 @@ export async function onGithubUrl(projectId: string): Promise<string | null> {
 /**
  * The project's git status (#491): active branch, dirty flag, linked PR. Null when not a repo /
  * relay. Pass a live `runId` to read that run's worktree, which is the branch and the dirty
- * state that actually belong to it (#738).
+ * state that actually belong to it (#738). A run-scoped read is since-filtered (#1255): a run on
+ * a reused pinned branch must not wear a predecessor's merged PR as its own badge.
  */
 export async function onGitStatus(projectId: string, runId?: string): Promise<GitStatus | null> {
   return relayOr(runId, 'onGitStatus', [projectId, runId], async () => {
     const cwd = await resolveRunPath(projectId, runId)
     if (!cwd) return null
-    return (await readGitStatus(cwd)) ?? null
+    const since = runId !== undefined ? startedAtFromRunId(runId) : undefined
+    return (await readGitStatus(cwd, since !== undefined ? { since } : {})) ?? null
   }, null)
 }
 

--- a/packages/the-framework/src/dashboard/git-status.test.ts
+++ b/packages/the-framework/src/dashboard/git-status.test.ts
@@ -41,3 +41,47 @@ test('readGitStatus degrades to no PR when the lookup fails', async () => {
   })
   assert.deepEqual(status, { branch: 'main', dirty: false })
 })
+
+test('a run-scoped read does not wear a predecessor PR from a reused pinned branch (#1255)', async () => {
+  // The default lookup is `gh pr view`, newest PR in any state — on `the-framework/triage-quick`
+  // that is a merged PR from a previous firing. With `since` the pick runs through pickRunPr.
+  const old = { number: 1177, url: 'https://x/1177', state: 'MERGED', title: 'old triage', createdAt: '2026-07-25T00:00:00Z' }
+  const status = await readGitStatus('/repo', {
+    git: gitWith('the-framework/triage-quick', ''),
+    since: '2026-07-27T14:38:59Z',
+    prs: async () => [old],
+  })
+  assert.equal(status?.pr, undefined)
+})
+
+test('a run-scoped read still shows the run its own PR, open or just merged (#1255)', async () => {
+  const since = '2026-07-27T14:38:59Z'
+  const own = { number: 1301, url: 'https://x/1301', state: 'MERGED', title: 'this run', createdAt: '2026-07-27T15:00:00Z' }
+  const older = { number: 1177, url: 'https://x/1177', state: 'MERGED', title: 'old triage', createdAt: '2026-07-25T00:00:00Z' }
+  const status = await readGitStatus('/repo', {
+    git: gitWith('the-framework/triage-quick', ''),
+    since,
+    prs: async () => [own, older],
+  })
+  assert.equal(status?.pr?.number, 1301)
+
+  const open = { number: 1302, url: 'https://x/1302', state: 'OPEN', title: 'open pr' }
+  const withOpen = await readGitStatus('/repo', {
+    git: gitWith('the-framework/triage-quick', ''),
+    since,
+    prs: async () => [open, older],
+  })
+  assert.equal(withOpen?.pr?.number, 1302)
+})
+
+test('a failing history read degrades to no PR, like the plain lookup (#1255)', async () => {
+  const status = await readGitStatus('/repo', {
+    git: gitWith('main', ''),
+    since: '2026-07-27T14:38:59Z',
+    prs: async () => {
+      throw new Error('gh is down')
+    },
+  })
+  assert.equal(status?.pr, undefined)
+  assert.equal(status?.prPending, undefined)
+})

--- a/packages/the-framework/src/dashboard/git-status.ts
+++ b/packages/the-framework/src/dashboard/git-status.ts
@@ -1,5 +1,5 @@
 import { nodeGitRunner, type GitRunner } from '../project.js'
-import { cachedPrView, type LinkedPr, type PrLookup } from './gh.js'
+import { cachedPrView, cachedPrsForBranch, pickRunPr, type LinkedPr, type PrLookup } from './gh.js'
 
 // The project panel's git status (#491, part of #488): the active branch, whether the tree is
 // dirty, and the linked PR. Branch + dirty are a local git read; the PR is a best-effort gh
@@ -20,6 +20,16 @@ export interface GitStatus {
 export interface GitStatusDeps {
   git?: GitRunner
   pr?: PrLookup
+  /**
+   * The run's start, when the status is read for a run's checkout (#1255). The default lookup is
+   * `gh pr view`, which answers the newest PR for the branch *in any state* — so a run on a reused
+   * pinned branch (`the-framework/triage-quick`) wears a predecessor's merged PR as its own badge.
+   * With `since` set the PR is picked from the branch's whole history by {@link pickRunPr}
+   * instead: an open PR, or a closed one no older than the run itself.
+   */
+  since?: string
+  /** The branch's full PR history, for the {@link GitStatusDeps.since} path (default {@link cachedPrsForBranch}). */
+  prs?: (cwd: string, branch: string) => Promise<LinkedPr[]>
 }
 
 /**
@@ -39,8 +49,21 @@ export async function readGitStatus(cwd: string, deps: GitStatusDeps = {}): Prom
   // The branch and the dirty flag are what this row is for, and they are ten milliseconds of git.
   // The PR is a `gh` call an order of magnitude slower, so it is read through the cache and is
   // allowed to arrive late (#1028) rather than holding the whole row back on every poll.
-  const pr = deps.pr
-    ? { value: await deps.pr(cwd).catch(() => undefined), pending: false }
-    : await cachedPrView(cwd).catch(() => ({ value: undefined, pending: false }))
+  const pr = await linkedPr(cwd, branch, deps)
   return { branch, dirty, ...(pr.value ? { pr: pr.value } : {}), ...(pr.pending ? { prPending: true } : {}) }
+}
+
+/** The PR half of the status: the injected seam, the run-scoped history pick, or the plain view. */
+async function linkedPr(
+  cwd: string,
+  branch: string,
+  deps: GitStatusDeps,
+): Promise<{ value: LinkedPr | undefined; pending: boolean }> {
+  if (deps.pr) return { value: await deps.pr(cwd).catch(() => undefined), pending: false }
+  if (deps.since === undefined) return cachedPrView(cwd).catch(() => ({ value: undefined, pending: false }))
+  if (deps.prs) return { value: pickRunPr(await deps.prs(cwd, branch).catch(() => []), deps.since), pending: false }
+  return cachedPrsForBranch(cwd, branch).then(
+    read => ({ value: pickRunPr(read.value ?? [], deps.since), pending: read.pending }),
+    () => ({ value: undefined, pending: false }),
+  )
 }


### PR DESCRIPTION
The last live surface of the #1251/#1255 class, seen again on 2026-07-27: a stale merged PR badge (#1177) flashed on a run mid-work.

`#1257` made every run-PR resolution state-aware, but the run view's `GitStatusBar` polls `onGitStatus(projectId, runId)`, which reads the run worktree's status through the branchless `cachedPrView` = `gh pr view` = the newest PR for the checkout's branch in any state. On a reused pinned branch (`the-framework/triage-quick`) that answers a predecessor's merged PR, so every new triage run wears the old badge until teardown.

What this does:

- `readGitStatus` gains a `since` option: when set, the PR is picked from the branch's whole history (`cachedPrsForBranch`, the #1028 cache) by `pickRunPr`, i.e. an open PR, or a closed one no older than the run. The project-root panel (no `since`) keeps its current display.
- The two run-scoped call sites pass `since = startedAtFromRunId(runId)` (the #1257 trick, so no meta plumbing): `onGitStatus` with a `runId`, and `onRunWorktree`'s own-worktree case, whose "the status read's PR is right" assumption was exactly the broken half.
- A run's own PR still shows after it merges mid-view: `pickRunPr` keeps closed PRs created after the run started.

Framework suite 1492 pass / 0 fail (3 new tests: predecessor suppressed, own open/merged PR kept, failing history read degrades to no PR).
