### PR TITLE
Auto-merge requires the agent's setReadyForMerge signal (#1363)

### DIFF
--- a/.changeset/merge-requires-agent-signal.md
+++ b/.changeset/merge-requires-agent-signal.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+Auto-merge now requires the agent's word (#1363, rule settled on #1390). An armed merge only runs when the agent declared the session done via `setReadyForMerge()` — previously the merge fired on config alone, landing work on main that the agent never said was finished. Second check, a temporary safety belt: the session's own `TODO_<SESSION_NAME>.agent.md` must have no open entries. The global `TODO_AGENTS.md` queue never withholds a merge — it is decoupled from sessions. A withheld merge is not a skipped handoff: the branch is still pushed and the PR still opens, as a draft, and the handoff event says why the merge did not run. The system prompt's closing instruction is now a required terminal action rather than a suggestion, so agents reliably signal when their work is done.

--- a/packages/the-framework/prompts/system_prompt.md
+++ b/packages/the-framework/prompts/system_prompt.md
@@ -52,7 +52,9 @@ Measure "variability":
 
 ## After applying changes
 
-After you're done, consider whether <SESSION_NAME> is finished and there isn't any work left to do — if that's the case then call setReadyForMerge()
+After you're done, decide: is <SESSION_NAME> finished, with no work left to do?
+- Yes: call setReadyForMerge() — required, the work is never merged without it
+- No: don't call it; say what's left instead
 
 
 

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -24,10 +24,10 @@ import { hostExecutor } from './host-exec.js'
 import { startDashboard, singleProjectProvider, resolveDashboardBundle, type Dashboard } from './dashboard/index.js'
 import { startRelay, relayPublisher, type RelayPublisher } from './relay.js'
 import { randomUUID } from 'node:crypto'
-import { formatFrameworkEvent } from './terminal.js'
+import { formatFrameworkEvent, mergeWithheldWhy } from './terminal.js'
 import { CLAUDE_CODE_SESSION_LINK } from './session-link.js'
