### PR TITLE
feat(bridge): session start-queue for extension-created sessions (#1328)

### DIFF
--- a/.changeset/bridge-session-start-queue.md
+++ b/.changeset/bridge-session-start-queue.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': minor
+---
+
+The browser bridge gains a session start-queue: the daemon can queue a repo, branch and prompt for the extension to create a session from, and the extension reports back the session it became. Two new routes, `GET /_bridge/start` (claims the next request as it serves it, so two polling tabs cannot create two sessions for one request) and `POST /_bridge/started`. The queue lives daemon-side with a claim that ages out, so a browser that quits mid-creation retries rather than bricking the request. The bridge's input surface is unchanged: the daemon is the producer of a start request and the extension only ever posts back an id, a boolean and a session id.

--- a/packages/the-framework/src/dashboard/bridge-endpoints.test.ts
+++ b/packages/the-framework/src/dashboard/bridge-endpoints.test.ts
@@ -225,3 +225,97 @@ test('a daemon with no answer source degrades to null rather than failing (#1237
     await s.close()
   }
 })
+
+test('the start-queue is served to the extension and its report travels back (#1328)', async () => {
+  const reports: { id: string; ok: boolean; sessionId?: string; note?: string }[] = []
+  let pending: { id: string; repo: string; branch: string; prompt: string } | undefined = {
+    id: 'req-1',
+    repo: 'gemstack-land/the-framework',
+    branch: 'main',
+    prompt: 'Spike and plan the queue ticket',
+  }
+  const s = await serve({
+    token: TOKEN,
+    record: () => {},
+    // Claim-on-read, as the daemon wires it: a second poll must not be handed the same request.
+    start: () => {
+      const next = pending
+      pending = undefined
+      return next
+    },
+    started: (id, ok, sessionId, note) => void reports.push({ id, ok, ...(sessionId ? { sessionId } : {}), ...(note ? { note } : {}) }),
+  })
+  try {
+    const first = await fetch(`${s.url}${BRIDGE_PREFIX}/start`, { headers: { authorization: `Bearer ${TOKEN}` } })
+    assert.equal(first.status, 200)
+    assert.deepEqual(await first.json(), {
+      start: { id: 'req-1', repo: 'gemstack-land/the-framework', branch: 'main', prompt: 'Spike and plan the queue ticket' },
+    })
+
+    const second = await fetch(`${s.url}${BRIDGE_PREFIX}/start`, { headers: { authorization: `Bearer ${TOKEN}` } })
+    assert.deepEqual(await second.json(), { start: null }, 'claimed, so the next poll gets nothing')
+
+    const ack = await fetch(`${s.url}${BRIDGE_PREFIX}/started`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${TOKEN}` },
+      body: JSON.stringify({ id: 'req-1', ok: true, sessionId: 'session_018KtaRYq8N1T9mjrJBTvrNS' }),
+    })
+    assert.equal(ack.status, 204)
+    assert.deepEqual(reports, [{ id: 'req-1', ok: true, sessionId: 'session_018KtaRYq8N1T9mjrJBTvrNS' }])
+  } finally {
+    await s.close()
+  }
+})
+
+test('a daemon with no start-queue degrades to null rather than failing (#1328)', async () => {
+  // An extension that knows about session creation must do nothing at all against an older daemon.
+  const s = await serve({ token: TOKEN, record: () => {} })
+  try {
+    const res = await fetch(`${s.url}${BRIDGE_PREFIX}/start`, { headers: { authorization: `Bearer ${TOKEN}` } })
+    assert.equal(res.status, 200)
+    assert.deepEqual(await res.json(), { start: null })
+    const ack = await fetch(`${s.url}${BRIDGE_PREFIX}/started`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${TOKEN}` },
+      body: JSON.stringify({ id: 'req-1', ok: true, sessionId: 'session_018KtaRYq8N1T9mjrJBTvrNS' }),
+    })
+    assert.equal(ack.status, 204, 'accepted and dropped')
+  } finally {
+    await s.close()
+  }
+})
+
+test('the start report is validated field by field (#1328)', async () => {
+  const s = await serve({ token: TOKEN, record: () => {}, started: () => {} })
+  const send = (body: unknown): Promise<Response> =>
+    fetch(`${s.url}${BRIDGE_PREFIX}/started`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${TOKEN}` },
+      body: JSON.stringify(body),
+    })
+  try {
+    assert.equal((await send({ ok: true })).status, 400, 'no id')
+    assert.equal((await send({ id: 'x'.repeat(65), ok: true })).status, 400, 'absurd id')
+    assert.equal((await send({ id: 'r', ok: 'yes' })).status, 400, 'ok must be a boolean')
+    assert.equal((await send({ id: 'r', ok: true, sessionId: 'not-a-session' })).status, 400, 'bad session id')
+    assert.equal((await send({ id: 'r', ok: false, note: 42 })).status, 400, 'note must be a string')
+    assert.equal((await send({ id: 'r', ok: false })).status, 204, 'a plain failure is fine')
+  } finally {
+    await s.close()
+  }
+})
+
+test('the start routes demand the bearer token, and reject the wrong method (#1328)', async () => {
+  const s = await serve({ token: TOKEN, record: () => {}, start: () => undefined, started: () => {} })
+  try {
+    assert.equal((await fetch(`${s.url}${BRIDGE_PREFIX}/start`)).status, 401)
+    assert.equal((await fetch(`${s.url}${BRIDGE_PREFIX}/started`, { method: 'POST' })).status, 401)
+    const wrongMethod = await fetch(`${s.url}${BRIDGE_PREFIX}/start`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${TOKEN}` },
+    })
+    assert.equal(wrongMethod.status, 405)
+  } finally {
+    await s.close()
+  }
+})

--- a/packages/the-framework/src/dashboard/bridge-endpoints.ts
+++ b/packages/the-framework/src/dashboard/bridge-endpoints.ts
@@ -63,6 +63,21 @@ export interface BridgeSession {
   url: string
 }
 
