### PR TITLE
feat: the bridge panel folds down to its title bar (#1237)

### DIFF
--- a/spike/cc-web-extension/README.md
+++ b/spike/cc-web-extension/README.md
@@ -52,10 +52,11 @@ catches the session's own DOM changes immediately; the slow interval is only a b
 node check.mjs
 ```
 
-Thirteen cases: the ten extraction ones, including the four that broke it on a real session
+Fourteen cases: the ten extraction ones, including the four that broke it on a real session
 (`<code>` with no `<pre>`, content behind a shadow root, an indentation the parser had not
-guessed, and our own protocol spec appearing on the page as a decoy), plus three for the answer
-delivery: fill and click send, the Enter fallback, and refusing a page with no composer.
+guessed, and our own protocol spec appearing on the page as a decoy), three for the answer
+delivery: fill and click send, the Enter fallback, and refusing a page with no composer, and
+one for the panel's collapse toggle folding it to its title bar and back.
 
 After editing any file here, reload the extension on `chrome://extensions` AND reload the open
 claude.ai tabs: reloading the extension does not re-inject content scripts, and an orphaned

--- a/spike/cc-web-extension/check.mjs
+++ b/spike/cc-web-extension/check.mjs
@@ -157,5 +157,33 @@ async function deliver(body, prepare) {
   dom.window.close()
 }
 
+// ---------------------------------------------------------------------------
+// The collapse toggle: the panel folds down to its title bar and unfolds back with the rows
+// intact. chrome.storage is extension-only, so in jsdom the fold simply lives for the page's
+// lifetime, which is exactly the degradation the guard in content.js promises.
+
+{
+  const dom = new JSDOM(
+    `<!doctype html><html><body><main><pre><code>${block}</code></pre><div contenteditable="true"></div></main></body></html>`,
+    { url: 'https://claude.ai/code/session_01TEST', runScripts: 'outside-only' },
+  )
+  dom.window.eval(script)
+  const panel = dom.window.document.getElementById('tf-bridge-panel')
+  // The toggle is the one button carrying aria-expanded; Copy report and Fill composer do not.
+  const toggle = () => panel.querySelector('button[aria-expanded]')
+  const expanded = /question found/.test(panel.textContent)
+  toggle().click()
+  const folded =
+    !/question found/.test(panel.textContent) &&
+    /The Framework bridge/.test(panel.textContent) &&
+    toggle().getAttribute('aria-expanded') === 'false'
+  toggle().click()
+  const restored = /question found\s*yes/.test(panel.textContent)
+  const ok = expanded && folded && restored
+  if (!ok) failed++
+  console.log(`${ok ? 'PASS' : 'FAIL'}  panel folds to its title bar and back  (expanded=${expanded}, folded=${folded}, restored=${restored})`)
+  dom.window.close()
+}
+
 console.log(failed ? `\n${failed} case(s) failed` : '\nall cases passed')
 process.exit(failed ? 1 : 0)

--- a/spike/cc-web-extension/content.js
+++ b/spike/cc-web-extension/content.js
@@ -522,6 +522,24 @@ if (!IS_TOP) {
 
   let latest = survey()
 
+  // Whether the panel is folded down to its title bar. Remembered in chrome.storage rather than
+  // the page's localStorage: the preference should survive a reload, and nothing the extension
+  // keeps should be readable by the page it watches. Restored asynchronously, so the panel can
+  // open expanded for a beat before the remembered fold lands.
+  let collapsed = false
+  if (typeof chrome !== 'undefined' && chrome.storage?.local) {
+    try {
+      chrome.storage.local.get('panelCollapsed', stored => {
+        if (!chrome.runtime.lastError && stored?.panelCollapsed) {
+          collapsed = true
+          render()
+        }
+      })
+    } catch {
+      // Dead context; the panel starts expanded, and reloading the tab is the fix anyway.
+    }
+  }
+
   const button = (label, onClick) => {
     const b = document.createElement('button')
     b.textContent = label
@@ -536,6 +554,37 @@ if (!IS_TOP) {
     latest = { ...top, fromFrame: fromFrame ?? null }
     const winner = top.choiceFound ? top : fromFrame?.choiceFound ? fromFrame : top
     const d = top.diagnostics
+    panel.innerHTML = ''
+    panel.style.width = collapsed ? 'auto' : '360px'
+    const head = document.createElement('div')
+    head.style.cssText = `display:flex;align-items:center;gap:8px${collapsed ? '' : ';margin-bottom:6px'}`
+    const title = document.createElement('span')
+    const version = typeof chrome !== 'undefined' && chrome.runtime?.getManifest ? chrome.runtime.getManifest().version : '?'
+    title.textContent = `The Framework bridge v${version}`
+    title.style.cssText = 'font-weight:600;color:#a7c080;flex:1'
+    const toggle = document.createElement('button')
+    toggle.textContent = collapsed ? '+' : '−'
+    toggle.title = collapsed ? 'Expand' : 'Collapse'
+    toggle.setAttribute('aria-label', toggle.title)
+    toggle.setAttribute('aria-expanded', String(!collapsed))
+    toggle.style.cssText =
+      'flex:none;width:20px;height:20px;padding:0;cursor:pointer;background:#2d3441;color:#dbdbdb;border:1px solid #3a4150;border-radius:5px;font:inherit;line-height:1'
+    toggle.addEventListener('click', () => {
+      collapsed = !collapsed
+      if (typeof chrome !== 'undefined' && chrome.storage?.local) {
+        try {
+          chrome.storage.local.set({ panelCollapsed: collapsed }, () => void chrome.runtime.lastError)
+        } catch {
+          // Dead context; the choice still holds until the tab reloads.
+        }
+      }
+      render()
+    })
+    head.append(title, toggle)
+    panel.appendChild(head)
+    // Folded, the title bar is all there is to draw. The survey above still ran: collapsing
+    // hides the detail, not the bridge, so the daemon keeps hearing from this page.
+    if (collapsed) return
     const rows = [
       ['question found', winner.choiceFound ? `yes (${winner.choiceVia}${winner === fromFrame ? ', in iframe' : ''})` : 'no'],
       ['title', winner.choiceTitle ?? '-'],
@@ -560,12 +609,6 @@ if (!IS_TOP) {
         ['frame reported', fromFrame ? 'yes' : 'no'],
       )
     }
-    panel.innerHTML = ''
-    const head = document.createElement('div')
-    const version = typeof chrome !== 'undefined' && chrome.runtime?.getManifest ? chrome.runtime.getManifest().version : '?'
-    head.textContent = `The Framework bridge v${version}`
-    head.style.cssText = 'font-weight:600;margin-bottom:6px;color:#a7c080'
-    panel.appendChild(head)
     for (const [k, v] of rows) {
       const line = document.createElement('div')
       line.style.cssText = 'display:flex;gap:8px;margin:2px 0'

--- a/spike/cc-web-extension/manifest.json
+++ b/spike/cc-web-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "The Framework: Claude web bridge",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Shows the question a Claude Code cloud session is parked on in your local The Framework dashboard, and types the answer you pick there back into the session.",
   "permissions": [
     "storage",


### PR DESCRIPTION
## What

Adds a collapse button to the web bridge's diagnostics panel (the fixed overlay in the bottom-right of every claude.ai session page). The title bar now carries a `−` / `+` toggle: collapsing folds the panel down to just its title, expanding brings the rows and action buttons back.

## How

- **State survives the render loop.** `render()` wipes and rebuilds the panel on every DOM mutation, so the fold lives in a `collapsed` variable outside it, and `render()` early-returns after drawing the title bar when folded.
- **Collapsing hides the detail, not the bridge.** The survey still runs first on every render, so question reports and the transcript mirror keep flowing to the daemon while the panel is folded.
- **The preference is remembered in `chrome.storage.local`**, matching the extension's existing state — never the page's `localStorage`, so nothing the extension keeps is readable by the page it watches. In the jsdom harness (`chrome` undefined) the fold simply lasts for the page's lifetime.
- **Manifest bumped to 0.7.2**, since the panel's version line is how a stale content script is told apart from a current one.

## Testing

`check.mjs` gains a fourteenth case: fold to the title bar, unfold, rows intact — asserted via the toggle's `aria-expanded` and the panel's text. All 14 cases pass offline (`node --experimental-vm-modules check.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8UCUL9zRqA7ZU7ZnG8wz4

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8UCUL9zRqA7ZU7ZnG8wz4)_