### PR TITLE
the resume handle survives a mid-turn Stop: the session id is announced at turn start, not held for result (fix #1322)

### DIFF
--- a/.changeset/resume-handle-survives-stop.md
+++ b/.changeset/resume-handle-survives-stop.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+The "Copy resume command" action survives a mid-turn Stop (#1322): the session id was only surfaced when a turn's `result` arrived, so a run stopped (or dying) during a turn — most visibly during its first — never recorded the id and lost its `claude --resume` handle, making the button appear on some sessions and not others. The Claude driver now announces the id the moment the stream states it (its very first line), and telemetry emits the `session-update` right then — so the handle exists seconds after launch and no ending can take it away.

--- a/packages/the-framework/src/driver/actions.test.ts
+++ b/packages/the-framework/src/driver/actions.test.ts
@@ -283,7 +283,8 @@ test('replayTranscript reads the action execution file with the existing stream 
   assert.equal(turn.sessionId, 'sess-abc')
   assert.deepEqual(
     events.map(e => e.type),
-    ['text', 'action'],
+    // The parser announces the session id up front (#1322) before the conversation replays.
+    ['session', 'text', 'action'],
   )
 })
 

--- a/packages/the-framework/src/driver/claude-code.spec.md
+++ b/packages/the-framework/src/driver/claude-code.spec.md
@@ -4,7 +4,7 @@ The first real `Driver`: wraps the Claude Code CLI in print mode (`claude -p --o
 
 - `ClaudeCodeDriver.start` boots a `ClaudeCodeSession`; `readQuota` delegates to `readClaudeQuota` (account-wide, no session).
 - `ClaudeCodeSession.prompt` builds argv, runs it through `runAgentCli` with a `StreamJsonParser`, and tracks the agent's own session id so `resume: true` prompts pass `--resume <id>` (#714) and a finished run can be revived via `resumeSessionId` (#720).
-- `StreamJsonParser` folds the NDJSON dialect: assistant text → `text` events, `tool_use` → `action` (name only), `rate_limit_event` → `rate-limit` (#517), `result` line → final text + usage (#322).
+- `StreamJsonParser` folds the NDJSON dialect: assistant text → `text` events, `tool_use` → `action` (name only), `rate_limit_event` → `rate-limit` (#517), `result` line → final text + usage (#322). The first `session_id` sighted (any line — in practice the opening `system: init`) → a `session` event, re-emitted only on change (#1322): surfaced at turn start rather than held for `result`, so a stopped or dying turn keeps the run's `claude --resume` handle.
 - Optional per-session MCP servers (#452) are written to a lazily-created temp `--mcp-config` file (merged with the user's own servers — no `--strict-mcp-config`), removed on `dispose`.
 
 ## Problems

--- a/packages/the-framework/src/driver/claude-code.test.ts
+++ b/packages/the-framework/src/driver/claude-code.test.ts
@@ -8,7 +8,11 @@ import type { DriverEvent } from './types.js'
 
 test('StreamJsonParser surfaces assistant text + tool names, keeps the result', () => {
   const p = new StreamJsonParser()
-  assert.deepEqual(p.push(JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sess-1' })), [])
+  // The very first line announces the session id (#1322): surfaced immediately, not held for
+  // `result`, so a turn that is stopped mid-flight keeps its `claude --resume` handle.
+  assert.deepEqual(p.push(JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sess-1' })), [
+    { type: 'session', sessionId: 'sess-1' },
+  ])
   const assistant = p.push(
     JSON.stringify({
       type: 'assistant',
@@ -65,6 +69,14 @@ test('StreamJsonParser omits costUsd (never 0) when tokens report but no price (
   assert.equal(usage?.costUsd, undefined)
   assert.equal(Object.prototype.hasOwnProperty.call(usage, 'costUsd'), false)
   assert.deepEqual(usage, { inputTokens: 100, outputTokens: 40, cacheReadTokens: 900, cacheCreationTokens: 50 })
+})
+
+test('StreamJsonParser announces the session id once, re-announcing only a change (#1322)', () => {
+  const p = new StreamJsonParser()
+  assert.deepEqual(p.push(JSON.stringify({ type: 'system', subtype: 'init', session_id: 'a' })), [{ type: 'session', sessionId: 'a' }])
+  // Every subsequent line repeats the id; repeating the announcement would be noise.
+  assert.deepEqual(p.push(JSON.stringify({ type: 'system', subtype: 'other', session_id: 'a' })), [])
+  assert.deepEqual(p.push(JSON.stringify({ type: 'system', subtype: 'other', session_id: 'b' })), [{ type: 'session', sessionId: 'b' }])
 })
 
 test('StreamJsonParser ignores non-JSON noise and falls back to assistant text', () => {
@@ -302,7 +314,9 @@ test('StreamJsonParser surfaces the rate-limit telemetry the agent emits per tur
     }),
   )
   assert.deepEqual(events, [
-    // Seconds in, millis out.
+    // The first sighting of the id announces it (#1322)…
+    { type: 'session', sessionId: 'sess-1' },
+    // …and the telemetry converts, seconds in, millis out.
     { type: 'rate-limit', limit: { status: 'allowed', window: 'five_hour', resetsAt: 1784079000_000 } },
   ])
   // Telemetry must not disturb the turn itself.

--- a/packages/the-framework/src/driver/claude-code.ts
+++ b/packages/the-framework/src/driver/claude-code.ts
@@ -226,22 +226,29 @@ export class StreamJsonParser {
       return [] // Non-JSON noise (banners etc.); ignore.
     }
 
-    if (typeof obj['session_id'] === 'string') this.sessionId = obj['session_id']
+    // Announced on the very first stream line, so it must not wait for `result`: a turn that is
+    // stopped or dies mid-flight would take the id — the run's `claude --resume` handle — with
+    // it (#1322). Emitted only when it changes; every subsequent line repeats the same id.
+    const announced: DriverEvent[] = []
+    if (typeof obj['session_id'] === 'string' && obj['session_id'] !== this.sessionId) {
+      this.sessionId = obj['session_id']
+      announced.push({ type: 'session', sessionId: this.sessionId })
+    }
     const type = obj['type']
 
-    if (type === 'assistant') return this.handleAssistant(obj)
+    if (type === 'assistant') return [...announced, ...this.handleAssistant(obj)]
     if (type === 'rate_limit_event') {
       const limit = parseRateLimit(obj)
-      return limit ? [{ type: 'rate-limit', limit }] : []
+      return limit ? [...announced, { type: 'rate-limit', limit }] : announced
     }
     if (type === 'result') {
       const result = obj['result']
       if (typeof result === 'string') this.finalText = result
       const usage = parseUsage(obj)
       if (usage) this.usage = usage
-      return [] // The `result` event is emitted by the runner after `close`.
+      return announced // The `result` event is emitted by the runner after `close`.
     }
-    return []
+    return announced
   }
 
   private handleAssistant(obj: Record<string, unknown>): DriverEvent[] {

--- a/packages/the-framework/src/driver/types.spec.md
+++ b/packages/the-framework/src/driver/types.spec.md
@@ -8,7 +8,7 @@ The driver seam's contract: the one abstraction The Framework wraps a coding-age
 - `DriverPromptOptions` — per-call `system`, `signal`, `resume` (#714: continue the previous turn, best-effort).
 - `DriverTurn` — final `text`, agent's own `sessionId` (the MVP persistence shortcut: forward the agent's transcript, #165), optional `usage`.
 - Telemetry types: `DriverUsage` (#322 per-turn tokens + optional cost), `DriverRateLimit` (#517 per-turn traffic light), `DriverQuota`/`DriverQuotaWindow` (#521 proportion of window consumed — the only one that can fill a progress bar), `DriverQuotaUnavailableReason` + `isTransientQuotaReason`.
-- `DriverEvent` — `start` / `text` / `action` (tool name only, never arguments) / `result` (with optional `sessionLink`, #1317) / `rate-limit` / `error` / `notice` (#778).
+- `DriverEvent` — `start` / `session` (the id announced at turn start, #1322; telemetry consumes it rather than forwarding) / `text` / `action` (tool name only, never arguments) / `result` (with optional `sessionLink`, #1317) / `rate-limit` / `error` / `notice` (#778).
 
 ## Decisions
 

--- a/packages/the-framework/src/driver/types.ts
+++ b/packages/the-framework/src/driver/types.ts
@@ -266,6 +266,13 @@ export type DriverQuota =
 export type DriverEvent =
   /** A prompt was sent; the agent's loop is starting. */
   | { type: 'start'; prompt: string }
+  /**
+   * The agent announced its session id, at the start of the turn (#1322). `result` repeats it,
+   * but a turn that never settles — a manual Stop, an error, a kill — used to take the id down
+   * with it, and with it the run's `claude --resume` handle. Telemetry consumes this one rather
+   * than forwarding it: the id is plumbing, not conversation.
+   */
+  | { type: 'session'; sessionId: string }
   /** An assistant text chunk streamed out. */
   | { type: 'text'; text: string }
   /** The agent used a tool. We surface the name only, not the arguments. */

--- a/packages/the-framework/src/run-telemetry.spec.md
+++ b/packages/the-framework/src/run-telemetry.spec.md
@@ -4,6 +4,7 @@ The run telemetry both entry paths share: session naming, driver-event accountin
 
 - `emitSessionStart()`: the opening `session` event; a literal `--session-link` shows right away, a `{sessionId}` template waits for the driver's real id.
 - `createDriverEventHandler()`: wires the driver's black-box event stream (#165) into the run stream — re-emits `session-update` when the session id changes (it changes per prompt), folds each turn's usage into a `UsageMeter` total, and trips the budget (#322) and consumption (#529) self-stops.
+- The driver's `session` announcement (#1322) is consumed here, never forwarded as a `driver` event: it emits the `session-update` at turn *start*, so a turn stopped or dying mid-flight keeps the run's `claude --resume` handle (the update used to wait for `result`, and the resume button vanished with the turn). Same id-change dedup as the result path; the template link applies, and a later result repeating the id does not re-emit (a cloud result's own deep link still wins on first sighting, as before).
 - `createRunControls()`: composes the run's `AbortSignal.any` of the caller's signal + budget + consumption + plan-decline (#358) controllers, so everything downstream stops the same way whichever fired.
 - `endStopDetail()`: classifies why the turn loop threw (caller stop / budget / declined plan / quota pause vs real failure) and renders the `end` event's `detail`; writes the resume note for a quota pause.
 
@@ -18,5 +19,5 @@ The run telemetry both entry paths share: session naming, driver-event accountin
 
 ## Flows
 
-- driver event: `emit(driver)` → on `result`: session-id change → `session-update`; usage → meter → `usage` event → budget check → abort; consumption gate → abort with trip label.
+- driver event: on `session`: id change → `session-update`, consumed (no `driver` emit); else `emit(driver)` → on `result`: session-id change → `session-update`; usage → meter → `usage` event → budget check → abort; consumption gate → abort with trip label.
 - run end (error path): `endStopDetail` → classify (declined > budget > paused > real error) → resume note if paused → `{stopped, detail}` for the `end` event.

--- a/packages/the-framework/src/run-telemetry.test.ts
+++ b/packages/the-framework/src/run-telemetry.test.ts
@@ -1,0 +1,40 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { createDriverEventHandler } from './run-telemetry.js'
+import type { FrameworkEvent } from './events.js'
+
+// #1322: the resume button needed a `session-update`, which only fired at `result` — a turn
+// stopped mid-flight took the session id (the run's `claude --resume` handle) down with it.
+// The driver's turn-start announcement now lands the update before anything can lose it.
+
+function handler(events: FrameworkEvent[], sessionLink?: string) {
+  return createDriverEventHandler({
+    emit: e => events.push(e),
+    ...(sessionLink ? { sessionLink } : {}),
+    budgetController: new AbortController(),
+    consumptionController: new AbortController(),
+  })
+}
+
+test('a session announcement emits session-update at turn start and is consumed, not forwarded (#1322)', () => {
+  const events: FrameworkEvent[] = []
+  handler(events, 'https://example.test/{sessionId}').onDriverEvent({ type: 'session', sessionId: 's1' })
+  assert.deepEqual(events, [{ kind: 'session-update', sessionId: 's1', sessionLink: 'https://example.test/s1' }])
+})
+
+test('the result repeating the announced id does not emit a second session-update (#1322)', () => {
+  const events: FrameworkEvent[] = []
+  const h = handler(events)
+  h.onDriverEvent({ type: 'session', sessionId: 's1' })
+  h.onDriverEvent({ type: 'result', text: 'done', sessionId: 's1' })
+  assert.equal(events.filter(e => e.kind === 'session-update').length, 1)
+})
+
+test('a result with a fresh id still emits, the pre-#1322 path unchanged', () => {
+  const events: FrameworkEvent[] = []
+  handler(events).onDriverEvent({ type: 'result', text: 'done', sessionId: 's2' })
+  assert.deepEqual(
+    events.filter(e => e.kind === 'session-update'),
+    [{ kind: 'session-update', sessionId: 's2' }],
+  )
+})

--- a/packages/the-framework/src/run-telemetry.ts
+++ b/packages/the-framework/src/run-telemetry.ts
@@ -82,6 +82,17 @@ export function createDriverEventHandler(opts: DriverEventHandlerOptions): Drive
   const usage = new UsageMeter()
 
   const onDriverEvent = (event: DriverEvent): void => {
+    // The turn-start id announcement (#1322) is consumed here, not forwarded: it exists so the
+    // `session-update` below lands before a Stop or a crash can lose the turn, and a transcript
+    // row repeating an id the very next event also carries would only be noise.
+    if (event.type === 'session') {
+      if (event.sessionId !== lastSessionId) {
+        lastSessionId = event.sessionId
+        const link = opts.sessionLink ? resolveSessionLink(opts.sessionLink, event.sessionId) : undefined
+        emit({ kind: 'session-update', sessionId: event.sessionId, ...(link ? { sessionLink: link } : {}) })
+      }
+      return
+    }
     emit({ kind: 'driver', event })
     if (event.type !== 'result') return
     if (event.sessionId && event.sessionId !== lastSessionId) {

--- a/packages/the-framework/src/terminal.ts
+++ b/packages/the-framework/src/terminal.ts
@@ -174,6 +174,10 @@ function formatDriverEvent(event: DriverEvent): string {
   switch (event.type) {
     case 'start':
       return `  › prompt: ${truncate(event.prompt, 140)}`
+    // Normally consumed by telemetry before it reaches a stream (#1322); rendered anyway so a
+    // stray one reads as what it is rather than crashing the formatter.
+    case 'session':
+      return `  session ${event.sessionId}`
     case 'text':
       return `    ${truncate(event.text)}`
     case 'action':


### PR DESCRIPTION
Why the "Copy resume command" button showed on some sessions and not others: the session id only reached the run's stream as a `session-update` when a turn's `result` event arrived — but Claude's stream states `session_id` on its very first line, and the parser was already capturing it (claude-code.ts) while only surfacing it at `result()`. So any run whose current turn never settled — a manual Stop mid-turn (the reported repro), an error, a kill — recorded no id, and the button vanished with the turn. A run stopped during its *first* turn never had a handle at all.

The fix surfaces the id the moment it is known:
- `StreamJsonParser` emits a new `{ type: 'session', sessionId }` driver event on first sighting (re-emitted only on change).
- `createDriverEventHandler` **consumes** it — not forwarded as a `driver` transcript row (the id is plumbing, not conversation) — and emits the existing `session-update` right then, with the same id-change dedup as the result path. A later `result` repeating the id does not re-emit; a cloud result's own deep link still wins on first sighting, unchanged (#1317).
- Side effect: the resume command is copyable seconds after launch instead of after the first full turn.

Tests: parser announce/dedup/re-announce-on-change, and a new `run-telemetry.test.ts` pinning consume-not-forward, turn-start emission, and no-duplicate-on-result. Two existing exact-list assertions updated for the announcement (actions replay, rate-limit line).

Daemon behavior → dogfood loop owed post-merge; live check = start a trivial run, Stop it mid-first-turn, the ⋮ menu should still offer the resume command.

Suites: framework 1633 pass / 0 fail, dashboard 677/677.

🤖 Generated with [Claude Code](https://claude.com/claude-code)