### PR TITLE
feat: warn before a Claude web run on an untrusted project (#1318)

### DIFF
--- a/.changeset/trust-warning-launcher.md
+++ b/.changeset/trust-warning-launcher.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': minor
+---
+
+The launcher now warns before a Claude web run on a project Claude Code has not been trusted in (#1318): the run would die on the CLI's interactive trust dialog (#1314), so the dashboard says so up front and names the one-time fix, instead of the user discovering it through dead runs

--- a/packages/framework-dashboard/components/StartRunForm.test.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.test.tsx
@@ -4,13 +4,16 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 // Everything the form reads goes through a lib module, so the mocks stop short of telefunc: an
 // unmocked `*.telefunc.js` in the import graph fails as an assertIsNotBrowser bug report.
 const onProjects = vi.hoisted(() => vi.fn())
-vi.mock('../server/projects.telefunc.js', () => ({ onProjects }))
+const onClaudeTrust = vi.hoisted(() => vi.fn())
+vi.mock('../server/projects.telefunc.js', () => ({ onProjects, onClaudeTrust }))
 
 const onSystemPromptUser = vi.hoisted(() => vi.fn())
 vi.mock('../server/reads.telefunc.js', () => ({ onSystemPromptUser }))
 
+// Mutable so a test can pick the run target (#1318); reset to Global defaults after each.
+const prefs = vi.hoisted(() => ({ current: {} as Record<string, unknown> }))
 vi.mock('../lib/preferences.js', () => ({
-  usePreferences: () => ({}),
+  usePreferences: () => prefs.current,
   updatePreferences: vi.fn(),
   autopilotEnabled: () => false,
 }))
@@ -46,6 +49,8 @@ const { StartRunForm } = await import('./StartRunForm.js')
 afterEach(() => {
   cleanup()
   start.mockReset()
+  onClaudeTrust.mockReset()
+  prefs.current = {}
 })
 
 const props = {
@@ -78,5 +83,44 @@ describe('StartRunForm submit (#1279)', () => {
     await waitFor(() => expect(start).toHaveBeenCalled())
     expect(start.mock.calls[0]![2]).toBe('build')
     expect(start.mock.calls[0]![3]).not.toHaveProperty('unattended')
+  })
+})
+
+describe('StartRunForm web-run trust warning (#1318)', () => {
+  test('an untrusted project warns before a web run, naming the root (#1314)', async () => {
+    onProjects.mockResolvedValue([])
+    onSystemPromptUser.mockResolvedValue(null)
+    prefs.current = { target: 'web' }
+    onClaudeTrust.mockResolvedValue({ known: true, trusted: false, root: '/repo' })
+    render(<StartRunForm {...props} />)
+    await waitFor(() => expect(screen.getByText(/has not been trusted/)).toBeTruthy())
+    expect(screen.getByText('/repo')).toBeTruthy()
+  })
+
+  test('a trusted project, an unknown answer, or a local target shows no warning', async () => {
+    onProjects.mockResolvedValue([])
+    onSystemPromptUser.mockResolvedValue(null)
+
+    prefs.current = { target: 'web' }
+    onClaudeTrust.mockResolvedValue({ known: true, trusted: true, root: '/repo' })
+    const trusted = render(<StartRunForm {...props} />)
+    await waitFor(() => expect(onClaudeTrust).toHaveBeenCalled())
+    expect(screen.queryByText(/has not been trusted/)).toBeNull()
+    trusted.unmount()
+
+    // Config unreadable: do not cry wolf — the run's own failure advice is the fallback.
+    onClaudeTrust.mockResolvedValue({ known: false, trusted: false, root: '/repo' })
+    const unknown = render(<StartRunForm {...props} />)
+    await waitFor(() => expect(onClaudeTrust).toHaveBeenCalledTimes(2))
+    expect(screen.queryByText(/has not been trusted/)).toBeNull()
+    unknown.unmount()
+
+    // A local run never asks the question at all.
+    prefs.current = {}
+    onClaudeTrust.mockClear()
+    render(<StartRunForm {...props} />)
+    await waitFor(() => expect(onProjects).toHaveBeenCalled())
+    expect(onClaudeTrust).not.toHaveBeenCalled()
+    expect(screen.queryByText(/has not been trusted/)).toBeNull()
   })
 })

--- a/packages/framework-dashboard/components/StartRunForm.tsx
+++ b/packages/framework-dashboard/components/StartRunForm.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react'
 import type { ProjectSummary } from '@gemstack/the-framework'
 import { runOptionsFromPreferences } from '@gemstack/the-framework/client'
-import { onProjects } from '../server/projects.telefunc.js'
+import { onClaudeTrust, onProjects } from '../server/projects.telefunc.js'
 import { onSystemPromptUser } from '../server/reads.telefunc.js'
 import { usePreferences, updatePreferences, autopilotEnabled } from '../lib/preferences.js'
 import { useConnectionProfiles } from '../lib/profiles.js'
@@ -87,6 +87,18 @@ export function StartRunForm({
     ...(remoteDevice ? { remote: { url: remoteDevice.url, token: remoteDevice.token, label: remoteDevice.label } } : {}),
   }
 
+  // A web run on a project Claude Code has not been trusted in dies on the CLI's interactive
+  // trust dialog (#1314), so say so BEFORE the run is spent, with the one-time fix (#1318).
+  // Read only when web is the target; `known: false` (config unreadable) shows nothing rather
+  // than crying wolf, and the run's own failure advice remains the fallback.
+  const web = options.target === 'web' && !remoteDevice
+  const trust = useLoaded<Awaited<ReturnType<typeof onClaudeTrust>>>(
+    () => (web ? onClaudeTrust(projectId) : Promise.resolve(null)),
+    null,
+    [projectId, web],
+  )
+  const untrusted = web && trust !== null && trust.known && !trust.trusted
+
   const submit = async (text: string, submitKind: 'build' | 'prompt') => {
     if (busy) return
     setNote('Starting…')
@@ -168,6 +180,15 @@ export function StartRunForm({
           expanded, tall) Context disclosure, past the fold from the Start button that caused it. */}
       {error && <p role="alert" className="mt-2 text-xs text-danger">{error}</p>}
       {note && !error && <p role="status" className="mt-2 text-xs text-muted-foreground">{note}</p>}
+      {/* The doomed-web-run warning (#1318): before the start, not after three dead runs (#1314). */}
+      {untrusted && (
+        <p role="alert" className="mt-2 text-xs text-warning">
+          Claude Code has not been trusted in this project, so a Claude web run cannot start a cloud
+          session. One-time fix: run <code className="font-mono">claude</code> in{' '}
+          <code className="font-mono">{trust!.root}</code> once and accept the trust prompt, then start
+          the session — future runs inherit it.
+        </p>
+      )}
     </form>
   )
 }

--- a/packages/framework-dashboard/server/projects.telefunc.ts
+++ b/packages/framework-dashboard/server/projects.telefunc.ts
@@ -4,6 +4,6 @@
 // Imported then exported, not re-exported (#1014): telefunc's dev transform appends
 // `__decorateTelefunction(<name>, ...)` per export, which needs a local binding. An
 // `export ... from` creates none, so `pnpm dev` died with `<name> is not defined`.
-import { onProjects, sendAddProject, onOnboarding } from '@gemstack/the-framework/dashboard-rpc'
+import { onProjects, sendAddProject, onOnboarding, onClaudeTrust } from '@gemstack/the-framework/dashboard-rpc'
 
-export { onProjects, sendAddProject, onOnboarding }
+export { onProjects, sendAddProject, onOnboarding, onClaudeTrust }

--- a/packages/the-framework/src/claude-trust.test.ts
+++ b/packages/the-framework/src/claude-trust.test.ts
@@ -1,0 +1,41 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { readClaudeTrust } from './claude-trust.js'
+
+async function configFile(content: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'claude-trust-'))
+  const path = join(dir, 'claude.json')
+  await writeFile(path, content, 'utf8')
+  return path
+}
+
+test('a trusted root reads as trusted, an asked-but-declined one as untrusted (#1318)', async () => {
+  const path = await configFile(
+    JSON.stringify({
+      projects: {
+        '/repo/trusted': { hasTrustDialogAccepted: true },
+        '/repo/declined': { hasTrustDialogAccepted: false },
+      },
+    }),
+  )
+  assert.deepEqual(await readClaudeTrust('/repo/trusted', path), { known: true, trusted: true })
+  assert.deepEqual(await readClaudeTrust('/repo/declined', path), { known: true, trusted: false })
+})
+
+test('a root the CLI has never seen is known-untrusted, not unknown (#1318)', async () => {
+  // The distinction matters: "no entry" means the dialog will fire on the next start there,
+  // which is exactly when the launcher should warn. Unknown is reserved for a file we could
+  // not read or did not understand.
+  const path = await configFile(JSON.stringify({ projects: {} }))
+  assert.deepEqual(await readClaudeTrust('/repo/new', path), { known: true, trusted: false })
+})
+
+test('a missing, unparseable or reshaped config answers unknown (#1318)', async () => {
+  assert.deepEqual(await readClaudeTrust('/repo', '/nowhere/claude.json'), { known: false, trusted: false })
+  assert.deepEqual(await readClaudeTrust('/repo', await configFile('not json {')), { known: false, trusted: false })
+  assert.deepEqual(await readClaudeTrust('/repo', await configFile('{"projects": []}')), { known: false, trusted: false })
+  assert.deepEqual(await readClaudeTrust('/repo', await configFile('"just a string"')), { known: false, trusted: false })
+})

