### PR TITLE
Run-scoped events tails resolve an ended run to its archive, not the root journal

### DIFF
--- a/packages/the-framework/src/daemon-runtime.ts
+++ b/packages/the-framework/src/daemon-runtime.ts
@@ -21,7 +21,7 @@ import {
   pruneWorktrees,
   readLiveMetas,
   readLiveMeta,
-  resolveRunCheckout,
+  resolveRunEventsPath,
   FRAMEWORK_DIR,
   EVENTS_FILE,
   META_FILE,
@@ -1011,14 +1011,14 @@ export function createProjectRuntime({ cwd, env, binPath, retryDelayMs, agentPre
   const remoteEventsSource: EventsSource = (_projectId, runId) => relayedRuns.get(runId)
 
   // Tail a relay-started run's own log (#1067) for the `/_relay/events` endpoint. Resolving the run's
-  // worktree is async, so a stop is returned immediately and the tail attaches once the path is known.
+  // journal is async, so a stop is returned immediately and the tail attaches once the path is known.
   const tailRelayEvents = (runId: string, onEvent: (event: FrameworkEvent) => void): (() => void) => {
     let stop = (): void => {}
     let cancelled = false
-    void resolveRunCheckout(cwd, runId)
-      .then(checkout => {
+    void resolveRunEventsPath(cwd, runId)
+      .then(path => {
         if (cancelled) return
-        stop = tailEvents(join(checkout, FRAMEWORK_DIR, EVENTS_FILE), onEvent)
+        stop = tailEvents(path, onEvent)
       })
       .catch(() => {})
     return () => {

--- a/packages/the-framework/src/dashboard-rpc/events.telefunc.spec.md
+++ b/packages/the-framework/src/dashboard-rpc/events.telefunc.spec.md
@@ -4,7 +4,7 @@ The live event stream telefunction (#405): `onEvents(projectId, runId?)` returns
 
 - Two sources, chosen by the mount: an in-memory `EventsSource` on the context wins (the relay's own run #426, or a run the daemon relays from a device #1067, replay+follow via `forwardStream`); otherwise the run's on-disk `events.jsonl` is tailed via `tailEvents`.
 - The daemon's source answers only for relayed runs, so ordinary local runs fall through to file tailing unchanged.
-- With `runId` the tail follows that run's own log inside its worktree (#749) — since #736 runs append there, so the project-root feed for a worktree run is empty; omitting it keeps pre-#736 behavior.
+- With `runId` the tail follows that run's own log inside its worktree (#749) — since #736 runs append there, so the project-root feed for a worktree run is empty; omitting it keeps pre-#736 behavior. Once the run has ended and its worktree is gone, its archived `<id>.jsonl` is tailed instead of the root journal (#1472, via `resolveRunEventsPath`).
 - Unknown project → a channel that closes immediately, mirroring the read model's empty results rather than throwing at the client.
 - `stream-sync` (#1383): sent once per subscription by the on-disk tail after the replay is delivered, so a reconnecting client can swap its feed atomically instead of blanking while history re-streams. Wire-only — not a `FrameworkEvent`, never journaled, swallowed client-side. The in-memory sources have no replay boundary to report and send none; the client falls back to a grace deadline.
 

--- a/packages/the-framework/src/dashboard-rpc/events.telefunc.ts
+++ b/packages/the-framework/src/dashboard-rpc/events.telefunc.ts
@@ -1,7 +1,6 @@
-import { join } from 'node:path'
 import type { ClientChannel } from 'telefunc'
-import { FRAMEWORK_DIR, EVENTS_FILE } from '../store/index.js'
-import { contextEventsSource, resolveRunPath } from './context.js'
+import { resolveRunEventsPath } from '../store/index.js'
+import { contextEventsSource, resolveProjectPath } from './context.js'
 import type { FrameworkEvent } from '../events.js'
 import { tailEvents } from './events-tail.js'
 import { forwardStream, streamChannel } from './stream-channel.js'
@@ -15,11 +14,13 @@ import { forwardStream, streamChannel } from './stream-channel.js'
 /**
  * The events file to tail, or undefined when the project is unknown. With a `runId` this is
  * that run's own log inside its worktree (#749): since #736 a run appends there, not to the
- * project root, so streaming the project path would follow a file nothing writes to.
+ * project root, so streaming the project path would follow a file nothing writes to. Once the
+ * run has ended and its worktree is gone, the run's archived `<id>.jsonl` is that log (#1472) —
+ * tailing the project root there would stream a foreign run's journal.
  */
 async function resolveEventsPath(projectId: string, runId?: string): Promise<string | undefined> {
-  const path = await resolveRunPath(projectId, runId)
-  return path ? join(path, FRAMEWORK_DIR, EVENTS_FILE) : undefined
+  const cwd = await resolveProjectPath(projectId)
+  return cwd ? resolveRunEventsPath(cwd, runId) : undefined
 }
 
 /**

--- a/packages/the-framework/src/store/index.ts
+++ b/packages/the-framework/src/store/index.ts
@@ -32,7 +32,7 @@ export {
   type RunStatus,
   type OpenStoreOptions,
 } from './run-store.js'
-export { resolveRunCheckout } from './run-checkout.js'
+export { resolveRunCheckout, resolveRunEventsPath } from './run-checkout.js'
 export {
   addWorktree,
   attachWorktree,

--- a/packages/the-framework/src/store/run-checkout.spec.md
+++ b/packages/the-framework/src/store/run-checkout.spec.md
@@ -10,3 +10,10 @@ Resolves the checkout a run id addresses (#738/#797): the run's own worktree whi
 - The worktree directory exists before the run has written its `run.json` (#766): the daemon creates the dir, spawns the process, and only then does the run write meta — so a lookup by run state alone misses a run that certainly exists; hence the directory probe.
 - The probe matters beyond a slow first read: a Telefunc Channel resolves its path once at subscribe time, so a wrong fallback would tail the wrong file for the life of the subscription — how a newly started run once showed a previous run's output.
 - Unknown/finished ids fall back to the project root rather than failing: the worktree may already be gone and the project's own state is still the sane thing to act on.
+
+## resolveRunEventsPath (#1472)
+
+- The events-journal variant of the same resolution, used only by the events tails (`onEvents`, the daemon's `/_relay/events`): live meta cwd → worktree → the run's **archived** `<id>.jsonl` → root journal.
+- Where `resolveRunCheckout` would fall back to the root, an existing archive wins: the archive proves the run ended and is the run's own record, while the root journal belongs to whatever root run wrote it last — tailing it streamed a foreign run's feed (masked client-side until #1471, wasted IO regardless).
+- The root journal stays the final fallback for the no-archive residue, so a just-starting root run (no meta yet, no worktree to probe — the #766 window) streams exactly as before.
+- Ordering matters for a resumed run: its recreated worktree (live journal) must beat its stale archive from the earlier leg.

--- a/packages/the-framework/src/store/run-checkout.test.ts
+++ b/packages/the-framework/src/store/run-checkout.test.ts
@@ -1,0 +1,90 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { resolveRunEventsPath } from './run-checkout.js'
+import { FRAMEWORK_DIR, EVENTS_FILE, WORKTREES_DIR, RUNS_DIR, SESSIONS_DIR } from './run-store.js'
+
+// resolveRunEventsPath probes the real filesystem (same as resolveRunCheckout), so these
+// tests build a throwaway project directory rather than a memory fs.
+
+const RUN_ID = '2026-07-04T00-00-00-000Z'
+
+async function makeProject(): Promise<string> {
+  const cwd = await mkdtemp(join(tmpdir(), 'tf-run-checkout-'))
+  await mkdir(join(cwd, FRAMEWORK_DIR), { recursive: true })
+  return cwd
+}
+
+const rootJournal = (cwd: string): string => join(cwd, FRAMEWORK_DIR, EVENTS_FILE)
+
+async function seedArchive(cwd: string, runsDir: string): Promise<string> {
+  await mkdir(runsDir, { recursive: true })
+  await writeFile(join(runsDir, `${RUN_ID}.json`), '{}')
+  const events = join(runsDir, `${RUN_ID}.jsonl`)
+  await writeFile(events, '')
+  return events
+}
+
+test('resolveRunEventsPath: no run id (and unsafe ids) resolve to the root journal', async () => {
+  const cwd = await makeProject()
+  try {
+    assert.equal(await resolveRunEventsPath(cwd, undefined), rootJournal(cwd))
+    assert.equal(await resolveRunEventsPath(cwd, '../escape'), rootJournal(cwd))
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('resolveRunEventsPath: an existing worktree resolves to its own journal', async () => {
+  const cwd = await makeProject()
+  try {
+    const worktree = join(cwd, FRAMEWORK_DIR, WORKTREES_DIR, RUN_ID)
+    await mkdir(worktree, { recursive: true })
+    assert.equal(await resolveRunEventsPath(cwd, RUN_ID), join(worktree, FRAMEWORK_DIR, EVENTS_FILE))
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('resolveRunEventsPath: an ended run (worktree gone) resolves to its archived log, not the root journal (#1472)', async () => {
+  const cwd = await makeProject()
+  try {
+    const events = await seedArchive(cwd, join(cwd, FRAMEWORK_DIR, RUNS_DIR))
+    assert.equal(await resolveRunEventsPath(cwd, RUN_ID), events)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('resolveRunEventsPath: finds an archive filed under a user sessions dir (#1179)', async () => {
+  const cwd = await makeProject()
+  try {
+    const events = await seedArchive(cwd, join(cwd, FRAMEWORK_DIR, 'someone', SESSIONS_DIR))
+    assert.equal(await resolveRunEventsPath(cwd, RUN_ID), events)
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('resolveRunEventsPath: a live worktree beats a stale archive (a resumed run)', async () => {
+  const cwd = await makeProject()
+  try {
+    await seedArchive(cwd, join(cwd, FRAMEWORK_DIR, RUNS_DIR))
+    const worktree = join(cwd, FRAMEWORK_DIR, WORKTREES_DIR, RUN_ID)
+    await mkdir(worktree, { recursive: true })
+    assert.equal(await resolveRunEventsPath(cwd, RUN_ID), join(worktree, FRAMEWORK_DIR, EVENTS_FILE))
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('resolveRunEventsPath: an unknown id with no archive keeps the root-journal fallback (#766 root runs)', async () => {
+  const cwd = await makeProject()
+  try {
+    assert.equal(await resolveRunEventsPath(cwd, RUN_ID), rootJournal(cwd))
+  } finally {
+    await rm(cwd, { recursive: true, force: true })
+  }
+})

--- a/packages/the-framework/src/store/run-checkout.ts
+++ b/packages/the-framework/src/store/run-checkout.ts
@@ -1,4 +1,5 @@
-import { isSafeRunId, readLiveMetas } from './run-store.js'
+import { join } from 'node:path'
+import { archivedRunPaths, isSafeRunId, readLiveMetas, EVENTS_FILE, FRAMEWORK_DIR } from './run-store.js'
 import { worktreePath } from './worktree.js'
 import { nodeFs } from '../node-fs.js'
 
@@ -26,4 +27,29 @@ export async function resolveRunCheckout(projectCwd: string, runId: string | und
   if (running) return running
   const path = worktreePath(projectCwd, runId)
   return (await nodeFs().isDirectory(path)) ? path : projectCwd
+}
+
+/**
+ * The events journal a run-scoped subscribe should tail (#1472). Follows
+ * {@link resolveRunCheckout}'s order — live meta cwd, then the worktree — but where that
+ * resolution would fall back to the project root, an ended run's **archived** `<id>.jsonl`
+ * wins: the archive existing proves the run ended, and it is the run's own record, where the
+ * root journal belongs to whatever root run wrote it last. The root journal stays the final
+ * fallback for the no-archive residue, so a just-starting root run (no meta yet, #766, and no
+ * worktree to probe) streams exactly as before.
+ *
+ * Only the events tails resolve here; every other run-addressed surface keeps
+ * {@link resolveRunCheckout}'s root fallback, where the project's own state is the sane
+ * thing to act on.
+ */
+export async function resolveRunEventsPath(projectCwd: string, runId: string | undefined): Promise<string> {
+  const rootJournal = join(projectCwd, FRAMEWORK_DIR, EVENTS_FILE)
+  if (!runId || !isSafeRunId(runId)) return rootJournal
+  const live = await readLiveMetas(projectCwd).catch(() => [])
+  const running = live.find(run => run.id === runId)?.cwd
+  if (running) return join(running, FRAMEWORK_DIR, EVENTS_FILE)
+  const path = worktreePath(projectCwd, runId)
+  if (await nodeFs().isDirectory(path)) return join(path, FRAMEWORK_DIR, EVENTS_FILE)
+  const [, archivedEvents] = await archivedRunPaths(projectCwd, runId)
+  return archivedEvents ?? rootJournal
 }


### PR DESCRIPTION
Fixes #1472 — the server half of the #1471 foreign-journal problem.

## What

A run-scoped events subscribe (`onEvents`, and the daemon's `/_relay/events` tail, which had the identical shape) for an **ended** run whose worktree is gone fell through `resolveRunCheckout`'s project-root fallback and tailed the project ROOT `events.jsonl` — a journal belonging to whatever root run wrote it last. #1471 taught the client to reject that foreign feed; the transport still streamed it, one watcher + 1s poll per open ended-session view.

## How

New `resolveRunEventsPath` (store/run-checkout.ts) — the events-journal variant of the shared resolution:

1. live meta cwd → its journal (unchanged)
2. existing worktree → its journal (unchanged; keeps the #766 first-seconds cover, and a **resumed** run's recreated worktree beats its stale archive)
3. the run's **archived** `<id>.jsonl` (`archivedRunPaths` — per-user `sessions/` + legacy `runs/`): the archive existing proves the run ended, and it IS the run's journal snapshot
4. root journal — only for the no-archive residue, so a just-starting root run streams exactly as before

Scoped to the two events tails; every other run-addressed surface keeps `resolveRunCheckout` untouched.

## Tests

New `run-checkout.test.ts`: fallback→archive redirect (legacy `runs/` and user `sessions/`), worktree-beats-archive ordering, unsafe-id and no-archive fallbacks. Full suite: 1679 pass.

Part of the #1460 family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)