### PR TITLE
feat(dashboard): AI Queue entries link to what they name and start on click

### DIFF
--- a/.changeset/queue-rows-act.md
+++ b/.changeset/queue-rows-act.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework-dashboard': patch
+---
+
+The Overview's AI Queue card now lets you act on an entry, two ways. An entry that links somewhere is a link: a queued ticket (the `[Title](tickets/x.md)` style) opens that ticket's own page, and an absolute http(s) target opens in a new tab — an entry pointing anywhere else keeps its title and stays plain text rather than pretending to have a page. And every open entry carries a play button that spins up an agent working on that one entry immediately — the same unattended work the drain sweep would get to, but on your click, with the drain's own vocabulary narrowed to the entry so the agent checks off exactly the line you started. The card previously was read-only: titles you could not open, and no way to start a queued task short of draining the whole queue.

--- a/packages/framework-dashboard/components/AiQueue.test.tsx
+++ b/packages/framework-dashboard/components/AiQueue.test.tsx
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { Preferences, ProjectQueue } from '@gemstack/the-framework'
+import { hoverTooltip } from '../test-utils.js'
+
+// The card reads nothing of its own — the queue arrives as a prop — so the only mocks are the
+// start path and the preferences it folds into a start's options.
+let prefs: Preferences = {}
+vi.mock('../lib/preferences.js', () => ({ usePreferences: () => prefs }))
+
+const start = vi.hoisted(() => vi.fn())
+let busy = false
+let startError: string | null = null
+vi.mock('../lib/use-start-run.js', () => ({
+  useStartRun: () => ({ busy, error: startError, reset: () => {}, start }),
+}))
+
+const { AiQueue, workOnEntryPrompt } = await import('./AiQueue.js')
+
+const RUN_LABEL = 'Spin up an agent working on this entry'
+
+const queue = (items: { text: string; done?: boolean }[], over: Partial<ProjectQueue> = {}): ProjectQueue => {
+  const full = items.map(i => ({ text: i.text, done: i.done ?? false }))
+  return {
+    projectId: 'p1',
+    projectName: 'gemstack',
+    open: full.filter(i => !i.done).length,
+    total: full.length,
+    items: full,
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  prefs = {}
+  busy = false
+  startError = null
+  start.mockReset()
+  start.mockResolvedValue({ ok: true, runId: 'run-1' })
+})
+afterEach(cleanup)
+
+describe('AiQueue', () => {
+  test('a queued ticket reads as its title and opens its ticket page (#1144)', async () => {
+    const opened: unknown[][] = []
+    const entry = '[Improve tooltip](tickets/2026-07-25_improve-tooltip.md) — agent note'
+    render(
+      <AiQueue
+        queue={[queue([{ text: entry }])]}
+        loading={false}
+        onOpenTicket={(...args) => opened.push(args)}
+        onRunStarted={() => {}}
+      />,
+    )
+    const row = screen.getByRole('button', { name: 'Improve tooltip' })
+    // The whole line stays on the row as its hint, agent note and all.
+    expect(row.getAttribute('title')).toBe(entry)
+    fireEvent.click(row)
+    // The bare filename — the same slug the tickets route carries.
+    expect(opened).toEqual([['p1', '2026-07-25_improve-tooltip.md']])
+  })
+
+  test('an entry linking out of the workspace is a real link in a new tab', () => {
+    const url = 'https://github.com/gemstack-land/the-framework/issues/42'
+    render(
+      <AiQueue
+        queue={[queue([{ text: `[Fix the publish job](${url})` }])]}
+        loading={false}
+        onOpenTicket={() => {}}
+        onRunStarted={() => {}}
+      />,
+    )
+    const link = screen.getByText('Fix the publish job') as HTMLAnchorElement
+    expect(link.tagName).toBe('A')
+    expect(link.href).toBe(url)
+    expect(link.target).toBe('_blank')
+  })
+
+  test('a plain entry stays plain text: nothing to open, so nothing pretends to', () => {
+    render(
+      <AiQueue
+        queue={[queue([{ text: 'Apply the maintainability preset' }])]}
+        loading={false}
+        onOpenTicket={() => {}}
+        onRunStarted={() => {}}
+      />,
+    )
+    const label = screen.getByText('Apply the maintainability preset')
+    expect(label.tagName).toBe('SPAN')
+    // The one button on the row is the play button, not the title.
+    expect(screen.getAllByRole('button')).toHaveLength(1)
+  })
+
+  test('the play button starts an unattended run on that one entry and selects it (#1191)', async () => {
+    const started: unknown[][] = []
+    const entry = '[Improve tooltip](tickets/2026-07-25_improve-tooltip.md) — agent note'
+    render(
+      <AiQueue
+        queue={[queue([{ text: 'first entry' }, { text: entry }])]}
+        loading={false}
+        onOpenTicket={() => {}}
+        onRunStarted={(...args) => started.push(args)}
+      />,
+    )
+    // The second row's button, so the prompt provably carries the clicked entry, not the first.
+    fireEvent.click(screen.getAllByRole('button', { name: RUN_LABEL })[1]!)
+    await waitFor(() => expect(start).toHaveBeenCalled())
+    const [projectId, prompt, kind, options] = start.mock.calls[0]!
+    expect(projectId).toBe('p1')
+    // The raw line, not the pretty label: the agent must find exactly this entry to check it off.
+    expect(prompt).toBe(workOnEntryPrompt(entry))
+    expect(prompt).toContain(entry)
+    expect(kind).toBe('prompt')
+    // Unattended (#1279): card-started queue work runs the way the drain sweep runs it.
+    expect(options).toMatchObject({ unattended: true })
+    await waitFor(() => expect(started).toHaveLength(1))
+    expect(started[0]).toEqual(['p1', workOnEntryPrompt(entry), 'run-1'])
+  })
+
+  test('the play button says what it does on hover', async () => {
+    render(
+      <AiQueue queue={[queue([{ text: 'entry' }])]} loading={false} onOpenTicket={() => {}} onRunStarted={() => {}} />,
+    )
+    const button = screen.getByRole('button', { name: RUN_LABEL })
+    expect((await hoverTooltip(button)).textContent).toBe(RUN_LABEL)
+  })
+
+  test('a start that reports no run id still hands the project over, for the adopt fallback (#1191)', async () => {
+    start.mockResolvedValue({ ok: true })
+    const started: unknown[][] = []
+    render(
+      <AiQueue
+        queue={[queue([{ text: 'entry' }])]}
+        loading={false}
+        onOpenTicket={() => {}}
+        onRunStarted={(...args) => started.push(args)}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: RUN_LABEL }))
+    await waitFor(() => expect(started).toHaveLength(1))
+    expect(started[0]).toEqual(['p1', workOnEntryPrompt('entry'), undefined])
+  })
+
+  test('a failed start neither navigates nor hides the refusal', async () => {
+    start.mockResolvedValue(undefined)
+    startError = 'A session is already active for this project.'
+    const started: unknown[][] = []
+    render(
+      <AiQueue
+        queue={[queue([{ text: 'entry' }])]}
+        loading={false}
+        onOpenTicket={() => {}}
+        onRunStarted={(...args) => started.push(args)}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: RUN_LABEL }))
+    await waitFor(() => expect(start).toHaveBeenCalled())
+    expect(started).toHaveLength(0)
+    expect(screen.getByRole('alert').textContent).toMatch(/already active/)
+  })
+
+  test('a start already in flight disables every play button', () => {
+    busy = true
+    render(
+      <AiQueue
+        queue={[queue([{ text: 'one' }, { text: 'two' }])]}
+        loading={false}
+        onOpenTicket={() => {}}
+        onRunStarted={() => {}}
+      />,
+    )
+    for (const button of screen.getAllByRole('button', { name: RUN_LABEL })) {
+      expect((button as HTMLButtonElement).disabled).toBe(true)
+    }
+  })
+
+  test('done entries and projects with nothing open are not shown', () => {
+    render(
+      <AiQueue
+        queue={[
+          queue([{ text: 'open entry' }, { text: 'finished entry', done: true }]),
+          queue([{ text: 'all done', done: true }], { projectId: 'p2', projectName: 'rudder' }),
+        ]}
+        loading={false}
+        onOpenTicket={() => {}}
+        onRunStarted={() => {}}
+      />,
+    )
+    expect(screen.getByText('open entry')).toBeTruthy()
+    expect(screen.queryByText('finished entry')).toBeNull()
+    expect(screen.queryByText('rudder')).toBeNull()
+  })
+
+  test('loading and empty read as themselves', () => {
+    const { rerender } = render(
+      <AiQueue queue={[]} loading={true} onOpenTicket={() => {}} onRunStarted={() => {}} />,
+    )
+    expect(screen.getByText('Loading…')).toBeTruthy()
+    rerender(<AiQueue queue={[]} loading={false} onOpenTicket={() => {}} onRunStarted={() => {}} />)
+    expect(screen.getByText('Nothing queued.')).toBeTruthy()
+  })
+})

