### PR TITLE
Enter sends the prompt, Shift+Enter breaks the line (fix #1510)

### DIFF
--- a/packages/framework-dashboard/components/Composer.tsx
+++ b/packages/framework-dashboard/components/Composer.tsx
@@ -389,7 +389,7 @@ export const Composer = forwardRef<ComposerHandle, {
       >
         {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowUp className="h-4 w-4" />}
       </TooltipTrigger>
-      <TooltipContent>{busy ? submitBusyLabel : `${submitLabel}  (⌘↵ / Ctrl+Enter)`}</TooltipContent>
+      <TooltipContent>{busy ? submitBusyLabel : `${submitLabel}  (Enter · Shift+Enter for a new line)`}</TooltipContent>
     </Tooltip>
   )
 

--- a/packages/framework-dashboard/components/PromptEditor.test.tsx
+++ b/packages/framework-dashboard/components/PromptEditor.test.tsx
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { PromptEditor } from './PromptEditor.js'
+
+// The real Tiptap editor (no mock): what's under test is the keyboard seam itself — which
+// Enter reaches the submit callback and which stays an editing key (#1510).
+
+afterEach(cleanup)
+
+async function renderEditor() {
+  const onSubmit = vi.fn()
+  const onChange = vi.fn()
+  render(<PromptEditor onChange={onChange} onSubmit={onSubmit} projects={[]} presets={[]} />)
+  // immediatelyRender: false — the contenteditable appears a tick after mount.
+  const box = await waitFor(() => {
+    const el = document.querySelector('[role="textbox"]')
+    if (!el) throw new Error('editor not mounted yet')
+    return el as HTMLElement
+  })
+  return { box, onSubmit }
+}
+
+describe('Enter sends the prompt (#1510)', () => {
+  test('plain Enter submits; Shift+Enter and Alt+Enter do not', async () => {
+    const { box, onSubmit } = await renderEditor()
+    fireEvent.keyDown(box, { key: 'Enter' })
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    fireEvent.keyDown(box, { key: 'Enter', shiftKey: true })
+    fireEvent.keyDown(box, { key: 'Enter', altKey: true })
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  test('Cmd/Ctrl+Enter still submits', async () => {
+    const { box, onSubmit } = await renderEditor()
+    fireEvent.keyDown(box, { key: 'Enter', metaKey: true })
+    fireEvent.keyDown(box, { key: 'Enter', ctrlKey: true })
+    expect(onSubmit).toHaveBeenCalledTimes(2)
+  })
+
+  test('Enter is left to an open suggestion menu (aria-expanded), which uses it to pick', async () => {
+    const { box, onSubmit } = await renderEditor()
+    // The suggestion render marks the editor while its menu is visible; the guard reads that mark.
+    box.setAttribute('aria-expanded', 'true')
+    fireEvent.keyDown(box, { key: 'Enter' })
+    expect(onSubmit).not.toHaveBeenCalled()
+    box.setAttribute('aria-expanded', 'false')
+    fireEvent.keyDown(box, { key: 'Enter' })
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  test('Enter during IME composition is not a send', async () => {
+    const { box, onSubmit } = await renderEditor()
+    fireEvent.keyDown(box, { key: 'Enter', isComposing: true })
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/packages/framework-dashboard/components/PromptEditor.tsx
+++ b/packages/framework-dashboard/components/PromptEditor.tsx
@@ -30,7 +30,7 @@ export interface PromptEditorHandle {
 
 interface PromptEditorProps {
   onChange: (markdown: string) => void
-  /** Cmd/Ctrl+Enter. */
+  /** Enter (and Cmd/Ctrl+Enter); Shift+Enter stays a line break (#1510). */
   onSubmit: () => void
   /** A preset picked from the `/` menu (so the form can flip to a `prompt` run). `replaced` says
    *  whether a typed draft was overwritten — undo brings it back, and the form's note says so. */
@@ -310,8 +310,19 @@ export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(fu
         'aria-label': 'Prompt',
         'aria-placeholder': placeholder,
       },
-      handleKeyDown: (_view, event) => {
+      handleKeyDown: (view, event) => {
         if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+          event.preventDefault()
+          onSubmitRef.current()
+          return true
+        }
+        // Enter sends, Shift+Enter breaks the line (#1510) — Claude Code web's bindings. This
+        // direct prop outranks the plugins' handlers, so it must step aside where Enter already
+        // means something: picking from an open suggestion menu (aria-expanded mirrors its
+        // visibility), typing a newline in a code block, or confirming an IME composition.
+        if (event.key === 'Enter' && !event.shiftKey && !event.altKey && !event.isComposing) {
+          if (view.dom.getAttribute('aria-expanded') === 'true') return false
+          if (view.state.selection.$from.parent.type.name === 'codeBlock') return false
           event.preventDefault()
           onSubmitRef.current()
           return true

--- a/packages/framework-dashboard/components/prompt-editor/suggestion.ts
+++ b/packages/framework-dashboard/components/prompt-editor/suggestion.ts
@@ -68,7 +68,13 @@ function makeRender(config: TriggerConfig) {
     // stray `<`/`@` in prose is not a trap. The plugin stays active — the menu reappears if
     // a later key matches.
     const note = items.length === 0 && !props.query ? config.emptyNote : undefined
-    if (el) el.style.display = items.length === 0 && !note ? 'none' : ''
+    const visible = items.length > 0 || !!note
+    if (el) el.style.display = visible ? '' : 'none'
+    // aria-expanded tracks what the user actually sees, not the plugin's active range: a
+    // mistyped query hides the menu while the plugin stays armed, and both the a11y tree and
+    // the editor's Enter-to-send guard (#1510) read this attribute as "a menu is open".
+    editorDom?.setAttribute('aria-expanded', visible ? 'true' : 'false')
+    if (!visible) setActive(null)
     root?.render(
       createElement(SuggestionList, {
         items,
@@ -95,7 +101,6 @@ function makeRender(config: TriggerConfig) {
       root = createRoot(el)
       getRect = props.clientRect ?? null
       editorDom = props.editor?.view.dom ?? null
-      editorDom?.setAttribute('aria-expanded', 'true')
       reposition()
       draw(props)
       // Capture-phase scroll catches the editor's own scroll container, not just the window.


### PR DESCRIPTION
## What

Plain **Enter** now submits the composer, matching Claude Code web (#1510); **Shift+Enter** stays a line break, and **Cmd/Ctrl+Enter** keeps working everywhere it did.

Enter steps aside where it already means something at the caret:

- an **open suggestion menu** (`/` `<` `@` `#`) — Enter picks the highlighted item, as before
- a **code block** — Enter types a newline
- an **IME composition** — confirming a composition never sends

## How

The direct `editorProps.handleKeyDown` outranks the suggestion plugins' handlers, so it can't just grab Enter — it checks the editor's `aria-expanded` before submitting. That attribute (set by the suggestion popup) now tracks the menu's **actual visibility** rather than the plugin's active range: a non-matching query hides the menu but used to leave `aria-expanded="true"` behind, which both lied to the a11y tree and would have swallowed Enter. `draw()` now owns the attribute and clears `aria-activedescendant` when the menu hides.

One change covers every composer surface (launcher, in-session, compact navbar) — they all render `PromptEditor`. The submit button's tooltip hint updates from `(⌘↵ / Ctrl+Enter)` to `(Enter · Shift+Enter for a new line)`.

## Tests

New `PromptEditor.test.tsx` mounts the **real** Tiptap editor (the existing Composer tests mock it, so the keyboard seam itself was uncovered): plain Enter submits; Shift/Alt+Enter don't; Cmd/Ctrl+Enter still do; Enter is left alone while `aria-expanded="true"`; Enter during IME composition doesn't send.

Full dashboard suite: **82 files / 801 tests passing**, typecheck clean.

Worth a quick manual pass on the menu flow (type `/`, Enter picks — doesn't send) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)