### PR TITLE
fix: claude-web trust failure names the project root, not the ephemeral worktree

### DIFF
--- a/.changeset/cloud-trust-advice.md
+++ b/.changeset/cloud-trust-advice.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+claude-web runs that die on the Claude Code folder-trust dialog now fail with the one-time fix (trust the project root once; run worktrees inherit it) instead of the raw dialog text, and the notice no longer points at the ephemeral worktree path (#1314)

--- a/packages/the-framework/src/driver/cloud.test.ts
+++ b/packages/the-framework/src/driver/cloud.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { CLOUD_COMMAND, CloudDriver, type RunPtyOptions } from './cloud.js'
+import { CLOUD_COMMAND, CloudDriver, trustRootOf, type RunPtyOptions } from './cloud.js'
 import type { DriverEvent } from './types.js'
 
 /**
@@ -111,10 +111,40 @@ test('an untrusted workspace fails fast and says how to fix it, rather than hang
     },
   })
   const session = await driver.start({ cwd: '/repo', onEvent: e => events.push(e) })
-  await assert.rejects(session.prompt('go'), /no cloud session was created/)
+  await assert.rejects(session.prompt('go'), /no cloud session was created — the workspace is not trusted[\s\S]*Run `claude` in \/repo once/)
   const notice = events.find(e => e.type === 'notice')
   assert.ok(notice && /has not been trusted in \/repo/.test(notice.message))
-  assert.ok(notice && /Run `claude` there once/.test(notice.message))
+  assert.ok(notice && /Run `claude` in \/repo once/.test(notice.message))
+})
+
+test('trust advice for a run worktree names the project root, which outlives the worktree', async () => {
+  // Trust is per directory and inherited downward (a fresh worktree of a trusted root shows
+  // no dialog), so trusting the root once covers every run worktree — the old advice named
+  // the ephemeral worktree path, which is gone before anyone could follow it.
+  const events: DriverEvent[] = []
+  const driver = new CloudDriver({
+    runTag: () => 'tag',
+    timeoutMs: 1000,
+    runPty: async opts => {
+      opts.onData('Quick\x1b[Csafety\x1b[Ccheck\r\n1.\x1b[CYes,\x1b[CI\x1b[Ctrust\x1b[Cthis\x1b[Cfolder\r\n')
+      if (!opts.signal.aborted) await new Promise<void>(r => opts.signal.addEventListener('abort', () => r(), { once: true }))
+    },
+  })
+  const cwd = '/repo/.the-framework/worktrees/2026-07-27T17-30-20-703Z'
+  const session = await driver.start({ cwd, onEvent: e => events.push(e) })
+  await assert.rejects(session.prompt('go'), /Run `claude` in \/repo once/)
+  const notice = events.find(e => e.type === 'notice')
+  assert.ok(notice && /has not been trusted in \/repo,/.test(notice.message), 'the notice must name the root, not the worktree')
+  assert.ok(notice && !notice.message.includes('/worktrees/'), 'the worktree path helps nobody')
+})
+
+test('trustRootOf strips exactly the run-worktree suffix and nothing else', () => {
+  assert.equal(trustRootOf('/repo/.the-framework/worktrees/2026-01-01T00-00-00-000Z'), '/repo')
+  assert.equal(trustRootOf('/repo'), '/repo')
+  assert.equal(trustRootOf('/repo/packages/app'), '/repo/packages/app')
+  // A deeper path inside a run worktree is not the worktree itself: leave it alone rather
+  // than guess.
+  assert.equal(trustRootOf('/repo/.the-framework/worktrees/run1/nested'), '/repo/.the-framework/worktrees/run1/nested')
 })
 
 test('the prompt sits directly after --cloud, ahead of the model flag', () => {

--- a/packages/the-framework/src/driver/cloud.ts
+++ b/packages/the-framework/src/driver/cloud.ts
@@ -109,6 +109,26 @@ const SESSION_URL = /https:\/\/claude\.ai\/code\/(session_[A-Za-z0-9]+)\S*/
  */
 const TRUST_PROMPT = 'trustthisfolder'
 
+/**
+ * The project root a run worktree belongs to, which is where trust has to be granted.
+ *
+ * The CLI records trust per directory and everything under a trusted directory inherits it
+ * (verified live: a fresh worktree of a trusted root boots straight to the REPL, a fresh
+ * worktree of an untrusted root always shows the dialog). A run's cwd is an ephemeral
+ * worktree — gone before the user could act on advice that names it — so the only advice
+ * that works is: trust the root once, and every run worktree under it is covered.
+ */
+export function trustRootOf(cwd: string): string {
+  const match = /^(.+?)\/\.the-framework\/worktrees\/[^/]+\/?$/.exec(cwd)
+  return match ? match[1]! : cwd
+}
+
+/** The one-time fix for an untrusted workspace, phrased against the root, not the worktree. */
+function trustAdvice(cwd: string): string {
+  const root = trustRootOf(cwd)
+  return `Run \`claude\` in ${root} once and accept the trust prompt — run worktrees inherit the root's trust — then start a new web run.`
+}
+
 /** Model ids we will pass through, kept to characters that cannot act as shell syntax. */
 const SAFE_MODEL = /^[A-Za-z0-9._:-]+$/
 
@@ -201,7 +221,7 @@ export class CloudSession implements DriverSession {
             trusting = true
             this.emit({
               type: 'notice',
-              message: `Claude Code has not been trusted in ${this.cwd} yet, so it is asking before it will start. Run \`claude\` there once and accept, then try this again.`,
+              message: `Claude Code has not been trusted in ${trustRootOf(this.cwd)}, so it asks before it will start and the cloud session is never created. ${trustAdvice(this.cwd)}`,
             })
             controller.abort()
           }
@@ -212,6 +232,11 @@ export class CloudSession implements DriverSession {
       this.controllers.delete(controller)
     }
 
+    // The trust dialog is a one-time, per-root fix, so fail with that instead of the raw
+    // dialog text — three identical "no cloud session was created" runs in a row is what
+    // this looked like before the failure named its own cure.
+    if (!found && trusting)
+      throw new Error(`[framework] claude-web: no cloud session was created — the workspace is not trusted by Claude Code. ${trustAdvice(this.cwd)}`)
     if (!found) throw new Error(`[framework] claude-web: no cloud session was created.\n${tail(output.replace(ANSI, ''))}`)
 
     this.handedOff = found


### PR DESCRIPTION
Closes #1314

Web runs on an untrusted project fail with `no cloud session was created`: `claude --cloud` shows the CLI folder-trust dialog in the run's fresh worktree, nothing can answer it, and the driver aborts. The failure detail was the raw dialog text and the notice told the user to trust the worktree path, which no longer exists by the time they read it.

Verified live: trust is per directory and inherited downward. A fresh worktree under a trusted root (gemstack) shows no dialog; under an untrusted root (framework-serve-demo) it always does. So the one-time fix is trusting the **project root** once.

Changes:
- `trustRootOf()` strips exactly the run-worktree suffix (`<root>/.the-framework/worktrees/<id>`), otherwise returns the cwd unchanged.
- The notice and the thrown error name the root and say worktrees inherit its trust; no more raw TUI dump for this case.
- Deliberately unchanged: the driver still never answers the dialog or touches the CLI's trust config. That is the user's call.

Tests: 3 new (root derivation, worktree advice, updated untrusted-workspace wording). Framework suite 1505 pass / 0 fail.