### PR TITLE
Launcher shows Docs and History in the main column (#1455 items 2/3)

### DIFF
--- a/.changeset/docs-history-main-column.md
+++ b/.changeset/docs-history-main-column.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/framework-dashboard': minor
+---
+
+Launcher shows Docs and History in the main column (#1455 items 2/3): new `ProjectDocs` / `ProjectHistory` sections under the launcher reuse the rail's panels, and the right rail withholds its Docs/History tabs (and skips their polls) while the launcher is the main view. Session views keep the full rail.

--- a/packages/framework-dashboard/components/ProjectDocs.spec.md
+++ b/packages/framework-dashboard/components/ProjectDocs.spec.md
@@ -1,0 +1,7 @@
+The workspace's PLAN/TODO docs on the launcher (#1455 item 2): moved out of the right rail into the main column, in the same `DocsPanel` presentation.
+
+## TLDR
+
+- Polls `onDocs(projectId)` (4s, the rail's own cadence) and renders `DocsPanel` — the rail's panel reused verbatim, so the two surfaces cannot drift; while this section shows, the rail withholds its Docs tab (`docsInMain`).
+- A project with no docs gets no section — the rail's earned-by-content rule (#1146) carried over.
+- The section caps its height (`max-h-[28rem]`) so a long PLAN scrolls inside it rather than taking the launcher column; `DocsPanel`'s own ScrollArea does the scrolling.

--- a/packages/framework-dashboard/components/ProjectDocs.test.tsx
+++ b/packages/framework-dashboard/components/ProjectDocs.test.tsx
@@ -1,0 +1,30 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+
+// The section polls onDocs itself (the ProjectTickets pattern); DocsPanel renders what it is given.
+const onDocs = vi.hoisted(() => vi.fn())
+vi.mock('../server/reads.telefunc.js', () => ({ onDocs }))
+
+const { ProjectDocs } = await import('./ProjectDocs.js')
+
+beforeEach(() => {
+  onDocs.mockReset().mockResolvedValue([])
+})
+
+afterEach(cleanup)
+
+describe('ProjectDocs (#1455 item 2)', () => {
+  test('a project with no docs gets no section at all', async () => {
+    const { container } = render(<ProjectDocs projectId="p1" />)
+    await waitFor(() => expect(onDocs).toHaveBeenCalledWith('p1'))
+    expect(container.textContent).toBe('')
+  })
+
+  test('docs render under a Docs heading in the DocsPanel presentation', async () => {
+    onDocs.mockResolvedValue([{ name: 'PLAN.md', content: '# the plan' }])
+    render(<ProjectDocs projectId="p1" />)
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Docs' })).toBeTruthy())
+    expect(screen.getByText('PLAN.md')).toBeTruthy()
+    expect(screen.getByText('the plan')).toBeTruthy()
+  })
+})

--- a/packages/framework-dashboard/components/ProjectDocs.tsx
+++ b/packages/framework-dashboard/components/ProjectDocs.tsx
@@ -1,0 +1,26 @@
+import type { WorkspaceDoc } from '@gemstack/the-framework'
+import { onDocs } from '../server/reads.telefunc.js'
+import { usePolled } from '../lib/use-async.js'
+import { DocsPanel } from './DocsPanel.js'
+
+/** Stable initial for the poll, so it does not churn on every render. */
+const EMPTY_DOCS: WorkspaceDoc[] = []
+
+/**
+ * The workspace's PLAN/TODO docs on the launcher (#1455 item 2): moved out of the right rail
+ * into the main column, same DocsPanel presentation. A project with no docs gets no section —
+ * the rail's earned-by-content rule (#1146) applies here unchanged. The section caps its own
+ * height so a long PLAN scrolls inside it rather than taking the whole launcher column.
+ */
+export function ProjectDocs({ projectId }: { projectId: string }) {
+  const { value: docs, loaded } = usePolled<WorkspaceDoc[]>(() => onDocs(projectId), EMPTY_DOCS, 4000, [projectId])
+  if (!loaded || docs.length === 0) return null
+  return (
+    <section aria-label="Docs" className="border-t border-border p-3">
+      <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Docs</h2>
+      <div className="flex max-h-[28rem] flex-col overflow-hidden rounded-md border border-border">
+        <DocsPanel docs={docs} loaded />
+      </div>
+    </section>
+  )
+}

--- a/packages/framework-dashboard/components/ProjectHistory.spec.md
+++ b/packages/framework-dashboard/components/ProjectHistory.spec.md
@@ -1,0 +1,7 @@
+The project's session history on the launcher (#1455 item 3): moved out of the right rail into the main column, in the same `ProjectLogPanel` presentation (the committed `.the-framework/LOGS.md`, newest first).
+
+## TLDR
+
+- Polls `onProjectLog(projectId)` (10s, the rail's own cadence) and renders `ProjectLogPanel` — the rail's panel reused verbatim, so the two surfaces cannot drift; while this section shows, the rail withholds its History tab (`docsInMain`).
+- A project with no finished sessions gets no section — the rail's earned-by-content rule (#1146) carried over.
+- Height-capped (`max-h-[24rem]`) like the Docs section, so a long history scrolls inside it.

--- a/packages/framework-dashboard/components/ProjectHistory.test.tsx
+++ b/packages/framework-dashboard/components/ProjectHistory.test.tsx
@@ -1,0 +1,30 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+
+// The section polls onProjectLog itself (the ProjectTickets pattern); ProjectLogPanel renders
+// what it is given.
+const onProjectLog = vi.hoisted(() => vi.fn())
+vi.mock('../server/reads.telefunc.js', () => ({ onProjectLog }))
+
+const { ProjectHistory } = await import('./ProjectHistory.js')
+
+beforeEach(() => {
+  onProjectLog.mockReset().mockResolvedValue([])
+})
+
+afterEach(cleanup)
+
+describe('ProjectHistory (#1455 item 3)', () => {
+  test('a project with no finished sessions gets no section at all', async () => {
+    const { container } = render(<ProjectHistory projectId="p1" />)
+    await waitFor(() => expect(onProjectLog).toHaveBeenCalledWith('p1'))
+    expect(container.textContent).toBe('')
+  })
+
+  test('log entries render under a History heading in the ProjectLogPanel presentation', async () => {
+    onProjectLog.mockResolvedValue([{ kind: 'prompt', status: 'done', at: '2026-07-25T00:00:00.000Z', title: 'add a haiku' }])
+    render(<ProjectHistory projectId="p1" />)
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'History' })).toBeTruthy())
+    expect(screen.getByText('add a haiku')).toBeTruthy()
+  })
+})

