### PR TITLE
Remove test29.md / test30.md resume-flow test debris

### DIFF
--- a/test29.md
+++ b/test29.md
@@ -1,3 +1,0 @@
-apple
-banana
-cherry

--- a/test30.md
+++ b/test30.md
@@ -1,3 +1,0 @@
-cherry
-banana
-apple


### PR DESCRIPTION
The two files landed on main via PR #1477 — the live verification run for the resumed-build-flow work (Stop mid-build → composer Resume → full build ending → merge-on-green). They were the run's scratch payload, not real content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)