### PR TITLE
fix: carry the cloud session's real URL into the run meta (#1317)

### DIFF
--- a/.changeset/cloud-session-link-meta.md
+++ b/.changeset/cloud-session-link-meta.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+A web run's meta now records the cloud session's real URL instead of the generic claude.ai/code entry point (#1317): the cloud hand-off's result event carries the session link, and the session-update prefers a driver-supplied URL over the --session-link template

--- a/packages/the-framework/src/cloud-session-link.test.ts
+++ b/packages/the-framework/src/cloud-session-link.test.ts
@@ -1,0 +1,49 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { CloudDriver } from './driver/cloud.js'
+import { createDriverEventHandler, emitSessionStart } from './run-telemetry.js'
+import { metaFromEvents } from './store/index.js'
+import { CLAUDE_CODE_SESSION_LINK } from './session-link.js'
+import type { FrameworkEvent } from './events.js'
+
+// #1317: a web run's meta dead-ended on the generic https://claude.ai/code — recorded by the
+// opening `session` event before any session existed — even though the CloudDriver had the real
+// URL in hand. This wires the real driver through the real telemetry into the real meta fold,
+// so the contract that the deep link wins is pinned end to end, not per layer.
+
+const URL = 'https://claude.ai/code/session_01ABCdefGHIjklMNO?from=cli&m=0'
+const CREATED = [
+  '\x1b[?25l\x1b[2K',
+  'Created cloud session: Add the --verbose flag\r\n',
+  `View: \x1b[4m${URL}\x1b[24m\r\n`,
+  'Resume with: claude --teleport session_01ABCdefGHIjklMNO\r\n',
+  '\x1b[?25h',
+].join('')
+
+test('a cloud run meta ends with the real session URL, not the generic entry point (#1317)', async () => {
+  const events: FrameworkEvent[] = []
+  const handler = createDriverEventHandler({
+    emit: e => events.push(e),
+    // What a Claude run gets without an explicit --session-link: the generic entry point.
+    sessionLink: CLAUDE_CODE_SESSION_LINK,
+    budgetController: new AbortController(),
+    consumptionController: new AbortController(),
+  })
+  const driver = new CloudDriver({
+    runTag: () => 'tag',
+    timeoutMs: 1000,
+    runPty: async opts => {
+      opts.onData(CREATED)
+      if (!opts.signal.aborted) await new Promise<void>(r => opts.signal.addEventListener('abort', () => r(), { once: true }))
+    },
+  })
+  emitSessionStart({ emit: e => events.push(e), driver, cwd: '/repo', sessionLink: CLAUDE_CODE_SESSION_LINK })
+  const session = await driver.start({ cwd: '/repo', onEvent: handler.onDriverEvent })
+  await session.prompt('go')
+
+  const meta = metaFromEvents(events, '2026-01-01T00:00:00.000Z')
+  assert.equal(meta.sessionLink, URL, 'the meta must carry the deep link once the hand-off knows it')
+  // The opening event still honestly says what was known before the session existed.
+  const opening = events.find(e => e.kind === 'session')
+  assert.ok(opening && 'sessionLink' in opening && opening.sessionLink === CLAUDE_CODE_SESSION_LINK)
+})

--- a/packages/the-framework/src/driver/cloud.test.ts
+++ b/packages/the-framework/src/driver/cloud.test.ts
@@ -52,6 +52,8 @@ test('the session link rides an `action` event, the way the Actions run link doe
   await session.prompt('go')
   assert.ok(events.some(e => e.type === 'action' && e.label === `cloud ${URL}`))
   assert.ok(events.some(e => e.type === 'result' && e.sessionId === SESSION))
+  // The result also carries the real URL (#1317), which is what reaches the run meta.
+  assert.ok(events.some(e => e.type === 'result' && e.sessionLink === URL))
 })
 
 test('the prompt carries the session framing and the per-call system prompt', async () => {

--- a/packages/the-framework/src/driver/cloud.ts
+++ b/packages/the-framework/src/driver/cloud.ts
@@ -261,7 +261,9 @@ export class CloudSession implements DriverSession {
             `View the session: ${session.url}`,
             `Continue it here: claude --teleport ${session.sessionId}`,
           ].join('\n')
-    this.emit({ type: 'result', text: summary, sessionId: session.sessionId })
+    // The result also carries the session's real URL (#1317): the action above is what the
+    // run view links through, the result is what reaches the meta.
+    this.emit({ type: 'result', text: summary, sessionId: session.sessionId, sessionLink: session.url })
     return { text: summary, sessionId: session.sessionId }
   }
 

--- a/packages/the-framework/src/driver/types.ts
+++ b/packages/the-framework/src/driver/types.ts
@@ -270,8 +270,12 @@ export type DriverEvent =
   | { type: 'text'; text: string }
   /** The agent used a tool. We surface the name only, not the arguments. */
   | { type: 'action'; label: string }
-  /** The turn settled with this final text. */
-  | { type: 'result'; text: string; sessionId?: string; usage?: DriverUsage }
+  /**
+   * The turn settled with this final text. `sessionLink` is the real URL of the session,
+   * for a driver whose session has one of its own (#1317) — the cloud hand-off — so the
+   * meta can link there instead of the generic entry point; drivers without one omit it.
+   */
+  | { type: 'result'; text: string; sessionId?: string; sessionLink?: string; usage?: DriverUsage }
   /** Where the account's subscription quota stands (#517). */
   | { type: 'rate-limit'; limit: DriverRateLimit }
   /** The agent (or its transport) errored. */

--- a/packages/the-framework/src/run-telemetry.ts
+++ b/packages/the-framework/src/run-telemetry.ts
@@ -86,7 +86,9 @@ export function createDriverEventHandler(opts: DriverEventHandlerOptions): Drive
     if (event.type !== 'result') return
     if (event.sessionId && event.sessionId !== lastSessionId) {
       lastSessionId = event.sessionId
-      const link = opts.sessionLink ? resolveSessionLink(opts.sessionLink, event.sessionId) : undefined
+      // A driver that knows its session's real URL (#1317, the cloud hand-off) beats the
+      // `--session-link` template, whose Claude default is the generic entry point.
+      const link = event.sessionLink ?? (opts.sessionLink ? resolveSessionLink(opts.sessionLink, event.sessionId) : undefined)
       emit({ kind: 'session-update', sessionId: event.sessionId, ...(link ? { sessionLink: link } : {}) })
     }
     if (!event.usage) return


### PR DESCRIPTION
Closes #1317

Design by the stranded verification cloud session (https://claude.ai/code/session_011PbhEaDhQWZvZAJBDSAJPW, could not push per #1320); re-implemented locally following its report.

- `driver/types.ts`: the `result` driver event gains an optional `sessionLink` - the real URL of that session, for a driver that has one. No new event kind; drivers without one omit it.
- `driver/cloud.ts`: the hand-off puts the session URL on its result event alongside the existing `cloud <url>` action. The action is what the run view links through; the result is what reaches the meta.
- `run-telemetry.ts`: the session-update prefers a driver-supplied URL over the `--session-link` template, whose Claude default is the generic entry point. Unchanged for drivers that report no URL.

Tests: new `cloud-session-link.test.ts` wires the real CloudDriver through the real telemetry into `metaFromEvents` and pins that the meta ends with the deep link while the opening session event still carries the generic one (fails without the telemetry change - revert-proven); driver-level assertion in `cloud.test.ts`. Framework suite 1520 pass / 0 fail.