### PR TITLE
Validate the Host header on the dashboard's loopback Telefunc mount

### DIFF
--- a/packages/the-framework/src/daemon.spec.md
+++ b/packages/the-framework/src/daemon.spec.md
@@ -28,7 +28,7 @@ The machine-global daemon lifecycle (#302/#393): the liveness state file, ensure
 ## Facts
 
 - `DEFAULT_DAEMON_PORT` 4200; `DAEMON_STATE_HEARTBEAT_MS` 5000; ensure/stop grace default 5000ms.
-- `isLoopbackHost`: `localhost`, `::1`, `[::1]`, `127.*` — anything else gates behind the token.
+- `isLoopbackHost`: `localhost`, `::1`, `[::1]`, `127.*` — anything else gates behind the token. Defined in `loopback-host.ts` (the Telefunc mount shares it) and re-exported here.
 - `state.host` is absent in files written before #1051; readers treat it as optional.
 - `EventTailer` is `JsonlTailer<FrameworkEvent>` kept under its historical public name.
 - `listBridgeSessions` collects cloud runs across every registered project (a cloud run is not tied to the home checkout), best-effort per project so one unreadable repo cannot empty the list.

--- a/packages/the-framework/src/daemon.ts
+++ b/packages/the-framework/src/daemon.ts
@@ -13,6 +13,7 @@ import { addProject, ensureDaemonToken, listProjects, nodeRegistryFs, readPrefer
 import { listReposInDirectory } from './repos-directory.js'
 import { registryDiscordCredentialsStore } from './discord-credentials-store.js'
 import { JsonlTailer } from './jsonl-tail.js'
+import { isLoopbackHost } from './loopback-host.js'
 import { bridgeSessionsFrom } from './dashboard/bridge-sessions.js'
 import { readAllRuns } from './store/index.js'
 import type { BridgeSession } from './dashboard/index.js'
@@ -48,11 +49,10 @@ export const DEFAULT_DAEMON_HOST = '127.0.0.1'
 
 /**
  * True when `host` is a loopback address the browser reaches without leaving the machine (#1051).
- * A bind-all (`0.0.0.0`, `::`) or a routable address is not, and gates behind the shared token.
+ * Defined in its own leaf module so the dashboard's Telefunc mount can share the one definition
+ * without importing this one back (a cycle); re-exported here for the callers that already had it.
  */
-export function isLoopbackHost(host: string): boolean {
-  return host === 'localhost' || host === '::1' || host === '[::1]' || host.startsWith('127.')
-}
+export { isLoopbackHost }
 
 /** What a running daemon writes so a later `framework` invocation can find it. */
 export interface DaemonState {

--- a/packages/the-framework/src/dashboard/index.ts
+++ b/packages/the-framework/src/dashboard/index.ts
@@ -10,7 +10,7 @@ export {
   type SummarizeDeps,
 } from './projects.js'
 export { resolveDashboardBundle } from './bundle.js'
-export { makeTelefuncMount, isSameOriginRequest, type EventsSource } from './telefunc-serve.js'
+export { makeTelefuncMount, isSameOriginRequest, isExpectedHost, type EventsSource } from './telefunc-serve.js'
 export { serveClientBundle } from './static.js'
 export { readDocs, DOC_CATEGORIES, type WorkspaceDoc } from './docs.js'
 export { readTickets, readTicket, readTicketsMeta, type WorkspaceTicket, type WorkspaceTicketDetail, type TicketsMeta, type TicketGithubLink } from './tickets.js'

--- a/packages/the-framework/src/dashboard/server.test.ts
+++ b/packages/the-framework/src/dashboard/server.test.ts
@@ -6,7 +6,7 @@ import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { startDashboard } from './server.js'
-import { isSameOriginRequest } from './telefunc-serve.js'
+import { isExpectedHost, isSameOriginRequest } from './telefunc-serve.js'
 import type { FrameworkEvent } from '../events.js'
 import type { StartRunKind, StartRunOptions, StartRunResult } from './types.js'
 import type { IncomingMessage } from 'node:http'
@@ -63,6 +63,24 @@ function rawRequest(url: string, requestLine: string): Promise<string> {
 function postCrossOrigin(url: string): Promise<{ status: number; body: string }> {
   return new Promise((resolvePromise, rejectPromise) => {
     const req = request(url, { method: 'POST', headers: { origin: 'http://evil.com', 'content-type': 'application/json' } }, res => {
+      let body = ''
+      res.on('data', c => (body += c))
+      res.on('end', () => resolvePromise({ status: res.statusCode ?? 0, body }))
+    })
+    req.on('error', rejectPromise)
+    req.end('{}')
+  })
+}
+
+/**
+ * A POST as a DNS-rebinding attacker's page makes it: the browser resolved `evil.com` to
+ * 127.0.0.1, so it believes the request is same-origin and sends a matching `Origin` — the
+ * `Host` is the only header that still names who the page really is.
+ */
+function postRebound(url: string, host = 'evil.com'): Promise<{ status: number; body: string }> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const headers = { host, origin: `http://${host}`, 'content-type': 'application/json' }
+    const req = request(url, { method: 'POST', headers }, res => {
       let body = ''
       res.on('data', c => (body += c))
       res.on('end', () => resolvePromise({ status: res.statusCode ?? 0, body }))
@@ -174,6 +192,25 @@ test('the Telefunc mount rejects a cross-origin POST (CSRF guard)', async () => 
     const { status, body } = await postCrossOrigin(dash.url + '/_telefunc')
     assert.equal(status, 403)
     assert.match(body, /cross-origin/)
+  } finally {
+    await dash.close()
+    await rm(bundle, { recursive: true, force: true })
+  }
+})
+
+test('the Telefunc mount rejects a rebound Host, which the Origin check alone lets through', async () => {
+  const bundle = await fakeBundle()
+  const dash = await startDashboard({ port: 0, clientBundleDir: bundle })
+  try {
+    // The attack: same-origin as far as the browser is concerned, so `isSameOriginRequest` passes it.
+    const rebound = await postRebound(dash.url + '/_telefunc')
+    assert.equal(rebound.status, 403)
+    assert.match(rebound.body, /Host/)
+
+    // The real thing still gets through: same request, but the Host the user actually typed.
+    // It reaches telefunc, which logs a parse error over the `{}` body — expected, not a failure.
+    const loopback = await postRebound(dash.url + '/_telefunc', new URL(dash.url).host)
+    assert.notEqual(loopback.status, 403)
   } finally {
     await dash.close()
     await rm(bundle, { recursive: true, force: true })
@@ -421,4 +458,23 @@ test('isSameOriginRequest: absent Origin passes; same host + loopback pass; evil
   assert.equal(isSameOriginRequest(req({ origin: 'http://[::1]' })), true)
   assert.equal(isSameOriginRequest(req({ host: 'localhost:4200', origin: 'http://evil.com' })), false)
   assert.equal(isSameOriginRequest(req({ origin: 'not-a-url' })), false)
+})
+
+test('isExpectedHost: on a loopback bind only a loopback Host passes (DNS rebinding)', () => {
+  const req = (headers: Record<string, string>): IncomingMessage => ({ headers } as IncomingMessage)
+  const bound = '127.0.0.1'
+  assert.equal(isExpectedHost(req({ host: '127.0.0.1:4200' }), bound), true)
+  assert.equal(isExpectedHost(req({ host: 'localhost:4200' }), bound), true)
+  assert.equal(isExpectedHost(req({ host: '[::1]:4200' }), bound), true) // the port split must not eat the IPv6 colons
+  assert.equal(isExpectedHost(req({ host: 'evil.com' }), bound), false) // rebound: resolves here, names someone else
+  assert.equal(isExpectedHost(req({ host: 'evil.com:4200' }), bound), false)
+  assert.equal(isExpectedHost(req({}), bound), false) // HTTP/1.1 requires Host; every browser sends it
+
+  // A non-loopback bind is reached by a name we cannot predict, so there is nothing to check
+  // against — that case gates behind the shared token (#1051) instead. The relay passes no host.
+  assert.equal(isExpectedHost(req({ host: 'evil.com' }), '0.0.0.0'), true)
+  assert.equal(isExpectedHost(req({ host: 'dash.example.com' }), undefined), true)
+
+  // The bound address itself passes even when it is not one of the loopback spellings.
+  assert.equal(isExpectedHost(req({ host: 'localhost:4200' }), 'localhost'), true)
 })

--- a/packages/the-framework/src/dashboard/server.ts
+++ b/packages/the-framework/src/dashboard/server.ts
@@ -180,19 +180,24 @@ export function startDashboard(opts: DashboardOptions = {}): Promise<Dashboard> 
   // `projects` is passed raw (may be undefined) so the mount falls back to the global
   // registry, byte-identical to the daemon default; the per-run dashboard passes a
   // single-project provider, the relay an empty one.
-  const telefuncMount = makeTelefuncMount({
-    ...(opts.onStart ? { startRun: opts.onStart } : {}),
-    ...(opts.projects ? { projects: opts.projects } : {}),
-    ...(opts.onAddProject ? { addProject: opts.onAddProject } : {}),
-    ...(opts.preview ? { preview: opts.preview } : {}),
-    ...(opts.eventsSource ? { eventsSource: opts.eventsSource } : {}),
-    ...(opts.remote ? { remote: opts.remote } : {}),
-    preferences: opts.preferences ?? registryPreferencesStore(),
-    discord: opts.discord ?? registryDiscordCredentialsStore(),
-    ...(opts.autoPm ? { autoPm: opts.autoPm } : {}),
-    ...(opts.autoPmSweep ? { autoPmSweep: opts.autoPmSweep } : {}),
-    quota,
-  })
+  const telefuncMount = makeTelefuncMount(
+    {
+      ...(opts.onStart ? { startRun: opts.onStart } : {}),
+      ...(opts.projects ? { projects: opts.projects } : {}),
+      ...(opts.onAddProject ? { addProject: opts.onAddProject } : {}),
+      ...(opts.preview ? { preview: opts.preview } : {}),
+      ...(opts.eventsSource ? { eventsSource: opts.eventsSource } : {}),
+      ...(opts.remote ? { remote: opts.remote } : {}),
+      preferences: opts.preferences ?? registryPreferencesStore(),
+      discord: opts.discord ?? registryDiscordCredentialsStore(),
+      ...(opts.autoPm ? { autoPm: opts.autoPm } : {}),
+      ...(opts.autoPmSweep ? { autoPmSweep: opts.autoPmSweep } : {}),
+      quota,
+    },
+    // The bound host, so the mount can reject a rebound `Host`: a page on evil.com whose DNS
+    // answers 127.0.0.1 is same-origin to the browser, so the Origin check alone lets it in.
+    { host },
+  )
 
   // The device-to-daemon relay endpoints (#1067): wired only when the daemon supplies both a start
   // and an events tail. Fronted by the same token guard as every other route below.

--- a/packages/the-framework/src/dashboard/telefunc-serve.spec.md
+++ b/packages/the-framework/src/dashboard/telefunc-serve.spec.md
@@ -2,11 +2,14 @@ Mounts the dashboard's Telefunc surface (#405) on the daemon's HTTP server — R
 
 ## TLDR
 
-- `makeTelefuncMount(context)`: rejects cross-origin POSTs (403), lazily sets up the singleton `Telefunc` instance (registering the telefunctions from `dashboard-rpc/register.js`), and serves; returns whether the request was Telefunc's.
+- `makeTelefuncMount(context, opts)`: rejects cross-origin POSTs and rebound `Host`s (403), lazily sets up the singleton `Telefunc` instance (registering the telefunctions from `dashboard-rpc/register.js`), and serves; returns whether the request was Telefunc's. `opts.host` is the address the server is bound to, which enables the `Host` check.
 - `DashboardContext` is the per-host wiring seam: `startRun`, `addProject`, `preview` (#475), `projects` (#427), `eventsSource` (#426/#1067 — in-memory stream else `onEvents` tails the on-disk log), `remote` (#1067 slice 2: relayed-run lookup so run-scoped RPCs forward to the owning device), `preferences`, `quota`, `discord`, `autoPm`/`autoPmSweep` (#1161/#1210, daemon-only since the sweep loop lives in that process).
 - `isSameOriginRequest`: absent Origin passes (curl/tests have no ambient session to abuse); matching host or loopback hostnames pass; anything else — including malformed Origins — is rejected, or a page on evil.com could `fetch()` localhost and spawn/steer a run.
+- `isExpectedHost`: the DNS-rebinding half of the same guard. On a loopback bind, only a loopback `Host` — or the bound address itself — passes; an absent one does not. A non-loopback bind and a host that passes no bind address are not checked.
 
 ## Decisions
 
+- The `Origin` check cannot stand alone: under DNS rebinding the browser resolves `evil.com` to `127.0.0.1` and treats the daemon as evil.com's own origin, so the attacker's `fetch()` is same-origin and passes. `Host` still carries the name the browser was asked for, so it is what the second check reads.
+- The `Host` check is enforced only for a loopback bind. A `--host` bind (#1051) is reached by a hostname the daemon cannot predict — there is no allowlist to build — and already gates behind the shared token; the relay serves a public domain and passes no bind host at all, so it is unaffected.
 - Telefunc shield generation and the naming convention are disabled: no Vite build runs over these functions (so no generated shields), the mount is localhost/same-origin guarded, every write funnels through appendControl or the busy-guarded startRun, and the names are `onX`/`sendX`, not telefunc's query/mutation hint.
 - `tf.serve` is wrapped in try/catch: telefunc 0.2.22 throws on a bare `GET /_telefunc` (it passes the request as a body, which `new Request()` rejects for GET), and a browser tab hits that on reconnect — it must not become a daemon-killing unhandled rejection.

--- a/packages/the-framework/src/dashboard/telefunc-serve.ts
+++ b/packages/the-framework/src/dashboard/telefunc-serve.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { config } from 'telefunc'
 import { Telefunc } from 'telefunc/node'
+import { hostnameFromHostHeader, isLoopbackHost } from '../loopback-host.js'
 import { registerDashboardTelefunctions } from '../dashboard-rpc/register.js'
 import type { ProjectsProvider } from './projects.js'
 import type { FrameworkEvent } from '../events.js'
@@ -122,22 +123,55 @@ export function isSameOriginRequest(req: IncomingMessage): boolean {
 }
 
 /**
+ * DNS-rebinding guard, the other half of the CSRF check above. A page on `evil.com` whose DNS
+ * re-answers as `127.0.0.1` is *same-origin* with this server as far as the browser is concerned,
+ * so its `fetch()` takes the passing branch of {@link isSameOriginRequest} — and every RPC behind
+ * the mount, `sendStart` included, is reachable from a page the user merely visited.
+ *
+ * The `Host` header is what still gives the attacker away: it carries the name the browser was
+ * asked for (`evil.com`), not the address it resolved to. So when we are bound to loopback, the
+ * only `Host` a real user's browser can send is a loopback one (or the bound address itself) —
+ * anything else is a rebound name and is rejected. An absent `Host` is rejected too when we are
+ * enforcing: HTTP/1.1 requires it, and every browser sends it.
+ *
+ * A non-loopback bind (`--host`, #1051) is reached by a hostname we cannot predict, so there is
+ * no allowlist to check against; that case gates behind the shared daemon token instead. Hosts
+ * that never pass a bind host at all (the relay, which serves a public domain) are unaffected.
+ */
+export function isExpectedHost(req: IncomingMessage, boundHost: string | undefined): boolean {
+  if (boundHost === undefined || !isLoopbackHost(boundHost)) return true
+  const header = req.headers.host
+  if (!header) return false
+  const hostname = hostnameFromHostHeader(header)
+  return isLoopbackHost(hostname) || hostname === boundHost
+}
+
+/**
  * Mount the dashboard's Telefunc surface (#405) on the daemon's `node:http` server: one
  * `serve()` handles both the RPCs and the Channel SSE stream at `/_telefunc`. Telefunc
  * runs in the daemon process, so a `sendStart` telefunction can call the daemon's own
  * `startRun` via the request context. The `context` is exactly what each telefunction
  * reaches through {@link getContext} (see {@link DashboardContext}): the daemon wires the
  * full set, the relay passes only an events source plus an empty projects provider. Cross-
- * origin POSTs are rejected (CSRF: a page on evil.com must not steer or start a run).
- * Returns whether the request was Telefunc's.
+ * origin POSTs are rejected (CSRF: a page on evil.com must not steer or start a run), as are
+ * requests carrying someone else's `Host` when we are bound to loopback (DNS rebinding: the
+ * same page must not reach us by pointing its own name at `127.0.0.1`). Pass `opts.host` — the
+ * address the server is bound to — to enable that second check; a host serving a public domain
+ * (the relay) leaves it unset. Returns whether the request was Telefunc's.
  */
 export function makeTelefuncMount(
   context: DashboardContext = {},
+  opts: { host?: string } = {},
 ): (req: IncomingMessage, res: ServerResponse) => Promise<boolean> {
   return async (req, res) => {
     if (!isSameOriginRequest(req)) {
       res.writeHead(403, { 'content-type': 'text/plain' })
       res.end('cross-origin request forbidden')
+      return true
+    }
+    if (!isExpectedHost(req, opts.host)) {
+      res.writeHead(403, { 'content-type': 'text/plain' })
+      res.end('unexpected Host header')
       return true
     }
     const tf = setup()

--- a/packages/the-framework/src/loopback-host.spec.md
+++ b/packages/the-framework/src/loopback-host.spec.md
@@ -1,0 +1,11 @@
+Loopback-address helpers shared by the daemon and the dashboard's Telefunc mount.
+
+## TLDR
+
+- `isLoopbackHost`: `localhost`, `::1`, `[::1]`, `127.*` — anything else (a bind-all `0.0.0.0`/`::`, a routable address) is not loopback, and the daemon gates it behind the shared token (#1051).
+- `hostnameFromHostHeader`: drops the port from a `Host` header, keeping the bracketed IPv6 form (`[::1]:4200` → `[::1]`) that splitting on the first colon would mangle.
+
+## Decisions
+
+- A leaf module with no imports of its own: `daemon.ts` imports the dashboard, so the Telefunc mount cannot reach back into `daemon.ts` for `isLoopbackHost` without a cycle. `daemon.ts` re-exports it so its own callers (`cli.ts`) are unaffected.
+- A single definition rather than a copy per caller: the daemon's "does this bind need a token" decision and the mount's "is this `Host` a rebinding attempt" decision must not drift apart.

--- a/packages/the-framework/src/loopback-host.ts
+++ b/packages/the-framework/src/loopback-host.ts
@@ -1,0 +1,26 @@
+/**
+ * Loopback-address helpers, shared by the daemon (deciding whether a bind gates behind the
+ * token, #1051) and the Telefunc mount (rejecting a rebound `Host`). A leaf module on purpose:
+ * `daemon.ts` imports the dashboard, so the mount cannot import these back out of it.
+ */
+
+/**
+ * True when `host` is a loopback address the browser reaches without leaving the machine (#1051).
+ * A bind-all (`0.0.0.0`, `::`) or a routable address is not, and gates behind the shared token.
+ */
+export function isLoopbackHost(host: string): boolean {
+  return host === 'localhost' || host === '::1' || host === '[::1]' || host.startsWith('127.')
+}
+
+/**
+ * The hostname a `Host` header names, with the port dropped. Keeps the bracketed IPv6 form
+ * (`[::1]:4200` → `[::1]`), which splitting on the first colon would mangle.
+ */
+export function hostnameFromHostHeader(header: string): string {
+  if (header.startsWith('[')) {
+    const close = header.indexOf(']')
+    return close === -1 ? header : header.slice(0, close + 1)
+  }
+  const colon = header.indexOf(':')
+  return colon === -1 ? header : header.slice(0, colon)
+}


### PR DESCRIPTION
The Telefunc mount's only guard was the Origin check, which passes any request whose `Origin` matches the server's `Host`. `Host` itself was never validated — anywhere in the daemon; it was read only to compare against `Origin`.

That leaves a gap for DNS rebinding: a page whose DNS re-answers as `127.0.0.1` is same-origin with the daemon as far as the browser is concerned, so its `fetch()` carries a matching `Origin` and takes the passing branch. Every RPC behind the mount is reachable that way, `sendStart` included.

`Host` still carries the name the browser was asked for, so that is what the new check reads.

## What changed

- `isExpectedHost` in `telefunc-serve.ts`, enforced at the mount alongside the Origin check: on a loopback bind, only a loopback `Host` — or the bound address itself — passes. An absent `Host` is rejected while enforcing; HTTP/1.1 requires it and every browser sends it.
- `server.ts` passes the address it bound to, which is what enables the check.
- `isLoopbackHost` moves to a new leaf module, `loopback-host.ts`, and is re-exported from `daemon.ts` for its existing callers. The mount cannot import from `daemon.ts` (that imports the dashboard, so it would be a cycle), and the daemon's "does this bind need a token" test and the mount's "is this Host rebound" test must not drift apart.
- Specs updated for both touched modules; a new spec for the leaf module.

## Scope

Enforcement is limited to loopback binds. A `--host` bind (#1051) is reached by a hostname the daemon cannot predict, so there is no allowlist to build; that path gates behind the shared daemon token instead. The relay serves a public domain and passes no bind host, so it is unaffected.

`isSameOriginRequest` keeps its existing contract — an absent `Origin` still passes, for curl and the test suite — so the Host check lives in its own function and the existing assertion for it is unchanged.

## Testing

- End-to-end: a POST to `/_telefunc` with a rebound `Host` (and the matching `Origin` a rebound browser would send) gets a 403, while the identical request carrying the real `Host` does not.
- Unit: loopback spellings, the bound address, an absent `Host`, a non-loopback bind, no bind host, and the bracketed IPv6 form `[::1]:4200` that a naive port split would mangle.
- Full `the-framework` suite: 1629 tests, 0 failures. `turbo run typecheck`: 22/22 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)