### PR TITLE
fix: take the Actions token from the gh CLI when GH_TOKEN is unset (#1352)

### DIFF
--- a/.changeset/actions-token-from-gh-cli.md
+++ b/.changeset/actions-token-from-gh-cli.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+An Actions run now falls back to the `gh` CLI's credential when `GH_TOKEN` is unset. The framework already opens every one of its PRs through the authenticated `gh` CLI, but `--run-on actions` demanded a raw environment variable and failed the run without it — so a machine that could open a PR still could not run a single Actions session, with the credential sitting one `gh auth token` away. The environment variables stay the override, since CI sets them and must beat whatever `gh` is logged in as on the runner. When there is no token to be had either way, the run says both ways to fix it and which process needs it: the daemon hands each run its own environment, so exporting the variable in a shell does nothing for a daemon that is already up.

--- a/packages/the-framework/src/cli.test.ts
+++ b/packages/the-framework/src/cli.test.ts
@@ -1044,7 +1044,7 @@ test('naming the session renames the run-id branch and records it as a branch ev
  * exit, which only a process can demonstrate. `--skip-preflight` keeps it independent of whether
  * an agent CLI is installed — the abort under test happens well before any driver starts.
  */
-test('a --run-on actions run with no GH_TOKEN ends failed instead of hanging as running', async t => {
+test('a --run-on actions run with no token anywhere ends failed instead of hanging as running', async t => {
   const { execFileSync, spawn } = await import('node:child_process')
   const repo = await mkdtemp(join(tmpdir(), 'fw-actions-abort-'))
   t.after(() => rm(repo, { recursive: true, force: true }))
@@ -1055,10 +1055,19 @@ test('a --run-on actions run with no GH_TOKEN ends failed instead of hanging as 
   git('remote', 'add', 'origin', 'https://github.com/example/repo.git')
   git('commit', '--allow-empty', '-q', '-m', 'seed')
 
+  // "No token" has to mean no token *anywhere* since #1352, or this asserts nothing on a developer
+  // machine whose `gh` is logged in: the env vars are scrubbed, and a stub `gh` that refuses goes
+  // first on PATH so the CLI fallback finds nothing either. The rest of PATH is kept, because the
+  // run still resolves its origin remote with the real git.
+  const stubBin = await mkdtemp(join(tmpdir(), 'fw-actions-stub-bin-'))
+  t.after(() => rm(stubBin, { recursive: true, force: true }))
+  await writeFile(join(stubBin, 'gh'), '#!/bin/sh\nexit 1\n', { mode: 0o755 })
+
   const bin = new URL('./bin.js', import.meta.url)
   // Scrubbed, not overridden: an inherited token from the developer's shell would take the run
   // past the very branch under test.
-  const { GH_TOKEN: _gh, GITHUB_TOKEN: _gathub, ...env } = process.env
+  const { GH_TOKEN: _gh, GITHUB_TOKEN: _gathub, ...rest } = process.env
+  const env = { ...rest, PATH: `${stubBin}:${rest.PATH ?? ''}` }
   const exit = await new Promise<number | null>((resolvePromise, rejectPromise) => {
     const child = spawn(
       process.execPath,
@@ -1088,5 +1097,7 @@ test('a --run-on actions run with no GH_TOKEN ends failed instead of hanging as 
   const end = events.find(e => e.kind === 'end')
   assert.ok(end, `expected an end event, got: ${events.map(e => e.kind).join(', ')}`)
   assert.equal(end.ok, false)
+  // The reason names both ways out (#1352): the variable CI sets, and the login a laptop has.
   assert.match(end.detail ?? '', /GH_TOKEN/)
+  assert.match(end.detail ?? '', /gh auth login/)
 })

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -16,6 +16,7 @@ import { type ClaudeCodeDriverOptions, type Driver, type DriverSession, type Per
 import { AGENTS, AGENT_SPECS, isAgentName, type AgentName } from './agent.js'
 import { createRunDriver } from './run-driver.js'
 import { githubSlugFor } from './dashboard/github.js'
+import { githubToken } from './dashboard/gh.js'
 import type { ActionsDriverOptions } from './driver/index.js'
 import { launchSharedBrowser, withBrowser, type SharedBrowser } from './browser.js'
 import { connectCdp, startBrowserStream, type BrowserStream } from './browser-stream.js'
@@ -168,8 +169,9 @@ Options:
                          the session says so at startup rather than imply a guard.
   --run-on <local|actions|web>   Where the run executes (default: local, this
                          device). actions drives it on a fresh GitHub Actions runner;
-                         needs a GitHub origin remote and a user token in GH_TOKEN
-                         (repo + workflow scopes). web hands the task to a Claude Code
+                         needs a GitHub origin remote and a user token with repo +
+                         workflow scopes, from GH_TOKEN or from "gh auth login".
+                         web hands the task to a Claude Code
                          cloud session on your own account, which runs it off this
                          machine and opens its own PR; follow it on claude.ai or pull
                          it back with claude --teleport.
@@ -1707,19 +1709,25 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
   }
 
   // Run on GitHub Actions (#1050): owner/repo come from the project's origin remote, the token from
-  // GH_TOKEN. The token is read from the environment, never the committed the-framework.yml, since a
-  // repo file is public and this must be a user PAT. Resolved before the driver so a missing remote
-  // or token fails the run with a clear reason rather than deep inside ActionsDriver.
+  // the environment or, failing that, the `gh` CLI (#1352) — never the committed the-framework.yml,
+  // since a repo file is public and this must be a user credential. Resolved before the driver so a
+  // missing remote or token fails the run with a clear reason rather than deep inside ActionsDriver.
   let actionsConfig: ActionsDriverOptions | undefined
   if (opts.target === 'actions' && !fake) {
     const slug = await githubSlugFor(cwd)
-    const token = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN
+    const token = await githubToken(cwd)
     if (!slug) {
       return await abortBeforeDriver('--run-on actions needs a GitHub origin remote on this repo.')
     }
     if (!token) {
+      // Both ways out, because neither is guessable from the other: the env var is what CI sets,
+      // and `gh auth login` is what a laptop has. Says which process needs it, too — the daemon
+      // hands each run its own environment, so exporting the variable in a shell does nothing for
+      // a daemon that is already up.
       return await abortBeforeDriver(
-        '--run-on actions needs a GitHub user token in GH_TOKEN (repo + workflow scopes).',
+        '--run-on actions needs a GitHub user token (repo + workflow scopes): set GH_TOKEN in the environment ' +
+          'the daemon runs in, or log in with `gh auth login`. It must belong to a user, not an App — the agent ' +
+          'workflow refuses a bot-triggered run.',
       )
     }
     actionsConfig = { owner: slug.owner, repo: slug.repo, token }

--- a/packages/the-framework/src/dashboard/gh.test.ts
+++ b/packages/the-framework/src/dashboard/gh.test.ts
@@ -1,0 +1,55 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { githubToken } from './gh.js'
+import type { GhRunner } from './gh.js'
+
+/** A `gh` that answers with `stdout`, or rejects, and records what it was asked. */
+function fakeGh(stdout: string | Error): { gh: GhRunner; calls: string[][] } {
+  const calls: string[][] = []
+  const gh: GhRunner = async args => {
+    calls.push(args)
+    if (stdout instanceof Error) throw stdout
+    return stdout
+  }
+  return { gh, calls }
+}
+
+test('GH_TOKEN wins over the gh CLI, which is not consulted at all', async () => {
+  // CI sets the variable and must beat whatever gh happens to be logged in as on the runner.
+  const { gh, calls } = fakeGh('gho_from_cli\n')
+  assert.equal(await githubToken('/repo', { GH_TOKEN: 'ghp_from_env' }, gh), 'ghp_from_env')
+  assert.deepEqual(calls, [])
+})
+
+test('GITHUB_TOKEN is honoured too, as the second environment spelling', async () => {
+  const { gh } = fakeGh('gho_from_cli\n')
+  assert.equal(await githubToken('/repo', { GITHUB_TOKEN: 'ghp_from_env' }, gh), 'ghp_from_env')
+})
+
+test('with no token in the environment, the gh CLI credential is used (#1352)', async () => {
+  // The point of the change: a machine whose gh can already open PRs can run an Actions session,
+  // instead of failing with the credential sitting one `gh auth token` away.
+  const { gh, calls } = fakeGh('gho_from_cli\n')
+  assert.equal(await githubToken('/repo', {}, gh), 'gho_from_cli')
+  assert.deepEqual(calls, [['auth', 'token']])
+})
+
+test('a gh that is missing, logged out, or refusing yields no token rather than throwing', async () => {
+  // The caller turns undefined into the run's stated reason; a rejection here would instead
+  // surface as an unhandled failure deep in the start path.
+  const { gh } = fakeGh(new Error('gh: command not found'))
+  assert.equal(await githubToken('/repo', {}, gh), undefined)
+})
+
+test('an empty or blank gh answer is no token, not an empty-string one', async () => {
+  // `gh auth token` prints nothing when logged out of the active host. An empty string would sail
+  // past the caller's `if (!token)` check as a real credential and fail later, at the API.
+  assert.equal(await githubToken('/repo', {}, fakeGh('').gh), undefined)
+  assert.equal(await githubToken('/repo', {}, fakeGh('  \n').gh), undefined)
+})
+
+test('an empty environment variable falls through to the CLI rather than counting as a token', async () => {
+  // `GH_TOKEN=` in a shell profile is the same as unset, and used to be treated as a real value.
+  const { gh } = fakeGh('gho_from_cli\n')
+  assert.equal(await githubToken('/repo', { GH_TOKEN: '' }, gh), 'gho_from_cli')
+})

--- a/packages/the-framework/src/dashboard/gh.ts
+++ b/packages/the-framework/src/dashboard/gh.ts
@@ -28,6 +28,34 @@ export function nodeGhRunner(): GhRunner {
  */
 const readGh = cliRunner({ bin: 'gh', timeoutMs: 8_000 })
 
+/**
+ * The GitHub token an Actions run authenticates with (#1352).
+ *
+ * `GH_TOKEN` / `GITHUB_TOKEN` win, because CI sets them and must beat whatever `gh` happens to be
+ * logged in as on the runner. With neither set, fall back to the `gh` CLI's own credential — the
+ * same one every PR this framework opens is already authenticated by. A machine that can open a PR
+ * could always have run an Actions session too; it just had no way to say so, and the run failed
+ * with the credential sitting one `gh auth token` away.
+ *
+ * Undefined when there is no token to be had (gh missing, logged out, or refusing to hand it over),
+ * which the caller turns into the run's stated reason for not starting. Deliberately quiet about
+ * *why* gh declined: the caller's message names both ways to fix it, and a keyring prompt's stderr
+ * is not something to put in front of someone who simply has not set GH_TOKEN.
+ */
+export async function githubToken(
+  cwd: string,
+  env: Record<string, string | undefined> = process.env,
+  gh: GhRunner = readGh,
+): Promise<string | undefined> {
+  const fromEnv = env['GH_TOKEN'] ?? env['GITHUB_TOKEN']
+  if (fromEnv) return fromEnv
+  try {
+    return (await gh(['auth', 'token'], cwd)).trim() || undefined
+  } catch {
+    return undefined
+  }
+}
+
 /** A forgiving `gh --json` read: resolves `empty` when gh is missing/unauthed, or its output is not JSON. */
 export async function ghJson<T>(args: string[], cwd: string, empty: T): Promise<T> {
   try {


### PR DESCRIPTION
Fixes #1352.

The codebase authenticated to GitHub two different ways.

**Everything else shells out to the `gh` CLI**, which carries its own keyring auth — that is how every PR the framework opens gets created:

```ts
// dashboard/gh.ts:22
return cliRunner({ bin: "gh", timeoutMs: 60_000, preferStderr: true })
```

**The Actions driver demanded a raw environment variable** and failed the run outright without it (`cli.ts:1716`). So a machine the framework was already happily opening PRs from could not run a single Actions session, with the credential sitting one `gh auth token` away.

## Change

`githubToken(cwd, env, gh)` in `dashboard/gh.ts` — the module that already owns the `gh` runner. Environment first, CLI as the fallback:

- `GH_TOKEN` / `GITHUB_TOKEN` stay the **override**, because CI sets them and must beat whatever `gh` is logged in as on the runner.
- An **empty** variable falls through to the CLI rather than counting as a token (`GH_TOKEN=` in a shell profile is the same as unset, and used to be treated as a real value).
- A `gh` that is missing, logged out, or refusing yields `undefined` rather than throwing, so the caller states it as the run's reason instead of it surfacing as an unhandled failure in the start path.

The failure message now names **both ways out and which process needs it**:

> `--run-on actions needs a GitHub user token (repo + workflow scopes): set GH_TOKEN in the environment the daemon runs in, or log in with "gh auth login". It must belong to a user, not an App — the agent workflow refuses a bot-triggered run.`

That second half mattered as much as the first. The daemon hands each run its own environment, so exporting the variable in a shell does nothing for a daemon that is already up — the trap that made this a long detour. The `checkHumanActor` constraint (`driver/actions.ts:54`) stays named, since a bot login satisfies the token check but not the workflow.

`--help` updated to stop naming `GH_TOKEN` as the only source.

## Tests

**Six unit tests** on the resolver (`dashboard/gh.test.ts`): env wins and the CLI is not consulted at all; `GITHUB_TOKEN` honoured as the second spelling; CLI used when neither is set; a refusing gh yields undefined; blank CLI output is not a token; an empty variable falls through.

**The #1348 abort test needed reworking to keep asserting anything.** With the fallback in place, "no `GH_TOKEN`" is no longer "no token" on a developer machine whose `gh` is logged in — the test passed its env scrub and then sailed past the branch under test. It now also puts a refusing stub `gh` first on PATH, so "no token anywhere" is real and deterministic, and additionally asserts the message names `gh auth login`.

**Verified end to end against the real `gh`:** with both variables scrubbed, a run reaches `◆ run on: GitHub Actions (…)` and its dispatch is answered **404** for the missing repo rather than 401 — the CLI credential was accepted and used.

Full suite: **1579 passed, 0 failed, 1 skipped.**

## Why it matters

Same shape as #1348 one layer up: a precondition knowable locally, not checked, failing a run with a message that led nowhere. Also in the way of #1327 — a fan-out of Actions agents inherits this per-daemon, so every agent in the batch failed identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)