-import { type AutoHandoffSkip, type ChoicePick, type ChoiceRequest, type FrameworkEvent, type OnBeforeMergeableSkip } from './events.js'
-import { runAutoHandoff } from './dashboard/run-handoff.js'
+import { type AutoHandoffSkip, type ChoicePick, type ChoiceRequest, type FrameworkEvent, type MergeWithheldReason, type OnBeforeMergeableSkip } from './events.js'
+import { runAutoHandoff, withheldMerge } from './dashboard/run-handoff.js'
 import {
   runFramework,
   type AppPreview,
@@ -39,6 +39,7 @@ import {
 import { FAKE_DEPLOY, FAKE_INTENT, FAKE_SIGNALS, fakeDriver } from './fake-script.js'
 import { readProjectSignals } from './project.js'
 import { isTicketPath } from './tickets.js'
+import { sessionTodoPending } from './todo-loop.js'
 import { loadFrameworkConfig, type FrameworkFileConfig } from './config.js'
 import {
   describeResolvedConfig,
@@ -1678,6 +1679,23 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
     // teardown still rescues the work onto the branch afterwards.
     if (opts.runId && !(await commitPendingWork(cwd))) return skip('commit-failed')
 
+    // The merge half is authorized, not just configured (#1363; rule settled on #1390): the
+    // agent's setReadyForMerge() — the same signal maybeFireOnBeforeMergeable requires above —
+    // is what says the work may land unattended, plus the session's own TODO file having no
+    // open entries. Never the global TODO_AGENTS.md: the queue is decoupled from sessions.
+    // Withheld is not skipped — push and PR go ahead, and with `armed.merge` off the PR opens
+    // as a draft for a human. Said on the handoff event (#835), or "auto-merge was on and
+    // nothing merged" has no answer.
+    let mergeGate: MergeWithheldReason | undefined
+    if (armed.merge) {
+      const ready = journal.sawReadyForMerge()
+      mergeGate = withheldMerge({
+        readyForMerge: ready,
+        sessionTodoOpen: ready && (await sessionTodoPending(cwd, journal.sessionName())),
+      })
+      if (mergeGate) armed.merge = false
+    }
+
     // The branch as it is now, not as it was named at start: #326 lets the agent rename it, and
     // the rename is exactly what the PR should be opened against.
     const branch = await currentBranch(cwd)
@@ -1689,7 +1707,11 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
       ...(sessionName ? { sessionName } : {}),
       ...(intent ? { intent } : {}),
     }
-    const outcome = await runAutoHandoff(cwd, run, armed)
+    const handedOff = await runAutoHandoff(cwd, run, armed)
+    const outcome =
+      mergeGate && handedOff.outcome !== 'failed'
+        ? { ...handedOff, merge: { outcome: 'withheld' as const, reason: mergeGate } }
+        : handedOff
     onEvent({ kind: 'handoff', ...outcome })
     if (outcome.outcome === 'failed') io.err(`✗ could not ${outcome.step === 'pr' ? 'open the PR' : 'push the branch'}: ${outcome.error}`)
     else if (outcome.outcome === 'done' && outcome.url) io.out(`\n◆ Opened ${outcome.url}`)
@@ -1699,6 +1721,7 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
     const merge = outcome.outcome !== 'failed' ? outcome.merge : undefined
     if (merge?.outcome === 'auto-armed') io.out('◆ Auto-merge armed: the PR lands when its checks pass.')
     else if (merge?.outcome === 'merged') io.out('◆ Merged the PR.')
+    else if (merge?.outcome === 'withheld') io.out(`◆ Merge withheld: ${mergeWithheldWhy(merge.reason)}.`)
     else if (merge?.outcome === 'failed') io.err(`✗ could not merge the PR: ${merge.error}`)
   }
 

--- a/packages/the-framework/src/dashboard/run-handoff.test.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
-import { readRunHandoff, resolveRunPr, runBranchFor, pushRunBranch, openRunPullRequest, gitReason, runAutoHandoff, isSessionBranch, prBaseName, commitSessionWork } from './run-handoff.js'
+import { readRunHandoff, resolveRunPr, runBranchFor, pushRunBranch, openRunPullRequest, gitReason, runAutoHandoff, isSessionBranch, prBaseName, commitSessionWork, withheldMerge } from './run-handoff.js'
 import { pickRunPr } from './gh.js'
 import { nodeGitRunner, GIT_SLOW_TIMEOUT_MS, type GitRunner } from '../project.js'
 import { CliTimeoutError, isCliTimeout } from '../cli-exec.js'
@@ -716,4 +716,16 @@ test('resolveRunPr reports pending only while nothing was found and a lookup is 
   const found = await resolveRunPr('/repo', { id: 'r1', sessionName: 'named' }, prs)
   assert.equal(found.value, undefined)
   assert.equal(found.pending, true)
+})
+
+test('withheldMerge authorizes only a declared-done session with an empty session TODO (#1363)', () => {
+  // The rule settled on #1390: config arms the merge, the agent authorizes it. No signal means
+  // no merge, whatever else is true — this is what row 3 of the live matrix proved was missing
+  // (the daemon merged 3s after the PR opened, with setReadyForMerge never called).
+  assert.equal(withheldMerge({ readyForMerge: false, sessionTodoOpen: false }), 'not-ready-for-merge')
+  assert.equal(withheldMerge({ readyForMerge: false, sessionTodoOpen: true }), 'not-ready-for-merge')
+  // The temporary safety belt: the agent said done but its own session file says otherwise.
+  assert.equal(withheldMerge({ readyForMerge: true, sessionTodoOpen: true }), 'session-todo-open')
+  // Declared done, nothing pending in this session: the merge may run.
+  assert.equal(withheldMerge({ readyForMerge: true, sessionTodoOpen: false }), undefined)
 })

--- a/packages/the-framework/src/dashboard/run-handoff.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.ts
@@ -15,7 +15,7 @@ import type { Cached } from './cache.js'
 import { parseNumstat } from './file-diff.js'
 import { parsePorcelain } from './file-status.js'
 import { errorMessage } from '../error-message.js'
