### PR TITLE
A merged PR no longer blocks the handoff: work past its head gets a fresh PR (fix #1512)

### DIFF
--- a/packages/the-framework/src/dashboard/gh.ts
+++ b/packages/the-framework/src/dashboard/gh.ts
@@ -76,6 +76,11 @@ export interface LinkedPr {
   title: string
   /** ISO creation time, when the read included it: what tells one run's PR from a predecessor's. */
   createdAt?: string
+  /**
+   * The head commit the PR covers, when the read included it (#1512): what tells "the branch's
+   * PR already landed everything" from "the session kept working after its PR merged".
+   */
+  headRefOid?: string
 }
 
 /**
@@ -139,7 +144,7 @@ function prCacheKey(cwd: string, branch?: string): string {
  * indistinguishable from "no PRs", which is what every caller would do with a failure anyway.
  */
 export async function ghPrsForBranch(cwd: string, branch: string): Promise<LinkedPr[]> {
-  const fields = 'number,url,state,title,createdAt'
+  const fields = 'number,url,state,title,createdAt,headRefOid'
   const args = ['pr', 'list', '--head', branch, '--state', 'all', '--limit', '20', '--json', fields]
   const prs = await ghJson<LinkedPr[]>(args, cwd, [])
   return prs.map(pr => ({
@@ -148,6 +153,7 @@ export async function ghPrsForBranch(cwd: string, branch: string): Promise<Linke
     state: pr.state,
     title: pr.title,
     ...(pr.createdAt ? { createdAt: pr.createdAt } : {}),
+    ...(pr.headRefOid ? { headRefOid: pr.headRefOid } : {}),
   }))
 }
 
@@ -366,14 +372,21 @@ function branchPrsCacheKey(cwd: string, branch: string): string {
  * this run's handoff opened. Anything older is a previous run's PR wearing the same branch name,
  * which is exactly what showed a merged two-day-old PR as a fresh session's own. Without `since`
  * only an open PR is trusted.
+ *
+ * `order` exists for the one caller asking a different question (#1512). `'first'` answers
+ * identity — which PR did *this run* open, so a later run's must not be the answer. `'latest'`
+ * answers the handoff decision — which PR last saw the branch, so "did the session keep working
+ * past it" is readable off that PR's `headRefOid`; there the oldest entry would call work that a
+ * second PR already landed unlanded.
  */
-export function pickRunPr(prs: LinkedPr[], since?: string): LinkedPr | undefined {
+export function pickRunPr(prs: LinkedPr[], since?: string, order: 'first' | 'latest' = 'first'): LinkedPr | undefined {
   const open = prs.find(pr => pr.state === 'OPEN')
   if (open) return open
   if (!since) return undefined
-  return prs
+  const closed = prs
     .filter(pr => pr.createdAt && pr.createdAt >= since)
-    .sort((a, b) => ((a.createdAt ?? '') < (b.createdAt ?? '') ? -1 : 1))[0]
+    .sort((a, b) => ((a.createdAt ?? '') < (b.createdAt ?? '') ? -1 : 1))
+  return order === 'latest' ? closed.at(-1) : closed[0]
 }
 
 /** An open PR on the interventions queue (#632). */

--- a/packages/the-framework/src/dashboard/run-handoff.test.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.test.ts
@@ -375,6 +375,57 @@ test('a branch that already has a PR is never given a second one (#1102)', async
   assert.deepEqual(outcome, { outcome: 'skipped', reason: 'already-open' })
 })
 
+test('a session that kept working after its PR merged gets a fresh PR (#1512)', async () => {
+  // The #1512 session: its PR merged mid-run, the user asked for more, the branch tip moved past
+  // the merged head. "The branch already has a pull request" was how that work reached nobody.
+  const gh: string[][] = []
+  const { git } = fakeGit({ ...READY, push: '' })
+  const outcome = await runAutoHandoff(
+    '/repo',
+    { id: 'r1', branch: 'the-framework/x' },
+    { push: true, pr: true },
+    {
+      git,
+      pr: async () => ({ number: 1509, url: 'u1509', state: 'MERGED', title: 'landed', headRefOid: 'ffff00' }),
+      gh: async args => (gh.push(args), 'https://github.com/o/r/pull/1513\n'),
+    },
+  )
+  assert.equal(gh[0]?.[1], 'create')
+  assert.deepEqual(outcome, { outcome: 'done', pushed: true, url: 'https://github.com/o/r/pull/1513' })
+})
+
+test('a merged PR whose head is still the branch tip means everything landed (#1512)', async () => {
+  // READY's branch tip is abc123: a merged PR carrying that head covered all of the session's
+  // work, so there is nothing left to publish — and the skip says landed, not "already has a PR".
+  const { git } = fakeGit(READY)
+  const outcome = await runAutoHandoff(
+    '/repo',
+    { id: 'r1', branch: 'the-framework/x' },
+    { push: true, pr: true },
+    {
+      git,
+      pr: async () => ({ number: 1509, url: 'u1509', state: 'MERGED', title: 'landed', headRefOid: 'abc123' }),
+      gh: async () => assert.fail('everything already landed: nothing to open'),
+    },
+  )
+  assert.deepEqual(outcome, { outcome: 'skipped', reason: 'already-landed' })
+})
+
+test('a merged PR without a head to compare never risks a duplicate (#1512)', async () => {
+  const { git } = fakeGit(READY)
+  const outcome = await runAutoHandoff(
+    '/repo',
+    { id: 'r1', branch: 'the-framework/x' },
+    { push: true, pr: true },
+    {
+      git,
+      pr: async () => ({ number: 1509, url: 'u1509', state: 'MERGED', title: 'landed' }),
+      gh: async () => assert.fail('without the head the safe answer is to skip'),
+    },
+  )
+  assert.deepEqual(outcome, { outcome: 'skipped', reason: 'already-landed' })
+})
+
 test('an armed merge follows the PR it just opened (#1216)', async () => {
   const gh: string[][] = []
   const { git } = fakeGit({ ...READY, push: '' })
@@ -672,6 +723,10 @@ test('pickRunPr trusts an open PR, and otherwise only one created after the run 
   // Without a start time only an open PR is trusted.
   assert.equal(pickRunPr([stale, own, later]), undefined)
   assert.equal(pickRunPr([stale, open])?.number, 1301)
+  // `latest` order (#1512): the handoff decision wants the PR that last saw the branch, so a
+  // second PR's landed head is not mistaken for work the first PR never carried.
+  assert.equal(pickRunPr([later, own, stale], since, 'latest')?.number, 1300)
+  assert.equal(pickRunPr([stale, open], since, 'latest')?.number, 1301)
 })
 
 test('a gone branch still reports its PR: it is a remote question (#1255)', async () => {

--- a/packages/the-framework/src/dashboard/run-handoff.ts
+++ b/packages/the-framework/src/dashboard/run-handoff.ts
@@ -501,6 +501,18 @@ export async function openRunPullRequest(
 }
 
 /**
+ * Whether the session kept committing after its PR merged or closed (#1512): the PR carries a
+ * head, the branch has a tip, and they disagree. False for an open PR (pushed commits still land
+ * on it), for a headless read (an older cache or injected lookup — never risk a duplicate PR on
+ * a guess), and for a gone branch (no tip to compare; the PR stays the best answer, #1255).
+ */
+function movedPastPr(state: Pick<RunHandoff, 'pr' | 'commits'>): boolean {
+  if (!state.pr || state.pr.state === 'OPEN') return false
+  const tip = state.commits[0]?.sha
+  return Boolean(state.pr.headRefOid && tip && state.pr.headRefOid !== tip)
+}
+
+/**
  * Open a PR for a finished session, deciding from what the run recorded which cases should not
  * open one. Reads the branch's handoff first: a branch that no longer exists, or a session that
  * changed nothing, is a clear error rather than an empty PR, and a branch that already has a PR
@@ -517,7 +529,9 @@ export async function openSessionPullRequest(
   const handoff = await readRunHandoff(cwd, branch, { since: run.startedAt }).catch(() => undefined)
   // The run's PR first, even when its branch is gone locally: a hands-off web run's branch only
   // ever existed on the remote, and its PR is the answer the button exists to give (#1255).
-  if (handoff?.pr) return { ok: true, url: handoff.pr.url }
+  // Unless the session demonstrably kept committing after that PR merged or closed (#1512) —
+  // then the old PR is not the answer, the new work needs its own.
+  if (handoff?.pr && !movedPastPr(handoff)) return { ok: true, url: handoff.pr.url }
   if (handoff && !handoff.exists) return { ok: false, error: `branch ${branch} no longer exists` }
   // Refuse rather than open an empty PR: a session that changed nothing has nothing to hand off.
   if (handoff?.empty) return { ok: false, error: 'this session produced no commits to open a PR for' }
@@ -585,8 +599,10 @@ export type AutoHandoffOutcome =
  * draft PR for it, or both.
  *
  * Reads the branch first and refuses on everything that is not a clean hand-off — a branch that is
- * gone, a session that committed nothing, a repo with no remote, a branch that already has a PR.
- * Those are the cases where doing it anyway would produce a confusing artefact rather than help.
+ * gone, a session that committed nothing, a repo with no remote, a branch whose PR already covers
+ * everything on it. Those are the cases where doing it anyway would produce a confusing artefact
+ * rather than help. A merged PR the session kept working past is NOT one of them (#1512): the
+ * work after the merge gets a fresh PR, or it reaches nobody.
  *
  * The PR is a draft on purpose. Opening one by itself at the end of every session must not put a
  * review request in anyone's inbox, and the interventions queue keeps listing a session's draft
@@ -608,22 +624,32 @@ export async function runAutoHandoff(
   // only `gh` refusing the duplicate stopped it. This runs once, at the end of a session, so it
   // can afford to wait for a real answer. Filtered by the run's start time (#1251): a merged PR
   // from an earlier run on the same branch name must not stop this run from opening its own.
-  const runPr: BranchPrLookup = async (c, b) => pickRunPr(await ghPrsForBranch(c, b), since)
+  // `latest` order (#1512): the decision below compares the branch tip against the PR's head, and
+  // only the last PR that saw the branch answers that — against the first, work a second PR
+  // already landed would read as unlanded and reopen.
+  const runPr: BranchPrLookup = async (c, b) => pickRunPr(await ghPrsForBranch(c, b), since, 'latest')
   const state = await readRunHandoff(cwd, branch, { pr: runPr, ...readDeps }).catch(() => undefined)
   if (!state || !state.exists) return { outcome: 'skipped', reason: 'branch-gone' }
   if (state.empty) return { outcome: 'skipped', reason: 'no-commits' }
   if (!state.hasRemote) return { outcome: 'skipped', reason: 'no-remote' }
-  // A PR already covers both halves: it means the branch is published and the human has a place
+  // An OPEN PR covers both halves: it means the branch is published and the human has a place
   // to answer. Opening a second one is the one mistake this must never make. An armed merge
   // (#1216) still applies to the open PR — this is a rerun or a restart finding the PR its
   // predecessor opened, and the merge is the half that has not happened yet.
-  if (state.pr) {
-    if (intent.merge && state.pr.state === 'OPEN') {
+  if (state.pr?.state === 'OPEN') {
+    if (intent.merge) {
       // `watch` mode (#1418), like the freshly-opened path below: an auto merge must wait for the
       // PR's checks rather than land on the direct fallback before they run (#1406).
       return { outcome: 'skipped', reason: 'already-open', merge: await ghMergePr(cwd, state.pr.number, gh, { whenUnarmed: 'watch' }) }
     }
     return { outcome: 'skipped', reason: 'already-open' }
+  }
+  // A merged or closed PR only covers the branch up to the head it carried (#1512). A tip it
+  // already landed means everything reached the human — done, not blocked. A tip past it means
+  // the session kept working after the PR closed, and refusing here is how that work reached
+  // nobody: fall through and open a fresh PR for it.
+  if (state.pr && !movedPastPr(state)) {
+    return { outcome: 'skipped', reason: 'already-landed' }
   }
 
   if (intent.pr) {

--- a/packages/the-framework/src/events.test.ts
+++ b/packages/the-framework/src/events.test.ts
@@ -206,4 +206,10 @@ test('formatFrameworkEvent gives the merge half of a handoff its own line, withh
   )
   // No merge half: the line stays exactly what it was.
   assert.equal(formatFrameworkEvent({ kind: 'handoff', outcome: 'done', pushed: true }), '✓ branch pushed')
+  // A landed PR is not "the branch already has a pull request" (#1512): the reader was told their
+  // work was blocked when it had in fact arrived.
+  assert.match(
+    formatFrameworkEvent({ kind: 'handoff', outcome: 'skipped', reason: 'already-landed' })!,
+    /handoff skipped: the branch's pull request already landed everything the session did/,
+  )
 })

--- a/packages/the-framework/src/events.ts
+++ b/packages/the-framework/src/events.ts
@@ -88,6 +88,12 @@ export type AutoHandoffSkip =
   | 'no-remote'
   /** The branch already has a PR: opening a second one is the one mistake this must not make. */
   | 'already-open'
+  /**
+   * The branch's PR is merged or closed and its head is still the branch tip (#1512): everything
+   * the session did already reached the human, so there is nothing left to publish. Only that
+   * exact case — a session that kept committing after its PR merged gets a fresh PR instead.
+   */
+  | 'already-landed'
   /** The branch is already on the remote at this commit, and only the push was asked for. */
   | 'already-pushed'
   /** The run was stopped (Stop button, Ctrl+C, budget cap) rather than finished. */

--- a/packages/the-framework/src/terminal.ts
+++ b/packages/the-framework/src/terminal.ts
@@ -165,6 +165,8 @@ function handoffSkipReason(reason: AutoHandoffSkip): string {
       return 'this repo has no remote to push to'
     case 'already-open':
       return 'the branch already has a pull request'
+    case 'already-landed':
+      return "the branch's pull request already landed everything the session did"
     case 'already-pushed':
       return 'the branch is already on the remote'
     case 'run-stopped':


### PR DESCRIPTION
Fixes #1512.

## The bug

The #1512 session (screenshots on the issue): its PR #1509 merged mid-run, Rom asked the session for more work — literally "Create new PR" — and the run still ended with

> ~ handoff skipped: the branch already has a pull request

The post-merge commits reached nobody. Root cause: the handoff's rule was hardwired as "a PR exists on this branch → never open another", with no regard for the PR's state.

## The reframe

Per Rom's comment on the issue — capabilities, not imprisonment — the rule becomes:

- **An open PR is never duplicated.** Unchanged; opening a second PR against an open one stays the one mistake the handoff must never make.
- **A merged/closed PR only covers the branch up to the head it carried.** `ghPrsForBranch` now brings `headRefOid` along, and the handoff compares it to the branch tip:
  - tip **equals** the merged head → everything already landed. Skip, but say so: new reason `already-landed` renders as *"the branch's pull request already landed everything the session did"* instead of the misleading "already has a pull request".
  - tip **moved past** the merged head → the session kept working after its PR landed, and that work now gets a fresh PR (same push-then-create path as a first PR).
  - **no head to compare** (older cache, injected lookup) → conservative skip; never risk a duplicate on a guess.

The decision picks the PR that *last* saw the branch (`pickRunPr` gains a `'latest'` order), so on a run whose second PR also merged, a rerun doesn't mistake PR-2's landed head for work PR-1 never carried and open a junk third PR. Identity lookups (which PR is "this run's" for display and merge) keep the existing oldest-post-start semantics untouched (#1251/#1255).

Same rule on the dashboard's Open PR action, which used to answer any merged PR's URL as if that landed the new work.

## Tests

Suite 1745/0 on top of current main. New: the #1512 scenario opens a fresh PR; a landed-head merge skips as `already-landed`; a headless lookup never duplicates; the `'latest'` pick order; the new skip line's wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)