### PR TITLE
Install SDD: SPEC.md beside every subsystem carrying business logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,2 +1,3 @@
 - The project isn't released, it has zero users
   - Thus, breaking changes aren't a problem, so prefer clean code over breaking changes
+- Before writing SPEC.md files, read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,48 @@
+Autonomous AI programming: humans make the important decisions while The Framework runs coding agents unattended — planning its own work, spending idle subscription quota on the roadmap, and handing everything off as pull requests for review.
+
+## TLDR
+
+- The product is a local daemon plus a dashboard: you register your repos, and from then on coding agents (Claude Code today, others behind the same seam) work on them in sessions that each get a throwaway copy of the repo and hand their result off as a pull request.
+- The human's job shrinks to decisions — answer the questions a session parks on, accept or reject proposed tickets, review PRs — while everything else the daemon does by itself when nobody is at the keyboard, as far as the account's quota allows.
+- The coding agent is a black box that keeps its own subscription login: The Framework prompts it, reads the resulting code and the turn's final message, and never micro-manages individual tool calls.
+- The product sits on two engines that also ship on their own: an orchestration layer (scope → build → review loops until production-grade) and an agent runtime (providers, tools, streaming).
+- The Framework develops itself: this repo's `tickets/` and `TODO_AGENTS.md` are its own roadmap and queue, worked by the very loops described here.
+
+## Flows
+
+How the pieces relate:
+
+```mermaid
+graph TD
+    ext["<b>chrome-extension</b><br/>bridges Claude cloud sessions<br/>back to the dashboard"]
+    dash["<b>framework-dashboard</b><br/>the UI — a pure projection of<br/>the files the daemon writes"]
+    product["<b>the-framework</b><br/>the product: CLI + daemon + session lifecycle,<br/>git handoff, autonomy, chat surfaces"]
+    autopilot["<b>ai-autopilot</b><br/>orchestration: bootstrap spine,<br/>review loops, supervisor"]
+    sdk["<b>ai-sdk</b><br/>agent runtime: providers,<br/>tools, streaming"]
+
+    dash --> product
+    ext --> product
+    product --> autopilot
+    autopilot --> sdk
+```
+
+One family, one rule: the arrows point one way and nothing depends "up". (`the-framework.ai` is the product's public website and sits outside the runtime.)
+
+- **A repo's life.** You register a repo once; from then on sessions work on it — started by you, by a routine, or by the daemon's own idle sweep — and every session that produced real work ends as a pull request for you to review.
+- **The human loop.** Whatever needs a person becomes a card or a notification: a question a session parked on, a proposed ticket, a PR to review. Answering steers the agent; everything else keeps moving without you.
+- **The autonomous loop.** When nobody is around, the daemon drains the confirmed-work queue, refills it by triaging and planning tickets, keeps CI green on the PRs it opened, and merges them once checks pass — all bounded by the account's own quota week.
+
+## Rationales
+
+- **Files are the seam.** A session appends its events to a log file; the daemon tails it and pushes to browsers; steering flows back through a control file the session tails. There is no direct process-to-process channel.
+- **The dashboard is a projection.** It never holds authoritative state; it renders what is on disk.
+- **The agent is a black box.** The Framework gates on code and outcomes, never on the agent's individual tool calls — and the agent keeps its own subscription login, so The Framework adds orchestration, not another AI bill.
+- **Every session runs on its own branch, in its own worktree.** The user's checkout is never the agent's workspace.
+- **The daemon writes to the project checkout, the agent does not.** And when it does, it commits only the exact files it means to — the user's in-progress work can never ride along.
+- **Spend the whole week's quota, never starve the user.** Unattended work stands down as spending catches up with the clock; work the user asks for always goes first.
+- **Proposals vs. decisions.** Agents propose (tickets, plans, PRs); humans decide. The queue holds only confirmed work.
+- **Refuse loudly, degrade quietly.** A guard that cannot be enforced is announced; a read that fails yields an empty result rather than a crash.
+
+## Before writing SPEC.md files
+
+Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/ai-autopilot/SPEC.md
+++ b/packages/ai-autopilot/SPEC.md
@@ -1,0 +1,36 @@
+The orchestration engine: how many agent runs are composed into one outcome — a bootstrap spine that takes an app from nothing to production-grade, review loops that gate on verdicts instead of vibes, and a supervisor that fans work out and synthesizes it back.
+
+## TLDR
+
+- This layer is policy, not mechanism: which agents run, in what order, how results combine, when to stop, under what budget — anything that is just "call the agent runtime" stays in the runtime.
+- The core conviction: don't trust a single pass — work is re-examined with fresh eyes against an explicit list of blockers, and only an empty list counts as done.
+- Everything long-running streams progress events and can be watched from a terminal, a UI, or a detached background handle — the same replayable stream, joinable late from any offset.
+
+## Flows
+
+- **Bootstrap** sequences four phases: **scope → build → loop → deploy**. Scope is the one and only interrogation — is this a prototype or the real thing, and what is it for. Build produces the app. The loop then repeats a production-grade checklist, fixing what it finds, until the checklist reports no blockers or the pass budget runs out. The checklist can be composed with a serve check that actually installs, boots, and fetches the app — so "production-grade" must both read true and demonstrably run. Deploy decides the app's shape (server-rendered, static, single-page) and hands execution to a target adapter (Cloudflare and Dokploy ship real ones; a plan-only target just narrates). Every phase is injectable, so the whole flow runs offline in tests.
+- **The verdict convention**: a review prompt ends its answer with a machine-readable list of blockers — empty means passing; non-empty is the concrete work still required.
+- **The loop** maps semantic events — "major change", "new UI flow" — to ordered chains of review prompts, each run for a configured number of fresh-context passes. By default a chain fires and reports; switched to gate mode, it stops hard at the first non-passing prompt.
+- **The decisions ledger** records settled choices and rejected ideas with their reasons, round-tripped to a human-editable markdown file. Agents consult it through tools and get a briefing of relevant decisions prepended to their prompts — a convention the prompts follow, not a hard gate.
+- **Scale mode** keeps a code-overview map current for large repos, refreshing it only on a *material* change — build or test tooling changed, a restructuring, a change sweeping many files across several areas — never on every edit.
+- **Framework detection** scores a project's dependencies and files against presets, and always falls back to the flagship preset so a run is never without one.
+- **Domain presets** bundle the loops and prompts a domain works under (software development, web development, data science, …) as one selectable, composable unit — authored in code or loaded from a folder of markdown files, with variants picked by declared conditions, most specific eligible one winning. The shipped presets and prompt bodies are data, editable without touching the engine.
+- **The supervisor** is the fan-out topology: a planner decomposes the task (capped, so a runaway plan is trimmed), workers run subtasks concurrently under a bounded pool and an optional token budget, one worker's failure never takes down the batch, and a synthesizer combines the results.
+- **The runner** is the pluggable workspace where an app gets built and run: in-memory fake, the local machine, a container, or an in-browser sandbox — with tools exposing a booted workspace to an agent, and escapes from the workspace root blocked. The ledger and the overview persist inside a sandboxed workspace exactly as they do on a real disk.
+
+## Rationales
+
+- Each review pass gets a fresh agent with no context carried over — fresh eyes are the whole point of re-examination.
+- Scope is the only phase allowed to stop and ask; letting every phase interrogate the human would defeat unattended operation.
+- An exhausted pass budget is recorded as stopped-early, not passed — running out of retries is not the same as being done.
+- Loops gate on *what the review concluded*, never on whether the prompt merely ran.
+- A workspace that cannot run background processes skips the serve-check boot with a note rather than blocking forever.
+- The loop is event-driven quality, not run-everything-on-every-change.
+- The decisions ledger exists so a later run stops re-pitching what was already turned down.
+- Scale mode refreshes only on material change because a stale map is worse than none.
+- In framework detection, dependencies weigh double — files lie more; and a new framework is a new preset, not a fork in the engine.
+- A supervisor worker that pauses mid-run to ask counts as failed — there is no durable resume at this layer yet.
+
+## Before writing SPEC.md files
+
+Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/ai-sdk/SPEC.md
+++ b/packages/ai-sdk/SPEC.md
@@ -1,0 +1,32 @@
+The agent runtime: define an agent once — model, instructions, tools, guardrails — and run it against any of a dozen AI providers, with streaming, memory, sub-agents, and human-in-the-loop pauses built in.
+
+## TLDR
+
+- An agent runs as a loop — ask the model, execute the tools it called, feed the results back, repeat — until a stop condition fires or the step budget runs out, with middleware and hooks observing or adjusting every step.
+- Providers are interchangeable behind one contract per capability — chat, embeddings, reranking, image generation, speech in and out, file storage, vector stores — resolved by plain `provider/model` names.
+- Humans stay in the loop where it matters: a tool can pause the run to be resolved in the browser, a risky call can pause for approval, and both resume the same logical run.
+- Any agent can be handed control outright, or mounted as a tool inside another agent — including suspendable sub-agents resumed later, alone or in batches.
+- The package trusts nothing external by default: persistence is a set of neutral contracts with in-memory defaults, and a full fake provider stands in for every capability.
+
+## Flows
+
+- **Talking to a model.** Messages carry text, images, and documents; audio is its own surface (speech-to-text in, text-to-speech out), as is image generation — each with failover and optional storage of what was produced. Responses stream over the package's own wire protocol or over the Vercel AI SDK's, for UIs already speaking it. If the model fails, the loop fails over to the declared alternates and remembers that it did. Declaring an agent cacheable turns into each provider's native prompt caching. Provider-hosted tools — web search, web fetch, code execution — are used natively where the provider has them and emulated where it doesn't.
+- **Tools.** Tools declare typed inputs that are validated before the handler runs. A family of capabilities can be collapsed into one flat tool. Structured output is a helper the caller composes: instructions in, validated parse out.
+- **Remembering.** An agent opted into memory extracts durable facts from each turn and injects the relevant ones into the next, per user. A conversational agent loads its history before every prompt and appends after, so callers just keep prompting.
+- **Finding things.** Retrieval is either the provider's own hosted file search (with a local fallback to configure for providers that have none) or a direct similarity search over the application's own data — embed the query, return the top matches, optionally reranked; embeddings are cached.
+- **Spending.** A budget is enforced per period as middleware around every step: an estimate is debited before the model call and trued up after, against a maintained price catalog. Queue-backed jobs stream their progress through neutral queue contracts; durability belongs to the host application.
+- **Proving it works.** Eval suites run cases with assertions — exact and fuzzy matching, shape checks, an LLM judge, token-cost bounds — with recorded fixtures for replay and reports for humans and machines.
+- **Reaching the real world.** Computer use gives an agent a real browser to drive (the provider's native computer-use capability; one provider supports it today). React bindings drive a run from a component, surfacing pending client tools and approvals while the run stays logically "running" — the state machine underneath is framework-free.
+
+## Rationales
+
+- Both ends of the streaming wire protocol ship in the package — server and browser — so the vocabulary can't drift.
+- Collapsing a tool family into one flat tool exists so small models see one call instead of many.
+- Structured output throws on mismatch and nothing retries automatically — retrying is the caller's decision to make.
+- The budget debits an estimate before the call and trues up after, because the real cost is only known once the response exists.
+- Evals run against the very same agent instances the application uses — testing a copy would prove nothing.
+- In-memory persistence defaults and the full fake provider exist so applications test without spending a token.
+
+## Before writing SPEC.md files
+
+Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/chrome-extension/SPEC.md
+++ b/packages/chrome-extension/SPEC.md
@@ -1,0 +1,22 @@
+The Claude web bridge: a Chrome extension inside the user's own claude.ai tab that carries a cloud session's parked question home to the local dashboard, and types the picked answer back into the session's composer.
+
+## TLDR
+
+- A cloud run hands off and ends, so when the session later asks something there is nothing streaming back — the question is stranded on claude.ai; this extension watches the signed-in session page and reports the question to the daemon.
+- The answer travels the other way: pick an option in the dashboard, confirm the send, and the extension types that label into the session's composer and submits it.
+- The extension only ever types a label the session itself offered, the pick has to be confirmed in the dashboard, and a queued pick can be withdrawn until the extension collects it.
+
+## Flows
+
+- **Question out**: the page script spots the parked question in the session page and hands it to the background worker, which posts it to the daemon's bridge; the dashboard shows it as an answerable card within seconds.
+- **Answer back**: the worker polls the daemon for a confirmed pick, delivers it to the page script to type and submit, and acknowledges the delivery so it is never typed twice.
+
+## Rationales
+
+- The daemon's token lives in the background worker, never in the page — a page script shares the tab with claude.ai, and nothing on that page should be able to read the secret that talks to a daemon.
+- The daemon deliberately answers no cross-origin headers (a wildcard would let any site you visit post to your dashboard), so the fetch must come from the worker, which isn't subject to that restriction.
+- The page is watched rather than polled, because Chrome slows timers in long-hidden tabs and the bridge is meant to run from a pinned background tab; the slow interval is only a backstop.
+
+## Before writing SPEC.md files
+
+Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/framework-dashboard/SPEC.md
+++ b/packages/framework-dashboard/SPEC.md
@@ -1,0 +1,29 @@
+The dashboard UI: a browser app served by the daemon that renders everything the daemon knows and steers sessions through it — holding no authoritative state of its own.
+
+## TLDR
+
+- Every read is a projection of state the daemon assembles (session logs, tickets, the queue, git and GitHub state, preferences); every write is a call into the daemon.
+- The URL is the selection: the overview at `/`, a project at `/{projectId}`, one session at `/{projectId}/{sessionId}`, plus cross-project tickets, a per-ticket page and its plan page, and settings.
+- A session's events stream live over one channel bound to that session's own log; everything else polls, and a finished session reads from the archive instead.
+- Watch mode: opened against a shared relay link, the same app renders one session read-only.
+
+## Flows
+
+- **The overview** is ordered by what governs what: the quota bar first (a week-track with pace and projection — the one figure that decides what agents may do next), then everything that needs *you* — the open-questions hub, every session's unanswered question across all projects, answerable right there in one scrolling view — then the agents working now, the full AI queue of every project, routine work, and the hottest tickets. An onboarding checklist sits on top until dismissed; each step's "done" is derived from a real fact (a registered project, a ticket on disk, a granted permission, stored credentials).
+- **The composer** starts and steers sessions. Typing a prompt starts an attended build session; picking a preset starts an unattended one. In-editor triggers pull in presets and actions, files, projects, and macro tags; option menus write straight to the user's or project's preferences. Pre-flight checks warn before the session is spent — a missing or logged-out GitHub CLI, a repo that can't auto-merge. Inside a session, the composer is the session control: a live session takes messages, a stopped one offers to resume with reduced options, and the submit slot doubles as Stop while the agent works.
+- **The session view** is a transcript with the controls inline: the agent's questions render as answerable cards exactly where they happened (resolved ones collapse to a checkmark), and the session's live browser screencast renders inline too, degrading to a last still when the session ends. Around the transcript: changed files with diffs, git status, the handoff panel (push, open PR, merge), agent-authored views, docs, and history rails, and an actions menu (stop, serve/preview, open in editor or on GitHub, remove worktree, delete session, copy a resume command, copy a shareable watch link).
+- **Tickets** are the roadmap surface: a cross-project list with client-side faceted filtering (text, priority/effort/uncertainty buckets or ranges, topics, planning stage, project), sorting, and a group-by-project toggle — the whole view mirrored to the URL so it can be shared. Each ticket row leads with a start button that spins up an unattended agent implementing that one ticket, and shows whether a plan exists: a link to a page rendering the plan when it does, a button that starts a session to write one when it doesn't. Queueing a ticket into the AI queue happens from the ticket's own page.
+- **Settings** covers appearance, agent and model defaults, run options, saved devices, eco mode, notification channels, automation (the idle sweep and the spend slider), and the cloud-session bridge token.
+
+## Rationales
+
+- The URL being the selection means a session is a link you can paste, reload, and bookmark — there is no selection state to disagree with the address bar.
+- The one exception to "the daemon holds everything" is saved remote devices: their access tokens stay in this browser only, handed to the daemon per call.
+- A finished session's live channel is replaced by the archive, catching up whenever the live channel outgrew it — so a watcher never misses the ending.
+- Onboarding steps derive "done" from real facts so a step cannot be ticked by clicking it, and work done outside the dashboard shows up ticked anyway.
+- The overview's AI queue renders uncollapsed: a plan you cannot read is not a plan.
+- Composer options are baked at spawn and hidden for a live session — changing them mid-run would promise what the running agent never heard.
+
+## Before writing SPEC.md files
+
+Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework.ai/SPEC.md
+++ b/packages/the-framework.ai/SPEC.md
@@ -1,0 +1,5 @@
+The product's public website ([the-framework.ai](https://the-framework.ai)): a landing page that tells the product's story, plus a go-to-dashboard page that hands visitors the install command and sends them on to their locally running dashboard.
+
+## Before writing SPEC.md files
+
+Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/SPEC.md
+++ b/packages/the-framework/SPEC.md
@@ -1,0 +1,85 @@
+The product: turnkey AI orchestration that wraps a coding-agent CLI (Claude Code today) as a black box and takes an idea, a ticket, or a queue entry to a reviewed pull request — a CLI, a per-machine daemon, and a localhost dashboard over sessions that run unattended.
+
+## TLDR
+
+- One daemon per machine: running the CLI in any registered repo finds it, and it serves the dashboard, spawns sessions, and runs the background services (autonomy sweeps, notifications, chat, CI watch).
+- A session is one agent working one task in its own git worktree on its own branch, streaming what it does as events; the human can watch, answer its questions, and chat with it live — or not be there at all.
+- A session that ends with real work is pushed and opened as a PR; empty sessions publish nothing, and no PR number is ever stored — every surface re-resolves the PR live from the session's branch.
+- When nobody is around, the daemon plays product manager: it drains the confirmed-task queue, refills it by triaging and planning tickets, keeps CI green on the PRs it opened, and merges them once checks pass — bounded by the account's own quota week.
+- The agent stays swappable behind a driver seam and keeps its own subscription auth; The Framework never runs its own model calls for the coding work.
+
+## Flows
+
+A session, from start to merge:
+
+```mermaid
+flowchart TD
+    Trigger["Composer / routine / queue play button / CLI"] --> Workspace["Own git worktree,<br/>own branch"]
+    Workspace --> Drive["Driver runs the agent<br/>turn by turn"]
+    Drive --> Kind{Build task or<br/>direct prompt?}
+    Kind -->|build| Build["scope → build → production-grade<br/>checklist → improve, until no blockers"]
+    Kind -->|research/review| Prompt["one prompt, honoring gates"]
+    Build --> Parse["Parse each turn's final message<br/>(name, views, gates, ready-for-merge)"]
+    Prompt --> Parse
+    Parse --> Gates["Await gates & live chat"]
+    Gates -->|answer| Parse
+    Parse --> Backlog["Drain the session's own backlog,<br/>one entry per turn"]
+    Backlog --> Settle["Settle: quality hook → handoff → archive"]
+    Settle --> Handoff["Commit → push → open PR<br/>(empty sessions skip)"]
+    Handoff --> Teardown["Teardown & retention"]
+```
+
+- **Setup.** Activating a repo commits any dirty state first, creates the `.the-framework/` state directory, seeds the project log, teaches `.gitignore` which parts stay untracked, and registers the project in a per-machine registry in the user's home — the same registry that holds the user's dashboard preferences (project settings override user settings, only for keys a project may override) and the daemon's secrets. Optionally the daemon scans one designated directory on boot and auto-registers every git repo in it.
+- **Preflight.** Before a session spawns anything, a preflight probes the agent CLI the session actually picked, so a missing prerequisite fails early and clearly.
+- **Start.** A session starts from the dashboard composer, a routine's "Run now", a queue entry's play button, onboarding, or the CLI; the daemon resolves the project, allocates the workspace, guards against a busy project, and spawns the session as a detached process. A session aimed at a saved remote device is relayed to that device's daemon instead; a "topic" session (no project yet) starts in a neutral scratch directory and re-homes into a project once the conversation binds one.
+- **Workspace.** Every session gets its own git worktree on its own branch; dependency directories are shared from the parent checkout instead of reinstalled. A non-git project falls back to the main checkout, one session at a time.
+- **Driving the agent.** The driver runs each agent turn as a black box to completion; everything The Framework learns from a turn, it learns by parsing the turn's final message — the session name the agent invented (the branch is renamed to match), agent-authored views for the dashboard, the ready-for-merge signal, and blocking gates. The protocol for these signals is appended to the system prompt at runtime.
+- **Build vs. direct prompt.** A build task runs the full spine — scope, build, then a production-grade checklist repeated against its list of blockers until none remain, optionally including actually booting the app to prove it serves. A research- or review-shaped task runs as one prompt that honors gates, with no build scaffolding. A hands-off target (a cloud session) drops every phase after the work is dispatched.
+- **Gates and chat.** When the agent stops to ask, the session parks and the question becomes a card: choices in the dashboard, a message on Discord, a notification. The answer travels back over the session's control file and the agent continues from it. The human can also speak unprompted; each message continues the same agent conversation, and an idle attended session stays open waiting for the next one. Unattended sessions disable gates entirely and end when the work does.
+- **The session's own backlog.** Once the main work settles, the session drains the queue file one entry per turn — read, complete exactly one entry, check it off, repeat — with a per-entry gate that autopilot auto-accepts.
+- **Settle and handoff.** Settling is strictly ordered: a final quality turn (which queues the quality presets as backlog entries rather than running them, and folds new learnings into the project docs) → the git handoff → close and archive the session history. The handoff runs only on the success path and first decides whether the session is *empty* — no commits, or only bookkeeping files changed; empty sessions are never published, otherwise pending work is committed, the branch pushed, and a PR opened.
+- **Teardown and retention.** A session that finished cleanly has its worktree removed; one that failed or was stopped keeps its checkout. The branch and the archived session history always survive the worktree. A session that died on a transient error (connection drop, rate limit) is retried in the same worktree before being declared failed, and a finished session can be reopened later — its history restored so it continues as the same conversation. Acting on a session the instant it finishes is safe: everything that touches that session's checkout takes its turn rather than racing, so a click that lands mid-teardown (a resume included) waits a beat instead of failing.
+- **The queue.** The repo-root queue file (`TODO_AGENTS.md`) is the durable, priority-ordered list of confirmed work — written directly by sessions, unlike a *ticket*, which is a proposal for a human to accept. The daemon promotes a session's queue edits back into the project checkout, committing only that one file, and skipping with a stated reason whenever anything looks unexpected. An entry stays claimed while its session is live or its PR is open.
+- **The idle sweep.** On a timer, per project, the daemon asks one policy question — "is now a good time to spend quota on our own roadmap?" — checking the cheapest facts first: feature on? concurrency free? cooldown elapsed? queue readable? quota headroom left? Then: a non-empty queue is drained one entry per session; an empty queue is refilled by rotating through quick triage → consensual triage → ticket planning. Ticket planning fans out several agents, each pinned to exactly one ticket and claimed via a lock file beside the ticket on the default branch. A calendar-paced maintenance sweep (review the commits each repo grew since its last review) sits outside the rotation and takes precedence when due.
+- **Merging and CI watch.** Configuration only *arms* auto-merge; what *authorizes* it is the agent's own ready-for-merge signal plus an empty session backlog, and an armed-but-unauthorized merge is recorded as withheld, with the reason. The daemon polls the PRs the framework is waiting to land: green checks on an armed PR merge it — merge-on-green works even where GitHub's native auto-merge is off; red checks start one unattended fix session per failing head commit, told to land the fix on the PR's own branch, and after two failed attempts a human keeps it. Housekeeping sweeps retire what has landed: worktrees whose branch merged are removed, and a pinned routine branch left behind by a closed PR is released so the routine can fire again.
+- **Spending limits.** The whole quota policy is one line: unattended work may spend up to the pro-rated share of the account's week that has elapsed, rising continuously with the clock — nothing to configure, the week is read from the account itself. A slider moves that stand-down line either side of the boundary, and it is re-read live, so raising it unparks a waiting session without a restart. Inside a run, a consumption guard polls the account and aborts the session when the limit is crossed.
+- **Dashboard serving.** The daemon serves the dashboard and answers all its reads from the files sessions write. For a saved remote device, the local daemon — never the browser — talks to the device's daemon and streams its events back over the local origin.
+- **Sharing.** A hosted relay ingests a session's event stream and re-serves the same dashboard read-only to anyone with the URL, so two people on different machines watch one session live.
+- **Elsewhere targets.** A session can run on a Claude cloud session (fire-and-forget: it opens its own PR and the local run ends with the link) or on GitHub Actions (dispatch, poll, read back the uploaded transcript; continuity between turns is the branch the previous turn pushed). A browser extension inside the user's own claude.ai tab bridges cloud sessions back: a question a cloud run parks on becomes a dashboard card, and the picked answer travels back for the extension to deliver.
+- **The browser.** A session can launch a real Chrome that both the agent and a watching human attach to at once: the dashboard shows a live screencast and forwards clicks and keys, and when the agent hits a login wall, captcha, or 2FA it parks on a gate and hands the browser to the human — the agent never types a password.
+- **App preview.** One click boots the project's app (its dev script when it has one, else a static server) to *show* it — the decoupled twin of the serve check, which boots it to *verify* it. A session can preview its own worktree; the preview stops before that worktree is removed.
+- **Discord.** Outbound, two notification watchers — session activity, and what needs a human — each posting only *new* items to a webhook. Inbound, a chatbot: a channel message answers a parked question, steers a live session, or starts one, through the same control channel a dashboard click uses; a reply mirror posts the session's answers back to the channel that asked.
+- **What lands in git.** Conversations (each session's human turns and agent replies, one file per session); session history (finished sessions archived under a per-user directory); tickets (`tickets/<DATE>_<SLUG>.md`, the human-facing roadmap, with optional plan and claim siblings, parsed tolerantly); the queue file; and a human-readable project log of what The Framework did.
+- **Prompts and presets.** One assembly path composes the system prompt for every session — the built-in protocol, the extra protocol each of the session's capabilities brings, the user's own system file, and the picked context — and the exact composed text is recorded, so the dashboard can show precisely what the agent ran under. Modes dial the wrapping down: *vanilla* drops the built-in enhanced prompt while keeping the framework integration; *transparent* is the master off-switch — no framework channel at all; *eco* trims the prompt's automatic behaviors one by one. Presets (triage, research, security audit, drain-the-queue, …) are one catalog with prompt text authored as prose; custom presets save to either the user tier (follows the person, private) or the project tier (travels with the repo, shared). A per-repo config file records which domain preset and modes a project builds under, resolved layer over layer so a project overrides only what it actually sets.
+
+## Rationales
+
+- Activation commits dirty state first so the activation commit itself is clean.
+- A guard the picked agent cannot honor (e.g. a cost cap on an agent that reports no price) is announced rather than silently ignored.
+- A git project whose worktree creation failed does **not** fall back to the main checkout — the session fails, because a failed session is recoverable and a checkout with stray agent edits is not.
+- Sharing dependency directories from the parent checkout makes workspaces instant and costs no extra disk.
+- Unattended sessions disable gates because nobody is there to answer.
+- A hands-off target drops every phase after dispatch because there is nothing to read back — and the driver flags itself hands-off so later phases don't mistake its own summary for the agent's answer.
+- Empty sessions are never published; both handoff halves default on — that is the zero-config promise: a session left alone publishes itself. They form a ladder, not a pair: pushing is the rung under the PR, so turning push off publishes nothing, and "PR without push" is not a state a session can be asked for.
+- A failed or stopped session keeps its worktree because that is exactly when you want to inspect the half-finished tree.
+- No PR number is ever stored; every surface re-resolves the PR live from the session's branch, so state can never disagree with GitHub.
+- The queue must be promoted back to the project checkout because sessions run in worktrees — their queue edits would land on a branch nobody reads.
+- Claimed queue entries keep parallel drains from double-assigning work.
+- Ticket claims live in lock files beside the ticket on the default branch so agents on other machines and cloud sessions see the claim too.
+- Every autonomy refusal is phrased as a reason, so a setting never reads as a bug.
+- Arming and authorizing a merge are separate on purpose: configuration can only ever *allow* a merge, and the agent's own ready-for-merge signal is what makes it happen — a withheld merge records why.
+- After two failed CI-fix attempts the failure is evidently not agent-shaped, so a human keeps it.
+- Two properties fall out of the pro-rated quota boundary: nothing is left on the floor (the boundary reaches the full allowance exactly as the week resets), and background work cannot starve the user (their work borrows against days to come).
+- For work the user asked for, the spend slider only ever *loosens* the gate — the user outranks their own safety margin.
+- The two quota gates fail in opposite directions on purpose: no readable quota means unattended work does not start, while user-requested work carries on — with the per-session cost cap still underneath it.
+- Quota reads are expensive (they spawn the whole agent CLI), so polling is deliberately slow — the boundary moves over days.
+- Non-local dashboard binds demand a shared token, because a daemon that spawns processes on a reachable port is remote code execution.
+- A remote device's token is saved only in the user's own browser and handed to the local daemon per call, never persisted by it.
+- The browser proxy takes the session's port from the session's own record, never from the client, so the proxy cannot be aimed at anything else.
+- Conversations land one file per session because concurrent sessions would conflict on a shared file — and they are deliberately not the verbose tool-call transcript: what lands is what a person would reread.
+- The daemon commits main-checkout conversations only after an idle window, only the conversation files, never the user's in-progress work — and skips entirely while someone else is mid-rebase or holds the index.
+- Tickets are parsed tolerantly so imported tickets that predate the format still list.
+
+## Before writing SPEC.md files
+
+Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/src/dashboard-rpc/SPEC.md
+++ b/packages/the-framework/src/dashboard-rpc/SPEC.md
@@ -1,0 +1,23 @@
+The browser's call surface into the daemon: every dashboard read and write arrives here, and steering a session means appending a command to that session's own control file — the same append no matter who asked (dashboard click, Discord message, or remote device).
+
+## TLDR
+
+- Reads are thin projections of the daemon's read models; live session events stream over one channel per session, tailing that session's own log.
+- Writes are commands: stop, answer a choice, send a message, arm the handoff, push, open PR, merge, start a session, queue a ticket — each becomes an entry in the target session's control file, which the session tails.
+- Two routing decisions live here and nowhere else: which checkout a session-scoped call resolves to (the session's worktree vs. the project root), and whether a call is local or belongs to a relayed session on a remote device — in which case it is forwarded.
+
+## Flows
+
+- **A read**: project the daemon's read models to the browser, nothing more.
+- **A live session stream**: one channel per session tails that session's log; when the log is archived out from under it at teardown, the stream follows it into the archive and delivers exactly what it had not yet shown — once.
+- **A write**: append the command to the target session's control file and let the session pick it up.
+- **A relayed call**: recognized as belonging to a remote device's session and forwarded to that device's daemon, against a deliberate allowlist on the device side.
+
+## Rationales
+
+- Commands travel through the control file because there is no direct channel into the running process — a session can be steered identically whether it is local, remote, or watched from Discord.
+- The stream following the archived log is what guarantees a watcher never misses a session's ending.
+
+## Before writing SPEC.md files
+
+Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/src/dashboard/SPEC.md
+++ b/packages/the-framework/src/dashboard/SPEC.md
@@ -1,0 +1,30 @@
+The daemon's serving and projection layer: the HTTP host behind the dashboard, the read models it assembles from disk and git, the git handoff (push → PR → merge), and the notification watchers.
+
+## TLDR
+
+- Everything the dashboard shows is assembled here from what is already on disk — session logs, tickets, the queue, git state, GitHub state — and whatever fails to read yields an empty result, never a crash at the view.
+- Serving is guarded by where the daemon is bound: on localhost, browser calls must come from the dashboard's own origin; on a reachable address, everything demands a shared token.
+- Expensive questions (GitHub ones cost hundreds of times a git read) go through a cache that asks once for all concurrent callers and serves the last good answer while refreshing.
+
+## Flows
+
+- **The handoff.** When a session settles cleanly, decide whether it is empty (no commits, or only bookkeeping changes) — empty sessions are never published. Otherwise commit what the agent left uncommitted, push the branch, open the PR. Every surface re-resolves the PR live from the session's recorded branch (falling back to the session-name and run-id branches), preferring an open PR.
+- **Merging.** Configuration arms auto-merge; only the agent's ready-for-merge signal plus an empty session backlog authorizes it, and an armed-but-unauthorized merge is recorded as withheld, with the reason. On a repo without native auto-merge the PR is handed to the CI watch to merge once checks pass, and the merge outcome lands on the session so every surface can say what happened.
+- **Watchers.** Two Discord notification watchers — activity (sessions started and finished) and interventions (an open PR to review, a session parked on a question, a finished session whose commits were never pushed) — each remembering what it already announced, so only new items post. The open-questions hub gathers every parked question across all sessions, with its full options read back from each session's own log.
+- **Remote devices.** The local daemon — never the browser — talks to a saved device's daemon: it starts the session there and streams the events back over the browser's normal same-origin channel; session-scoped calls are forwarded the same way. An unreachable device answers like any failed local read: empty.
+- **The cloud-session bridge.** A browser extension inside the user's own claude.ai tab posts parked questions in; picked answers queue back out for the extension to type into the cloud composer.
+- **The live browser.** The dashboard cannot reach a session's Chrome directly (wrong origin), so the daemon proxies the screencast and the clicks.
+
+## Rationales
+
+- A daemon that spawns processes on an open port is remote code execution — that is why a non-local bind demands the token.
+- The GitHub cache answers "pending" — not "failed" — when a cold ask exceeds its time budget, so a caller that must not act on a half-answer can hold off; a failure never overwrites the last good value.
+- No PR number is ever stored, and a closed PR is accepted only if it was created after the session started — so a reused routine branch can't wear an old merged PR.
+- A watcher's first look only takes a baseline, and the cursor keeps advancing while notifications are off: turning them on starts from now instead of flushing a backlog.
+- The device side of remote forwarding accepts only an allowlisted set of calls — reads and steering; starting and deleting are deliberately not remotable this way.
+- The bridge payload is tiny and fully validated — no paths, no commands, no free text — so the worst a stolen token buys is a bogus question card.
+- The browser proxy takes the session's port from the session's own record, never from the client, which is what keeps the proxy from being an open relay into anything else on the machine.
+
+## Before writing SPEC.md files
+
+Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/src/discord/SPEC.md
+++ b/packages/the-framework/src/discord/SPEC.md
@@ -1,0 +1,22 @@
+Discord as a chat surface for sessions: read messages from a channel, act on them exactly as a dashboard click would, and mirror the session's answers back.
+
+## TLDR
+
+- Inbound: a minimal hand-rolled Discord gateway client feeds pure routing rules — given a message and a snapshot of the project's state, decide what it means: answer the parked question (by option number or label), send the session a message, start a session, stop one, or just reply.
+- Outbound (the reply mirror): a session's answers are posted back to the channel that asked.
+- Accepted MVP limit: chat models one live session per project and always routes to the newest.
+
+## Flows
+
+- **A channel message arrives**: the routing rules pick an action, and it goes through the same control channel as a dashboard click, so the session can't tell the difference.
+- **A session answers**: the reply mirror posts the settled text back to the recorded channel, advancing a cursor so nothing posts twice.
+
+## Rationales
+
+- The mirror's source is the committed conversation — the settled text a person actually read — not the raw event log.
+- The mirrored channel is a recorded binding, not a guess; the baseline is taken at bind time so no backlog is ever replayed into a channel; the cursor advances even while the bot is off; and a binding that stops resolving is eventually released.
+- The chatbot and the notification watchers deliberately use separate transports — bot-token API vs. plain webhook — so notifications work without a bot, and the bot works without webhooks.
+
+## Before writing SPEC.md files
+
+Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/src/driver/SPEC.md
+++ b/packages/the-framework/src/driver/SPEC.md
@@ -1,0 +1,29 @@
+The driver seam: the one abstraction a coding agent is wrapped behind, so the whole product works the same whether the work happens in a local Claude Code or Codex process, a Claude cloud session, a GitHub Actions job, or a deterministic fake.
+
+## TLDR
+
+- A driver can start a session, prompt it turn by turn, read the resulting code, report the account's quota, and dispose — that is the entire contract, deliberately *the code and the outcome*, never the agent's inner workings.
+- Each turn runs to completion as a black box; a turn whose process exits abnormally fails, even if it streamed plausible text first.
+- Every child process is its own process group and a registry kills whole groups, so an interrupted session cannot orphan a tree of helpers.
+
+## Flows
+
+- **Local agents.** Claude Code runs with edits auto-accepted by default; skipping its permission system entirely is an explicit opt-in. Codex runs inside its own workspace-write sandbox and the bypass flag is never passed. Extra MCP servers (e.g. the browser tools) are merged alongside the user's own, never replacing them.
+- **Hands-off targets.** A cloud session is handed the task once and the run ends with the link: there is nothing to read back, and the driver flags itself hands-off so later phases don't mistake its own summary for the agent's answer. A GitHub Actions run is dispatched, polled, and read back from the transcript the workflow uploads; continuity between turns is the branch the previous turn pushed plus the carried session id.
+- **Quota and cost.** Drivers that can, report the account's quota window — read via the agent's own usage command, and cheaply between turns from the rate-limit telemetry the stream already carries. A failed read is classified: a transient failure (network, timeout) leaves the last good reading in force, while "the agent isn't installed / has no subscription" invalidates it.
+- **The fake.** A scripted, offline driver that exercises every path deterministically — the product's whole lifecycle is testable without spending a token.
+
+## Rationales
+
+- Tool calls surface only as named actions for the watching human; their arguments are never seen and never branched on — that is what keeps the agent a black box.
+- An abnormal exit fails the turn even after plausible text because the product gates on outcomes, and a crash mid-work must not pass as a result.
+- The agent's session id is captured from the first thing it says, not from the end of the turn, so a stopped or killed turn cannot take the resume handle with it.
+- A resume that fails because the agent forgot the session silently reruns as a fresh conversation, with a notice, rather than losing the message the user already sent.
+- A graceful stop escalates to a hard kill only after a grace period.
+- The task is handed to a cloud session exactly once per session, so one run can never fan out into several cloud sessions racing on one repo.
+- The GitHub Actions driver requires a real user's token — it refuses bot-triggered agent runs.
+- A driver that cannot price turns reports cost as unknown — never zero — so the budget cap simply cannot fire rather than counting everything as free.
+
+## Before writing SPEC.md files
+
+Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/src/store/SPEC.md
+++ b/packages/the-framework/src/store/SPEC.md
@@ -1,0 +1,29 @@
+Session persistence and workspaces: the append-only event log every surface is a projection of, and the per-session git worktrees the agents work in.
+
+## TLDR
+
+- Persisting *is* logging: a session's history is the events it appended, and everything else — status, name, branch, outcomes — is folded from that log into a small snapshot for cheap list reads.
+- A session that crashed without saying goodbye is healed on the next boot: the missing end is synthesized, so no session stays "running" forever.
+- Finished sessions are archived into the repo under a per-user directory, and live state beats the archive when both exist.
+- Each session works in its own worktree on its own branch, with the parent checkout's dependency directories linked in instead of reinstalled.
+- A daemon shutting down writes down which sessions were mid-flight so they can be offered for resume on the next boot.
+
+## Flows
+
+- **Persist by appending.** Every surface reads projections of the session's own event log; a restarted dashboard rehydrates by replaying it.
+- **Heal on boot.** For a session with no recorded end, check whether its process is genuinely dead before synthesizing the missing end.
+- **Archive on finish.** A finished session's history moves into the repo under a directory keyed by the user's configured git identity, visible to the whole team.
+- **Workspace per session.** Create a worktree on a fresh branch, rename the branch once the agent picks a session name, link in the parent checkout's dependency directories, and hide the links from git.
+- **Shutdown bookkeeping.** Mid-flight sessions are recorded at shutdown and offered for resume on the next boot — but only for a day.
+
+## Rationales
+
+- Folding status from the log instead of storing it separately means there is no second source of truth to drift.
+- Sessions archive into the repo because the live state directory is untracked and an ordinary `git clean` used to erase a project's entire history.
+- The archive is per-user (keyed by the git identity already configured) so two people on one repo sit side by side instead of conflicting — every user's archive being visible to the whole team is the point, not a leak.
+- Dependency links are hidden from git so an agent's sweeping commit can't drag them onto the PR.
+- Resume offers expire after a day; past that, a "resume?" would be more confusing than helpful.
+
+## Before writing SPEC.md files
+
+Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md


### PR DESCRIPTION
Installs https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md, per its own Install section:

1. **Generate `SPEC.md` files** — the repo had none left after the old-format wipe (e871aad). Twelve files: root, each package, and the main package's five subsystems (`driver`, `store`, `dashboard`, `dashboard-rpc`, `discord`), all in the new format — one-sentence description, `TLDR` / `Flows` / `Rationales`, and the mandatory `## Before writing SPEC.md files` closer.
2. **`AGENTS.md`** now tells agents to read the SDD format before writing SPEC.md files.

What went into the content:

- The story carries over from the wiped `spec.md` files (they were maintained until Aug 10, so drift was small), restructured into the new format's split: *Flows* say what happens, *Rationales* hold the non-obvious whys that were previously woven into the prose.
- Refreshed for what changed since the last spec updates: `chrome-extension` was promoted from `spike/` to a package (#1526) and gets its own SPEC.md; the website (`the-framework.ai`) gets a minimal one (one-sentence description, as sdd.md allows for small scopes). The removed ai-skills/MCP repo-history note was dropped — it's about the repository, not the product, so it fails sdd.md's litmus test.
- Test dirs get no spec, following the earlier ruling (77321c0) that the E2E dir is documented by a README, not a spec.
- Granularity matches the previous spec set (root + packages + major subsystems of `the-framework`) — sdd.md's "only code carrying *major* business logic", with 100% coverage of the business logic rather than the file tree.

---
_Generated by [Claude Code](https://claude.ai/code/session_011BcYdUZJQwjyA6Szjq5LPU)_