-import type { AutoHandoffSkip, AutoMergeOutcome } from '../events.js'
+import type { AutoHandoffSkip, AutoMergeOutcome, MergeWithheldReason } from '../events.js'
 import { commitPendingWork, currentBranch, startedAtFromRunId, FRAMEWORK_DIR, type RunMeta } from '../store/index.js'
 
 // What a finished session produced, and what is left to do with it (#799).
@@ -516,6 +516,25 @@ export interface HandoffIntent {
 
 /** Both halves armed — the default a session starts from. */
 export const ARMED_HANDOFF: HandoffIntent = { push: true, pr: true }
+
+/**
+ * Whether an armed merge may actually run (#1363), and if not, why.
+ *
+ * The rule settled on #1390: config *arms* the merge, the agent *authorizes* it. Landing on the
+ * default branch unattended takes (a) the agent having declared the session done via
+ * setReadyForMerge() — the same signal the on-before-mergeable step requires — and (b) the
+ * framework not already knowing of work pending in this session (its own TODO file; never the
+ * global queue, which is decoupled from sessions). A withheld merge is not a failed handoff:
+ * push and PR go ahead, the PR just opens as a draft for a human.
+ *
+ * (b) is a temporary safety belt: the agent's word should ultimately be enough. Deleting it means
+ * deleting `sessionTodoOpen` here and `sessionTodoPending` in todo-loop.ts.
+ */
+export function withheldMerge(deps: { readyForMerge: boolean; sessionTodoOpen: boolean }): MergeWithheldReason | undefined {
+  if (!deps.readyForMerge) return 'not-ready-for-merge'
+  if (deps.sessionTodoOpen) return 'session-todo-open'
+  return undefined
+}
 
 /**
  * What auto-handoff did, so the run can say it as an event (#835).

--- a/packages/the-framework/src/events.test.ts
+++ b/packages/the-framework/src/events.test.ts
@@ -180,3 +180,30 @@ test('formatFrameworkEvent renders every post-merge cleanup outcome, naming the 
   assert.match(skipped('no-session-name'), /skipped: the session never called setSessionName\(\)/)
   assert.match(skipped('no-bin-path'), /skipped: the framework binary path is unknown/)
 })
+
+test('formatFrameworkEvent gives the merge half of a handoff its own line, withheld included (#1363)', () => {
+  // After "auto-merge was on", silence about the merge reads as "it merged" — every outcome is said.
+  assert.equal(
+    formatFrameworkEvent({ kind: 'handoff', outcome: 'done', pushed: true, url: 'https://x/pr/1', merge: { outcome: 'merged' } }),
+    '✓ opened https://x/pr/1\n✓ merged the PR',
+  )
+  assert.match(
+    formatFrameworkEvent({ kind: 'handoff', outcome: 'done', pushed: true, merge: { outcome: 'auto-armed' } })!,
+    /auto-merge armed: the PR lands when its checks pass/,
+  )
+  assert.match(
+    formatFrameworkEvent({ kind: 'handoff', outcome: 'done', pushed: true, merge: { outcome: 'failed', error: 'checks red' } })!,
+    /! could not merge the PR: checks red/,
+  )
+  // The gate (#1363): armed but not authorized. The reason travels in the reader's terms.
+  assert.match(
+    formatFrameworkEvent({ kind: 'handoff', outcome: 'done', pushed: true, merge: { outcome: 'withheld', reason: 'not-ready-for-merge' } })!,
+    /~ merge withheld: the session never signalled ready-for-merge/,
+  )
+  assert.match(
+    formatFrameworkEvent({ kind: 'handoff', outcome: 'skipped', reason: 'already-open', merge: { outcome: 'withheld', reason: 'session-todo-open' } })!,
+    /~ merge withheld: the session's own TODO file still has open entries/,
+  )
+  // No merge half: the line stays exactly what it was.
+  assert.equal(formatFrameworkEvent({ kind: 'handoff', outcome: 'done', pushed: true }), '✓ branch pushed')
+})

--- a/packages/the-framework/src/events.ts
+++ b/packages/the-framework/src/events.ts
@@ -96,16 +96,30 @@ export type AutoHandoffSkip =
   | 'fake-run'
 
 /**
+ * Why an armed merge did not run (#1363). The run's config arms the merge; the authorization is
+ * the agent's, not the config's (rule settled on #1390): the agent must have declared the work
+ * done, and the framework must not already know of work pending in this session. The global
+ * `TODO_AGENTS.md` queue never withholds a merge — it is decoupled from sessions.
+ */
+export type MergeWithheldReason =
+  /** The agent never called setReadyForMerge(): the work was never declared done. */
+  | 'not-ready-for-merge'
+  /** The session's own `TODO_<SESSION_NAME>.agent.md` still has open entries. */
+  | 'session-todo-open'
+
+/**
  * How the merge half of a handoff went (#1216), when the run was armed for it. Lives here beside
  * {@link AutoHandoffSkip} for the same leaf-module reason.
  *
  * `auto-armed` is the preferred outcome: GitHub's own auto-merge takes the PR, so it lands when
  * its checks pass rather than before them. `merged` is the fallback where the repo does not allow
  * auto-merge and the PR was merged directly. `failed` never fails the handoff — the PR exists
- * either way, a human can still merge it by hand.
+ * either way, a human can still merge it by hand. `withheld` means the merge never ran at all
+ * (#1363): it was armed but not authorized, and the PR opened as a draft for a human instead.
  */
 export type AutoMergeOutcome =
   | { outcome: 'auto-armed' | 'merged' }
+  | { outcome: 'withheld'; reason: MergeWithheldReason }
   | { outcome: 'failed'; error: string }
 
 /** Who resolved a {@link ChoiceRequest}: a human, the autopilot countdown, or a headless auto-accept. */

--- a/packages/the-framework/src/terminal.ts
+++ b/packages/the-framework/src/terminal.ts
@@ -1,6 +1,6 @@
 import type { BootstrapEvent } from '@gemstack/ai-autopilot'
 import type { DriverEvent, DriverRateLimit } from './driver/index.js'
-import { pickedIds, type AutoHandoffSkip, type ChoiceOption, type FrameworkEvent, type OnBeforeMergeableSkip } from './events.js'
+import { pickedIds, type AutoHandoffSkip, type AutoMergeOutcome, type ChoiceOption, type FrameworkEvent, type MergeWithheldReason, type OnBeforeMergeableSkip } from './events.js'
 
 // The terminal surface for the run's event stream: render one {@link FrameworkEvent} as one
 // human-readable line. This is the CLI's counterpart to the dashboard's read-model
@@ -58,15 +58,20 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
       if (event.push) return `  when this ends: push the branch`
       return `  when this ends: nothing — push and PR are both off`
     }
