### PR TITLE
fix(dashboard): retire the "starting…" row when its run lands, not when one runs (#1350)

### DIFF
--- a/.changeset/starting-row-retires-on-landing.md
+++ b/.changeset/starting-row-retires-on-landing.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework-dashboard': patch
+---
+
+The rail no longer shows a phantom second session when a run finishes as fast as it started. The "starting…" stand-in row waited for a `running` row to hand over to, but the runs list polls every two seconds, so a session that starts and finishes inside one interval is never once observed running — the stand-in then sat beside the finished session's own row, reading as a duplicate session that was starting, until a 20-second deadline swept it. It now retires on the real signal: the first run to appear that was not in the list when Start was clicked, whatever status it landed in. The deadline stays as the backstop for a start that produces no run at all.

--- a/packages/framework-dashboard/components/RunHistory.test.tsx
+++ b/packages/framework-dashboard/components/RunHistory.test.tsx
@@ -73,6 +73,54 @@ describe('RunHistory (#785)', () => {
     expect(home?.className).not.toContain('bg-accent')
   })
 
+  test('the starting row retires when the run it stands in for lands, even if it never ran', () => {
+    // The runs list polls every 2s, so a session that starts and fails inside one interval is never
+    // once observed `running`. The stand-in used to wait for a running row to hand over to, so it
+    // sat beside the finished session's own row claiming a second session was starting, until a
+    // 20s deadline swept it. Landing is the handover, whatever status the run landed in.
+    const { container, rerender } = renderRail(
+      <RunHistory projectId="p1" runs={[]} selectedRunId={null} onSelect={() => {}} startTick={0} startIntent="" />,
+    )
+    rerender(
+      <SidebarProvider>
+        <RunHistory projectId="p1" runs={[]} selectedRunId={null} onSelect={() => {}} startTick={1} startIntent="hi" />
+      </SidebarProvider>,
+    )
+    expect([...container.querySelectorAll('button')].some(row => row.textContent?.includes('starting…'))).toBe(true)
+
+    // The poll catches up: the run is already over, and was never seen running.
+    rerender(
+      <SidebarProvider>
+        <RunHistory
+          projectId="p1"
+          runs={[run({ id: 'run-9', status: 'failed', intent: 'hi' })]}
+          selectedRunId={null}
+          onSelect={() => {}}
+          startTick={1}
+          startIntent="hi"
+        />
+      </SidebarProvider>,
+    )
+    const rows = [...container.querySelectorAll('button')]
+    expect(rows.some(row => row.textContent?.includes('starting…'))).toBe(false)
+    expect(rows.some(row => row.textContent?.includes('failed'))).toBe(true)
+  })
+
+  test('the starting row survives a run that was already there when Start was clicked', () => {
+    // The guard against retiring the stand-in on the wrong evidence: an older session in the list
+    // is not the one being waited for, so its presence must not count as the handover.
+    const older = run({ id: 'run-old', status: 'done', intent: 'earlier work' })
+    const { container, rerender } = renderRail(
+      <RunHistory projectId="p1" runs={[older]} selectedRunId={null} onSelect={() => {}} startTick={0} startIntent="" />,
+    )
+    rerender(
+      <SidebarProvider>
+        <RunHistory projectId="p1" runs={[older]} selectedRunId={null} onSelect={() => {}} startTick={1} startIntent="hi" />
+      </SidebarProvider>,
+    )
+    expect([...container.querySelectorAll('button')].some(row => row.textContent?.includes('starting…'))).toBe(true)
+  })
+
   test('a finished run is finished, never waiting', () => {
     // settledAt is cleared on `end`, but a stale one must not relabel a terminal status.
     renderRail(

--- a/packages/framework-dashboard/components/RunHistory.tsx
+++ b/packages/framework-dashboard/components/RunHistory.tsx
@@ -104,23 +104,36 @@ export function RunHistory({
    *  the run's real id. A run that did report one is selected by URL instead (#784). */
   followLive?: boolean
 }) {
-  const [optimistic, setOptimistic] = useState<string | null>(null)
+  // The optimistic row, and the runs that already existed when Start was clicked. The two are one
+  // piece of state on purpose: the row stands in for a session that is not in `known` yet, so a
+  // snapshot taken at any other moment would be measuring against the wrong list.
+  const [optimistic, setOptimistic] = useState<{ intent: string; known: ReadonlySet<string> } | null>(null)
 
   useEffect(() => {
-    if (startTick > 0) setOptimistic(startIntent)
+    if (startTick > 0) setOptimistic({ intent: startIntent, known: new Set(runs.map(run => run.id)) })
   }, [startTick]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const hasRunning = runs.some(run => run.status === 'running')
   const newestRunningId = runs.find(run => run.status === 'running')?.id
+  // The handover: the row this one stands in for has landed once a run appears that was not in the
+  // list when Start was clicked — whatever its status.
+  //
+  // Watching `running` alone was too narrow. The runs list polls every 2s, so a session that starts
+  // and finishes inside one interval is never once observed running, and the stand-in had nothing to
+  // hand over to: it sat beside the finished session's own row, claiming a second session was
+  // starting, until the deadline below swept it. That was hard to hit while a broken run hung as
+  // `running` forever; it stopped being hard once such runs began failing in milliseconds.
+  const landed = optimistic !== null && runs.some(run => !optimistic.known.has(run.id))
   useEffect(() => {
-    if (hasRunning) setOptimistic(null)
-  }, [hasRunning])
+    if (landed) setOptimistic(null)
+  }, [landed])
   useEffect(() => {
     setOptimistic(null)
   }, [projectId])
-  // A failed start has no running run to hand over to, so without a deadline the row said
-  // "starting…" forever (#948). The Start form surfaces the actual error; this just stops
-  // the rail pretending.
+  // A start that never produces a run at all has nothing to hand over to either, so without a
+  // deadline the row said "starting…" forever (#948). The Start form surfaces the actual error;
+  // this just stops the rail pretending. Still the backstop, not the usual path: `landed` above
+  // retires the row as soon as the real one exists.
   useEffect(() => {
     if (optimistic === null || hasRunning) return
     const timer = setTimeout(() => setOptimistic(null), 20_000)
@@ -130,7 +143,9 @@ export function RunHistory({
   // The Overview pools every project's sessions; a selected project shows just its own.
   const crossProject = projectId === null && recentRuns !== undefined
   // On the Overview the optimistic launch row belongs to a project, so it only applies in-project.
-  const showOptimistic = !crossProject && optimistic !== null && !hasRunning
+  // `landed` is checked here as well as in its effect so the stand-in and the real row are never
+  // painted together for a frame while the effect is still queued.
+  const showOptimistic = !crossProject && optimistic !== null && !hasRunning && !landed
 
   // A session selected but not in the list is one just started, whose row lands with its run.json
   // a beat later (#784): the optimistic row is standing in for it, so highlight that. Following a
@@ -223,7 +238,7 @@ export function RunHistory({
                 {/* A just-started run, before its run.json exists — highlighted while following it. */}
                 {showOptimistic && (
                   <SidebarMenuItem>
-                    <RunRow status="running" intent={optimistic ?? undefined} subtitle="starting…" active={starting} dim onClick={() => onSelect(null)} />
+                    <RunRow status="running" intent={optimistic?.intent ?? undefined} subtitle="starting…" active={starting} dim onClick={() => onSelect(null)} />
                   </SidebarMenuItem>
                 )}
                 {rows.map(row => (


### PR DESCRIPTION
Fixes #1350. Follow-up to #1349, which exposed it.

Starting a session showed the real row as `failed` **and** a second row above it reading `RUNNING starting…` with the same prompt, which vanished on its own a few seconds later — looking exactly like a duplicate session had been started and abandoned. Nothing extra was ever started: one run, one worktree, one `end` event.

## Cause

The rail renders an optimistic stand-in the instant Start is clicked, covering the gap until the real `run.json` lands (#784). It was retired on one signal:

```ts
const hasRunning = runs.some(run => run.status === "running")
useEffect(() => { if (hasRunning) setOptimistic(null) }, [hasRunning])
```

The runs list polls every 2s (`use-runs.ts:13`). The run that exposed this went from `running` to `failed` in **27ms**:

```
startedAt  2026-07-28T20:18:39.104Z
updatedAt  2026-07-28T20:18:39.131Z
```

The poll never once observed it running, so `hasRunning` never went true and the stand-in had nothing to hand over to. It sat beside the finished run's own row until the 20s deadline from #948 swept it — the "disappears after a few seconds".

Latent rather than new: it needed a run fast enough to fall between two polls, which barely happened while a broken run hung as `running` forever. #1349 fixed that hang, so config-fault runs now fail in milliseconds and hit this window every time. Any fast-failing run does — a bad preset name, a failed preflight, an unwritable worktree.

The #948 deadline anticipated the neighbouring case (a start that produces no run at all), but not a run that lands already finished.

## Change

Retire the stand-in on the real signal — **the row it stands in for has landed** — rather than on "a running row appeared". The optimistic state now carries the run ids that existed when Start was clicked; the first id outside that set is the handover, whatever status it landed in. Kept as one piece of state with the intent, so the snapshot can never be taken at a different moment than the row it measures. `landed` is also checked at render, not only in its effect, so the stand-in and the real row are never painted together for a frame.

The 20s deadline stays as the backstop for a start that produces no run at all.

## Tests

`RunHistory.test.tsx`, both new:

- **a run that lands already `failed`, never seen running, retires the stand-in** — verified to fail before the fix (the ghost row persists), pass after.
- **a run already in the list when Start was clicked does not count as the handover** — the guard against retiring on the wrong evidence.

Full dashboard suite: **651 passed, 73 files.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)