### PR TITLE
fix: queue claims count any open PR whose diff retires the entry (#1313)

### DIFF
--- a/.changeset/cross-machine-claims.md
+++ b/.changeset/cross-machine-claims.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+Queue claims now see other machines (#1313): an entry is also claimed when any open PR's TODO_AGENTS.md diff retires it (checked off or removed), so two daemons or a cloud session draining the same queue no longer double-assign an entry whose work is already in an open PR

--- a/packages/the-framework/src/daemon-services.ts
+++ b/packages/the-framework/src/daemon-services.ts
@@ -13,6 +13,8 @@ import { startAutoPm, AUTO_PM_JOBS, type AutoPmReport } from './auto-pm.js'
 import { releaseStalePinnedBranch } from './stale-branch.js'
 import { maintenanceDue, readMaintenanceState, mergeMaintenanceState } from './maintenance.js'
 import { claimedQueueEntries, promoteQueue } from './queue-promote.js'
+import { FLAT_TODO_FILE } from './tickets.js'
+import { cachedOpenPrFilePatches } from './dashboard/gh.js'
 import { findTodoBacklog, nextQueuedTicket, ticketFromQueueEntry } from './todo-loop.js'
 import { startConversationCommitter } from './conversation-commit.js'
 import { startMergedWorktreeSweep } from './merged-worktrees.js'
@@ -179,7 +181,13 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
     // process's memory. The PR lookup rides the #1257 cache, so a sweep costs at most one `gh`
     // read per open entry per TTL.
     claimedEntries: async (project, candidates) =>
-      claimedQueueEntries(project.path, candidates, { runs: listRuns, pr: resolveRunPr }),
+      claimedQueueEntries(project.path, candidates, {
+        runs: listRuns,
+        pr: resolveRunPr,
+        // The cross-machine leg (#1313): an open PR retires its entry whichever machine — or
+        // cloud session — drained it. Rides the same #1028 cache as the PR lookups.
+        queuePatches: path => cachedOpenPrFilePatches(path, FLAT_TODO_FILE),
+      }),
     // The daemon promotes the queue, never the agent (#852): the run stays sandboxed in its
     // worktree, and one known file is copied across once it has finished cleanly.
     promote: async (project, { runId, entry }) => {

--- a/packages/the-framework/src/dashboard/gh.ts
+++ b/packages/the-framework/src/dashboard/gh.ts
@@ -183,3 +183,41 @@ export async function ghPrList(cwd: string): Promise<OpenPr[]> {
 
 /** Lists a checkout's open PRs; resolves `[]` when there is no remote / gh is unavailable. */
 export type PrLister = (cwd: string) => Promise<OpenPr[]>
+
+/** One open PR's diff of a single file (#1313). */
+export interface OpenPrFilePatch {
+  number: number
+  patch: string
+}
+
+/**
+ * The `file` diff of every open PR that touches it (#1313). One `gh api` read per open PR, so
+ * callers go through {@link cachedOpenPrFilePatches}. The files endpoint belongs to the base
+ * repo, so cross-fork PRs answer too. First 100 changed files per PR only — a PR burying the
+ * queue file deeper than that simply contributes no claim, which is today's behavior anyway.
+ * Resolves `[]` when gh is missing/unauthed.
+ */
+export async function ghOpenPrFilePatches(cwd: string, file: string, prs?: OpenPr[]): Promise<OpenPrFilePatch[]> {
+  const open = prs ?? (await ghPrList(cwd))
+  const patches: OpenPrFilePatch[] = []
+  for (const pr of open) {
+    const files = await ghJson<{ filename: string; patch?: string }[]>(
+      ['api', `repos/{owner}/{repo}/pulls/${pr.number}/files?per_page=100`],
+      cwd,
+      [],
+    )
+    const patch = files.find(f => f.filename === file)?.patch
+    if (patch) patches.push({ number: pr.number, patch })
+  }
+  return patches
+}
+
+/**
+ * The cached form of {@link ghOpenPrFilePatches} (#1028). The cold budget is generous where the
+ * PR caches' is not: the one caller is the sweep's claim check, and a drain the user just clicked
+ * should wait a few seconds for the real answer rather than stand down for a whole tick.
+ */
+export async function cachedOpenPrFilePatches(cwd: string, file: string): Promise<Cached<OpenPrFilePatch[]>> {
+  const key = ['pr-file-patches', cwd, file].join(KEY_SEP)
+  return cachedRead(key, () => ghOpenPrFilePatches(cwd, file), { ttlMs: 60_000, budgetMs: 5_000 })
+}

--- a/packages/the-framework/src/queue-promote.test.ts
+++ b/packages/the-framework/src/queue-promote.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
-import { claimedQueueEntries, promoteQueue, landPinnedEntry } from './queue-promote.js'
+import { claimedQueueEntries, entriesRetiredByPatch, promoteQueue, landPinnedEntry } from './queue-promote.js'
 import type { GitRunner } from './project.js'
 
 // Pins the retry contract auto PM acts on: the callee flags the one retryable skip, so the
@@ -168,4 +168,83 @@ test('claimedQueueEntries: an unreadable run list claims nothing rather than sta
     pr: async () => ({ value: undefined, pending: false }),
   })
   assert.deepEqual(claimed, [])
+})
+
+// #1313: claims must not stop at this machine's run metas. Another daemon's drain — or a cloud
+// session — shows up only as an open PR whose queue diff retires the entry.
+
+test('entriesRetiredByPatch: a check-off and a removal both retire, an early fork point cannot (#1313)', () => {
+  const patch = [
+    '@@ -1,4 +1,4 @@',
+    ' ## Priority 8',
+    '-- [ ] entry a',
+    '+- [x] entry a',
+    '-- [ ] entry b',
+    ' - [ ] entry c',
+  ].join('\n')
+  assert.deepEqual(entriesRetiredByPatch(patch, ['entry a', 'entry b', 'entry c', 'entry d']), ['entry a', 'entry b'])
+  // entry d is simply not in the diff — absent on the branch means nothing here, by construction.
+})
+
+test('entriesRetiredByPatch: a remove-and-re-add-open shuffle is not a retirement (#1313)', () => {
+  const patch = ['@@ -1,2 +1,2 @@', '-- [ ] entry a', '+- [ ] entry a', '+- [x] entry b'].join('\n')
+  assert.deepEqual(entriesRetiredByPatch(patch, ['entry a', 'entry b']), ['entry b'])
+})
+
+test('entriesRetiredByPatch: link-bullet entries with no checkbox count as open when removed (#1313)', () => {
+  // The #1164 queue style: a plain link bullet is an open entry (#1297 pinned both parsers to that).
+  const patch = ['@@ -1,1 +0,0 @@', '-- [Fix the thing](tickets/2026-01-01_thing.md) — details'].join('\n')
+  assert.deepEqual(entriesRetiredByPatch(patch, ['[Fix the thing](tickets/2026-01-01_thing.md) — details']), [
+    '[Fix the thing](tickets/2026-01-01_thing.md) — details',
+  ])
+})
+
+test('claimedQueueEntries: an open PR from another machine claims its entry (#1313)', async () => {
+  const claimed = await claimedQueueEntries('/repo', ['entry a', 'entry b'], {
+    runs: async () => [], // nothing local: the drain ran elsewhere
+    pr: async () => ({ value: undefined, pending: false }),
+    queuePatches: async () => ({ value: [{ patch: '@@ -1 +1 @@\n-- [ ] entry a\n+- [x] entry a' }], pending: false }),
+  })
+  assert.deepEqual(claimed, ['entry a'])
+})
+
+test('claimedQueueEntries: warming queue diffs claim everything for one tick, and a failing lookup none (#1313)', async () => {
+  const warming = await claimedQueueEntries('/repo', ['entry a', 'entry b'], {
+    runs: async () => [],
+    pr: async () => ({ value: undefined, pending: false }),
+    queuePatches: async () => ({ value: undefined, pending: true }),
+  })
+  assert.deepEqual(warming.sort(), ['entry a', 'entry b'], 'slow answer = stand down, never double-assign')
+
+  const failing = await claimedQueueEntries('/repo', ['entry a'], {
+    runs: async () => [],
+    pr: async () => ({ value: undefined, pending: false }),
+    queuePatches: async () => {
+      throw new Error('gh unavailable')
+    },
+  })
+  assert.deepEqual(failing, [], 'no gh = local-only claims, as before')
+})
+
+test('claimedQueueEntries: local claims and PR-diff claims combine (#1313)', async () => {
+  const claimed = await claimedQueueEntries('/repo', ['entry a', 'entry b', 'entry c'], {
+    runs: async () => [{ id: 'r1', status: 'running', queueEntry: 'entry a' }],
+    pr: async () => ({ value: undefined, pending: false }),
+    queuePatches: async () => ({ value: [{ patch: '@@ -1 +0,0 @@\n-- [ ] entry b' }], pending: false }),
+  })
+  assert.deepEqual(claimed.sort(), ['entry a', 'entry b'])
+})
+
+test('claimedQueueEntries: everything already claimed locally skips the remote read (#1313)', async () => {
+  let asked = 0
+  const claimed = await claimedQueueEntries('/repo', ['entry a'], {
+    runs: async () => [{ id: 'r1', status: 'running', queueEntry: 'entry a' }],
+    pr: async () => ({ value: undefined, pending: false }),
+    queuePatches: async () => {
+      asked++
+      return { value: [], pending: false }
+    },
+  })
+  assert.deepEqual(claimed, ['entry a'])
+  assert.equal(asked, 0, 'a fully-claimed queue costs no gh read')
 })

--- a/packages/the-framework/src/queue-promote.ts
+++ b/packages/the-framework/src/queue-promote.ts
@@ -163,6 +163,38 @@ export function landPinnedEntry(
   return `${body}${separator}${added.map(text => `- [ ] ${text}`).join('\n')}\n`
 }
 
+/** A queue-file diff carried by one open PR (#1313). Structurally `OpenPrFilePatch`. */
+export interface QueuePatch {
+  patch: string
+}
+
+/**
+ * Which of `candidates` a unified diff retires (#1313): the patch adds the entry checked, or
+ * removes its open form without re-adding it open.
+ *
+ * Diff lines are exact about what the PR itself changed, which is what makes this safe: an entry
+ * merely *absent* on a branch that forked before the entry was added never counts, and that
+ * failure mode is what ruled out comparing whole files. A remove-and-re-add-open pair (a
+ * formatting shuffle) cancels out. "Open" follows the sweep's grammar: any list item is open
+ * unless its checkbox is ticked (#1164/#1297).
+ */
+export function entriesRetiredByPatch(patch: string, candidates: readonly string[]): string[] {
+  const addedChecked = new Set<string>()
+  const addedOpen = new Set<string>()
+  const removedOpen = new Set<string>()
+  for (const raw of patch.split('\n')) {
+    const sign = raw[0]
+    if ((sign !== '+' && sign !== '-') || raw.startsWith('+++') || raw.startsWith('---')) continue
+    const item = ENTRY_LINE.exec(raw.slice(1))
+    const text = item?.[3]?.trim()
+    if (!text) continue
+    const open = item![2] === undefined || item![2] === ' '
+    if (sign === '+') (open ? addedOpen : addedChecked).add(text)
+    else if (open) removedOpen.add(text)
+  }
+  return candidates.filter(text => addedChecked.has(text) || (removedOpen.has(text) && !addedOpen.has(text)))
+}
+
 /** The little {@link claimedQueueEntries} needs to know about a run. Structurally a `RunMeta`. */
 export interface QueueClaimRun {
   id: string
@@ -177,6 +209,11 @@ export interface QueueClaimRun {
 export interface QueueClaimDeps {
   runs(path: string): Promise<readonly QueueClaimRun[]>
   pr(path: string, run: QueueClaimRun): Promise<{ value?: { state: string } | undefined; pending: boolean }>
+  /**
+   * The queue-file diffs of the repo's open PRs (#1313), whoever opened them. Absent = claims
+   * stay local-only, as before — the graceful shape for a repo with no remote or no gh.
+   */
+  queuePatches?(path: string): Promise<{ value?: readonly QueuePatch[] | undefined; pending: boolean }>
 }
 
 /**
@@ -209,6 +246,19 @@ export async function claimedQueueEntries(
     else if (run.status === 'done') {
       const pr = await deps.pr(path, run).catch(() => ({ value: undefined, pending: false }))
       if (pr.pending || pr.value?.state === 'OPEN') claimed.add(entry)
+    }
+  }
+
+  // The cross-machine leg (#1313): another daemon's drain — or a cloud session — is invisible to
+  // this machine's run metas, but its open PR is not, and the PR's queue diff carries the entry's
+  // check-off or removal. A lookup still warming claims everything for one tick, for the same
+  // reason a pending PR lookup does above: handing an entry out because the answer was slow is
+  // the exact double-assignment this exists to prevent.
+  if (deps.queuePatches && claimed.size < wanted.size) {
+    const patches = await deps.queuePatches(path).catch(() => undefined)
+    if (patches?.pending) return [...wanted]
+    for (const { patch } of patches?.value ?? []) {
+      for (const text of entriesRetiredByPatch(patch, candidates)) claimed.add(text)
     }
   }
   return [...claimed]


### PR DESCRIPTION
Closes #1313

Queue claims (#1253) were resolved against the local daemon's run metas only, so a drain running on another machine, or a Claude web session, was invisible: the sweep saw the entry open and unclaimed and pinned a second agent to it. Live repro in the issue (PR #1309 vs run 2026-07-27T18-05-38-506Z).

Fix direction 1 from the issue, on the existing seams:

- `entriesRetiredByPatch()` (queue-promote.ts): a unified diff retires an entry when it adds it checked or removes its open form without re-adding it open. Diff lines are exact about what the PR itself changed, so an entry merely absent on a branch that forked before the entry existed never counts. That failure mode is what ruled out comparing whole files. Link-bullet entries with no checkbox count as open, matching the #1297 parser contract.
- `claimedQueueEntries()` gains an optional `queuePatches` dep: after local claims, any open PR whose queue diff retires a candidate claims it. Still-warming lookups claim everything for one tick (same conservative rule as the existing pending-PR case); a failing lookup degrades to local-only claims, exactly today's behavior.
- `ghOpenPrFilePatches()` / `cachedOpenPrFilePatches()` (dashboard/gh.ts): one `gh api pulls/{n}/files` read per open PR, through the #1028 cache (ttl 60s). Generous 5s cold budget so a drain the user just clicked waits for the real answer instead of standing down for a tick.
- Wired in daemon-services' `claimedEntries`.

Live-verified the diff shape against real PR #1309: its TODO_AGENTS.md patch removes the settle-moment entry's open line, which the new leg counts as a claim. With this in place the 18:05Z double-assignment does not happen.

Tests: 8 new (patch parsing incl. shuffle and link-bullet cases; cross-machine claim; warming/failing lookups; local+remote combination; fully-claimed short-circuit). Framework suite 1510 pass / 0 fail.