--- a/packages/the-framework/src/claude-trust.ts
+++ b/packages/the-framework/src/claude-trust.ts
@@ -1,0 +1,45 @@
+import { readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * Claude Code's folder trust, read (never written) for the dashboard (#1318).
+ *
+ * The CLI asks its one-time "do you trust this folder?" question interactively, which a
+ * `--cloud` start under the daemon's pty can never answer (#1314) — a web run on an
+ * untrusted project is doomed before it starts. The dashboard can at least know that
+ * before the run is spent: this reads the CLI's own record of the decision.
+ *
+ * Read-only on purpose. Trusting a folder is a security decision the CLI owns; the
+ * framework reports it and tells the user the one-time step, it does not make it for them.
+ * Fail-quiet on an unexpected file: a missing, unreadable or reshaped `~/.claude.json`
+ * answers "unknown", and the dashboard simply shows nothing extra.
+ */
+
+/** Where the Claude Code CLI records per-directory trust. */
+export function claudeConfigPath(home: string = homedir()): string {
+  return join(home, '.claude.json')
+}
+
+/** What the dashboard knows about a root's trust. `known: false` means the file could not say. */
+export interface ClaudeTrust {
+  known: boolean
+  trusted: boolean
+}
+
+/** Whether the CLI trusts `root`. Unknown when the config is missing or not understood. */
+export async function readClaudeTrust(root: string, path: string = claudeConfigPath()): Promise<ClaudeTrust> {
+  let config: unknown
+  try {
+    config = JSON.parse(await readFile(path, 'utf8'))
+  } catch {
+    return { known: false, trusted: false }
+  }
+  if (typeof config !== 'object' || config === null) return { known: false, trusted: false }
+  const projects = (config as Record<string, unknown>).projects
+  if (typeof projects !== 'object' || projects === null || Array.isArray(projects)) return { known: false, trusted: false }
+  const entry = (projects as Record<string, unknown>)[root]
+  const trusted =
+    typeof entry === 'object' && entry !== null && (entry as Record<string, unknown>).hasTrustDialogAccepted === true
+  return { known: true, trusted }
+}

--- a/packages/the-framework/src/dashboard-rpc/index.ts
+++ b/packages/the-framework/src/dashboard-rpc/index.ts
@@ -5,7 +5,7 @@
 export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onRecentRuns, onHotTickets, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent, onTickets, onTicket, onTicketsMeta, onAllTickets, onRetainedWorktrees, onRunWorktree, onRunHandoff, onSystemPromptUser, onBridgeQuestion, onBridgeStatus, onBridgeToken, onBridgeEvents, onBridgeAnswer } from './reads.telefunc.js'
 export { sendStop, sendChoice, sendBridgeAnswer, sendBridgeAnswerCancel, sendMessage, sendSetHandoff, sendStart, sendStartTopic, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendDeleteSession, sendPushBranch, sendOpenPullRequest, sendQueueTicket, type QueueTicketResult, type QueuedTicket } from './control.telefunc.js'
 export { onEvents } from './events.telefunc.js'
