### PR TITLE
feat: retire the session-scoped TODO_<slug>.agent.md backlog (#1369)

### DIFF
--- a/.changeset/retire-session-scoped-todo.md
+++ b/.changeset/retire-session-scoped-todo.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+Retire the session-scoped `TODO_<slug>.agent.md` backlog (#1369) — `TODO_AGENTS.md` superseded it. The [Research] preset (its last writer) now points its `TODO_FILE` at the flat queue, and the session-scoped machinery is deleted: `TODO_FILE_PATTERN` and the scoped branch of the backlog lookup are gone, so `findTodoBacklog` / `appendTodoEntry` read and write only the flat file (`TODO_AGENTS.md`, or a legacy `tickets/TODO.md` / root `TODO.md`). A leftover session file in a checkout is ignored, not drained. The backlog loop itself (`todo-loop.ts`) is untouched — it is the `TODO_AGENTS.md` reader and stays load-bearing.

--- a/packages/the-framework/prompts/presets/research.md
+++ b/packages/the-framework/prompts/presets/research.md
@@ -9,5 +9,5 @@ Measure "problem variability" of ${{ tf.params.what }}
 
 AWAIT: Stop, await user answer before resuming
 REVIEW_FILE: `REVIEW-PROBLEMS_<SESSION_NAME>.agent.md`
-TODO_FILE: `TODO_<SESSION_NAME>.agent.md`
+TODO_FILE: `TODO_AGENTS.md`
 SESSION_NAME: the name of the current Git branch — sanitize it to be a SLUG, if name is generic (e.g. `main`) then create a succinct SLUG

--- a/packages/the-framework/src/index.ts
+++ b/packages/the-framework/src/index.ts
@@ -334,7 +334,6 @@ export {
   findTodoBacklog,
   parseTodoEntries,
   insertTodoEntry,
-  TODO_FILE_PATTERN,
   FLAT_TODO_FILE,
   LEGACY_HYPHEN_TODO_FILE,
   LEGACY_TICKETS_TODO_FILE,

--- a/packages/the-framework/src/preset-catalog.test.ts
+++ b/packages/the-framework/src/preset-catalog.test.ts
@@ -108,12 +108,15 @@ test('UX runs to completion instead of gating on a human (#962)', () => {
   assert.match(out, /that's a sign you've been lazy/)
 })
 
-test('Research gates on a multi-select and writes its own review/TODO files (#331)', () => {
+test('Research gates on a multi-select and writes its own review file (#331)', () => {
   assert.match(presets.research.template, /problem variability/)
   assert.match(presets.research.template, /showMultiSelect\(\)/)
   assert.match(presets.research.template, /<AWAIT>/)
   assert.match(presets.research.template, /<REVIEW_FILE>/)
   assert.match(presets.research.template, /<TODO_FILE>/)
+  // #1369: the deep-dive picks land on the flat queue, not a session-scoped backlog.
+  assert.match(presets.research.template, /TODO_FILE: `TODO_AGENTS\.md`/)
+  assert.doesNotMatch(presets.research.template, /TODO_<SESSION_NAME>/)
 })
 
 test('the Maintenance template queues work rather than doing it (#881)', () => {

--- a/packages/the-framework/src/run.ts
+++ b/packages/the-framework/src/run.ts
@@ -208,7 +208,7 @@ export interface RunFrameworkOptions {
   consumptionGate?: () => string | null
   /**
    * Run the backlog loop (#323) after the build settles: consume the agent's own
-   * `TODO_<slug>.agent.md` / `TODO_AGENTS.md` one entry per turn until empty, gating
+   * `TODO_AGENTS.md` one entry per turn until empty, gating
    * before each entry when {@link requestChoice} is wired. Default: on for real
    * drivers, off for the fake one (its scripted demo writes no backlog and must
    * stay deterministic). Set explicitly to force either way.

--- a/packages/the-framework/src/tickets.spec.md
+++ b/packages/the-framework/src/tickets.spec.md
@@ -2,7 +2,7 @@ The repo conventions for the human-facing roadmap: the `tickets/` directory (#62
 
 ## TLDR
 
-- `TICKETS_DIR` = `tickets/` (only ticket files, `<DATE>_<SLUG>.md`, since #682 moved the backlog out); `FLAT_TODO_FILE` = root `TODO_AGENTS.md` — the durable AI task queue a run drains and the dashboard surfaces (session-scoped `TODO_<slug>.agent.md` files are separate).
+- `TICKETS_DIR` = `tickets/` (only ticket files, `<DATE>_<SLUG>.md`, since #682 moved the backlog out); `FLAT_TODO_FILE` = root `TODO_AGENTS.md` — the durable AI task queue a run drains and the dashboard surfaces (the session-scoped `TODO_<slug>.agent.md` files are retired, #1369).
 - `findFlatTodo()`: locates the flat backlog newest-convention-first: `TODO_AGENTS.md` → legacy `TODO-AGENTS.md` (hyphen spelling from the #682 brief) → `tickets/TODO.md` (#629 location) → root `TODO.md` (pre-#629). New backlogs are always created at `FLAT_TODO_FILE`.
 - `todoPriorityForTicket()` (#1164): maps a ticket's `priority:` words onto the backlog's number scale — urgent→9, high→7, low→2, unmarked→5.
 - `ticketFromQueueEntry()` / `isTicketPath()` (#1117): read a queue entry's markdown link back to its ticket; only `tickets/<name>.md` counts (no relative segments, absolute paths, URLs, dotfiles, or nesting) — one gate for both ends of the link, since the result is a path the dashboard renders and a reader opens.

--- a/packages/the-framework/src/tickets.ts
+++ b/packages/the-framework/src/tickets.ts
@@ -14,8 +14,8 @@ export const TICKETS_DIR = 'tickets'
  * The flat, durable backlog/roadmap file — the confirmed-task queue (the "AI task queue"
  * the #683 context fragment names). Lives at the repo root as `TODO_AGENTS.md` (#682):
  * moved out of `tickets/` so that directory holds only tickets. This is the file a run
- * drains and the dashboard surfaces; the session-scoped `TODO_<slug>.agent.md` files the
- * system prompt writes are separate and also live at the root.
+ * drains and the dashboard surfaces — the only backlog kind since the session-scoped
+ * `TODO_<slug>.agent.md` files were retired (#1369).
  */
 export const FLAT_TODO_FILE = 'TODO_AGENTS.md'
 

--- a/packages/the-framework/src/todo-loop.spec.md
+++ b/packages/the-framework/src/todo-loop.spec.md
@@ -3,8 +3,8 @@ The backlog loop (#323): once the main work settles, consume the agent's own TOD
 ## TLDR
 
 - `parseTodoEntries()`: open entries = markdown list items (`-`, `*`, `1.`) whose checkbox is absent or unchecked; checked `[x]` = done; headings/prose/blanks are not entries.
-- `backlogCandidates()` / `findTodoBacklog()`: the most recently modified session-scoped `TODO_<slug>.agent.md` first (the newest is this run's), then the flat file via `findFlatTodo`.
-- `appendTodoEntry()` (whichever backlog wins) vs `appendFlatTodoEntry()` (the durable global queue specifically — a human's dashboard pick landing in some run's own backlog could quietly never be seen again, #697/#624/#852).
+- `findTodoBacklog()`: the flat file via `findFlatTodo` (`TODO_AGENTS.md`, or a legacy `tickets/TODO.md` / root `TODO.md`); a leftover session-scoped `TODO_<slug>.agent.md` is ignored (#1369).
+- `appendTodoEntry()` (plain append — resume notes and agent follow-ups) vs `appendFlatTodoEntry()` (priority placement for dashboard picks, #697/#1164). Both write the flat queue — the durable one `promoteQueue` carries between branches (#624/#852).
 - `insertTodoEntry()` (#1164): pure priority placement into the `## Priority N` sections — join an existing section's end, create before the first lower-priority section, or land above the first heading; a plain append had put a just-queued ticket at the *end* of the file, worked last.
 - `nextQueuedTicket()` / `ticketForPrompt()` (#1117): the ticket the next drain run will pick up (first open entry of the flat backlog, same read as the sweep's) — a best guess that only labels an Overview lane, never starts or steers a run.
 - `leaveResumeNote()` (#529): a paused run leaves `Resume <session-name>` on the backlog so a later run picks the work back up — the backlog is already what a run drains, so a resume note needs no machinery of its own.
@@ -22,10 +22,10 @@ The backlog loop (#323): once the main work settles, consume the agent's own TOD
 - One `createTurnSignalEmitter` for the whole backlog, so `ready-for-merge` fires once across every item and a session name only re-emits on an actual rename.
 - A backlog turn is a turn like any other: await gates and signals are honored (via `runAwaitRounds`); a declined plan ends the item turn and the stall check takes it from there.
 - Plain append (no priority) is kept for resume notes and agent follow-ups: those are a running list whose order is theirs.
+- The session-scoped `TODO_<SESSION_NAME>.agent.md` backlog is retired (#1369): `TODO_AGENTS.md` superseded it — the system prompt migrated long ago, and the [Research] preset (its last writer) now points at the flat queue too. A leftover session file in a checkout is ignored, not drained.
 
 ## Facts
 
-- `TODO_FILE_PATTERN` = `/^TODO_[a-z0-9-]+\.agent\.md$/` (the session-scoped filename the #326 prompt writes).
 - The item prompt pins scope: "work on the FIRST open entry only … check the entry off (or remove it). Do not start any other entry."
 - Drain detection (`ticketForPrompt`) keys off `drainsQueue(prompt)` from the preset catalog.
 

--- a/packages/the-framework/src/todo-loop.test.ts
+++ b/packages/the-framework/src/todo-loop.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { writeFileSync } from 'node:fs'
-import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { FakeDriver } from './driver/fake.js'
@@ -58,7 +58,7 @@ test('the #880 priority sections need no parser support: headings are skipped, s
   ])
 })
 
-test('findTodoBacklog prefers the newest session-scoped file, falls back to flat TODO.md', async () => {
+test('findTodoBacklog reads the flat backlog and falls back to a flat TODO.md', async () => {
   const cwd = await tmpWorkspace()
   try {
     assert.equal(await findTodoBacklog(cwd), undefined) // nothing yet
@@ -66,20 +66,9 @@ test('findTodoBacklog prefers the newest session-scoped file, falls back to flat
     await writeFile(join(cwd, 'TODO.md'), '- flat entry\n')
     assert.equal((await findTodoBacklog(cwd))?.name, 'TODO.md')
 
-    // A session-scoped backlog wins over the flat one.
-    await writeFile(join(cwd, 'TODO_feat-x.agent.md'), '- [ ] scoped entry\n')
-    assert.deepEqual(await findTodoBacklog(cwd), { name: 'TODO_feat-x.agent.md', entries: ['scoped entry'] })
-
-    // Two sessions: the most recently modified wins.
-    await writeFile(join(cwd, 'TODO_feat-y.agent.md'), '- newer entry\n')
-    const past = new Date(Date.now() - 60_000)
-    await utimes(join(cwd, 'TODO_feat-x.agent.md'), past, past)
-    assert.equal((await findTodoBacklog(cwd))?.name, 'TODO_feat-y.agent.md')
-
-    // A fully checked-off scoped backlog is skipped in favor of the next candidate.
-    await writeFile(join(cwd, 'TODO_feat-y.agent.md'), '- [x] all done\n')
-    await writeFile(join(cwd, 'TODO_feat-x.agent.md'), '- [x] all done\n')
-    assert.equal((await findTodoBacklog(cwd))?.name, 'TODO.md')
+    // A fully checked-off backlog is no backlog.
+    await writeFile(join(cwd, 'TODO.md'), '- [x] all done\n')
+    assert.equal(await findTodoBacklog(cwd), undefined)
   } finally {
     await rm(cwd, { recursive: true, force: true })
   }
@@ -91,9 +80,9 @@ test('findTodoBacklog reads the flat backlog from the root TODO_AGENTS.md (#682)
     await writeFile(join(cwd, 'TODO_AGENTS.md'), '- [ ] roadmap entry\n')
     assert.deepEqual(await findTodoBacklog(cwd), { name: 'TODO_AGENTS.md', entries: ['roadmap entry'] })
 
-    // A session-scoped backlog still wins over the flat one, wherever the flat one lives.
+    // The retired session-scoped backlog (#1369) is ignored, even when it has open entries.
     await writeFile(join(cwd, 'TODO_feat-x.agent.md'), '- [ ] scoped entry\n')
-    assert.equal((await findTodoBacklog(cwd))?.name, 'TODO_feat-x.agent.md')
+    assert.equal((await findTodoBacklog(cwd))?.name, 'TODO_AGENTS.md')
   } finally {
     await rm(cwd, { recursive: true, force: true })
   }
@@ -127,7 +116,7 @@ test('appendTodoEntry creates the root TODO_AGENTS.md when the workspace has no 
 
 test('runTodoLoop works the backlog to empty, one entry per turn (#323)', async () => {
   const cwd = await tmpWorkspace()
-  const file = join(cwd, 'TODO_feat-x.agent.md')
+  const file = join(cwd, 'TODO_AGENTS.md')
   await writeFile(file, '- [ ] first task\n- [ ] second task\n')
   try {
     const events: FrameworkEvent[] = []
@@ -144,9 +133,9 @@ test('runTodoLoop works the backlog to empty, one entry per turn (#323)', async 
     const session = await driver.start({ cwd })
     const result = await runTodoLoop({ session, cwd, emit: e => events.push(e) })
 
-    assert.deepEqual(result, { completed: 2, reason: 'empty', file: 'TODO_feat-x.agent.md' })
+    assert.deepEqual(result, { completed: 2, reason: 'empty', file: 'TODO_AGENTS.md' })
     assert.equal(prompts.length, 2)
-    assert.match(prompts[0]!, /TODO_feat-x\.agent\.md/)
+    assert.match(prompts[0]!, /TODO_AGENTS\.md/)
     assert.match(prompts[0]!, /FIRST open entry only/)
     // Narrated: the opening count, each item, and the completion line.
     assert.ok(events.some(e => e.kind === 'log' && /has 2 open item\(s\)/.test(e.message)))
@@ -316,7 +305,7 @@ test('an aborted signal ends the loop before starting another entry', async () =
 
 test('a backlog turn emits its signals: views, session name, ready-for-merge', async () => {
   const cwd = await tmpWorkspace()
-  const file = join(cwd, 'TODO_feat-x.agent.md')
+  const file = join(cwd, 'TODO_AGENTS.md')
   await writeFile(file, '- [ ] tidy the login redirect\n')
   try {
     const events: FrameworkEvent[] = []
@@ -353,7 +342,7 @@ test('a backlog turn emits its signals: views, session name, ready-for-merge', a
 
 test('ready-for-merge is emitted once across a multi-item backlog', async () => {
   const cwd = await tmpWorkspace()
-  const file = join(cwd, 'TODO_feat-x.agent.md')
+  const file = join(cwd, 'TODO_AGENTS.md')
   await writeFile(file, '- [ ] first task\n- [ ] second task\n')
   try {
     const events: FrameworkEvent[] = []
@@ -374,21 +363,19 @@ test('ready-for-merge is emitted once across a multi-item backlog', async () => 
   }
 })
 
-// #697: a human queueing a ticket from the dashboard means the project's queue, not whichever
-// run's session-scoped backlog happens to be lying in the checkout. Only the flat file is
-// carried between branches by promoteQueue (#852), so the other one can vanish unseen.
-test('appendFlatTodoEntry writes the flat queue even when a session backlog exists (#697)', async () => {
+// #697/#1369: everything lands on the project's flat queue — a leftover session-scoped
+// backlog in the checkout is retired and never written to. Only the flat file is carried
+// between branches by promoteQueue (#852), so an entry elsewhere could vanish unseen.
+test('both append helpers write the flat queue even when a session backlog exists (#697/#1369)', async () => {
   const cwd = await tmpWorkspace()
   try {
     await writeFile(join(cwd, 'TODO_a-session.agent.md'), '- [ ] a run\n', 'utf8')
 
-    // The run-facing helper prefers the session file, which is what it is for.
-    assert.equal(await appendTodoEntry(cwd, 'from the run'), 'TODO_a-session.agent.md')
-
-    // The dashboard-facing one does not.
+    assert.equal(await appendTodoEntry(cwd, 'from the run'), 'TODO_AGENTS.md')
     assert.equal(await appendFlatTodoEntry(cwd, 'Do ticket 42'), 'TODO_AGENTS.md')
-    assert.equal(await readFile(join(cwd, 'TODO_AGENTS.md'), 'utf8'), '- [ ] Do ticket 42\n')
-    assert.equal(await readFile(join(cwd, 'TODO_a-session.agent.md'), 'utf8'), '- [ ] a run\n- [ ] from the run\n')
+    assert.equal(await readFile(join(cwd, 'TODO_AGENTS.md'), 'utf8'), '- [ ] from the run\n- [ ] Do ticket 42\n')
+    // The leftover session file is untouched.
+    assert.equal(await readFile(join(cwd, 'TODO_a-session.agent.md'), 'utf8'), '- [ ] a run\n')
   } finally {
     await rm(cwd, { recursive: true, force: true })
   }

--- a/packages/the-framework/src/todo-loop.ts
+++ b/packages/the-framework/src/todo-loop.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import type { DriverSession } from './driver/index.js'
 import type { ChoicePick, ChoiceRequest, FrameworkEvent } from './events.js'
@@ -21,12 +21,9 @@ export { FLAT_TODO_FILE, LEGACY_HYPHEN_TODO_FILE, LEGACY_TICKETS_TODO_FILE, LEGA
  * consumes the whole backlog unattended; autopilot off pauses before each entry.
  */
 
-/** The session-scoped backlog filename the #326 prompt writes. */
-export const TODO_FILE_PATTERN = /^TODO_[a-z0-9-]+\.agent\.md$/
-
 /** A located backlog: its filename and the entries still open. */
 export interface TodoBacklog {
-  /** The backlog filename (workspace-root relative, e.g. `TODO_feat-x.agent.md`). */
+  /** The backlog filename (workspace-root relative, e.g. `TODO_AGENTS.md`). */
   name: string
   /** The open (unchecked) entries, in file order. */
   entries: string[]
@@ -56,36 +53,7 @@ export function parseTodoEntries(md: string): string[] {
 }
 
 /**
- * The workspace's backlog files, best first: the most recently modified
- * session-scoped `TODO_<slug>.agent.md` (#323/#326), then the flat backlog
- * (`TODO_AGENTS.md`, or a legacy `tickets/TODO.md` / root `TODO.md`) — the same
- * convention as the doc sidebar.
- */
-async function backlogCandidates(cwd: string): Promise<string[]> {
-  let names: string[]
-  try {
-    names = (await readdir(cwd, { withFileTypes: true })).filter(e => e.isFile()).map(e => e.name)
-  } catch {
-    return []
-  }
-  const scoped = names.filter(name => TODO_FILE_PATTERN.test(name))
-  const candidates: string[] = []
-  if (scoped.length > 1) {
-    // More than one session's backlog: the newest is this run's.
-    const withTimes = await Promise.all(
-      scoped.map(async name => ({ name, mtime: (await stat(join(cwd, name)).catch(() => undefined))?.mtimeMs ?? 0 })),
-    )
-    candidates.push(...withTimes.sort((a, b) => b.mtime - a.mtime).map(e => e.name))
-  } else {
-    candidates.push(...scoped)
-  }
-  const flat = await findFlatTodo(cwd)
-  if (flat) candidates.push(flat)
-  return candidates
-}
-
-/**
- * Append an open entry to this run's backlog, creating the flat {@link FLAT_TODO_FILE}
+ * Append an open entry to the workspace's backlog, creating the flat {@link FLAT_TODO_FILE}
  * when the workspace has none. Resolves with the file written, or `undefined` if
  * it couldn't be written.
  *
@@ -95,18 +63,17 @@ async function backlogCandidates(cwd: string): Promise<string[]> {
  * unwinding, and must not mask the reason it stopped.
  */
 export async function appendTodoEntry(cwd: string, entry: string): Promise<string | undefined> {
-  return writeTodoEntry(cwd, (await backlogCandidates(cwd))[0] ?? FLAT_TODO_FILE, entry)
+  return writeTodoEntry(cwd, (await findFlatTodo(cwd)) ?? FLAT_TODO_FILE, entry)
 }
 
 /**
- * Append an open entry to the workspace's *flat* backlog specifically, creating
+ * Append an open entry to the workspace's flat backlog with a priority, creating
  * {@link FLAT_TODO_FILE} when there is none.
  *
- * The difference from {@link appendTodoEntry} is which file wins while a session-scoped
- * `TODO_<slug>.agent.md` is lying around: that one belongs to a run, and something a human
- * queued from the dashboard (#697) belongs to the project. The flat file is the durable global
- * queue #624 settled on, and the only one `promoteQueue` carries between branches (#852), so a
- * pick that landed in some run's own backlog could quietly never be seen again.
+ * The difference from {@link appendTodoEntry} is the priority placement (#1164): a dashboard
+ * pick (#697) lands in its `## Priority N` section rather than at the end of the file. The flat
+ * file is the durable global queue #624 settled on, and the only one `promoteQueue` carries
+ * between branches (#852).
  */
 export async function appendFlatTodoEntry(
   cwd: string,
@@ -211,18 +178,18 @@ async function writeTodoEntry(
 }
 
 /**
- * Locate the workspace's backlog and its open entries. Returns `undefined` when
- * no backlog exists or none of them has an open entry.
+ * Locate the workspace's backlog and its open entries: the flat file via `findFlatTodo`
+ * (`TODO_AGENTS.md`, or a legacy `tickets/TODO.md` / root `TODO.md`). Returns `undefined`
+ * when no backlog exists or it has no open entry. Session-scoped `TODO_<slug>.agent.md`
+ * files are retired (#1369) — a leftover one in the checkout is ignored.
  */
 export async function findTodoBacklog(cwd: string): Promise<TodoBacklog | undefined> {
-  const candidates = await backlogCandidates(cwd)
-  for (const name of candidates) {
-    const md = await readFile(join(cwd, name), 'utf8').catch(() => undefined)
-    if (md === undefined) continue
-    const entries = parseTodoEntries(md)
-    if (entries.length) return { name, entries }
-  }
-  return undefined
+  const name = await findFlatTodo(cwd)
+  if (!name) return undefined
+  const md = await readFile(join(cwd, name), 'utf8').catch(() => undefined)
+  if (md === undefined) return undefined
+  const entries = parseTodoEntries(md)
+  return entries.length ? { name, entries } : undefined
 }
 
 /**


### PR DESCRIPTION
Closes #1369.

From Rom's Discord question ("can we remove todo-loop.spec.md? doesn't TODO_AGENTS.md supersede it?"): the module stays — `todo-loop.ts` is the `TODO_AGENTS.md` reader — but the session-scoped half really was superseded. This PR retires it, per the issue's two steps:

1. **The [Research] preset's `TODO_FILE` now points at `TODO_AGENTS.md`** (it was the last remaining writer of `TODO_<SESSION_NAME>.agent.md`; the system prompt migrated long ago). Its `SESSION_NAME` definition stays — `REVIEW_FILE` still uses it.
2. **The session-scoped machinery is deleted:**
   - `TODO_FILE_PATTERN` (and its `index.ts` export) is gone.
   - `backlogCandidates()`'s scoped branch is gone; with only the flat candidate left the function collapsed away — `findTodoBacklog()` reads the flat file via `findFlatTodo` directly, and `appendTodoEntry()` writes it. A leftover session file in a checkout is ignored, not drained (regression-tested).
   - `appendTodoEntry` vs `appendFlatTodoEntry` now differ only in priority placement (#1164); docstrings and `todo-loop.spec.md` updated to say so, plus a Decisions entry recording the retirement.

Not touched, per the issue's non-scope: `todo-loop.ts` / `todo-loop.spec.md` themselves, and the dashboard doc sidebar / queue rollup — those surface whatever files exist in a checkout, and old checkouts may still hold session files worth displaying.

Tests: full `the-framework` suite green locally (1608 pass, 0 fail, 1 skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
