### PR TITLE
Open TODO_AGENTS.md and work on this one open entry only, then check it 

### DIFF
--- a/.changeset/settle-moment-no-diff-guard.md
+++ b/.changeset/settle-moment-no-diff-guard.md
@@ -1,0 +1,8 @@
+---
+'@gemstack/the-framework': minor
+'@gemstack/framework-dashboard': patch
+---
+
+The settle moment now follows the #1173 maintainer decisions to the end. A branch with no diff never offers `Open PR` — GitHub would refuse it with "No commits between main and \<branch\>" — and when the session left work uncommitted, that work is named right in the bar (`Nothing committed — index.html left uncommitted.`), with the full list behind the bar's disclosure. The handoff read now carries the pending paths (`RunHandoff.pendingFiles`) instead of a bare count to make that possible. Unattended runs keep committing their work automatically on the way out, so for them the guard is a rare sight; an attended session parked in the chat can be told to commit right below the message.
+
+The push setting the launcher gear no longer shows (one `Open PR` row since #1181) is now really available where the thread said it stays: `the-framework.yml` accepts `autoPushBranch` and `autoOpenPr` beside the other booleans, resolving through the usual layers (flag > yml > default on), narrated like the rest, and feeding the launcher's repo tier. The CLI pair became tri-state to let the file decide when the run says nothing. The postponed `Auto commit` / `Auto push` settings split is deliberately not added.

--- a/.the-framework/conversations/2026-07-27T16-52-27-859Z.md
+++ b/.the-framework/conversations/2026-07-27T16-52-27-859Z.md
@@ -1,0 +1,7 @@
+# Conversation 2026-07-27T16-52-27-859Z
+
+## 2026-07-27T16:52:28.902Z · user · cli
+
+Open TODO_AGENTS.md and work on this one open entry only, then check it off. Do not start any other entry. The entry:
+
+[Settle-moment UX: always offer `Open PR`, auto-commit, no-diff guard](tickets/2026-07-25_unclear-ux-what-now.md) — implement the in-thread maintainer decisions: default `[x] Open PR`; unattended runs commit their work automatically (safe: every run is on its own branch); when the branch has no diff, don't offer `Open PR` — say so and name the uncommitted work; launcher gear reduced to one `Open PR` row (the push setting stays available in `the-framework.yml` and the CLI flag). The `Auto commit`/`Auto push` settings split is explicitly postponed — do not add settings.

--- a/TODO_AGENTS.md
+++ b/TODO_AGENTS.md
@@ -2,7 +2,6 @@
 
 ## Priority 8
 
-- [Settle-moment UX: always offer `Open PR`, auto-commit, no-diff guard](tickets/2026-07-25_unclear-ux-what-now.md) — implement the in-thread maintainer decisions: default `[x] Open PR`; unattended runs commit their work automatically (safe: every run is on its own branch); when the branch has no diff, don't offer `Open PR` — say so and name the uncommitted work; launcher gear reduced to one `Open PR` row (the push setting stays available in `the-framework.yml` and the CLI flag). The `Auto commit`/`Auto push` settings split is explicitly postponed — do not add settings.
 - [Remove the "do NOT re-scaffold" babysitting paragraph from the system prompt](tickets/2026-07-26_remove-ugly-babysitting.md) — delete the paragraph at `packages/the-framework/src/steps.ts:62` and update the assertions in `packages/the-framework/src/steps.test.ts` (~lines 198 and 227) that match on its text.
 - [Root-cause the white-screen crash behind the Serve menu item](tickets/2026-07-25_bug-white-blank.md) — deterministic repro confirmed by the maintainer: hovering the "Serve" menu item blanks the whole UI; #1196 landed as an explicit mitigation and the issue was deliberately kept open for the real fix. Start from the Serve state in `packages/framework-dashboard/components/SessionActionsMenu.tsx` and the #1196 mitigation diff, find the crash, fix its root cause; if it turns out architectural rather than a contained bug, report the diagnosis instead of forcing a fix.
 

--- a/packages/framework-dashboard/components/RunHandoff.test.tsx
+++ b/packages/framework-dashboard/components/RunHandoff.test.tsx
@@ -88,14 +88,32 @@ describe('run handoff (#799)', () => {
     expect(screen.getByText('Nothing committed — no PR to open.')).toBeTruthy()
   })
 
-  test('an empty branch with work waiting in the tree is offered, not called a dead end (#1173)', async () => {
-    onRunHandoff.mockResolvedValue({ ...worked, commits: [], files: [], insertions: 0, deletions: 0, empty: true, pending: 2 })
+  test('an empty branch with work waiting in the tree names the work, never a button (#1173)', async () => {
+    onRunHandoff.mockResolvedValue({
+      ...worked,
+      commits: [],
+      files: [],
+      insertions: 0,
+      deletions: 0,
+      empty: true,
+      pendingFiles: ['index.html', 'src/app.ts'],
+    })
     render(<Harness />)
-    // The agent commits what it found and nothing it wrote, so a settled session holding its whole
-    // output in the tree is the ordinary case, not a session that did nothing. Opening the PR
-    // commits what is waiting, so the button is offered.
-    await waitFor(() => expect(screen.getByText('Open PR')).toBeTruthy())
-    expect(screen.queryByText('Nothing committed — no PR to open.')).toBeNull()
+    // A no-diff branch never gets the Open PR button — GitHub would refuse it with "No commits
+    // between main and <branch>", the confusion this ticket started from. What is waiting is said
+    // by name instead, and the disclosure lists all of it.
+    await waitFor(() => expect(screen.getByText('Nothing committed — index.html, src/app.ts left uncommitted.')).toBeTruthy())
+    expect(screen.queryByText('Open PR')).toBeNull()
+    expect(screen.getByText('Uncommitted files')).toBeTruthy()
+    expect(screen.getByText('index.html')).toBeTruthy()
+  })
+
+  test('past two uncommitted files the rest are counted, and the hover carries them all (#1173)', async () => {
+    const pendingFiles = ['a.ts', 'b.ts', 'c.ts', 'd.ts']
+    onRunHandoff.mockResolvedValue({ ...worked, commits: [], files: [], insertions: 0, deletions: 0, empty: true, pendingFiles })
+    render(<Harness open={false} />)
+    const reason = await screen.findByText('Nothing committed — a.ts, b.ts and 2 more left uncommitted.')
+    expect(reason.getAttribute('title')).toBe(pendingFiles.join('\n'))
   })
 
   test('a branch that is gone is reported, not shown as work', async () => {

--- a/packages/framework-dashboard/components/RunHandoff.tsx
+++ b/packages/framework-dashboard/components/RunHandoff.tsx
@@ -24,9 +24,9 @@ import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip.js'
 const MAX_COMMITS = 6
 const MAX_FILES = 10
 
-/** True when there is a commit list and a file list worth expanding the bar for. */
+/** True when there is a commit list, a file list, or uncommitted work worth expanding the bar for. */
 export function handoffExpandable(handoff: RunHandoff | null): boolean {
-  return Boolean(handoff && handoff.exists && !handoff.empty)
+  return Boolean(handoff && handoff.exists && (!handoff.empty || handoff.pendingFiles?.length))
 }
 
 /** The one-line verdict, in the action bar: what the session left behind, or that it left nothing. */
@@ -170,13 +170,16 @@ export function HandoffActions({
   // From here every branch says something. A session that has finished and shows no control at all
   // is #1173: the reason there is nothing to press is exactly what the reader came for.
   if (!handoff.exists) return <Reason>Branch gone — nothing to open a PR from.</Reason>
-  // A branch with no commits and nothing waiting in the tree: the session genuinely produced
-  // nothing. Said plainly, rather than shown as a button that could only fail (#1173).
-  //
-  // Uncommitted work is the other half of that case and is not a dead end: the agent commits what
-  // it found before it starts and nothing at the end, so its whole output routinely sits in the
-  // tree. Opening the PR commits it first, so the button is offered rather than explained away.
-  if (handoff.empty && !handoff.pending) return <Reason>Nothing committed — no PR to open.</Reason>
+  // A branch with no diff never gets the button (#1173): there is nothing GitHub would accept a PR
+  // for, and offering one that fails with "No commits between main and <branch>" is the dead end
+  // this bar exists to prevent. When the tree holds uncommitted work, that work is named — the
+  // reader's next step is to have the session commit it (the composer is right below), and an
+  // unattended run commits it by itself on the way out.
+  if (handoff.empty) {
+    const pending = handoff.pendingFiles ?? []
+    if (pending.length === 0) return <Reason>Nothing committed — no PR to open.</Reason>
+    return <Reason title={pending.join('\n')}>Nothing committed — {namePending(pending)} left uncommitted.</Reason>
+  }
   if (!handoff.hasRemote) return <Reason>No remote to push to.</Reason>
   // One button, not two (#1173). "Push branch" and "Open PR" sat side by side as equals, and
   // nobody could say what pushing without a PR was for — a control nobody can
@@ -195,9 +198,25 @@ export function HandoffActions({
   )
 }
 
+/**
+ * The uncommitted paths, worded for a one-line bar: the first couple named, the rest counted.
+ * The full list is one hover (the Reason's title) or one disclosure (the details pane) away.
+ */
+function namePending(paths: string[]): string {
+  const shown = paths.slice(0, 2).join(', ')
+  const rest = paths.length - Math.min(paths.length, 2)
+  return rest > 0 ? `${shown} and ${rest} more` : shown
+}
+
 /** Why there is nothing to press. Reads as part of the bar, not as an error. */
-function Reason({ children }: { children: ReactNode }) {
-  return <span className="text-xs text-muted-foreground">{children}</span>
+function Reason({ children, title }: { children: ReactNode; title?: string }) {
+  // Capped and truncated: the bar's actions never shrink, so a long file name must ellipsize here
+  // rather than push the row wide.
+  return (
+    <span className="inline-block max-w-[24rem] truncate align-middle text-xs text-muted-foreground" {...(title ? { title } : {})}>
+      {children}
+    </span>
+  )
 }
 
 /** What the branch holds, revealed by the bar's disclosure. Never rendered when there is nothing. */
@@ -205,14 +224,16 @@ export function RunHandoffDetails({ handoff }: { handoff: RunHandoff | null }) {
   if (!handoffExpandable(handoff) || !handoff) return null
   // A column with no rows is a heading over nothing: a session can commit all of its work and
   // leave the tree clean, and then "Changed files" has nothing to list.
-  const both = handoff.commits.length > 0 && handoff.files.length > 0
+  const pendingFiles = handoff.pendingFiles ?? []
+  const sections = [handoff.commits.length > 0, handoff.files.length > 0, pendingFiles.length > 0].filter(Boolean).length
   return (
     <section
-      className={cn('grid gap-3 border-b border-border px-4 py-3 text-xs', both && 'sm:grid-cols-2')}
+      className={cn('grid gap-3 border-b border-border px-4 py-3 text-xs', sections > 1 && 'sm:grid-cols-2')}
       aria-label="Session handoff"
     >
       {handoff.commits.length > 0 && <Commits handoff={handoff} />}
       {handoff.files.length > 0 && <Files handoff={handoff} />}
+      {pendingFiles.length > 0 && <PendingFiles paths={pendingFiles} />}
     </section>
   )
 }
@@ -231,6 +252,25 @@ function Commits({ handoff }: { handoff: RunHandoff }) {
             <span className="truncate" title={commit.subject}>
               {commit.subject}
             </span>
+          </li>
+        ))}
+      </ul>
+      {rest > 0 && <p className="mt-1 text-muted-foreground">and {rest} more</p>}
+    </div>
+  )
+}
+
+/** The work the session never committed (#1173) — the full list behind the bar's one-line naming. */
+function PendingFiles({ paths }: { paths: string[] }) {
+  const shown = paths.slice(0, MAX_FILES)
+  const rest = paths.length - shown.length
+  return (
+    <div>
+      <h3 className="mb-1.5 text-muted-foreground">Uncommitted files</h3>
+      <ul className="space-y-1">
+        {shown.map(path => (
+          <li key={path} className="truncate" title={path}>
+            {path}
           </li>
         ))}
       </ul>

--- a/packages/the-framework/README.md
+++ b/packages/the-framework/README.md
@@ -222,6 +222,8 @@ autopilot: true      # activate the preset's Autopilot mode variants
 technical: false
 event: bug-fix        # the build event kind its review loop fires for
 antiLazyPill: false   # remove the built-in system prompt (default: on)
+autoOpenPr: false     # do not open a draft PR when a session finishes (default: on)
+autoPushBranch: true  # with autoOpenPr off: still push the session's branch (default: on)
 ```
 
 Every field is optional. Config resolves layer by layer, and the nearest layer that
@@ -232,6 +234,10 @@ Every field is optional. Config resolves layer by layer, and the nearest layer t
   `--transparent` pairs) > the file's boolean > off. Without either flag the file
   decides, so a repo that turns a mode on can be turned back off for one run with
   `--no-<mode>`.
+- **handoff**: `--auto-open-pr` / `--no-auto-open-pr` (and the `--auto-push-branch`
+  pair) > the file's boolean > **on** (#1102): a session nobody configured pushes its
+  branch and opens a draft PR when it finishes. The launcher offers the one `Open PR`
+  toggle; push-without-PR lives here and in the flags.
 - **event**: `--kind` > `the-framework.yml` `event` > the preset's own default > `major-change`
 
 When any layer contributes something, the run narrates what won and where it came

--- a/packages/the-framework/src/cli.test.ts
+++ b/packages/the-framework/src/cli.test.ts
@@ -89,13 +89,30 @@ test('parseArgs reads --browser (#452)', () => {
   assert.equal(parseArgs(['--browser', 'x']).browser, true)
 })
 
-test('the handoff flags default ON, which is what makes it zero-config (#1102)', () => {
-  // Unlike every other toggle here, saying nothing means yes: a plain run pushes its branch and
-  // opens a draft PR when it finishes.
-  assert.equal(parseArgs(['x']).autoPushBranch, true)
-  assert.equal(parseArgs(['x']).autoOpenPr, true)
+test('the handoff flags resolve ON, which is what makes it zero-config (#1102)', () => {
+  // Unlike most toggles, nobody saying anything means yes: a plain run pushes its branch and
+  // opens a draft PR when it finishes. Tri-state at the flag tier (#841), so the repo's
+  // the-framework.yml can decide when the run says nothing (#1173).
+  assert.equal(parseArgs(['x']).autoPushBranch, undefined)
+  assert.equal(parseArgs(['x']).autoOpenPr, undefined)
   assert.equal(parseArgs(['--no-auto-push-branch', 'x']).autoPushBranch, false)
   assert.equal(parseArgs(['--no-auto-open-pr', 'x']).autoOpenPr, false)
+  const bare = mergeRunConfig(parseArgs(['x']), {})
+  assert.equal(bare.autoPushBranch, true)
+  assert.equal(bare.autoOpenPr, true)
+})
+
+test('the-framework.yml can disarm the handoff, and a flag overrides the file (#1173)', () => {
+  // The launcher gear offers one `Open PR` row; the push setting stays reachable here and as the
+  // CLI flag pair. Nearest layer wins, like every other yml boolean.
+  const fromFile = mergeRunConfig(parseArgs(['x']), { autoOpenPr: false })
+  assert.equal(fromFile.autoOpenPr, false)
+  assert.equal(fromFile.autoPushBranch, true) // push-only: the file said nothing about the push
+  assert.equal(fromFile.sources.autoOpenPr, 'the-framework.yml')
+  const overridden = mergeRunConfig(parseArgs(['--auto-open-pr', 'x']), { autoOpenPr: false })
+  assert.equal(overridden.autoOpenPr, true)
+  assert.equal(overridden.sources.autoOpenPr, 'flag')
+  assert.equal(mergeRunConfig(parseArgs(['x']), { autoPushBranch: false, autoOpenPr: false }).autoPushBranch, false)
 })
 
 test('parseArgs reads --resume-session to continue a finished run (#720)', () => {

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -215,9 +215,11 @@ Options:
                          inspect the DOM, and screenshot. Off by default (#452).
   --no-auto-push-branch  Do not push this session's branch to origin when it finishes.
                          Pushing is the default, so the work does not sit on a local
-                         branch nobody is told about (#1102).
+                         branch nobody is told about (#1102). Without either flag the
+                         repo's the-framework.yml autoPushBranch decides.
   --no-auto-open-pr      Do not open a draft PR when the session finishes. Opening one
-                         is the default; it implies the push above (#1102).
+                         is the default; it implies the push above (#1102). Without
+                         either flag the-framework.yml autoOpenPr decides.
   --unattended           Nobody is watching: choice gates take the recommended option
                          instead of waiting for an answer. Stop still works (#846).
   --kind <name>          Build event kind the preset's review loop fires for, e.g.
@@ -338,11 +340,13 @@ export interface CliOptions {
   browser: boolean
   /**
    * `--auto-push-branch` / `--no-auto-push-branch` (#1102): push this session's branch to `origin`
-   * when it finishes. On by default, which is what makes the handoff zero-config.
+   * when it finishes. Tri-state like the mode toggles (#841): `undefined` is "this run said
+   * nothing", so the repo's the-framework.yml decides, and nobody setting it resolves to on —
+   * which is what makes the handoff zero-config.
    */
-  autoPushBranch: boolean
-  /** `--auto-open-pr` / `--no-auto-open-pr` (#1102): open a draft PR when the session finishes. On by default; implies {@link autoPushBranch}. */
-  autoOpenPr: boolean
+  autoPushBranch?: boolean | undefined
+  /** `--auto-open-pr` / `--no-auto-open-pr` (#1102): open a draft PR when the session finishes. Tri-state like {@link autoPushBranch}; resolves to on. Implies the push. */
+  autoOpenPr?: boolean | undefined
   buildEvent?: string | undefined
   maxPasses?: number
   maxCost?: number
@@ -406,10 +410,9 @@ export function parseArgs(argv: string[]): CliOptions {
     context: [],
     onBeforeMergeable: false,
     browser: false,
-    // On unless said otherwise (#1102): the whole point is that a session left alone hands its
-    // work back by itself.
-    autoPushBranch: true,
-    autoOpenPr: true,
+    // The handoff pair is left unset here on purpose: like the mode toggles it resolves over the
+    // config layers (#841), where no layer setting it means on (#1102) — a session left alone
+    // hands its work back by itself.
     dashboard: true,
     relayServe: false,
     skipPermissions: false,
@@ -819,11 +822,16 @@ export function flagConfigLayer(opts: RunConfigFlags): ConfigLayer {
       // --vanilla is the negative face of the same key: it removes the built-in prompt.
       ...(opts.vanilla !== undefined ? { antiLazyPill: !opts.vanilla } : {}),
       ...(opts.transparent !== undefined ? { transparent: opts.transparent } : {}),
+      ...(opts.autoPushBranch !== undefined ? { autoPushBranch: opts.autoPushBranch } : {}),
+      ...(opts.autoOpenPr !== undefined ? { autoOpenPr: opts.autoOpenPr } : {}),
     },
   }
 }
 
-type RunConfigFlags = Pick<CliOptions, 'preset' | 'autopilot' | 'technical' | 'buildEvent' | 'vanilla' | 'transparent'>
+type RunConfigFlags = Pick<
+  CliOptions,
+  'preset' | 'autopilot' | 'technical' | 'buildEvent' | 'vanilla' | 'transparent' | 'autoPushBranch' | 'autoOpenPr'
+>
 
 /**
  * Resolve a run's config over its layers, nearest wins (#841): the run's flags, then the repo's
@@ -1449,7 +1457,7 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
   // disarm it at any point up to the moment it settles, which is the whole point of them being
   // pre-commitments rather than buttons. Opening a PR implies pushing, so the pair is normalised
   // wherever it is set.
-  const armedHandoff = { push: opts.autoPushBranch || opts.autoOpenPr, pr: opts.autoOpenPr }
+  const armedHandoff = { push: config.autoPushBranch || config.autoOpenPr, pr: config.autoOpenPr }
   // Assigned once the journal exists, which is after the control watcher is wired: a change that
   // arrives before then still lands on `armedHandoff`, it just has no event to announce it yet.
   let announceHandoff: ((push: boolean, pr: boolean) => void) | undefined

--- a/packages/the-framework/src/config-layers.test.ts
+++ b/packages/the-framework/src/config-layers.test.ts
@@ -53,6 +53,9 @@ test('resolveRunConfig: each layer can win, and each can be absent (#841)', () =
   assert.equal(bare.technical, RUN_CONFIG_DEFAULTS.technical)
   assert.equal(bare.antiLazyPill, RUN_CONFIG_DEFAULTS.antiLazyPill)
   assert.equal(bare.transparent, RUN_CONFIG_DEFAULTS.transparent)
+  // The handoff pair defaults on (#1102): a session nobody configured hands itself back.
+  assert.equal(bare.autoPushBranch, true)
+  assert.equal(bare.autoOpenPr, true)
   assert.equal(bare.presetName, undefined)
   assert.equal(bare.buildEvent, undefined)
   assert.deepEqual(bare.sources, {})

--- a/packages/the-framework/src/config-layers.ts
+++ b/packages/the-framework/src/config-layers.ts
@@ -24,6 +24,10 @@ export interface RunConfigValues {
   antiLazyPill?: boolean | undefined
   /** Run the wrapped agent fully raw (#625). */
   transparent?: boolean | undefined
+  /** Push a session's branch to `origin` when it finishes (#1102/#1173). */
+  autoPushBranch?: boolean | undefined
+  /** Open a draft PR for a session's branch when it finishes (#1102/#1173). */
+  autoOpenPr?: boolean | undefined
 }
 
 /** One tier of config, with the label the run narrates when this tier wins a key. */
@@ -39,6 +43,10 @@ export const RUN_CONFIG_DEFAULTS = {
   technical: false,
   antiLazyPill: true,
   transparent: false,
+  // On by default (#1102): the zero-config handoff is what makes a session left alone hand
+  // itself back.
+  autoPushBranch: true,
+  autoOpenPr: true,
 } as const
 
 /**
@@ -64,6 +72,8 @@ export interface ResolvedRunConfig {
   technical: boolean
   antiLazyPill: boolean
   transparent: boolean
+  autoPushBranch: boolean
+  autoOpenPr: boolean
   /** Winning layer name per key; a key left to its default is absent here. */
   sources: Partial<Record<keyof RunConfigValues, string>>
 }

--- a/packages/the-framework/src/config.test.ts
+++ b/packages/the-framework/src/config.test.ts
@@ -27,6 +27,15 @@ test('parseFrameworkConfig reads the transparent toggle (#625)', () => {
   assert.throws(() => parseFrameworkConfig('transparent: nope\n'), /"transparent" must be a boolean/)
 })
 
+test('parseFrameworkConfig reads the handoff pair (#1173)', () => {
+  // Where the push setting lives now the launcher gear offers a single `Open PR` row.
+  assert.deepEqual(parseFrameworkConfig('autoPushBranch: false\nautoOpenPr: false\n'), {
+    autoPushBranch: false,
+    autoOpenPr: false,
+  })
+  assert.throws(() => parseFrameworkConfig('autoOpenPr: nope\n'), /"autoOpenPr" must be a boolean/)
+})
+
 test('parseFrameworkConfig treats an empty document as {}', () => {
   assert.deepEqual(parseFrameworkConfig(''), {})
   assert.deepEqual(parseFrameworkConfig('# just a comment\n'), {})

--- a/packages/the-framework/src/config.ts
+++ b/packages/the-framework/src/config.ts
@@ -25,6 +25,15 @@ export interface FrameworkFileConfig {
    * coarse "only-pick-what-you-need" master off-switch, at the per-project tier. Default `false`.
    */
   transparent?: boolean
+  /**
+   * Push a session's branch to `origin` when it finishes (#1102/#1173). Default `true`. Whether a
+   * session publishes itself is a fact about the repo, so it belongs in the file that travels with
+   * it — this pair is where push-without-PR stays reachable now the launcher offers one `Open PR`
+   * row. Only meaningful with {@link autoOpenPr} off: opening a PR pushes on the way.
+   */
+  autoPushBranch?: boolean
+  /** Open a draft PR for a session's branch when it finishes (#1102/#1173). Default `true`; implies {@link autoPushBranch}. */
+  autoOpenPr?: boolean
 }
 
 /** Config file names read from the workspace root, in precedence order. */
@@ -37,7 +46,7 @@ export const STRING_CONFIG_KEYS = ['preset', 'event'] as const
  * resolution, and the resolved-config summary all iterate it, so a new mode is added here once and
  * flows through them (only its default and any renamed output field are declared per key).
  */
-export const BOOLEAN_CONFIG_KEYS = ['autopilot', 'technical', 'antiLazyPill', 'transparent'] as const
+export const BOOLEAN_CONFIG_KEYS = ['autopilot', 'technical', 'antiLazyPill', 'transparent', 'autoPushBranch', 'autoOpenPr'] as const
 /** Every config key, string then boolean, in declaration order. */
 export const CONFIG_KEYS = [...STRING_CONFIG_KEYS, ...BOOLEAN_CONFIG_KEYS] as const
 

--- a/packages/the-framework/src/dashboard/file-status.ts
+++ b/packages/the-framework/src/dashboard/file-status.ts
@@ -12,6 +12,29 @@ function unquotePath(path: string): string {
   return path.length >= 2 && path.startsWith('"') && path.endsWith('"') ? path.slice(1, -1) : path
 }
 
+/** One `git status --porcelain` line: the two status columns and the path they are about. */
+export interface PorcelainEntry {
+  code: string
+  /** Repo-relative; a rename resolves to the new path. */
+  path: string
+}
+
+/** Parse `git status --porcelain` output. Shared with the handoff's pending-files read (#1173). */
+export function parsePorcelain(out: string): PorcelainEntry[] {
+  const entries: PorcelainEntry[] = []
+  for (const line of out.split('\n')) {
+    if (line.length < 4) continue
+    const code = line.slice(0, 2)
+    let path = line.slice(3)
+    const arrow = path.indexOf(' -> ')
+    if (arrow !== -1) path = path.slice(arrow + 4) // a rename: the new path is the one that exists
+    path = unquotePath(path)
+    if (!path) continue
+    entries.push({ code, path })
+  }
+  return entries
+}
+
 /**
  * Read each changed file's status from `git status --porcelain`, keyed by repo-relative path.
  * `??` is untracked, a `D` in either column is deleted, anything else (M/A/R/C…) reads as
@@ -20,14 +43,7 @@ function unquotePath(path: string): string {
 export async function readFileStatuses(cwd: string, git: GitRunner = nodeGitRunner()): Promise<Record<string, FileGitStatus>> {
   const out = await git(['status', '--porcelain'], cwd).catch(() => '')
   const map: Record<string, FileGitStatus> = {}
-  for (const line of out.split('\n')) {
-    if (line.length < 4) continue
-    const code = line.slice(0, 2)
-    let path = line.slice(3)
-    const arrow = path.indexOf(' -> ')
-    if (arrow !== -1) path = path.slice(arrow + 4) // a rename: dot the new path
-    path = unquotePath(path)
-    if (!path) continue
+  for (const { code, path } of parsePorcelain(out)) {
     map[path] = code === '??' ? 'untracked' : code.includes('D') ? 'deleted' : 'modified'
   }
   return map

--- a/packages/the-framework/src/dashboard/run-handoff.test.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.test.ts
@@ -494,9 +494,9 @@ test('uncommitted work is counted from the session checkout, not the project (#1
     checkout: '/repo/.the-framework/worktrees/r1',
   })
   // The branch really is empty; the work is real and sitting next to it. Both are true at once,
-  // which is the whole of #1173.
+  // which is the whole of #1173 — and the paths are what the bar names instead of a dead button.
   assert.equal(handoff?.empty, true)
-  assert.equal(handoff?.pending, 2)
+  assert.deepEqual(handoff?.pendingFiles, ['src/app.ts', 'src/new.ts'])
   assert.ok(calls.some(args => args[0] === 'status'), 'the checkout should have been asked')
 })
 
@@ -513,7 +513,7 @@ test('pending is absent, not zero, when no session checkout was given (#1173)', 
   })
   const handoff = await readRunHandoff('/repo', 'the-framework/quiet', { git, pr: async () => undefined })
   // "Nobody asked" must not read as "asked, tree clean": only the second may be shown as a dead end.
-  assert.equal(handoff?.pending, undefined)
+  assert.equal(handoff?.pendingFiles, undefined)
   assert.ok(!calls.some(args => args[0] === 'status'), 'no checkout means no status read')
 })
 
@@ -552,13 +552,13 @@ test('a real repo: the finishing step commits what the agent left in its worktre
 
     const before = await readRunHandoff(dir, branch, { git, pr: async () => undefined, checkout })
     assert.equal(before?.empty, true, 'the branch carries nothing yet')
-    assert.equal(before?.pending, 1, 'and the work is sitting in the checkout')
+    assert.deepEqual(before?.pendingFiles, ['index.html'], 'and the work is sitting in the checkout, by name')
 
     assert.equal(await commitSessionWork(checkout, dir, branch, git), true)
 
     const after = await readRunHandoff(dir, branch, { git, pr: async () => undefined, checkout })
     assert.equal(after?.empty, false, 'the work is on the branch now, so a PR has something to say')
-    assert.equal(after?.pending, 0)
+    assert.deepEqual(after?.pendingFiles, [])
     assert.deepEqual(after?.commits.map(c => c.subject), ['[The Framework] uncommitted changes'])
     assert.deepEqual(after?.files.map(f => f.path), ['index.html'])
 

--- a/packages/the-framework/src/dashboard/run-handoff.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.ts
@@ -12,6 +12,7 @@ import {
 } from './gh.js'
 import type { Cached } from './cache.js'
 import { parseNumstat } from './file-diff.js'
+import { parsePorcelain } from './file-status.js'
 import { errorMessage } from '../error-message.js'
 import type { AutoHandoffSkip } from '../events.js'
 import { commitPendingWork, currentBranch, startedAtFromRunId, FRAMEWORK_DIR, type RunMeta } from '../store/index.js'
@@ -78,14 +79,16 @@ export interface RunHandoff {
   /** The PR is not known yet, rather than absent (#1028): the lookup is still running. */
   prPending?: boolean
   /**
-   * Files the session changed and never committed, counted in its own checkout (#1173).
+   * The files the session changed and never committed, read from its own checkout (#1173).
    *
    * The agent is instructed to commit what it *found*, never what it *wrote*, so a settled session
    * can hold its whole output in an uncommitted tree. That work is not on the branch yet, so it is
-   * not in {@link commits} and it does not make {@link empty} false. Absent when the caller did not
-   * say which checkout the session worked in.
+   * not in {@link commits} and it does not make {@link empty} false. Paths rather than a count,
+   * because a no-diff branch must *name* what is waiting instead of offering an Open PR that
+   * GitHub can only refuse. Absent when the caller did not say which checkout the session worked
+   * in — "nobody asked" and "asked, tree clean" are different answers.
    */
-  pending?: number
+  pendingFiles?: string[]
 }
 
 /** Injectable seams so the reader is unit-testable off disk, plus the checkout the session worked in. */
@@ -319,29 +322,29 @@ export async function readRunHandoff(
 }
 
 /**
- * How many files the session left uncommitted in its own checkout, as a spreadable field.
+ * The files the session left uncommitted in its own checkout, as a spreadable field.
  *
- * Absent rather than 0 when no checkout was given: "nobody asked" and "asked, nothing pending" are
- * different answers, and only the second one may be shown as a clean tree.
+ * Absent rather than `[]` when no checkout was given (or git could not answer): "nobody asked" and
+ * "asked, nothing pending" are different answers, and only the second one may be shown as a clean
+ * tree.
  */
-async function countPendingWork(git: GitRunner, checkout: string | undefined): Promise<{ pending?: number }> {
+async function countPendingWork(git: GitRunner, checkout: string | undefined): Promise<{ pendingFiles?: string[] }> {
   if (!checkout) return {}
   const status = await git(['status', '--porcelain'], checkout).catch(() => undefined)
   if (status === undefined) return {}
-  const lines = status.split('\n').filter(line => line.trim().length > 0)
-  return { pending: lines.length }
+  return { pendingFiles: parsePorcelain(status).map(entry => entry.path) }
 }
 
 /**
  * Commit what a session left uncommitted, so what it did is what gets handed off (#1173).
  *
- * The agent is instructed to commit what it *found* before it starts, and nothing at the end, so a
- * settled session routinely holds its whole output in an uncommitted tree: the branch carries no
- * commit and a button offering to publish it can only fail with GitHub's "No commits between ...".
- * The automatic handoff already commits this on the run's way out, but that happens when the run
- * process exits, and the finishing step is offered as soon as the agent settles (#1178), which for
- * a session left open for another turn is much earlier. Pressing the button is the same instruction
- * given by hand, so it does the same thing rather than reporting a dead end.
+ * The automatic handoff commits the session's leftovers on the run's way out, but that happens
+ * when the run process exits, and the finishing step is offered as soon as the agent settles
+ * (#1178), which for a session left open for another turn is much earlier. Pressing the button is
+ * the same instruction given by hand, so it sweeps the same leftovers into what it publishes. The
+ * button only shows for a branch that already carries commits (#1173): a no-diff branch names its
+ * uncommitted work instead of offering a step, so this never turns "nothing committed" into a PR
+ * by itself.
  *
  * Two guards, because both failure modes end with the user's own work committed for them: the
  * checkout has to be the session's own (#453) rather than the project root that `resolveRunCheckout`

--- a/packages/the-framework/src/run-options.test.ts
+++ b/packages/the-framework/src/run-options.test.ts
@@ -58,6 +58,12 @@ test('preferencesFromFileConfig maps the repo yml onto the preference keys (#842
   assert.deepEqual(preferencesFromFileConfig({ antiLazyPill: false }), { vanilla: true })
   assert.deepEqual(preferencesFromFileConfig({ antiLazyPill: true }), { vanilla: false })
   assert.deepEqual(preferencesFromFileConfig({ transparent: true }), { transparent: true })
+  // The handoff pair rides the committed file too (#1173): the push setting's home now the
+  // launcher gear offers a single `Open PR` row.
+  assert.deepEqual(preferencesFromFileConfig({ autoPushBranch: false, autoOpenPr: false }), {
+    autoPushBranch: false,
+    autoOpenPr: false,
+  })
   // preset and event have no preference counterpart, so they are not mapped.
   assert.deepEqual(preferencesFromFileConfig({ preset: 'software-development', event: 'bug-fix' }), {})
 })

--- a/packages/the-framework/src/run-options.ts
+++ b/packages/the-framework/src/run-options.ts
@@ -32,6 +32,11 @@ export function preferencesFromFileConfig(file: FrameworkFileConfig): Preference
     ...(file.technical !== undefined ? { technical: file.technical } : {}),
     ...(file.transparent !== undefined ? { transparent: file.transparent } : {}),
     ...(file.antiLazyPill !== undefined ? { vanilla: !file.antiLazyPill } : {}),
+    // The handoff pair (#1102/#1173): whether a session publishes itself is a fact about the repo,
+    // so the committed file may say it — and it is where push-without-PR stays reachable now the
+    // launcher offers a single `Open PR` row.
+    ...(file.autoPushBranch !== undefined ? { autoPushBranch: file.autoPushBranch } : {}),
+    ...(file.autoOpenPr !== undefined ? { autoOpenPr: file.autoOpenPr } : {}),
   }
 }
 


### PR DESCRIPTION
Open TODO_AGENTS.md and work on this one open entry only, then check it off. Do not start any other entry. The entry:

[Settle-moment UX: always offer `Open PR`, auto-commit, no-diff guard](tickets/2026-07-25_unclear-ux-what-now.md) — implement the in-thread maintainer decisions: default `[x] Open PR`; unattended runs commit their work automatically (safe: every run is on its own branch); when the branch has no diff, don't offer `Open PR` — say so and name the uncommitted work; launcher gear reduced to one `Open PR` row (the push setting stays available in `the-framework.yml` and the CLI flag). The `Auto commit`/`Auto push` settings split is explicitly postponed — do not add settings.

Opened from The Framework session `2026-07-27T16-52-27-859Z`.