### PR TITLE
feat(launcher): show the publish ladder — Push branch → Open PR → Auto-merge (#1379)

### DIFF
--- a/.changeset/launcher-publish-ladder.md
+++ b/.changeset/launcher-publish-ladder.md
@@ -1,0 +1,6 @@
+---
+'@gemstack/the-framework': patch
+'@gemstack/framework-dashboard': patch
+---
+
+The launcher now shows the whole publish ladder (#1379): **Push branch** → **Open PR** → **Auto-merge**, each enabled only while the rung below it is on. Previously only Open PR and Auto-merge were offered, so unticking Open PR silently meant "push-only" — the launcher read as "publishing off" while the session still pushed the branch. Unticking Push branch now publishes nothing, and `handoffFromPreferences` treats `autoPushBranch` as the master rather than letting an armed PR force the push back on. Defaults are unchanged: push and PR on, auto-merge off.

--- a/packages/framework-dashboard/lib/run-option-rows.spec.md
+++ b/packages/framework-dashboard/lib/run-option-rows.spec.md
@@ -3,18 +3,18 @@ The Global run options as one pure-data table (#314) — `runOptionRows(preferen
 ## TLDR
 
 - `OptionRow`: `key` (a `Preferences` key), `label`, `title` (tooltip), `description` (#654), `checked`, optional `disabled` + `disabledReason`.
-- Main rows: Transparent, Autopilot, Technical control, Disable system prompt (vanilla), Eco, Post-merge cleanup (`onBeforeMergeableQuality`), Open PR (`autoOpenPr`), Auto-merge (`autoMerge`, #1216: default off, disabled while Open PR is off — nothing to merge), Browser. Eco sub-drops: `ecoPlanning`, `ecoResearch`, `ecoMaintenance`.
+- Main rows: Transparent, Autopilot, Technical control, Disable system prompt (vanilla), Eco, Post-merge cleanup (`onBeforeMergeableQuality`), then the publish ladder — Push branch (`autoPushBranch`, default on), Open PR (`autoOpenPr`, default on, disabled while Push branch is off — nothing to open), Auto-merge (`autoMerge`, #1216: default off, disabled while Open PR is off — nothing to merge) — then Browser. Eco sub-drops: `ecoPlanning`, `ecoResearch`, `ecoMaintenance`.
 - Rules: Transparent (#625) is the master off-switch overriding everything below it; Eco is inert under Vanilla/Transparent (no system prompt left to trim); eco sub-drops need Eco in force; `ecoMaintenance` additionally needs Post-merge cleanup (#556 moved Maintenance into the on-before-mergeable prompt); Browser needs `agent === 'claude'` (#801, rides Claude Code's MCP config).
 
 ## Decisions
 
 - Pure data, no JSX: the launcher renders it as dropdown items, the settings page (#958) as page rows — one table so the rules can't drift between the two surfaces (it used to be built inline in the composer).
 - `checked` is the *effective* value, not the stored one: an option overridden by Transparent reads off, because that is what the run will do — a surface can never claim an option is on while the run ignores it.
-- One `Open PR` row instead of the old `Push branch`/`Open PR` pair (#1164/#1173): PR implies push, so `Push branch` was greyed out almost always; push-without-PR stays reachable via the `autoPushBranch` key, `--auto-push-branch`, and `the-framework.yml`.
+- The publish ladder (#1379) replaces the single `Open PR` row of #1164/#1173, which in turn had replaced an ungated `Push branch`/`Open PR` pair. Three rungs, each enabled only while the one below it is on: a strict ladder cannot express the contradictory state (PR on / push off) that made the old pair unreadable, and unlike the one-row version it does not leave "Open PR: off" silently meaning push-only — which read as "publishing off" to the user while the session header armed `Push branch: on`. "Publish nothing" is now reachable from the launcher rather than only via the `autoPushBranch` key, `--auto-push-branch`, and `the-framework.yml`.
 - `disabledReason` renders in the description because a disabled dropdown item takes no pointer events, so its tooltip never opens.
 - Transparent's copy names the selected agent (#948) — "Raw Claude Code" was a lie under Codex; but the Browser rule tests the stored `agent` value directly (the label fallback to Claude is cosmetic).
 
 ## Facts
 
-- Defaults: autopilot via `autopilotEnabled()` (default-on), handoff via `handoffFromPreferences()` (default-on #1102, and what makes PR imply push), `agent ?? 'claude'` (#650); everything else `?? false`.
+- Defaults: autopilot via `autopilotEnabled()` (default-on), handoff via `handoffFromPreferences()` (default-on #1102, and what makes push the master rung — #1379), `agent ?? 'claude'` (#650); everything else `?? false`.
 - The launcher hides the eco sub-drops instead of greying them (renders them only while Eco is on), so the `ecoOff` disable only bites on surfaces listing them unconditionally.

--- a/packages/framework-dashboard/lib/run-option-rows.test.ts
+++ b/packages/framework-dashboard/lib/run-option-rows.test.ts
@@ -10,17 +10,31 @@ const rows = (preferences: Preferences) => runOptionRows(preferences)
 const find = (list: OptionRow[], key: string) => list.find(r => r.key === key)!
 
 describe('runOptionRows', () => {
-  test('the handoff is one row, Open PR, not a pair with a greyed-out sibling (#1164/#1173)', () => {
-    // It used to offer `Push branch` beside it, disabled and explained away as "opening a PR
-    // already pushes the branch" whenever Open PR was on — which is the default, so the row was
-    // greyed out almost every time anyone opened the gear.
+  test('the publish ladder shows all three rungs, in order, both on by default (#1379)', () => {
+    // The pair this replaced showed only Open PR, so "Open PR: off" silently meant push-only — the
+    // launcher said publishing was off while the session header armed "Push branch: on".
     const main = rows({}).main
-    expect(main.filter(r => r.key === 'autoOpenPr')).toHaveLength(1)
-    expect(main.find(r => r.key === 'autoPushBranch')).toBeUndefined()
+    const ladder = main.filter(r => ['autoPushBranch', 'autoOpenPr', 'autoMerge'].includes(r.key))
+    expect(ladder.map(r => r.key)).toEqual(['autoPushBranch', 'autoOpenPr', 'autoMerge'])
+    expect(find(main, 'autoPushBranch').checked).toBe(true)
     expect(find(main, 'autoOpenPr').checked).toBe(true)
-    // The preference itself is untouched: push-without-PR stays reachable from the-framework.yml
-    // and the CLI flag, it just no longer competes for attention in the menu.
     expect(find(rows({ autoOpenPr: false }).main, 'autoOpenPr').checked).toBe(false)
+  })
+
+  test('Open PR needs Push branch, and unticking push disarms the whole ladder (#1379)', () => {
+    // The gating is what makes the contradictory state (PR on / push off) unreachable, and what
+    // finally makes "publish nothing" expressible from the launcher.
+    const noPush = rows({ autoPushBranch: false, autoOpenPr: true, autoMerge: true }).main
+    expect(find(noPush, 'autoPushBranch').checked).toBe(false)
+    const pr = find(noPush, 'autoOpenPr')
+    expect(pr.checked).toBe(false)
+    expect(pr.disabled).toBe(true)
+    expect(pr.disabledReason).toMatch(/Push branch/)
+    // The rung above it goes with it rather than staying live over a disarmed PR.
+    expect(find(noPush, 'autoMerge').checked).toBe(false)
+    expect(find(noPush, 'autoMerge').disabled).toBe(true)
+    // With push on, Open PR is an ordinary live row again.
+    expect(find(rows({}).main, 'autoOpenPr').disabled).toBeUndefined()
   })
 
   test('Auto-merge is off by default and needs Open PR to mean anything (#1216)', () => {

--- a/packages/framework-dashboard/lib/run-option-rows.ts
+++ b/packages/framework-dashboard/lib/run-option-rows.ts
@@ -118,21 +118,30 @@ export function runOptionRows(preferences: Preferences): RunOptionRows {
       checked: onBeforeMergeableQuality && !transparent,
       ...overriddenByTransparent(transparent),
     },
-    // Where the handoff gets its default (#1102). A session's own action bar can still untick it for
-    // that one run; this is what every new session starts from.
+    // Where the handoff gets its default (#1102). A session's own action bar can still untick the
+    // whole ladder for that one run (#1173); this is what every new session starts from.
     //
-    // One row, not the `Push branch` / `Open PR` pair this used to be (#1164/#1173). Opening a PR
-    // pushes the branch on the way, so `Push branch` was disabled and explained away as "opening a
-    // PR already pushes the branch" whenever `Open PR` was on, which is the default: a control that
-    // is greyed out almost always, and that nobody could say the purpose of when it was not.
-    // Push-without-PR stays reachable where someone deliberately wanting it would look: the
-    // `autoPushBranch` preference key, the `--auto-push-branch` flag, and `the-framework.yml`.
+    // The publish ladder (#1379): three rungs, each enabled only while the one below it is on. The
+    // pair this replaced (#1164/#1173) showed only `Open PR`, so "Open PR: off" silently meant
+    // "push-only" — a user who read that as "publishing off" still got their branch pushed, and the
+    // launcher disagreed with the session header, where unticking means the session hands off
+    // nothing. A strict ladder cannot express the contradictory state (PR on / push off) that made
+    // the old two-equal-boxes UI unreadable, and it finally makes "publish nothing" reachable here
+    // rather than only via the preference key, `--auto-push-branch`, and `the-framework.yml`.
+    {
+      key: 'autoPushBranch',
+      label: 'Push branch',
+      description: 'Pushes the session branch when it finishes.',
+      title: "Push the session's branch to the remote when it finishes. The bottom rung: with this off the session publishes nothing, and neither PR nor merge can run",
+      checked: handoff.push,
+    },
     {
       key: 'autoOpenPr',
       label: 'Open PR',
       description: 'Opens a draft pull request when it finishes.',
       title: 'Open a draft pull request when the session finishes, pushing the branch on the way. Draft, so it does not request review; it still shows on the needs-you queue',
       checked: handoff.pr,
+      ...(handoff.push ? {} : { disabled: true, disabledReason: 'nothing to open while Push branch is off' }),
     },
     // Default-off, unlike the row above (#1216): publishing a branch is reversible, landing it on
     // the default branch is not. The routines that merge their own work (the queue drain) say so

--- a/packages/the-framework/src/run-options.spec.md
+++ b/packages/the-framework/src/run-options.spec.md
@@ -4,7 +4,7 @@ Pure mapping from the user's resolved preferences to the `StartRunOptions` a run
 
 - `runOptionsFromPreferences()`: the one mapping (autopilot defaults on, browser Claude-only, eco drops suppressed under vanilla/transparent, four eco preferences collapsed into one object, non-local `target` only when set).
 - `preferencesFromFileConfig()` (#842): a repo's committed `the-framework.yml` translated into preference keys (only keys the file set come back; `antiLazyPill` is the file's name for the inverse of `vanilla`).
-- `handoffFromPreferences()` (#1102): both halves default on; opening a PR implies pushing (gh won't open one for a branch the remote has never seen), normalised here rather than in the three places that read it.
+- `handoffFromPreferences()` (#1102/#1379): both halves default on; a ladder, so `autoPushBranch` is the master and turning it off yields `{push: false, pr: false}` whatever the PR half says. gh won't open a PR for a branch the remote has never seen, so "PR without push" was never honourable — it used to force push back *on*, which left "publish nothing" unreachable from the launcher. Normalised here rather than in the three places that read it.
 - `autopilotEnabled()`: absent = on (the demo default, matching old localStorage semantics).
 
 ## Decisions

--- a/packages/the-framework/src/run-options.test.ts
+++ b/packages/the-framework/src/run-options.test.ts
@@ -31,12 +31,14 @@ test('auto-merge travels explicitly in both directions (#1216)', () => {
   assert.equal(runOptionsFromPreferences({}).autoMerge, false)
 })
 
-test('the handoff defaults to armed, and opening a PR implies pushing (#1102)', () => {
+test('the handoff defaults to armed, and push is the rung under the PR (#1102/#1379)', () => {
   assert.deepEqual(handoffFromPreferences({}), { push: true, pr: true })
-  // Unticking only the push half while the PR half stays on cannot disarm the push: `gh` will not
-  // open a PR for a branch the remote has never seen, so the pair is normalised rather than left
-  // to fail at the end of a session.
-  assert.deepEqual(handoffFromPreferences({ autoPushBranch: false }), { push: true, pr: true })
+  // Turning the push rung off publishes nothing, whatever the PR half says: `gh` will not open a
+  // PR for a branch the remote has never seen, so "PR without push" was never a state a run could
+  // honour. It used to resolve that by forcing push back on, which left "publish nothing"
+  // unreachable from the launcher — the ladder resolves it the other way.
+  assert.deepEqual(handoffFromPreferences({ autoPushBranch: false }), { push: false, pr: false })
+  assert.deepEqual(handoffFromPreferences({ autoPushBranch: false, autoOpenPr: true }), { push: false, pr: false })
   assert.deepEqual(handoffFromPreferences({ autoOpenPr: false }), { push: true, pr: false })
   assert.deepEqual(handoffFromPreferences({ autoPushBranch: false, autoOpenPr: false }), { push: false, pr: false })
 })

--- a/packages/the-framework/src/run-options.ts
+++ b/packages/the-framework/src/run-options.ts
@@ -50,12 +50,17 @@ export function autopilotEnabled(preferences: Preferences): boolean {
  * The end-of-session handoff a set of preferences arms (#1102). Both halves default on, which is
  * what makes it zero-config: a session left alone pushes its branch and opens a draft PR.
  *
- * Opening a PR implies pushing — `gh` will not open one for a branch the remote has never seen —
- * so the pair is normalised here rather than in the three places that read it.
+ * A ladder, not a pair (#1379): pushing is the rung under opening a PR, so `autoPushBranch` is the
+ * master and turning it off publishes nothing. `gh` will not open a PR for a branch the remote has
+ * never seen, so "PR without push" was never a state a run could honour — it used to resolve the
+ * contradiction by turning push back *on*, which meant a launcher that offered "publish nothing"
+ * could not deliver it. Normalised here rather than in the three places that read it.
+ *
+ * Defaults are untouched: both on, so anyone who never opens the menu gets identical behaviour.
  */
 export function handoffFromPreferences(preferences: Preferences): { push: boolean; pr: boolean } {
-  const pr = preferences.autoOpenPr ?? true
-  return { push: pr || (preferences.autoPushBranch ?? true), pr }
+  const push = preferences.autoPushBranch ?? true
+  return { push, pr: push && (preferences.autoOpenPr ?? true) }
 }
 
 /**


### PR DESCRIPTION
Closes #1379.

The launcher offered only the top two rungs of publishing, so unticking **Open PR** silently meant *push-only*. A user who read that as "publishing off" still got their branch pushed — and the launcher disagreed with the session header, where unticking means the session hands off nothing.

## The ladder

Three rows, each enabled only while the rung below it is on:

1. **Push branch** — default on
2. **Open PR** — default on, disabled while Push branch is off ("nothing to open while Push branch is off")
3. **Auto-merge** — default off, disabled while Open PR is off (unchanged, #1216)

A strict ladder cannot express the contradictory state (PR on / push off) that made the old two-equal-boxes UI unreadable in #1164/#1173, and it extends the grammar Auto-merge already uses. "Publish nothing" becomes reachable from the launcher instead of only via the `autoPushBranch` key, `--auto-push-branch`, and `the-framework.yml`.

## The one semantic change

`handoffFromPreferences` now treats `autoPushBranch` as the master:

```diff
-const pr = preferences.autoOpenPr ?? true
-return { push: pr || (preferences.autoPushBranch ?? true), pr }
+const push = preferences.autoPushBranch ?? true
+return { push, pr: push && (preferences.autoOpenPr ?? true) }
```

`gh` will not open a PR for a branch the remote has never seen, so "PR without push" was never a state a run could honour. It used to resolve that by forcing push back *on*, which is exactly what left "publish nothing" unreachable. The ladder resolves it the other way.

**Defaults are untouched** — push and PR on, merge off — so anyone who never opens the menu gets identical behaviour. The only changed case is an explicit `autoPushBranch: false`, which previously still pushed and PR'd if `autoOpenPr` was on.

## Open question for review

#1379's guardrail says routine/unattended runs must not have what they publish altered. Routine jobs arm `autoMerge` per job, and that still rides through — but push/PR for those runs come from preferences via `resolveProjectRunOptions`, as they did before. So a user who unticks **Push branch** now disarms publishing for auto-PM sweeps and queue drains too. That follows from "off means off", and it is the same way unticking **Open PR** already affected them, but it is a real behaviour question rather than something I should settle silently. If routine runs should keep their own handoff floor, that is a follow-up.

## Testing

- `run-options.test.ts`: the ladder's truth table, including `autoPushBranch: false` + `autoOpenPr: true` now yielding `{push: false, pr: false}`.
- `run-option-rows.test.ts`: all three rungs present and ordered; unticking push disables Open PR with its reason and takes Auto-merge down with it.
- Full suites green: `the-framework` 1632 tests, `framework-dashboard` 655 tests, `turbo run typecheck` 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)