### PR TITLE
feat: the folded bridge panel shrinks to a TF tab (#1237)

### DIFF
--- a/spike/cc-web-extension/README.md
+++ b/spike/cc-web-extension/README.md
@@ -56,7 +56,7 @@ Fourteen cases: the ten extraction ones, including the four that broke it on a r
 (`<code>` with no `<pre>`, content behind a shadow root, an indentation the parser had not
 guessed, and our own protocol spec appearing on the page as a decoy), three for the answer
 delivery: fill and click send, the Enter fallback, and refusing a page with no composer, and
-one for the panel's collapse toggle folding it to its title bar and back.
+one for the panel's collapse toggle folding it down to a compact `TF` tab and back.
 
 After editing any file here, reload the extension on `chrome://extensions` AND reload the open
 claude.ai tabs: reloading the extension does not re-inject content scripts, and an orphaned

--- a/spike/cc-web-extension/check.mjs
+++ b/spike/cc-web-extension/check.mjs
@@ -158,9 +158,10 @@ async function deliver(body, prepare) {
 }
 
 // ---------------------------------------------------------------------------
-// The collapse toggle: the panel folds down to its title bar and unfolds back with the rows
-// intact. chrome.storage is extension-only, so in jsdom the fold simply lives for the page's
-// lifetime, which is exactly the degradation the guard in content.js promises.
+// The collapse toggle: the panel folds down to a compact "TF" tab — the full title retreats to
+// the tooltip so the fold actually gives the corner back — and unfolds with the rows intact.
+// chrome.storage is extension-only, so in jsdom the fold simply lives for the page's lifetime,
+// which is exactly the degradation the guard in content.js promises.
 
 {
   const dom = new JSDOM(
@@ -171,17 +172,18 @@ async function deliver(body, prepare) {
   const panel = dom.window.document.getElementById('tf-bridge-panel')
   // The toggle is the one button carrying aria-expanded; Copy report and Fill composer do not.
   const toggle = () => panel.querySelector('button[aria-expanded]')
-  const expanded = /question found/.test(panel.textContent)
+  const expanded = /question found/.test(panel.textContent) && /The Framework bridge/.test(panel.textContent)
   toggle().click()
   const folded =
     !/question found/.test(panel.textContent) &&
-    /The Framework bridge/.test(panel.textContent) &&
+    !/The Framework bridge/.test(panel.textContent) &&
+    /TF/.test(panel.textContent) &&
     toggle().getAttribute('aria-expanded') === 'false'
   toggle().click()
   const restored = /question found\s*yes/.test(panel.textContent)
   const ok = expanded && folded && restored
   if (!ok) failed++
-  console.log(`${ok ? 'PASS' : 'FAIL'}  panel folds to its title bar and back  (expanded=${expanded}, folded=${folded}, restored=${restored})`)
+  console.log(`${ok ? 'PASS' : 'FAIL'}  panel folds to a compact TF tab and back  (expanded=${expanded}, folded=${folded}, restored=${restored})`)
   dom.window.close()
 }
 

--- a/spike/cc-web-extension/check.spec.md
+++ b/spike/cc-web-extension/check.spec.md
@@ -4,7 +4,7 @@ Offline harness that runs `content.js` inside jsdom against synthetic pages — 
 
 - 10 extraction cases, including the four that broke real sessions: `<code>` with no `<pre>`, content behind an open shadow root, a 4-space indentation, and the system-prompt spec as a decoy (spec-then-real must pick the real question; spec alone must find nothing); also a highlighter splitting the block across spans, prose around it, and a no-question page.
 - 3 delivery cases via `window.__tfBridgeDeliverAnswer`: fill + click of the `aria-label="Send message"` button, Enter fallback when no button exists, and honest refusal on a composer-less page (wait shortened via `window.__tfComposerWaitMs`).
-- 1 collapse case: the panel folds to its title bar (the toggle is the one button with `aria-expanded`) and restores with rows intact.
+- 1 collapse case: the panel folds to a compact `TF` tab — the full title gone from its text — (the toggle is the one button with `aria-expanded`) and restores with rows intact.
 - Assertions read the injected panel's text — the panel is appended to `documentElement`, not `body`.
 
 ## Facts

--- a/spike/cc-web-extension/content.js
+++ b/spike/cc-web-extension/content.js
@@ -522,7 +522,7 @@ if (!IS_TOP) {
 
   let latest = survey()
 
-  // Whether the panel is folded down to its title bar. Remembered in chrome.storage rather than
+  // Whether the panel is folded down to a compact TF tab. Remembered in chrome.storage rather than
   // the page's localStorage: the preference should survive a reload, and nothing the extension
   // keeps should be readable by the page it watches. Restored asynchronously, so the panel can
   // open expanded for a beat before the remembered fold lands.
@@ -556,11 +556,16 @@ if (!IS_TOP) {
     const d = top.diagnostics
     panel.innerHTML = ''
     panel.style.width = collapsed ? 'auto' : '360px'
+    panel.style.padding = collapsed ? '6px 8px' : '10px 12px'
     const head = document.createElement('div')
     head.style.cssText = `display:flex;align-items:center;gap:8px${collapsed ? '' : ';margin-bottom:6px'}`
     const title = document.createElement('span')
     const version = typeof chrome !== 'undefined' && chrome.runtime?.getManifest ? chrome.runtime.getManifest().version : '?'
-    title.textContent = `The Framework bridge v${version}`
+    const fullTitle = `The Framework bridge v${version}`
+    // Folded, the label shrinks to "TF": the fold exists to give the corner back, so the full
+    // name and version retreat to the tooltip.
+    title.textContent = collapsed ? 'TF' : fullTitle
+    if (collapsed) title.title = fullTitle
     title.style.cssText = 'font-weight:600;color:#a7c080;flex:1'
     const toggle = document.createElement('button')
     toggle.textContent = collapsed ? '+' : '−'
@@ -582,7 +587,7 @@ if (!IS_TOP) {
     })
     head.append(title, toggle)
     panel.appendChild(head)
-    // Folded, the title bar is all there is to draw. The survey above still ran: collapsing
+    // Folded, the TF tab is all there is to draw. The survey above still ran: collapsing
     // hides the detail, not the bridge, so the daemon keeps hearing from this page.
     if (collapsed) return
     const rows = [

--- a/spike/cc-web-extension/content.spec.md
+++ b/spike/cc-web-extension/content.spec.md
@@ -6,7 +6,7 @@ Content-script half of the Claude web bridge (#1237): finds the question a cloud
 - `isTemplate()` filters the decoy: the page renders our own system prompt, so its await-choices spec (all-placeholder `<...>` values) appears as a JSON block before any real question.
 - Transcript: one block per `article` element (composer-only articles skipped); with no articles, mirrors the conversation container (`main`/`[role=main]` preferred over `body`, icon-font glyphs `-` stripped) as one block sliced from the END; only changed blocks re-post (`sentEvents` by seq).
 - Answer delivery (top frame only): waits up to 20s for a composer, fills contenteditable via `execCommand('insertText')` with a `textContent` + `InputEvent` fallback (or sets `textarea.value`), settles 400ms, clicks the LAST enabled `aria-label~=send` button, else dispatches Enter keydown/keyup.
-- Panel: fixed bottom-right in the top frame; rows for question/composer/bridge/answer/transcript status + failure diagnostics; collapsible (fold stored in `chrome.storage`, restored async); "Copy report" and "Fill composer (does not send)" buttons.
+- Panel: fixed bottom-right in the top frame; rows for question/composer/bridge/answer/transcript status + failure diagnostics; collapsible down to a compact `TF` tab, full title in the tooltip (fold stored in `chrome.storage`, restored async); "Copy report" and "Fill composer (does not send)" buttons.
 - Child frames run the same survey and `postMessage` findings up to the top frame — a child-frame find means the content lives in an iframe, which is the finding.
 - `watch()`: MutationObserver (debounced 250ms) plus a slow interval backstop (60s); an `alive()` guard disconnects both once the extension context dies.
 

--- a/spike/cc-web-extension/manifest.json
+++ b/spike/cc-web-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "The Framework: Claude web bridge",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Shows the question a Claude Code cloud session is parked on in your local The Framework dashboard, and types the answer you pick there back into the session.",
   "permissions": [
     "storage",


### PR DESCRIPTION
## What

Follow-up to #1333. Collapsed, the bridge panel kept its full `The Framework bridge v0.7.2` title bar, so the fold gave back height but held the corner at nearly full label width. Now the collapsed panel shrinks to a small `TF` tab: compact label, tighter padding, full name and version in the tooltip.

## How

- `render()` swaps the title to `TF` when folded and moves the full `The Framework bridge v…` label to the span's tooltip, so the version stays checkable without unfolding.
- Collapsed padding tightens to `6px 8px` (expanded keeps `10px 12px`), alongside the existing `width: auto`.
- Comments and specs (`content.spec.md`, `check.spec.md`, README) updated to describe the compact tab.
- Manifest bumped to 0.7.3, since the panel's version line is how a stale content script is told apart from a current one.

## Testing

The harness's collapse case now asserts the compact form: folded, the panel text carries `TF` and **not** the full title; unfolded, the title and rows come back intact. All 14 cases pass offline (`node --experimental-vm-modules check.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8UCUL9zRqA7ZU7ZnG8wz4

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8UCUL9zRqA7ZU7ZnG8wz4)_