--- a/packages/framework-dashboard/components/ProjectHistory.tsx
+++ b/packages/framework-dashboard/components/ProjectHistory.tsx
@@ -1,0 +1,26 @@
+import type { LogEntry } from '@gemstack/the-framework'
+import { onProjectLog } from '../server/reads.telefunc.js'
+import { usePolled } from '../lib/use-async.js'
+import { ProjectLogPanel } from './ProjectLogPanel.js'
+
+/** Stable initial for the poll, so it does not churn on every render. */
+const EMPTY_LOGS: LogEntry[] = []
+
+/**
+ * The project's session history on the launcher (#1455 item 3): moved out of the right rail
+ * into the main column, same ProjectLogPanel presentation (the committed `.the-framework/LOGS.md`,
+ * newest first). A project with no finished sessions gets no section — the rail's
+ * earned-by-content rule (#1146) applies here unchanged. Height-capped like the Docs section.
+ */
+export function ProjectHistory({ projectId }: { projectId: string }) {
+  const { value: logs, loaded } = usePolled<LogEntry[]>(() => onProjectLog(projectId), EMPTY_LOGS, 10_000, [projectId])
+  if (!loaded || logs.length === 0) return null
+  return (
+    <section aria-label="History" className="border-t border-border p-3">
+      <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">History</h2>
+      <div className="flex max-h-[24rem] flex-col overflow-hidden rounded-md border border-border">
+        <ProjectLogPanel logs={logs} loaded />
+      </div>
+    </section>
+  )
+}