+/**
+ * A session the daemon wants the extension to create on claude.ai (#1328).
+ *
+ * This is the one shape that travels *out* of the bridge carrying free text, and that direction
+ * is what keeps the "deliberately tiny input" rule above intact: the daemon writes it, the
+ * extension reads it, and what comes back is only an id, a boolean and a session id.
+ */
+export interface BridgeStart {
+  id: string
+  /** `owner/name`, as the repo picker lists it. */
+  repo: string
+  branch: string
+  prompt: string
+}
+
 /** What the daemon wires behind the bridge. Absent when the feature is off, which 404s it. */
 export interface BridgeHandlers {
   /** The shared secret every bridge call must present. */
@@ -84,6 +99,15 @@ export interface BridgeHandlers {
   answer?: (sessionId: string) => { id: string; label: string } | undefined
   /** The extension's word on what a delivery attempt did. */
   answered?: (sessionId: string, id: string, ok: boolean, note?: string) => void
+  /**
+   * The next session the daemon wants created, claimed for whoever is asking (#1328).
+   *
+   * Claiming is the callee's job, not this route's: two tabs polling must not both be handed the
+   * same request, because a duplicate here is a duplicate cloud session on the user's account.
+   */
+  start?: () => BridgeStart | undefined
+  /** The extension's word on what a creation attempt did (#1328). */
+  started?: (id: string, ok: boolean, sessionId?: string, note?: string) => void
   now?: () => Date
 }
 
@@ -118,6 +142,8 @@ export async function handleBridgeRequest(
   if (pathname === `${BRIDGE_PREFIX}/hello`) return handleHello(req, res, handlers)
   if (pathname === `${BRIDGE_PREFIX}/answer`) return handleAnswer(req, res, handlers)
   if (pathname === `${BRIDGE_PREFIX}/answered`) return handleAnswered(req, res, handlers)
+  if (pathname === `${BRIDGE_PREFIX}/start`) return handleStart(req, res, handlers)
+  if (pathname === `${BRIDGE_PREFIX}/started`) return handleStarted(req, res, handlers)
   end(res, 404, 'not found')
 }
 
@@ -284,6 +310,50 @@ async function handleAnswered(req: IncomingMessage, res: ServerResponse, handler
   if (typeof ok !== 'boolean') return end(res, 400, 'ok must be a boolean')
   if (note !== undefined && typeof note !== 'string') return end(res, 400, 'note must be a string')
   handlers.answered?.(sessionId, id, ok, typeof note === 'string' ? note.slice(0, 300) : undefined)
+  end(res, 204, '')
+}
+
+/**
+ * `GET /_bridge/start`: the next session the daemon wants created, claimed by this call (#1328).
+ *
+ * Always 200 with `{start: ...}`, null when there is nothing to do, so the extension can poll it
+ * blindly alongside `/answer`. Degrades to null on a daemon that wired no queue, so an extension
+ * that knows about session creation does nothing at all against an older daemon.
+ *
+ * A GET that mutates, which is not the usual shape. The mutation is the point: handing the same
+ * request to two polling tabs would create two cloud sessions, so taking it off the queue has to
+ * happen in the same step as reading it.
+ */
+async function handleStart(req: IncomingMessage, res: ServerResponse, handlers: BridgeHandlers): Promise<void> {
+  if (req.method !== 'GET') return end(res, 405, 'method not allowed', { allow: 'GET' })
+  const start = handlers.start?.()
+  res.writeHead(200, { 'content-type': 'application/json' })
+  res.end(JSON.stringify({ start: start ?? null }))
+}
+
+/** `POST /_bridge/started`: what the extension's creation attempt did (#1328). */
+async function handleStarted(req: IncomingMessage, res: ServerResponse, handlers: BridgeHandlers): Promise<void> {
+  if (req.method !== 'POST') return end(res, 405, 'method not allowed', { allow: 'POST' })
+  let body: unknown
+  try {
+    body = await readJsonBody(req, MAX_BODY)
+  } catch (err) {
+    return end(res, 400, (err as Error).message)
+  }
+  if (typeof body !== 'object' || body === null) return end(res, 400, 'body must be an object')
+  const { id, ok, sessionId, note } = body as Record<string, unknown>
+  if (typeof id !== 'string' || !id || id.length > 64) return end(res, 400, 'id must be the start request id')
+  if (typeof ok !== 'boolean') return end(res, 400, 'ok must be a boolean')
+  if (sessionId !== undefined && (typeof sessionId !== 'string' || !SESSION_ID.test(sessionId))) {
+    return end(res, 400, 'sessionId must look like session_<id>')
+  }
+  if (note !== undefined && typeof note !== 'string') return end(res, 400, 'note must be a string')
+  handlers.started?.(
+    id,
+    ok,
+    typeof sessionId === 'string' ? sessionId : undefined,
+    typeof note === 'string' ? note.slice(0, 300) : undefined,
+  )
   end(res, 204, '')
 }
 

--- a/packages/the-framework/src/dashboard/bridge-starts.test.ts
+++ b/packages/the-framework/src/dashboard/bridge-starts.test.ts
@@ -1,0 +1,113 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { BridgeStarts, START_CLAIM_TTL_MS, bridgeStarts, resetBridgeStarts } from './bridge-starts.js'
+
+const INPUT = { repo: 'gemstack-land/the-framework', branch: 'main', prompt: 'Do the thing' }
+
+test('a queued start carries the repo, branch and prompt (#1328)', () => {
+  const starts = new BridgeStarts()
+  const queued = starts.request(INPUT, new Date('2026-07-28T10:00:00Z'))
+  assert.ok(typeof queued !== 'string', 'accepted')
+  assert.equal(queued.repo, 'gemstack-land/the-framework')
+  assert.equal(queued.branch, 'main')
+  assert.equal(queued.prompt, 'Do the thing')
+  assert.equal(queued.state, 'queued')
+})
+
+test('a repo that is not owner/name is refused (#1328)', () => {
+  const starts = new BridgeStarts()
+  for (const repo of ['the-framework', 'a/b/c', '../etc', 'owner/..', './x', 'owner/name; rm -rf /', '']) {
+    assert.equal(typeof starts.request({ ...INPUT, repo }), 'string', `${JSON.stringify(repo)} refused`)
+  }
+  // A leading dot is legal in a real repo name, so only the all-dots segments are the traversal.
+  assert.ok(typeof starts.request({ ...INPUT, repo: 'gemstack-land/.github' }) !== 'string', 'owner/.github passes')
+})
+
+test('a branch that could act as syntax is refused (#1328)', () => {
+  const starts = new BridgeStarts()
+  for (const branch of ['a branch', 'main;whoami', '$(id)', '', 'x'.repeat(300)]) {
+    assert.equal(typeof starts.request({ ...INPUT, branch }), 'string', `${JSON.stringify(branch)} refused`)
+  }
+  assert.ok(typeof starts.request({ ...INPUT, branch: 'suleimansh/feat/x_1.2-3' }) !== 'string', 'a real branch name passes')
+})
+
+test('an empty or absurd prompt is refused (#1328)', () => {
+  const starts = new BridgeStarts()
+  assert.equal(typeof starts.request({ ...INPUT, prompt: '   ' }), 'string')
+  assert.equal(typeof starts.request({ ...INPUT, prompt: 'x'.repeat(20_001) }), 'string')
+})
+
+test('claiming hands out the oldest request, once (#1328)', () => {
+  // The duplicate this prevents is a second cloud session on the user's account, not a stray row.
+  const starts = new BridgeStarts()
+  starts.request({ ...INPUT, prompt: 'first' }, new Date('2026-07-28T10:00:00Z'))
+  starts.request({ ...INPUT, prompt: 'second' }, new Date('2026-07-28T10:01:00Z'))
+  const now = new Date('2026-07-28T10:02:00Z')
+  assert.equal(starts.claimNext(now)?.prompt, 'first')
+  assert.equal(starts.claimNext(now)?.prompt, 'second')
+  assert.equal(starts.claimNext(now), undefined, 'nothing left to hand out')
+})
+
+test('a claim nobody resolved goes back on the queue (#1328)', () => {
+  // A tab closed mid-creation would otherwise brick its request for the life of the daemon.
+  const starts = new BridgeStarts()
+  starts.request(INPUT, new Date('2026-07-28T10:00:00Z'))
+  const claimedAt = new Date('2026-07-28T10:00:01Z')
+  assert.ok(starts.claimNext(claimedAt), 'claimed')
+  const stillFresh = new Date(claimedAt.getTime() + START_CLAIM_TTL_MS - 1000)
+  assert.equal(starts.claimNext(stillFresh), undefined, 'a live claim is honoured')
+  const expired = new Date(claimedAt.getTime() + START_CLAIM_TTL_MS + 1000)
+  assert.ok(starts.claimNext(expired), 'an expired claim is offered again')
+})
+
+test('a success records the session and its url (#1328)', () => {
+  const starts = new BridgeStarts()
+  const queued = starts.request(INPUT)
+  assert.ok(typeof queued !== 'string')
+  starts.claimNext()
+  starts.resolve(queued.id, true, 'session_01ABC')
+  const done = starts.get(queued.id)
+  assert.equal(done?.state, 'created')
+  assert.equal(done?.sessionId, 'session_01ABC')
+  assert.equal(done?.url, 'https://claude.ai/code/session_01ABC')
+})
+
+test('success without a session id is recorded as a failure (#1328)', () => {
+  // The run would have nowhere to point, so "created, location unknown" is not a usable outcome.
+  const starts = new BridgeStarts()
+  const queued = starts.request(INPUT)
+  assert.ok(typeof queued !== 'string')
+  starts.claimNext()
+  starts.resolve(queued.id, true)
+  assert.equal(starts.get(queued.id)?.state, 'failed')
+})
+
+test('only a claimed request can be resolved (#1328)', () => {
+  // A tab that died after its claim expired must not overwrite the retry that replaced it.
+  const starts = new BridgeStarts()
+  const queued = starts.request(INPUT)
+  assert.ok(typeof queued !== 'string')
+  starts.resolve(queued.id, true, 'session_01ABC')
+  assert.equal(starts.get(queued.id)?.state, 'queued', 'never claimed, so the report is ignored')
+  starts.resolve('no-such-id', true, 'session_01ABC')
+})
+
+test('a failure keeps the extension note (#1328)', () => {
+  const starts = new BridgeStarts()
+  const queued = starts.request(INPUT)
+  assert.ok(typeof queued !== 'string')
+  starts.claimNext()
+  starts.resolve(queued.id, false, undefined, 'no repo picker on the page')
+  const failed = starts.get(queued.id)
+  assert.equal(failed?.state, 'failed')
+  assert.equal(failed?.note, 'no repo picker on the page')
+})
+
+test('the store is a singleton, and resettable for tests (#1328)', () => {
+  resetBridgeStarts()
+  assert.equal(bridgeStarts(), bridgeStarts())
+  bridgeStarts().request(INPUT)
+  assert.equal(bridgeStarts().list().length, 1)
+  resetBridgeStarts()
+  assert.equal(bridgeStarts().list().length, 0)
+})

--- a/packages/the-framework/src/dashboard/bridge-starts.ts
+++ b/packages/the-framework/src/dashboard/bridge-starts.ts
@@ -1,0 +1,186 @@
+import { randomUUID } from 'node:crypto'
+
+/**
+ * The session start-queue (#1328): sessions the daemon wants created on claude.ai, waiting for
+ * the extension to go and create them.
+ *
+ * **Why this exists.** `claude --cloud` is the CLI's own path to a cloud session, and on at least
+ * one account every session it creates is a bundle upload that can never push (#1320, upstream
+ * anthropics/claude-code#81776). Sessions created through the claude.ai UI *with the repo picker*
+ * are repo-bound and do push. The extension already lives on those pages, so it is the half of
+ * this system that can reach the working path; this queue is how the daemon asks it to.
+ *
+ * **Direction is the security property.** The bridge's input surface is deliberately tiny: no
+ * path, command, prompt or free text is ever *posted to* the daemon, so the worst a stolen bridge
+ * token buys is a bogus card in someone's dashboard. A start request carries a repo, a branch and
+ * a prompt — exactly the free text that rule excludes — and it stays excluded, because the daemon
+ * is the *producer*. The extension reads a request and posts back only an id, a boolean and a
+ * session id. Nothing here widens what an attacker holding the token can say.
+ *
+ * **In memory, like the questions store.** A queued start is only meaningful while the daemon that
+ * wants it is running; surviving a restart would re-create sessions for runs that are already
+ * gone, which costs real quota.
+ */
+
+/**
+ * Where a start request has got to.
+ *
+ * `claimed` is a real state rather than a flag because two polls must not create two sessions for
+ * one request — the extension can have several tabs, and a duplicate here is a duplicate cloud
+ * session on the user's account.
+ */
+export type BridgeStartState = 'queued' | 'claimed' | 'created' | 'failed'
+
+/** One session the daemon wants created, and what became of it. */
+export interface BridgeStartRequest {
+  id: string
+  /** `owner/name`, as the repo picker lists it. */
+  repo: string
+  branch: string
+  prompt: string
+  queuedAt: string
+  state: BridgeStartState
+  /** When the extension took it, which is what {@link BridgeStarts.claimNext} ages out. */
+  claimedAt?: string
+  /** The cloud session it became, once the extension reports one. */
+  sessionId?: string
+  url?: string
+  note?: string
+}
+
+/** What {@link BridgeStarts.request} needs. */
+export interface BridgeStartInput {
+  repo: string
+  branch: string
+  prompt: string
+}
+
+/**
+ * How long a claim is honoured before the request goes back on the queue.
+ *
+ * A tab that is closed mid-creation, or a browser that quits, leaves a claim nobody will ever
+ * resolve. Without an expiry that request is bricked for the life of the daemon, which is the
+ * same failure the #1327 locks need a staleness rule for. Long enough that a slow page load does
+ * not double-create, short enough that a person watching does not conclude it hung.
+ */
+export const START_CLAIM_TTL_MS = 90_000
+
+/** `owner/name`: no slashes beyond the one, nothing shell-shaped. */
+const REPO = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/
+/**
+ * A segment that is nothing but dots — `.` or `..`.
+ *
+ * The character class above happily matches `../etc`, because both `..` and `etc` are made of
+ * legal characters. Checked separately rather than by tightening the class, because a leading dot
+ * is legal in a real repo name (`owner/.github`) and only the all-dots segments are the traversal.
+ */
+const DOTS_ONLY = /^\.+$/
+/** Git branch names we will hand over, kept to characters that cannot act as syntax anywhere. */
+const BRANCH = /^[A-Za-z0-9._\-/]{1,255}$/
+/** Past this a prompt is not a prompt, and the composer would not take it well either. */
+const MAX_PROMPT = 20_000
+
+/** The session start-queue. See the module comment for why the daemon is the producer. */
+export class BridgeStarts {
+  private readonly byId = new Map<string, BridgeStartRequest>()
+
+  /**
+   * Queue a session for the extension to create, or say why it cannot be.
+   *
+   * Validated here rather than at the endpoint because this is the *only* way in: the routes
+   * expose reading and resolving, never queueing, so a caller holding the bridge token cannot
+   * put a prompt on this queue at all.
+   */
+  request(input: BridgeStartInput, now = new Date()): BridgeStartRequest | string {
+    const repo = input.repo.trim()
+    if (!REPO.test(repo) || repo.split('/').some(segment => DOTS_ONLY.test(segment))) return 'repo must look like owner/name'
+    const branch = input.branch.trim()
+    if (!BRANCH.test(branch)) return 'branch must be a git branch name'
+    const prompt = input.prompt.trim()
+    if (!prompt) return 'prompt must not be empty'
+    if (prompt.length > MAX_PROMPT) return `prompt must be at most ${MAX_PROMPT} characters`
+    const start: BridgeStartRequest = {
+      id: randomUUID(),
+      repo,
+      branch,
+      prompt,
+      queuedAt: now.toISOString(),
+      state: 'queued',
+    }
+    this.byId.set(start.id, start)
+    return start
+  }
+
+  /**
+   * Hand the oldest waiting request to whoever is asking, and mark it claimed.
+   *
+   * Oldest first so a queue drains in the order it was filled. A claim older than
+   * {@link START_CLAIM_TTL_MS} is treated as waiting again — see that constant for why.
+   */
+  claimNext(now = new Date()): BridgeStartRequest | undefined {
+    const stale = now.getTime() - START_CLAIM_TTL_MS
+    const waiting = [...this.byId.values()]
+      .filter(start => start.state === 'queued' || (start.state === 'claimed' && Date.parse(start.claimedAt ?? '') <= stale))
+      .sort((a, b) => a.queuedAt.localeCompare(b.queuedAt))
+    const next = waiting[0]
+    if (!next) return undefined
+    const claimed: BridgeStartRequest = { ...next, state: 'claimed', claimedAt: now.toISOString() }
+    this.byId.set(claimed.id, claimed)
+    return claimed
+  }
+
+  /**
+   * The extension's word on what a creation attempt did.
+   *
+   * A success needs the session id: without it the run has nowhere to point, so a report that
+   * claims success and names no session is recorded as a failure rather than a session we cannot
+   * find. Only a claimed request can be resolved, so a stale report from a tab that died after its
+   * claim expired cannot overwrite the retry that replaced it.
+   */
+  resolve(id: string, ok: boolean, sessionId?: string, note?: string): void {
+    const start = this.byId.get(id)
+    if (!start || start.state !== 'claimed') return
+    if (ok && !sessionId) {
+      this.byId.set(id, { ...start, state: 'failed', note: note ?? 'reported success without a session id' })
+      return
+    }
+    this.byId.set(id, {
+      ...start,
+      state: ok ? 'created' : 'failed',
+      ...(sessionId ? { sessionId, url: `https://claude.ai/code/${sessionId}` } : {}),
+      ...(note ? { note } : {}),
+    })
+  }
+
+  /** One request, in whatever state. */
+  get(id: string): BridgeStartRequest | undefined {
+    return this.byId.get(id)
+  }
+
+  /** Every request, newest first. */
+  list(): BridgeStartRequest[] {
+    return [...this.byId.values()].sort((a, b) => b.queuedAt.localeCompare(a.queuedAt))
+  }
+
+  /** Forget one request, once whoever asked for it has read the outcome. */
+  clear(id: string): void {
+    this.byId.delete(id)
+  }
+}
+
+/**
+ * The daemon's one start-queue. A module singleton for the same reason the questions store is
+ * one: the bridge endpoint writes from the raw HTTP handler and the driver reads from elsewhere
+ * in the process, and neither can be handed the other's object.
+ */
+let instance: BridgeStarts | undefined
+
+export function bridgeStarts(): BridgeStarts {
+  if (!instance) instance = new BridgeStarts()
+  return instance
+}
+
+/** Replace the store. Tests only: a module singleton would otherwise leak between them. */
+export function resetBridgeStarts(): void {
+  instance = undefined
+}

--- a/packages/the-framework/src/dashboard/index.ts
+++ b/packages/the-framework/src/dashboard/index.ts
@@ -44,6 +44,7 @@ export {
 } from './interventions.js'
 export { buildActivity, activityKey, pickNewActivity, activityLine, postActivityDiscord, type Activity, type ActivityDeps } from './activity.js'
 export { startKeyedWatcher, SeenTracker, type KeyedWatcher, type KeyedWatcherOptions } from './keyed-watcher.js'
-export { BRIDGE_PREFIX, handleBridgeRequest, type BridgeHandlers, type BridgeQuestion, type BridgeSession, type BridgeEvent, type BridgeHello } from './bridge-endpoints.js'
+export { BRIDGE_PREFIX, handleBridgeRequest, type BridgeHandlers, type BridgeQuestion, type BridgeSession, type BridgeEvent, type BridgeHello, type BridgeStart } from './bridge-endpoints.js'
 export { bridgeSessionsFrom, BRIDGE_SESSION_WINDOW_MS, BRIDGE_SESSION_LIMIT } from './bridge-sessions.js'
 export { bridgeQuestions, resetBridgeQuestions, BridgeQuestions, type BridgeContact, type BridgeAnswer } from './bridge-store.js'
+export { bridgeStarts, resetBridgeStarts, BridgeStarts, START_CLAIM_TTL_MS, type BridgeStartRequest, type BridgeStartState, type BridgeStartInput } from './bridge-starts.js'

--- a/packages/the-framework/src/dashboard/server.ts
+++ b/packages/the-framework/src/dashboard/server.ts
@@ -16,6 +16,7 @@ import type { EventsSource, PreviewHandlers, RemoteRuns } from './telefunc-serve
 import { handleRelayRequest, RELAY_PREFIX, type RelayHandlers } from './relay-endpoints.js'
 import { BRIDGE_PREFIX, handleBridgeRequest, type BridgeHandlers } from './bridge-endpoints.js'
 import { bridgeQuestions } from './bridge-store.js'
+import { bridgeStarts } from './bridge-starts.js'
 
 /** Options for {@link startDashboard}. */
 export interface DashboardOptions {
@@ -215,6 +216,13 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
           return pending ? { id: pending.id, label: pending.label } : undefined
         },
         answered: (sessionId, id, ok, note) => bridgeQuestions().resolveAnswer(sessionId, id, ok, note),
+        // The session start-queue (#1328). The claim happens inside claimNext, not in the route:
+        // two polling tabs handed the same request would create two cloud sessions.
+        start: () => {
+          const next = bridgeStarts().claimNext()
+          return next ? { id: next.id, repo: next.repo, branch: next.branch, prompt: next.prompt } : undefined
+        },
+        started: (id, ok, sessionId, note) => bridgeStarts().resolve(id, ok, sessionId, note),
         ...(opts.bridgeSessions ? { sessions: opts.bridgeSessions } : {}),
       }
     : undefined

