### PR TITLE
One GitHub sync: the import preset goes, the update's empty branch is the first import (fix #1501)

### DIFF
--- a/.changeset/one-github-sync-preset.md
+++ b/.changeset/one-github-sync-preset.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': minor
+---
+
+The separate "Import tickets from GitHub" preset is gone; "Update from GitHub" is the one GitHub sync. The update prompt already treats an empty `tickets/` as its first import — every open issue comes across — so the import preset was a second button for the same work, and two entry points meant two prompts to keep honest. Every surface that offered the import (the empty backlog panel, the onboarding checklist) now offers the update under its own label, sending the same preset text verbatim wherever it is pressed.

--- a/packages/the-framework/dashboard/components/Composer.test.tsx
+++ b/packages/the-framework/dashboard/components/Composer.test.tsx
@@ -205,11 +205,11 @@ describe('Composer (#721)', () => {
   test('a new-session preset marks its submit, and a normal one does not (#959)', () => {
     const { onSubmit } = renderComposer()
     fireEvent.click(screen.getByRole('button', { name: /Presets/ }))
-    fireEvent.click(screen.getByText('Import tickets from GitHub'))
+    fireEvent.click(screen.getByText('Update from GitHub'))
     fireEvent.click(screen.getByRole('button', { name: 'Send' }))
     // The menu row is the label; what is submitted is the preset's prompt. They used to be the same
     // string, which is how the import shipped asking for nothing in particular (#697).
-    expect(onSubmit).toHaveBeenCalledWith(presets.importTickets.render(), 'prompt', { newAgent: true })
+    expect(onSubmit).toHaveBeenCalledWith(presets.updateTickets.render(), 'prompt', { newAgent: true })
 
     cleanup()
     const second = renderComposer()
@@ -250,7 +250,7 @@ describe('Composer (#721)', () => {
   test('emptying the box drops the preset\'s new-session rule with the preset (#959)', () => {
     const { onSubmit } = renderComposer()
     fireEvent.click(screen.getByRole('button', { name: /Presets/ }))
-    fireEvent.click(screen.getByText('Import tickets from GitHub'))
+    fireEvent.click(screen.getByText('Update from GitHub'))
     // The stub editor does not mirror the loaded text into the DOM input, and jsdom drops a
     // change event whose value did not actually change — so give it something to clear.
     fireEvent.change(screen.getByLabelText('prompt'), { target: { value: 'edited' } })

--- a/packages/the-framework/dashboard/components/OnboardingChecklist.SPEC.md
+++ b/packages/the-framework/dashboard/components/OnboardingChecklist.SPEC.md
@@ -4,7 +4,7 @@ The onboarding checklist: what a new install needs, each step shown in the state
 
 - Every "done" derives from a real fact — a registered project, a filled AI queue, tickets on disk, a granted notification permission, saved Discord credentials — so a step cannot be ticked by clicking it, and one done outside the dashboard ticks itself.
 - Only adding a project and filling the AI queue are essential; the rest are marked optional because nothing breaks without them.
-- Undone steps carry their own actions: register the current directory or pick one, start an unattended agent that imports tickets from GitHub (landing on it), enable browser notifications, open the Discord setups.
+- Undone steps carry their own actions: register the current directory or pick one, start an unattended agent that fills `tickets/` from GitHub via the one update preset (landing on it), enable browser notifications, open the Discord setups.
 - It renders dismissible on the Overview and permanent on the settings page — which is what dismissing promises you can come back to.
 
 ## Before writing SPEC.md files

--- a/packages/the-framework/dashboard/components/OnboardingChecklist.test.SPEC.md
+++ b/packages/the-framework/dashboard/components/OnboardingChecklist.test.SPEC.md
@@ -1,4 +1,4 @@
-Covers the checklist: which steps are optional versus essential, that rows read as checkboxes rather than radio buttons, and the GitHub ticket import — started unattended, landing on the agent it starts (or staying put with the reason when the start is refused).
+Covers the checklist: which steps are optional versus essential, that rows read as checkboxes rather than radio buttons, and the GitHub ticket sync (the one update preset, whose empty branch is the first import) — started unattended, landing on the agent it starts (or staying put with the reason when the start is refused).
 
 ## Before writing SPEC.md files
 

--- a/packages/the-framework/dashboard/components/OnboardingChecklist.test.tsx
+++ b/packages/the-framework/dashboard/components/OnboardingChecklist.test.tsx
@@ -51,7 +51,7 @@ const WITH_PROJECT: DashboardData = {
 
 /** Click the import step and wait for the start to have been attempted. */
 const clickImport = async () => {
-  fireEvent.click(await screen.findByRole('button', { name: /import tickets from github/i }))
+  fireEvent.click(await screen.findByRole('button', { name: /update from github/i }))
   await waitFor(() => expect(startAgent.start).toHaveBeenCalled())
 }
 
@@ -92,8 +92,8 @@ describe('the GitHub import lands on the session it starts (#1169)', () => {
 
     // The project travels with it: this surface has none selected, so an id alone cannot be routed.
     // Unattended (#1279): a checklist-fired routine ends at settle instead of parking in the chat loop.
-    expect(startAgent.start).toHaveBeenCalledWith('p1', presets.importTickets.render(), 'prompt', { unattended: true })
-    await waitFor(() => expect(onAgentStarted).toHaveBeenCalledWith('p1', presets.importTickets.render(), 'run-7'))
+    expect(startAgent.start).toHaveBeenCalledWith('p1', presets.updateTickets.render(), 'prompt', { unattended: true })
+    await waitFor(() => expect(onAgentStarted).toHaveBeenCalledWith('p1', presets.updateTickets.render(), 'run-7'))
   })
 
   test('a project with no worktree hands up no id, so the shell can adopt the running one', async () => {
@@ -104,7 +104,7 @@ describe('the GitHub import lands on the session it starts (#1169)', () => {
     render(<OnboardingChecklist onAgentStarted={onAgentStarted} />)
     await clickImport()
 
-    await waitFor(() => expect(onAgentStarted).toHaveBeenCalledWith('p1', presets.importTickets.render(), undefined))
+    await waitFor(() => expect(onAgentStarted).toHaveBeenCalledWith('p1', presets.updateTickets.render(), undefined))
   })
 
   test('a refused start says why and moves you nowhere', async () => {

--- a/packages/the-framework/dashboard/components/OnboardingChecklist.tsx
+++ b/packages/the-framework/dashboard/components/OnboardingChecklist.tsx
@@ -99,9 +99,11 @@ export function OnboardingChecklist({
     if (permission === 'default') void Notification.requestPermission()
   }
 
-  const importTickets = async () => {
+  const populateTickets = async () => {
     if (!targetProjectId) return
-    const intent = presets.importTickets.render()
+    // The update preset (#1501): its empty branch is the first import, so one preset serves both
+    // this checklist's fresh project and the panel's filled one — one label, one instruction.
+    const intent = presets.updateTickets.render()
     // Unattended (#1279): a checklist-fired routine ends at settle instead of parking in the chat loop.
     const started = await start(targetProjectId, intent, 'prompt', { unattended: true })
     // Land on the session doing the import, not the project's launcher (#1169): its id is what
@@ -147,8 +149,8 @@ export function OnboardingChecklist({
       optional: true,
       action: (
         <div className="flex flex-col items-end gap-1">
-          <Button size="sm" onClick={importTickets} disabled={!targetProjectId || starting}>
-            {starting ? 'Starting…' : 'Import tickets from GitHub'}
+          <Button size="sm" onClick={populateTickets} disabled={!targetProjectId || starting}>
+            {starting ? 'Starting…' : 'Update from GitHub'}
           </Button>
           {!targetProjectId && <span className="text-xs text-muted-foreground">Add a project first</span>}
           {startError && <span className="text-xs text-destructive">{startError}</span>}

--- a/packages/the-framework/dashboard/components/TicketsPage.test.tsx
+++ b/packages/the-framework/dashboard/components/TicketsPage.test.tsx
@@ -52,11 +52,11 @@ describe('TicketsPage (#1144)', () => {
     expect(onOpenTicket).toHaveBeenCalledWith('p1', 't.md')
   })
 
-  test('a project with no tickets still offers its own GitHub import, not a dead end', async () => {
+  test('a project with no tickets still offers its own GitHub update, not a dead end', async () => {
     onAllTickets.mockResolvedValue([{ projectId: 'p1', projectName: 'Alpha', tickets: [] }])
     render(<TicketsPage onOpenTicket={() => {}} />)
     expect(await screen.findByText('Alpha')).toBeTruthy()
-    expect(screen.getByRole('button', { name: /import tickets from github/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /update from github/i })).toBeTruthy()
   })
 
   test('no registered projects says so rather than an empty page', async () => {
@@ -71,7 +71,7 @@ describe('TicketsPage (#1144)', () => {
     vi.mocked(sendStart).mockResolvedValue({ ok: true, agentId: 'r1' })
     const onAgentStarted = vi.fn()
     render(<TicketsPage onOpenTicket={() => {}} onAgentStarted={onAgentStarted} />)
-    fireEvent.click(await screen.findByRole('button', { name: /import tickets from github/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /update from github/i }))
     await waitFor(() => expect(onAgentStarted).toHaveBeenCalledWith('p1', expect.any(String), 'r1'))
   })
 })
@@ -192,8 +192,8 @@ describe('TicketsPage filters (#1144)', () => {
     window.history.replaceState(null, '', '/tickets?q=zzz-no-match')
     render(<TicketsPage onOpenTicket={() => {}} />)
     expect(await screen.findByText(/2 tickets hidden by the current filters/i)).toBeTruthy()
-    // Not the import offer — these tickets exist, they are filtered (#1230's rule, kept).
-    expect(screen.queryByRole('button', { name: /import tickets from github/i })).toBeNull()
+    // Not the update offer — these tickets exist, they are filtered (#1230's rule, kept).
+    expect(screen.queryByRole('button', { name: /update from github/i })).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: /clear filters/i }))
     expect(await screen.findByText('Improve the lock')).toBeTruthy()
     expect(window.location.search).toBe('')

--- a/packages/the-framework/dashboard/components/TicketsPanel.SPEC.md
+++ b/packages/the-framework/dashboard/components/TicketsPanel.SPEC.md
@@ -1,12 +1,12 @@
-A project's tickets as scannable one-liner rows — start column, title, topics, claim, effort, priority, age, plan column, GitHub link — plus the GitHub import and update.
+A project's tickets as scannable one-liner rows — start column, title, topics, claim, effort, priority, age, plan column, GitHub link — plus the GitHub update.
 
 ## TLDR
 
 - The start column spins up an unattended agent on that one ticket, the ticket named on the agent so its record says what it implements; opening the row goes to the detail page instead — starting is not opening.
 - The plan column links an existing plan, or starts an agent to write one — attended, because a plan is written for a human to review.
 - A claimed ticket wears a hammer with its holder named inline: an agent is planning or implementing it.
-- An empty backlog offers to import the repo's GitHub issues; a filled one offers an update that reconciles what changed, stamped with when it last caught up and admitting when there is no record.
-- Buttons send their presets' text verbatim — one label, one instruction, wherever offered — and empty-because-filtered says so instead of offering an import for work already done.
+- Empty or filled, the backlog offers the one GitHub update — its empty branch is the first import — the filled panel adding the stamp of when it last caught up and admitting when there is no record.
+- Buttons send their presets' text verbatim — one label, one instruction, wherever offered — and empty-because-filtered says so instead of offering an update for work already done.
 
 ## Before writing SPEC.md files
 

--- a/packages/the-framework/dashboard/components/TicketsPanel.test.SPEC.md
+++ b/packages/the-framework/dashboard/components/TicketsPanel.test.SPEC.md
@@ -1,4 +1,4 @@
-Covers the one-liner rows (meta and its order, the claim marker with inline holder, topic and claim clicks filtering without navigating, the GitHub link not hijacking the row), the start and plan columns sending their exact exported prompts with the right attended/unattended split, the import and update offers with their verbatim preset texts, last-caught-up stamp and refusal handling, and the filtered-empty vs genuinely-empty distinction.
+Covers the one-liner rows (meta and its order, the claim marker with inline holder, topic and claim clicks filtering without navigating, the GitHub link not hijacking the row), the start and plan columns sending their exact exported prompts with the right attended/unattended split, the one GitHub update offered empty and filled with its verbatim preset text, last-caught-up stamp and refusal handling, and the filtered-empty vs genuinely-empty distinction.
 
 ## Before writing SPEC.md files
 

--- a/packages/the-framework/dashboard/components/TicketsPanel.test.tsx
+++ b/packages/the-framework/dashboard/components/TicketsPanel.test.tsx
@@ -205,50 +205,49 @@ describe('TicketsPanel (#697/#1144)', () => {
     expect(onOpen).toHaveBeenCalledWith('2026-07-20_do-the-thing.md')
   })
 
-  test('an empty tickets/ offers the GitHub import instead of a dead end', async () => {
+  test('an empty tickets/ offers the GitHub update instead of a dead end (#1501)', async () => {
     sendStart.mockResolvedValue({ ok: true, agentId: 'r1' })
     const onAgentStarted = vi.fn()
     render(<TicketsPanel projectId="p1" tickets={[]} loaded onOpen={() => {}} onAgentStarted={onAgentStarted} />)
-    fireEvent.click(await screen.findByRole('button', { name: /import tickets from github/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /update from github/i }))
     await waitFor(() => expect(sendStart).toHaveBeenCalled())
     // A fixed prompt, so it takes the verbatim-text path rather than a build.
     expect(sendStart.mock.calls[0]?.[2]).toBe('prompt')
-    expect(sendStart.mock.calls[0]?.[1]).toMatch(/GitHub issues into tickets\//i)
     // And it is the preset's own text: the onboarding checklist offers this button under the same
-    // label and sends `presets.importTickets`, so a second source here means one label, two asks.
-    expect(sendStart.mock.calls[0]?.[1]).toBe(presets.importTickets.render())
-    // Unattended (#1279): a button-fired import ends at settle instead of parking in the chat loop.
+    // label, so a second source here means one label, two asks. Its empty branch is the first
+    // import (#1501), which is why an empty tickets/ needs no preset of its own.
+    expect(sendStart.mock.calls[0]?.[1]).toBe(presets.updateTickets.render())
+    // Unattended (#1279): a button-fired update ends at settle instead of parking in the chat loop.
     expect(sendStart.mock.calls[0]?.[3]).toEqual({ unattended: true })
-    // The agent id is what lands you on the import session rather than the project home (#1169).
+    // The agent id is what lands you on the update session rather than the project home (#1169).
     await waitFor(() => expect(onAgentStarted).toHaveBeenCalledWith(expect.any(String), 'r1'))
   })
 
-  test('a refused import says why and moves you nowhere (#1169)', async () => {
+  test('a refused update says why and moves you nowhere (#1169)', async () => {
     sendStart.mockResolvedValue({ ok: false, error: 'a session is already active' })
     const onAgentStarted = vi.fn()
     render(<TicketsPanel projectId="p1" tickets={[]} loaded onOpen={() => {}} onAgentStarted={onAgentStarted} />)
-    fireEvent.click(await screen.findByRole('button', { name: /import tickets from github/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /update from github/i }))
     expect(await screen.findByText(/already active/i)).toBeTruthy()
     expect(onAgentStarted).not.toHaveBeenCalled()
   })
 
-  test('a filled tickets/ offers the update, and sends the update preset verbatim (#1208)', async () => {
+  test('a filled tickets/ offers the same update beside the stamp (#1208)', async () => {
     sendStart.mockResolvedValue({ ok: true, agentId: 'r2' })
     const onAgentStarted = vi.fn()
     render(<TicketsPanel projectId="p1" tickets={[ticket()]} loaded onOpen={() => {}} onAgentStarted={onAgentStarted} />)
     fireEvent.click(await screen.findByRole('button', { name: /update from github/i }))
     await waitFor(() => expect(sendStart).toHaveBeenCalled())
     expect(sendStart.mock.calls[0]?.[2]).toBe('prompt')
-    // Its own preset, not the import's: the two ask for different work on a full directory.
     expect(sendStart.mock.calls[0]?.[1]).toBe(presets.updateTickets.render())
-    expect(sendStart.mock.calls[0]?.[1]).not.toBe(presets.importTickets.render())
     await waitFor(() => expect(onAgentStarted).toHaveBeenCalledWith(expect.any(String), 'r2'))
   })
 
-  test('the update is not offered on an empty tickets/, where importing is the word (#1208)', async () => {
+  test('the empty state offers exactly one update button, without the stamp row (#1501)', async () => {
     render(<TicketsPanel projectId="p1" tickets={[]} loaded onOpen={() => {}} />)
-    expect(await screen.findByRole('button', { name: /import tickets from github/i })).toBeTruthy()
-    expect(screen.queryByRole('button', { name: /update from github/i })).toBeNull()
+    // One button, one preset: the stamp row and its sibling button belong to the filled panel.
+    expect((await screen.findAllByRole('button', { name: /update from github/i })).length).toBe(1)
+    expect(screen.queryByText(/No record of an import yet/i)).toBeNull()
   })
 
   test('the stamp says when tickets/ last caught up, and admits when it does not know (#1208)', async () => {
@@ -271,10 +270,10 @@ describe('TicketsPanel (#697/#1144)', () => {
     expect(onAgentStarted).not.toHaveBeenCalled()
   })
 
-  test('an empty list with hiddenByFilter says so, rather than offering an import for work already done (#1144/#1230)', async () => {
+  test('an empty list with hiddenByFilter says so, rather than offering an update for work already done (#1144/#1230)', async () => {
     render(<TicketsPanel projectId="p1" tickets={[]} loaded hiddenByFilter={3} onOpen={() => {}} />)
     expect(await screen.findByText(/3 tickets hidden by the current filter/i)).toBeTruthy()
-    expect(screen.queryByRole('button', { name: /import tickets from github/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /update from github/i })).toBeNull()
   })
 
   test('no project renders nothing at all', () => {

--- a/packages/the-framework/dashboard/components/TicketsPanel.tsx
+++ b/packages/the-framework/dashboard/components/TicketsPanel.tsx
@@ -13,23 +13,13 @@ import { cn } from '../lib/utils.js'
 import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip.js'
 
 /**
- * The prompt behind "Import tickets from GitHub" (#697), read from the preset rather than written
- * here. This panel and the onboarding checklist offer the same button under the same label, and
- * they were sending different instructions: this text, against the preset's four bare words. Two
- * prompts behind one label is a button whose behaviour depends on where it was pressed.
+ * The prompt behind "Update from GitHub" (#1208), read from the preset rather than written here:
+ * this panel and the onboarding checklist offer the same button under the same label, and one
+ * label must mean one instruction wherever it is pressed (#697's lesson, when two surfaces sent
+ * different texts behind the same words).
  *
- * Deliberately short even so: the agent has `gh` and the ticket format already, and #674 settled
- * that over-specifying a preset earns nothing the context fragment does not already carry.
- */
-const IMPORT_PROMPT = presets.importTickets.render()
-
-/**
- * The prompt behind "Update from GitHub" (#1208), the second and every later import. Read from its
- * own preset for the same reason: one label, one instruction, wherever it is offered from.
- *
- * A separate preset rather than a flag on the import, because the two ask for different work. The
- * import fills an empty directory; this one reconciles a full one against what changed, and has to
- * be told to leave the plans already written against a ticket alone.
+ * The one GitHub sync since #1501: the preset's own empty branch treats a bare `tickets/` as the
+ * first import, so the separate import preset could go.
  */
 const UPDATE_PROMPT = presets.updateTickets.render()
 
@@ -318,9 +308,8 @@ export function TicketsPanel({
     if (result?.ok) onAgentStarted?.(prompt, result.agentId)
   }
 
-  // Unattended (#1279): an import/update fired by a button is routine work, not a conversation — it
+  // Unattended (#1279): an update fired by a button is routine work, not a conversation — it
   // ends at settle and its armed handoff fires, as when the sweep starts the same routine.
-  const importFromGithub = () => startSession(IMPORT_PROMPT, 'The import could not be started.', { unattended: true })
   const updateFromGithub = () => startSession(UPDATE_PROMPT, 'The update could not be started.', { unattended: true })
   // Attended, unlike the imports above: a plan is written per-ticket for a human to read and act
   // on, so the session stays a conversation you land in and steer rather than one that settles and
@@ -358,8 +347,8 @@ export function TicketsPanel({
           plans from.
         </p>
         {error && <p className="text-xs text-danger">{error}</p>}
-        <Button size="sm" variant="outline" disabled={busy} onClick={() => void importFromGithub()}>
-          {busy ? 'Starting…' : 'Import tickets from GitHub'}
+        <Button size="sm" variant="outline" disabled={busy} onClick={() => void updateFromGithub()}>
+          {busy ? 'Starting…' : 'Update from GitHub'}
         </Button>
       </div>
     )
@@ -368,9 +357,8 @@ export function TicketsPanel({
   return (
     <div className="overflow-hidden rounded-lg border border-border">
       {error && <p className="border-b border-border p-2 text-xs text-danger">{error}</p>}
-      {/* Offered once there is something to update (#1208). On an empty `tickets/` the button
-          above says "Import" instead: same work, but "update" would be a strange word for
-          filling a directory that has never been filled. */}
+      {/* The same update as the empty state's button (#1501): one preset covers both, its empty
+          branch being the first import. Here it sits beside the stamp it acts on. */}
       <div className="flex items-center gap-2 border-b border-border bg-muted/40 px-2 py-1.5">
         {/* The stamp and its action side by side (#1265) — the button used to sit flush right,
             a whole panel-width away from the line it acts on. */}

--- a/packages/the-framework/prompts/presets/import_tickets.md
+++ b/packages/the-framework/prompts/presets/import_tickets.md
@@ -1,5 +1,0 @@
-Note the current UTC time before you fetch anything, in ISO 8601.
-
-Import this repo's open GitHub issues into tickets/, one file per issue, following the ticket format.
-
-Finish by writing `tickets/meta.json` as `{"lastImportedAt": "<the UTC time you noted at the start>"}`, so a later update knows where to resume from.

--- a/packages/the-framework/src/preset-catalog.SPEC.md
+++ b/packages/the-framework/src/preset-catalog.SPEC.md
@@ -3,9 +3,9 @@ The one table of every built-in preset — the prompts the product offers as one
 ## TLDR
 
 - The quality reviews (research, maintainability, readability, security audit, UX) take a target, defaulting to the launching agent or the whole codebase.
-- The PM cluster scopes itself to the repo's own tickets and queue: import and update tickets from GitHub, plan them, suggest new tickets or features, pick what to work on, triage into the queue, and drain the queue.
+- The PM cluster scopes itself to the repo's own tickets and queue: update tickets from GitHub (an empty `tickets/` gets a full first import — there is no separate import preset), plan them, suggest new tickets or features, pick what to work on, triage into the queue, and drain the queue.
 - Presets that pause for a human are kept off unattended schedules; the scheduled triage pair pins its own session name so a firing aborts instead of triaging twice.
-- The two GitHub-import presets always open an agent of their own — their work is about the repo, not the conversation they were clicked from.
+- The GitHub-sync preset always opens an agent of its own — its work is about the repo, not the conversation it was clicked from.
 - The launcher's menu is one ordered list here; the queue-drain preset is daemon-only and absent from it.
 - Recognising "the prompt that drains the queue" compares against the rendered preset itself, so rewording the preset cannot silently break the detection.
 

--- a/packages/the-framework/src/preset-catalog.test.SPEC.md
+++ b/packages/the-framework/src/preset-catalog.test.SPEC.md
@@ -1,4 +1,4 @@
-Covers the preset catalog: every preset's pinned name and launcher membership, which take a target and which scope themselves, which gate on a human versus run unattended, and the key instructions each prompt must carry.
+Covers the preset catalog: every preset's pinned name and launcher membership, which take a target and which scope themselves, which gate on a human versus run unattended, and the key instructions each prompt must carry — including that the one GitHub sync treats an empty `tickets/` as its first import.
 
 ## Before writing SPEC.md files
 

--- a/packages/the-framework/src/preset-catalog.test.ts
+++ b/packages/the-framework/src/preset-catalog.test.ts
@@ -20,7 +20,6 @@ const PARAMETERIZED = [
 /** The presets that scope themselves, so there is no blank for a user to fill. */
 const PARAMLESS = [
   presets.marketResearch,
-  presets.importTickets,
   presets.planTickets,
   presets.suggestNewTickets,
   presets.suggestNewFeatures,
@@ -37,7 +36,7 @@ test('every preset keeps its exact run-kind name', () => {
   assert.deepEqual(
     Object.values(presets).map(p => p.name).sort(),
     [
-      'drain-queue', 'import-tickets', 'maintainability', 'maintenance', 'market-research',
+      'drain-queue', 'maintainability', 'maintenance', 'market-research',
       'plan-tickets', 'readability', 'research', 'security-audit',
       'suggest-new-features', 'suggest-new-tickets', 'suggest-tickets-to-work-on',
       'triage-consensual', 'triage-quick', 'update-tickets', 'ux',
@@ -202,34 +201,22 @@ test('neither ungated triage preset waits on a human (#891/#892 vs #698)', () =>
   assert.ok(presets.suggestTicketsToWorkOn.template.includes('<AWAIT>'), 'the gated preset still awaits')
 })
 
-test('the two GitHub-import presets, and only those, always open a session of their own (#959/#1208)', () => {
+test('the GitHub-sync preset, and only it, always opens a session of its own (#959/#1208/#1501)', () => {
   // The flag is a property of the work, not of the surface that fires it, so it is pinned here
-  // rather than in the dashboard: both read GitHub and write `tickets/`, which has nothing to do
+  // rather than in the dashboard: it reads GitHub and writes `tickets/`, which has nothing to do
   // with whatever session the user happened to be reading when they clicked.
   const marked = Object.values(presets).filter(p => p.newAgent).map(p => p.name)
-  assert.deepEqual(marked.sort(), ['import-tickets', 'update-tickets'])
-  assert.equal(LAUNCHER_PRESETS.includes(presets.importTickets), true)
+  assert.deepEqual(marked.sort(), ['update-tickets'])
   assert.equal(LAUNCHER_PRESETS.includes(presets.updateTickets), true)
-})
-
-test('the import preset names where the tickets go, not just the button (#697)', () => {
-  // It read "Import tickets from GitHub", the label repeated back: no destination, no format. The
-  // rail's panel had spelled out the real ask in its own constant, so the same button asked for two
-  // different things depending on where it was pressed. The instruction lives on the preset now.
-  const prompt = presets.importTickets.render()
-  assert.equal(prompt, presets.importTickets.template)
-  assert.match(prompt, /tickets\//)
-  assert.match(prompt, /one file per issue/)
-  assert.notEqual(prompt, presets.importTickets.label)
-  // It also leaves the stamp behind (#1208), so the first update has somewhere to resume from
-  // instead of re-importing the whole repo.
-  assert.match(prompt, /tickets\/meta\.json/)
-  assert.match(prompt, /lastImportedAt/)
 })
 
 test('the update preset resumes from the stamp and keeps our own work (#1208)', () => {
   const prompt = presets.updateTickets.render()
   assert.equal(prompt, presets.updateTickets.template)
+  // It names the destination, not just the button back (#697's lesson): the instruction lives on
+  // the preset, so every surface offering the label sends the same ask.
+  assert.match(prompt, /tickets\//)
+  assert.notEqual(prompt, presets.updateTickets.label)
   // Resuming is the whole point: with no `since` an update is just a slower re-import.
   assert.match(prompt, /tickets\/meta\.json/)
   assert.match(prompt, /lastImportedAt/)
@@ -243,7 +230,8 @@ test('the update preset resumes from the stamp and keeps our own work (#1208)', 
   // agent's own work every time someone pressed the button.
   assert.match(prompt, /\.plan\.md/)
   assert.match(prompt, /closed/)
-  // And it must not read as the first import: that is the other preset, under the other button.
-  assert.notEqual(prompt, presets.importTickets.render())
+  // The empty branch is the first import (#1501): the reason no separate import preset exists.
+  assert.match(prompt, /\[Empty\]/)
+  assert.match(prompt, /every open issue/)
 })
 

--- a/packages/the-framework/src/preset-catalog.ts
+++ b/packages/the-framework/src/preset-catalog.ts
@@ -1,7 +1,6 @@
 import { definePreset, type PresetDef } from './preset-prompt.js'
 import {
   PRESETS_DRAIN_QUEUE,
-  PRESETS_IMPORT_TICKETS,
   PRESETS_MAINTAINABILITY,
   PRESETS_MAINTENANCE,
   PRESETS_MARKET_RESEARCH,
@@ -76,27 +75,20 @@ export const presets = {
   marketResearch: definePreset({ name: 'market-research', template: PRESETS_MARKET_RESEARCH, label: 'Market research' }),
 
   /**
-   * [Import tickets from GitHub] (#959): fill `tickets/` from the repo's own issues, so the
-   * triage and planning presets have a backlog to read. One line of prompt, because the system
-   * prompt already tells the agent what a ticket is and where it goes.
-   *
-   * Marked {@link PresetSpec.newAgent}, like its update sibling: importing is repo work, not a
-   * reply, so it opens its own session rather than appending to whichever one the user happens to
-   * be reading.
-   */
-  importTickets: definePreset({ name: 'import-tickets', template: PRESETS_IMPORT_TICKETS, label: 'Import tickets from GitHub', newAgent: true, tooltip: 'Fill `tickets/` from the GitHub issues. Always runs in a new session.' }),
-
-  /**
-   * [Update from GitHub] (#1208): the second and every later import. It resumes from the
+   * [Update from GitHub] (#1208, #1501): the one GitHub sync. It resumes from the
    * `lastImportedAt` in `tickets/meta.json` and reconciles rather than refilling — an existing
    * ticket is edited in place, keeping the `.plan.md` written against it, and a
-   * closed issue's ticket goes.
+   * closed issue's ticket goes. An empty `tickets/` is its first-import branch: every open issue
+   * comes across, which is why the separate import preset could go (#1501).
    *
    * The timestamp is read by the agent out of the repo rather than rendered into the prompt: the
    * file travels in the same commit as the tickets it describes, so an agent whose work never landed
    * cannot leave behind a stamp claiming those issues were imported.
+   *
+   * Marked {@link PresetSpec.newAgent}: syncing is repo work, not a reply, so it opens its own
+   * session rather than appending to whichever one the user happens to be reading.
    */
-  updateTickets: definePreset({ name: 'update-tickets', template: PRESETS_UPDATE_TICKETS, label: 'Update from GitHub', newAgent: true, tooltip: 'Bring `tickets/` up to date with the issues and comments changed since the last import.' }),
+  updateTickets: definePreset({ name: 'update-tickets', template: PRESETS_UPDATE_TICKETS, label: 'Update from GitHub', newAgent: true, tooltip: 'Bring `tickets/` up to date with the GitHub issues. An empty `tickets/` gets a full first import.' }),
 
   /** [Plan tickets] (#685): turn tickets into costed plans. */
   planTickets: definePreset({ name: 'plan-tickets', template: PRESETS_PLAN_TICKETS, label: 'Plan tickets (aka spike)' }),
@@ -178,7 +170,6 @@ export const LAUNCHER_PRESETS: readonly PresetDef[] = [
   presets.suggestTicketsToWorkOn,
   presets.planTickets,
   presets.marketResearch,
-  presets.importTickets,
   presets.updateTickets,
   presets.maintenance,
   presets.triageQuick,


### PR DESCRIPTION
Builds #1501 as decided there: the `import-tickets` preset is removed in favor of `update_tickets`, whose `[Empty]` branch already treats a bare `tickets/` as a first import (every open issue comes across).

## What changes

- **`import_tickets.md` deleted**, `importTickets` preset removed from the catalog and launcher list. `update-tickets` is now the only `newAgent`-marked preset.
- **Every surface that offered the import now offers the update**, under the preset's own label, sending its text verbatim — the empty backlog panel (project + all-tickets pages), the onboarding checklist's "Populate tickets/" step, and the composer's preset menu. One label, one instruction, wherever pressed (#697's rule, now with one fewer prompt to keep honest).
- The update preset's tooltip now says an empty `tickets/` gets a full first import.
- Tests moved with it: the catalog's pinned-names list, the newAgent pinning, and the prompt-content test now assert the `[Empty]` first-import branch; panel/page/onboarding/composer tests target the one button.

## Notes for review

@brillout — prompt surface, so flagging per the usual: no prompt text changed, only `import_tickets.md` deleted; `update_tickets.md` is untouched and carries the whole load, exactly the shape you linked in the issue.

One wording call worth a look: the empty-state and onboarding buttons now say **"Update from GitHub"** even on a never-filled `tickets/`. That keeps label = preset label everywhere; if "update" reads oddly there, relabeling is a one-liner (at the cost of two labels for one preset).

Suite: 1428 node + 774 dashboard, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)