### PR TITLE
the routine card gets the sweep outcomes it was promised (#1433 follow-up)

### DIFF
--- a/.changeset/sweep-report-survives-await.md
+++ b/.changeset/sweep-report-survives-await.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+"Trigger routine now" answers with the sweep's real outcome lines again: the RPC read the Telefunc request context after an await, which does not survive one, so every click fell back to the generic "The sweep ran." The reporter is now captured before the sweep runs.

--- a/packages/the-framework/src/dashboard-rpc/quota.telefunc.test.ts
+++ b/packages/the-framework/src/dashboard-rpc/quota.telefunc.test.ts
@@ -30,6 +30,22 @@ test('sendAutoPmSweep awaits the sweep, then answers with the outcomes it decide
   assert.deepEqual(result, { ok: true, outcomes: [OUTCOME] })
 })
 
+test('the outcomes survive the await — the request context does not, so the reporter is captured first (#1433)', async () => {
+  // In production the Telefunc context is request-scoped and gone after the first await, so a
+  // post-await `contextAutoPm()` read found nothing and every real click fell back to a bare
+  // `{ok:true}` — while this suite's provideTelefuncContext global happily outlived the await
+  // and hid it. Model the loss: the fake sweep yanks the context mid-flight, the way resolving
+  // the tick does for a real request.
+  provideTelefuncContext({
+    autoPmSweep: async () => {
+      await Promise.resolve()
+      provideTelefuncContext({} as never)
+    },
+    autoPm: () => ({ nextSweepAt: 0, outcomes: [OUTCOME] }),
+  } as never)
+  assert.deepEqual(await sendAutoPmSweep(), { ok: true, outcomes: [OUTCOME] })
+})
+
 test('a host with no loop still answers ok:false — the relay has nothing to trigger (#1210)', async () => {
   provideTelefuncContext({} as never)
   assert.deepEqual(await sendAutoPmSweep(), { ok: false })

--- a/packages/the-framework/src/dashboard-rpc/quota.telefunc.ts
+++ b/packages/the-framework/src/dashboard-rpc/quota.telefunc.ts
@@ -62,16 +62,21 @@ export async function onAutoPm(): Promise<AutoPmReport | undefined> {
  */
 export async function sendAutoPmSweep(opts?: { drainOnly?: boolean }): Promise<{ ok: boolean; outcomes?: AutoPmOutcome[] }> {
   const sweep = contextAutoPmSweep()
+  // The reporter is captured BEFORE the sweep is awaited: the Telefunc request context does not
+  // survive an await, so a post-await `contextAutoPm()` found nothing on every real request and
+  // the card fell back to "The sweep ran." — the very fallback this RPC exists to avoid. The
+  // captured closure needs no context to be called later.
+  const reporter = contextAutoPm()
   if (!sweep) return { ok: false }
   try {
     await sweep(opts?.drainOnly ? { drainOnly: true } : undefined)
   } catch {
     return { ok: false }
   }
-  // The outcomes live on the loop's report — the same lines `onAutoPm` polls — read here once
-  // the tick has resolved, so they describe the sweep this click fired.
+  // The outcomes live on the loop's report — the same lines `onAutoPm` polls — read once the
+  // tick has resolved, so they describe the sweep this click fired.
   try {
-    const report = contextAutoPm()?.()
+    const report = reporter?.()
     return { ok: true, ...(report ? { outcomes: report.outcomes } : {}) }
   } catch {
     return { ok: true }


### PR DESCRIPTION
The #1447 plumbing shipped dead at its last hop: `sendAutoPmSweep` read `contextAutoPm()` **after** `await sweep(...)`, and the Telefunc request context does not survive an await — `fromContext` swallows the loss into `undefined`, so every real click answered a bare `{ok:true}` and the card fell back to the generic **"The sweep ran."** instead of the outcome lines.

Found live tonight while running the owed #1433 check: the daemon log carried the #1432 stand-down sentence verbatim, a read-only `onAutoPm` probe returned all three outcomes — and the card still showed the fallback. CI never saw it because the tests provide context via `provideTelefuncContext`, a global that happily outlives awaits (the same tests-mock-the-seam pattern as #1443's dead probe).

**Fix:** capture the reporter closure before the sweep runs — it needs no context to be called later. One reorder, no behavior change elsewhere.

**Test:** models the context loss by yanking the provided context inside the fake sweep (`provideTelefuncContext({})` post-await); verified it fails against the old code. Suite 1638/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)