### PR TITLE
fix: restore the .the-framework ignore rules and untrack the runtime control channel

### DIFF
--- a/.the-framework/.gitignore
+++ b/.the-framework/.gitignore
@@ -1,3 +1,12 @@
+# The Framework: the committed project DB; session state is transient.
+*
+!.gitignore
+!LOGS.md
+!conversations/
+!conversations/**
 !git@brillout.com/
 !git@brillout.com/sessions/
 !git@brillout.com/sessions/**
+!suleiman@averotech.com/
+!suleiman@averotech.com/sessions/
+!suleiman@averotech.com/sessions/**


### PR DESCRIPTION
Live evidence for #1298, found during today's queue-drain dogfood.

`.the-framework/.gitignore` on main had been churned down to only one user's session un-ignore lines. The leading `*` rule, `!.gitignore`, `!LOGS.md` and the conversations rules were gone. Two consequences, both observed today:

- With no `*` rule, nothing under `.the-framework/` is ignored, so a drain run's pre-work safety commit swept the runtime control channel (`control.jsonl`) into its branch, and #1310's merge made it a tracked file. Every daemon write now dirties every checkout.
- Because the file no longer contains `!LOGS.md`, `ensureSessionsIgnored` (sessions.ts:78) classifies it as hand-edited and refuses to heal it, so it stays broken on every machine.

This PR restores the canonical file (seed rules + conversations rules + both users' session rules) and untracks `control.jsonl` (it stays on disk; the restored `*` rule ignores it from here on).

The structural fix (stop sharing this file through git at all) stays #1298; this just stops the bleeding.
