### PR TITLE
Squash-merge closes the ticket's issue: (fix #N) rides the PR title (#1334)

### DIFF
--- a/.changeset/squash-merge-closes-ticket-issue.md
+++ b/.changeset/squash-merge-closes-ticket-issue.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+A run implementing a ticket now carries the ticket's GitHub issue into its PR title as `(fix #42)`, read off the ticket's `GitHub:` header (#1334). The squash-merge commit inherits the title, so merging the PR closes the issue — before, an autonomously merged quick-win left its ticket open.

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import { spawn } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
@@ -38,7 +39,7 @@ import {
 } from './run.js'
 import { FAKE_DEPLOY, FAKE_INTENT, FAKE_SIGNALS, fakeDriver } from './fake-script.js'
 import { readProjectSignals } from './project.js'
-import { isTicketPath } from './tickets.js'
+import { isTicketPath, ticketIssueRef } from './tickets.js'
 import { loadFrameworkConfig, type FrameworkFileConfig } from './config.js'
 import {
   describeResolvedConfig,
@@ -1683,11 +1684,18 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
     const branch = await currentBranch(cwd)
     if (!branch) return skip('branch-gone')
     const sessionName = journal.sessionName()
+    // The ticket's GitHub issue rides the PR title as `(fix #42)` (#1334): the squash-merge
+    // subject inherits the title, so the merge closes the issue — without it, an auto-merged
+    // quick-win leaves its ticket open. Best-effort: a ticket that cannot be read fixes nothing.
+    const fixes = opts.ticket && isTicketPath(opts.ticket)
+      ? ticketIssueRef(await readFile(join(cwd, opts.ticket), 'utf8').catch(() => ''))
+      : undefined
     const run = {
       id: opts.runId ?? '',
       branch,
       ...(sessionName ? { sessionName } : {}),
       ...(intent ? { intent } : {}),
+      ...(fixes ? { fixes } : {}),
     }
     const outcome = await runAutoHandoff(cwd, run, armed)
     onEvent({ kind: 'handoff', ...outcome })

--- a/packages/the-framework/src/dashboard/run-handoff.test.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.test.ts
@@ -717,3 +717,25 @@ test('resolveRunPr reports pending only while nothing was found and a lookup is 
   assert.equal(found.value, undefined)
   assert.equal(found.pending, true)
 })
+
+test("a run implementing a ticket carries its issue as `(fix #42)` in the PR title (#1334)", async () => {
+  // The squash-merge subject inherits the title, so this is what closes the ticket's issue on
+  // merge; without it an auto-merged quick-win leaves its ticket open.
+  const gh: string[][] = []
+  const { git } = fakeGit({ ...READY, push: '' })
+  await runAutoHandoff(
+    '/repo',
+    { id: 'r1', branch: 'the-framework/x', sessionName: 'fix-login', fixes: '#42' },
+    { push: true, pr: true },
+    {
+      git,
+      pr: async () => undefined,
+      gh: async args => {
+        gh.push(args)
+        return 'https://github.com/o/r/pull/9\n'
+      },
+    },
+  )
+  const title = gh[0]?.[gh[0].indexOf('--title') + 1]
+  assert.equal(title, 'fix-login (fix #42)')
+})

--- a/packages/the-framework/src/dashboard/run-handoff.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.ts
@@ -490,7 +490,7 @@ export async function openSessionPullRequest(
   // Refuse rather than open an empty PR: a session that changed nothing has nothing to hand off.
   if (handoff?.empty) return { ok: false, error: 'this session produced no commits to open a PR for' }
   return openRunPullRequest(cwd, branch, {
-    title: run.sessionName ?? run.intent?.split('\n')[0]?.slice(0, 72) ?? `Session ${run.id}`,
+    title: sessionPrTitle(run),
     body: sessionPrBody(run),
     ...(handoff?.base ? { base: handoff.base } : {}),
     ...(options.draft ? { draft: true } : {}),
@@ -579,7 +579,7 @@ export async function runAutoHandoff(
       cwd,
       branch,
       {
-        title: run.sessionName ?? run.intent?.split('\n')[0]?.slice(0, 72) ?? `Session ${run.id}`,
+        title: sessionPrTitle(run),
         body: sessionPrBody(run),
         // GitHub refuses to merge or auto-merge a draft, so an armed merge (#1216) opens the PR
         // ready: its review happened on the queue before the run, which is the same reason the
@@ -616,7 +616,21 @@ export async function runAutoHandoff(
  * the PR. Narrower than {@link RunMeta} so the run process can call this before its meta is
  * final, and so a caller cannot quietly start depending on the rest of the run's state.
  */
-export type HandoffRun = Pick<RunMeta, 'id' | 'branch' | 'sessionName' | 'intent'> & Partial<Pick<RunMeta, 'startedAt'>>
+export type HandoffRun = Pick<RunMeta, 'id' | 'branch' | 'sessionName' | 'intent'> &
+  Partial<Pick<RunMeta, 'startedAt'>> & {
+    /**
+     * The GitHub issue the run's ticket tracks (`#42`), when it implements one (#1334). Carried
+     * into the PR title as `(fix #42)` so the squash-merge commit — which inherits the title —
+     * closes the issue; without it an auto-merged quick-win leaves its ticket open.
+     */
+    fixes?: string
+  }
+
+/** The PR title for a session (#1102), with the ticket's issue reference riding along (#1334). */
+function sessionPrTitle(run: Pick<HandoffRun, 'id' | 'sessionName' | 'intent' | 'fixes'>): string {
+  const title = run.sessionName ?? run.intent?.split('\n')[0]?.slice(0, 72) ?? `Session ${run.id}`
+  return run.fixes ? `${title} (fix ${run.fixes})` : title
+}
 
 /** The PR number out of the URL `gh pr create` prints, e.g. `…/pull/123` (#1216). */
 function prNumberFromUrl(url: string | undefined): number | undefined {

--- a/packages/the-framework/src/tickets.test.ts
+++ b/packages/the-framework/src/tickets.test.ts
@@ -12,6 +12,7 @@ import {
   findFlatTodo,
   isTicketPath,
   ticketFromQueueEntry,
+  ticketIssueRef,
   todoPriorityForTicket,
 } from './tickets.js'
 import { TICKETING_FORMAT, TODO_FORMAT } from './prompts.generated.js'
@@ -123,4 +124,16 @@ test('only a plain file inside tickets/ counts as a ticket path (#1117)', () => 
   }
   // A traversal dressed as a link is refused at the same gate.
   assert.equal(ticketFromQueueEntry('[sneaky](tickets/../../etc/passwd)'), undefined)
+})
+
+test('ticketIssueRef reads the issue off the GitHub header line, URL first (#1334)', () => {
+  const md = 'Status: open\nGitHub: [#42](https://github.com/org/repo/issues/42)\n\n# T\n'
+  assert.equal(ticketIssueRef(md), '#42')
+  // The URL is the identity: a label that disagrees with it loses.
+  assert.equal(ticketIssueRef('GitHub: [gh-7](https://github.com/o/r/issues/99)\n'), '#99')
+  // A hand-written line with no URL still counts by its label.
+  assert.equal(ticketIssueRef('GitHub: #13\n'), '#13')
+  // No header, or one naming no number, fixes nothing.
+  assert.equal(ticketIssueRef('# A ticket with no GitHub line\n'), undefined)
+  assert.equal(ticketIssueRef('GitHub: none yet\n'), undefined)
 })

--- a/packages/the-framework/src/tickets.ts
+++ b/packages/the-framework/src/tickets.ts
@@ -92,6 +92,24 @@ export function isTicketPath(path: string): boolean {
   return file.endsWith('.md') && !file.includes('/') && !file.startsWith('.')
 }
 
+/**
+ * The GitHub issue a ticket tracks, as a `#42` reference, or `undefined` when it tracks none.
+ *
+ * Read off the ticket's `GitHub: [#42](…/issues/42)` header line (`prompts/ticketing_format.md`).
+ * The number comes from the URL when there is one — the label is display text, the URL is the
+ * identity — with the label's own `#42` as the fallback for a hand-written line.
+ *
+ * This is what lets a merge close the ticket's issue (#1334): the reference rides the PR title
+ * as `(fix #42)`, and GitHub's squash subject inherits the title.
+ */
+export function ticketIssueRef(md: string): string | undefined {
+  const line = md.split('\n').find(l => l.trim().toLowerCase().startsWith('github:'))
+  if (!line) return undefined
+  const url = /\((?:[^)]*\/)?(?:issues|pull)\/(\d+)\)/.exec(line)
+  const match = url ?? /#(\d+)/.exec(line)
+  return match ? `#${match[1]}` : undefined
+}
+
 /** The brief hyphen spelling from #682, read as a fallback after #674 settled on the underscore. */
 export const LEGACY_HYPHEN_TODO_FILE = 'TODO-AGENTS.md'
 


### PR DESCRIPTION
TLDR: implements the unchecked #1334 item — "Ensure the squash-merge commit contains `(fix #1234)`, otherwise the ticket stays open."

A run that implements a ticket now reads the issue number off the ticket's `GitHub: [#42](…)` header and opens its PR titled `<session> (fix #42)`. GitHub's default squash subject inherits the PR title, so the merge commit carries the reference and closes the issue — on the auto-merge path (`--auto`) and the direct-merge fallback alike, since both squash. Before, an autonomously merged quick-win left its ticket open.

Best-effort by design: no ticket, no `GitHub:` line, or an unreadable file simply means no reference — nothing fails.

Tests: `ticketIssueRef` parsing (URL wins over label, hand-written `#13` accepted, no line → nothing) and the PR-title composition through `runAutoHandoff`. Suite 1633/0. Changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)