### PR TITLE
feat: a build that declares small scope skips the production-grade checklist (#1356)

### DIFF
--- a/.changeset/scope-gate.md
+++ b/.changeset/scope-gate.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+A run whose build declares small scope skips the production-grade checklist (#1356). The signal protocol gains a `set-scope` block (`small` / `large` / `very-large`); a `small` verdict resolves the checklist pass clean without dispatching an agent, with a log saying why. Only an explicit `small` skips — no verdict (an older prompt, a run without the protocols) keeps the full checklist, so the gate can only ever drop work the agent said was unnecessary.

--- a/packages/the-framework/prompts/protocols/signal.md
+++ b/packages/the-framework/prompts/protocols/signal.md
@@ -5,6 +5,13 @@ When you call setSessionName(<name>) (after creating and checking out the `the-f
 ```
 You do not stop; re-emit it if you rename the session.
 
+## Scope verdict
+When you have sized the work the prompt asks for (e.g. your analysis's scope entry), emit a `set-scope` block naming the verdict, so the framework can right-size the rest of the run — a `small` verdict skips the app-wide production-grade review, whose cost would exceed the change it examines. The first non-empty line is the verdict, one of `small` / `large` / `very-large`:
+```set-scope
+small
+```
+You do not stop; re-emit it if the scope turns out bigger as you work. Omit the block when unsure — no verdict means the full review runs.
+
 ## Ready for merge
 When you call setReadyForMerge() — you believe the work is complete and ready for human review — emit an empty `ready-for-merge` block. This flips the dashboard status from building to ready; it does not stop your turn.
 ```ready-for-merge

--- a/packages/the-framework/src/events.ts
+++ b/packages/the-framework/src/events.ts
@@ -179,6 +179,14 @@ export type FrameworkEvent =
    */
   | { kind: 'session-name'; name: string }
   /**
+   * The agent's own sizing of the work (#1356), from a `set-scope` block. `small` lets the
+   * run skip the production-grade checklist — an app-wide review would cost more than the
+   * change it examines. No verdict means no claim, and the checklist runs as it always has;
+   * the gate only ever drops work the agent explicitly said was unnecessary. Re-emitted when
+   * the agent revises the verdict mid-run.
+   */
+  | { kind: 'scope-verdict'; scope: 'small' | 'large' | 'very-large' }
+  /**
    * The agent signalled `setReadyForMerge()` (#326): it believes the work is complete
    * and ready for human review. Non-blocking — it flips the run's dashboard status from
    * building (orange) to ready (green); the on-before-mergeable quality prompts hang off it.

--- a/packages/the-framework/src/run.spec.md
+++ b/packages/the-framework/src/run.spec.md
@@ -12,6 +12,7 @@ The build-run orchestrator: `runFramework()` drives ai-autopilot's `Bootstrap` (
 ## Problems
 
 - Hand-off drivers (#1225): the prompt leaves the machine and the reply never comes back, so every phase after build would read the driver's own "handed off to <url>" summary as agent output — producing a bogus missing-verdict blocker and an unanswerable backlog gate. Fix: with `driver.handsOff`, checklist/improve steps are omitted (Bootstrap then skips its whole loop), the todo loop and chat phase are skipped, and a closing log explains the run continues in its own session.
+- Scope gate (#1356): the Bootstrap fixes scope before the build, but the agent sizes the work *during* it — so the gate wraps the checklist step instead. A `scope-verdict` event of `small` (from a `set-scope` block, tracked off the emit stream) makes the checklist resolve `{ blockers: [] }` without dispatching, after a log saying why. Only an explicit `small` skips: no verdict (older prompts, no protocols) keeps the full checklist, and `handsOff` is untouched.
 - An empty workspace after the build turn means the agent stalled instead of scaffolding (#182) — unless the turn ended on an await block (#337/#339), in which case it stopped *on purpose* to ask and the scaffold retry must not clobber the question.
 - The fake driver writes no files, so workspace verification and the todo loop are disabled for it to stay deterministic.
 

--- a/packages/the-framework/src/run.test.ts
+++ b/packages/the-framework/src/run.test.ts
@@ -475,6 +475,53 @@ test('a build turn that stops to ask fires a live gate and resumes on the pick (
   assert.equal(result.productionGrade, true)
 })
 
+test('a build that declares small scope skips the production-grade checklist (#1356)', async () => {
+  const driver = new FakeDriver({
+    respond: (prompt: string): string => {
+      if (/Build this app end to end/.test(prompt))
+        return 'One-line change, done.\n```set-scope\nsmall\n```'
+      if (/production-grade checklist/.test(prompt)) throw new Error('the checklist must not dispatch (#1356)')
+      return 'done'
+    },
+    sessionId: 'scope1356',
+  })
+  const events: FrameworkEvent[] = []
+  const { result } = await runFramework({
+    intent: FAKE_INTENT,
+    driver,
+    cwd: '/tmp/ws',
+    signals: FAKE_SIGNALS,
+    onEvent: e => events.push(e),
+  })
+  // The pass resolved clean without an agent, and the dashboard says why instead of showing a
+  // silent instant pass.
+  assert.equal(result.productionGrade, true)
+  assert.equal(result.passes, 1)
+  assert.ok(events.some(e => e.kind === 'scope-verdict' && e.scope === 'small'))
+  assert.ok(events.some(e => e.kind === 'log' && /Skipping the production-grade checklist/.test(e.message)))
+})
+
+test('a large or missing verdict keeps the full checklist (#1356)', async () => {
+  for (const tail of ['\n```set-scope\nlarge\n```', '']) {
+    const prompts: string[] = []
+    const driver = new FakeDriver({
+      respond: (prompt: string): string => {
+        prompts.push(prompt)
+        if (/Build this app end to end/.test(prompt)) return `Built the whole feature.${tail}`
+        if (/production-grade checklist/.test(prompt)) return 'Reviewed.\n```json\n{ "blockers": [] }\n```'
+        return 'done'
+      },
+      sessionId: 'scope1356full',
+    })
+    const events: FrameworkEvent[] = []
+    await runFramework({ intent: FAKE_INTENT, driver, cwd: '/tmp/ws', signals: FAKE_SIGNALS, onEvent: e => events.push(e) })
+    // The gate only ever drops work the agent explicitly said was unnecessary (#1356): no
+    // verdict — an older prompt, a run without the protocols — reviews exactly as before.
+    assert.ok(prompts.some(p => /production-grade checklist/.test(p)), `expected a checklist pass with tail ${JSON.stringify(tail)}`)
+    assert.ok(!events.some(e => e.kind === 'log' && /Skipping the production-grade checklist/.test(e.message)))
+  }
+})
+
 test('a build turn that stops to showMultiSelect fires a checklist gate and resumes (#339)', async () => {
   const awaitBlock =
     'Rated the problems.\n```await-multiselect\n' +

--- a/packages/the-framework/src/run.ts
+++ b/packages/the-framework/src/run.ts
@@ -25,7 +25,7 @@ import { snapshotWorkspace } from './sandbox.js'
 import type { Driver, DriverSession } from './driver/index.js'
 import { composeRunSystem, type EcoOptions, type TfContext } from './system-prompt.js'
 import { createRunControls, emitSessionStart, endStopDetail } from './run-telemetry.js'
-import { AWAIT_PROTOCOL, createTurnSignalEmitter } from './turn-gate.js'
+import { AWAIT_PROTOCOL, createTurnSignalEmitter, type ScopeVerdict } from './turn-gate.js'
 import { drainGates, runChatPhase, type BindProjectDeps, type RecordMessage } from './await-gate.js'
 import { leaveResumeNote, runTodoLoop, type TodoLoopResult } from './todo-loop.js'
 import { continueAfterChoice, decideDeploy, deployWith, domainLoopChecklist, driverBuild, driverChecklist, driverImprove, driverLoopPrompts } from './steps.js'
@@ -276,7 +276,12 @@ export interface RunFrameworkResult {
  */
 export async function runFramework(opts: RunFrameworkOptions): Promise<RunFrameworkResult> {
   const events: FrameworkEvent[] = []
+  // The agent's latest scope verdict (#1356), read off the event stream: every phase that
+  // parses turn signals (the build, its await rounds) already emits through here, so the
+  // checklist gate below needs no plumbing of its own.
+  let declaredScope: ScopeVerdict | undefined
   const emit = (event: FrameworkEvent) => {
+    if (event.kind === 'scope-verdict') declaredScope = event.scope
     events.push(event)
     if (opts.onEvent) {
       try {
@@ -380,6 +385,17 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
     injectedRunner: opts.runner !== undefined,
     emit,
   })
+  // The scope gate (#1356). The Bootstrap fixes its scope before the build runs, but the
+  // agent only sizes the work *during* the build — so the gate sits on the checklist step
+  // instead: a build that declared small scope resolves the pass clean without dispatching
+  // anyone, because an app-wide review costs more than the change it would examine and sits
+  // between the task and the handoff. Only an explicit `small` skips; no verdict keeps the
+  // full checklist, so the gate can only ever drop work the agent said was unnecessary.
+  const gatedChecklist: typeof checklist = async ctx => {
+    if (declaredScope !== 'small') return checklist(ctx)
+    emit({ kind: 'log', message: 'Skipping the production-grade checklist: the build declared small scope.' })
+    return { blockers: [] }
+  }
 
   // A real driver writes files to the workspace, so the build/improve steps can
   // detect an empty workspace and hard-scaffold it (#182). The fake driver writes
@@ -415,7 +431,7 @@ export async function runFramework(opts: RunFrameworkOptions): Promise<RunFramew
       steps: {
         scope: () => ({ scope: opts.scope ?? 'full', intent: opts.intent }),
         build: agentAwaitGate(driverBuild(session, workspaceOpt), session, gateDeps),
-        ...(handsOff ? {} : { checklist, improve: driverImprove(session, workspaceOpt) }),
+        ...(handsOff ? {} : { checklist: gatedChecklist, improve: driverImprove(session, workspaceOpt) }),
         ...(opts.deploy
           ? {
               deploy: opts.deployTarget

--- a/packages/the-framework/src/terminal.ts
+++ b/packages/the-framework/src/terminal.ts
@@ -28,6 +28,8 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
       return `▶ view: ${event.title}`
     case 'session-name':
       return `  session: ${event.name}`
+    case 'scope-verdict':
+      return `  scope: ${event.scope}`
     case 'ready-for-merge':
       return `✓ ready for merge`
     case 'settled':

--- a/packages/the-framework/src/turn-gate.test.ts
+++ b/packages/the-framework/src/turn-gate.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { continuationPrompt, isDeclinedConfirmation, parseAwaitGate, parseChoicesGate, parseConfirmationGate, parseMarkdownViews, parseMultiSelectGate, parseSessionName, parseReadyForMerge } from './turn-gate.js'
+import { continuationPrompt, isDeclinedConfirmation, parseAwaitGate, parseChoicesGate, parseConfirmationGate, parseMarkdownViews, parseMultiSelectGate, parseScopeVerdict, parseSessionName, parseReadyForMerge } from './turn-gate.js'
 
 const block = (json: string): string => 'Here are the options.\n```await-choices\n' + json + '\n```'
 const multiBlock = (json: string): string => 'Pick some.\n```await-multiselect\n' + json + '\n```'
@@ -195,4 +195,24 @@ test('parseReadyForMerge is true only when a ready-for-merge block is present (#
   assert.equal(parseReadyForMerge('Still building the feature.'), false)
   assert.equal(parseReadyForMerge('All done.\n```ready-for-merge\n```'), true)
   assert.equal(parseReadyForMerge('```ready-for-merge```'), true) // empty, no inner newline
+})
+
+test('parseScopeVerdict reads the verdict from a set-scope block (#1356)', () => {
+  assert.equal(parseScopeVerdict('No verdict in this turn.'), undefined)
+  assert.equal(parseScopeVerdict('```set-scope\nsmall\n```'), 'small')
+  assert.equal(parseScopeVerdict('analysis first…\n```set-scope\n  Large  \n```\n…then work'), 'large')
+  assert.equal(parseScopeVerdict('```set-scope\n\nvery-large\nignored\n```'), 'very-large')
+})
+
+test('parseScopeVerdict ignores a spelling the protocol does not name (#1356)', () => {
+  // The verdict can skip review work, so a guess ("tiny" ≈ small?) is the one mistake this
+  // must never make — an unknown word is no verdict at all.
+  assert.equal(parseScopeVerdict('```set-scope\ntiny\n```'), undefined)
+  assert.equal(parseScopeVerdict('```set-scope\nvery large\n```'), undefined)
+  // …and does not erase a valid verdict from an earlier block in the same turn.
+  assert.equal(parseScopeVerdict('```set-scope\nsmall\n```\n```set-scope\ntiny\n```'), 'small')
+})
+
+test('parseScopeVerdict keeps the later block when the agent revises mid-turn (#1356)', () => {
+  assert.equal(parseScopeVerdict('```set-scope\nsmall\n```\noh wait…\n```set-scope\nlarge\n```'), 'large')
 })

--- a/packages/the-framework/src/turn-gate.ts
+++ b/packages/the-framework/src/turn-gate.ts
@@ -233,6 +233,30 @@ export function parseReadyForMerge(text: string): boolean {
   return /```ready-for-merge(?:\s[\s\S]*?)?```/.test(text)
 }
 
+/** The verdicts a `set-scope` block may carry (#1356), exactly as the protocol spells them. */
+const SCOPE_VERDICTS = ['small', 'large', 'very-large'] as const
+
+/** The agent's own sizing of the work (#1356): what a `set-scope` block declared. */
+export type ScopeVerdict = (typeof SCOPE_VERDICTS)[number]
+
+/**
+ * Parse the scope the agent declared this turn (#1356), from the last `set-scope` block
+ * (per {@link SIGNAL_PROTOCOL}) — its first non-empty line. Returns `undefined` when the
+ * turn declared none (the common case). An unrecognized spelling is ignored rather than
+ * guessed at: the verdict can skip review work, so only the protocol's exact words count.
+ * A later block in the same turn wins (the agent revised while working).
+ */
+export function parseScopeVerdict(text: string): ScopeVerdict | undefined {
+  const re = /```set-scope\s+([\s\S]*?)```/g
+  let verdict: ScopeVerdict | undefined
+  for (const m of text.matchAll(re)) {
+    const line = (m[1] ?? '').split('\n').map(l => l.trim()).find(Boolean)?.toLowerCase()
+    const known = SCOPE_VERDICTS.find(v => v === line)
+    if (known) verdict = known
+  }
+  return verdict
+}
+
 /** Find the body + start index of the last fenced block with `tag` in `text`. */
 function lastBlock(text: string, tag: string): { body: string; index: number } | undefined {
   const re = new RegExp('```' + tag + '\\s+([\\s\\S]*?)```', 'g')
@@ -441,6 +465,7 @@ function tagged<K extends ParsedAwaitGate['kind'], G extends object>(kind: K, ga
  */
 export function createTurnSignalEmitter(emit: (event: FrameworkEvent) => void): (text: string) => void {
   let named: string | undefined
+  let scoped: ScopeVerdict | undefined
   let ready = false
   return (text: string): void => {
     for (const view of parseMarkdownViews(text)) emit({ kind: 'view', ...view })
@@ -448,6 +473,12 @@ export function createTurnSignalEmitter(emit: (event: FrameworkEvent) => void): 
     if (name && name !== named) {
       named = name
       emit({ kind: 'session-name', name })
+    }
+    // Dedupes like the name: re-emits only on an actual revision (#1356).
+    const scope = parseScopeVerdict(text)
+    if (scope && scope !== scoped) {
+      scoped = scope
+      emit({ kind: 'scope-verdict', scope })
     }
     if (!ready && parseReadyForMerge(text)) {
       ready = true


### PR DESCRIPTION
Closes #1356

Observed three times on 2026-07-28/29: a one-line prompt finishes in one turn, then the bootstrap's "Checking the app is production-grade" phase spends minutes and the run's dominant token cost reviewing the whole app — and it sits between the task and the handoff, so twice the maintainer gave up and stopped the run before its PR ever opened.

## How

The agent's protocol already makes it size the work ("whether the scope is small, large, or very large") — the verdict just went nowhere. Now:

- **Protocol**: a `set-scope` signal block (`small` / `large` / `very-large`), documented next to `set-session-name` in `prompts/protocols/signal.md`. Omitting it means the full review runs.
- **Turn-gate**: `parseScopeVerdict` — last block wins, unknown spellings ignored (a guess could skip review work, so only the protocol's exact words count) — emitting a `scope-verdict` run event, deduped like the session name.
- **run.ts**: the Bootstrap fixes its scope before the build, but the agent only sizes the work *during* it — so the gate sits on the checklist step: a declared `small` resolves the pass clean without dispatching anyone, after a log line saying so. No verdict / `large` / `very-large` / hands-off: unchanged. The gate can only ever drop work the agent explicitly said was unnecessary.

## Notes

- `prompts/system_prompt.md` is deliberately untouched: `check-prompt-drift.mjs` pins it to issue #326's body. The signal protocol file is composed into every run's system channel regardless, so the block works even for "Disable system prompt" runs. Worth mirroring a sentence into #326's Scope section when convenient.
- New agent-facing protocol wording — worth a human read.

Tests: 3 new turn-gate tests + 2 run-gate tests; the-framework 1599 (0 fail), dashboard 652 green, root build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)