### PR TITLE
fix: stop the conversation committer failing on a pathspec with nothing under it

### DIFF
--- a/.changeset/quiet-conversation-commit-pathspec.md
+++ b/.changeset/quiet-conversation-commit-pathspec.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+The conversation committer only passes the pathspecs that actually have something pending. A project with no `.the-framework/conversations` directory — every project until its first recorded chat — made `git add`/`git commit` abort with "pathspec ... did not match any files", so its sessions never committed and the daemon log carried that failure on every poll. Nothing to commit under a pattern is now the ordinary skip it always was, while real git failures are still reported.

--- a/packages/the-framework/src/conversation-commit.test.ts
+++ b/packages/the-framework/src/conversation-commit.test.ts
@@ -1,11 +1,13 @@
 import { strict as assert } from 'node:assert'
+import { join } from 'node:path'
 import { test } from 'node:test'
 import type { ProjectSummary } from './dashboard/projects.js'
-import type { GitRunner } from './project.js'
+import { nodeGitRunner, type GitRunner } from './project.js'
 import {
   commitConversations,
   commitMessage,
   gitBusy,
+  pathspecsFor,
   pendingConversations,
   startConversationCommitter,
   CONVERSATIONS_PATHSPEC,
@@ -137,10 +139,13 @@ test('a non-repo is busy rather than committed into (#912)', async () => {
 test('a commit stages and commits the pathspec, and never add -A (#912)', async () => {
   const { git, calls } = fakeGit({
     'rev-parse': '/repo/.git\n',
-    status: '?? .the-framework/conversations/a.md',
+    status: ['?? .the-framework/conversations/a.md', '?? .the-framework/git@example.com/sessions/r1.json'].join('\n'),
   })
   const outcome = await commitConversations('/repo', git, noLocks)
-  assert.deepEqual(outcome, { committed: true, files: ['.the-framework/conversations/a.md'] })
+  assert.deepEqual(outcome, {
+    committed: true,
+    files: ['.the-framework/conversations/a.md', '.the-framework/git@example.com/sessions/r1.json'],
+  })
 
   assert.deepEqual(
     calls.find(args => args[0] === 'add'),
@@ -150,7 +155,7 @@ test('a commit stages and commits the pathspec, and never add -A (#912)', async 
   assert.deepEqual(calls.find(args => args[0] === 'commit'), [
     'commit',
     '-m',
-    '[The Framework] a conversation',
+    '[The Framework] a conversation and a session',
     '--',
     ...COMMITTED_PATHSPECS,
   ])
@@ -158,6 +163,98 @@ test('a commit stages and commits the pathspec, and never add -A (#912)', async 
     !calls.some(args => args.includes('-A') || args.includes('--all')),
     'the user checkout is never swept wholesale',
   )
+})
+
+test('a pathspec with nothing under it is left out rather than failing the commit', async () => {
+  // git aborts the whole `add`/`commit` on a pathspec that matches no file, so a project that has
+  // sessions but has never recorded a conversation — every project, until its first chat — used to
+  // fail on every poll and put "pathspec ... did not match any files" in the daemon log each time.
+  assert.deepEqual(pathspecsFor(['.the-framework/conversations/a.md']), [CONVERSATIONS_PATHSPEC])
+  assert.deepEqual(pathspecsFor(['.the-framework/git@example.com/sessions/r1.json']), [SESSIONS_PATHSPEC])
+  assert.deepEqual(
+    pathspecsFor(['.the-framework/conversations/a.md', '.the-framework/git@example.com/sessions/r1.json']),
+    [...COMMITTED_PATHSPECS],
+    'both are passed when both have something pending',
+  )
+  assert.deepEqual(pathspecsFor([]), [], 'and nothing pending names no pathspec at all')
+})
+
+test('a project with no conversations directory commits its sessions without a pathspec error', async () => {
+  const { git, calls } = fakeGit({
+    'rev-parse': '/repo/.git\n',
+    status: '?? .the-framework/git@example.com/sessions/r1.json',
+  })
+  const outcome = await commitConversations('/repo', git, noLocks)
+  assert.deepEqual(outcome, { committed: true, files: ['.the-framework/git@example.com/sessions/r1.json'] })
+  assert.deepEqual(
+    calls.find(args => args[0] === 'add'),
+    ['add', '--', SESSIONS_PATHSPEC],
+    'the conversations pathspec, which would match nothing, is not passed',
+  )
+  assert.deepEqual(calls.find(args => args[0] === 'commit'), [
+    'commit',
+    '-m',
+    '[The Framework] a session',
+    '--',
+    SESSIONS_PATHSPEC,
+  ])
+})
+
+test('a pending file under neither pathspec is skipped, never committed with an empty pathspec', async () => {
+  // Unreachable in practice — `status` is scoped to the same pathspecs — but an empty pathspec list
+  // means "everything" to git, so the fallback has to be a skip and not a wide-open commit.
+  const { git, calls } = fakeGit({ 'rev-parse': '/repo/.git\n', status: '?? src/app.ts' })
+  assert.deepEqual(await commitConversations('/repo', git, noLocks), {
+    committed: false,
+    reason: 'no conversation changes',
+  })
+  assert.ok(!calls.some(args => args[0] === 'add' || args[0] === 'commit'), 'nothing touched the index')
+})
+
+test('against real git: a missing or empty conversations directory is quietly skipped, not an error', async () => {
+  // Real git because the fake one never rejects a pathspec, and the rejection is the whole bug. It
+  // also shows the two failures land in different commands: `add` tolerates an existing-but-empty
+  // directory and `commit` is the one that rejects it, once the pathspec must match a known file.
+  const { mkdtemp, mkdir, writeFile, rm } = await import('node:fs/promises')
+  const { tmpdir } = await import('node:os')
+
+  const repo = await mkdtemp(join(tmpdir(), 'fw-commit-'))
+  const git = nodeGitRunner()
+  try {
+    await git(['init', '-q'], repo)
+    await git(['config', 'user.email', 'git@example.com'], repo)
+    await git(['config', 'user.name', 'Test'], repo)
+    const fw = join(repo, '.the-framework')
+    await mkdir(join(fw, 'git@example.com', 'sessions'), { recursive: true })
+    await writeFile(join(fw, 'git@example.com', 'sessions', 'r1.json'), '{"id":"r1"}\n')
+
+    // No `.the-framework/conversations` at all: the state of every project before its first chat.
+    const first = await commitConversations(repo, git)
+    assert.deepEqual(first, { committed: true, files: ['.the-framework/git@example.com/sessions/r1.json'] })
+
+    // And an existing directory holding nothing git can see, which `add` lets through.
+    await mkdir(join(fw, 'conversations'), { recursive: true })
+    await writeFile(join(fw, 'git@example.com', 'sessions', 'r2.json'), '{"id":"r2"}\n')
+    const second = await commitConversations(repo, git)
+    assert.deepEqual(second, { committed: true, files: ['.the-framework/git@example.com/sessions/r2.json'] })
+
+    // The real conversation still commits once there is one, and nothing else rode along.
+    await writeFile(join(fw, 'conversations', 'a.md'), '# chat\n')
+    await writeFile(join(repo, 'user-work.txt'), 'not ours\n')
+    const third = await commitConversations(repo, git)
+    assert.deepEqual(third, { committed: true, files: ['.the-framework/conversations/a.md'] })
+
+    const log = await git(['log', '--format=%s'], repo)
+    assert.deepEqual(log.trim().split('\n'), [
+      '[The Framework] a conversation',
+      '[The Framework] a session',
+      '[The Framework] a session',
+    ])
+    const status = await git(['status', '--porcelain', '-uall'], repo)
+    assert.equal(status.trim(), '?? user-work.txt', "the user's own work is left where it was")
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
 })
 
 test('a busy repo is skipped without staging anything (#912)', async () => {

--- a/packages/the-framework/src/conversation-commit.ts
+++ b/packages/the-framework/src/conversation-commit.ts
@@ -21,7 +21,8 @@ import { errorMessage } from './error-message.js'
  * Path-scoped, never `git add -A`. The pathspec names the conversations directory and nothing
  * else, the way `queue-promote.ts` names the queue file, so whatever the user has in progress
  * cannot ride along in our commit. A pathspec commit also leaves their index alone: what they had
- * staged is still staged afterwards.
+ * staged is still staged afterwards. Scoped down further at commit time to the pathspecs that
+ * actually have something pending — see {@link pathspecsFor}.
  *
  * Debounced on an idle window rather than committed per turn. A chat turn is seconds apart, and a
  * commit each would bury the project's real history under transcript noise. A poll that sees the
@@ -59,6 +60,34 @@ export const SESSIONS_PATHSPEC = `:(glob)${THE_FRAMEWORK_DIR}/*/${SESSIONS_DIR}/
  * would double the noise in the project's log.
  */
 export const COMMITTED_PATHSPECS: readonly string[] = [CONVERSATIONS_PATHSPEC, SESSIONS_PATHSPEC]
+
+/**
+ * Which pending file belongs to which pathspec, so a pathspec with nothing under it can be left out
+ * of `add`/`commit` (see {@link pathspecsFor}). Kept beside the pathspecs themselves: a predicate
+ * that drifts from the pattern it mirrors would silently drop a file from every commit.
+ */
+const PATHSPEC_MEMBERSHIP: ReadonlyArray<readonly [pathspec: string, holds: (file: string) => boolean]> = [
+  [CONVERSATIONS_PATHSPEC, file => file.startsWith(`${CONVERSATIONS_PATHSPEC}/`)],
+  [SESSIONS_PATHSPEC, file => file.startsWith(`${THE_FRAMEWORK_DIR}/`) && file.includes(`/${SESSIONS_DIR}/`)],
+]
+
+/**
+ * The subset of {@link COMMITTED_PATHSPECS} that `files` actually has something under.
+ *
+ * `git add` and `git commit` are all-or-nothing about their pathspecs: one that matches no file
+ * aborts the whole command with "pathspec ... did not match any files", so passing both patterns
+ * unconditionally means a project that has sessions but has never recorded a conversation — every
+ * project, until its first chat — fails to commit and puts that failure in the daemon log on every
+ * poll. Nothing to commit under a pattern is the ordinary state, not an error, so the pattern is
+ * dropped instead.
+ *
+ * This covers the empty directory as well as the missing one, and the two fail in different places:
+ * `git add` tolerates an existing-but-empty directory, and then `git commit` rejects it, because by
+ * then the pathspec has to match a file git knows about.
+ */
+export function pathspecsFor(files: readonly string[]): string[] {
+  return PATHSPEC_MEMBERSHIP.filter(([, holds]) => files.some(holds)).map(([pathspec]) => pathspec)
+}
 
 /** How often the committer looks for settled conversations. */
 export const COMMIT_POLL_MS = 30_000
@@ -178,11 +207,13 @@ export async function gitBusy(
 const NOTHING_PENDING = 'no conversation changes'
 
 /**
- * Stage and commit the pending conversations under `cwd`, scoped to {@link CONVERSATIONS_PATHSPEC}.
+ * Stage and commit the pending conversations under `cwd`, scoped to {@link COMMITTED_PATHSPECS}.
  *
  * `add` before `commit` because a brand-new conversation is untracked, and `git commit -- <path>`
  * only knows paths git already knows. Both are pathspec-scoped, so the staging is as narrow as the
- * commit and the user's own staged work is neither swept in nor disturbed.
+ * commit and the user's own staged work is neither swept in nor disturbed, and both are narrowed to
+ * the pathspecs that have something pending ({@link pathspecsFor}) — a pathspec matching nothing is
+ * a hard error to git, and "no conversation has been recorded here yet" is not an error at all.
  *
  * Never throws: this runs on a background tick with nothing to catch it.
  */
@@ -197,9 +228,16 @@ export async function commitConversations(
   const files = await pendingConversations(cwd, git)
   if (files.length === 0) return { committed: false, reason: NOTHING_PENDING }
 
+  // Only the pathspecs that have something pending, or git aborts on the one that matches nothing.
+  // An empty result should be unreachable — `status` was scoped to these same pathspecs — but an
+  // empty pathspec list means "everything", which would sweep the user's whole checkout into our
+  // commit, so it reads as nothing pending rather than as a commit.
+  const pathspecs = pathspecsFor(files)
+  if (pathspecs.length === 0) return { committed: false, reason: NOTHING_PENDING }
+
   try {
-    await git(['add', '--', ...COMMITTED_PATHSPECS], cwd)
-    await git(['commit', '-m', commitMessage(files), '--', ...COMMITTED_PATHSPECS], cwd)
+    await git(['add', '--', ...pathspecs], cwd)
+    await git(['commit', '-m', commitMessage(files), '--', ...pathspecs], cwd)
     return { committed: true, files }
   } catch (err) {
     return { committed: false, reason: errorMessage(err) }

--- a/packages/the-framework/src/index.ts
+++ b/packages/the-framework/src/index.ts
@@ -184,6 +184,7 @@ export {
   gitBusy,
   commitMessage,
   nodePathProbe,
+  pathspecsFor,
   CONVERSATIONS_PATHSPEC,
   COMMIT_POLL_MS,
   COMMIT_MAX_WAIT_MS,


### PR DESCRIPTION
Work done end-to-end by a Claude web session (https://claude.ai/code/session_01SiSWRCyY73fduiXzRS5PKi), delivered by git-am because the session could not push (#1320). Applied clean onto current main; the full suite passes locally, 1516/0, including the 10 daemon tests the cloud container could not run.

## What was wrong

`commitConversations` staged and committed with both `COMMITTED_PATHSPECS` unconditionally. git treats pathspecs as all-or-nothing: one that matches no file aborts the whole command with `fatal: pathspec '.the-framework/conversations' did not match any files`. So a project that has archived sessions but has never recorded a conversation (the state of every project until its first chat) failed on every poll. Two consequences, one of them not just noise:

- the failure landed in the daemon log, on a repo state that is entirely normal, and
- the sessions it could have committed were never committed either, because the aborted `add` took the whole batch with it.

The empty directory fails too, one command later: `git add` tolerates an existing-but-empty directory, and `git commit` then rejects it.

## The fix

`pathspecsFor(files)` returns the subset of `COMMITTED_PATHSPECS` that the pending set actually has files under, and `add`/`commit` are given that. A pattern with nothing under it is dropped rather than passed and failed on, while a real git failure still rejects and is still logged by the poller on change.

An empty result should be unreachable, but it is handled explicitly: an empty pathspec list means everything to git, which would sweep the user's whole checkout into our commit, so it reads as nothing pending instead.

## Tests

- `pathspecsFor` maps each pending set to the pathspecs it needs.
- A project with no conversations directory commits its sessions, and the conversations pathspec is not passed.
- A pending file under neither pathspec is skipped rather than committed with an empty pathspec.
- Against real git in a temp repo: missing directory, then empty directory, then a real conversation - three commits, and the user's own untracked file is left alone. Real git because the fake runner never rejects a pathspec, and the rejection is the entire bug.

Both missing-directory tests fail against the previous implementation and pass with the fix (revert-proven).

## Changeset

`.changeset/quiet-conversation-commit-pathspec.md` - `@gemstack/the-framework`: patch.