### PR TITLE
fix: keep the checkout of a run that never booted (#1325)

### DIFF
--- a/.changeset/keep-boot-dead-checkouts.md
+++ b/.changeset/keep-boot-dead-checkouts.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+The startup sweep no longer deletes the checkout of a run that never booted (#1325). A run whose child died before it committed anything leaves a branch with no commits, which `git branch --merged` lists like any landed work, so the sweep removed the checkout and reported the session as merged into the base. That checkout is the evidence of what went wrong, and it was being destroyed for looking like the success it is the opposite of. The local ancestor signal now reclaims a checkout only for a run that finished cleanly; a failed or stopped run, or one whose meta is missing, needs a merged PR to say the work landed. A merged PR still reclaims either way, so nothing that really landed is kept on disk.

--- a/packages/the-framework/src/merged-worktrees.test.ts
+++ b/packages/the-framework/src/merged-worktrees.test.ts
@@ -14,6 +14,7 @@ import { readRunHandoff, type RunHandoff } from './dashboard/run-handoff.js'
 import { addWorktree, runBranchName } from './store/index.js'
 import { nodeGitRunner } from './project.js'
 import type { WorktreeRow } from './worktrees.js'
+import type { RunMeta } from './store/index.js'
 
 // #1036: a session's checkout is reclaimed once its work has landed. The branch, its commits and
 // the session's own records are kept, which is what makes deleting the checkout safe at all.
@@ -60,13 +61,21 @@ test('a branch with neither signal has not landed (#1036)', () => {
   assert.equal(landedVia(handoff()), undefined)
 })
 
+/**
+ * A run that finished cleanly. The local signal only reclaims a checkout for one of these
+ * (#1325), so a sweep test that is not about the run's outcome says so with this.
+ */
+function doneRun(id: string, status: RunMeta['status'] = 'done'): RunMeta {
+  return { version: 1, status, id, startedAt: '2026-07-27T20:00:00.000Z', updatedAt: '2026-07-27T20:01:00.000Z', passes: 0 }
+}
+
 /** A sweep over fixed rows, recording which run ids removal was asked for. */
-function fakeSweep(rows: WorktreeRow[], states: Record<string, RunHandoff | undefined>) {
+function fakeSweep(rows: WorktreeRow[], states: Record<string, RunHandoff | undefined>, metas?: RunMeta[]) {
   const asked: string[] = []
   const run = (over: { remove?: (cwd: string, runId: string) => Promise<{ ok: true } | { ok: false; error: string }> } = {}) =>
     removeMergedWorktrees('/repo', {
       worktrees: async () => rows,
-      runs: async () => [],
+      runs: async () => metas ?? rows.map(r => doneRun(r.runId)),
       handoff: async (_cwd, branch) => states[branch],
       remove: async (_cwd, runId) => {
         asked.push(runId)
@@ -236,7 +245,7 @@ test('a merged session loses its checkout and keeps its branch and commit (#1036
   const git = nodeGitRunner()
   try {
     await git(['merge', '--no-ff', '-m', 'merge the session', branch], repo)
-    const result = await removeMergedWorktrees(repo, { handoff: localHandoff })
+    const result = await removeMergedWorktrees(repo, { handoff: localHandoff, runs: async () => [doneRun(RUN_ID)] })
 
     assert.deepEqual(result.removed, [{ runId: RUN_ID, branch, via: 'branch' }])
     await assert.rejects(() => stat(path), 'the checkout is gone')
@@ -294,11 +303,60 @@ test('uncommitted work in a landed checkout is committed to the kept branch, not
     await git(['merge', '--no-ff', '-m', 'merge the session', branch], repo)
     await writeFile(join(path, 'notes.txt'), 'something the agent had not committed\n')
 
-    const result = await removeMergedWorktrees(repo, { handoff: localHandoff })
+    const result = await removeMergedWorktrees(repo, { handoff: localHandoff, runs: async () => [doneRun(RUN_ID)] })
     assert.deepEqual(result.failed, [])
     await assert.rejects(() => stat(path), 'the checkout is gone')
     assert.match(await git(['show', `${branch}:notes.txt`], repo), /had not committed/, 'the stray work is on the branch')
   } finally {
     await rm(repo, { recursive: true, force: true })
   }
+})
+
+// #1325: a run that died at boot never commits, so its branch tip is the base tip and
+// `git branch --merged` lists it like any landed work. Its checkout is the evidence of what went
+// wrong, and the sweep was deleting it while reporting it as merged.
+
+test('a run that died at boot keeps its checkout, however merged its empty branch looks (#1325)', async () => {
+  const { asked, run } = fakeSweep(
+    [row({ runId: 'boot-dead' })],
+    // Exactly what a zero-commit branch reads as: an ancestor of the base, with nothing on it.
+    { 'the-framework/run-boot-dead': handoff({ branch: 'the-framework/run-boot-dead', merged: true, empty: true }) },
+    [doneRun('boot-dead', 'failed')],
+  )
+  assert.deepEqual(await run(), { removed: [], failed: [] })
+  assert.deepEqual(asked, [], 'the checkout of a failed run is the one most worth reading')
+})
+
+test('a stopped run keeps its checkout on the local signal alone (#1325)', async () => {
+  const { asked, run } = fakeSweep(
+    [row({ runId: 'stopped' })],
+    { 'the-framework/run-stopped': handoff({ branch: 'the-framework/run-stopped', merged: true }) },
+    [doneRun('stopped', 'stopped')],
+  )
+  await run()
+  assert.deepEqual(asked, [])
+})
+
+test('a run with no meta at all is kept: unknown is not landed (#1325)', async () => {
+  // The pre-#1272 shape of the same failure — a child that died before writing any meta.
+  const { asked, run } = fakeSweep(
+    [row({ runId: 'no-meta' })],
+    { 'the-framework/run-no-meta': handoff({ branch: 'the-framework/run-no-meta', merged: true }) },
+    [],
+  )
+  await run()
+  assert.deepEqual(asked, [])
+})
+
+test('a merged PR still reclaims a failed run: the remote said the work landed (#1325)', async () => {
+  // The guard is on the ancestor signal only. GitHub saying MERGED is a statement about the work,
+  // not an artefact of the branch being empty, so it survives whatever the run's own outcome was.
+  const { asked, run } = fakeSweep(
+    [row({ runId: 'failed-but-merged' })],
+    { 'the-framework/run-failed-but-merged': handoff({ branch: 'the-framework/run-failed-but-merged', pr: pr('MERGED') }) },
+    [doneRun('failed-but-merged', 'failed')],
+  )
+  const result = await run()
+  assert.deepEqual(asked, ['failed-but-merged'])
+  assert.deepEqual(result.removed, [{ runId: 'failed-but-merged', branch: 'the-framework/run-failed-but-merged', via: 'pr' }])
 })

--- a/packages/the-framework/src/merged-worktrees.ts
+++ b/packages/the-framework/src/merged-worktrees.ts
@@ -119,6 +119,19 @@ export async function removeMergedWorktrees(cwd: string, deps: MergedSweepDeps =
     if (!state || !state.exists) continue
     const via = landedVia(state)
     if (!via) continue
+    // The ancestor signal cannot tell a branch whose commits are now in the base from one that
+    // never had any (#1325): both answer `base..branch` with nothing, and a zero-commit branch is
+    // trivially reachable from the base. A run that died at boot is exactly the second case, and
+    // its checkout is the one most worth reading — so it was being destroyed for looking like the
+    // success it is the opposite of.
+    //
+    // `empty` cannot be the guard, tempting as it looks: a genuinely merged branch is empty by the
+    // same measure (`base..branch` is the branch's own commits, run-handoff.ts:276), so gating on
+    // it would switch the local signal off altogether. What separates the two is what the run did,
+    // which only its meta records. So the ancestor signal on its own reclaims a checkout for a run
+    // that finished cleanly; anything else — failed, stopped, or a run whose meta is missing
+    // entirely — needs the PR to say the work landed.
+    if (via === 'branch' && meta?.status !== 'done') continue
     const outcome = await remove(cwd, row.runId)
     if (outcome.ok) result.removed.push({ runId: row.runId, branch, via })
     else result.failed.push({ runId: row.runId, error: outcome.error })


### PR DESCRIPTION
Closes #1325

## The bug

A run whose child dies at boot commits nothing, so its branch tip *is* the base tip. `git branch --merged <base>` lists any branch reachable from the base, and a zero-commit branch trivially is. `landedVia` answered `branch`, and the startup sweep removed the checkout while printing:

> removed the worktree for session 2026-07-27T20-18-39-016Z: the-framework/run-… is merged into the base. The branch and the session are kept.

The checkout of a run that produced nothing is the evidence of what went wrong. It was being destroyed for looking like the success it is the opposite of. Seen live in #1323.

## Why the issue's fix direction does not work

The issue proposed that an `empty` handoff must not count as landed via the branch signal. I tried to write that and it fails: `empty` is computed from `base..branch`, which is the branch's *own* commits (`run-handoff.ts:276`). Once a branch is genuinely merged, the base contains its commits, so `base..branch` is empty too. Gating the local signal on `!empty` would switch it off for every real merge, which is most of what #1036 exists to reclaim.

So `empty` cannot separate these two cases. Both are empty. Both are ancestors.

## What does separate them

What the run actually did, which only its meta records. The ancestor signal on its own now reclaims a checkout for a run that finished cleanly:

```ts
if (via === 'branch' && meta?.status !== 'done') continue
```

- a **failed** run keeps its checkout (the reported bug)
- a **stopped** run keeps its checkout
- a run whose **meta is missing entirely** keeps its checkout, which is the pre-#1272 shape of the same failure, when a child could die before writing any meta at all
- a **merged PR** still reclaims either way: GitHub saying MERGED is a statement about the work, not an artefact of the branch being empty, so a failed run whose work did land is still cleaned up

The polarity matches the rest of the module, which already skips a branch it cannot read rather than guessing: for a destructive operation, positive evidence is the bar.

## Tests

Framework suite 1554 pass / 0 fail (1 skipped). Four new cases: boot-dead, stopped, no-meta, and the merged-PR escape hatch.

Revert-proven: dropping the one guard line fails exactly the three "keeps its checkout" tests and leaves the merged-PR one passing.

The existing sweep tests passed `runs: async () => []`, i.e. no metas, back when the meta did not affect the decision. They now state which run finished cleanly, which is the precondition they were always implicitly relying on.