### PR TITLE
remove scratch file test24.md (#1431 live-test leftover)

### DIFF
--- a/test24.md
+++ b/test24.md
@@ -1,1 +1,0 @@
-publishing sub-state test (#1431)


### PR DESCRIPTION
Scratch file from the #1431 publishing-window live test (merged via PR #1452). The follow-up delete run could not remove it — its worktree forked a local main that predated the merge, so the handoff skipped with `no-commits`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)