### PR TITLE
Fix a batch of bugs across ai-sdk, drivers, autopilot, dashboard, and mcp

### DIFF
--- a/packages/ai-autopilot/src/decisions/markdown.ts
+++ b/packages/ai-autopilot/src/decisions/markdown.ts
@@ -41,7 +41,9 @@ export function serializeDecisions(decisions: readonly Decision[]): string {
   return `${HEADER}\n\n${INTRO}\n\n${blocks.join('\n\n')}\n`.replace(/\n{3,}/g, '\n\n')
 }
 
-const HEADING_RE = /^##\s+(?:\[(\w+)\]\s*)?(.+?)\s*$/
+// Only a real status counts as the bracket prefix: a hand-written tag like `## [Frontend] …`
+// keeps its bracket in the title (and takes the default status) instead of being eaten.
+const HEADING_RE = /^##\s+(?:\[(rejected|accepted|superseded)\]\s*)?(.+?)\s*$/i
 const META_RE = /^-\s+([a-z-]+)\s*:\s*(.*)$/i
 
 /** Parse `DECISIONS.md` contents into decisions. Malformed sections are skipped. */

--- a/packages/ai-autopilot/src/loop/verdict.ts
+++ b/packages/ai-autopilot/src/loop/verdict.ts
@@ -42,16 +42,18 @@ export function parseVerdict(text: string): Verdict | undefined {
 
   const candidates: string[] = []
   for (const m of text.matchAll(FENCE)) candidates.push(m[1]!)
-  // Fallback: a bare object somewhere in the text (take the last `{`-to-`}` run).
-  const lastOpen = text.lastIndexOf('{')
-  const lastClose = text.lastIndexOf('}')
-  if (lastOpen !== -1 && lastClose > lastOpen) candidates.push(text.slice(lastOpen, lastClose + 1))
 
-  // Later candidates win, so scan from the end.
+  // Later fences win, so scan from the end.
   for (let i = candidates.length - 1; i >= 0; i--) {
     const verdict = coerce(candidates[i]!)
     if (verdict) return verdict
   }
+  // Fallback — only when no fence parsed: a bare object somewhere in the text (the last
+  // `{`-to-`}` run). Tried after the fences so brace-shaped prose trailing the real fenced
+  // verdict can never outrank it.
+  const lastOpen = text.lastIndexOf('{')
+  const lastClose = text.lastIndexOf('}')
+  if (lastOpen !== -1 && lastClose > lastOpen) return coerce(text.slice(lastOpen, lastClose + 1))
   return undefined
 }
 

--- a/packages/ai-autopilot/src/overview/markdown.ts
+++ b/packages/ai-autopilot/src/overview/markdown.ts
@@ -54,7 +54,10 @@ export function parseOverview(markdown: string): CodeOverview {
       current = { title: heading[1]!.trim(), body: [] }
       continue
     }
