### PR TITLE
fix: a --run-on actions run with no GH_TOKEN fails instead of hanging as running (#1348)

### DIFF
--- a/.changeset/actions-config-abort-hangs.md
+++ b/.changeset/actions-config-abort-hangs.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+A `--run-on actions` run that cannot start now fails instead of hanging forever as `running`. Missing a GitHub origin remote or a `GH_TOKEN` is caught before the driver starts, but that check sits after `run.json` has been written and before `settleRun` owns the run, so giving up there left the status at `running` with nobody to correct it — and the control tail the run had already wired kept the process alive, so it never exited either. From the dashboard that was a session stuck on "running" forever, with the real reason sitting unread in `stderr.log`. Both halves are fixed: the abort records an `end` event carrying the reason and releases the run's handles, and `followFile`'s `unref` option now covers the `fs.watch` handle as well as the poll timer, so opting out of holding the process open actually does.

--- a/packages/the-framework/src/cli.test.ts
+++ b/packages/the-framework/src/cli.test.ts
@@ -1030,3 +1030,63 @@ test('naming the session renames the run-id branch and records it as a branch ev
   )
   assert.equal(git('rev-parse', '--abbrev-ref', 'HEAD').trim(), 'the-framework/cool-name')
 })
+
+/**
+ * A `--run-on actions` run with no token must end as `failed`, and must end at all.
+ *
+ * Both halves regressed together. The config check sits after `run.json` is written but before
+ * `settleRun` owns the run, so returning raw left the status at `running` with nobody to correct
+ * it; and the control tail it had already wired held the event loop open, so the process never
+ * exited either. From the dashboard that was a session stuck on "running" forever, with the real
+ * reason sitting unread in stderr.log.
+ *
+ * Driven through the real binary rather than a unit seam: the defect was the process failing to
+ * exit, which only a process can demonstrate. `--skip-preflight` keeps it independent of whether
+ * an agent CLI is installed — the abort under test happens well before any driver starts.
+ */
+test('a --run-on actions run with no GH_TOKEN ends failed instead of hanging as running', async t => {
+  const { execFileSync, spawn } = await import('node:child_process')
+  const repo = await mkdtemp(join(tmpdir(), 'fw-actions-abort-'))
+  t.after(() => rm(repo, { recursive: true, force: true }))
+  const git = (...args: string[]): string => execFileSync('git', args, { cwd: repo, encoding: 'utf8' })
+  git('init', '-q')
+  git('config', 'user.email', 'test@example.com')
+  git('config', 'user.name', 'Test')
+  git('remote', 'add', 'origin', 'https://github.com/example/repo.git')
+  git('commit', '--allow-empty', '-q', '-m', 'seed')
+
+  const bin = new URL('./bin.js', import.meta.url)
+  // Scrubbed, not overridden: an inherited token from the developer's shell would take the run
+  // past the very branch under test.
+  const { GH_TOKEN: _gh, GITHUB_TOKEN: _gathub, ...env } = process.env
+  const exit = await new Promise<number | null>((resolvePromise, rejectPromise) => {
+    const child = spawn(
+      process.execPath,
+      [bin.pathname, 'hi', '--run-on', 'actions', '--skip-preflight', '--no-dashboard', '--run-id', 'r-actions', '--cwd', repo],
+      { cwd: repo, env, stdio: 'ignore' },
+    )
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      rejectPromise(new Error('the run never exited; it hung with its status left at running'))
+    }, 30_000)
+    child.once('error', rejectPromise)
+    child.once('exit', code => {
+      clearTimeout(timer)
+      resolvePromise(code)
+    })
+  })
+  assert.equal(exit, 2)
+
+  const meta = JSON.parse(await readFile(join(repo, FRAMEWORK_DIR, 'run.json'), 'utf8')) as {
+    status: string
+  }
+  assert.equal(meta.status, 'failed')
+  const events = (await readFile(join(repo, FRAMEWORK_DIR, EVENTS_FILE), 'utf8'))
+    .split('\n')
+    .filter(Boolean)
+    .map(l => JSON.parse(l) as { kind: string; ok?: boolean; detail?: string })
+  const end = events.find(e => e.kind === 'end')
+  assert.ok(end, `expected an end event, got: ${events.map(e => e.kind).join(', ')}`)
+  assert.equal(end.ok, false)
+  assert.match(end.detail ?? '', /GH_TOKEN/)
+})

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -1680,6 +1680,32 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
     io.err('note: no Chrome found, so --browser falls back to its own browser (no preview).')
   }
 
