### PR TITLE
the right rail narrows to 22rem (#1455)

### DIFF
--- a/packages/framework-dashboard/components/RightRail.spec.md
+++ b/packages/framework-dashboard/components/RightRail.spec.md
@@ -10,7 +10,7 @@ The right sidebar (#314 third rail): a tabbed panel column offering Files, Choic
 
 ## Decisions
 
-- Fixed `w-[27rem]` width for every tab — the per-tab wide mode from #862 was dropped so the rail reads as one stable column.
+- Fixed `w-[22rem]` width for every tab — the per-tab wide mode from #862 was dropped so the rail reads as one stable column.
 - Browser tab requires `hasBrowser && target !== 'actions'` (#1053: no browser on a GitHub Actions runner) plus a `runId`; a dead tab "teaches people the preview is broken".
 - If the remembered tab loses its content (last doc deleted, gate resolved), fall back to the first tab that still exists rather than render an empty panel.
 - Tickets was a rail read (#697) but moved to its own full page (#1144).

--- a/packages/framework-dashboard/components/RightRail.test.tsx
+++ b/packages/framework-dashboard/components/RightRail.test.tsx
@@ -45,19 +45,19 @@ describe('RightRail width', () => {
 
   test('a list-shaped tab holds the fixed width', () => {
     const { container } = render(<RightRail {...baseProps} />)
-    expect(rail(container).className).toContain('w-[27rem]')
+    expect(rail(container).className).toContain('w-[22rem]')
   })
 
   test('a pushed view keeps the same width — no expand', () => {
     const { container } = render(<RightRail {...baseProps} views={[view]} />)
     // The first view pulls the rail to the Views tab on its own, but the width does not change.
-    expect(rail(container).className).toContain('w-[27rem]')
+    expect(rail(container).className).toContain('w-[22rem]')
   })
 
   test('the width is unchanged after switching away from a view', () => {
     const { container } = render(<RightRail {...baseProps} views={[view]} />)
     fireEvent.click(screen.getByRole('tab', { name: /docs/i }))
-    expect(rail(container).className).toContain('w-[27rem]')
+    expect(rail(container).className).toContain('w-[22rem]')
   })
 
   test('no project means no rail', () => {

--- a/packages/framework-dashboard/components/RightRail.tsx
+++ b/packages/framework-dashboard/components/RightRail.tsx
@@ -136,7 +136,7 @@ export function RightRail({
   return (
     <aside
       className={cn(
-        'flex w-[27rem] shrink-0 flex-col border-l border-border',
+        'flex w-[22rem] shrink-0 flex-col border-l border-border',
       )}
     >
       {/* flex-wrap: up to 7 tabs share a w-80 rail, and without it the tail clipped (#948).

--- a/packages/framework-dashboard/components/TicketsPage.tsx
+++ b/packages/framework-dashboard/components/TicketsPage.tsx
@@ -37,7 +37,7 @@ function sortTickets(tickets: WorkspaceTicket[], sortBy: SortBy): WorkspaceTicke
 }
 
 // The Tickets view (#1144): every registered project's `tickets/*.md`, one section per project —
-// its own full page rather than a tab squeezed into the 27rem right rail, and cross-project rather
+// its own full page rather than a tab squeezed into the 22rem right rail, and cross-project rather
 // than scoped to whichever project happened to be selected, since the backlog is worth seeing
 // whole. Each section is its own poll-independent TicketsPanel (list, priority/topics/date, its own
 // Update-from-GitHub bar), so one project's slow read never blanks another's.

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -218,7 +218,7 @@ export default function Page() {
   }
 
   // Tickets (#1144): every registered project's backlog, one section each — required reading for a
-  // demo, so it gets the full width rather than the 27rem right rail. A cross-project destination
+  // demo, so it gets the full width rather than the 22rem right rail. A cross-project destination
   // like the Overview, not scoped to whichever project happened to be selected.
   const showTickets = () => {
     setAdopting(false)


### PR DESCRIPTION
First sub-item of #1455 (deliberately no closing keyword — the issue holds seven more): the launcher/overview right rail (tabs area) goes `w-[27rem]` → `w-[22rem]`. Width tests, the RightRail spec bullet, and the two comments citing 27rem updated to match. Dashboard suite 697/697.

🤖 Generated with [Claude Code](https://claude.com/claude-code)