### PR TITLE
Per-run quota guard honors the spend slider when it loosens the gate (fix #1490)

### DIFF
--- a/.changeset/guard-honors-spend-slider.md
+++ b/.changeset/guard-honors-spend-slider.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+The per-run quota guard now honors the Usage panel's spend slider when it loosens the gate (fix #1490): the line a run pauses at is `max(default half-day cushion, autoSpendOffset)`, read fresh around each between-turns check so dragging the slider unblocks a parked run without a restart. Before, the guard hard-coded the default cushion and a run paused on a window the Usage bar showed as having room — the exact bar/gate disagreement #960 forbids. The slider still never tightens the gate on work the user asked for.

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -66,6 +66,7 @@ import { createGateKeepalive } from './gate-keepalive.js'
 import { nodeGitRunner } from './project.js'
 import { addProject, ensureDaemonToken, listProjects, readDaemonToken, readPreferences, resolveProjectPath } from './registry.js'
 import { startConsumptionGuard } from './consumption-guard.js'
+import { DEFAULT_SPEND_OFFSET } from './preference-defaults.js'
 import {
   planMaintenanceSweep,
   maintainSweep,
@@ -1913,7 +1914,15 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
   // leaves the run ungated — the fail-open Rom confirmed.
   // Transparent mode (#625) leaves the run fully raw, so the guard is off with it — the run is
   // `claude -p` with no framework behavior, spend included.
-  const guard = transparent ? undefined : startConsumptionGuard({ driver, ...(opts.model ? { model: opts.model } : {}) })
+  const guard = transparent
+    ? undefined
+    : startConsumptionGuard({
+        driver,
+        // The #960 slider joins the per-run gate (#1490), read from the registry the same way
+        // the daemon's quota source reads it — so the Usage bar and this gate cannot disagree.
+        limitOffset: async () => (await readPreferences()).autoSpendOffset ?? DEFAULT_SPEND_OFFSET,
+        ...(opts.model ? { model: opts.model } : {}),
+      })
   if (transparent) io.out(`◆ transparent: on — raw ${AGENT_SPECS[opts.agent].label}, no framework prompt, guard, dashboard, or TODO loop`)
   else if (guard) io.out('◆ quota boundary: on')
   else if (!fake) {

--- a/packages/the-framework/src/consumption-guard.spec.md
+++ b/packages/the-framework/src/consumption-guard.spec.md
@@ -2,12 +2,13 @@ Wires the quota boundary up for one run (#879): polls the wrapped agent's quota 
 
 ## TLDR
 
-- `startConsumptionGuard({driver, model})` → `{gate, poller, stop}`, or `undefined` when the driver has no `readQuota` (fake driver, or an agent without such a command).
-- `gate()` answers from the `QuotaPoller`'s cached readings via `quotaBoundaryStatus` with the default half-day spend offset; returns the reached window's label, or null while there is room.
+- `startConsumptionGuard({driver, model, limitOffset})` → `{gate, poller, stop}`, or `undefined` when the driver has no `readQuota` (fake driver, or an agent without such a command).
+- `gate()` answers from the `QuotaPoller`'s cached readings via `quotaBoundaryStatus` with `max(DEFAULT_SPEND_OFFSET, the user's slider)`; returns the reached window's label, or null while there is room.
+- `limitOffset` is an async supplier of the #960 slider value (cli.ts reads `preferences.autoSpendOffset` from the registry, the same source the daemon's quota bar reads). The gate stays synchronous: the supplier is refreshed in the background around each check and the check uses the last value that landed — one turn behind at worst, so dragging the slider unblocks a parked run's next boundary check without a restart (#1490).
 
 ## Decisions
 
 - The boundary is derived from the account's own reported week — a comparison of two numbers the agent reports, not a total we accumulate — so nothing to configure and nothing to remember between restarts.
 - Fails open (no reading → work carries on), the fail-open Rom confirmed on #519 and the opposite of the auto-PM gate: this guards work the user asked for, and the per-run budget cap still sits underneath.
 - The first quota read is deliberately not awaited: it spawns the whole agent CLI (~5s), and making every run wait that long to *maybe* learn it has budget is a poor trade — the reading lands a moment into the run.
-- Uses `DEFAULT_SPEND_OFFSET` (the half-day cushion of #960), never the user's slider: the slider sets where *unattended* work stands down and must not tighten the gate on user-requested work. Without the cushion the continuous boundary starts the week at zero and the first integer percent the agent reports would pause the user's own first run of the week over ordinary rounding.
+- The user's slider joins the gate only when it LOOSENS it (#1490): `max(DEFAULT_SPEND_OFFSET, slider)`. Raising the limit must unblock the runs the Usage bar says have room — the bar and the gate disagreeing is the exact thing #960 forbids (before #1490, the guard hard-coded the default and a run paused on a window the bar showed as fine). Lowering it sets where *unattended* work stands down and must never tighten the gate on user-requested work — the default half-day cushion stays the floor: without it the continuous boundary starts the week at zero and the first integer percent the agent reports would pause the user's own first run of the week over ordinary rounding.

--- a/packages/the-framework/src/consumption-guard.test.ts
+++ b/packages/the-framework/src/consumption-guard.test.ts
@@ -84,6 +84,43 @@ test('startConsumptionGuard keeps a half-day cushion, so a fresh week is not pau
   guard.stop()
 })
 
+test('startConsumptionGuard honors the slider when it loosens the gate (#1490)', async () => {
+  // T0 sits ~31.5% into the week; the default line is ~38.6%. A window at 45% pauses under the
+  // default policy, but the user dragged the slider to boundary+20 (~51.5%) — the Usage bar
+  // shows room, so the gate must agree.
+  const guard = startConsumptionGuard({ driver: quotaDriver(week(45)), limitOffset: () => 20, now: () => T0 })
+  assert.ok(guard)
+  await guard.poller.poll()
+  guard.gate() // first check kicks off the offset refresh…
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(guard.gate(), null) // …and the next one sees it
+  guard.stop()
+})
+
+test('startConsumptionGuard never lets the slider tighten the gate on work the user asked for (#1490)', async () => {
+  // The slider pulled hard left (disabling unattended work) must not pause the user's own run:
+  // a window just past the boundary but inside the default half-day cushion stays ungated.
+  const guard = startConsumptionGuard({ driver: quotaDriver(week(35)), limitOffset: () => -50, now: () => T0 })
+  assert.ok(guard)
+  await guard.poller.poll()
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(guard.gate(), null)
+  guard.stop()
+})
+
+test('startConsumptionGuard picks up a slider drag between checks, without a restart (#1490)', async () => {
+  let offset = 0
+  const guard = startConsumptionGuard({ driver: quotaDriver(week(45)), limitOffset: () => offset, now: () => T0 })
+  assert.ok(guard)
+  await guard.poller.poll()
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(guard.gate(), 'Current week (all models)') // 45% is past boundary+default
+  offset = 20 // the user drags the handle right while the run is parked…
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(guard.gate(), null) // …and the next boundary check lets the run carry on
+  guard.stop()
+})
+
 test('startConsumptionGuard gate carries on when the quota cannot be read (#531)', async () => {
   const guard = startConsumptionGuard({ driver: quotaDriver({ available: false, reason: 'fetch-failed' }), now: () => T0 })
   assert.ok(guard)

--- a/packages/the-framework/src/consumption-guard.ts
+++ b/packages/the-framework/src/consumption-guard.ts
@@ -24,6 +24,13 @@ export interface StartConsumptionGuardOptions {
   driver: Driver
   /** The model the run is on. Brings that model's own weekly window into the gate (#879). */
   model?: string
+  /**
+   * The user's spend-limit offset — the #960 slider — read fresh around each gate check so
+   * dragging it unblocks a parked run's next boundary check without a restart (#1490). It only
+   * ever LOOSENS the gate (see the gate's comment); absent or unreadable means the default
+   * policy, the same fallback the daemon's quota source uses.
+   */
+  limitOffset?: () => number | Promise<number>
   /** Clock, injectable for tests. */
   now?: () => number
 }
@@ -55,19 +62,39 @@ export function startConsumptionGuard(opts: StartConsumptionGuardOptions): Consu
   const poller = new QuotaPoller({ read: () => readQuota(), now })
   poller.start()
 
+  // The slider's latest resolved value. The gate stays synchronous — it answers from cached
+  // readings — so the offset is refreshed in the background around each check and the check
+  // uses the last value that landed: one turn behind at worst, which is also how fresh the
+  // quota reading itself is.
+  let userOffset = DEFAULT_SPEND_OFFSET
+  const refreshOffset = () => {
+    if (!opts.limitOffset) return
+    void Promise.resolve()
+      .then(opts.limitOffset)
+      .then(value => {
+        if (Number.isFinite(value)) userOffset = value
+      })
+      .catch(() => {}) // an unreadable registry means the default policy
+  }
+  refreshOffset()
+
   return {
     poller,
     stop: () => poller.stop(),
     gate: () => {
+      refreshOffset()
       const windows = poller.current().lastGood?.windows
       if (!windows) return null
       // The same half-day cushion unattended work gets by default (#960 Edit). The continuous
       // boundary starts the week at zero, so without one the first integer percent the agent
       // reports outruns it and the user's own first run of the week is paused over ordinary
       // rounding — the stepped line this replaces always kept the current day's seventh in hand.
-      // Deliberately not the user's slider: that sets where *unattended* work stands down, and
+      // The user's slider joins the gate only when it LOOSENS it (#1490): raising the limit must
+      // unblock the runs the Usage bar says have room — the bar and this gate disagreeing is the
+      // exact thing #960 forbids — but lowering it sets where *unattended* work stands down, and
       // holding it back must never tighten the gate on work the user asked for.
-      const status = quotaBoundaryStatus({ windows, now: now(), limitOffset: DEFAULT_SPEND_OFFSET, ...(opts.model ? { model: opts.model } : {}) })
+      const limitOffset = Math.max(DEFAULT_SPEND_OFFSET, userOffset)
+      const status = quotaBoundaryStatus({ windows, now: now(), limitOffset, ...(opts.model ? { model: opts.model } : {}) })
       return status?.reached?.label ?? null
     },
   }


### PR DESCRIPTION
Fixes #1490 — live repro tonight: Fable week 40% used, boundary ~25%, slider dragged to ~65%, and the run still paused with `Quota boundary reached (Current week (Fable))` while the Usage bar showed room.

## What

- `startConsumptionGuard` gains a `limitOffset` supplier. `cli.ts` feeds it `preferences.autoSpendOffset` from the registry — the same single source `defaultQuotaSource` reads for the Usage bar and auto-PM, per #960's "cannot disagree" rule.
- **The slider only ever loosens the gate**: the line in force is `max(DEFAULT_SPEND_OFFSET, slider)`. The guard's existing rule — lowering the slider (to stand down unattended work) must never tighten the gate on work the user asked for — is kept and now has a test pinning it.
- The gate stays synchronous (it answers from cached poller readings): the supplier is refreshed in the background around each between-turns check, and the check uses the last value that landed — one turn behind at worst, same freshness as the quota reading itself. So dragging the slider unblocks a *parked* run's next boundary check without a restart.

## Tests

Three new cases in `consumption-guard.test.ts`: slider loosens (45% window passes under boundary+20), slider never tightens (hard-left slider leaves a within-cushion window ungated), and a mid-run drag is picked up between checks. Suite 1691/0. Spec + changeset updated.

## Verify live

Drag the Usage handle above the Fable weekly "% used" (show-all-limits tooltip), start a trivial Fable run — it should now sail past the turn boundary into the ending (synthesize → backlog gate) instead of pausing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)