-export { onProjects, sendAddProject, onOnboarding } from './projects.telefunc.js'
+export { onProjects, sendAddProject, onOnboarding, onClaudeTrust } from './projects.telefunc.js'
 export {
   onPreferences,
   savePreferences,

--- a/packages/the-framework/src/dashboard-rpc/projects.telefunc.ts
+++ b/packages/the-framework/src/dashboard-rpc/projects.telefunc.ts
@@ -1,5 +1,6 @@
 import { getContext } from 'telefunc'
 import { contextProjects } from './context.js'
+import { readClaudeTrust, type ClaudeTrust } from '../claude-trust.js'
 import type { ProjectSummary } from '../dashboard/projects.js'
 import type { AddProjectResult, OnboardingSuggestion } from '../dashboard/types.js'
 import type { DashboardContext } from '../dashboard/telefunc-serve.js'
@@ -40,4 +41,18 @@ export async function onOnboarding(): Promise<OnboardingSuggestion> {
   const cwd = process.cwd()
   const registered = await contextProjects().list()
   return { cwd, cwdProjectId: registered.find(p => p.path === cwd)?.id ?? null }
+}
+
+/**
+ * Whether Claude Code trusts this project's root (#1318): the launcher warns before a web run
+ * on an untrusted project, which is doomed to die on the CLI's interactive trust dialog
+ * (#1314), instead of after it. Read-only — trusting a folder stays the user's own act in the
+ * CLI; run worktrees inherit the root's answer. `null` when the project is unknown here, and
+ * `known: false` when the CLI's config could not say.
+ */
+export async function onClaudeTrust(projectId: string): Promise<(ClaudeTrust & { root: string }) | null> {
+  const projects = await contextProjects().list()
+  const root = projects.find(p => p.id === projectId)?.path
+  if (!root) return null
+  return { ...(await readClaudeTrust(root)), root }
 }


### PR DESCRIPTION
Closes #1318

Follow-up to #1315. The trust failure now warns BEFORE the run instead of after it dies:

- `claude-trust.ts`: `readClaudeTrust(root)` reads the CLI's own record (`~/.claude.json`, `projects[root].hasTrustDialogAccepted`). Read-only and fail-quiet: a missing/unreadable/reshaped config answers unknown and the dashboard shows nothing extra.
- `onClaudeTrust(projectId)` telefunc (projects module, auto-registered; shim updated).
- StartRunForm: when the run target is Claude web and the project root is untrusted, an inline warning names the root and the one-time fix. `known: false` stays silent rather than crying wolf; local runs never ask.

About the one-click Trust button the issue asks for: I attempted it (a `grantClaudeTrust` writing exactly what the CLI's own Enter records, behind an explicit dashboard click) and my tooling's safety policy blocked authoring code that grants Claude Code folder trust programmatically. So this PR ships the detect-and-warn half; the grant write is a ~25-line human-authored follow-up if we still want it, and the warning text keeps the CLI step as the documented path meanwhile.

Tests: 3 new unit tests for `readClaudeTrust`, 2 new StartRunForm tests (warning shown for untrusted web target; silent for trusted/unknown/local). Framework 1515 pass / 0 fail, dashboard 633/633 (one unrelated known-flake failure cleared on rerun).