-    case 'handoff':
+    case 'handoff': {
+      // The merge half rides the same event (#1216) and gets its own line: after "auto-merge
+      // was on", silence about the merge reads as "it merged" (#1363), so every outcome —
+      // armed, merged, withheld, failed — is said.
+      const merge = event.outcome !== 'failed' && event.merge ? `\n${mergeLine(event.merge)}` : ''
       switch (event.outcome) {
         case 'done':
-          return event.url ? `✓ opened ${event.url}` : `✓ branch pushed`
+          return (event.url ? `✓ opened ${event.url}` : `✓ branch pushed`) + merge
         case 'skipped':
-          return `  ~ handoff skipped: ${handoffSkipReason(event.reason)}`
+          return `  ~ handoff skipped: ${handoffSkipReason(event.reason)}` + merge
         case 'failed':
           return `  ! could not ${event.step === 'pr' ? 'open the PR' : 'push the branch'}: ${event.error}`
       }
+    }
     case 'usage': {
       const turns = `over ${event.turns} turn${event.turns === 1 ? '' : 's'}`
       // No price to show: report the tokens the agent *did* report, rather than a
@@ -95,6 +100,33 @@ export function formatFrameworkEvent(event: FrameworkEvent): string {
       return formatBootstrapEvent(event.event)
     case 'end':
       return event.ok ? '✓ finished' : event.stopped ? '■ stopped' : `✗ failed: ${event.detail ?? 'unknown error'}`
+  }
+}
+
+/** One line for the merge half of a handoff (#1216/#1363), matching the CLI's own wording. */
+function mergeLine(merge: AutoMergeOutcome): string {
+  switch (merge.outcome) {
+    case 'auto-armed':
+      return '✓ auto-merge armed: the PR lands when its checks pass'
+    case 'merged':
+      return '✓ merged the PR'
+    case 'withheld':
+      return `  ~ merge withheld: ${mergeWithheldWhy(merge.reason)}`
+    case 'failed':
+      return `  ! could not merge the PR: ${merge.error}`
+  }
+}
+
+/**
+ * Say why an armed merge was withheld (#1363) in the reader's terms. Exported for the CLI's
+ * own stdout line, so the two surfaces cannot drift.
+ */
+export function mergeWithheldWhy(reason: MergeWithheldReason): string {
+  switch (reason) {
+    case 'not-ready-for-merge':
+      return 'the session never signalled ready-for-merge'
+    case 'session-todo-open':
+      return "the session's own TODO file still has open entries"
   }
 }
 

