### PR TITLE
spike & plan queues the <COUNT> most important tickets, default 10 (fix #1421)

### DIFF
--- a/.changeset/spike-plan-top-n.md
+++ b/.changeset/spike-plan-top-n.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+[Spike & plan] now queues plan work for the `<COUNT>` most important tickets instead of every open one, with `COUNT: 10` as the prompt-defined default (#1421). The parameter lives in the prompt itself, following the prompts' own placeholder-footer convention, so changing the default — or overriding it from a derived prompt — is a one-line prose edit.

--- a/packages/the-framework/prompts/presets/spike_and_plan.md
+++ b/packages/the-framework/prompts/presets/spike_and_plan.md
@@ -1,4 +1,6 @@
-For every ticket `tickets/<TICKET>.md` without `<TICKET>.plan.md` and `<TICKET>.lock.md`, add the following to TODO_AGENTS.md
+For the <COUNT> most important tickets `tickets/<TICKET>.md` without `<TICKET>.plan.md` and `<TICKET>.lock.md`, add the following to TODO_AGENTS.md
 - "Create tickets/<TICKET>.plan.md"
 
 Put the entries in the right `## Priority` following a mix of sensible criteria after reading `tickets/<TICKET>.md` (e.g. if ticket seems low effort => higher priority).
+
+COUNT: 10


### PR DESCRIPTION
Fixes #1421 — the prompt made the agent queue plan work for *every* open ticket; it now caps at the `<COUNT>` most important, default 10.

The parameter is prompt-native: `<COUNT>` in the body, defined in a footer line (`COUNT: 10`), following the prompts' own placeholder convention (`AWAIT:`, `SESSION_NAME:`, …). So changing the default — or overriding it from a derived prompt by appending a different `COUNT:` line — is a one-line prose edit, and no launcher UI or param machinery was added (that half stays postponable per the issue's "postpone if not a quick-win").

@brillout — prompt-file change (`prompts/presets/spike_and_plan.md`), your wording call: happy to rephrase.

Cost context from the first live fan-out: a plan run costs ~$4.70, so an uncapped sweep over a large backlog compounds fast; 10 ≈ $50 per sweep.

Suite: the-framework 1623/0 (1 skipped). Changeset: patch. `prompts.generated.ts` is gitignored and regenerates on build, so the diff is the prompt + changeset only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)