### PR TITLE
fix: make session un-ignore rules user-agnostic globs

### DIFF
--- a/.changeset/sessions-gitignore-globs.md
+++ b/.changeset/sessions-gitignore-globs.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+The session un-ignore rules in `.the-framework/.gitignore` are now user-agnostic globs, so the file is written once instead of once per person. Every user who ran a session appended their own three `!<email>/...` lines to a tracked file: their checkout went dirty, the next safety commit swept the edit into a branch, and two machines doing it near each other conflicted on a delete-vs-modify. One `!*/sessions/**` rule covers everyone, including people who have not run anything yet. A file that still names users is upgraded to the glob form in place, in the same write that removes the per-user lines, and a file already on the glob form is never written again. Unrelated rules, including the conversations rules, are kept exactly as they are.

--- a/packages/the-framework/src/sessions.test.ts
+++ b/packages/the-framework/src/sessions.test.ts
@@ -7,6 +7,7 @@ import {
   userDirName,
   sessionsDir,
   sessionsGitignore,
+  withoutPerUserRules,
   ensureSessionsIgnored,
   resolveUserDir,
   forgetUserDirs,
@@ -74,8 +75,8 @@ test('sessions live under the user, inside .the-framework (#1179)', () => {
 test('the ignore rules re-include every directory on the way down (#1179)', () => {
   // The seeded allow-list ignores everything with `*`, and git never descends into an ignored
   // directory — so un-ignoring only the files would never be reached.
-  const rules = sessionsGitignore('me@example.com')
-  assert.equal(rules, '!me@example.com/\n!me@example.com/sessions/\n!me@example.com/sessions/**\n')
+  const rules = sessionsGitignore()
+  assert.equal(rules, '!*/\n!*/sessions/\n!*/sessions/**\n')
 })
 
 test('a repo with no ignore file gets the full allow-list plus its rules (#1179)', async () => {
@@ -83,7 +84,7 @@ test('a repo with no ignore file gets the full allow-list plus its rules (#1179)
   assert.equal(await ensureSessionsIgnored('/repo', 'me@example.com', fs), true)
   const written = fs.files.get(IGNORE)!
   assert.ok(written.startsWith(LOGS_GITIGNORE), 'the transient run state stays ignored')
-  assert.ok(written.includes('!me@example.com/sessions/**'))
+  assert.ok(written.includes('!*/sessions/**'))
 })
 
 test('an existing ignore file is appended to, once (#1179)', async () => {
@@ -91,18 +92,44 @@ test('an existing ignore file is appended to, once (#1179)', async () => {
   assert.equal(await ensureSessionsIgnored('/repo', 'me@example.com', fs), true)
   assert.equal(await ensureSessionsIgnored('/repo', 'me@example.com', fs), false, 'already there, so nothing written')
   const written = fs.files.get(IGNORE)!
-  assert.equal(written.match(/!me@example\.com\/sessions\/\*\*/g)?.length, 1)
+  assert.equal(written.match(/!\*\/sessions\/\*\*/g)?.length, 1)
 })
 
-test('a second user adds their own rules beside the first (#1179)', async () => {
-  // Two people on one repo is the case the per-user directory exists for, and the ignore file has
-  // to name both or the second one's history is silently untracked.
+test('a second user writes nothing: the rules already cover them (#1312)', async () => {
+  // The whole point of the glob. Under the per-user form this was two writes to a tracked file,
+  // one per person, each dirtying its own checkout.
   const fs = memFs({ [IGNORE]: LOGS_GITIGNORE })
-  await ensureSessionsIgnored('/repo', 'a@example.com', fs)
-  await ensureSessionsIgnored('/repo', 'b@example.com', fs)
+  assert.equal(await ensureSessionsIgnored('/repo', 'a@example.com', fs), true)
+  assert.equal(await ensureSessionsIgnored('/repo', 'b@example.com', fs), false, 'the glob already covers them')
   const written = fs.files.get(IGNORE)!
-  assert.ok(written.includes('!a@example.com/sessions/**'))
-  assert.ok(written.includes('!b@example.com/sessions/**'))
+  assert.equal(written.match(/!\*\/sessions\/\*\*/g)?.length, 1)
+  assert.ok(!written.includes('@example.com'), 'no user is named')
+})
+
+test('a file still naming users is upgraded to the glob form, once (#1312)', async () => {
+  const legacy = LOGS_GITIGNORE + '!a@example.com/\n!a@example.com/sessions/\n!a@example.com/sessions/**\n'
+  const fs = memFs({ [IGNORE]: legacy })
+  assert.equal(await ensureSessionsIgnored('/repo', 'b@example.com', fs), true)
+  const written = fs.files.get(IGNORE)!
+  assert.ok(written.includes('!*/sessions/**'), 'the glob is in')
+  assert.ok(!written.includes('a@example.com'), 'the per-user lines came out in the same write')
+  assert.equal(await ensureSessionsIgnored('/repo', 'c@example.com', fs), false, 'and it never writes again')
+})
+
+test('the upgrade keeps every line it does not recognize (#1312)', () => {
+  // The conversations rules (#908) sit in the same file and are a literal directory, not a user.
+  const before = LOGS_GITIGNORE + '!conversations/\n!conversations/**\n!a@x.com/\n!a@x.com/sessions/\n!a@x.com/sessions/**\n# mine\n!keep-me/\n'
+  const after = withoutPerUserRules(before)
+  assert.ok(after.includes('!conversations/'), 'conversations survive')
+  assert.ok(after.includes('!conversations/**'))
+  assert.ok(after.includes('# mine'), 'comments survive')
+  assert.ok(after.includes('!keep-me/'), 'an unrelated rule survives')
+  assert.ok(!after.includes('a@x.com'), 'only the named user goes')
+})
+
+test('a file with no per-user rules is returned untouched (#1312)', () => {
+  const md = LOGS_GITIGNORE + '!conversations/\n!conversations/**\n'
+  assert.equal(withoutPerUserRules(md), md)
 })
 
 test('an unrecognized ignore file is left alone (#1179)', async () => {

--- a/packages/the-framework/src/sessions.ts
+++ b/packages/the-framework/src/sessions.ts
@@ -57,35 +57,76 @@ export function sessionsDir(cwd: string, user: string): string {
 }
 
 /**
- * The `.the-framework/.gitignore` rules that make one user's sessions tracked. Three lines, not
+ * The `.the-framework/.gitignore` rules that make every user's sessions tracked. Three lines, not
  * one: the seeded allow-list ignores everything with `*`, and git never descends into an ignored
  * directory, so each directory on the way down has to be re-included before the files under it can
  * be. Same shape as the conversations rules (#908), which this sits beside.
+ *
+ * User-agnostic on purpose (#1312). Naming each user meant every person who ever ran a session in
+ * the repo appended their own three lines to a *tracked* file: their checkout went dirty, the next
+ * safety commit swept the edit into a branch, and two machines doing it near each other conflicted.
+ * A glob covers everyone, including people who have not run anything yet, so the file is written
+ * once and then never again.
+ *
+ * A star matches one path segment and never a slash, so the sessions rule reaches exactly
+ * `<user>/sessions/` and not `worktrees/<run>/sessions/`. The transient siblings stay ignored
+ * either way: un-ignoring a directory only lets git descend into it, and the bare `*` still
+ * ignores every file it finds there.
  */
-export function sessionsGitignore(user: string): string {
-  return `!${user}/\n!${user}/${SESSIONS_DIR}/\n!${user}/${SESSIONS_DIR}/**\n`
+export function sessionsGitignore(): string {
+  return `!*/\n!*/${SESSIONS_DIR}/\n!*/${SESSIONS_DIR}/**\n`
+}
+
+/** The glob rule whose presence means a file is already on the #1312 form. */
+const GLOB_RULE = `!*/${SESSIONS_DIR}/**`
+
+/** `!<user>/`, `!<user>/sessions/` and `!<user>/sessions/**` for one named user. */
+function perUserRules(user: string): readonly string[] {
+  return [`!${user}/`, `!${user}/${SESSIONS_DIR}/`, `!${user}/${SESSIONS_DIR}/**`]
 }
 
 /**
- * Make sure `.the-framework/.gitignore` un-ignores this user's sessions, returning whether it
- * wrote. Done lazily on archive rather than at install time: the ignore file is seeded once and
- * only when absent, so every repo activated before this feature carries the old allow-list — and a
- * second person joining a repo needs their own rules added to a file that already exists.
+ * Drop the per-user session rules, keeping every other line.
  *
- * Only a file we recognize is upgraded; anything hand-edited beyond recognition is left alone
- * rather than appended to.
+ * Only users the file actually names a `sessions` rule for are stripped, and only those three
+ * exact lines. The conversations rules (#908) are a literal directory name rather than a user, so
+ * they never match, and a hand-written rule this does not recognize is left where it is.
  */
-export async function ensureSessionsIgnored(cwd: string, user: string, fs: StoreFs = nodeStoreFs()): Promise<boolean> {
+export function withoutPerUserRules(md: string): string {
+  const lines = md.split('\n')
+  const users = lines
+    .map(line => /^!(.+)\/sessions\/\*\*$/.exec(line.trim())?.[1])
+    .filter((user): user is string => user !== undefined && user !== '*')
+  if (!users.length) return md
+  const drop = new Set(users.flatMap(perUserRules))
+  return lines.filter(line => !drop.has(line.trim())).join('\n')
+}
+
+/**
+ * Make sure `.the-framework/.gitignore` un-ignores archived sessions, returning whether it wrote.
+ * Done lazily on archive rather than at install time: the ignore file is seeded once and only when
+ * absent, so every repo activated before this feature carries the old allow-list.
+ *
+ * Writes at most twice in a repo's life, and usually once: a file already on the glob form is left
+ * alone, and a file still naming users is upgraded to the glob form in place — the per-user lines
+ * come out in the same write that puts the glob in, so the churn (#1312) ends rather than being
+ * added to. `user` no longer selects the rules; it stays because the caller has it and a future
+ * rule may need it again.
+ *
+ * Only a file we recognize is touched; anything hand-edited beyond recognition is left alone.
+ */
+export async function ensureSessionsIgnored(cwd: string, _user: string, fs: StoreFs = nodeStoreFs()): Promise<boolean> {
   const path = gitignorePath(cwd)
-  const rules = sessionsGitignore(user)
+  const rules = sessionsGitignore()
   if (!(await fs.exists(path))) {
     await fs.write(path, LOGS_GITIGNORE + rules)
     return true
   }
   const current = await fs.read(path)
-  if (current.includes(`!${user}/${SESSIONS_DIR}/**`)) return false
+  if (current.includes(GLOB_RULE)) return false
   if (!current.includes('!LOGS.md')) return false
-  await fs.write(path, current.endsWith('\n') ? current + rules : current + '\n' + rules)
+  const pruned = withoutPerUserRules(current)
+  await fs.write(path, pruned.endsWith('\n') ? pruned + rules : pruned + '\n' + rules)
   return true
 }
 


### PR DESCRIPTION
Closes #1312.

## The churn

`ensureSessionsIgnored` appended three `!<email>/...` lines to the **tracked** `.the-framework/.gitignore` the first time each person archived a session. So every new user dirtied their checkout once, the next safety commit swept that edit into a branch, and two machines doing it near each other produced the delete-vs-modify conflicts that made the file look "random" (#1298).

## The fix

The rules stop naming users:

```
!*/
!*/sessions/
!*/sessions/**
```

A star matches one path segment and never a slash, so `*/sessions/**` reaches exactly `<user>/sessions/` and not `worktrees/<run>/sessions/`. The transient siblings stay ignored either way: un-ignoring a directory only lets git descend into it, and the bare `*` still ignores every file found there. The real-git test pins that end to end (`runs/`, `events.jsonl` and `worktrees/` all stay out of `git status` while the archived session is visible and survives `git clean -fdx`).

Writes at most twice in a repo's life, and usually once:

- already on the glob form -> nothing written, ever again
- still naming users -> upgraded in place, with the per-user lines removed **in the same write** that adds the glob, so the churn ends rather than being added to
- unrecognized (no `!LOGS.md`) -> left alone, as before

`withoutPerUserRules` only strips the three exact lines belonging to a user the file actually names a `sessions` rule for. The conversations rules (#908) are a literal directory rather than a user, so they never match; comments and hand-written rules survive.

`ensureSessionsIgnored` keeps its `user` parameter: the caller has it, and it costs nothing to leave the seam for a future rule that needs it.

## Checks

Framework suite 1523/0 (1 pre-existing skip), typecheck clean.

Proof by revert: reverting only the write logic while keeping the new exports fails exactly the tests that pin the new behaviour: the second-user test, the upgrade test, the appended-once test, and the real-git leak test. (A separate `#1120` failure appears in that run and is the known pre-existing flake, unrelated to this diff.)

## Scope

Out of scope, stays with #1298: untracking the file entirely. That kills the clean-slate conflict class too, but it changes what travels in the repo, so it is the maintainer's call.