### PR TITLE
test: the Research preset writes a session-scoped TODO file again

### DIFF
--- a/packages/the-framework/src/preset-catalog.test.ts
+++ b/packages/the-framework/src/preset-catalog.test.ts
@@ -114,9 +114,11 @@ test('Research gates on a multi-select and writes its own review file (#331)', (
   assert.match(presets.research.template, /<AWAIT>/)
   assert.match(presets.research.template, /<REVIEW_FILE>/)
   assert.match(presets.research.template, /<TODO_FILE>/)
-  // #1369: the deep-dive picks land on the flat queue, not a session-scoped backlog.
-  assert.match(presets.research.template, /TODO_FILE: `TODO_AGENTS\.md`/)
-  assert.doesNotMatch(presets.research.template, /TODO_<SESSION_NAME>/)
+  // Session-scoped on purpose (42fd47d, brillout on #1370): routing the deep-dive picks to the
+  // flat `TODO_AGENTS.md` queue delays the research work, because the queue is what gets drained
+  // into follow-up agents. These picks stay beside the review file for the session instead.
+  assert.match(presets.research.template, /TODO_FILE: `TODO_<SESSION_NAME>\.agent\.md`/)
+  assert.doesNotMatch(presets.research.template, /TODO_AGENTS\.md/)
 })
 
 test('the Maintenance template queues work rather than doing it (#881)', () => {

--- a/packages/the-framework/src/todo-loop.spec.md
+++ b/packages/the-framework/src/todo-loop.spec.md
@@ -22,7 +22,7 @@ The backlog loop (#323): once the main work settles, consume the agent's own TOD
 - One `createTurnSignalEmitter` for the whole backlog, so `ready-for-merge` fires once across every item and a session name only re-emits on an actual rename.
 - A backlog turn is a turn like any other: await gates and signals are honored (via `runAwaitRounds`); a declined plan ends the item turn and the stall check takes it from there.
 - Plain append (no priority) is kept for resume notes and agent follow-ups: those are a running list whose order is theirs.
-- The session-scoped `TODO_<SESSION_NAME>.agent.md` backlog is retired (#1369): `TODO_AGENTS.md` superseded it — the system prompt migrated long ago, and the [Research] preset (its last writer) now points at the flat queue too. A leftover session file in a checkout is ignored, not drained.
+- The session-scoped `TODO_<SESSION_NAME>.agent.md` backlog is retired *as a drained queue* (#1369): `TODO_AGENTS.md` superseded it and the system prompt migrated long ago. A session file in a checkout is ignored here, not drained. The [Research] preset still writes one on purpose (42fd47d): its deep-dive picks are session notes, and putting them on the flat queue would spawn follow-up agents that delay the research itself.
 
 ## Facts
 


### PR DESCRIPTION
`main`'s CI has been red since `42fd47d`: that commit pointed the Research preset's `TODO_FILE` back at `TODO_<SESSION_NAME>.agent.md`, and `preset-catalog.test.ts` still asserted the flat `TODO_AGENTS.md` filename that #1370 had put there.

This follows the prompt rather than the other way around. Per brillout on #1370, the change is deliberate — routing the deep-dive picks to the flat queue delays the research work, because that queue is what gets drained into follow-up agents. So the picks stay beside the review file for the session.

- `preset-catalog.test.ts`: assert the session-scoped filename, and that the preset does *not* name the flat queue. The comment records the reason so the next person doesn't "fix" it back.
- `todo-loop.spec.md`: one line still claimed the Research preset points at the flat queue. Retiring the session-scoped file as a *drained queue* (#1369) is unchanged — a session file in a checkout is still ignored there.

No production code changes.

Full `the-framework` suite: 1630 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)