--- a/spike/cc-web-extension/check.mjs
+++ b/spike/cc-web-extension/check.mjs
@@ -157,5 +157,169 @@ async function deliver(body, prepare) {
   dom.window.close()
 }
 
+// ---------------------------------------------------------------------------
+// Creating a session (#1328), against a fake new-session page.
+//
+// Every selector in `createSession` is a guess about someone else's markup, so what these prove
+// is the FLOW, not that claude.ai looks like this: that a repo and a branch are chosen from
+// menus before the prompt is sent, that the session id is read from the URL rather than from
+// anything on the page, and that each way it can go wrong is reported with the control it could
+// not find. Whether the real page matches is what `probeNewSession` is for.
+
+/** A stand-in new-session page: two menus, a composer, a send button. */
+function newSessionPage({ repos = ['someone/other-repo', 'gemstack-land/the-framework'], branches = ['main', 'dev'], composer = true, repoLabel = 'Select repository', branchLabel = 'Select branch' } = {}) {
+  const options = (items, menu) =>
+    items.map(text => `<div role="option" aria-hidden="true" data-menu="${menu}">${text}</div>`).join('')
+  return [
+    `<button id="repo-trigger" aria-haspopup="listbox">${repoLabel}</button>`,
+    `<div>${options(repos, 'repo')}</div>`,
+    `<button id="branch-trigger" aria-haspopup="listbox">${branchLabel}</button>`,
+    `<div>${options(branches, 'branch')}</div>`,
+    composer ? '<div contenteditable="true"></div>' : '<p>no composer here</p>',
+    '<button aria-label="Send message" id="send"></button>',
+  ].join('')
+}
+
+/**
+ * Run `createSession` against a fake page.
+ *
+ * The menus toggle on their trigger exactly as a real one would, and the send button is what
+ * turns the page into a session: jsdom cannot navigate, so the harness reconfigures the URL on
+ * click, which is the same observable the content script waits for.
+ */
+async function createOn(page, { becomesSession = 'session_01FAKE', ...opts } = {}) {
+  const dom = new JSDOM(`<!doctype html><html><body><main>${page}</main></body></html>`, {
+    // No session id yet: this is the page a session is started FROM.
+    url: 'https://claude.ai/code',
+    runScripts: 'outside-only',
+  })
+  dom.window.eval(script)
+  const w = dom.window
+  w.__tfComposerWaitMs = 200
+  w.__tfMenuSettleMs = 10
+  w.__tfSessionWaitMs = 2000
+
+  const toggle = menu => {
+    for (const option of w.document.querySelectorAll(`[data-menu="${menu}"]`)) {
+      option.setAttribute('aria-hidden', option.getAttribute('aria-hidden') === 'true' ? 'false' : 'true')
+    }
+  }
+  w.document.getElementById('repo-trigger')?.addEventListener('click', () => toggle('repo'))
+  w.document.getElementById('branch-trigger')?.addEventListener('click', () => toggle('branch'))
+  if (becomesSession) {
+    w.document.getElementById('send')?.addEventListener('click', () => {
+      dom.reconfigure({ url: `https://claude.ai/code/${becomesSession}` })
+    })
+  }
+
+  const result = await w.__tfBridgeCreateSession({
+    repo: 'gemstack-land/the-framework',
+    branch: 'main',
+    prompt: 'Spike and plan the queue ticket',
+    ...opts,
+  })
+  return { dom, w, result }
+}
+
+{
+  const { dom, w, result } = await createOn(newSessionPage())
+  const typed = w.document.querySelector('[contenteditable="true"]').textContent
+  const ok =
+    result.ok &&
+    result.sessionId === 'session_01FAKE' &&
+    typed === 'Spike and plan the queue ticket' &&
+    /repository: clicked "gemstack-land\/the-framework"/.test(result.note) &&
+    /branch: clicked "main"/.test(result.note)
+  if (!ok) failed++
+  console.log(`${ok ? 'PASS' : 'FAIL'}  create picks repo and branch, types the prompt, reports the session  (id=${result.sessionId}, note=${result.note})`)
+  dom.window.close()
+}
+
+{
+  // The repo the daemon asked for is not on offer: refuse, and say which control failed. Sending
+  // anyway would start a session against whatever repo happened to be selected.
+  const { dom, result } = await createOn(newSessionPage({ repos: ['someone/other-repo'] }))
+  const ok = !result.ok && /repository/.test(result.note) && !/branch:/.test(result.note)
+  if (!ok) failed++
+  console.log(`${ok ? 'PASS' : 'FAIL'}  create refuses when the repo is not offered  (note=${result.note})`)
+  dom.window.close()
+}
+
+{
+  const { dom, result } = await createOn(newSessionPage({ branches: ['dev'] }))
+  const ok = !result.ok && /branch/.test(result.note)
+  if (!ok) failed++
+  console.log(`${ok ? 'PASS' : 'FAIL'}  create refuses when the branch is not offered  (note=${result.note})`)
+  dom.window.close()
+}
+
+{
+  const { dom, result } = await createOn(newSessionPage({ composer: false }))
+  const ok = !result.ok && /no composer/.test(result.note)
+  if (!ok) failed++
+  console.log(`${ok ? 'PASS' : 'FAIL'}  create refuses a page with no composer  (note=${result.note})`)
+  dom.window.close()
+}
+
+{
+  // Sent, but the page never became a session. Reporting success here would leave the daemon
+  // holding a run that points nowhere, which is worse than a clean failure.
+  const { dom, result } = await createOn(newSessionPage(), { becomesSession: null })
+  const ok = !result.ok && /never became a session URL/.test(result.note)
+  if (!ok) failed++
+  console.log(`${ok ? 'PASS' : 'FAIL'}  create refuses when no session URL appears  (note=${result.note})`)
+  dom.window.close()
+}
+
+{
+  // A page already showing the wanted repo and branch: nothing to pick, and nothing clicked.
+  const { dom, result } = await createOn(
+    newSessionPage({ repoLabel: 'gemstack-land/the-framework', branchLabel: 'main' }),
+  )
+  const ok = result.ok && /already set to gemstack-land\/the-framework/.test(result.note) && /already set to main/.test(result.note)
+  if (!ok) failed++
+  console.log(`${ok ? 'PASS' : 'FAIL'}  create leaves an already-correct repo and branch alone  (note=${result.note})`)
+  dom.window.close()
+}
+
+{
+  // The exact-match guard: a repo whose name contains the branch text must not be mistaken for
+  // the branch already being set, or the branch is never chosen at all.
+  const { dom, result } = await createOn(
+    newSessionPage({ repos: ['acme/domain-tools'], branches: ['main', 'dev'], repoLabel: 'acme/domain-tools' }),
+    { repo: 'acme/domain-tools' },
+  )
+  const ok = result.ok && /branch: clicked "main"/.test(result.note)
+  if (!ok) failed++
+  console.log(`${ok ? 'PASS' : 'FAIL'}  a repo name containing the branch text does not skip the branch  (note=${result.note})`)
+  dom.window.close()
+}
+
+{
+  // The probe reads and reports; it must not open a menu or fill anything, because it is what
+  // runs first against a page nobody has inspected yet.
+  const dom = new JSDOM(`<!doctype html><html><body><main>${newSessionPage()}</main></body></html>`, {
+    url: 'https://claude.ai/code',
+    runScripts: 'outside-only',
+  })
+  dom.window.eval(script)
+  const report = dom.window.__tfBridgeProbeNewSession()
+  const hidden = [...dom.window.document.querySelectorAll('[role="option"]')].every(
+    el => el.getAttribute('aria-hidden') === 'true',
+  )
+  const typed = dom.window.document.querySelector('[contenteditable="true"]').textContent
+  const ok =
+    report.composer === 'contenteditable' &&
+    report.sendButton === true &&
+    report.sessionId === null &&
+    report.triggers.some(t => /Select repository/.test(t.text)) &&
+    report.triggers.some(t => /Select branch/.test(t.text)) &&
+    hidden &&
+    typed === ''
+  if (!ok) failed++
+  console.log(`${ok ? 'PASS' : 'FAIL'}  probe describes the controls without touching them  (triggers=${report.triggers.length}, menusStillClosed=${hidden})`)
+  dom.window.close()
+}
+
 console.log(failed ? `\n${failed} case(s) failed` : '\nall cases passed')
 process.exit(failed ? 1 : 0)

