### PR TITLE
A resumed session reads as running again: status folds scope to the current segment

### DIFF
--- a/.changeset/resumed-run-status-current-segment.md
+++ b/.changeset/resumed-run-status-current-segment.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework-dashboard': patch
+---
+
+A resumed session reads as running again: `isRunActive` and `runOutcome` now fold over the current `session` segment instead of the whole feed. The resume fix keeps the full multi-segment transcript on screen, which exposed the stopped segment's `end` event to the status folds — the pill stayed yellow "stopped" and the ⋮ menu hid "Stop session" while the resumed agent was live, and a resumed run that later finished clean would have stayed "stopped" for ever.

--- a/packages/framework-dashboard/lib/live-state.spec.md
+++ b/packages/framework-dashboard/lib/live-state.spec.md
@@ -5,9 +5,9 @@ Pure selectors deriving live-run UI state from a run's `FrameworkEvent[]` stream
 - The dashboard is a projection of the same `events.jsonl` the run writes; the interactive gate and the Stop button read this projection rather than any extra state.
 - `pendingChoices` — open choice gates in fire order: a `choice` event opens (a re-fired id replaces in place), a matching `choice-resolved` closes; several can be parked at once (#440 shows them all in the right rail). An `end` event closes every open gate (#1359) — the meta fold's "a finished run is not awaiting anything" rule — so a run that died mid-gate (whose ending is the store's surrogate end, never a `choice-resolved`) stops rendering its question as answerable.
 - `agentViews` (#441) — the agent's ad-hoc markdown rail views, one entry per id in first-seen order; a re-shown id updates in place rather than stacking a duplicate.
-- `isRunActive` — anything streamed and no `end` event yet (whether Stop is worth showing).
+- `isRunActive` — anything streamed and no `end` event yet IN THE CURRENT SEGMENT (whether Stop is worth showing). A resumed session (#762) appends a second `session` boundary after its `end` to the same journal; "was there ever an end" read a resumed-live run as inactive and hid Stop.
 - `agentSettled` (#785/#1173) — parked-on-you vs process-alive: `settled` sets it, a driver `start` clears it (answering puts it back to work), `end` clears it (over ≠ settled).
-- `runOutcome` (#948) — how the run ended off its single `end` event: `{ ok, stopped, detail? }`, so the overview pill tells a crash, a user stop, and a clean finish apart.
+- `runOutcome` (#948) — how the run ended off the CURRENT segment's `end` event: `{ ok, stopped, detail? }`, so the overview pill tells a crash, a user stop, and a clean finish apart. Mid-resume there is no end in the newest segment yet and the answer is `undefined` — first-end-wins kept a resumed run "stopped" for ever, even after it later finished clean.
 - `actionsRunUrl` (#1053) / `cloudSession` (#610) — external-run links parsed from driver `action` labels; last match wins across turns.
 - `currentRunEvents` — the tail from the last `session` event, so a subscription spanning a run boundary does not show the previous run.
 

--- a/packages/framework-dashboard/lib/live-state.test.ts
+++ b/packages/framework-dashboard/lib/live-state.test.ts
@@ -71,6 +71,18 @@ describe('isRunActive', () => {
     expect(isRunActive([{ kind: 'log', message: 'go' }])).toBe(true)
     expect(isRunActive([{ kind: 'log', message: 'go' }, { kind: 'end', ok: true }])).toBe(false)
   })
+
+  test('a resumed session is active again: the stopped segment\'s end does not count (#762)', () => {
+    // A resume appends a second `session` boundary to the SAME journal. "Was there ever an end"
+    // read the resumed-live run as inactive — hiding Stop while the agent worked.
+    const resumed = [
+      { kind: 'session' },
+      { kind: 'end', ok: false, stopped: true },
+      { kind: 'session' },
+      { kind: 'log', message: 'back at it' },
+    ] as FrameworkEvent[]
+    expect(isRunActive(resumed)).toBe(true)
+  })
 })
 
 describe('currentRunEvents', () => {
@@ -134,6 +146,16 @@ describe('runOutcome', () => {
 
   test('a user stop is a stop, not a failure', () => {
     expect(runOutcome([{ kind: 'end', ok: false, stopped: true }])).toEqual({ ok: false, stopped: true })
+  })
+
+  test('a resumed session has no outcome until ITS segment ends (#762)', () => {
+    // First-end-wins kept a resumed run "stopped" for ever: while it was live again, and even
+    // after it later finished clean. The ending is the current segment's, or nothing yet.
+    const stopped = { kind: 'end', ok: false, stopped: true }
+    const midResume = [{ kind: 'session' }, stopped, { kind: 'session' }, { kind: 'log', message: 'go' }] as FrameworkEvent[]
+    expect(runOutcome(midResume)).toBeUndefined()
+    const finishedClean = [...midResume, { kind: 'end', ok: true }] as FrameworkEvent[]
+    expect(runOutcome(finishedClean)).toEqual({ ok: true, stopped: false })
   })
 })
 

--- a/packages/framework-dashboard/lib/live-state.ts
+++ b/packages/framework-dashboard/lib/live-state.ts
@@ -71,7 +71,11 @@ export function agentViews(events: readonly FrameworkEvent[]): AgentView[] {
  * single `end` event; until one arrives (and once anything has streamed) it is live.
  */
 export function isRunActive(events: readonly FrameworkEvent[]): boolean {
-  return events.length > 0 && !events.some(event => event.kind === 'end')
+  // Asked of the CURRENT segment, not the whole feed: a resumed session (#762) appends a second
+  // `session` boundary after its `end` to the same journal, and "was there ever an end" read a
+  // resumed-live run as inactive — hiding Stop and settling the pill while the agent worked.
+  const current = currentRunEvents(events)
+  return current.length > 0 && !current.some(event => event.kind === 'end')
 }
 
 /**
@@ -110,7 +114,11 @@ export interface RunOutcome {
  * pill said "finished" for a crash and a clean pass alike.
  */
 export function runOutcome(events: readonly FrameworkEvent[]): RunOutcome | undefined {
-  const end = events.find(event => event.kind === 'end')
+  // The ending of the CURRENT segment: a resumed session (#762) carries its stopped segment's
+  // `end` in the same journal, and the first-end-wins read kept a resumed run "stopped" for
+  // ever — while it was live again, and even after it later finished clean. Mid-resume there is
+  // no end in the newest segment yet, and "undefined while it is still going" is the truth.
+  const end = currentRunEvents(events).find(event => event.kind === 'end')
   if (!end || end.kind !== 'end') return undefined
   return { ok: end.ok, stopped: end.stopped === true, ...(end.detail !== undefined ? { detail: end.detail } : {}) }
 }

--- a/packages/framework-dashboard/lib/run-status.test.ts
+++ b/packages/framework-dashboard/lib/run-status.test.ts
@@ -33,4 +33,12 @@ describe('runStatusPill', () => {
       label: 'failed — exit 1',
     })
   })
+
+  test('a resumed session builds again — the stopped segment does not hold the pill (#762)', () => {
+    // A resume appends a second `session` boundary to the same journal; the yellow "stopped"
+    // stuck to a live run because first-end-wins outranked everything that followed.
+    const resumed = [named, ended({ ok: false, stopped: true }), { kind: 'session' } as FrameworkEvent]
+    expect(runStatusPill(resumed)).toMatchObject({ label: 'building…' })
+    expect(runStatusPill([...resumed, ended({ ok: true })])).toMatchObject({ label: 'finished' })
+  })
 })


### PR DESCRIPTION
Live repro (Suleiman, run `2026-07-31T21-15-20-028Z`): after pressing the new Resume button (#1448), the run resumed and streamed — but the topbar pill stayed yellow **stopped** and the ⋮ menu never offered **Stop session**, while the rail row and composer correctly said running.

Root cause: #1448 deliberately keeps the whole multi-segment transcript on screen (a resume appends a second `session` boundary to the SAME journal), which exposed the stopped segment's `end` event to two folds that scan the entire feed:

- `isRunActive` was "was there ever an `end`" → a resumed-live run read as inactive → Stop hidden, pill never pulsed.
- `runOutcome` was FIRST-end-wins → "stopped" outranked everything for ever — while live again, and even after the resumed run later finished clean.

Both now slice at the newest `session` boundary (`currentRunEvents`, the same segment rule the right rail uses). Semantics are unchanged for single-segment feeds; mid-resume `runOutcome` answers `undefined`, which is its documented "still going" truth. This also keeps the Resume button honest: a resumed-then-finished run stops offering it.

Callers audited: `runStatusPill` (pill), `SessionActionsMenu` (Stop/Merge gating), `RelayView` (working state) — all want segment semantics.

Tests: dashboard 690/690 (3 new: active-again, no-outcome-mid-resume + last-ending-wins, pill builds-again). Dashboard-only.

Known cosmetic leftover, not in this PR: the feed's scroll position jumps once at the ended→live flip (the feed switches from static `openAt: end` to follow-mode). Flagged as polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)