-    if (/^#\s+/.test(line)) continue // the top-level `# Code Overview` title
+    // The top-level `# Code Overview` title — only before any real content, so a `# `-prefixed
+    // line inside a body or summary (a shell comment in a fenced block, a hand-written h1)
+    // survives the round-trip instead of being dropped as a second title.
+    if (/^#\s+/.test(line) && !current && sections.length === 0 && summaryLines.every(l => !l.trim())) continue
     if (current) current.body.push(line)
     else summaryLines.push(line)
   }

--- a/packages/ai-autopilot/src/surface/events.ts
+++ b/packages/ai-autopilot/src/surface/events.ts
@@ -74,8 +74,13 @@ export class EventStream<E = SupervisorEvent> {
         return new Promise(resolve => {
           const wake = (): void => {
             pending = undefined
-            if (done || index >= stream.buffer.length) resolve({ value: undefined, done: true })
-            else resolve({ value: stream.buffer[index++]!, done: false })
+            if (done) return resolve({ value: undefined, done: true })
+            if (index < stream.buffer.length) return resolve({ value: stream.buffer[index++]!, done: false })
+            if (stream.closed) return resolve({ value: undefined, done: true })
+            // Woken with nothing left for us (a concurrent next() on this iterator took the
+            // event): the stream is still open, so wait again rather than resolve a false done.
+            pending = wake
+            stream.waiters.push(wake)
           }
           pending = wake
           stream.waiters.push(wake)

--- a/packages/ai-sdk/src/agent.ts
+++ b/packages/ai-sdk/src/agent.ts
@@ -929,7 +929,10 @@ function buildSubAgentSnapshotMessages(userPrompt: string, response: AgentRespon
  * server-side tool results so the next resume sees the full history.
  */
 function buildResumeSnapshotMessages(priorMessages: AiMessage[], response: AgentResponse): AiMessage[] {
-  const out: AiMessage[] = [...priorMessages]
+  // The resumed tool results answer a `tool_use` already in `priorMessages` (the just-approved
+  // call), so they come first — omitting them leaves that `tool_use` unpaired, which the next
+  // resume replays into a provider 400 (or an OpenAI "tool result missing" stub).
+  const out: AiMessage[] = [...priorMessages, ...(response.resumedToolMessages ?? [])]
   for (const step of response.steps) {
     out.push(step.message)
     for (const tr of step.toolResults) {
@@ -1390,6 +1393,13 @@ export interface LoopContext {
    */
   pendingHandoff?:                   PendingHandoff
   stopForHandoff:                    boolean
+  /**
+   * Set by the tool phase when `onBeforeToolCall` middleware returned
+   * `{ type: 'abort' }`. Stops the loop instead of letting it make another
+   * provider call with the aborted tool's `tool_use` left unanswered — an
+   * abort from a guard middleware has to actually halt the run.
+   */
+  stopForAbort:                      boolean
 }
 
 export type { PendingHandoff } from './handoffs-driver.js'
@@ -1646,6 +1656,7 @@ async function initializeLoop(
     resumedToolMessages:     [],
     failoverAttempts:        0,
     stopForHandoff:          false,
+    stopForAbort:            false,
   }
 
   // Resume server tools left pending by a previous approval round-trip.
@@ -1865,7 +1876,7 @@ async function runAgentLoopOnce(a: Agent, input: string, options?: AgentPromptOp
       steps.push(step)
       emitObserverStepCompleted(loopCtx, iteration, false)
 
-      if (loopCtx.stopForClientTools || loopCtx.stopForApproval || loopCtx.stopForHandoff) break
+      if (loopCtx.stopForClientTools || loopCtx.stopForApproval || loopCtx.stopForHandoff || loopCtx.stopForAbort) break
 
       const shouldStop = stopConditions.some(cond =>
         cond({ steps, iteration, lastMessage: response.message }),
@@ -2016,7 +2027,7 @@ function runAgentLoopStreamingOnce(a: Agent, input: string, options?: AgentPromp
         steps.push(step)
         emitObserverStepCompleted(loopCtx, iteration, true)
 
-        if (loopCtx.stopForClientTools || loopCtx.stopForApproval || loopCtx.stopForHandoff) break
+        if (loopCtx.stopForClientTools || loopCtx.stopForApproval || loopCtx.stopForHandoff || loopCtx.stopForAbort) break
 
         const shouldStop = stopConditions.some(cond =>
           cond({ steps, iteration, lastMessage: step.message }),

--- a/packages/ai-sdk/src/fake.ts
+++ b/packages/ai-sdk/src/fake.ts
@@ -372,7 +372,9 @@ export class AiFake {
     if (this.calls.length === 0) throw new Error('[ai-sdk] Expected at least one prompt, but none were sent.')
     if (predicate) {
       const match = this.calls.some(c => {
-        const userMsg = c.messages.find(m => m.role === 'user')
+        // The last user message is this call's actual prompt; the first is stale history
+        // when the call carried any (an approval round-trip, a loaded conversation).
+        const userMsg = [...c.messages].reverse().find(m => m.role === 'user')
         if (!userMsg) return false
         const text = typeof userMsg.content === 'string' ? userMsg.content : userMsg.content.filter(p => p.type === 'text').map(p => (p as { text: string }).text).join('')
         return predicate(text)

--- a/packages/ai-sdk/src/google-cache.test.ts
+++ b/packages/ai-sdk/src/google-cache.test.ts
@@ -302,7 +302,7 @@ describe('GoogleAdapter cache wiring', () => {
     const cfg = payload['config'] as Record<string, unknown>
     assert.ok(cfg['cachedContent'], 'request should carry cachedContent')
     assert.equal(cfg['tools'], undefined, 'tools should be omitted when cached')
-    assert.equal(payload['systemInstruction'], undefined, 'systemInstruction should be omitted when cached')
+    assert.equal(cfg['systemInstruction'], undefined, 'systemInstruction should be omitted when cached')
     assert.deepStrictEqual(
       (payload['contents'] as unknown[]).length, 1, 'only the fresh tail of the message list goes on the request',
     )
@@ -328,7 +328,8 @@ describe('GoogleAdapter cache wiring', () => {
     const payload = counters.generatePayloads[0]!
     const cfg = payload['config'] as Record<string, unknown>
     assert.equal(cfg['cachedContent'], undefined, 'cachedContent must NOT be set when registry returned null')
-    assert.ok(payload['systemInstruction'], 'systemInstruction is still sent on the uncached fallback')
+    // The SDK reads `config.systemInstruction`; a top-level sibling would be dropped.
+    assert.ok(cfg['systemInstruction'], 'systemInstruction is still sent on the uncached fallback')
   })
 
   it('recreates and retries once on a 404 stale-cache error', async () => {

--- a/packages/ai-sdk/src/index.test.ts
+++ b/packages/ai-sdk/src/index.test.ts
@@ -2019,6 +2019,38 @@ describe('client tool execution', () => {
     assert.ok(chunkTypes.includes('pending-client-tools'), `expected pending-client-tools, got: ${chunkTypes.join(',')}`)
   })
 
+  it('an onBeforeToolCall abort stops the loop and pairs the tool call', async () => {
+    // A guard middleware that "blocks" a dangerous tool must actually halt the run: without
+    // stopping the loop it made a second provider call with the aborted tool_use unanswered.
+    let executed = false
+    const dangerous = toolDefinition({
+      name: 'delete_everything',
+      description: 'destructive',
+      inputSchema: z.object({}),
+    }).server(async () => { executed = true; return 'done' })
+
+    const guard: AiMiddleware = {
+      name: 'guard',
+      async onBeforeToolCall(_ctx, toolName) {
+        if (toolName === 'delete_everything') return { type: 'abort', reason: 'Blocked by guard' }
+      },
+    }
+
+    _script = [
+      { toolCalls: [{ id: 'd1', name: 'delete_everything', arguments: {} }] },
+      { text: 'should not be reached' },
+    ]
+
+    const result = await agent({ instructions: 'sys', tools: [dangerous], middleware: [guard] }).prompt('go')
+
+    assert.strictEqual(executed, false, 'the aborted tool must not run')
+    assert.strictEqual(_calls.length, 1, 'the loop must not make a second provider call after an abort')
+    assert.strictEqual(result.finishReason, 'stop')
+    // The aborted tool_use is answered, so a resumed / persisted thread stays valid.
+    assert.strictEqual(result.steps.at(-1)!.toolResults.length, 1)
+    assert.match(String(result.steps.at(-1)!.toolResults[0]!.result), /Blocked by guard/)
+  })
+
   it('dynamicTool() builds a Tool whose input is unknown', () => {
     const t = dynamicTool({
       name: 'runtime_built',

--- a/packages/ai-sdk/src/provider-protocol-fixes.test.ts
+++ b/packages/ai-sdk/src/provider-protocol-fixes.test.ts
@@ -56,7 +56,8 @@ describe('google prompt cache — only the regions actually cached are dropped',
     const payload = payloads[0]!
     const cfg = payload['config'] as Record<string, unknown>
     assert.ok(cfg['cachedContent'], 'the cached path must be the one under test')
-    assert.ok(payload['systemInstruction'], 'system instruction must be sent when it was not cached')
+    // The SDK only reads `config.systemInstruction`; a top-level sibling is silently dropped.
+    assert.ok(cfg['systemInstruction'], 'system instruction must be sent when it was not cached')
     assert.ok(cfg['tools'], 'tools must be sent when they were not cached')
   })
 })

--- a/packages/ai-sdk/src/provider-tools.test.ts
+++ b/packages/ai-sdk/src/provider-tools.test.ts
@@ -150,7 +150,7 @@ describe('GoogleAdapter — google_search hint via tools array', () => {
     return { adapter: a, captured: () => captured }
   }
 
-  it('emits { google_search: {} } as a separate top-level tools entry', async () => {
+  it('emits { googleSearch: {} } as a separate top-level tools entry', async () => {
     const { adapter: a, captured } = adapter()
     const def    = WebSearch.make().toTool()
     const schema = toolToSchema(def)
@@ -163,7 +163,8 @@ describe('GoogleAdapter — google_search hint via tools array', () => {
     assert.ok(Array.isArray(tools), 'tools array set on config')
     // No functionDeclarations entry when the only tool is a native one.
     assert.equal(tools.length, 1)
-    assert.deepEqual(tools[0], { google_search: {} })
+    // camelCase: the SDK strips an unknown `google_search` key to an empty tool.
+    assert.deepEqual(tools[0], { googleSearch: {} })
   })
 
   it('mixes function declarations + native blocks (decls first)', async () => {
@@ -186,7 +187,7 @@ describe('GoogleAdapter — google_search hint via tools array', () => {
     const decls = tools[0]['functionDeclarations'] as Array<Record<string, unknown>>
     assert.equal(decls.length, 1)
     assert.equal(decls[0]?.['name'], 'lookup_user')
-    assert.deepEqual(tools[1], { google_search: {} })
+    assert.deepEqual(tools[1], { googleSearch: {} })
   })
 
   it('plain function-call tool still wraps into one functionDeclarations entry', async () => {

--- a/packages/ai-sdk/src/providers/anthropic-stream.ts
+++ b/packages/ai-sdk/src/providers/anthropic-stream.ts
@@ -45,7 +45,16 @@ export function* mapAnthropicStreamEvent(
     const completionTokens = event['usage']?.output_tokens ?? 0
     yield {
       type: 'finish',
-      finishReason: event['delta']?.stop_reason === 'tool_use' ? 'tool_calls' : 'stop',
+      // A truncation (`max_tokens`) or refusal must not report a clean `stop`, or a caller
+      // cannot tell a complete answer from a cut-off one.
+      finishReason:
+        event['delta']?.stop_reason === 'tool_use'
+          ? 'tool_calls'
+          : event['delta']?.stop_reason === 'max_tokens'
+            ? 'length'
+            : event['delta']?.stop_reason === 'refusal'
+              ? 'content_filter'
+              : 'stop',
       usage: {
         promptTokens: state.lastPromptTokens,
         completionTokens,

--- a/packages/ai-sdk/src/providers/anthropic.ts
+++ b/packages/ai-sdk/src/providers/anthropic.ts
@@ -13,6 +13,7 @@ import type {
   AiMessage,
   ToolCall,
   ToolChoice,
+  FinishReason,
 } from '../types.js'
 import { base64ToUtf8 } from '../base64.js'
 import { contentToString } from '../util/content.js'
@@ -315,7 +316,21 @@ export function fromAnthropicResponse(response: any): ProviderResponse {
       completionTokens: response.usage?.output_tokens ?? 0,
       totalTokens: (response.usage?.input_tokens ?? 0) + (response.usage?.output_tokens ?? 0),
     },
-    finishReason: response.stop_reason === 'tool_use' ? 'tool_calls' : 'stop',
+    finishReason: mapAnthropicStopReason(response.stop_reason),
+  }
+}
+
+/**
+ * Map a Claude `stop_reason` onto the neutral {@link FinishReason}. Without the
+ * `max_tokens`/`refusal` cases a truncated or refused answer reports a clean
+ * `stop`, so a caller cannot tell a complete answer from a cut-off one.
+ */
+export function mapAnthropicStopReason(reason: string | null | undefined): FinishReason {
+  switch (reason) {
+    case 'tool_use':   return 'tool_calls'
+    case 'max_tokens': return 'length'
+    case 'refusal':    return 'content_filter'
+    default:           return 'stop'
   }
 }
 
@@ -333,9 +348,11 @@ class AnthropicFileAdapter implements FileAdapter {
     const data = await readFile(options.filePath)
     const filename = basename(options.filePath)
 
-    const response = await client.files.upload({
-      file: new Blob([data]),
-      purpose: options.purpose ?? 'assistants',
+    // The Files API lives under `client.beta.files` (there is no `client.files`), takes a named
+    // uploadable rather than a bare Blob, and has no `purpose` param — that is an OpenAI concept.
+    const sdk = await import(/* @vite-ignore */ '@anthropic-ai/sdk')
+    const response = await client.beta.files.upload({
+      file: await sdk.toFile(data, filename),
     })
 
     return {
@@ -348,14 +365,13 @@ class AnthropicFileAdapter implements FileAdapter {
 
   async list(): Promise<FileListResult> {
     const client = await this.getClient()
-    const response = await client.files.list()
+    const response = await client.beta.files.list()
     const files: FileUploadResult[] = []
     for await (const f of response) {
       files.push({
         id: f.id,
         filename: f.filename ?? f.id,
-        bytes: f.size ?? 0,
-        purpose: f.purpose,
+        bytes: f.size_bytes ?? 0,
       })
     }
     return { files }
@@ -363,12 +379,12 @@ class AnthropicFileAdapter implements FileAdapter {
 
   async delete(fileId: string): Promise<void> {
     const client = await this.getClient()
-    await client.files.delete(fileId)
+    await client.beta.files.delete(fileId)
   }
 
   async retrieve(fileId: string): Promise<FileContent> {
     const client = await this.getClient()
-    const response = await client.files.content(fileId)
+    const response = await client.beta.files.download(fileId)
     const buffer = Buffer.from(await response.arrayBuffer())
     return { data: buffer, mimeType: 'application/octet-stream' }
   }

--- a/packages/ai-sdk/src/providers/cohere.ts
+++ b/packages/ai-sdk/src/providers/cohere.ts
@@ -63,7 +63,8 @@ class CohereRerankingAdapter implements RerankingAdapter {
     const response = await client.rerank({
       model: this.model,
       query: options.query,
-      documents: options.documents.map(d => ({ text: d })),
+      // v2 takes plain strings; the `{ text }` object shape is the v1 request the v2 client rejects.
+      documents: options.documents,
       ...(options.topK !== undefined ? { topN: options.topK } : {}),
     })
 

--- a/packages/ai-sdk/src/providers/google/chat.ts
+++ b/packages/ai-sdk/src/providers/google/chat.ts
@@ -87,22 +87,24 @@ export class GoogleAdapter implements ProviderAdapter {
       if (options.cache?.tools) delete configForCachedRequest['tools']
       configForCachedRequest['cachedContent'] = cacheName
       const systemIsCached = Boolean(options.cache?.instructions && system)
+      // The SDK only reads `config.systemInstruction` — a top-level sibling of
+      // `contents` is silently dropped, which loses the whole system prompt.
+      if (system && !systemIsCached) configForCachedRequest['systemInstruction'] = { parts: [{ text: system }] }
       return {
         payload: {
           model: this.model,
           contents: fresh,
-          ...(system && !systemIsCached ? { systemInstruction: { parts: [{ text: system }] } } : {}),
           config: configForCachedRequest,
         },
         cacheKey,
       }
     }
 
+    if (system) config['systemInstruction'] = { parts: [{ text: system }] }
     return {
       payload: {
         model: this.model,
         contents,
-        ...(system ? { systemInstruction: { parts: [{ text: system }] } } : {}),
         config,
       },
       cacheKey,
@@ -296,11 +298,13 @@ function toGeminiTools(tools: ToolDefinitionSchema[]): unknown[] {
   const blocks:  unknown[] = []
   for (const t of tools) {
     if (t.providerHint?.type === 'web-search') {
-      // Gemini's native search tool. The block's `google_search: {}` form is
-      // intentional — Gemini doesn't accept allowed_domains / max_uses on
-      // this block, so the WebSearch.domains() / .maxResults() opts are
-      // ignored on this provider (documented on WebSearch).
-      blocks.push({ google_search: {} })
+      // Gemini's native search tool. The empty block is intentional — Gemini
+      // doesn't accept allowed_domains / max_uses on it, so the
+      // WebSearch.domains() / .maxResults() opts are ignored on this provider
+      // (documented on WebSearch). Must be camelCase: the SDK's tool mapper
+      // only knows `googleSearch`, and strips an unknown `google_search` key
+      // to an empty tool entry.
+      blocks.push({ googleSearch: {} })
       continue
     }
     if (t.providerHint?.type === 'file-search') {
@@ -370,6 +374,8 @@ function fromGeminiResponse(response: any): ProviderResponse {
       completionTokens: response.usageMetadata?.candidatesTokenCount ?? 0,
       totalTokens: response.usageMetadata?.totalTokenCount ?? 0,
     },
-    finishReason: toolCalls.length > 0 ? 'tool_calls' : 'stop',
+    // Same mapping as the stream path: a truncation or safety stop must not
+    // report a clean `stop`.
+    finishReason: mapGeminiFinishReason(candidate?.finishReason ?? '', toolCalls.length > 0),
   }
 }

--- a/packages/ai-sdk/src/providers/google/embeddings.ts
+++ b/packages/ai-sdk/src/providers/google/embeddings.ts
@@ -20,13 +20,15 @@ export class GoogleEmbeddingAdapter implements EmbeddingAdapter {
     const results = await Promise.all(
       inputs.map(text =>
         client.models.embedContent({
+          // The SDK takes `contents` (a list) and answers with `embeddings`,
+          // one per content — the singular forms are silently unknown to it.
           model: this.model,
-          content: { parts: [{ text }] },
+          contents: [{ parts: [{ text }] }],
         }),
       ),
     )
 
-    const embeddings = results.map((r: any) => r.embedding?.values ?? [])
+    const embeddings = results.map((r: any) => r.embeddings?.[0]?.values ?? [])
 
     return {
       embeddings,

--- a/packages/ai-sdk/src/providers/google/files.ts
+++ b/packages/ai-sdk/src/providers/google/files.ts
@@ -37,9 +37,11 @@ export class GoogleFileAdapter implements FileAdapter {
 
   async list(): Promise<FileListResult> {
     const client = await this.getClient()
+    // The SDK answers with a Pager — async-iterable only; it has no `.files`
+    // array and no sync iterator.
     const response = await client.files.list()
     const files: FileUploadResult[] = []
-    for (const f of response.files ?? response ?? []) {
+    for await (const f of response) {
       files.push({
         id: f.name ?? f.uri,
         filename: f.displayName ?? f.name ?? '',

--- a/packages/ai-sdk/src/providers/google/images.ts
+++ b/packages/ai-sdk/src/providers/google/images.ts
@@ -13,6 +13,25 @@ const GOOGLE_IMAGE_SIZE_MAP: Record<string, string> = {
   portrait: '1024x1792',
 }
 
+/**
+ * Imagen's `aspectRatio` takes an enumerated ratio (`1:1`, `16:9`, …), not a pixel
+ * pair — `1024:1024` is rejected. Map a width/height to the nearest supported ratio.
+ */
+function toImagenAspectRatio(width: number, height: number): string | undefined {
+  if (!width || !height) return undefined
+  const ratio = width / height
+  const options: Array<[string, number]> = [
+    ['1:1', 1],
+    ['16:9', 16 / 9],
+    ['9:16', 9 / 16],
+    ['4:3', 4 / 3],
+    ['3:4', 3 / 4],
+  ]
+  return options.reduce((best, cur) =>
+    Math.abs(cur[1] - ratio) < Math.abs(best[1] - ratio) ? cur : best,
+  )[0]
+}
+
 export class GoogleImageAdapter implements ImageGenerationAdapter {
   constructor(
     private readonly config: GoogleConfig,
@@ -25,12 +44,13 @@ export class GoogleImageAdapter implements ImageGenerationAdapter {
       : '1024x1024'
 
     const [width, height] = size.split('x').map(Number)
+    const aspectRatio = toImagenAspectRatio(width ?? 0, height ?? 0)
 
     const body: Record<string, unknown> = {
       instances: [{ prompt: options.prompt }],
       parameters: {
         sampleCount: options.n ?? 1,
-        ...(width && height ? { aspectRatio: `${width}:${height}` } : {}),
+        ...(aspectRatio ? { aspectRatio } : {}),
       },
     }
 

--- a/packages/ai-sdk/src/providers/openai/chat.ts
+++ b/packages/ai-sdk/src/providers/openai/chat.ts
@@ -149,9 +149,14 @@ function contentToOpenAIParts(content: string | import('../../types.js').Content
   return content.map(p => {
     if (p.type === 'text') return { type: 'text', text: p.text }
     if (p.type === 'image') return { type: 'image_url', image_url: { url: `data:${p.mimeType};base64,${p.data}` } }
-    // document — for text-based docs, decode to text; for PDFs, send as image_url (GPT-4o supports)
+    // document — for text-based docs, decode to text; for PDFs, use the file part, whose
+    // fields are `file_data` (a data URI) / `file_id` / `filename` — a bare `data`/`mime_type`
+    // is rejected, and the PDF never reaches the model.
     if (p.mimeType === 'application/pdf') {
-      return { type: 'file', file: { data: p.data, mime_type: p.mimeType } }
+      return {
+        type: 'file',
+        file: { filename: p.name ?? 'document.pdf', file_data: `data:${p.mimeType};base64,${p.data}` },
+      }
     }
     return { type: 'text', text: base64ToUtf8(p.data) }
   })

--- a/packages/ai-sdk/src/providers/openai/files.ts
+++ b/packages/ai-sdk/src/providers/openai/files.ts
@@ -49,7 +49,8 @@ export class OpenAIFileAdapter implements FileAdapter {
 
   async delete(fileId: string): Promise<void> {
     const client = await this.getClient()
-    await client.files.del(fileId)
+    // `del` was the v4 name; v5+ (and the version this package resolves) is `delete`.
+    await client.files.delete(fileId)
   }
 
   async retrieve(fileId: string): Promise<FileContent> {

--- a/packages/ai-sdk/src/providers/openai/vector-store.ts
+++ b/packages/ai-sdk/src/providers/openai/vector-store.ts
@@ -61,7 +61,8 @@ export class OpenAIVectorStoreAdapter implements VectorStoreAdapter {
 
   async delete(id: string): Promise<void> {
     const client = await this.getClient()
-    await client.vectorStores.del(id)
+    // `del` was the v4 name; v5+ (and the version this package resolves) is `delete`.
+    await client.vectorStores.delete(id)
   }
 
   async addFile(storeId: string, opts: VectorStoreAddOptions): Promise<VectorStoreFileInfo> {
@@ -104,13 +105,15 @@ export class OpenAIVectorStoreAdapter implements VectorStoreAdapter {
         )
       }
       await sleep(pollInterval)
-      current = await client.vectorStores.files.retrieve(storeId, fileId)
+      // v5+ signature: the file id is first, the store id rides in the params object.
+      current = await client.vectorStores.files.retrieve(fileId, { vector_store_id: storeId })
     }
   }
 
   async removeFile(storeId: string, fileId: string): Promise<void> {
     const client = await this.getClient()
-    await client.vectorStores.files.del(storeId, fileId)
+    // `del(storeId, fileId)` was the v4 shape; v5+ is `delete(fileId, { vector_store_id })`.
+    await client.vectorStores.files.delete(fileId, { vector_store_id: storeId })
   }
 
   async listFiles(storeId: string, opts?: VectorStoreListOptions): Promise<VectorStoreFileList> {

--- a/packages/ai-sdk/src/tool-execution.ts
+++ b/packages/ai-sdk/src/tool-execution.ts
@@ -185,7 +185,7 @@ type NonReadyDecision =
   | { kind: 'rejected';                 tc: ToolCall; result: { rejected: true; reason: string } }
   | { kind: 'pending-approval';         tc: ToolCall }
   | { kind: 'mw-skip';                  tc: ToolCall; toolArgs: Record<string, unknown>; result: unknown }
-  | { kind: 'mw-abort';                 tc: ToolCall }
+  | { kind: 'mw-abort';                 tc: ToolCall; reason: string }
   | { kind: 'validation-error';         tc: ToolCall; toolArgs: Record<string, unknown>; error: InvalidToolArgumentsError }
 
 type ToolCallDecision = NonReadyDecision | ReadyDecision
@@ -288,7 +288,12 @@ async function decideToolCall(loopCtx: LoopContext, tc: ToolCall): Promise<ToolC
       }
       if (beforeResult.type === 'abort') {
         await runOnAbort(middlewares, ctx, beforeResult.reason)
-        return { kind: 'mw-abort', tc }
+        // Stop the whole loop, not just this tool phase: without this the loop makes
+        // another provider call with the aborted tool's `tool_use` unanswered, so a guard
+        // middleware that "blocks" a dangerous tool doesn't actually halt the agent.
+        loopCtx.stopForAbort = true
+        loopCtx.loopFinishReason = 'stop'
+        return { kind: 'mw-abort', tc, reason: beforeResult.reason }
       }
       if (beforeResult.type === 'transformArgs') {
         toolArgs = beforeResult.args
@@ -377,8 +382,15 @@ async function* emitDecision(
       return
     }
     case 'mw-abort': {
-      // `onAbort` already ran in decideToolCall; the aborted call emits
-      // nothing and the caller halts the phase.
+      // `onAbort` already ran in decideToolCall, and `stopForAbort` halts the loop.
+      // Still pair the tool_use with a result: the assistant message carrying it is
+      // already in `messages`, so an unanswered `tool_use` would 400 the provider on
+      // the next call (or on a persisted-then-resumed thread).
+      const aborted = `Aborted: ${decision.reason}`
+      toolResults.push({ toolCallId: tc.id, result: aborted })
+      messages.push({ role: 'tool', content: aborted, toolCallId: tc.id })
+      yield { type: 'tool-call' as const, toolCall: tc }
+      yield { type: 'tool-result' as const, toolCall: tc, result: aborted }
       return
     }
     case 'validation-error': {

--- a/packages/framework-dashboard/lib/format-date.ts
+++ b/packages/framework-dashboard/lib/format-date.ts
@@ -56,8 +56,9 @@ export function formatAge(value: string | undefined, fallback = '—'): string {
   if (hours < 24) return `${hours}h ago`
   const days = Math.floor(hours / 24)
   if (days < 7) return `${days}d ago`
-  const weeks = Math.floor(days / 7)
-  if (weeks < 52) return `${weeks}w ago`
+  // Gate on days, not weeks: at 364 days `weeks` is 52 but `days/365` floors to 0, which would
+  // read "0y ago" for a full day before the year rolls over.
+  if (days < 365) return `${Math.floor(days / 7)}w ago`
   return `${Math.floor(days / 365)}y ago`
 }
 

--- a/packages/framework-dashboard/lib/use-device-status.ts
+++ b/packages/framework-dashboard/lib/use-device-status.ts
@@ -21,8 +21,10 @@ const POLL_MS = 10_000
  */
 export function useDeviceStatus(profiles: ConnectionProfile[]): Record<string, DeviceStatus> {
   const targets = profiles.filter(p => p.token).map(p => ({ id: p.id, url: p.url, token: p.token }))
-  // Re-poll only when the device set itself changes, not on every render (targets is a fresh array).
-  const key = targets.map(t => t.id).join('|')
+  // Re-poll when the device set OR any device's token changes, not on every render (targets is a
+  // fresh array). The token is in the key because a re-paste refreshes it without changing the id
+  // (the id is the URL) — keying on ids alone kept pinging with the dead token and showed offline.
+  const key = targets.map(t => `${t.id} ${t.token}`).join('|')
   const load = useMemo(
     () => (targets.length ? () => checkDevices(targets) : null),
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/framework-dashboard/lib/use-notifications.ts
+++ b/packages/framework-dashboard/lib/use-notifications.ts
@@ -49,8 +49,15 @@ function fire<T>(items: T[], spec: NotificationSpec<T>): void {
 function useNewItemNotifications<T>(items: T[], enabled: boolean, spec: NotificationSpec<T>): void {
   const seen = useRef<Set<string>>(new Set())
   const observations = useRef(0)
+  const lastItems = useRef<T[] | undefined>(undefined)
 
   useEffect(() => {
+    // A toggle flip re-runs this effect with the SAME feed. Counting that as an observation
+    // burns a warmup slot, so the first real fetch after enabling is treated as post-baseline
+    // and notifies for the whole backlog — the exact thing the warmup exists to prevent. Only a
+    // genuine feed change advances the baseline; an `enabled` flip with unchanged items is a no-op.
+    if (items === lastItems.current) return
+    lastItems.current = items
     const fresh = spec.pickNew(seen.current, items)
     if (observations.current < WARMUP) {
       observations.current += 1 // still warming up: fold these into the baseline, don't notify

--- a/packages/framework-dashboard/lib/use-run-handoff.ts
+++ b/packages/framework-dashboard/lib/use-run-handoff.ts
@@ -31,6 +31,9 @@ export function useRunHandoff(projectId: string, runId: string | null | undefine
     null,
     everyMs,
     [projectId, runId, enabled, everyMs],
+    // Keep the last answer while the cadence flips (prPending 15s↔1s), or the summary blanks and
+    // the action bar falls back to the live counts for a beat — the same reason GitStatusBar does.
+    true,
   )
   useEffect(() => setEveryMs(handoff?.prPending ? 1_000 : 15_000), [handoff?.prPending])
   const { busy, error, run } = useAction()

--- a/packages/mcp/src/runtime/node-handler.ts
+++ b/packages/mcp/src/runtime/node-handler.ts
@@ -90,6 +90,12 @@ async function writeWebResponse(res: ServerResponse, response: Response): Promis
   }
 
   const reader = response.body.getReader()
+  // A client that vanishes mid-stream (an SSE channel especially) never ends the source, so
+  // the read below would stay parked forever and the session it feeds would never release.
+  // Cancelling the body is what lets the web handler's release-on-cancel run.
+  res.on('close', () => {
+    void reader.cancel().catch(() => {})
+  })
   try {
     for (;;) {
       const { done, value } = await reader.read()
@@ -101,6 +107,8 @@ async function writeWebResponse(res: ServerResponse, response: Response): Promis
   }
 }
 
+/** A chain of proxies appends to `X-Forwarded-*` (comma-joined by Node); the client-facing hop is first. */
 function firstHeader(v: string | string[] | undefined): string | undefined {
-  return Array.isArray(v) ? v[0] : v
+  const raw = Array.isArray(v) ? v[0] : v
+  return raw?.split(',')[0]?.trim() || undefined
 }

--- a/packages/the-framework.ai/pages/index/Hero.tsx
+++ b/packages/the-framework.ai/pages/index/Hero.tsx
@@ -6,7 +6,10 @@ export const PMS = {
   npm: { try: 'npx @gemstack/the-framework', install: 'npm i -g @gemstack/the-framework' },
   pnpm: { try: 'pnpm dlx @gemstack/the-framework', install: 'pnpm add -g @gemstack/the-framework' },
   bun: { try: 'bunx @gemstack/the-framework', install: 'bun add -g @gemstack/the-framework' },
-  yarn: { try: 'yarn dlx @gemstack/the-framework', install: 'yarn global add @gemstack/the-framework' },
+  // `yarn dlx` is Yarn 2+ (Berry), which removed `yarn global add` — so the install line
+  // falls back to npm, which every yarn user has, rather than pairing two commands no
+  // single yarn generation can both run.
+  yarn: { try: 'yarn dlx @gemstack/the-framework', install: 'npm i -g @gemstack/the-framework' },
 } as const
 export type Pm = keyof typeof PMS
 

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -1402,6 +1402,31 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
     domainPreset = resolved.preset
   }
 
+  // The fake demo defaults to a Cloudflare deploy decision so the flow ends with
+  // a deploy phase; a live run only narrates deploy when asked.
+  const deploy: DeployDecision | undefined = opts.deploy
+    ? { render: 'ssr', target: opts.deploy, reason: `deploy to ${opts.deploy}` }
+    : fake
+      ? FAKE_DEPLOY
+      : undefined
+
+  // A real deploy target actually ships the app. Only for live runs against a
+  // known target; --fake stays plan-only and deterministic. An unknown target
+  // just narrates the decision. Real targets never throw on missing creds.
+  // Validated up front like --preset: a bad flag combination is a usage error, and it must
+  // fail before the dashboard / store / control channel are wired — a raw return after them
+  // leaked every handle and left the run recorded as `running` forever.
+  let deployTarget: DeployTarget | undefined
+  if (!fake && opts.deploy) {
+    const built = buildDeployTarget(opts.deploy, opts, cwd)
+    if (built.error) {
+      io.err(built.error)
+      io.err('Run `framework --help` for usage.')
+      return 2
+    }
+    deployTarget = built.target
+  }
+
   // Fail early and clearly if a live run's prerequisites are missing — before the
   // run, which needs the wrapped agent.
   if (!fake && !opts.skipPreflight) {
@@ -1741,6 +1766,11 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
     // opposite of what stopping meant. Same call the on-before-mergeable step makes.
     if (journal.stoppedCleanly()) return skip('run-stopped')
     if (fake) return skip('fake-run')
+    // A topic run (#1120) lives in a project-less scratch dir: no repo, no branch, nothing to
+    // publish. Without this, the commit attempt below burns its retries against a non-repo and
+    // labels the end `commit-failed` — alarming copy about work that never existed. It never
+    // had a branch, which is what branch-gone says.
+    if (opts.topic) return skip('branch-gone')
 
     // The daemon commits whatever the agent left uncommitted, but only after this process exits
     // (`tearDownWorktree`), so at this point the tree can still hold real work. Pushing first
@@ -1831,8 +1861,14 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
   // The run owns the browser (#793): launching it here, rather than letting chrome-devtools-mcp
   // launch its own, is what lets the #609 preview attach to the same page. Undefined when the
   // machine has no Chrome, which leaves `--browser` on its old path rather than failing the run.
-  const sharedBrowser = opts.browser && !fake ? await launchSharedBrowser() : undefined
-  if (opts.browser && !fake && !sharedBrowser) {
+  // Local runs only: the browser tools are wired on this machine, so a `--run-on web`/`actions`
+  // session could never reach them — launching Chrome here would leak a headless browser per
+  // run, and the system channel must only claim a browser the run really has (#824).
+  const localRun = opts.target === undefined || opts.target === 'local'
+  const sharedBrowser = opts.browser && !fake && localRun ? await launchSharedBrowser() : undefined
+  if (opts.browser && !fake && !localRun) {
+    io.err(`note: --browser has no effect with --run-on ${opts.target}: the browser tools are wired on this machine, and the session runs elsewhere.`)
+  } else if (opts.browser && !fake && !sharedBrowser) {
     io.err('note: no Chrome found, so --browser falls back to its own browser (no preview).')
   }
 
@@ -1851,14 +1887,20 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
    */
   const abortBeforeDriver = async (reason: string): Promise<number> => {
     io.err(reason)
+    // Release every handle settleRun would: the armed interrupt trap, the run's own dashboard
+    // server, and the LOGS.md entry — leaving any of them behind kept the process alive with a
+    // swallowed first Ctrl+C, exactly the hang this helper exists to prevent.
+    clearInterrupt()
     try {
       await store?.append({ kind: 'end', ok: false, detail: reason })
       await store?.close()
     } catch {
       // Persistence is never allowed to be the thing that keeps a failing run alive.
     }
+    await journal.finishLog().catch(() => {})
     control?.close()
     await sharedBrowser?.close().catch(() => {})
+    await dashboard?.close().catch(() => {})
     return 2
   }
 
@@ -1910,9 +1952,9 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
 
   // Whether the agent actually ends up with browser tools, which is narrower than the flag: they
   // ride Claude Code's MCP config, so `--browser` on another agent wires nothing (see
-  // `unguardedNotices`), and the fake driver has no tools at all. The system channel must only
-  // claim a browser the run really has (#824).
-  const browserAttached = opts.browser && !fake && opts.agent === 'claude'
+  // `unguardedNotices`), the fake driver has no tools at all, and a remote target never sees
+  // this machine's MCP config. The system channel must only claim a browser the run really has (#824).
+  const browserAttached = opts.browser && !fake && opts.agent === 'claude' && localRun
 
   // The preview of that browser (#802): the agent's Chrome is headless, so when it parks on an
   // `await-browser` gate (#796) there is nothing for a human to click. This serves it. Opening
@@ -2049,28 +2091,6 @@ async function runBuild(opts: CliOptions, io: CliIO): Promise<number> {
           : '\n✓ prompt session done.',
       }
     })
-  }
-
-  // The fake demo defaults to a Cloudflare deploy decision so the flow ends with
-  // a deploy phase; a live run only narrates deploy when asked.
-  const deploy: DeployDecision | undefined = opts.deploy
-    ? { render: 'ssr', target: opts.deploy, reason: `deploy to ${opts.deploy}` }
-    : fake
-      ? FAKE_DEPLOY
-      : undefined
-
-  // A real deploy target actually ships the app. Only for live runs against a
-  // known target; --fake stays plan-only and deterministic. An unknown target
-  // just narrates the decision. Real targets never throw on missing creds.
-  let deployTarget: DeployTarget | undefined
-  if (!fake && opts.deploy) {
-    const built = buildDeployTarget(opts.deploy, opts, cwd)
-    if (built.error) {
-      io.err(built.error)
-      io.err('Run `framework --help` for usage.')
-      return 2
-    }
-    deployTarget = built.target
   }
 
   const serve: ServeConfig | undefined = opts.serve

--- a/packages/the-framework/src/dashboard/file-read.ts
+++ b/packages/the-framework/src/dashboard/file-read.ts
@@ -26,7 +26,8 @@ export function safeRepoPath(path: string): boolean {
   if (!path || path.length > 1024 || path.includes('\0')) return false
   if (path.startsWith('/') || path.startsWith('-') || /^[a-zA-Z]:/.test(path)) return false
   const parts = path.split(/[\\/]/)
-  if (parts[0] === '.git') return false
+  // Any `.git` segment, not just a leading one: a nested repo's `.git/config` holds credentials too.
+  if (parts.includes('.git')) return false
   return parts.every(part => part !== '' && part !== '.' && part !== '..')
 }
 

--- a/packages/the-framework/src/dashboard/server.test.ts
+++ b/packages/the-framework/src/dashboard/server.test.ts
@@ -457,6 +457,7 @@ test('isSameOriginRequest: absent Origin passes; same host + loopback pass; evil
   assert.equal(isSameOriginRequest(req({ origin: 'http://127.0.0.1:9999' })), true)
   assert.equal(isSameOriginRequest(req({ origin: 'http://[::1]' })), true)
   assert.equal(isSameOriginRequest(req({ host: 'localhost:4200', origin: 'http://evil.com' })), false)
+  assert.equal(isSameOriginRequest(req({ origin: 'http://127.evil.com' })), false) // rebound name, not a loopback address
   assert.equal(isSameOriginRequest(req({ origin: 'not-a-url' })), false)
 })
 
@@ -468,6 +469,10 @@ test('isExpectedHost: on a loopback bind only a loopback Host passes (DNS rebind
   assert.equal(isExpectedHost(req({ host: '[::1]:4200' }), bound), true) // the port split must not eat the IPv6 colons
   assert.equal(isExpectedHost(req({ host: 'evil.com' }), bound), false) // rebound: resolves here, names someone else
   assert.equal(isExpectedHost(req({ host: 'evil.com:4200' }), bound), false)
+  // A registrable name that merely starts with `127.` is a rebound name, not a loopback address:
+  // it can resolve to 127.0.0.1, so it must be rejected like any other rebound Host.
+  assert.equal(isExpectedHost(req({ host: '127.evil.com' }), bound), false)
+  assert.equal(isExpectedHost(req({ host: '127.0.0.1.evil.com:4200' }), bound), false)
   assert.equal(isExpectedHost(req({}), bound), false) // HTTP/1.1 requires Host; every browser sends it
 
   // A non-loopback bind is reached by a name we cannot predict, so there is nothing to check

--- a/packages/the-framework/src/dashboard/telefunc-serve.ts
+++ b/packages/the-framework/src/dashboard/telefunc-serve.ts
@@ -118,7 +118,7 @@ export function isSameOriginRequest(req: IncomingMessage): boolean {
   } catch {
     return false // malformed Origin: treat as cross-origin
   }
-  return hostname === 'localhost' || hostname === '::1' || hostname === '[::1]' || hostname.startsWith('127.')
+  return isLoopbackHost(hostname)
 }
 
 /**

--- a/packages/the-framework/src/driver/actions.ts
+++ b/packages/the-framework/src/driver/actions.ts
@@ -138,7 +138,7 @@ export class ActionsSession implements DriverSession {
     await this.dispatch(prompt, correlationId, resume)
     emit({ type: 'notice', message: `Dispatched ${correlationId} to ${this.config.owner}/${this.config.repo}; waiting for the runner.` })
 
-    const run = await this.awaitRun(correlationId, emit)
+    const run = await this.awaitRun(correlationId, emit, opts.signal)
     const artifact = await this.readRunArtifact(run.id, correlationId)
     if (artifact.branch) this.branch = artifact.branch
 
@@ -181,7 +181,11 @@ export class ActionsSession implements DriverSession {
   }
 
   /** Poll until our run appears and finishes. Identified by the correlation id in its `run-name`. */
-  private async awaitRun(correlationId: string, emit: (event: DriverEvent) => void): Promise<WorkflowRun> {
+  private async awaitRun(
+    correlationId: string,
+    emit: (event: DriverEvent) => void,
+    promptSignal?: AbortSignal,
+  ): Promise<WorkflowRun> {
     const now = this.config.now ?? Date.now
     const sleep = this.config.sleep ?? (ms => new Promise<void>(r => setTimeout(r, ms)))
     const interval = this.config.pollIntervalMs ?? 5000
@@ -201,9 +205,9 @@ export class ActionsSession implements DriverSession {
         }
       }
       if (now() >= deadline) throw new Error(`Timed out waiting for the GitHub Actions run (${correlationId}).`)
-      this.throwIfAborted()
+      this.throwIfAborted(promptSignal)
       await sleep(interval)
-      this.throwIfAborted()
+      this.throwIfAborted(promptSignal)
     }
   }
 
@@ -233,8 +237,10 @@ export class ActionsSession implements DriverSession {
     return `${this.config.owner}/${this.config.repo}`
   }
 
-  private throwIfAborted(): void {
-    if (this.startOpts.signal?.aborted) throw new Error('Session aborted while waiting for the GitHub Actions run.')
+  /** The session-wide signal or the per-prompt one (`DriverPromptOptions.signal`) both stop the poll. */
+  private throwIfAborted(promptSignal?: AbortSignal): void {
+    if (this.startOpts.signal?.aborted || promptSignal?.aborted)
+      throw new Error('Session aborted while waiting for the GitHub Actions run.')
   }
 
   /** A REST call that expects JSON back. */

--- a/packages/the-framework/src/driver/agent-cli.ts
+++ b/packages/the-framework/src/driver/agent-cli.ts
@@ -89,7 +89,9 @@ export function runAgentCli(opts: RunAgentCliOptions): Promise<DriverTurn> {
     const agent = opts.agent ?? 'claude-code'
     let settled = false
     let hardKillTimer: ReturnType<typeof setTimeout> | undefined
-    const stderrChunks: string[] = []
+    // Raw bytes, decoded once at close: a per-chunk `String(chunk)` corrupts a multibyte
+    // UTF-8 codepoint split across two chunks, and this text becomes the turn's error detail.
+    const stderrChunks: Buffer[] = []
 
     // Kill the agent's whole process group: SIGTERM to let it flush, then a
     // SIGKILL after a grace window in case it ignores the term (mid tool-call).
@@ -139,7 +141,7 @@ export function runAgentCli(opts: RunAgentCliOptions): Promise<DriverTurn> {
       })
     }
     if (child.stderr) {
-      child.stderr.on('data', (chunk: Buffer | string) => stderrChunks.push(String(chunk)))
+      child.stderr.on('data', (chunk: Buffer | string) => stderrChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)))
     }
 
     child.on('close', code => {
@@ -152,7 +154,7 @@ export function runAgentCli(opts: RunAgentCliOptions): Promise<DriverTurn> {
       // first: the loop gates on the outcome, so a crash mid-build must not pass
       // as a result. Surface stderr, else the partial text, as context.
       if (code !== 0) {
-        const detail = stderrChunks.join('').trim() || turn.text.trim() || `exit code ${code ?? 'null'}`
+        const detail = Buffer.concat(stderrChunks).toString('utf8').trim() || turn.text.trim() || `exit code ${code ?? 'null'}`
         opts.emit({ type: 'error', message: detail })
         finish(() => rejectPromise(new Error(`[framework] ${agent} exited (${code ?? 'null'}): ${detail}`)))
         return

--- a/packages/the-framework/src/driver/claude-code-quota.ts
+++ b/packages/the-framework/src/driver/claude-code-quota.ts
@@ -107,7 +107,10 @@ export function readClaudeQuota(opts: ReadClaudeQuotaOptions = {}): Promise<Driv
     })
 
     let settled = false
-    const chunks: string[] = []
+    // Raw bytes, decoded once at the end: a per-chunk `String(chunk)` corrupts a multibyte
+    // UTF-8 codepoint split across two chunks (the readout's `·` is one), and a corrupted
+    // readout parses as 'unrecognized' instead of the real quota.
+    const chunks: Buffer[] = []
     const settle = (quota: DriverQuota) => {
       if (settled) return
       settled = true
@@ -130,7 +133,7 @@ export function readClaudeQuota(opts: ReadClaudeQuotaOptions = {}): Promise<Driv
       settle({ available: false, reason: 'timeout' })
     }, opts.timeoutMs ?? READ_TIMEOUT_MS)
 
-    child.stdout?.on('data', (chunk: Buffer | string) => chunks.push(String(chunk)))
+    child.stdout?.on('data', (chunk: Buffer | string) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)))
     // ENOENT lands here rather than as a non-zero exit.
     child.on('error', () => settle({ available: false, reason: 'agent-not-found' }))
     child.on('close', code => {
@@ -138,7 +141,7 @@ export function readClaudeQuota(opts: ReadClaudeQuotaOptions = {}): Promise<Driv
         settle({ available: false, reason: 'fetch-failed' })
         return
       }
-      settle(parseQuotaResponse(chunks.join('')))
+      settle(parseQuotaResponse(Buffer.concat(chunks).toString('utf8')))
     })
   })
 }

--- a/packages/the-framework/src/driver/claude-code.ts
+++ b/packages/the-framework/src/driver/claude-code.ts
@@ -105,7 +105,7 @@ export class ClaudeCodeSession implements DriverSession {
     const resumeId = opts.resume ? this.lastSessionId : undefined
     const emit = makeEmit(this.startOpts.onEvent, 'claude-code')
     const signals = combineSignals(this.startOpts.signal, opts.signal)
-    const run = (id: string | undefined): Promise<DriverTurn> =>
+    const run = (id: string | undefined, emitFn: (event: DriverEvent) => void): Promise<DriverTurn> =>
       runClaude({
         bin: this.config.bin ?? 'claude',
         args: this.buildArgs(system, id),
@@ -113,22 +113,38 @@ export class ClaudeCodeSession implements DriverSession {
         env: this.config.env ?? process.env,
         prompt: text,
         spawn: this.config.spawn ?? (nodeSpawn as unknown as SpawnLike),
-        emit,
+        emit: emitFn,
         signals,
       })
 
     let turn: DriverTurn
+    // On a resume attempt, hold the failure's `error` event back until the conversation-gone
+    // case (#778) is ruled out: a turn that recovers on the retry must not show a failed row.
+    // Safe to hold — runAgentCli emits `error` exactly once, right before it rejects.
+    let heldError: DriverEvent | undefined
     try {
-      turn = await run(resumeId)
+      turn = await run(resumeId, resumeId === undefined ? emit : event => {
+        if (event.type === 'error') heldError = event
+        else emit(event)
+      })
     } catch (err) {
       // The id we captured outlives what the CLI will resume (#778) — its retention, a
       // cleared history, another machine. There is no way to ask first, so let it fail
       // once and continue as a fresh conversation (which gets the system framing back)
       // rather than losing the message the user already typed.
-      if (resumeId === undefined || !isConversationGone(err) || signals.some(s => s.aborted)) throw err
+      if (resumeId === undefined || !isConversationGone(err) || signals.some(s => s.aborted)) {
+        if (heldError) emit(heldError)
+        throw err
+      }
       this.lastSessionId = undefined
       emit({ type: 'notice', message: 'That conversation is no longer available; continuing without its history.' })
-      turn = await run(undefined)
+      // The retry re-sends the same prompt; swallow its duplicate `start` so the user's
+      // message appears once in the transcript, not twice.
+      let startSeen = false
+      turn = await run(undefined, event => {
+        if (event.type === 'start' && !startSeen) startSeen = true
+        else emit(event)
+      })
     }
     // Track the agent's session so a later resume continues this exact conversation.
     if (turn.sessionId) this.lastSessionId = turn.sessionId

--- a/packages/the-framework/src/driver/cloud.ts
+++ b/packages/the-framework/src/driver/cloud.ts
@@ -232,6 +232,11 @@ export class CloudSession implements DriverSession {
       this.controllers.delete(controller)
     }
 
+    // A user abort (Stop, the run signal) also lands here with `found` unset — the pty run
+    // resolves once the controller aborts. Name it what it was, not "no cloud session was
+    // created", which is the CLI-failure message.
+    if (!found && (this.startOpts.signal?.aborted || opts.signal?.aborted))
+      throw new Error('[framework] claude-web prompt aborted')
     // The trust dialog is a one-time, per-root fix, so fail with that instead of the raw
     // dialog text — three identical "no cloud session was created" runs in a row is what
     // this looked like before the failure named its own cure.

--- a/packages/the-framework/src/loopback-host.ts
+++ b/packages/the-framework/src/loopback-host.ts
@@ -4,12 +4,19 @@
  * `daemon.ts` imports the dashboard, so the mount cannot import these back out of it.
  */
 
+/** The `127.0.0.0/8` loopback range, in dotted-quad form. */
+const LOOPBACK_V4 = /^127(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}$/
+
 /**
  * True when `host` is a loopback address the browser reaches without leaving the machine (#1051).
  * A bind-all (`0.0.0.0`, `::`) or a routable address is not, and gates behind the shared token.
+ *
+ * The IPv4 check matches the whole `127.0.0.0/8` range but only as an address: a bare
+ * `startsWith('127.')` also accepts a *registrable name* like `127.evil.com`, which is exactly the
+ * rebound `Host` the DNS-rebinding guard exists to reject (it can resolve to `127.0.0.1`).
  */
 export function isLoopbackHost(host: string): boolean {
-  return host === 'localhost' || host === '::1' || host === '[::1]' || host.startsWith('127.')
+  return host === 'localhost' || host === '::1' || host === '[::1]' || LOOPBACK_V4.test(host)
 }
 
 /**

--- a/packages/the-framework/src/project.ts
+++ b/packages/the-framework/src/project.ts
@@ -91,7 +91,7 @@ const GIT_READ_OPS = new Set([
 ])
 
 /** Subcommands bounded by the network rather than by this machine. */
-const GIT_SLOW_OPS = new Set(['clone', 'fetch', 'pull', 'push'])
+const GIT_SLOW_OPS = new Set(['clone', 'fetch', 'pull', 'push', 'ls-remote'])
 
 /** Global options whose value is the next word, so that word is not the subcommand. */
 const GIT_GLOBAL_VALUE_OPTIONS = new Set(['-C', '-c', '--git-dir', '--work-tree', '--namespace', '--exec-path'])

--- a/packages/the-framework/src/queue-promote.test.ts
+++ b/packages/the-framework/src/queue-promote.test.ts
@@ -76,6 +76,15 @@ test('landPinnedEntry leaves prose and an already-retired entry untouched (#1204
   assert.equal(landPinnedEntry(checkout, checkout, 'never queued', checkout), checkout)
 })
 
+test('landPinnedEntry retires a no-checkbox open entry, not only a [ ] one (#1164/#1297)', () => {
+  // Agents write plain bullets without a box; the rest of the sweep counts those as open, so
+  // the pin must retire them too — otherwise the entry stays open and is re-drained forever.
+  const checkout = ['## Priority 7', '', '- entry a', '- [ ] entry b', ''].join('\n')
+  const out = landPinnedEntry(checkout, checkout, 'entry a', checkout)
+  assert.match(out, /- \[x\] entry a/)
+  assert.match(out, /- \[ \] entry b/)
+})
+
 test('a pinned run lands only its entry, and commits just the queue file (#1204)', async () => {
   const calls: string[][] = []
   const written: string[] = []

--- a/packages/the-framework/src/queue-promote.ts
+++ b/packages/the-framework/src/queue-promote.ts
@@ -148,7 +148,10 @@ export function landPinnedEntry(
 ): string {
   const lines = inCheckout.split('\n').map(line => {
     const item = ENTRY_LINE.exec(line)
-    if (!item || item[3]?.trim() !== entry || item[2] === undefined || item[2] !== ' ') return line
+    // Retire any *open* entry that matches — an empty `[ ]` box or a no-checkbox bullet alike,
+    // the same "open" grammar `entriesRetiredByPatch` and `parseTodoEntries` use (#1164/#1297).
+    // Skipping the no-checkbox form left it open, so the sweep re-drained it after the PR closed.
+    if (!item || item[3]?.trim() !== entry || item[2] === 'x' || item[2] === 'X') return line
     return `${item[1]}[x] ${item[3]!.trim()}`
   })
 


### PR DESCRIPTION
A repo-wide bug hunt across every package. Each fix is verified against the provider SDK types, the adjacent tests, or the code's own documented intent. The whole workspace stays green after the changes — typecheck clean, and every suite passes (the-framework 1691, ai-sdk 956, ai-autopilot 306, dashboard + mcp + connectors + examples all passing; 21/21 turbo tasks).

## ai-sdk — provider adapters (wrong SDK shapes that were silently dropped or threw)

- **google/chat**: put `systemInstruction` under `config` — the `@google/genai` SDK only reads `config.systemInstruction`, so a top-level sibling was silently dropped and **every Gemini request ran with no system prompt**. Also emit `googleSearch` instead of `google_search` (the snake_case key serialized to an empty tool, so native web search never activated), and map the non-streaming `finishReason` so a truncation/safety stop isn't reported as a clean `stop`.
- **google/embeddings**: use `contents`/`embeddings` — the singular `content`/`embedding` forms threw, and even fixed would have returned empty vectors.
- **google/files**: iterate the returned `Pager` with `for await` — it has no `.files` array, so `list()` always threw.
- **google/images**: send an enumerated Imagen `aspectRatio` (`1:1`/`16:9`/…), not a pixel pair like `1024:1024`, which the predict endpoint rejects.
- **anthropic**: the Files API lives at `client.beta.files.*` (`client.files` is `undefined`) and takes a named uploadable, not a bare `Blob` with a `purpose`; map `max_tokens`/`refusal` stop reasons in both the response and stream mappers so a truncated Claude answer isn't indistinguishable from a complete one.
- **openai**: `files.delete` / `vectorStores.delete` (v4's `del` was removed in v5/v6) and the v5 `vectorStores.files.retrieve(fileId, { vector_store_id })` signature; send PDFs as a `file_data` data URI, not a bare `data`/`mime_type` (rejected by the API).
- **cohere**: v2 `rerank` takes plain-string documents, not `{ text }` objects (which the v2 client rejects before the network call).

## ai-sdk — agent loop

- An `onBeforeToolCall` middleware returning `{ type: 'abort' }` now **stops the whole loop** and pairs the aborted `tool_use` with a result. Previously it halted only the tool phase, so a guard middleware "blocking" a dangerous tool didn't actually stop the agent — the next provider call carried an unanswered `tool_use` (a 400 on Anthropic). Adds a regression test.
- `buildResumeSnapshotMessages` now includes `resumedToolMessages`, so an approval resume doesn't drop the executed tool's result and leave a dangling `tool_use` for the next resume to choke on.
- `fake.assertPrompted` matches the last user message (the actual prompt), not the first (stale history).

## the-framework — drivers

- **actions**: honor the per-prompt abort signal — it was ignored, so an abort could leave the driver polling GitHub for up to an hour.
- **claude-code-quota / agent-cli**: collect stdout/stderr as `Buffer`s and decode once — a per-chunk `String(chunk)` corrupts a multibyte codepoint split across chunks (the quota readout's `·`, and turn error details).
- **claude-code**: on the conversation-gone retry (#778), suppress the failed attempt's `error` event and the retry's duplicate `start`, so a recovered turn's transcript doesn't show a phantom agent error and the user's message twice.
- **cloud**: report a user abort as "prompt aborted", not the misleading "no cloud session was created".

## the-framework — cli / core

- Validate `--deploy` **before** wiring the dashboard / store / control channel, and release every handle (interrupt trap, dashboard, LOGS.md) in `abortBeforeDriver` — a bad `--deploy dokploy` or `--run-on actions` left the process hung with the run stuck `running`.
- `--browser` is gated on a local run: a `--run-on web`/`actions` session can't reach this machine's browser, so the system prompt must not claim one, and no headless Chrome is leaked per remote run.
- A topic run skips the handoff commit (its scratch cwd is not a git repo), so it no longer reports an alarming `commit-failed` after ~600ms of pointless git retries.
- **loopback-host**: match the `127.0.0.0/8` range as an *address*, so a rebound `Host` like `127.evil.com` no longer bypasses the DNS-rebinding guard (fixed in the shared helper and the inline same-origin check). Adds regression assertions.
- **queue-promote**: `landPinnedEntry` retires a no-checkbox open entry too, matching the "open" grammar the rest of the sweep uses — otherwise it stayed open and was re-drained forever. Adds a regression test.
- **file-read**: reject any `.git` path segment, not just a leading one.
- **project**: give `git ls-remote` the network timeout, not the local-write one.

## ai-autopilot

- **overview/markdown**: only skip the top-level `#` title, so a `# ` line inside a body or fenced code block survives the round-trip.
- **loop/verdict**: try the bare-object fallback only when no fenced verdict parses, so brace-shaped prose after the real fence can't outrank it.
- **surface/events**: an `EventStream` iterator woken with nothing left re-waits instead of resolving a spurious `done` on a still-open stream (protocol violation under concurrent `next()`).
- **decisions/markdown**: only a real status counts as the `[status]` prefix, so a hand-written `[Frontend]`-style tag keeps its place in the title instead of being swallowed.

## framework-dashboard

- **use-notifications**: an enable-toggle flip no longer consumes a warmup slot, so enabling a feed mid-session doesn't fire a notification burst for the entire pre-existing backlog.
- **use-run-handoff**: `keepPrevious` across the poll-cadence flip, so the action-bar summary doesn't blink back to the live counts for a beat.
- **use-device-status**: key the poll on tokens too, so a refreshed device token isn't ignored until remount (which showed the device offline and blocked Start against it).
- **format-date**: `formatAge` no longer renders "0y ago" for an age of exactly 364 days.

## mcp

- **node-handler**: split a comma-joined `X-Forwarded-Proto` (a proxy chain otherwise 500s every request), and cancel the body reader on client disconnect so an abandoned SSE session doesn't leak its transport indefinitely.

## the-framework.ai

- **Hero**: the yarn install command no longer pairs Berry-only `yarn dlx` with the removed `yarn global add`.

## Deferred (found, not fixed — flagged for a follow-up)

- **ai-sdk** `prepareStep`'s `tools`/`toolChoice`/`providerOptions` and middleware `onConfig`'s `temperature`/`maxTokens`/`tools`/`providerOptions` are declared but silently ignored by `runFailover`. Real, but the fix threads many fields through the shared streaming + non-streaming failover path and wants its own dedicated tests — left out of this batch to keep it low-risk.
- **ai-sdk** OpenAI `fileSearch()` on chat-completions needs routing through the Responses API (a design change, not a shape fix).
- **ai-sdk** `newMessagesFromTurn` persists an empty `user('')` on a messages-mode continuation; low impact and the helper is documented to mirror the old persistence shape exactly, so it wants a design call rather than a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iof4vGKX2nrtPk8xPQU8y

---
_Generated by [Claude Code](https://claude.ai/code/session_016iof4vGKX2nrtPk8xPQU8y)_