--- a/spike/cc-web-extension/content.js
+++ b/spike/cc-web-extension/content.js
@@ -493,7 +493,11 @@ async function pickFromMenu(hint, want, wantAliases = []) {
   }
 
   // Already showing what we want (the page may default to it): nothing to do.
-  const showing = menuTriggers().find(trigger => matches(trigger.text))
+  //
+  // Exact match only, unlike choosing from a menu below. Contains-matching here reads any
+  // trigger that merely mentions the text as "already set", so branch `main` would be satisfied
+  // by a repo trigger showing `domain-tools` and the branch would never be picked at all.
+  const showing = menuTriggers().find(trigger => wanted.some(w => trigger.text.toLowerCase() === w))
   if (showing) return { ok: true, note: `${hint} already set to ${showing.text}` }
 
   const hintLower = hint.toLowerCase()

--- a/spike/cc-web-extension/content.js
+++ b/spike/cc-web-extension/content.js
@@ -413,10 +413,185 @@ async function deliverAnswer(text) {
   return { ok: true, note: `filled ${composer.via}, no send button, sent Enter` }
 }
 
+// ---------------------------------------------------------------------------
+// Creating a session (#1328).
+//
+// A session created through this page with the repo picker is repo-bound, and those are the ones
+// that can push and open a PR; `claude --cloud` produces a bundle upload that cannot (#1320).
+// So the daemon queues a repo, a branch and a prompt, and this drives the same three controls a
+// person would: pick the repo, pick the branch, type the prompt, send.
+//
+// **Every selector here is a guess about someone else's UI**, which is the whole risk. So this
+// half is built to report rather than to insist: `probeNewSession` describes what it can see
+// without touching anything, and every failure below names the control it could not find. The
+// first live run is expected to be a probe, not a success.
+
+/** Visible text of a control, trimmed and collapsed, for matching menu entries. */
+function controlText(el) {
+  return (el.textContent ?? '').replace(/\s+/g, ' ').trim()
+}
+
+/** Whether a control is actually usable: rendered, enabled, not aria-hidden. */
+function usable(el) {
+  if (!el || el.disabled) return false
+  if (el.getAttribute?.('aria-hidden') === 'true') return false
+  return true
+}
+
+/**
+ * Everything on the page that behaves like a dropdown trigger.
+ *
+ * Several strategies rather than one selector because the page is not ours and the markup for a
+ * picker varies: an ARIA combobox, a menu/listbox button, or a plain button whose label happens
+ * to name a repo. Ordered from most explicit to least, so a confident match wins.
+ */
+function menuTriggers() {
+  const out = []
+  const add = (el, via) => {
+    if (usable(el) && !out.some(entry => entry.el === el)) out.push({ el, via, text: controlText(el) })
+  }
+  for (const el of deepQueryAll('[role="combobox"]')) add(el, 'combobox')
+  for (const el of deepQueryAll('button[aria-haspopup="listbox"], button[aria-haspopup="menu"], button[aria-haspopup="true"]')) add(el, 'haspopup')
+  for (const el of deepQueryAll('button[aria-expanded]')) add(el, 'expandable')
+  for (const el of deepQueryAll('button')) add(el, 'button')
+  return out
+}
+
+/** Options currently on offer in an open menu. */
+function menuOptions() {
+  return deepQueryAll('[role="option"], [role="menuitem"], [role="menuitemradio"]')
+    .filter(usable)
+    .map(el => ({ el, text: controlText(el) }))
+}
+
+/** Wait for `read` to return something truthy, or give up. */
+async function waitFor(read, timeoutMs, stepMs = 150) {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const value = read()
+    if (value) return value
+    if (Date.now() >= deadline) return undefined
+    await new Promise(resolve => setTimeout(resolve, stepMs))
+  }
+}
+
+/** How long to wait for a menu to render, and for the page to become a session. */
+const MENU_WAIT_MS = 6000
+
+/**
+ * Open the picker whose current label best matches `hint`, then choose the entry matching `want`.
+ *
+ * Matching is exact-then-contains, case-insensitive, and a repo is also matched on its bare name
+ * so `owner/name` finds an entry rendered as just `name`. Returns a note either way; the caller
+ * turns that into the daemon-visible reason.
+ */
+async function pickFromMenu(hint, want, wantAliases = []) {
+  const wanted = [want, ...wantAliases].map(t => t.toLowerCase()).filter(Boolean)
+  const matches = text => {
+    const lower = text.toLowerCase()
+    return wanted.some(w => lower === w) || wanted.some(w => lower.includes(w))
+  }
+
+  // Already showing what we want (the page may default to it): nothing to do.
+  const showing = menuTriggers().find(trigger => matches(trigger.text))
+  if (showing) return { ok: true, note: `${hint} already set to ${showing.text}` }
+
+  const hintLower = hint.toLowerCase()
+  const candidates = menuTriggers().filter(trigger => trigger.text.toLowerCase().includes(hintLower))
+  const triggers = candidates.length ? candidates : menuTriggers()
+  for (const trigger of triggers.slice(0, 8)) {
+    trigger.el.click()
+    const options = await waitFor(() => {
+      const found = menuOptions()
+      return found.length ? found : undefined
+    }, MENU_WAIT_MS)
+    if (!options) continue
+    const hit = options.find(option => matches(option.text))
+    if (hit) {
+      hit.el.click()
+      return { ok: true, note: `${hint}: clicked "${hit.text}" via ${trigger.via}` }
+    }
+    // Wrong menu: shut it again so the next trigger is not clicked through an overlay.
+    trigger.el.click()
+  }
+  return { ok: false, note: `${hint}: no menu offered "${want}"` }
+}
+
+/**
+ * Describe the controls on this page without touching any of them (#1328).
+ *
+ * The point is a productive first round trip: rather than "it did not work", this says what the
+ * page actually offers, so the selectors above can be aimed at the real markup. Text only, capped,
+ * so the report is safe to paste into an issue.
+ */
+function probeNewSession() {
+  return {
+    url: location.href,
+    sessionId: sessionIdFromUrl() ?? null,
+    composer: findComposer()?.via ?? null,
+    sendButton: Boolean(findSendButton()),
+    triggers: menuTriggers()
+      .slice(0, 40)
+      .map(trigger => ({ via: trigger.via, text: trigger.text.slice(0, 80) }))
+      .filter(trigger => trigger.text),
+    openOptions: menuOptions()
+      .slice(0, 40)
+      .map(option => option.text.slice(0, 80)),
+  }
+}
+
+/**
+ * Drive the new-session flow: repo, branch, prompt, send, and report the session it became.
+ *
+ * The session id is read from the URL rather than from anything on the page, because that is the
+ * one thing claude.ai is guaranteed to tell us and it is exactly what the daemon joins runs on.
+ * A send that never becomes a session URL is a failure with a reason, never a silent success:
+ * the daemon would otherwise record a run pointing nowhere.
+ */
+async function createSession({ repo, branch, prompt }) {
+  const composerWait = window.__tfComposerWaitMs ?? 20000
+  const composer = await waitFor(findComposer, composerWait)
+  if (!composer) return { ok: false, note: 'no composer on the new-session page' }
+
+  const bareRepo = String(repo).split('/').pop() ?? repo
+  const repoPick = await pickFromMenu('repository', repo, [bareRepo])
+  if (!repoPick.ok) return { ok: false, note: repoPick.note }
+  // The branch list usually reloads once a repo is chosen; asking too early reads the old one.
+  await new Promise(resolve => setTimeout(resolve, window.__tfMenuSettleMs ?? 800))
+  const branchPick = await pickFromMenu('branch', branch)
+  if (!branchPick.ok) return { ok: false, note: branchPick.note }
+
+  fillComposer(composer, prompt)
+  await new Promise(resolve => setTimeout(resolve, 400))
+  const button = findSendButton()
+  if (button) button.click()
+  else {
+    for (const type of ['keydown', 'keyup']) {
+      composer.el.dispatchEvent(
+        new KeyboardEvent(type, { key: 'Enter', code: 'Enter', keyCode: 13, which: 13, bubbles: true, cancelable: true }),
+      )
+    }
+  }
+
+  const sessionId = await waitFor(sessionIdFromUrl, window.__tfSessionWaitMs ?? 60000, 500)
+  if (!sessionId) return { ok: false, note: `sent, but the page never became a session URL (${repoPick.note}; ${branchPick.note})` }
+  return { ok: true, sessionId, note: `${repoPick.note}; ${branchPick.note}; sent via ${button ? 'button' : 'enter'}` }
+}
+
 // The worker hands answers to the top frame only: the composer lives there, and a child frame
 // answering too would submit twice.
 if (IS_TOP && typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
   chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    if (message?.type === 'tf-probe-newsession') {
+      sendResponse(probeNewSession())
+      return true
+    }
+    if (message?.type === 'tf-create-session' && message.start) {
+      void createSession(message.start)
+        .then(sendResponse)
+        .catch(err => sendResponse({ ok: false, note: String(err?.message ?? err) }))
+      return true
+    }
     if (message?.type !== 'tf-deliver-answer' || typeof message.text !== 'string') return false
     void deliverAnswer(message.text)
       .then(sendResponse)
@@ -430,6 +605,8 @@ if (IS_TOP && typeof chrome !== 'undefined' && chrome.runtime?.onMessage) {
 // added to the window claude.ai can see.
 if (typeof chrome === 'undefined') {
   window.__tfBridgeDeliverAnswer = deliverAnswer
+  window.__tfBridgeCreateSession = createSession
+  window.__tfBridgeProbeNewSession = probeNewSession
 }
 
 /**


### PR DESCRIPTION
Refs #1328. **Incomplete on purpose - see "What is missing" before reviewing.**

## What is here

**Daemon half (complete, tested).** A start-queue the daemon fills and the extension drains.

- `bridge-starts.ts`: validation (`owner/name`, a git branch name, a bounded prompt), claim-on-read, and a claim that ages out after 90s so a browser quitting mid-creation retries instead of bricking the request.
- `GET /_bridge/start` claims the next request as it serves it. A GET that mutates, which is unusual and deliberate: handing the same request to two polling tabs would create two cloud sessions on the user's account.
- `POST /_bridge/started` takes back an id, a boolean, an optional session id and a note. Success without a session id is recorded as a *failure*, because a run pointing nowhere is not a usable outcome.

The bridge's "deliberately tiny input" rule is intact. A start request carries the free text that rule excludes, and it stays excluded because the direction is outward: the daemon produces it, the extension reads it, and what comes back is only an id, a boolean and a session id. Nothing here widens what someone holding the bridge token can say.

**Page half (`content.js`).** `createSession` drives the repo picker, the branch picker, the composer and send, then reads the session id from the URL - the one thing claude.ai is guaranteed to tell us and exactly what the daemon joins runs on. `probeNewSession` describes the page's controls without touching them.

Every selector in there is a guess about someone else's UI, so the code is built to report rather than insist: each failure names the control it could not find, and the probe exists so the first live run diagnoses instead of just failing.

## What is missing

**The service-worker loop in `background.js`** - poll `/_bridge/start`, open the new-session tab, hand the request to the content script, report back. My tooling refused to write it (a permission classifier blocked the edit), so it is deliberately absent rather than forgotten. Without it nothing drains the queue, so this PR changes no runtime behaviour: the routes exist, the queue exists, and nobody fills or empties it.

Also not started, both named in #1328: `CloudDriver`'s extension-backed mode (hand-off resolving on the bridge report), and the concurrency question. On the concurrency point the honest answer from the page half is that creation is inherently serial - the flow navigates one new-session page, so ten sessions are ten sequential creations, a throughput question rather than a correctness one.

## The policy question is still open

#1328 records that this direction needs the Usage Policy angle settled deliberately. My reading is that Consumer Terms section 3 does not permit it, and that the "user-installed extension in your own browser" arguments are not carve-outs; the two carve-outs are an API key or explicit permission. That is written up in full for the issue. This PR is the code that exists, not a verdict that the direction is settled.

## Checks

Framework suite 1535/0, typecheck clean. Extension harness (`node check.mjs`) 13/13, unchanged by the content.js additions.