### PR TITLE
docs: complete spec.md coverage — remaining product-core specs

### DIFF
--- a/packages/the-framework/spec.md
+++ b/packages/the-framework/spec.md
@@ -1,0 +1,15 @@
+`@gemstack/the-framework` — the product package: turnkey, zero-config AI orchestration ("Vite for AI") that wraps a coding-agent CLI (Claude Code today; Codex, GitHub Actions, cloud too) as a black box and takes an idea to a running app, with a CLI + daemon + localhost dashboard.
+
+## TLDR
+
+- `src/` — all implementation: CLI/daemon, run orchestration on ai-autopilot's spine, the driver seam, run store/worktrees, presets, quota, Discord bridge, dashboard serving (see `src/spec.md`).
+- `prompts/` — the prompting, authored as markdown and compiled into `src/prompts.generated.ts` at build time: `system_prompt.md` (ships verbatim from issue #326), `on_before_mergeable_prompt.md`, `ticketing_format.md`, `todo_format.md`, `presets/*.md` (16 preset prompts: security_audit, spike_and_plan, drain_queue, triage_*, research, ux, ...), `protocols/*.md` (await, browser, hands_off, signal).
+- `scripts/` — `gen-prompts.mjs` (md → ts), `check-prompt-drift.mjs` (prompts vs issue #326), `bundle-dashboard.mjs` (embed the prerendered dashboard), `run-tests.mjs`.
+- Docs: `README.md` (product + library API), `VISION-ROADMAP.md`/`VISION-BRAINSTORMING.md` (planning notes), `CHANGELOG.md`.
+
+## Facts
+
+- package.json: bin `the-framework` → `dist/bin.js`; publishes only `dist/`; exports `.` (full library), `./dashboard-rpc` (Telefunc surface for the dashboard app), `./client` (browser-safe client). Runtime deps are just `@gemstack/ai-autopilot`, `telefunc`, `yaml`; Node >= 22.12.
+- Every build/test/typecheck script runs `gen-prompts.mjs` first — `src/prompts.generated.ts` is generated, git-ignored, and required to compile.
+- The dashboard UI itself lives in the private sibling package `framework-dashboard`; its prerendered client bundle is copied into this package's dist for release (`bundle:dashboard`), with a legacy fallback page when absent.
+- Core stance (README): the framework does not run its own agent — it prompts, lets the agent's own loop run, reads the code, and gates on the outcome; the wrapped agent keeps its subscription auth and stays swappable.

--- a/packages/the-framework/src/dashboard/spec.md
+++ b/packages/the-framework/src/dashboard/spec.md
@@ -1,0 +1,25 @@
+The daemon-side dashboard backend: the HTTP server that hosts the prerendered SPA + Telefunc RPC surface, the read-only projections it serves (projects, runs, queue, tickets, git/PR state), the handoff and notification machinery, and the relay/bridge endpoints for remote runs and cloud sessions.
+
+## TLDR
+
+- **Server & transport**: `server.ts` (HTTP host, routing, #1051 token guard), `telefunc-serve.ts` (Telefunc mount, `DashboardContext` seam, CSRF guard), `static.ts` + `content-type.ts` + `bundle.ts` (SPA bundle serving/locating), `types.ts` (the Start/Add/Preview RPC vocabulary leaf).
+- **Project & run projections**: `projects.ts` (registry → summaries, the `ProjectsProvider` seam per host), `overview.ts` (working-now/recents/hot-tickets), `dashboard.ts` (#471 landing-page rollup), `queue.ts` (cross-project TODO parse), `docs.ts` (surfaced PLAN/TODO docs), `tickets.ts` (the `tickets/` backlog reader), `quota.ts` (usage-panel view).
+- **Git/GitHub reads**: `gh.ts` (the one `gh` adapter + PR caches + run-PR attribution), `cache.ts` (stale-while-revalidate read-through cache, #1028), `git-status.ts`, `github.ts` (origin → github.com URL), `file-status.ts`, `file-diff.ts`, `file-read.ts` (confined per-file reads for hover cards).
+- **Handoff**: `run-handoff.ts` — what a finished session left on its branch, push/open-PR actions, and the #1102 armed auto-handoff.
+- **Notifications**: `keyed-watcher.ts` (baseline-diff poll engine), `interventions.ts` ("needs you": PRs / parked gates / unpushed work), `activity.ts` (started/finished feed), `keys.ts` (pure item identities shared with the browser), `discord-webhook.ts` (the one webhook transport).
+- **Remote & bridge**: `relay-endpoints.ts` + `remote-run.ts` (device-to-device run relay, #1067), `browser-proxy.ts` (run's MJPEG browser preview, #813), `bridge-endpoints.ts` + `bridge-store.ts` + `bridge-sessions.ts` (Claude-web extension bridge for cloud-session questions, #1237).
+- **Actions**: `open-in-app.ts` (reveal in file manager / open in editor, editor detection).
+
+## Decisions
+
+- Everything the UI shows is a pure projection of on-disk files (`run.json`, `runs/`, `LOGS.md`, `TODO_AGENTS.md`, `tickets/`) or of git/gh reads — the server holds no run state of its own; live events stream over the Telefunc Channel from `events.jsonl`, steering goes through `control.jsonl`.
+- One `DashboardOptions`/`DashboardContext` seam, three hosts: the daemon wires everything; the per-run foreground dashboard wires a single-project provider; the public relay wires an empty provider + in-memory events source so file/registry RPCs return nothing unauthenticated.
+- Readers are forgiving throughout: a project that is missing, not a repo, without remote, or without `gh` contributes nothing or degrades — never a throw into a panel or watcher.
+- Slow `gh` reads (~600ms) go through `cache.ts` and are allowed to arrive late (`pending`/`prPending`, #1028), so polls repaint on ~10ms git reads; write actions invalidate the relevant keys.
+- Auth is layered by route class: the #1051 cookie guard on non-loopback binds, same-origin CSRF on `/_telefunc`, the bridge's own bearer token (the one deliberately cross-origin route), and the relay riding the #1051 cookie daemon-to-daemon.
+- Handlers dispatched void must never throw (#938): an unhandled rejection kills the daemon, so parsers and static serving swallow malformed input into fallbacks.
+
+## Facts
+
+- Cross-file contracts: `keys.ts` item identities are the daemon's dedupe keys AND the browser's (shared via client.ts); `queue.ts`'s list-item rule must match the sweep's `parseTodoEntries` (#1296); `parseNumstat` in `file-diff.ts` is the one numstat parser (run-handoff.ts imports it); session branches live under `the-framework/` (`SESSION_BRANCH_PREFIX`).
+- `RunMeta.sessionId` joins cloud runs to bridge questions; `RunMeta.ticket` joins live runs to hot tickets (#1117).

--- a/packages/the-framework/src/events.spec.md
+++ b/packages/the-framework/src/events.spec.md
@@ -1,0 +1,25 @@
+The single `FrameworkEvent` union the whole run streams over — bootstrap narration, the wrapped agent's own progress, and framework-level status unified into one timeline (guardrail #2, #165) — plus the interactive choice-gate types.
+
+## TLDR
+
+- Event kinds: `session`, `session-update`, `system-prompt` (#343), `bootstrap`, `driver` (forwarded verbatim, never gated on), `preview`, `browser-stream` (#813), `log`, `view` (#441), `session-name` (#326), `ready-for-merge`, `on-before-mergeable` (#835), `handoff-armed` (#1102), `ticket` (#1117), `queue-entry` (#1253), `branch` (#1277), `handoff` (#1102), `settled` (#785), `bind` (#1121), `usage` (#322), `modes` (#272), `choice` (#304), `choice-resolved`, `end`.
+- `ChoiceRequest` (#304): an interactive gate the run parks on until a pick arrives; variants: multi-select checklist (#332, pick resolves to a subset of ids), Approve/Decline confirm (#358), `autoAcceptMs` default 10s under autopilot, optional `file` for the doc sidebar.
+- Skip-reason unions `OnBeforeMergeableSkip` (#835) and `AutoHandoffSkip` (#1102): every decline carries one, so "it was on and nothing happened" has an answer in the log.
+- `ChoiceBy` = `user` | `autopilot` | `auto`; `pickedIds` normalizes single-id/subset picks; `OPEN_LOOP_MODES` = `['autopilot', 'technical']` is the single source for the mode checkboxes.
+
+## Decisions
+
+- We own this stream rather than surfacing the agent's transport directly (guardrail #2, #165); the dashboard and terminal render one timeline from it.
+- Several facts are events rather than start arguments or stdout because *only an event reaches the run's meta*, and the meta is what a dashboard tab opened mid-run can read: `ticket`, `queue-entry`, `handoff-armed`. Likewise `on-before-mergeable` and `handoff` outcomes are events because a dashboard-started run is spawned with `stdio: 'ignore'` — an outcome that is not an event is an outcome nobody learns.
+- `browser-stream` carries only the port: the dashboard reaches the stream through the daemon's proxy so the run's bridge stays unreachable from the web, and frames never enter the log — someone will type a password into that pane.
+- `branch` is observed off the checkout, emitted at start and again on rename; before it the branch was stamped only at teardown (#799) and earlier reads guessed among three naming schemes.
+- `settled` marks the run parked on the user as a conversation (#714), undone by the next `driver` `start`, so "working or waiting for me" is answerable from the log rather than inferred from a status that only changes at the end.
+- `queue-entry` exists because the drain's claim must outlive the sweep's memory: a daemon restart, or a hands-off run whose local process ends while a cloud session still works the entry.
+
+## Facts
+
+- `usage.costUsd` is absent when the agent reports tokens but no price (#540) — which is also when no budget cap can fire.
+- `end` distinguishes `stopped` (user interrupt: Stop button / Ctrl+C) from failure, so surfaces show "stopped" rather than "failed".
+- `session-update` re-emits when the id changes — each Claude Code prompt is a fresh session — keeping the session link current.
+- `view.id` is stable per title so re-showing a view updates in place instead of stacking duplicates.
+- `AutoHandoffSkip.already-open` guards the one mistake the handoff must not make: opening a second PR for a branch that has one.

--- a/packages/the-framework/src/fake-script.spec.md
+++ b/packages/the-framework/src/fake-script.spec.md
@@ -1,0 +1,8 @@
+The deterministic `--fake` demo scenario: a scripted `FakeDriver` whose turns walk the exact prompt order of the scope→deploy flow (build, checklist-with-blocker, improve, clean checklist) for a small Vike + Prisma orders app — fully offline, no CLI, no model, driven entirely through the driver seam.
+
+## TLDR
+
+- Exports `FAKE_INTENT` (paginated orders page with sign-in), `FAKE_SIGNALS` (vike-react/react/@prisma/client deps so the Vike preset wins detection), `FAKE_DEPLOY` (ssr on cloudflare), and `fakeDriver()` (sessionId `fake-orders-app`).
+- Each turn carries a small plausible usage so the demo shows spend accumulating (#322).
+- `FRAMEWORK_FAKE_AWAIT=choices|multiselect|confirmation` swaps the build turn for one ending in an ```await-choices```/```await-multiselect```/```await-confirmation``` block, followed by a `RESUME_TURN` — so the turn-boundary gates (#337 single-select, #339 multi-select, #358 confirmation) can be seen offline. Needs the dashboard on, so `requestChoice` is wired.
+- Mirrors the ai-autopilot bootstrap-quickstart, ending production-grade (blocker found, fixed, clean re-review).

--- a/packages/the-framework/src/format-bytes.spec.md
+++ b/packages/the-framework/src/format-bytes.spec.md
@@ -1,0 +1,1 @@
+Formats a byte count as a glanceable label (#798): `1536` → `1.5 KB` (one decimal below 10 when unit > B, whole numbers otherwise, units B..TB); absent/negative/unparseable reads as an en dash like a missing date.

--- a/packages/the-framework/src/framework-dir.spec.md
+++ b/packages/the-framework/src/framework-dir.spec.md
@@ -1,0 +1,1 @@
+Exports the `THE_FRAMEWORK_DIR = '.the-framework'` constant as its own module because it is the one piece of `logs.ts` the browser needs (preset `filePath`s, #874; dashboard preset rendering, #520) and `logs.ts` imports `node:path` so it cannot go there.

--- a/packages/the-framework/src/host-exec.spec.md
+++ b/packages/the-framework/src/host-exec.spec.md
@@ -1,0 +1,11 @@
+A `DeployExecutor` that runs shell commands on the host in the workspace the wrapped agent built, so real deploy targets (e.g. `cloudflareTarget`) can install/build/run `wrangler` against the code the agent just wrote.
+
+## TLDR
+
+- `hostExecutor(cwd, opts)` → `{ exec(command, execOpts) }` via `node:child_process` `exec`; relative `execOpts.cwd` resolves against the workspace `cwd`, env layers `opts.env ?? process.env` under per-call overrides.
+- Never rejects: non-zero exit or spawn error resolves to an `ExecResult` `{ stdout, stderr, exitCode }`, matching the runner-session contract deploy targets expect.
+
+## Facts
+
+- Exists because ai-autopilot's `LocalRunner` cannot serve deploys: it mkdtemps a fresh workspace and deletes it on dispose, so deploys must run on the host in the persistent workspace instead.
+- Default output buffer is 16 MiB per command; `execOpts.timeoutMs` defaults to 0 (no timeout).

--- a/packages/the-framework/src/index.spec.md
+++ b/packages/the-framework/src/index.spec.md
@@ -1,0 +1,11 @@
+Public API barrel of `@gemstack/the-framework` — re-exports the whole product surface and documents the package's thesis: wrap a coding-agent CLI as a black box and drive it from idea to running app.
+
+## TLDR
+
+- Pure re-export file; the doc comment is the package's front door: built on `@gemstack/ai-autopilot`'s spine, this package adds the two #166 pieces — the driver seam and the product shell (CLI + daemon + dashboard).
+- Export groups: driver seam (`Driver`/`DriverSession`, Claude Code/fake drivers, `createDriver`), driver-backed bootstrap steps, run orchestration (`runFramework`, events, await gates), the store (`RunStore`, run meta, JSONL files), project/registry/install, presets + prompt templating + system prompt, daemon + control channel + auto-PM + todo loop, dashboard (`startDashboard` and its many projection types), quota/consumption guards, logs/conversations, CLI (`runCli`).
+
+## Facts
+
+- The driver-seam guardrail stated here: the seam is the code the agent produced, never the agent's tool calls.
+- `system-prompt-file.js` is split from `system-prompt.js` so the pure composition stays browser-safe (#520); re-exported here so the entry's surface is unchanged.

--- a/packages/the-framework/src/install.spec.md
+++ b/packages/the-framework/src/install.spec.md
@@ -1,0 +1,18 @@
+Installs/activates a repo for The Framework (#391) — creates the `.the-framework/` marker with a seeded `LOGS.md` — and enumerates git repos for the repos-directory auto-registration.
+
+## TLDR
+
+- `installProject(cwd, deps)` — activate: commit any pre-existing dirty changes first (so the install commit is clean), `git init` when the folder isn't a repo yet, create `.the-framework/` + `LOGS.md`, seed `.the-framework/.gitignore`, materialize the quality presets, commit as `[The Framework] install The Framework`.
+- Failures are values, never throws: `{ ok: true, alreadyActivated?, initialized? } | { ok: false, error }`; a repo whose `LOGS.md` already exists is a no-op.
+- `enumerateGitRepos(dir, deps)` — the immediate child directories that are their own git repo roots, deduped and sorted; used by the repos-directory scan.
+- Pure core over injectable `GitRunner` + `StoreFs` + `DirLister` seams (`nodeDirLister` dynamic-imports `node:fs/promises`).
+
+## Decisions
+
+- Auto-`git init` non-repos instead of erroring: The Framework treats git as the source of truth.
+- Repo-root detection uses `git rev-parse --show-prefix` (empty = root) rather than comparing `--show-toplevel` paths, which breaks across symlinks (e.g. macOS `/var` → `/private/var`).
+- Presets are materialized into `.the-framework/` but kept out of git so they track the installed framework version instead of going stale in repo history (#326); the ticket-format spec is deliberately NOT materialized — it ships inside the package and is referenced via its `node_modules` path (#674, #683).
+
+## Facts
+
+- The committed database is `LOGS.md` (#313) plus conversations (#908); transient run state (`events.jsonl` / `run.json` / `runs/`) is gitignored via the seeded `.gitignore`.

--- a/packages/the-framework/src/turn-gate.spec.md
+++ b/packages/the-framework/src/turn-gate.spec.md
@@ -1,0 +1,28 @@
+The code side of the await/signal protocols (#337/#339): the protocol constants injected into the system channel, and the parsers that detect what an agent turn's final text emitted — blocking await gates, non-blocking views, and lifecycle signals.
+
+## TLDR
+
+- Protocol constants (text lives in `prompts/protocols/*.md`, #551): `AWAIT_PROTOCOL` (how to emit an awaited choice), `SIGNAL_PROTOCOL` (setSessionName()/setReadyForMerge()), `BROWSER_PROTOCOL` (#824, prefer chrome-devtools over WebFetch), `HANDS_OFF_PROTOCOL` (#1234, gates taught then declared unavailable).
+- Gate parsers, one per fenced-block tag: `await-choices` (#337, single-select with optional `recommended` by id or label), `await-multiselect` (#339), `await-confirmation` (#358, fixed Approve/Decline, optional `file`), `await-browser` (#796, human must *do* something — login wall/captcha; optional `url`), `await-bind-project` / `await-create-project` (#1121, topic runs).
+- `parseAwaitGate()`: whichever gate the turn ended on — when several block kinds are present the latest in the text wins, and a malformed later block falls back to an earlier one; `undefined` = the agent just finished (the common case).
+- Non-blocking signals: `parseMarkdownViews()` (#441, `show-markdown` blocks → side-panel views, id = title slug so re-shows update in place), `parseSessionName()` (last `set-session-name` block, slugified to the branch-name shape), `parseReadyForMerge()`.
+- `createTurnSignalEmitter()`: emits a turn's signals with dedupe state held across the turns it covers — `ready-for-merge` fires once, a session name only re-emits on an actual rename; one emitter per span of turns (a build's await rounds, the whole backlog).
+- `continuationPrompt()` + `MAX_AWAIT_ROUNDS` (5) + `isDeclinedConfirmation()`: the resume wording, ask-cap, and decline test every gated path shares.
+
+## Problems
+
+- The driver runs each agent turn as a black box to completion (#165), so a signal in the turn's final message is the only way the framework can learn the agent stopped to ask rather than deciding for itself — which is why the protocol pins *how* to emit, not *when* (the system prompt owns that).
+- Every parser is tolerant by design: a malformed block yields `undefined` (or a fallback title) rather than throwing — a bad parse must never crash a build. Label-less options are dropped; ids are synthesized (`opt:<i>`) when the agent named none; non-string fields are dropped rather than shown as "undefined".
+
+## Decisions
+
+- `parseSessionName` tests emptiness directly rather than via a fallback sentinel: a sentinel made a session legitimately named `view` indistinguishable from no name at all (#939).
+- `await-bind-project` carries only a title — the framework fills the project list from the registry at resolution time, so the agent never guesses which projects exist; an empty/malformed body still triggers the gate rather than being dropped.
+- A create-project confirmation IS the permission grant (registering a path hands the app filesystem access), so its resolution recommends Approve like a plan confirmation.
+- One `continuationPrompt` wording for every path (#570): the per-caller clause variants carried no distinct meaning; no "do not ask again" tail (babysitting left off until a run shows it is needed).
+- `MAX_AWAIT_ROUNDS` is a property of the protocol, shared, because build / direct prompt / backlog loop each used to declare their own.
+
+## Facts
+
+- Answer constants: `CONFIRM_APPROVED`/`CONFIRM_DECLINED` = `Approve`/`Decline`; `BROWSER_HANDLED`/`BROWSER_NOT_HANDLED`; `CREATE_PROJECT_APPROVE` = `Register and bind` / `CREATE_PROJECT_DECLINE` = `Not now`; `NO_PROJECTS_TO_BIND` for a bind gate over an empty registry.
+- Fenced-block grammar: last block of a tag wins within a turn; options gates require a JSON body with an `options` array; record gates (`confirmation`/`browser`/`create-project`) are a title plus one optional string field.

--- a/packages/the-framework/src/update-check.spec.md
+++ b/packages/the-framework/src/update-check.spec.md
@@ -1,0 +1,7 @@
+The CLI's "up-to-date?" check (#312): after the bare-`framework` version footer, tell the user whether a newer `@gemstack/the-framework` is on npm. Display only; auto-update is deferred.
+
+## TLDR
+
+- `nodeVersionFetcher()`: GETs the npm packument, reads `dist-tags.latest`, capped by a 2.5s `AbortSignal.timeout`; any error/non-ok/offline yields `undefined` (silently degrades to `unknown`, which `formatUpdateStatus` prints as nothing).
+- `compareVersions()`: numeric `major.minor.patch` compare, prerelease/build suffix stripped, missing parts read as 0 — no semver dependency.
+- `checkForUpdate()`: `current >= latest` is `up-to-date`, so running a local build ahead of the registry never reads as "update available". Same seam + node-adapter + forgiving-on-error convention as `project.ts` (#380).

--- a/packages/the-framework/src/usage.spec.md
+++ b/packages/the-framework/src/usage.spec.md
@@ -1,0 +1,6 @@
+`UsageMeter`: accumulates per-turn `DriverUsage` (tokens + cost + turn count) into a running total for the whole run, which the budget cap gates on (#322).
+
+## TLDR
+
+- `costUsd` starts absent rather than `0` and only appears once a turn reports a price: an agent that never prices a turn must not accumulate a total that reads as "this run was free" (#540). An unpriced turn still counts its tokens.
+- Tracks what *this run* spent — a separate question from where the account's subscription quota stands, which the agent reports per turn as `DriverRateLimit` (#517). (An earlier note claimed the account limit was unreachable under subscription auth; it isn't.)

--- a/packages/the-framework/src/worktrees.spec.md
+++ b/packages/the-framework/src/worktrees.spec.md
@@ -1,0 +1,22 @@
+Management of a project's retained run worktrees (#752): list, remove one, delete a whole session, prune all — the one implementation behind both the `framework worktrees` CLI verb and the dashboard's buttons.
+
+## TLDR
+
+- `listProjectWorktrees()`: every worktree dir with its run meta (branch/status), newest first; a live run's checkout is included and flagged `live` rather than hidden ("what is this directory and why can I not remove it" is exactly the question the list answers). Sizes skipped for live runs (a tree an agent is writing to gives a stale number) and when the caller opts out.
+- `removeProjectWorktree()` (#752/#737): reclaims the checkout, keeps the session's row and replayable log (history was archived at finish). Refuses while the run is running, and commits whatever the checkout still holds before removing — refusing when that commit fails (#982).
+- `deleteProjectRun()` (#1032): the destructive sibling — removes the archive too (run meta `<id>.json` and event log `<id>.jsonl`, wherever filed), so the row is gone for good; the worktree is force-removed (uncommitted work goes with the thrown-away session).
+- `pruneProjectWorktrees()`: remove every non-live worktree; live ones reported as skipped so counts always add up to what the list showed.
+- `formatWorktreeList()`: the pure, testable CLI table (SESSION/STATUS/SIZE/BRANCH), with a friendly message instead of an empty table.
+
+## Problems
+
+- The two surfaces used to be two copies of the same checks and had already drifted: a bogus session id read as a raw git error on one and a plain sentence on the other.
+- A worktree is only *retained* when its run failed or was stopped — precisely when it still holds uncommitted agent work — and `removeWorktree` forces past a dirty tree, so without the commit-first step both surfaces reliably deleted the very diff the checkout was kept for (#982).
+- Since #1179 sessions are archived under whichever user ran them, so a run id alone no longer names its archive path — `archivedRunPaths` looks the files up. Deletion tolerates absent files so a half-deleted session still finishes cleanly.
+
+## Decisions
+
+- Both remove and delete refuse while the run is still going: Stop is how a run ends, not pulling the floor out from under its agent.
+- Delete deliberately leaves what is git's, not the dashboard's: the branch (which may carry merged work or an open PR), the committed `LOGS.md` line, and the conversation record — delete means "remove from the dashboard", not "erase every trace". Since #1179 the archive is committed, so the deletion is itself a change git records.
+- `beforeRemove` hook: the dashboard stops the preview serving that tree (#797); the CLI has none to stop.
+- `isSafeRunId` guards both entry points before any path is built from the id.

--- a/spike/cc-web-extension/options.spec.md
+++ b/spike/cc-web-extension/options.spec.md
@@ -1,0 +1,13 @@
+The extension's options page logic: stores the daemon URL + bridge token in extension storage (so nothing on claude.ai can read the secret) and proves the connection end to end on save.
+
+## TLDR
+
+- Loads/saves `daemonUrl`, `token`, `autoOpen` via `chrome.storage.local`; auto-open defaults on once configured but is stored explicitly so the worker never guesses.
+- "Save then prove it": after saving, checks host permissions, pings `/_bridge/ping` with the bearer token, and distinguishes every failure (401 wrong token, 404 bridge off, unreachable daemon).
+- Also probes `/_bridge/sessions` so "connected" answers the next question too: is there anything to watch?
+- An "Open now" button triggers the worker's tab sweep on demand (`tf-open-now` message) instead of waiting for the once-a-minute alarm, reporting exactly why nothing opened.
+
+## Problems
+
+- Manifest-declared host permissions are not the same as granted ones: Chrome's per-site toggles can sit off for an unpacked extension, and since the daemon sends no CORS headers by design, the worker's fetch dies in the browser looking like any other failure — so grants are checked first now.
+- A 200 from the ping is not proof: the dashboard serves its SPA for unknown paths, so an old build answers 200 + HTML; the body must literally be `ok`.


### PR DESCRIPTION
## What

Follow-up to #1335, which was (auto-)merged mid-generation: adds the 14 specs the squash didn't include, completing the spec.md coverage of the codebase's business logic.

- `packages/the-framework/spec.md`, `src/dashboard/spec.md` — package and dashboard-backend directory overviews
- `src/` file specs: `events`, `turn-gate`, `worktrees`, `usage`, `update-check`, `install`, `host-exec`, `index`, `fake-script`, `format-bytes`, `framework-dir`
- `spike/cc-web-extension/options.spec.md`

## Verification

- Coverage re-verified against the current tree: **629 specs = 548 business-logic source files + 81 directories**, none missing, none out of scope.
- Specs `main` gained after the merge (e.g. for #1326 agent auth, #1359 gate keepalive) were left untouched — this branch was restarted from `main` and the diff is purely additive: 14 new files, zero modifications.
- Same scope rules as #1335: tests, demos/examples, styling, markup, assets, and CI plumbing carry no specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYZmRjbqWRkc6K7Zp6DqsK

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYZmRjbqWRkc6K7Zp6DqsK)_