### PR TITLE
Live feed: a reconnect never blanks a populated transcript (#1383)

### DIFF
--- a/.changeset/live-feed-replay-sync.md
+++ b/.changeset/live-feed-replay-sync.md
@@ -1,0 +1,6 @@
+---
+'@gemstack/the-framework': patch
+'@gemstack/framework-dashboard': patch
+---
+
+The live run feed no longer blanks mid-run on a stream reconnect (#1383). Every subscribe replays the whole log before following live, and the client used to clear its feed first — so after a transient channel drop the "stream lost" banner cleared and the transcript sat empty, bannerless, until the replay refilled it. The on-disk tail now sends a wire-only `stream-sync` marker when its replay is delivered, and a reconnecting client buffers the replay and swaps atomically on it — the feed never shows less than it already showed, the same rule #1402 set for the archive read. In-memory sources (the relay, relayed device runs) send no marker and fall back to a short grace deadline; a reconnect that dies mid-replay drops its partial buffer rather than swapping it in.

--- a/packages/framework-dashboard/lib/use-live-events.spec.md
+++ b/packages/framework-dashboard/lib/use-live-events.spec.md
@@ -10,7 +10,7 @@ The shared live run feed (#405): `useLiveEvents(projectId, runId?, resetKey?)` s
 
 - A dead stream used to be silent (#948): daemon restarts, events just stop, and "agent went quiet" was indistinguishable from "feed died". Now an errored close or failed subscribe flips `lost` and retries with backoff (1s/2s/4s then settling at 8s); a clean close is deliberate and neither alarms nor retries.
 - Run boundary vs. buffer: the subscription survives run boundaries (resets only on project/run-id change), so a new Start would keep showing the finished run until events.jsonl is truncated. `resetKey` (bumped by a fresh Start) clears the buffer WITHOUT tearing down the subscription; the pane waits empty and JsonlTailer's rewrite detection re-reads the truncated file (#705 jump-to-live would otherwise show the old run).
-- Reconnect duplicates: the tail replays the whole log on subscribe, so each (re)subscribe clears the buffer first rather than appending duplicate history.
+- Reconnect duplicates vs. the mid-run blank (#1383): the tail replays the whole log on subscribe. Clearing the buffer on every (re)subscribe avoided duplicate history but blanked a populated feed while the replay re-streamed — the lost banner cleared on resubscribe, then the feed sat empty until the replay caught up. Now only the FIRST subscribe of an effect starts clean (the pane was just cleared anyway); a RECONNECT buffers the replay and swaps atomically on the server's `stream-sync` marker, or at `SYNC_GRACE_MS` (1.5 s) for in-memory sources that send none (relay #426, relayed device #1067). The feed never shows less than it already showed (#1402's rule applied to the live channel). A close mid-replay drops the partial buffer — swapping it in would be the collapse this prevents.
 
 ## Decisions
 
@@ -19,5 +19,6 @@ The shared live run feed (#405): `useLiveEvents(projectId, runId?, resetKey?)` s
 
 ## Flows
 
-- subscribe: `onEvents(projectId, runId)` → clear buffer, `attempt = 0`, `lost = false` → `listen`: stamp + append each event → `onClose(err)`: err → `retry()` (backoff, `lost = true`); clean → `done = true`.
+- subscribe (first): `onEvents(projectId, runId)` → clear buffer, `attempt = 0`, `lost = false` → `listen`: swallow `stream-sync`, stamp + append each event → `onClose(err)`: err → `retry()` (backoff, `lost = true`); clean → `done = true`.
+- subscribe (reconnect): keep the shown feed → buffer replayed events → swap wholesale on `stream-sync` or at the grace deadline → append live after; a close mid-replay discards the buffer.
 - teardown/switch: effect cleanup sets `cancelled`, clears the retry timer, closes the channel.

--- a/packages/framework-dashboard/lib/use-live-events.test.tsx
+++ b/packages/framework-dashboard/lib/use-live-events.test.tsx
@@ -13,15 +13,17 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
-/** A channel stub that records its onClose callback so a test can drop the stream. */
+/** A channel stub that records its callbacks so a test can push events and drop the stream. */
 function fakeChannel() {
   const callbacks: Array<(err?: Error) => void> = []
+  const listeners: Array<(event: unknown) => void> = []
   return {
     channel: {
-      listen: () => {},
+      listen: (cb: (event: unknown) => void) => listeners.push(cb),
       close: () => {},
       onClose: (cb: (err?: Error) => void) => callbacks.push(cb),
     },
+    push: (event: unknown) => listeners.forEach(cb => cb(event)),
     dropWith: (err?: Error) => callbacks.forEach(cb => cb(err)),
   }
 }
@@ -90,5 +92,99 @@ describe('useLiveEvents stream loss (#948)', () => {
     render(<Probe projectId="p1" runId="run-a" />)
     await waitFor(() => expect(screen.getByText('lost')).toBeTruthy())
     await waitFor(() => expect(screen.getByText('live')).toBeTruthy(), { timeout: 3000 })
+  })
+})
+
+// #1383: every subscribe replays the whole log before following live. Blanking the feed while
+// that replay re-streamed was the mid-run flicker — the lost banner cleared on resubscribe, then
+// the feed sat empty until the replay caught up. A reconnect now buffers the replay and swaps
+// atomically on the server's stream-sync marker (or a grace deadline for sources that send none).
+describe('useLiveEvents reconnect keeps the feed (#1383)', () => {
+  const log = (message: string) => ({ kind: 'log', message })
+
+  function FeedProbe({ projectId, runId }: { projectId: string | null; runId?: string | null }) {
+    const { events } = useLiveEvents(projectId, runId)
+    return <span data-testid="feed">{events.map(e => (e.kind === 'log' ? e.message : e.kind)).join(',')}</span>
+  }
+  const feed = () => screen.getByTestId('feed').textContent
+
+  test('the first subscribe streams straight in, and the sync marker is swallowed', async () => {
+    const ch = fakeChannel()
+    onEvents.mockResolvedValue(ch.channel)
+    render(<FeedProbe projectId="p1" runId="run-a" />)
+    await waitFor(() => expect(onEvents).toHaveBeenCalledTimes(1))
+    ch.push(log('a'))
+    ch.push({ kind: 'stream-sync' })
+    ch.push(log('b'))
+    await waitFor(() => expect(feed()).toBe('a,b'))
+  })
+
+  test('a reconnect never shows less than it already showed: the replay swaps in atomically', async () => {
+    const first = fakeChannel()
+    const second = fakeChannel()
+    onEvents.mockResolvedValueOnce(first.channel).mockResolvedValue(second.channel)
+    render(<FeedProbe projectId="p1" runId="run-a" />)
+    await waitFor(() => expect(onEvents).toHaveBeenCalledTimes(1))
+    first.push(log('a'))
+    first.push({ kind: 'stream-sync' })
+    first.push(log('b'))
+    await waitFor(() => expect(feed()).toBe('a,b'))
+
+    first.dropWith(new Error('connection reset'))
+    await waitFor(() => expect(onEvents).toHaveBeenCalledTimes(2), { timeout: 3000 })
+    // The replay is streaming again — but the populated feed stays put until the marker.
+    second.push(log('a'))
+    second.push(log('b'))
+    expect(feed()).toBe('a,b')
+    second.push(log('c'))
+    second.push({ kind: 'stream-sync' })
+    // The swap is atomic: the whole replayed log at once, never a shorter prefix.
+    await waitFor(() => expect(feed()).toBe('a,b,c'))
+    second.push(log('d'))
+    await waitFor(() => expect(feed()).toBe('a,b,c,d'))
+  })
+
+  test('a source that sends no marker still swaps at the grace deadline (relay/remote)', async () => {
+    const first = fakeChannel()
+    const second = fakeChannel()
+    onEvents.mockResolvedValueOnce(first.channel).mockResolvedValue(second.channel)
+    render(<FeedProbe projectId="p1" runId="run-a" />)
+    await waitFor(() => expect(onEvents).toHaveBeenCalledTimes(1))
+    first.push(log('a'))
+    await waitFor(() => expect(feed()).toBe('a'))
+
+    first.dropWith(new Error('connection reset'))
+    await waitFor(() => expect(onEvents).toHaveBeenCalledTimes(2), { timeout: 3000 })
+    second.push(log('a'))
+    second.push(log('b'))
+    expect(feed()).toBe('a')
+    // No stream-sync ever arrives: the deadline swap keeps the feed from freezing.
+    await waitFor(() => expect(feed()).toBe('a,b'), { timeout: 3000 })
+  })
+
+  test('a reconnect that dies mid-replay drops the partial buffer rather than swapping it in', async () => {
+    const first = fakeChannel()
+    const second = fakeChannel()
+    const third = fakeChannel()
+    onEvents.mockResolvedValueOnce(first.channel).mockResolvedValueOnce(second.channel).mockResolvedValue(third.channel)
+    render(<FeedProbe projectId="p1" runId="run-a" />)
+    await waitFor(() => expect(onEvents).toHaveBeenCalledTimes(1))
+    first.push(log('a'))
+    first.push(log('b'))
+    first.push({ kind: 'stream-sync' })
+    await waitFor(() => expect(feed()).toBe('a,b'))
+
+    first.dropWith(new Error('connection reset'))
+    await waitFor(() => expect(onEvents).toHaveBeenCalledTimes(2), { timeout: 3000 })
+    second.push(log('a')) // replay cut short
+    second.dropWith(new Error('gone again'))
+    // The populated feed survives both drops; the third attempt replays and syncs in full.
+    expect(feed()).toBe('a,b')
+    await waitFor(() => expect(onEvents).toHaveBeenCalledTimes(3), { timeout: 4000 })
+    third.push(log('a'))
+    third.push(log('b'))
+    third.push(log('c'))
+    third.push({ kind: 'stream-sync' })
+    await waitFor(() => expect(feed()).toBe('a,b,c'))
   })
 })

--- a/packages/framework-dashboard/lib/use-live-events.ts
+++ b/packages/framework-dashboard/lib/use-live-events.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { FrameworkEvent } from '@gemstack/the-framework'
+import type { LiveFeedEvent } from '@gemstack/the-framework/dashboard-rpc'
 import type { ClientChannel } from 'telefunc'
 import { onEvents } from '../server/events.telefunc.js'
 import { currentRunEvents } from './live-state.js'
@@ -32,6 +33,14 @@ function retryDelay(attempt: number): number {
   return RETRY_DELAYS_MS[Math.min(attempt, RETRY_DELAYS_MS.length - 1)] as number
 }
 
+/**
+ * How long a reconnect waits for the server's end-of-replay marker before swapping anyway
+ * (#1383). The on-disk tail sends `stream-sync` the moment its replay is delivered, so this
+ * deadline only fires for the in-memory sources (relay #426, relayed device runs #1067),
+ * which have no replay boundary to report — their buffered history streams in well under it.
+ */
+const SYNC_GRACE_MS = 1500
+
 export function useLiveEvents(projectId: string | null, runId?: string | null, resetKey?: unknown): LiveEvents {
   const [events, setEvents] = useState<FrameworkEvent[]>([])
   const [lost, setLost] = useState(false)
@@ -52,10 +61,12 @@ export function useLiveEvents(projectId: string | null, runId?: string | null, r
     setLost(false)
     setDone(false)
     if (!projectId) return
-    let channel: ClientChannel<never, FrameworkEvent> | undefined
+    let channel: ClientChannel<never, LiveFeedEvent> | undefined
     let cancelled = false
     let attempt = 0
+    let first = true
     let timer: ReturnType<typeof setTimeout> | undefined
+    let graceTimer: ReturnType<typeof setTimeout> | undefined
 
     // A dead stream used to be silent: the daemon restarts, events just stop, and "the agent
     // went quiet" is indistinguishable from "the feed died" (#948). Now an errored close (or a
@@ -69,6 +80,15 @@ export function useLiveEvents(projectId: string | null, runId?: string | null, r
     }
 
     const subscribe = () => {
+      // Every subscribe replays the whole log before following live. The FIRST one streams into
+      // a pane this effect just cleared, so it renders as it arrives. A RECONNECT has a populated
+      // feed on screen, and blanking it while history re-streamed was #1383's mid-run flicker:
+      // the lost banner cleared on resubscribe, then the feed sat empty until the replay caught
+      // up. So a reconnect buffers the replay and swaps atomically — on the server's stream-sync
+      // marker, or at a grace deadline for the in-memory sources that send none. The feed never
+      // shows less than it already showed (#1402's rule, applied to the live channel).
+      const reconnect = !first
+      first = false
       void onEvents(projectId, runId ?? undefined).then(ch => {
         if (cancelled) {
           void ch.close()
@@ -77,14 +97,29 @@ export function useLiveEvents(projectId: string | null, runId?: string | null, r
         channel = ch
         attempt = 0
         setLost(false)
-        // The tail replays the whole log on subscribe, so a reconnect starts from an empty
-        // buffer rather than appending a duplicate history.
-        setEvents([])
+        let buffer: FrameworkEvent[] | undefined = reconnect ? [] : undefined
+        const swap = () => {
+          if (cancelled || buffer === undefined) return
+          const replay = buffer
+          buffer = undefined
+          setEvents(replay)
+        }
+        if (reconnect) graceTimer = setTimeout(swap, SYNC_GRACE_MS)
+        else setEvents([]) // fresh subscribe: start clean so the replay is not appended twice
         ch.listen(event => {
+          if (event.kind === 'stream-sync') {
+            swap()
+            return
+          }
           stampReceived(event)
-          setEvents(prev => [...prev, event])
+          if (buffer) buffer.push(event)
+          else setEvents(prev => [...prev, event])
         })
         ch.onClose(err => {
+          // A close mid-replay drops the partial buffer: swapping it in would be exactly the
+          // collapse this exists to prevent, and the next attempt replays from the top anyway.
+          buffer = undefined
+          if (graceTimer) clearTimeout(graceTimer)
           if (err) retry()
           else if (!cancelled) setDone(true)
         })
@@ -95,6 +130,7 @@ export function useLiveEvents(projectId: string | null, runId?: string | null, r
     return () => {
       cancelled = true
       if (timer) clearTimeout(timer)
+      if (graceTimer) clearTimeout(graceTimer)
       void channel?.close()
     }
     // runId is a dependency: selecting another run must resubscribe to that run's log (#749).

--- a/packages/the-framework/src/dashboard-rpc/events-tail.spec.md
+++ b/packages/the-framework/src/dashboard-rpc/events-tail.spec.md
@@ -1,4 +1,4 @@
-Tails a `.the-framework/events.jsonl` — replays what is logged, then follows appends, handing each parsed JSONL line to `onEvent` (malformed lines skipped) and returning a stop function.
+Tails a `.the-framework/events.jsonl` — replays what is logged, then follows appends, handing each parsed JSONL line to `onEvent` (malformed lines skipped) and returning a stop function. `onReplayed` fires once, between the replay and the first follow-append (#1383) — the boundary a reconnecting client swaps its feed on.
 
 ## Decisions
 
@@ -8,3 +8,4 @@ Tails a `.the-framework/events.jsonl` — replays what is logged, then follows a
 ## Facts
 
 - `fs.watch` is backstopped by a 1 s poll (`POLL_MS`).
+- `onReplayed` fires even when the first read fails or the log does not exist yet (an empty replay, not a marker withheld): a client waiting forever would freeze its feed; the follower's poll retries the read.

--- a/packages/the-framework/src/dashboard-rpc/events-tail.test.ts
+++ b/packages/the-framework/src/dashboard-rpc/events-tail.test.ts
@@ -74,3 +74,46 @@ test('tailEvents stops pulling once stopped, and skips malformed lines', async (
     await rm(cwd, { recursive: true, force: true })
   }
 })
+
+test('tailEvents reports the replay boundary after the backlog, before any follow-append (#1383)', async () => {
+  const cwd = await tmpWorkspace()
+  const path = join(cwd, 'events.jsonl')
+  await writeFile(path, line('first') + line('second'))
+  const order: string[] = []
+  const stop = tailEvents<FrameworkEvent>(
+    path,
+    e => void (e.kind === 'log' && order.push(e.message)),
+    () => order.push('<sync>'),
+  )
+  try {
+    await sleep(150)
+    // The marker lands exactly between the replay and anything the follower delivers.
+    assert.deepEqual(order, ['first', 'second', '<sync>'])
+    await appendFile(path, line('third'))
+    await sleep(1400) // fs.watch is unreliable on CI; wait out the poll backstop behind it
+    assert.deepEqual(order, ['first', 'second', '<sync>', 'third'])
+  } finally {
+    stop()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('tailEvents reports the replay boundary even when the log does not exist yet (#1383)', async () => {
+  const cwd = await tmpWorkspace()
+  const path = join(cwd, 'events.jsonl')
+  const order: string[] = []
+  const stop = tailEvents<FrameworkEvent>(
+    path,
+    e => void (e.kind === 'log' && order.push(e.message)),
+    () => order.push('<sync>'),
+  )
+  try {
+    await sleep(150)
+    // An absent log is an empty replay, not a marker withheld: a client waiting on it
+    // forever would freeze its feed.
+    assert.deepEqual(order, ['<sync>'])
+  } finally {
+    stop()
+    await rm(cwd, { recursive: true, force: true })
+  }
+})

--- a/packages/the-framework/src/dashboard-rpc/events-tail.ts
+++ b/packages/the-framework/src/dashboard-rpc/events-tail.ts
@@ -13,10 +13,28 @@ const POLL_MS = 1000
  * two pieces the run's control tail is built from. This used to be its own copy of both,
  * which is how it ended up missing the tailer's same-length-rewrite detection (#567).
  *
+ * `onReplayed` is told once the first pull — the replay of everything already logged — has
+ * been delivered (#1383). That boundary is what lets a reconnecting client buffer the replay
+ * and swap its feed atomically instead of blanking while history re-streams. The follower
+ * only starts after it, so no appended line can slip in ahead of the marker. Best-effort on
+ * a failed first read: the marker still fires (the poll retries the read), because a client
+ * waiting on it forever would freeze its feed.
+ *
  * Kept transport-agnostic (a plain `onEvent` callback, not a channel) so the file
  * side can be driven on its own; events.telefunc.ts wires it to a Telefunc Channel.
  */
-export function tailEvents<T = unknown>(path: string, onEvent: (event: T) => void): () => void {
+export function tailEvents<T = unknown>(path: string, onEvent: (event: T) => void, onReplayed?: () => void): () => void {
   const tailer = new JsonlTailer<T>(path, onEvent)
-  return followFile(dirname(path), () => tailer.pull(), { pollMs: POLL_MS })
+  let stopped = false
+  let stopFollow: (() => void) | undefined
+  const follow = (): void => {
+    if (stopped) return
+    onReplayed?.()
+    stopFollow = followFile(dirname(path), () => tailer.pull(), { pollMs: POLL_MS })
+  }
+  void tailer.pull().then(follow, follow)
+  return () => {
+    stopped = true
+    stopFollow?.()
+  }
 }

--- a/packages/the-framework/src/dashboard-rpc/events.telefunc.spec.md
+++ b/packages/the-framework/src/dashboard-rpc/events.telefunc.spec.md
@@ -1,4 +1,4 @@
-The live event stream telefunction (#405): `onEvents(projectId, runId?)` returns a Telefunc Channel streaming one run's `FrameworkEvent`s; `.close()` stops the tail.
+The live event stream telefunction (#405): `onEvents(projectId, runId?)` returns a Telefunc Channel streaming one run's feed — its `FrameworkEvent`s plus the wire-only `stream-sync` end-of-replay marker (#1383); `.close()` stops the tail.
 
 ## TLDR
 
@@ -6,6 +6,7 @@ The live event stream telefunction (#405): `onEvents(projectId, runId?)` returns
 - The daemon's source answers only for relayed runs, so ordinary local runs fall through to file tailing unchanged.
 - With `runId` the tail follows that run's own log inside its worktree (#749) — since #736 runs append there, so the project-root feed for a worktree run is empty; omitting it keeps pre-#736 behavior.
 - Unknown project → a channel that closes immediately, mirroring the read model's empty results rather than throwing at the client.
+- `stream-sync` (#1383): sent once per subscription by the on-disk tail after the replay is delivered, so a reconnecting client can swap its feed atomically instead of blanking while history re-streams. Wire-only — not a `FrameworkEvent`, never journaled, swallowed client-side. The in-memory sources have no replay boundary to report and send none; the client falls back to a grace deadline.
 
 ## Facts
 

--- a/packages/the-framework/src/dashboard-rpc/events.telefunc.ts
+++ b/packages/the-framework/src/dashboard-rpc/events.telefunc.ts
@@ -23,6 +23,18 @@ async function resolveEventsPath(projectId: string, runId?: string): Promise<str
 }
 
 /**
+ * The end-of-replay marker (#1383). A subscribe replays the whole log before following live,
+ * and without a boundary a reconnecting client cannot tell "replay still streaming" from "the
+ * log is genuinely this short" — so it blanked a populated feed and refilled it line by line.
+ * Sent once per subscription, after the on-disk replay is delivered. Wire-only: it is not a
+ * {@link FrameworkEvent}, is never written to any journal, and the client swallows it.
+ */
+export type StreamSync = { kind: 'stream-sync' }
+
+/** What `onEvents` streams: the run's events, plus the wire-only end-of-replay marker. */
+export type LiveFeedEvent = FrameworkEvent | StreamSync
+
+/**
  * `onEvents(projectId, runId?)` returns a Channel that streams one live run: the client
  * `.listen()`s for `FrameworkEvent`s and `.close()`s to unsubscribe, which stops the tail.
  * An unknown project yields a channel that closes immediately (mirrors the read model's
@@ -37,14 +49,18 @@ async function resolveEventsPath(projectId: string, runId?: string): Promise<str
  * (#426), or a run the daemon is relaying from a device (#1067). Otherwise the on-disk log. The
  * daemon sets a source that answers only for relayed runs, so an ordinary local run yields undefined
  * here and falls through to tailing the log, exactly as before.
+ *
+ * Only the on-disk tail sends the {@link StreamSync} marker: the in-memory sources have no
+ * replay boundary to report, so a reconnecting client falls back to a grace deadline before
+ * swapping its feed (see use-live-events in the dashboard).
  */
-export async function onEvents(projectId: string, runId?: string): Promise<ClientChannel<never, FrameworkEvent>> {
+export async function onEvents(projectId: string, runId?: string): Promise<ClientChannel<never, LiveFeedEvent>> {
   const stream = contextEventsSource()?.(projectId, runId)
   if (stream) {
     // An in-memory run: replay + follow it, mirroring how serveSSE consumes it.
-    return streamChannel<FrameworkEvent>(send => forwardStream(stream, send))
+    return streamChannel<LiveFeedEvent>(send => forwardStream(stream, send))
   }
   // Everywhere else: tail the run's on-disk events.jsonl (undefined path -> closed channel).
   const path = await resolveEventsPath(projectId, runId)
-  return streamChannel<FrameworkEvent>(send => (path ? tailEvents(path, send) : undefined))
+  return streamChannel<LiveFeedEvent>(send => (path ? tailEvents(path, send, () => send({ kind: 'stream-sync' })) : undefined))
 }

--- a/packages/the-framework/src/dashboard-rpc/index.ts
+++ b/packages/the-framework/src/dashboard-rpc/index.ts
@@ -4,7 +4,7 @@
 // these through thin re-export shims so the baked RPC keys stay `/server/*.telefunc.ts`.
 export { onRuns, onRun, onDocs, onProjectLog, onQueue, onOverview, onRecentRuns, onHotTickets, onInterventions, onActivity, onDashboard, onGithubUrl, onGitStatus, onProjectFiles, onProjectFileStatus, onFileDiff, onRunChanges, onFileContent, onTickets, onTicket, onTicketsMeta, onAllTickets, onRetainedWorktrees, onRunWorktree, onRunHandoff, onSystemPromptUser, onBridgeQuestion, onBridgeStatus, onBridgeToken, onBridgeEvents, onBridgeAnswer } from './reads.telefunc.js'
 export { sendStop, sendChoice, sendBridgeAnswer, sendBridgeAnswerCancel, sendMessage, sendSetHandoff, sendStart, sendStartTopic, sendPreview, onServeTargets, sendStopPreview, onPreviewStatus, sendOpenInApp, sendRemoveWorktree, sendDeleteSession, sendPushBranch, sendOpenPullRequest, sendMerge, sendQueueTicket, type QueueTicketResult, type QueuedTicket } from './control.telefunc.js'
-export { onEvents } from './events.telefunc.js'
+export { onEvents, type LiveFeedEvent, type StreamSync } from './events.telefunc.js'
 export { onProjects, sendAddProject, onOnboarding, onClaudeTrust, onAgentReady } from './projects.telefunc.js'
 export {
   onPreferences,


### PR DESCRIPTION
Fixes the last live observation on #1383 — the mid-run blank flicker. Mechanism (from the assessment comment there): every subscribe replays the whole log before following live, and `use-live-events` cleared its feed on each (re)subscribe. So after a transient channel drop, the "stream lost" banner cleared on resubscribe and the transcript sat **empty, with no banner**, until the replay re-streamed it line by line. A daemon restart mid-run did this to every open view.

## What changes

- **Server** (`events-tail.ts` / `events.telefunc.ts`): the on-disk tail owns its first pull and reports the replay boundary; `onEvents` sends a wire-only `stream-sync` marker at it, once per subscription. The marker is not a `FrameworkEvent`, is never journaled, and the follower only starts after it — no appended line can slip in ahead of it. It still fires on a missing/unreadable log (an empty replay is not a marker withheld; a client waiting forever would freeze its feed).
- **Client** (`use-live-events.ts`): the *first* subscribe of an effect is unchanged — the pane was just cleared, the replay streams straight in. A *reconnect* keeps the populated feed on screen, buffers the replay, and swaps atomically on `stream-sync` — the feed never shows less than it already showed, the same rule #1402 established for the archive read. In-memory sources (relay #426, relayed device runs #1067) have no replay boundary to report and send no marker; a reconnect to those swaps at a 1.5 s grace deadline instead. A reconnect that dies mid-replay drops its partial buffer rather than swapping in a shorter feed.

## Notes for review

- Only `onEvents` grows the union (`LiveFeedEvent = FrameworkEvent | StreamSync`); nothing downstream of the hook sees the marker.
- Duplicate-history protection is unchanged: the swap replaces (never appends to) the shown feed, and `currentRunEvents` still scopes mid-channel log truncations.
- Main currently has 3 unrelated failing tests (stale prompt-spec assertions from #1420's `ticketing_format.md` edit — the #1388 pattern); fix PR for those follows separately, after which this PR's CI should be green.

## Tests

- the-framework: +2 (replay boundary lands between replay and follow; fires even for a not-yet-created log)
- framework-dashboard: +4 (first-subscribe streaming + marker swallowed; atomic swap on reconnect; grace-deadline swap for markerless sources; mid-replay death keeps the old feed) — 666/666
- Suites otherwise green except the 3 pre-existing #1420 assertion breaks, reproduced on clean origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)