### PR TITLE
Track #1420's ticketing-format rename: channel bullet + stale test assertions

### DIFF
--- a/.changeset/ticketing-format-heading.md
+++ b/.changeset/ticketing-format-heading.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+The system channel's tickets bullet names the spec section that actually exists again: #1420 renamed the spec's heading to "Ticketing format", and the bullet still sent agents to follow a "Ticket format" section that was no longer there.

--- a/packages/the-framework/src/system-prompt.test.ts
+++ b/packages/the-framework/src/system-prompt.test.ts
@@ -49,7 +49,7 @@ test('CONTEXT_DOCS is the #683 fragment: business knowledge plus the roadmap/que
   // The two format-bearing bullets name a section of this same channel (#1163), not a file to go
   // and open: the spec they point at has to be something the agent has already been handed.
   const tickets = CONTEXT_DOCS.find(d => d.path === 'tickets/**.md')
-  assert.match(tickets?.comment ?? '', /format: the "Ticket format" section below/)
+  assert.match(tickets?.comment ?? '', /format: the "Ticketing format" section below/)
   const todo = CONTEXT_DOCS.find(d => d.path === FLAT_TODO_FILE)
   assert.match(todo?.comment ?? '', /format: the "TODO_AGENTS.md" section below/)
   // Nothing here may point into node_modules: that path resolves only when the framework is a root
@@ -99,8 +99,9 @@ test('SYSTEM_PROMPT_TEMPLATE carries the #326 sections verbatim', () => {
   }
   // Derived from the constant, not a literal (#885): the prompt tells the agent where to write
   // its backlog, and `promoteQueue` only carries FLAT_TODO_FILE off a run's branch. When the two
-  // disagree, an unattended run's queue is written to a name nothing ever promotes.
-  assert.ok(SYSTEM_PROMPT_TEMPLATE.includes(`TODO_FILE: \`${FLAT_TODO_FILE}\``))
+  // disagree, an unattended run's queue is written to a name nothing ever promotes. #1420 dropped
+  // the `TODO_FILE:` glossary line and names the file inline instead — the invariant is the name.
+  assert.ok(SYSTEM_PROMPT_TEMPLATE.includes(`\`${FLAT_TODO_FILE}\``))
   assert.ok(SYSTEM_PROMPT_TEMPLATE.includes('ADD_ANALYSIS_ENTRY: Add entry to the ANALYSIS_RESULT.md list'))
   assert.ok(SYSTEM_PROMPT_TEMPLATE.includes('${{tf.prompt}}'))
   // The whole block is the branch-free doc now: #326 moved the one `tf.params.autopilot`
@@ -140,7 +141,7 @@ test('the channel carries the ticket and backlog format specs, so a spec can be 
   // format it could not open, and `TODO_AGENTS.md` and `tickets/` both drifted from it.
   const block = systemPromptBlock()
   for (const [heading, spec] of [
-    ['Ticket format', TICKETING_FORMAT],
+    ['Ticketing format', TICKETING_FORMAT],
     ['TODO_AGENTS.md', TODO_FORMAT],
   ] as const) {
     assert.ok(block.includes(spec), `expected the ${heading} spec in the channel`)

--- a/packages/the-framework/src/system-prompt.ts
+++ b/packages/the-framework/src/system-prompt.ts
@@ -175,8 +175,10 @@ export const BUSINESS_KNOWLEDGE_DOCS: readonly ContextDoc[] = [DECISIONS_DOC, FA
  */
 const CONTEXT_FORMATS: readonly string[] = [TICKETING_FORMAT, TODO_FORMAT]
 
-/** The heading each spec opens with, so a bullet can name the section that answers it. */
-const TICKET_FORMAT_HEADING = 'Ticket format'
+/** The heading each spec opens with, so a bullet can name the section that answers it.
+ * Must track the spec's own H1 — #1420 renamed it "Ticketing format", and a bullet naming a
+ * section that does not exist sends the agent to follow a format it cannot find. */
+const TICKET_FORMAT_HEADING = 'Ticketing format'
 const TODO_FORMAT_HEADING = 'TODO_AGENTS.md'
 
 /**
@@ -184,7 +186,7 @@ const TODO_FORMAT_HEADING = 'TODO_AGENTS.md'
  * {@link systemPromptBlock} renders as the `Context:` bullets. A superset of
  * {@link BUSINESS_KNOWLEDGE_DOCS}: it adds `GOAL.md`, `BUSINESS_LOGIC.md`, and the
  * roadmap/queue/history pointers the agent reads but does *not* fold knowledge back into —
- * `tickets/**.md` (the potential work, whose file shape is the `Ticket format` spec, #684/#674),
+ * `tickets/**.md` (the potential work, whose file shape is the `Ticketing format` spec, #684/#674),
  * the `TODO_AGENTS.md` task queue (whose
  * shape is the `TODO_AGENTS.md` spec, #880), and the committed conversations (#683/#908). Repo-root
  * paths, because that is the agent's cwd. README is left out: a repo's own `README.md` already

--- a/packages/the-framework/src/tickets.test.ts
+++ b/packages/the-framework/src/tickets.test.ts
@@ -28,10 +28,12 @@ test('the flat backlog lives at the root TODO_AGENTS.md, with the legacy locatio
 test('the ticket-format spec ships in the package (not materialized), with priority/topics (#684/#674)', () => {
   // Per the #674 call it is not written into the repo, so the format versions with the package.
   // How the agent reads it is system-prompt.ts's job now (#1163): the content rides in the channel.
-  // The spec teaches both file shapes and the revised #684 optional priority/topics fields.
+  // The spec teaches the file shapes and the revised #684 optional priority/topics fields.
+  // #1420 folded the spike into the plan (Effort/Uncertainty 0-10) and added the .lock.md claim.
   assert.ok(TICKETING_FORMAT.includes('tickets/<DATE>_<SLUG>.md'))
-  assert.ok(TICKETING_FORMAT.includes('tickets/<DATE>_<SLUG>.spike.md'))
-  assert.ok(TICKETING_FORMAT.includes('Priority: 10-0'))
+  assert.ok(TICKETING_FORMAT.includes('tickets/<DATE>_<SLUG>.plan.md'))
+  assert.ok(TICKETING_FORMAT.includes('tickets/<DATE>_<SLUG>.lock.md'))
+  assert.ok(TICKETING_FORMAT.includes('Priority: 0-10'))
   assert.ok(TICKETING_FORMAT.includes('Topics:'))
   assert.ok(TICKETING_FORMAT.includes('GitHub:'))
 })


### PR DESCRIPTION
Main's CI went red with #1420 (the ticketing-format rework): three test assertions pinned the old prompt wording. Fixed forward per the #1388 precedent — no prompt files touched.

- `SYSTEM_PROMPT_TEMPLATE` assertion: the `TODO_FILE:` glossary line is gone; the #885 invariant (the prompt names `TODO_AGENTS.md`, derived from `FLAT_TODO_FILE`) is asserted on the inline mention instead.
- Ticketing-format assertions: `.spike.md` is folded into `.plan.md` and `.lock.md` is the new claim file; `Priority: 10-0` became `0-10`. Asserted accordingly.
- **One production fix rides along:** the system channel's `tickets/**.md` bullet derives its "follow the format of the … section below" name from `TICKET_FORMAT_HEADING`, which still said `Ticket format` — the spec's H1 is now `Ticketing format`, so agents were being pointed at a section that doesn't exist. Constant updated.

## Flagging, not fixing here — #1420 leaves two machine readers misaligned

The new format changes what agents will *write*, but two pieces of framework code still read the old shape:

1. `planned-quick-wins.ts` queues autonomous implementations off `Effort: quick-win` + `Consensus: consensual`. New plans will carry `Effort: 0-10` / `Uncertainty: 0-10`, which parse as *no verdict* — **autonomous quick-win queueing silently stops** for plans written under the new format.
2. `spike-locks.ts` (#1327) pre-creates `.spike.md` placeholders for a file kind the format no longer defines, and nothing yet reads or writes the new `.lock.md` claims it overlaps with.

Both look like the next slices of the #1420 redesign rather than accidents, so this PR only flags them.

Tests: the-framework 1644/0, framework-dashboard green. This unbreaks main's CI (and #1423's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)