+  /**
+   * Give up before a driver exists, on a config fault the run cannot recover from.
+   *
+   * These aborts sit in an awkward window: `run.json` already says `running` (it is written back
+   * at :1433), but {@link settleRun} — which owns the `end` event and the handle cleanup — does
+   * not wrap anything until its `ctx` is built further down. Returning raw therefore left the run
+   * recorded as `running` forever with nobody to correct it, and the dashboard showed a session
+   * that never moved. So close it out here the same way settleRun would: say why, record the
+   * failure, release the handles.
+   *
+   * Best-effort throughout, like every other persistence call on this path: a store that cannot
+   * write its own failure must still let the process exit, which is the whole point of the fix.
+   */
+  const abortBeforeDriver = async (reason: string): Promise<number> => {
+    io.err(reason)
+    try {
+      await store?.append({ kind: 'end', ok: false, detail: reason })
+      await store?.close()
+    } catch {
+      // Persistence is never allowed to be the thing that keeps a failing run alive.
+    }
+    control?.close()
+    await sharedBrowser?.close().catch(() => {})
+    return 2
+  }
+
   // Run on GitHub Actions (#1050): owner/repo come from the project's origin remote, the token from
   // GH_TOKEN. The token is read from the environment, never the committed the-framework.yml, since a
   // repo file is public and this must be a user PAT. Resolved before the driver so a missing remote
@@ -1689,12 +1715,12 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
     const slug = await githubSlugFor(cwd)
     const token = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN
     if (!slug) {
-      io.err('--run-on actions needs a GitHub origin remote on this repo.')
-      return 2
+      return await abortBeforeDriver('--run-on actions needs a GitHub origin remote on this repo.')
     }
     if (!token) {
-      io.err('--run-on actions needs a GitHub user token in GH_TOKEN (repo + workflow scopes).')
-      return 2
+      return await abortBeforeDriver(
+        '--run-on actions needs a GitHub user token in GH_TOKEN (repo + workflow scopes).',
+      )
     }
     actionsConfig = { owner: slug.owner, repo: slug.repo, token }
     io.out(`◆ run on: GitHub Actions (${slug.owner}/${slug.repo})`)

--- a/packages/the-framework/src/jsonl-tail.test.ts
+++ b/packages/the-framework/src/jsonl-tail.test.ts
@@ -110,3 +110,48 @@ test('a watcher error does not throw, and the poll keeps the tail alive (#996)',
     await rm(cwd, { recursive: true, force: true })
   }
 })
+
+/**
+ * `unref: true` must cover both handles `followFile` opens, not just the poll timer.
+ *
+ * The watcher was left ref'd, so a caller that opted out of holding the process open was still
+ * held open by it. That only stayed invisible while every caller closed its tail on the way out;
+ * a run that aborted on a config fault before its tail had an owner never exited, and sat there
+ * with the run recorded as `running` forever.
+ *
+ * Asserted in a child process, because that is the actual claim: not "unref was called" but "the
+ * process is able to exit". A ref'd watcher hangs it until the test timeout kills it.
+ */
+test('followFile with unref lets the process exit, watcher included', async () => {
+  const { spawn } = await import('node:child_process')
+  const cwd = await tmpWorkspace()
+  await writeFile(join(cwd, 'events.jsonl'), line('seed'))
+  const moduleUrl = new URL('./jsonl-tail.js', import.meta.url).href
+  try {
+    const code = await new Promise<number | null>((resolvePromise, rejectPromise) => {
+      // Nothing else in this child holds the loop: if it exits, the tail let go of it.
+      const child = spawn(
+        process.execPath,
+        [
+          '-e',
+          `import(${JSON.stringify(moduleUrl)}).then(m => {` +
+            `m.followFile(${JSON.stringify(cwd)}, async () => {}, { pollMs: 20, unref: true })` +
+            `})`,
+        ],
+        { stdio: 'ignore' },
+      )
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL')
+        rejectPromise(new Error('followFile({ unref: true }) kept the process alive'))
+      }, 10_000)
+      child.once('error', rejectPromise)
+      child.once('exit', exitCode => {
+        clearTimeout(timer)
+        resolvePromise(exitCode)
+      })
+    })
+    assert.equal(code, 0)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})

