### PR TITLE
Add the changeset #1387 shipped without

### DIFF
--- a/.changeset/host-header-guard.md
+++ b/.changeset/host-header-guard.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+The dashboard's loopback Telefunc mount now validates the `Host` header (#1387). Before this, a DNS-rebinding page could reach the daemon's run-starting RPCs from the victim's browser: the origin check passed Origin-less requests, and nothing pinned `Host` to a loopback name. Requests whose `Host` is not a loopback address are refused.


### PR DESCRIPTION
TLDR: #1387 (Host-header guard on the dashboard's loopback Telefunc mount) merged without a changeset, so the changelog would never mention the security fix. This adds the missing changeset — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)