### PR TITLE
A version-skewed extension is refused loudly instead of half-working (fix #1519)

### DIFF
--- a/.changeset/extension-version-gate.md
+++ b/.changeset/extension-version-gate.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': minor
+---
+
+A browser extension whose version does not match the daemon's is now blocked outright instead of half-working. A stale extension never failed loudly — it missed messages and silently ignored fields the newer protocol added, which read as dashboard bugs and burned debugging sessions on a problem whose only fix is reloading the extension. Every bridge call now states the extension's version, and a daemon expecting another refuses every route with an error naming both versions and the update path; the options page's connection test shows that answer verbatim, and the dashboard's bridge settings say the extension is blocked — with both versions — instead of the bridge merely looking disconnected. A test keeps the daemon's expected version and the extension's manifest in lockstep, so one cannot be bumped without the other.

--- a/packages/chrome-extension/SPEC.md
+++ b/packages/chrome-extension/SPEC.md
@@ -7,6 +7,7 @@ A Chrome extension bridging Claude Code cloud sessions on claude.ai to the local
 - Answers go the long way round: dashboard pick → daemon queue → worker → typed into the session's composer and submitted; the extension can only ever type a label the session itself offered, and the pick was confirmed in the dashboard first.
 - It keeps one pinned background tab per session the daemon watches, so the bridge works with nobody looking at claude.ai — closing tabs when watching stops, and never reopening one the user closed.
 - Reading is driven by page changes with a slow heartbeat backstop (it lives in background tabs), and every stage reports its status — on the page's panel and in the settings page's connection test — so a silent misconfiguration is visible.
+- The extension and the daemon insist on matching versions: every call states the manifest version, and a daemon expecting another blocks it with an error naming both and the update path, because a version-skewed pair half-works in ways that read as bugs.
 
 ## Before writing SPEC.md files
 

--- a/packages/chrome-extension/background.SPEC.md
+++ b/packages/chrome-extension/background.SPEC.md
@@ -7,6 +7,7 @@ The extension's daemon half: the only part holding the bridge token and talking 
 - Answers travel back: queued picks are fetched on a fast beat (a person is watching a spinner), handed to the page in that session's tab to type, and the outcome reported — typing before reporting, so a pick is never marked sent that a dying tab never typed; failed deliveries and reports are retried, not dropped.
 - One pinned, inactive tab opens per session the daemon says to watch — the extension cannot know on its own that a cloud agent started; stale ones close, and a tab the user closed is never reopened.
 - Every sweep records why it did or didn't act, so "tabs are not opening" is answerable from the options page.
+- Every daemon call states this extension's version; a daemon expecting another refuses outright with both versions named, so a stale install blocks loudly instead of half-working.
 
 ## Before writing SPEC.md files
 

--- a/packages/chrome-extension/background.js
+++ b/packages/chrome-extension/background.js
@@ -11,6 +11,11 @@
 
 const DEFAULT_DAEMON = 'http://localhost:4200'
 
+// Every daemon call states this extension's version, and a daemon expecting another refuses it
+// outright (#1519): a version-skewed extension half-works in ways that read as dashboard bugs,
+// so the daemon blocks rather than degrades, and the error it answers names both versions.
+const VERSION_HEADER = { 'x-tf-extension-version': chrome.runtime.getManifest().version }
+
 /** What we last successfully reported per session, so a re-render does not re-post. */
 const lastSent = new Map()
 
@@ -55,7 +60,7 @@ async function report(question) {
   const base = (daemonUrl || DEFAULT_DAEMON).replace(/\/+$/, '')
   const res = await fetch(`${base}/_bridge/question`, {
     method: 'POST',
-    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}`, ...VERSION_HEADER },
     body: JSON.stringify(question),
   })
   if (!res.ok) {
@@ -99,7 +104,7 @@ async function deliverAnswers(sessionIds) {
     let answer
     try {
       const res = await fetch(`${base}/_bridge/answer?sessionId=${sessionId}`, {
-        headers: { authorization: `Bearer ${token}` },
+        headers: { authorization: `Bearer ${token}`, ...VERSION_HEADER },
       })
       if (!res.ok) continue
       answer = (await res.json())?.answer
@@ -146,7 +151,7 @@ async function ack(base, token, body) {
   try {
     const res = await fetch(`${base}/_bridge/answered`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${token}`, ...VERSION_HEADER },
       body: JSON.stringify(body),
     })
     if (res.ok || res.status === 400) {
@@ -167,7 +172,7 @@ async function pollAnswers() {
   for (const body of [...pendingAcks.values()]) await ack(base, token, body)
   let sessions
   try {
-    const res = await fetch(`${base}/_bridge/sessions`, { headers: { authorization: `Bearer ${token}` } })
+    const res = await fetch(`${base}/_bridge/sessions`, { headers: { authorization: `Bearer ${token}`, ...VERSION_HEADER } })
     if (!res.ok) return
     sessions = (await res.json())?.sessions
   } catch {
@@ -184,7 +189,7 @@ async function post(path, body) {
   const base = (daemonUrl || DEFAULT_DAEMON).replace(/\/+$/, '')
   const res = await fetch(`${base}${path}`, {
     method: 'POST',
-    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}`, ...VERSION_HEADER },
     body: JSON.stringify(body),
   })
   if (!res.ok) return { ok: false, error: `daemon answered ${res.status}: ${(await res.text()).slice(0, 200)}` }
@@ -198,7 +203,7 @@ async function postEvents({ sessionId, events }) {
   const base = (daemonUrl || DEFAULT_DAEMON).replace(/\/+$/, '')
   const res = await fetch(`${base}/_bridge/events`, {
     method: 'POST',
-    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}`, ...VERSION_HEADER },
     body: JSON.stringify({ sessionId, events }),
   })
   if (!res.ok) return { ok: false, error: `daemon answered ${res.status}: ${(await res.text()).slice(0, 200)}` }
@@ -254,7 +259,7 @@ async function openWatchedTabs() {
 
   let sessions
   try {
-    const res = await fetch(`${base}/_bridge/sessions`, { headers: { authorization: `Bearer ${token}` } })
+    const res = await fetch(`${base}/_bridge/sessions`, { headers: { authorization: `Bearer ${token}`, ...VERSION_HEADER } })
     if (!res.ok) return note({ ok: false, reason: `daemon answered ${res.status} listing sessions` })
     sessions = (await res.json())?.sessions
   } catch (err) {

--- a/packages/chrome-extension/manifest.json
+++ b/packages/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "The Framework: Claude web bridge",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "Shows the question a Claude Code cloud session is parked on in your local The Framework dashboard, and types the answer you pick there back into the session.",
   "permissions": [
     "storage",

--- a/packages/chrome-extension/options.SPEC.md
+++ b/packages/chrome-extension/options.SPEC.md
@@ -2,7 +2,7 @@ The settings page: the daemon address, the bridge token, and the tab-opening swi
 
 ## TLDR
 
-- The test names the exact failure: Chrome not actually granting site access (declared is not granted, and without it the daemon sees nothing), daemon unreachable, token rejected, bridge switched off, or a dashboard too old to have a bridge — whose look-alike success page is not accepted as connected.
+- The test names the exact failure: Chrome not actually granting site access (declared is not granted, and without it the daemon sees nothing), daemon unreachable, token rejected, a version the daemon refuses (its answer, naming both versions and the way out, is shown verbatim), bridge switched off, or a dashboard too old to have a bridge — whose look-alike success page is not accepted as connected.
 - Success also says how many cloud sessions the daemon is watching, so "connected but nothing happens" answers itself.
 - A button runs the tab sweep on demand and reports what it did, sparing the wait on the timer.
 

--- a/packages/chrome-extension/options.js
+++ b/packages/chrome-extension/options.js
@@ -55,9 +55,13 @@ document.getElementById('save').addEventListener('click', async () => {
     )
   }
   try {
-    const res = await fetch(`${daemonUrl}/_bridge/ping`, { headers: { authorization: `Bearer ${token}` } })
+    const version = { 'x-tf-extension-version': chrome.runtime.getManifest().version }
+    const res = await fetch(`${daemonUrl}/_bridge/ping`, { headers: { authorization: `Bearer ${token}`, ...version } })
     if (res.status === 401) return say('The dashboard is reachable but rejected the token.', true)
     if (res.status === 404) return say('Reached the dashboard, but the bridge is off. Turn it on in The Framework.', true)
+    // The daemon refuses a version-skewed extension on every route (#1519); its answer names
+    // both versions and the way out, so hand it over verbatim.
+    if (res.status === 426) return say(await res.text(), true)
     if (!res.ok) return say(`The dashboard answered ${res.status}.`, true)
     // A 200 is not enough. The dashboard serves its single-page app for any path it does not
     // recognise, so a build with no bridge route answers 200 and a page of HTML, and treating
@@ -69,7 +73,7 @@ document.getElementById('save').addEventListener('click', async () => {
     // unanswered: does the daemon actually have anything for us to watch?
     let watching = ''
     try {
-      const list = await fetch(`${daemonUrl}/_bridge/sessions`, { headers: { authorization: `Bearer ${token}` } })
+      const list = await fetch(`${daemonUrl}/_bridge/sessions`, { headers: { authorization: `Bearer ${token}`, ...version } })
       const sessions = list.ok ? ((await list.json())?.sessions ?? []) : []
       watching = sessions.length
         ? ` Watching ${sessions.length} recent cloud session${sessions.length === 1 ? '' : 's'}${autoOpenEl.checked ? ', tabs opening shortly.' : ' (tab opening is off).'}`

--- a/packages/the-framework/dashboard/components/BridgeSettings.SPEC.md
+++ b/packages/the-framework/dashboard/components/BridgeSettings.SPEC.md
@@ -1,4 +1,4 @@
-The browser-bridge setup panel: shown while the bridge is on, it explains the extension install and hands over the bridge token — masked until revealed, so a secret is not sitting in every screenshot — or says a restart is needed when no token exists yet.
+The browser-bridge setup panel: shown while the bridge is on, it explains the extension install and hands over the bridge token — masked until revealed, so a secret is not sitting in every screenshot — or says a restart is needed when no token exists yet. When the daemon last refused the extension over its version, the panel says so with both versions and the update path, instead of the bridge merely looking disconnected.
 
 ## Before writing SPEC.md files
 

--- a/packages/the-framework/dashboard/components/BridgeSettings.test.SPEC.md
+++ b/packages/the-framework/dashboard/components/BridgeSettings.test.SPEC.md
@@ -1,0 +1,5 @@
+Covers the setup panel's version notice: an extension the daemon refused is named with both versions and the update path, and an accepted one leaves the panel without a blocked notice.
+
+## Before writing SPEC.md files
+
+Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/dashboard/components/BridgeSettings.test.tsx
+++ b/packages/the-framework/dashboard/components/BridgeSettings.test.tsx
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+
+const onBridgeToken = vi.hoisted(() => vi.fn(async (): Promise<string | null> => 'tok-1'))
+const onBridgeStatus = vi.hoisted(() =>
+  vi.fn(async () => ({ lastContact: null, questions: 0, page: null, version: null }) as {
+    lastContact: null
+    questions: number
+    page: null
+    version: { got: string; expected: string; blocked: boolean; at: string } | null
+  }),
+)
+vi.mock('../rpc/reads.js', () => ({ onBridgeToken, onBridgeStatus }))
+
+import { BridgeSettings } from './BridgeSettings.js'
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('BridgeSettings version gate (#1519)', () => {
+  test('a refused extension is named, with both versions and the way out', async () => {
+    // Without this line the block is invisible from the dashboard: the bridge just looks
+    // disconnected, which after a repo pull is exactly the wrong diagnosis to hand someone.
+    onBridgeStatus.mockResolvedValue({
+      lastContact: null,
+      questions: 0,
+      page: null,
+      version: { got: '0.7.3', expected: '0.8.0', blocked: true, at: '2026-08-17T12:00:00.000Z' },
+    })
+    render(<BridgeSettings enabled onChange={() => {}} />)
+    const notice = await screen.findByText(/blocked/)
+    expect(notice.textContent).toContain('0.7.3')
+    expect(notice.textContent).toContain('0.8.0')
+    expect(notice.textContent).toContain('chrome://extensions')
+  })
+
+  test('an accepted version shows no blocked notice', async () => {
+    onBridgeStatus.mockResolvedValue({
+      lastContact: null,
+      questions: 0,
+      page: null,
+      version: { got: '0.8.0', expected: '0.8.0', blocked: false, at: '2026-08-17T12:00:00.000Z' },
+    })
+    render(<BridgeSettings enabled onChange={() => {}} />)
+    // The token row proves the panel rendered before asserting the absence.
+    await screen.findByText(/paste this token/)
+    expect(screen.queryByText(/blocked/)).toBeNull()
+  })
+})

--- a/packages/the-framework/dashboard/components/BridgeSettings.tsx
+++ b/packages/the-framework/dashboard/components/BridgeSettings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { onBridgeToken } from '../rpc/reads.js'
+import { onBridgeStatus, onBridgeToken } from '../rpc/reads.js'
 import { Button } from './ui/button.js'
 import { CopyButton } from './ui/copy-button.js'
 
@@ -19,6 +19,30 @@ import { CopyButton } from './ui/copy-button.js'
 export function BridgeSettings({ enabled, onChange }: { enabled: boolean; onChange: (next: boolean) => void }) {
   const [token, setToken] = useState<string | null>(null)
   const [shown, setShown] = useState(false)
+  const [blocked, setBlocked] = useState<{ got: string; expected: string } | null>(null)
+
+  // The version gate's visible half (#1519): a refused extension would otherwise look merely
+  // disconnected, and "the bridge stopped working" after a pull is exactly this. Polled, because
+  // the block clears on the extension's own next call, not on anything this page does.
+  useEffect(() => {
+    if (!enabled) {
+      setBlocked(null)
+      return
+    }
+    let live = true
+    const read = () =>
+      void onBridgeStatus()
+        .then(status => {
+          if (live) setBlocked(status.version?.blocked ? { got: status.version.got, expected: status.version.expected } : null)
+        })
+        .catch(() => {})
+    read()
+    const timer = setInterval(read, 5000)
+    return () => {
+      live = false
+      clearInterval(timer)
+    }
+  }, [enabled])
 
   useEffect(() => {
     if (!enabled) {
@@ -44,6 +68,12 @@ export function BridgeSettings({ enabled, onChange }: { enabled: boolean; onChan
         Install the browser extension, open its options, and paste this token. It reports the question a Claude web
         session is parked on, so it shows up here instead of only on claude.ai.
       </p>
+      {blocked && (
+        <p className="text-danger">
+          The extension is blocked: it is v{blocked.got} and this dashboard expects v{blocked.expected}. Update it —
+          pull the repo, then reload the extension at chrome://extensions.
+        </p>
+      )}
       {token === null ? (
         // A restart is genuinely required: the token is read when the daemon starts.
         <p className="text-muted-foreground">Restart the dashboard to generate the token.</p>

--- a/packages/the-framework/src/dashboard-rpc/reads.ts
+++ b/packages/the-framework/src/dashboard-rpc/reads.ts
@@ -22,7 +22,7 @@ import { relayOr } from './relay-agent.js'
 import type { FrameworkEvent } from '../events.js'
 import { bridgeQuestions } from '../dashboard/bridge-store.js'
 import type { BridgeEvent, BridgeHello, BridgeQuestion } from '../dashboard/bridge-endpoints.js'
-import type { BridgeAnswer, BridgeContact } from '../dashboard/bridge-store.js'
+import type { BridgeAnswer, BridgeContact, BridgeVersion } from '../dashboard/bridge-store.js'
 import { readDaemonToken, readPreferences, type Preferences } from '../registry.js'
 
 // The read model behind the new dashboard (#405): the agent history, an agent's replay, the
@@ -394,9 +394,19 @@ export async function onBridgeQuestion(sessionId: string): Promise<BridgeQuestio
  * showing" cannot be diagnosed from the questions alone. A refused request at least proves
  * something is trying, and its status says which half is wrong.
  */
-export async function onBridgeStatus(): Promise<{ lastContact: BridgeContact | null; questions: number; page: BridgeHello | null }> {
+export async function onBridgeStatus(): Promise<{
+  lastContact: BridgeContact | null
+  questions: number
+  page: BridgeHello | null
+  version: BridgeVersion | null
+}> {
   const store = bridgeQuestions()
-  return { lastContact: store.lastContact() ?? null, questions: store.list().length, page: store.hello() ?? null }
+  return {
+    lastContact: store.lastContact() ?? null,
+    questions: store.list().length,
+    page: store.hello() ?? null,
+    version: store.version() ?? null,
+  }
 }
 
 /**

--- a/packages/the-framework/src/dashboard/bridge-endpoints.SPEC.md
+++ b/packages/the-framework/src/dashboard/bridge-endpoints.SPEC.md
@@ -6,6 +6,7 @@ The daemon's doorway for the browser extension in the user's own claude.ai tab: 
 - Payloads are tiny and validated field by field — no paths, no commands, no free text — so a stolen secret buys at worst a bogus question card.
 - The extension can also ask which cloud sessions deserve a tab, fetch a session's queued answer, and report how delivering it went.
 - With the feature off, everything answers "not found"; a daemon missing one piece degrades to "nothing" rather than an error.
+- The extension states its version on every call, and a daemon expecting another refuses every route — naming both versions and the way out — because a version-skewed extension half-works in ways that read as framework bugs; the expected version moves in lockstep with the extension's manifest.
 
 ## Rationales
 

--- a/packages/the-framework/src/dashboard/bridge-endpoints.test.SPEC.md
+++ b/packages/the-framework/src/dashboard/bridge-endpoints.test.SPEC.md
@@ -1,4 +1,4 @@
-Covers the bridge doorway: a valid question is recorded and timestamped by the daemon (never the caller), missing or wrong secrets and malformed, oversized, or off-shape payloads are refused with nothing recorded, no cross-origin access is offered, queued answers are served and their delivery acknowledgements accepted, and everything answers "not found" when the bridge is off.
+Covers the bridge doorway: a valid question is recorded and timestamped by the daemon (never the caller), missing or wrong secrets and malformed, oversized, or off-shape payloads are refused with nothing recorded, no cross-origin access is offered, queued answers are served and their delivery acknowledgements accepted, and everything answers "not found" when the bridge is off. A version-skewed or version-silent extension is refused on every route with both versions named while the matching one passes, the gate sits behind the token so an unauthenticated caller learns nothing, and the expected version stays in lockstep with the extension's manifest.
 
 ## Before writing SPEC.md files
 

--- a/packages/the-framework/src/dashboard/bridge-endpoints.test.ts
+++ b/packages/the-framework/src/dashboard/bridge-endpoints.test.ts
@@ -1,8 +1,16 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
+import { readFileSync } from 'node:fs'
 import { createServer, type Server } from 'node:http'
 import { AddressInfo } from 'node:net'
-import { BRIDGE_PREFIX, handleBridgeRequest, type BridgeHandlers, type BridgeQuestion } from './bridge-endpoints.js'
+import {
+  BRIDGE_PREFIX,
+  EXPECTED_EXTENSION_VERSION,
+  EXTENSION_VERSION_HEADER,
+  handleBridgeRequest,
+  type BridgeHandlers,
+  type BridgeQuestion,
+} from './bridge-endpoints.js'
 
 const TOKEN = 'a'.repeat(43)
 
@@ -224,4 +232,68 @@ test('a daemon with no answer source degrades to null rather than failing (#1237
   } finally {
     await s.close()
   }
+})
+
+test('a version-skewed or version-silent extension is refused on every route, both versions named (#1519)', async () => {
+  const seen: { got: string; blocked: boolean }[] = []
+  const s = await serve({
+    token: TOKEN,
+    record: () => {},
+    expectedExtensionVersion: '9.9.9',
+    extensionVersion: (got, blocked) => void seen.push({ got, blocked }),
+  })
+  try {
+    // No header at all is exactly the dangerous case: an extension too old to announce itself.
+    const bare = await post(s.url, QUESTION)
+    assert.equal(bare.status, 426)
+    const text = await bare.text()
+    assert.match(text, /unknown/)
+    assert.match(text, /9\.9\.9/)
+    assert.match(text, /chrome:\/\/extensions/)
+    // A wrong version is refused everywhere, ping included: no degraded mode.
+    const ping = await fetch(`${s.url}${BRIDGE_PREFIX}/ping`, {
+      headers: { authorization: `Bearer ${TOKEN}`, [EXTENSION_VERSION_HEADER]: '0.0.1' },
+    })
+    assert.equal(ping.status, 426)
+    // The matching version passes, and its claim is recorded too — that is what clears a
+    // blocked banner once the extension is updated.
+    const ok = await fetch(`${s.url}${BRIDGE_PREFIX}/ping`, {
+      headers: { authorization: `Bearer ${TOKEN}`, [EXTENSION_VERSION_HEADER]: '9.9.9' },
+    })
+    assert.equal(ok.status, 200)
+    assert.equal(s.got.length, 0)
+    assert.deepEqual(seen, [
+      { got: 'unknown', blocked: true },
+      { got: '0.0.1', blocked: true },
+      { got: '9.9.9', blocked: false },
+    ])
+  } finally {
+    await s.close()
+  }
+})
+
+test('the version gate sits behind the token, so an unauthenticated caller learns nothing (#1519)', async () => {
+  const seen: string[] = []
+  const s = await serve({
+    token: TOKEN,
+    record: () => {},
+    expectedExtensionVersion: '9.9.9',
+    extensionVersion: got => void seen.push(got),
+  })
+  try {
+    assert.equal((await post(s.url, QUESTION, null)).status, 401)
+    assert.equal((await post(s.url, QUESTION, 'b'.repeat(43))).status, 401)
+    assert.deepEqual(seen, [])
+  } finally {
+    await s.close()
+  }
+})
+
+test('the expected version and the extension manifest move in lockstep (#1519)', () => {
+  // Resolved from the compiled test's own location (dist-test/dashboard/) to the repo's
+  // extension package, so bumping one without the other fails here instead of in someone's browser.
+  const manifest = JSON.parse(readFileSync(new URL('../../../chrome-extension/manifest.json', import.meta.url), 'utf8')) as {
+    version: string
+  }
+  assert.equal(EXPECTED_EXTENSION_VERSION, manifest.version)
 })

--- a/packages/the-framework/src/dashboard/bridge-endpoints.ts
+++ b/packages/the-framework/src/dashboard/bridge-endpoints.ts
@@ -23,6 +23,18 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
  */
 export const BRIDGE_PREFIX = '/_bridge'
 
+/**
+ * The extension version this daemon speaks (#1519). The extension states its own version on
+ * every call, in this header, and a daemon expecting another refuses outright: a version-skewed
+ * extension does not fail loudly, it half-works — missed messages, silently ignored fields —
+ * which reads as a framework bug and burns a debugging session. The extension's manifest must
+ * carry the same number; a test keeps the two in lockstep.
+ */
+export const EXPECTED_EXTENSION_VERSION = '0.8.0'
+
+/** The header the extension states its version in. Lowercase, as node presents all headers. */
+export const EXTENSION_VERSION_HEADER = 'x-tf-extension-version'
+
 /** A question a cloud session is parked on, as reported by the bridge. */
 export interface BridgeQuestion {
   /** The cloud session that asked, which joins back to an agent through `AgentMeta.sessionId`. */
@@ -67,6 +79,14 @@ export interface BridgeSession {
 export interface BridgeHandlers {
   /** The shared secret every bridge call must present. */
   token: string
+  /**
+   * The extension version to insist on (#1519). When set, every route past the token demands a
+   * matching {@link EXTENSION_VERSION_HEADER} and answers 426 otherwise — no degraded mode,
+   * ping included, so the only path forward from a stale extension is updating it.
+   */
+  expectedExtensionVersion?: string
+  /** What version the caller claimed and whether it was turned away, for the dashboard. */
+  extensionVersion?: (got: string, blocked: boolean) => void
   record: (question: BridgeQuestion) => void
   /** Record what the session said, keyed by its position in the transcript. */
   recordEvent?: (event: BridgeEvent) => void
@@ -108,6 +128,20 @@ export async function handleBridgeRequest(
   if (!handlers) return end(res, 404, 'bridge not enabled')
   seen(handlers, pathname, res)
   if (!authorized(req, handlers.token)) return end(res, 401, 'unauthorized')
+  // The version gate (#1519), behind the token so an unauthenticated caller learns nothing.
+  if (handlers.expectedExtensionVersion !== undefined) {
+    const raw = req.headers[EXTENSION_VERSION_HEADER]
+    const got = (typeof raw === 'string' && raw ? raw : 'unknown').slice(0, 32)
+    const blocked = got !== handlers.expectedExtensionVersion
+    handlers.extensionVersion?.(got, blocked)
+    if (blocked) {
+      return end(
+        res,
+        426,
+        `extension v${got} does not match the v${handlers.expectedExtensionVersion} this daemon expects: update the extension (pull the repo, then reload it at chrome://extensions) and retry`,
+      )
+    }
+  }
   if (pathname === `${BRIDGE_PREFIX}/ping`) {
     if (req.method !== 'GET') return end(res, 405, 'method not allowed', { allow: 'GET' })
     return end(res, 200, 'ok')

--- a/packages/the-framework/src/dashboard/bridge-store.ts
+++ b/packages/the-framework/src/dashboard/bridge-store.ts
@@ -39,6 +39,14 @@ export interface BridgeContact {
   status: number
 }
 
+/** The extension's last version claim, and whether the doorway turned it away (#1519). */
+export interface BridgeVersion {
+  got: string
+  expected: string
+  blocked: boolean
+  at: string
+}
+
 export class BridgeQuestions {
   private readonly bySession = new Map<string, BridgeQuestion>()
   private contact: BridgeContact | undefined
@@ -52,6 +60,23 @@ export class BridgeQuestions {
    */
   recordContact(route: string, status: number): void {
     this.contact = { at: new Date().toISOString(), route, status }
+  }
+
+  private versionState: BridgeVersion | undefined
+
+  /**
+   * What version the extension last claimed and whether it was refused for it (#1519).
+   *
+   * The accepted claims are recorded too, which is what clears a blocked banner: the moment an
+   * updated extension gets through, the last word is no longer a refusal.
+   */
+  recordVersion(got: string, expected: string, blocked: boolean): void {
+    this.versionState = { got, expected, blocked, at: new Date().toISOString() }
+  }
+
+  /** The last version claim, or undefined while nothing has stated one. */
+  version(): BridgeVersion | undefined {
+    return this.versionState
   }
 
   private helloState: BridgeHello | undefined

--- a/packages/the-framework/src/dashboard/server.ts
+++ b/packages/the-framework/src/dashboard/server.ts
@@ -14,7 +14,7 @@ import { requestPathname } from '../request-path.js'
 import type { AddProjectResult, PreviewResult, PreviewStatus, StartAgentKind, StartAgentOptions, StartAgentResult } from './types.js'
 import type { EventsSource, RemoteAgents } from './rpc-serve.js'
 import { handleRelayRequest, RELAY_PREFIX, type RelayHandlers } from './relay-endpoints.js'
-import { BRIDGE_PREFIX, handleBridgeRequest, type BridgeHandlers } from './bridge-endpoints.js'
+import { BRIDGE_PREFIX, EXPECTED_EXTENSION_VERSION, handleBridgeRequest, type BridgeHandlers } from './bridge-endpoints.js'
 import { bridgeQuestions } from './bridge-store.js'
 
 /** Options for {@link startDashboard}. */
@@ -174,6 +174,9 @@ export function startDashboard(opts: DashboardOptions): Promise<Dashboard> {
   const bridgeHandlers: BridgeHandlers | undefined = opts.bridgeToken
     ? {
         token: opts.bridgeToken,
+        // The version gate (#1519): a stale extension is refused loudly rather than half-working.
+        expectedExtensionVersion: EXPECTED_EXTENSION_VERSION,
+        extensionVersion: (got, blocked) => bridgeQuestions().recordVersion(got, EXPECTED_EXTENSION_VERSION, blocked),
         record: question => bridgeQuestions().record(question),
         contact: (route, status) => bridgeQuestions().recordContact(route, status),
         recordEvent: event => bridgeQuestions().recordEvent(event),


### PR DESCRIPTION
Builds #1519 as specced there: **error + block, not a warning.**

## What changes

- **Every bridge call states the extension's version** (`x-tf-extension-version`, from the manifest) — all seven background-worker fetches and the options page's connection test.
- **The daemon refuses a mismatch on every route** — ping included, no degraded mode. The gate sits *behind* the bearer token, so an unauthenticated caller learns nothing. The 426 answer names both versions and the way out: `extension v0.7.3 does not match the v0.8.0 this daemon expects: update the extension (pull the repo, then reload it at chrome://extensions) and retry`.
- **A version-silent extension counts as mismatched** (`unknown`): an install too old to announce itself is exactly the dangerous case.
- **The blocked state is visible in both places that matter**: the extension options page relays the daemon's answer verbatim on its connection test, and the dashboard's bridge settings panel shows "the extension is blocked … v0.7.3 … expects v0.8.0" instead of the bridge merely looking disconnected. Accepted claims are recorded too, which is what clears the banner once the updated extension's next call gets through.
- **Lockstep test**: `EXPECTED_EXTENSION_VERSION` must equal `chrome-extension/manifest.json`'s version, so one cannot be bumped without the other. Manifest bumped 0.7.3 → 0.8.0 with this protocol change.

## Notes

- `expectedExtensionVersion` is optional on `BridgeHandlers` (the daemon always wires it); unit tests for other bridge behavior stay unversioned and unaffected.
- Suite: 1429 node + 774 dashboard, 0 fail (3 new endpoint tests, 2 new BridgeSettings tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)