### PR TITLE
test: harden the two remaining #1398 flakes (RoutineWork tooltip, PreviewBar picker)

### DIFF
--- a/packages/framework-dashboard/components/PreviewBar.test.tsx
+++ b/packages/framework-dashboard/components/PreviewBar.test.tsx
@@ -39,8 +39,20 @@ describe('PreviewBar serve picker (#651)', () => {
     render(<PreviewBar projectId="p2" inline />)
     // >1 target → a split control: [primary Serve, caret picker].
     await waitFor(() => expect(screen.getAllByRole('button')).toHaveLength(2))
-    fireEvent.click(screen.getAllByRole('button')[1]!) // open the caret dropdown
-    fireEvent.click(await screen.findByText('api'))
+    // Open the caret dropdown, re-clicking only while it still reads closed (#1398): a click
+    // dispatched before the trigger's listeners are attached opens nothing, and one findByText
+    // then times out on a menu that will never mount ("Unable to find … api" on a loaded CI
+    // runner, the caret's DOM dump still at aria-expanded="false"). Guarding on aria-expanded
+    // keeps the retry from toggling a menu that did open.
+    await waitFor(
+      () => {
+        const caret = screen.getAllByRole('button')[1]!
+        if (caret.getAttribute('aria-expanded') !== 'true') fireEvent.click(caret)
+        expect(caret.getAttribute('aria-expanded')).toBe('true')
+      },
+      { timeout: 5000 },
+    )
+    fireEvent.click(await screen.findByText('api', undefined, { timeout: 5000 }))
     await waitFor(() => expect(sendPreview).toHaveBeenCalledWith('p2', 'apps/api', undefined))
   })
 

--- a/packages/framework-dashboard/test-utils.ts
+++ b/packages/framework-dashboard/test-utils.ts
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 
 /**
  * Hover a tooltip trigger and hand back the tooltip it opens (#1149).
@@ -8,9 +8,18 @@ import { fireEvent, screen } from '@testing-library/react'
  * a move, and portals the popup out of the trigger's subtree.
  */
 export async function hoverTooltip(trigger: Element): Promise<HTMLElement> {
-  fireEvent.mouseEnter(trigger)
-  fireEvent.mouseMove(trigger)
-  return await screen.findByRole('tooltip')
+  // Re-fire the hover pair on every retry rather than once up front (#1398): a pair dispatched
+  // before the trigger's listeners are attached opens nothing, and a single findByRole then
+  // waits out its timeout on a tooltip that will never come ("Unable to find role=tooltip" on a
+  // loaded CI runner, fine locally). Repeating the events is idempotent for a hover.
+  return await waitFor(
+    () => {
+      fireEvent.mouseEnter(trigger)
+      fireEvent.mouseMove(trigger)
+      return screen.getByRole('tooltip')
+    },
+    { timeout: 5000 },
+  )
 }
 
 /** Move off a trigger, so the next {@link hoverTooltip} is the only tooltip open. */


### PR DESCRIPTION
Finishes #1398: flakes 2 and 3, same root cause, one cure each.

Both are Base UI floating elements whose open is triggered by an event the test fires exactly once. When that event lands before the trigger's listeners are attached (a loaded CI runner; fine locally), nothing opens — and the single `findBy*` that follows waits out its whole timeout on a popup that will never mount:

- **RoutineWork** — "with auto-run off the trigger still sweeps once (#1210)": `TestingLibraryElementError: Unable to find role="tooltip"` (run 30580356732, attempt 2 — the DOM dump shows no tooltip anywhere).
- **PreviewBar** — "a multi-target repo offers a picker": `Unable to find … 'api'`, the caret's dump still at `aria-expanded="false"` — the click never opened the menu.

Fixes:

- `hoverTooltip` (test-utils, 22 call sites) now re-fires the mouseEnter+mouseMove pair on **every** retry inside a `waitFor` instead of once up front — hover events are idempotent, so a too-early pair can no longer strand the wait.
- The PreviewBar test re-clicks the caret **only while it still reads `aria-expanded="false"`**, so a click that did land is never toggled back closed, then gives the item lookup a generous timeout.

No production code touched. Both files 5×5 green locally; dashboard suite 658/658.

With #1401 (flake 1, merged) this covers all three flakes — closes #1398 when merged. Also unblocks the parked #1406 (a required `build` check stops being a flake amplifier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)