### PR TITLE
Remove test27.md / test28.md resume-flow test debris

### DIFF
--- a/test27.md
+++ b/test27.md
@@ -1,4 +1,0 @@
-the run pauses here
-context saved beneath the frost
-a wakeup rings out
-the session resumes

--- a/test28.md
+++ b/test28.md
@@ -1,4 +1,0 @@
-the session resumes
-a wakeup rings out
-context saved beneath the frost
-the run pauses here


### PR DESCRIPTION
Deletes the two scratch files the resume-after-quota-reset live test published via PR #1483 (run `2026-08-01T22-12-40-791Z`, the paused Fable run resumed after the weekly boundary reset). Same pattern as #1479 (test29/30).

The test itself passed end-to-end — resume booted on the reset quota, found the work already committed, declared ready-for-merge, and published through the full ladder. Two findings it surfaced are filed: the stale-branch `LOGS.md` conflict + the CI watch never retrying a failed merge attempt (#1484).

🤖 Generated with [Claude Code](https://claude.com/claude-code)