### PR TITLE
fix: drop the how-to-behave rules from the existing-codebase prompt (#1224)

### DIFF
--- a/.changeset/extend-prompt-no-babysitting.md
+++ b/.changeset/extend-prompt-no-babysitting.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+A run against an existing codebase no longer opens by telling the agent how to behave (#1224). The prompt carried four lines of rules (do not re-scaffold or rebuild, do not swap the stack, read the existing code first, make the smallest coherent set of changes) that describe how any capable agent already works. What it cannot infer is that this workspace already holds a project, and that is the first line, so the framing that #185 added survives while the instruction not to infantilize it does not.

--- a/packages/the-framework/src/steps.spec.md
+++ b/packages/the-framework/src/steps.spec.md
@@ -2,7 +2,7 @@ Driver-backed implementations of ai-autopilot `Bootstrap`'s injectable steps (op
 
 ## TLDR
 
-- Prompt composers: `buildPrompt` (greenfield), `extendPrompt` (#185, existing codebase: extend, don't re-scaffold), `scaffoldPrompt` (#182, hard "create from scratch" directive), `PRODUCTION_GRADE_PROMPT` + `improvePrompt`.
+- Prompt composers: `buildPrompt` (greenfield), `extendPrompt` (#185, names the existing codebase and the intent; the how-to-behave rules were dropped in #1224), `scaffoldPrompt` (#182, hard "create from scratch" directive), `PRODUCTION_GRADE_PROMPT` + `improvePrompt`.
 - `driverBuild()`: one build turn wrapped in synthetic Supervisor plan/dispatch events; picks extend vs greenfield by whether the workspace holds source at build time; re-prompts once with `scaffoldPrompt` when the workspace is still empty after the turn (#182) — unless the turn ended on an await block, which means the agent stopped on purpose to ask (#337/#339).
 - `driverChecklist()`: re-prompts with the production-grade checklist and parses the verdict — failing closed: no parseable `{ blockers }` yields `MISSING_VERDICT_BLOCKER` so the loop re-prompts rather than declaring production-grade off an unverifiable reply.
 - `domainLoopChecklist()` (#252): each checklist pass dispatches a loop event (default `major-change`) through the preset's `LoopEngine`; no matching loop falls back to the built-in checklist so a run is never silently unreviewed. `verdictFromLoopRun()` unions every prompt's blockers; a prompt that failed to execute becomes a blocker (an errored review is not a pass), one that ran without a verdict is advisory.

--- a/packages/the-framework/src/steps.test.ts
+++ b/packages/the-framework/src/steps.test.ts
@@ -195,7 +195,7 @@ test('driverBuild extends an existing project instead of rebuilding it (#185)', 
     })
     // Existing codebase: extend framing, and no from-scratch scaffolding language.
     assert.equal(session.prompts.length, 1)
-    assert.match(session.prompts[0]!, /existing codebase|do NOT re-scaffold/i)
+    assert.match(session.prompts[0]!, /existing codebase/i)
     assert.doesNotMatch(session.prompts[0]!, /scaffold the whole project|workspace may be empty/i)
     const plan = events.find(e => e.type === 'plan')
     assert.ok(plan?.type === 'plan')
@@ -221,10 +221,13 @@ test('driverBuild uses greenfield framing for an empty workspace (#185)', async 
   }
 })
 
-test('extendPrompt names the intent and forbids a rebuild', () => {
+test('extendPrompt names the work and the workspace, and nothing else (#1224)', () => {
   const prompt = extendPrompt('add a settings page')
   assert.match(prompt, /add a settings page/)
-  assert.match(prompt, /do NOT re-scaffold|do not.*swap its stack/i)
+  // The one thing the agent cannot infer: this codebase already exists.
+  assert.match(prompt, /existing codebase/i)
+  // #1224: the rules telling it how to behave are gone, not reworded.
+  assert.doesNotMatch(prompt, /do NOT re-scaffold|swap its stack|smallest coherent|read the existing code first/i)
 })
 
 test('driverImprove scaffolds from scratch when the workspace is empty, else fixes blockers (#182)', async () => {

--- a/packages/the-framework/src/steps.ts
+++ b/packages/the-framework/src/steps.ts
@@ -50,19 +50,19 @@ export function buildPrompt(intent: string): string {
 }
 
 /**
- * Framing for a run against an *existing* codebase: extend it, do not rebuild it.
- * The greenfield {@link buildPrompt} tells the agent the workspace may be empty
- * and to scaffold from scratch, which is the wrong instruction when the user
- * pointed the framework at a project that already exists (#185). Chosen when the
- * workspace already holds source at build time.
+ * Framing for a run against an *existing* codebase. The greenfield {@link buildPrompt} tells the
+ * agent the workspace may be empty and to scaffold from scratch, which is the wrong instruction
+ * when the user pointed the framework at a project that already exists (#185).
+ *
+ * Naming the workspace is the whole job. The rules that used to follow it (do not re-scaffold,
+ * read the existing code first, make the smallest coherent set of changes) were dropped in #1224:
+ * they told a capable agent how to do its work rather than what the work was, and the one thing it
+ * cannot infer, that this codebase already exists, is in the first line. Chosen when the workspace
+ * already holds source at build time.
  */
 export function extendPrompt(intent: string): string {
   return [
     `Work within the existing codebase in this workspace to deliver: ${intent}`,
-    'This project already exists — do NOT re-scaffold or rebuild it, and do not',
-    'replace its structure or swap its stack. Read the existing code first, follow',
-    'its conventions, and make the smallest coherent set of changes that adds what',
-    'is asked; new files and dependencies are fine when the feature needs them.',
     'When done, summarize what you changed in one short paragraph.',
   ].join('\n')
 }


### PR DESCRIPTION
Closes #1224

The existing-codebase prompt opened with four lines of rules:

> This project already exists — do NOT re-scaffold or rebuild it, and do not replace its structure or swap its stack. Read the existing code first, follow its conventions, and make the smallest coherent set of changes that adds what is asked; new files and dependencies are fine when the feature needs them.

That is how a capable agent already works, so the lines bought nothing.

## What stays

The one thing an agent cannot infer is that the workspace already holds a project, and that is the first line. So #185's whole purpose (this is not a greenfield build, do not scaffold from scratch) survives:

```
Work within the existing codebase in this workspace to deliver: <intent>
When done, summarize what you changed in one short paragraph.
```

I kept the summarize line even though the quoted block includes it. It states a deliverable rather than a manner, and `buildPrompt` and `scaffoldPrompt` both carry the same sentence, so removing it only here would have made the three prompts disagree for no reason. Say the word if you want it gone too and I will drop all three.

## Proof

1571 pass, 0 fail. The updated test asserts the rules are *gone* rather than reworded:

```
assert.doesNotMatch(prompt, /do NOT re-scaffold|swap its stack|smallest coherent|read the existing code first/i)
```

Proven by revert: restoring the four lines fails `extendPrompt names the work and the workspace, and nothing else (#1224)` and nothing else.

One neighbouring assertion was an `or` (`/existing codebase|do NOT re-scaffold/`) that would have kept passing on the dead branch, so it is now tightened to the branch that still means something.