--- a/packages/the-framework/src/todo-loop.test.ts
+++ b/packages/the-framework/src/todo-loop.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { FakeDriver } from './driver/fake.js'
 import type { ChoicePick, ChoiceRequest, FrameworkEvent } from './events.js'
-import { appendTodoEntry, appendFlatTodoEntry, findTodoBacklog, insertTodoEntry, nextQueuedTicket, parseTodoEntries, runTodoLoop, ticketForPrompt } from './todo-loop.js'
+import { appendTodoEntry, appendFlatTodoEntry, findTodoBacklog, insertTodoEntry, nextQueuedTicket, parseTodoEntries, runTodoLoop, sessionTodoPending, ticketForPrompt } from './todo-loop.js'
 import { drainsQueue, presets } from './preset-catalog.js'
 import { AUTO_PM_DRAIN_JOB, AUTO_PM_JOBS } from './auto-pm.js'
 
@@ -521,4 +521,26 @@ test('the drain the sweep fires and the drain a click fires are the same drain (
   assert.equal(drainsQueue(AUTO_PM_DRAIN_JOB.prompt), true)
   // And nothing that merely puts work ON the queue counts as taking it off.
   for (const job of AUTO_PM_JOBS) assert.equal(drainsQueue(job.prompt), false, `${job.name} is not a drain`)
+})
+
+test('sessionTodoPending reads only the session-named TODO file (#1363)', async () => {
+  const cwd = await tmpWorkspace()
+  try {
+    // No file: no pendingness known. The global queue must not count — it is decoupled from
+    // sessions (#1390), and counting it would mean auto-merge never fires while any backlog exists.
+    await writeFile(join(cwd, 'TODO_AGENTS.md'), '- [ ] a standing project entry\n')
+    assert.equal(await sessionTodoPending(cwd, 'fix-login'), false)
+
+    // The session's own file with an open entry withholds; all-checked releases.
+    await writeFile(join(cwd, 'TODO_fix-login.agent.md'), '- [x] done part\n- [ ] open part\n')
+    assert.equal(await sessionTodoPending(cwd, 'fix-login'), true)
+    await writeFile(join(cwd, 'TODO_fix-login.agent.md'), '- [x] done part\n- [x] open part\n')
+    assert.equal(await sessionTodoPending(cwd, 'fix-login'), false)
+
+    // No session name, or one that cannot name a file, knows of nothing pending.
+    assert.equal(await sessionTodoPending(cwd, undefined), false)
+    assert.equal(await sessionTodoPending(cwd, '../escape'), false)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
 })

--- a/packages/the-framework/src/todo-loop.ts
+++ b/packages/the-framework/src/todo-loop.ts
@@ -193,6 +193,27 @@ export async function findTodoBacklog(cwd: string): Promise<TodoBacklog | undefi
 }
 
 /**
+ * Does this session's own backlog still have open work (#1363)?
+ *
+ * Reads only `TODO_<SESSION_NAME>.agent.md` — the file the [Research] preset (and a very-large
+ * scope) has the agent keep for its own session. Never the global `TODO_AGENTS.md`: the queue is
+ * decoupled from sessions (#1390), and withholding a merge on it would mean auto-merge never
+ * fires while the project has any backlog at all. `false` on a missing or unreadable file, and on
+ * a session name that could not name a file — no pendingness known is not pendingness.
+ *
+ * TEMPORARY SAFETY BELT, built to be deleted (#1390): the agent's setReadyForMerge() is the
+ * authorization, and this only catches the agent declaring done while its own session file says
+ * otherwise. When the agent's word is deemed enough, delete this function and its single call
+ * site in `maybeAutoHandoff`.
+ */
+export async function sessionTodoPending(cwd: string, sessionName: string | undefined): Promise<boolean> {
+  // The prompt asks for [a-z0-9-]+; anything wider (a path separator above all) names no file.
+  if (!sessionName || !/^[A-Za-z0-9._-]+$/.test(sessionName)) return false
+  const md = await readFile(join(cwd, `TODO_${sessionName}.agent.md`), 'utf8').catch(() => undefined)
+  return md !== undefined && parseTodoEntries(md).length > 0
+}
+
+/**
  * The ticket the next drain run will pick up, or `undefined` when there is none (#1117).
  *
  * "Next" is the first open entry of the flat backlog, because that is what the [Drain queue]


### PR DESCRIPTION
TLDR: an armed merge now runs only when the agent called `setReadyForMerge()` and its own session TODO file has no open entries. Push and PR are untouched; a withheld merge opens the PR as a draft and says why. The system prompt now makes the signal a required terminal action. Implements the rule settled on #1390 (fix #1363).

## The two halves (they must ship together)

1. **The gate** — `maybeAutoHandoff` withholds the merge unless (a) `journal.sawReadyForMerge()` (same signal the on-before-mergeable step already requires) and (b) `TODO_<SESSION_NAME>.agent.md` has no open entries. Never `TODO_AGENTS.md`: the global queue is decoupled from sessions, or auto-merge would never fire while any backlog exists.
2. **The prompt** — the closing "consider whether … then call setReadyForMerge()" is now a required yes/no terminal action. Without this half, gating on the signal silently stops auto-merge on simple runs — live matrix row 3 (#1363, run `00-21-32-410Z`) merged 3s after the PR opened with the signal never emitted.

## Built to be deleted

(b) is the temporary safety belt from #1390 — the agent's word should ultimately be enough. Deleting it = removing `sessionTodoOpen` from `withheldMerge()` and `sessionTodoPending()` in todo-loop.ts; both say so in their comments.

## Visibility

A withheld merge is not a skipped handoff: the branch pushes, the PR opens (as a draft, since `draft: !intent.merge`), and the `handoff` event carries `merge: { outcome: 'withheld', reason }`. The transcript now renders every merge outcome — before this, a merged/withheld/failed merge was invisible in a dashboard transcript.

## Tests

- `withheldMerge` decision table (run-handoff.test.ts)
- `sessionTodoPending` reads only the session file, ignores `TODO_AGENTS.md`, refuses path-escaping names (todo-loop.test.ts)
- transcript lines for all four merge outcomes (events.test.ts)
- Suites: the-framework 1637/0 (1 pre-existing skip), dashboard 655/655 (one PreviewBar flake on first run, clean on rerun)

Not yet done: a live matrix row (needs the main checkout's daemon — will dogfood after merge like rows 1–3).

@brillout this touches `prompts/system_prompt.md` — the new wording is the smallest change I could make that turns the suggestion into a required decision; rephrase freely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)