--- a/packages/framework-dashboard/components/ProjectHome.spec.md
+++ b/packages/framework-dashboard/components/ProjectHome.spec.md
@@ -1,9 +1,9 @@
-The project home / launcher (what "Live" selects): `ProjectActions` bar + `StartRunForm` + a `RunOverview` of current events + the two #1455 sections (`OpenQuestions`, `ProjectTickets`) — never consumed by a run, so you can keep launching.
+The project home / launcher (what "Live" selects): `ProjectActions` bar + `StartRunForm` + a `RunOverview` of current events + the #1455 sections (`OpenQuestions`, `ProjectTickets`, `ProjectDocs`, `ProjectHistory`) — never consumed by a run, so you can keep launching.
 
 ## TLDR
 
 - Starting a run appends it to the rail with its own RunView alongside; this page stays put (running several at once lands with git worktrees, #453).
 - Threads the Context-picking state (`files`, `context`, add/remove/toggle) into `StartRunForm`; `onRunStarted` carries the started run's id (and `runsOn`) up to the shell — dropping that id was bug #1169.
 - `RunOverview` renders only when there are events.
-- Below the form (#1455): `OpenQuestions` (every session's parked gate, answerable in place, item 4) and `ProjectTickets` (the active project's backlog in the /tickets presentation, item 5); `onOpenSession` / `onOpenTicket` / `onShowAllTickets` thread their navigation up to the shell.
-- The whole column is a `ScrollArea` since the two sections can be tall — the form alone never needed to scroll.
+- Below the form (#1455): `OpenQuestions` (every session's parked gate, answerable in place, item 4), `ProjectTickets` (the active project's backlog in the /tickets presentation, item 5), then `ProjectDocs` and `ProjectHistory` (items 2/3 — the rail's Docs/History panels moved into this column; the rail withholds those tabs while this page shows, via its `docsInMain` prop); `onOpenSession` / `onOpenTicket` / `onShowAllTickets` thread their navigation up to the shell.
+- The whole column is a `ScrollArea` since the sections can be tall — the form alone never needed to scroll.

--- a/packages/framework-dashboard/components/ProjectHome.tsx
+++ b/packages/framework-dashboard/components/ProjectHome.tsx
@@ -4,6 +4,8 @@ import { ProjectActions } from './ProjectActions.js'
 import { RunOverview } from './RunOverview.js'
 import { OpenQuestions } from './OpenQuestions.js'
 import { ProjectTickets } from './ProjectTickets.js'
+import { ProjectDocs } from './ProjectDocs.js'
+import { ProjectHistory } from './ProjectHistory.js'
 import { ScrollArea } from './ui/scroll-area.js'
 
 // The project home / launcher — what "Live" selects. Always the Start form + preset cards +
@@ -11,10 +13,12 @@ import { ScrollArea } from './ui/scroll-area.js'
 // the rail and adds that run's own view (RunView) alongside — this page stays put, so you can
 // launch again. (Actually running several at once lands with git worktrees, #453.)
 //
-// Below the form, the two #1455 sections: every session's open questions in one answerable
-// place (item 4, cross-project — the badge only counted them), and the active project's
-// tickets in the /tickets presentation (item 5). Both can be tall, which is why the whole
-// column scrolls (the form alone never needed to).
+// Below the form, the #1455 sections: every session's open questions in one answerable
+// place (item 4, cross-project — the badge only counted them), the active project's
+// tickets in the /tickets presentation (item 5), and the Docs + History panels moved out
+// of the right rail into this column (items 2/3 — the rail hides them while this page
+// shows, see RightRail's docsInMain). All can be tall, which is why the whole column
+// scrolls (the form alone never needed to).
 export function ProjectHome({
   projectId,
   events,
@@ -64,6 +68,8 @@ export function ProjectHome({
         onShowAllTickets={onShowAllTickets}
         onRunStarted={onRunStarted}
       />
+      <ProjectDocs projectId={projectId} />
+      <ProjectHistory projectId={projectId} />
     </ScrollArea>
   )
 }

--- a/packages/framework-dashboard/components/RightRail.spec.md
+++ b/packages/framework-dashboard/components/RightRail.spec.md
@@ -4,6 +4,7 @@ The right sidebar (#314 third rail): a tabbed panel column offering Files, Choic
 
 - Tabs: Files (project file tree, #492), Choices (interactive gates, #440), Views (agent-pushed markdown, #441), Browser (preview proxy, #813), Docs (PLAN/TODO), Log (committed project log).
 - Choices/views arrive via props from the shell's live event stream; docs/log are polled here via Telefunc (`onDocs` 4s, `onProjectLog` 10s) — read in the rail, not in the panels, because the rail must know emptiness to decide which tabs exist (#1146).
+- `docsInMain` (#1455 items 2/3): while the launcher is the main view it renders Docs/History in its own column (`ProjectDocs`/`ProjectHistory`), so the rail withholds both tabs and skips both polls; session views pass nothing and keep the full rail.
 - Every tab is earned by content (#1146): an empty panel gets no tab, and a rail with no tabs renders nothing (`null`). Not-yet-loaded counts as "has content" so project switches don't blink the rail.
 - Auto-focus rules (#695/U22): only a genuinely fresh choice gate (unseen id) or the *first* view pulls the active tab; after the user picks a tab manually (`touched` ref), no auto-defaulting.
 - `LoopStatusCard` is pinned under the panel, not a tab: a standing fact about the run, visible whichever tab is open, with its own scroller capped at 33% height.

--- a/packages/framework-dashboard/components/RightRail.test.tsx
+++ b/packages/framework-dashboard/components/RightRail.test.tsx
@@ -123,6 +123,38 @@ describe('RightRail tab labels (#1145)', () => {
 
 // Every tab is earned by its content (#1146): a panel that can only say "nothing yet" costs a tab
 // nobody wants, and when none of them has anything the rail itself is noise.
+describe('RightRail docsInMain (#1455 items 2/3)', () => {
+  const settle = () => act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+
+  test('the launcher owning Docs/History withholds both tabs and skips their reads', async () => {
+    render(<RightRail {...baseProps} files={['a.ts']} docsInMain />)
+    await settle()
+    expect(screen.queryByRole('tab', { name: /docs/i })).toBeNull()
+    expect(screen.queryByRole('tab', { name: /history/i })).toBeNull()
+    // Withheld means not even asked for: the main column polls these itself.
+    expect(onDocs).not.toHaveBeenCalled()
+    expect(onProjectLog).not.toHaveBeenCalled()
+    // The rest of the rail is untouched.
+    expect(screen.getByRole('tab', { name: /files/i })).toBeTruthy()
+  })
+
+  test('with only Docs/History to offer, the launcher shows no rail at all', async () => {
+    const { container } = render(<RightRail {...baseProps} docsInMain />)
+    await settle()
+    expect(container.querySelector('aside')).toBeNull()
+  })
+
+  test('a session view (docsInMain off) keeps both tabs, as before', async () => {
+    render(<RightRail {...baseProps} />)
+    await settle()
+    expect(screen.getByRole('tab', { name: /docs/i })).toBeTruthy()
+    expect(screen.getByRole('tab', { name: /history/i })).toBeTruthy()
+  })
+})
+
 describe('RightRail empty panels (#1146)', () => {
   const settle = () => act(async () => {
     await Promise.resolve()

--- a/packages/framework-dashboard/components/RightRail.tsx
+++ b/packages/framework-dashboard/components/RightRail.tsx
@@ -48,6 +48,7 @@ export function RightRail({
   hasBrowser = false,
   target,
   loop,
+  docsInMain = false,
 }: {
   projectId: string | null
   /** The selected run: resolves a choice pick's gate (#749) and scopes the tree to its worktree (#815). */
@@ -68,17 +69,24 @@ export function RightRail({
    *  of its own: it is a standing fact about the run, not a panel you browse, so it stays readable
    *  whichever tab is open. Null for a run that never looped (a prototype scope, or a plain prompt). */
   loop?: LoopStatus | null | undefined
+  /**
+   * The launcher renders Docs and History in its main column (#1455 items 2/3), so while it is
+   * the main view the rail must not repeat them: their tabs are withheld and their polls skipped.
+   * A session view passes false (or nothing) and keeps the full rail.
+   */
+  docsInMain?: boolean
 }) {
   // The two content panels are read here rather than each polling for itself: the rail has to
   // know whether they have anything before it can decide which tabs to offer, and whether to be
   // there at all (#1146). One read each, passed down; the panels render what they are given.
   // Tickets used to be a third one (#697) — now its own full page (#1144), not a rail read.
-  const { value: docs, loaded: docsLoaded } = usePolled<WorkspaceDoc[]>(projectId ? () => onDocs(projectId) : null, [], 4000, [projectId])
-  const { value: logs, loaded: logsLoaded } = usePolled<LogEntry[]>(projectId ? () => onProjectLog(projectId) : null, [], 10_000, [projectId])
+  const { value: docs, loaded: docsLoaded } = usePolled<WorkspaceDoc[]>(projectId && !docsInMain ? () => onDocs(projectId) : null, [], 4000, [projectId, docsInMain])
+  const { value: logs, loaded: logsLoaded } = usePolled<LogEntry[]>(projectId && !docsInMain ? () => onProjectLog(projectId) : null, [], 10_000, [projectId, docsInMain])
   // Hidden only once we KNOW it is empty: while the first read is out, the tab stays, so switching
-  // projects does not blink the rail out and back in.
-  const hasDocs = !docsLoaded || docs.length > 0
-  const hasLog = !logsLoaded || logs.length > 0
+  // projects does not blink the rail out and back in. While the launcher owns these panels
+  // (#1455 items 2/3), both tabs are withheld outright.
+  const hasDocs = !docsInMain && (!docsLoaded || docs.length > 0)
+  const hasLog = !docsInMain && (!logsLoaded || logs.length > 0)
 
   const [tab, setTab] = useState<Tab>('docs')
   // Once the user picks a tab, stop auto-defaulting (#695/U22) — only a genuinely new choice

--- a/packages/framework-dashboard/pages/index/+Page.tsx
+++ b/packages/framework-dashboard/pages/index/+Page.tsx
@@ -423,6 +423,10 @@ export default function Page() {
             hasBrowser={selectedRun?.status === 'running' && selectedRun.browserStreamPort !== undefined}
             target={selectedRun?.target}
             loop={loop}
+            // The launcher shows Docs/History in its main column (#1455 items 2/3): exactly when
+            // renderMain resolves to ProjectHome — a project selected, no run (and not adopting
+            // one), on the default view. Session views keep the full rail.
+            docsInMain={view !== 'settings' && !!projectId && !unknownProject && runId === null && !adopting}
           />
         )}
       </div>


### PR DESCRIPTION
Items 2/3 of #1455, green-lit by @brillout ("2/3/6 can be built"). Docs and History move out of the right rail into the launcher's main column; the rail stops repeating them there.

## What

- New `ProjectDocs` / `ProjectHistory` sections under the launcher (after Open questions + Tickets), following the `ProjectTickets` pattern: each polls its own read (`onDocs` 4s / `onProjectLog` 10s) and reuses the rail's panel (`DocsPanel` / `ProjectLogPanel`) verbatim, so the surfaces cannot drift. Empty → no section (the rail's earned-by-content rule #1146, carried over). Height-capped so a long PLAN or history scrolls inside its section, not the page.
- `RightRail` gains `docsInMain`: while the launcher is the main view, the Docs/History tabs are withheld and their polls skipped (the main column reads them instead). Session views pass nothing and keep the full rail — item 6 (inline interactions) is a separate slice.
- The shell passes `docsInMain` exactly when `renderMain` resolves to `ProjectHome` (project selected, no run, not adopting, default view).

## Not in this PR

- Item 11 (tickets folding into the same arrangement / trimming the big tickets list) — awaiting the layout opinion on the issue.
- What remains of the rail long-term (Rom's open question) — the rail still offers Files/Choices/Views/Browser everywhere, Docs/History on session views.

## Tests

- RightRail: `docsInMain` withholds both tabs, skips both reads, leaves the rest; rail disappears when nothing else earns a tab; session views unchanged.
- ProjectDocs/ProjectHistory: empty → no section; content renders under the section heading in the reused panel.
- Dashboard 729/729, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)