### PR TITLE
Spike-lock push targets origin's default branch; staleness 60min → 6h (#1364 review)

### DIFF
--- a/.changeset/spike-lock-review-smells.md
+++ b/.changeset/spike-lock-review-smells.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+Two fixes from the #1364 post-merge review. The spike-lock commit now pushes to origin's default branch — and only when the checkout is on it; before, it pushed `HEAD:<current branch>`, which published whatever branch the daemon's checkout happened to be on and left main-forked machines blind to the locks. `SPIKE_LOCK_STALE_MS` goes from 60 minutes to 6 hours: spiking and planning can take hours, and staleness release is a recovery mechanism that ideally never fires.

--- a/packages/the-framework/src/spike-locks.spec.md
+++ b/packages/the-framework/src/spike-locks.spec.md
@@ -2,15 +2,15 @@ The PENDING lock for concurrent spike agents (#1327): before a fanned-out [Spike
 
 ## TLDR
 
-- `acquireSpikeLocks(cwd, assignments)` — write both placeholders per ticket, one pathspec-scoped batch commit, push `HEAD:<current branch>`; resolves the subset actually locked. Skips a ticket whose sibling already exists (real or placeholder). Commit failure rolls the files back and resolves `[]`; push failure keeps the batch and logs.
-- `releaseStaleSpikeLocks(cwd)` — frees a lock that is all three of: still a placeholder, older than `SPIKE_LOCK_STALE_MS` (60 min, by its last commit time), and untouched by any open PR. One batch commit + best-effort push; resolves the released tickets.
+- `acquireSpikeLocks(cwd, assignments)` — write both placeholders per ticket, one pathspec-scoped batch commit, push to origin's default branch, only when the checkout is on it (`HEAD:main` from a feature branch would carry that branch's commits onto main — #1364 review); resolves the subset actually locked. Skips a ticket whose sibling already exists (real or placeholder). Commit failure rolls the files back and resolves `[]`; push failure keeps the batch and logs.
+- `releaseStaleSpikeLocks(cwd)` — frees a lock that is all three of: still a placeholder, older than `SPIKE_LOCK_STALE_MS` (6 h, by its last commit time — spiking and planning can take hours, and this is recovery, ideally never needed), and untouched by any open PR. One batch commit + best-effort push; resolves the released tickets.
 - `isSpikeLock(md)` / `spikeLockContent(agentId)` — the placeholder telling: first non-blank content starts with `PENDING:`. Shared with the dashboard's ticket reader so a lock never renders as a real spike.
 
 ## Problems
 
 - The guard cannot be daemon memory: a hands-off web run's local process ends at the hand-off (#1253), another machine's daemon shares nothing, and the #1313 PR-diff claims only start once a PR exists. The lock files cover the window *before* a PR; #1313 covers after.
 - Agents cannot push (#1320), so the daemon writes and pushes the locks — a lock that only existed inside the run it protects would protect nothing.
-- A dead agent must not brick its ticket forever, hence the staleness rule (#1327's thread): PENDING + no open PR + N minutes.
+- A dead agent must not brick its ticket forever, hence the staleness rule (#1327's thread): PENDING + no open PR + N hours.
 
 ## Decisions
 

--- a/packages/the-framework/src/spike-locks.test.ts
+++ b/packages/the-framework/src/spike-locks.test.ts
@@ -25,6 +25,7 @@ function checkout(files: Record<string, string> = {}) {
     git: async (args, _cwd) => {
       gitCalls.push(args)
       if (args[0] === 'rev-parse') return 'main\n'
+      if (args[0] === 'symbolic-ref') return 'origin/main\n'
       if (args[0] === 'log') return commitTimes.get(args[args.length - 1]!) ?? ''
       return ''
     },
@@ -207,4 +208,26 @@ test('releaseStaleSpikeLocks never touches a real spike or plan (#1327)', async 
   assert.deepEqual(released, ['a.md'])
   assert.equal(disk.has(join(CWD, 'tickets/a.spike.md')), true)
   assert.equal(disk.has(join(CWD, 'tickets/a.plan.md')), false)
+})
+
+test('a checkout on a feature branch keeps its lock commit local rather than pushing (#1364 review)', async () => {
+  // The push exists to land locks where other machines fork from: origin's default branch.
+  // From any other branch, `HEAD:main` would carry that branch's own commits onto main, and the
+  // old `HEAD:<current branch>` published whatever branch the checkout happened to be on — so
+  // the push is skipped, said out loud, and the commit still guards local forks.
+  const { gitCalls, logs, deps } = checkout({ 'tickets/a.md': '# a' })
+  const onFeature: SpikeLockDeps = {
+    ...deps,
+    git: async (args, cwd) => {
+      if (args[0] === 'rev-parse') {
+        gitCalls.push(args)
+        return 'my-feature\n'
+      }
+      return deps.git!(args, cwd)
+    },
+  }
+  const locked = await acquireSpikeLocks(CWD, [{ ticket: 'a.md', agentId: 'agent-0' }], onFeature)
+  assert.equal(locked.length, 1, 'the commit still locks: only the cross-machine push is off')
+  assert.equal(gitCalls.some(args => args[0] === 'push'), false)
+  assert.ok(logs.some(line => /not on the default branch/.test(line)))
 })

--- a/packages/the-framework/src/spike-locks.ts
+++ b/packages/the-framework/src/spike-locks.ts
@@ -24,11 +24,12 @@ export const SPIKE_LOCK_PREFIX = 'PENDING:'
 
 /**
  * How old a PENDING lock must be before it is presumed dead and released. Generous against the
- * slowest live path — a cloud spike that queues before it runs — because a lock released under a
- * live agent re-opens the double-work window the lock exists to close, while a dead agent's
- * ticket only waits one interval longer.
+ * slowest live path — spiking and planning can take hours, on top of a cloud queue — because a
+ * lock released under a live agent re-opens the double-work window the lock exists to close,
+ * while a dead agent's ticket only waits one interval longer. This is a bug-recovery mechanism
+ * that ideally never fires (#1364 review), so erring long costs nearly nothing.
  */
-export const SPIKE_LOCK_STALE_MS = 60 * 60 * 1000
+export const SPIKE_LOCK_STALE_MS = 6 * 60 * 60 * 1000
 
 /** Whether a sibling's content is a PENDING placeholder rather than a real spike or plan. */
 export function isSpikeLock(md: string): boolean {
@@ -81,6 +82,25 @@ const defaultPrTouches = async (cwd: string, file: string): Promise<boolean | un
   return value === undefined ? undefined : value.length > 0
 }
 
+/**
+ * Push the just-made lock commit to origin's default branch — the branch other machines fork
+ * from, the only place a lock closes the cross-machine window (#1320, #1364 review). Pushed only
+ * when the checkout is *on* that branch: `HEAD:main` from anywhere else would carry the branch's
+ * own commits onto main, and the old `HEAD:<current branch>` published whatever branch the
+ * checkout happened to be on. Resolves false when the push was skipped for that reason; a failed
+ * push still throws, so each caller keeps its own log line.
+ */
+async function pushLockCommit(git: GitRunner, cwd: string): Promise<boolean> {
+  const current = (await git(['rev-parse', '--abbrev-ref', 'HEAD'], cwd)).trim()
+  // `origin/main` in almost every checkout; asked rather than assumed, with the assumption as
+  // the fallback for a clone whose origin/HEAD was never set.
+  const head = await git(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], cwd).then(out => out.trim(), () => 'origin/main')
+  const target = head.replace(/^origin\//, '')
+  if (current !== target) return false
+  await git(['push', 'origin', `HEAD:${target}`], cwd)
+  return true
+}
+
 /** A ticket filename's lock paths, relative to the repo root. */
 function lockPaths(ticket: string): { spike: string; plan: string } {
   const stem = ticket.replace(/\.md$/, '')
@@ -92,8 +112,8 @@ function lockPaths(ticket: string): { spike: string; plan: string } {
 
 /**
  * Claim `assignments`' tickets for their agents: write both placeholder siblings per ticket,
- * commit the whole batch in one pathspec-scoped commit, and push it to the branch the checkout is
- * on. Resolves the subset actually locked — a ticket whose sibling appeared since the candidates
+ * commit the whole batch in one pathspec-scoped commit, and push it to origin's default branch
+ * ({@link pushLockCommit}). Resolves the subset actually locked — a ticket whose sibling appeared since the candidates
  * were enumerated is skipped, not overwritten: an existing file is someone's claim or someone's
  * work, and either outranks this batch.
  *
@@ -141,8 +161,8 @@ export async function acquireSpikeLocks(
     return []
   }
   try {
-    const branch = (await git(['rev-parse', '--abbrev-ref', 'HEAD'], cwd)).trim()
-    await git(['push', 'origin', `HEAD:${branch}`], cwd)
+    if (!(await pushLockCommit(git, cwd)))
+      log(`[framework] spike locks: the checkout is not on the default branch, so the lock commit was not pushed — agents on other machines cannot see these ${locked.length} claim(s)`)
   } catch {
     log(`[framework] spike locks: the lock commit could not be pushed, so agents on other machines cannot see these ${locked.length} claim(s)`)
   }
@@ -207,8 +227,8 @@ export async function releaseStaleSpikeLocks(cwd: string, deps: SpikeLockDeps = 
     await git(['add', '--', ...files], cwd)
     await git(['commit', '-m', releaseMessage(files.length), '--', ...files], cwd)
     try {
-      const branch = (await git(['rev-parse', '--abbrev-ref', 'HEAD'], cwd)).trim()
-      await git(['push', 'origin', `HEAD:${branch}`], cwd)
+      if (!(await pushLockCommit(git, cwd)))
+        log(`[framework] spike locks: the checkout is not on the default branch, so the release commit was not pushed`)
     } catch {
       log(`[framework] spike locks: the release commit could not be pushed`)
     }


### PR DESCRIPTION
TLDR: the two code smells from the #1364 post-merge review.

1. **Push target** — the lock commit pushed `HEAD:<current branch>`. That published whatever branch the daemon's checkout happened to be on, and locks never reached the branch other machines fork from. Now it pushes to origin's default branch — and only when the checkout is on it, because `HEAD:main` from a feature branch would carry that branch's own commits onto main. A skipped push is logged; the commit still guards local forks either way.
2. **`SPIKE_LOCK_STALE_MS`** — 60 min → 6 h. Spiking and planning can take hours, and staleness release is a bug-recovery mechanism that ideally never fires, so erring long is nearly free.

spec.md updated, feature-branch case tested, changeset included. Suite: 1632/0.

The third point of the review (LoC added vs deleted, "how much AI slop") is answered on #1364 directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)