--- a/packages/the-framework/src/jsonl-tail.ts
+++ b/packages/the-framework/src/jsonl-tail.ts
@@ -64,7 +64,11 @@ export class JsonlTailer<T> {
 export interface FollowFileOptions {
   /** How often the backstop poll runs. */
   pollMs: number
-  /** Let the process exit with the poll still scheduled (steering must never hold it open). */
+  /**
+   * Let the process exit with the tail still running (steering must never hold it open).
+   * Covers both handles this opens — the poll timer *and* the `fs.watch` — since either one
+   * on its own is enough to keep the event loop alive.
+   */
   unref?: boolean
 }
 
@@ -106,6 +110,12 @@ export function followFile(dir: string, pull: () => Promise<void>, opts: FollowF
       watcher?.close()
       watcher = undefined
     })
+    // Unref the watcher, not just the poll below: an `fs.watch` handle refs the event loop on
+    // its own, so unrefing only the timer left `unref: true` a half-measure that still pinned the
+    // process open. That is what wedged a run whose config check failed before its watcher had an
+    // owner to close it — the CLI returned, and the process then sat there forever with the run
+    // recorded as `running`.
+    if (opts.unref) watcher?.unref()
   } catch {
     // dir may not be watchable everywhere; the poll backstop still covers it
   }


### PR DESCRIPTION
Fixes #1348.

A session on a project whose preferences set `"target": "actions"` died at its config check one second in, and then sat there. Thirteen minutes later the process was still alive and `run.json` still said `"status": "running"`, with the real reason unread in `stderr.log`:

```
--run-on actions needs a GitHub user token in GH_TOKEN (repo + workflow scopes).
```

## Root cause

Two defects that only bite together.

**The abort left the run recorded as `running`.** `cli.ts:1697` returned raw. That check sits after `run.json` is written (`:1433`) and before `settleRun` — which owns the `end` event and the handle cleanup — wraps anything (its `ctx` is built at `:1759`), so nothing ever corrected the status.

**The process could not exit to let the daemon correct it either.** The daemon marks a run failed from `child.once("exit", ...)` (`daemon-runtime.ts:758`), which never fired. Probing the live process found exactly one active handle holding the event loop open — an `FSWatcher`, from `jsonl-tail.ts:112`:

```ts
const poll = setInterval(() => void pump(), opts.pollMs)
if (opts.unref) poll.unref()          // unrefs the timer — but not the watcher at line 101
```

`watchControl` passes `{ unref: true }` under the comment *"never keep the process alive just for steering"* (`control.ts:89`). Only half-implemented: the poll timer was unrefd, the `watch(dir, ...)` handle was not. Invisible while every caller closed its tail on the way out — but an abort before the tail had an owner never closes it.

Both early returns in that window were affected: `:1693` (missing origin remote) and `:1697` (missing token).

## Changes

- **`jsonl-tail.ts`** — `unref` now covers the watcher as well as the poll timer, so opting out of holding the process open actually does.
- **`cli.ts`** — both aborts go through one `abortBeforeDriver` helper: say why, append `end { ok: false, detail }` so the status lands on `failed`, release the run's handles. Mirrors what `settleRun` would have done had it owned the run yet. Best-effort throughout — a store that cannot write its own failure must still let the process exit, which is the whole point.

## Tests

Two regression tests, each verified to fail before its half of the fix by patching the compiled output back to the old behavior — neither is vacuous:

- **`jsonl-tail.test.ts`** — spawns a child whose only live handle is a `followFile({ unref: true })` and asserts it exits. Pre-fix it hangs the full 10s timeout (`Error: followFile({ unref: true }) kept the process alive`); post-fix it exits in 50ms. Asserted in a child process because that is the actual claim: not "unref was called" but "the process is able to exit".
- **`cli.test.ts`** — drives the real binary with `--run-on actions --skip-preflight` and no token, asserting exit code 2, `run.json` status `failed`, and an `end` event carrying the GH_TOKEN reason. `--skip-preflight` keeps it independent of whether an agent CLI is installed; the abort under test happens well before any driver starts. Checked that this half is load-bearing separately: with only the unref fix applied the process exits but the status still reads `running`, so the test pins both halves.

Full suite: **1573 passed, 0 failed, 1 skipped.**

## Why it matters beyond one run

Direct hazard for #1327: ten fan-out agents meeting a config fault would be ten wedged processes, all reading "running", none correctable — the same silent-stranding shape as #1320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)