--- a/packages/framework-dashboard/components/AiQueue.tsx
+++ b/packages/framework-dashboard/components/AiQueue.tsx
@@ -1,0 +1,174 @@
+import { useState } from 'react'
+import type { ProjectQueue } from '@gemstack/the-framework'
+import { runOptionsFromPreferences } from '@gemstack/the-framework/client'
+import { ListTodo, Loader2, Play } from 'lucide-react'
+import { queueEntryLabel } from '../lib/queue-entry.js'
+import { usePreferences } from '../lib/preferences.js'
+import { useStartRun } from '../lib/use-start-run.js'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card.js'
+import { Button } from './ui/button.js'
+import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip.js'
+
+// The Overview's AI Queue card (#1139): every project's open `TODO_AGENTS.md` items — the work the
+// framework picks up on its own — grouped by project and shown in full. No "+N more": this is the
+// plan, and a collapsed plan is one you cannot read.
+//
+// Two ways to act on an entry, and they are different acts. Its title opens what the entry NAMES:
+// a queued ticket links back to its ticket (#1164), so the title opens that ticket's own page
+// (#1144) — reading the plan, not starting it. The play button STARTS it: one agent, on that entry
+// alone, the same work the drain sweep would get to (#855) but on your click. The project header
+// stays a header — a project name that jumped to the launcher was the odd redirect #1139 called
+// out, and that is still true.
+//
+// Its own file rather than inline in DashboardPage, like every other card on the Overview:
+// DashboardPage has no test file, and opening tickets and starting runs are behaviour worth pinning.
+
+/**
+ * The prompt the play button starts an agent with: the drain preset's vocabulary ("work on … then
+ * check it off. Do not start any other entry.") narrowed from "the FIRST open entry" to the one
+ * entry the row shows. The raw `TODO_AGENTS.md` line, not the pretty label: the agent must find
+ * exactly this entry to check it off, and the line's link is how it opens the ticket (#1164).
+ * Exported so the test asserts against this and not a copy.
+ */
+export function workOnEntryPrompt(entry: string): string {
+  return `Open TODO_AGENTS.md and work on this one open entry only, then check it off. Do not start any other entry. The entry:\n\n${entry}`
+}
+
+export function AiQueue({
+  queue,
+  loading,
+  onOpenTicket,
+  onRunStarted,
+}: {
+  queue: ProjectQueue[]
+  loading: boolean
+  /** Open a queued ticket's own page (#1144), by project and the `WorkspaceTicket.file` slug. */
+  onOpenTicket: (projectId: string, file: string) => void
+  /**
+   * Told which run the play button just started (#1191). The project-carrying form, because the
+   * Overview has no project selected — each entry knows its own — so the shell cannot supply it.
+   */
+  onRunStarted: (projectId: string, intent: string, runId?: string) => void
+}) {
+  const preferences = usePreferences()
+  const { busy, error, start } = useStartRun()
+  // Which entry is in flight, keyed by content rather than index: the list is polled and can
+  // shift under a click, and only the clicked row's button should spin.
+  const [starting, setStarting] = useState<string | null>(null)
+
+  const runEntry = async (projectId: string, entry: string) => {
+    if (busy) return
+    const key = `${projectId}\n${entry}`
+    const prompt = workOnEntryPrompt(entry)
+    setStarting(key)
+    // Unattended (#1279): starting a queue entry from the card is the same work the drain sweep
+    // starts, so it runs the same way — gates auto-answer, the run ends at settle, and the armed
+    // handoff fires, instead of parking in the stay-open chat loop with its PR never opened.
+    const result = await start(projectId, prompt, 'prompt', { ...runOptionsFromPreferences(preferences), unattended: true })
+    setStarting(null)
+    // Go to the run itself (#1191): one agent on one named entry is a session to watch, unlike the
+    // sweep's fan-out, which lands in the Agents card. With no id yet the shell lands on the
+    // project and adopts the running run once the poll surfaces it.
+    if (result) onRunStarted(projectId, prompt, result.runId)
+  }
+
+  const withOpen = queue.filter(q => q.open > 0)
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <ListTodo className="h-4 w-4 text-muted-foreground" />
+          AI Queue
+        </CardTitle>
+        <p className="text-xs text-muted-foreground">Tasks AI will work on next</p>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <p className="py-2 text-sm text-muted-foreground">Loading…</p>
+        ) : withOpen.length === 0 ? (
+          <p className="py-2 text-sm text-muted-foreground">Nothing queued.</p>
+        ) : (
+          <ul className="space-y-4">
+            {withOpen.map(q => (
+              <li key={q.projectId}>
+                <div className="flex w-full items-center gap-2">
+                  <span className="truncate text-sm font-medium">{q.projectName}</span>
+                  <span className="ml-auto shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs tabular-nums text-muted-foreground">{q.open}</span>
+                </div>
+                <ul className="mt-1.5 space-y-1 pl-0.5">
+                  {q.items
+                    .filter(i => !i.done)
+                    .map((item, i) => {
+                      // The line is markdown, and a queued ticket is written as a link to it
+                      // (#1164), so print the title rather than the source; the whole line stays
+                      // in the tooltip.
+                      const label = queueEntryLabel(item.text)
+                      const key = `${q.projectId}\n${item.text}`
+                      return (
+                        <li key={i} className="flex items-center gap-2 text-sm text-muted-foreground">
+                          <span aria-hidden className="text-muted-foreground/50">•</span>
+                          {label.ticket !== undefined ? (
+                            // In-app, so a button rather than an anchor, like every other row that
+                            // navigates the shell; external targets get a real link in a new tab.
+                            <button
+                              type="button"
+                              onClick={() => onOpenTicket(q.projectId, label.ticket!)}
+                              className="min-w-0 flex-1 truncate text-left hover:text-foreground hover:underline"
+                              title={item.text}
+                            >
+                              {label.text}
+                            </button>
+                          ) : label.url !== undefined ? (
+                            <a
+                              href={label.url}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="min-w-0 flex-1 truncate hover:text-foreground hover:underline"
+                              title={item.text}
+                            >
+                              {label.text}
+                            </a>
+                          ) : (
+                            <span className="min-w-0 flex-1 truncate" title={item.text}>
+                              {label.text}
+                            </span>
+                          )}
+                          <Tooltip>
+                            <TooltipTrigger
+                              render={
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="icon-sm"
+                                  aria-label="Spin up an agent working on this entry"
+                                  disabled={busy}
+                                  onClick={() => void runEntry(q.projectId, item.text)}
+                                  className="shrink-0 text-muted-foreground hover:text-foreground"
+                                />
+                              }
+                            >
+                              {starting === key ? (
+                                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+                              ) : (
+                                <Play className="h-3.5 w-3.5" aria-hidden />
+                              )}
+                            </TooltipTrigger>
+                            <TooltipContent>Spin up an agent working on this entry</TooltipContent>
+                          </Tooltip>
+                        </li>
+                      )
+                    })}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        )}
+        {error && (
+          <p role="alert" className="mt-2 text-xs text-danger">
+            {error}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/packages/framework-dashboard/components/DashboardPage.tsx
+++ b/packages/framework-dashboard/components/DashboardPage.tsx
@@ -1,5 +1,5 @@
-import type { DashboardData, ProjectQueue, Intervention } from '@gemstack/the-framework'
-import { GitBranch, GitPullRequest, Inbox, ListTodo, MessageCircleQuestion } from 'lucide-react'
+import type { DashboardData, Intervention } from '@gemstack/the-framework'
+import { GitBranch, GitPullRequest, Inbox, MessageCircleQuestion } from 'lucide-react'
 import { onDashboard } from '../server/reads.telefunc.js'
 import { interventionKey } from '@gemstack/the-framework/client'
 import { Quota } from './Quota.js'
@@ -11,7 +11,7 @@ import { OnboardingChecklist } from './OnboardingChecklist.js'
 import { HotTickets } from './HotTickets.js'
 import { RoutineWork } from './RoutineWork.js'
 import { Agents } from './Agents.js'
-import { queueEntryLabel } from '../lib/queue-entry.js'
+import { AiQueue } from './AiQueue.js'
 import { ScrollArea } from './ui/scroll-area.js'
 
 // The Overview landing page (#1139): a focused at-a-glance board — usage first, then what needs a
@@ -27,12 +27,15 @@ import { ScrollArea } from './ui/scroll-area.js'
 export function DashboardPage({
   onSelectProject,
   onSelectRun,
+  onOpenTicket,
   onRunStarted,
   interventions,
 }: {
   onSelectProject: (id: string) => void
   /** Open one session (project + run): the Agents and hot-ticket rows link straight to a session. */
   onSelectRun: (projectId: string, runId: string) => void
+  /** Open one ticket's own page (#1144): a queued entry links to its ticket, so its row does too. */
+  onOpenTicket: (projectId: string, file: string) => void
   /** Where a session the onboarding checklist starts lands (#1169): on that session. */
   onRunStarted: (projectId: string, intent: string, runId?: string) => void
   interventions: Intervention[]
@@ -58,7 +61,7 @@ export function DashboardPage({
           <HumanQueue items={interventions} onSelectProject={onSelectProject} onSelectRun={onSelectRun} />
           <div className="space-y-4">
             <Agents working={data?.active ?? []} loading={loading} onSelectRun={onSelectRun} />
-            <AiQueue queue={data?.queue ?? []} loading={loading} />
+            <AiQueue queue={data?.queue ?? []} loading={loading} onOpenTicket={onOpenTicket} onRunStarted={onRunStarted} />
           </div>
         </div>
 
@@ -175,60 +178,6 @@ function HumanQueue({
                   </Tooltip>
 
                 )}
-              </li>
-            ))}
-          </ul>
-        )}
-      </CardContent>
-    </Card>
-  )
-}
-
-// The AI Queue (#1139): every project's open `TODO_AGENTS.md` items — the work the framework picks
-// up on its own — grouped by project and shown in full. No "+N more": this is the plan, and a
-// collapsed plan is one you cannot read. Bullets, not checkboxes: nothing here is yours to tick off.
-function AiQueue({ queue, loading }: { queue: ProjectQueue[]; loading: boolean }) {
-  const withOpen = queue.filter(q => q.open > 0)
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-base">
-          <ListTodo className="h-4 w-4 text-muted-foreground" />
-          AI Queue
-        </CardTitle>
-        <p className="text-xs text-muted-foreground">Tasks AI will work on next</p>
-      </CardHeader>
-      <CardContent>
-        {loading ? (
-          <p className="py-2 text-sm text-muted-foreground">Loading…</p>
-        ) : withOpen.length === 0 ? (
-          <p className="py-2 text-sm text-muted-foreground">Nothing queued.</p>
-        ) : (
-          <ul className="space-y-4">
-            {withOpen.map(q => (
-              <li key={q.projectId}>
-                {/* A group header, not a link (#1139): this card is the read-only "what's next" list,
-                    and a project name that jumped to the launcher was the odd redirect the thread
-                    called out. The work itself is opened from Hot tickets and Agents below. */}
-                <div className="flex w-full items-center gap-2">
-                  <span className="truncate text-sm font-medium">{q.projectName}</span>
-                  <span className="ml-auto shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs tabular-nums text-muted-foreground">{q.open}</span>
-                </div>
-                <ul className="mt-1.5 space-y-1 pl-0.5">
-                  {q.items
-                    .filter(i => !i.done)
-                    .map((item, i) => {
-                      // The line is markdown, and a queued ticket is written as a link to it (#1164),
-                      // so print the title rather than the source; the whole line stays in the tooltip.
-                      const label = queueEntryLabel(item.text)
-                      return (
-                        <li key={i} className="flex gap-2 text-sm text-muted-foreground">
-                          <span aria-hidden className="text-muted-foreground/50">•</span>
-                          <span className="truncate" title={item.text}>{label.text}</span>
-                        </li>
-                      )
-                    })}
-                </ul>
               </li>
             ))}
           </ul>

--- a/packages/framework-dashboard/lib/queue-entry.test.ts
+++ b/packages/framework-dashboard/lib/queue-entry.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, test } from 'vitest'
 import { queueEntryLabel } from './queue-entry.js'
 
 describe('queueEntryLabel (#1164)', () => {
-  test('a queued ticket reads as its title, not as markdown source', () => {
+  test('a queued ticket reads as its title, and names its ticket by bare filename', () => {
     // What the Overview card actually showed: `[Improve tooltip: show it with no...`, truncated
-    // mid-source, which is why the queue looked like it had not worked.
+    // mid-source, which is why the queue looked like it had not worked. The filename is bare —
+    // the `WorkspaceTicket.file` key — so the consumer can open the ticket's page with it.
     const entry = '[Improve tooltip](tickets/2026-07-25_improve-tooltip.md)'
-    expect(queueEntryLabel(entry)).toEqual({ text: 'Improve tooltip', ticket: 'tickets/2026-07-25_improve-tooltip.md' })
+    expect(queueEntryLabel(entry)).toEqual({ text: 'Improve tooltip', ticket: '2026-07-25_improve-tooltip.md' })
   })
 
   test("the agent's note after the link is dropped from the label, not the title", () => {
@@ -14,6 +15,19 @@ describe('queueEntryLabel (#1164)', () => {
     // one-line list entirely; the full text still goes in the tooltip.
     const entry = '[Let Fable be picked](tickets/2026-07-25_fable.md) — the model menu filters it out in AgentModelMenu.tsx:65'
     expect(queueEntryLabel(entry).text).toBe('Let Fable be picked')
+  })
+
+  test('an entry linking out of the workspace keeps its target as a url', () => {
+    const entry = '[Fix the flaky publish job](https://github.com/gemstack-land/the-framework/issues/42) — CI only'
+    expect(queueEntryLabel(entry)).toEqual({
+      text: 'Fix the flaky publish job',
+      url: 'https://github.com/gemstack-land/the-framework/issues/42',
+    })
+  })
+
+  test('a link to anything else keeps its title but points nowhere', () => {
+    // A bare repo path has no page of its own in the dashboard; a dead link would promise one.
+    expect(queueEntryLabel('[Read the docs](README.md)')).toEqual({ text: 'Read the docs' })
   })
 
   test('a plain entry is left exactly as it is', () => {

--- a/packages/framework-dashboard/lib/queue-entry.ts
+++ b/packages/framework-dashboard/lib/queue-entry.ts
@@ -10,23 +10,40 @@
 export interface QueueEntryLabel {
   /** The human part: the link's text, else the line itself. */
   text: string
-  /** The link target, when the entry is a link into `tickets/`. */
+  /**
+   * The ticket the entry links to, when it is a link into `tickets/`. The bare filename — the
+   * key `WorkspaceTicket.file` uses — so the consumer can open the ticket's own page with it.
+   */
   ticket?: string
+  /** The link's absolute http(s) target, when the entry points out of the workspace instead. */
+  url?: string
 }
 
 /** `[title](target)` at the start of a line, with the title allowed to contain anything but `]`. */
 const LEADING_LINK = /^\s*\[([^\]]+)\]\(([^)\s]+)\)\s*/
 
+/** Where a queued ticket's link points (#1164) — same prefix `sendQueueTicket` writes. */
+const TICKET_PREFIX = 'tickets/'
+
 /**
- * What one queue entry should read as.
+ * What one queue entry should read as, and where it points.
  *
  * Only a link at the START of the entry counts as its title: that is where {@link sendQueueTicket}
  * writes it, and a link further in is part of a sentence rather than the name of the work. Anything
  * after the link is the agent's own note, which is detail — it belongs in the tooltip, not in a
  * one-line list that would truncate the title away to show it.
+ *
+ * The target is classified the way the Overview's `queuedTicketFile` (overview.ts) classifies it:
+ * only one under `tickets/` names a ticket. An absolute http(s) target is kept as `url`; any other
+ * target (a bare repo path like `README.md`) has no page of its own in the dashboard, so the entry
+ * keeps the link's title but points nowhere rather than at a dead destination.
  */
 export function queueEntryLabel(entry: string): QueueEntryLabel {
   const link = LEADING_LINK.exec(entry)
   if (!link) return { text: entry.trim() }
-  return { text: link[1]!.trim(), ticket: link[2]! }
+  const text = link[1]!.trim()
+  const target = link[2]!
+  if (target.startsWith(TICKET_PREFIX)) return { text, ticket: target.slice(TICKET_PREFIX.length) }
+  if (/^https?:\/\//.test(target)) return { text, url: target }
+  return { text }
 }

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -276,6 +276,7 @@ export default function Page() {
         <DashboardPage
           onSelectProject={selectProject}
           onSelectRun={selectRunInProject}
+          onOpenTicket={openTicket}
           onRunStarted={runStarted}
           interventions={interventions}
         />


### PR DESCRIPTION
Two ways to act on an AI Queue entry on the Overview, where the card used to be read-only.

## If a link exists, the item is a link

- A queued ticket (the #1164 `[Title](tickets/x.md)` style) opens that ticket's own page (#1144) in the dashboard.
- An absolute http(s) target opens in a new tab.
- An entry pointing anywhere else (e.g. a bare repo path) keeps its title but stays plain text, rather than being a dead link to a page the dashboard doesn't have.

`queueEntryLabel` now classifies the leading link's target the way the Overview's `queuedTicketFile` (overview.ts) already does: a bare `tickets/` filename (the `WorkspaceTicket.file` key), or a `url`.

## A run button on each item

Every open entry carries a play button that spins up an agent working on that one entry immediately:

- The prompt is the drain preset's vocabulary narrowed from "the FIRST open entry" to the clicked one, carrying the raw `TODO_AGENTS.md` line so the agent finds exactly that entry, checks it off, and can open its ticket link.
- Started unattended (#1279), the way the sweep starts the same work: gates auto-answer, the run ends at settle, the armed handoff fires.
- On success the shell selects the run it started (#1191); a refused start (e.g. a session already active on that checkout) shows the refusal on the card instead of navigating.
- While spinning up, the clicked row's icon spins; all play buttons disable while a start is in flight.

## Structure

The card moves out of `DashboardPage.tsx` into its own `AiQueue.tsx` with a test file — the same reason `Agents.tsx` is its own file: this behaviour is worth pinning and DashboardPage has no test to pin it in. `+Page.tsx` hands the existing `openTicket` route down as `onOpenTicket`.

Tests: 10 new AiQueue tests, queue-entry tests extended for target classification. Full workspace `build` + `typecheck` + `test` green (21/21 turbo tasks, 631 dashboard tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fpw4wYTfYKLz8n6WGZpATh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fpw4wYTfYKLz8n6WGZpATh)_