### PR TITLE
The rendered protocol examples are never the session's question (fix #1568)

### DIFF
--- a/.changeset/decoy-question-filtered.md
+++ b/.changeset/decoy-question-filtered.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': patch
+---
+
+The bridge no longer reports the protocol's own rendered examples as a question the session asked. Every Claude web session page opens with the run's prompt, which quotes the whole protocol — and two of its examples slipped the old decoy filter: the browser-handoff one (placeholders joined by punctuation in the title, literal labels) and the approval one (literal end to end). On a live page the dashboard rendered an answerable question card for a session that had asked nothing, one click away from typing into its real composer. The content script now discards everything rendered inside the transcript's opening message, catches placeholder-plus-punctuation titles, and matches the two literal examples verbatim; the extension and the daemon's expected version move to 0.8.1 together, so a not-yet-reloaded extension is refused loudly instead of continuing to report decoys.

--- a/packages/chrome-extension/check.mjs
+++ b/packages/chrome-extension/check.mjs
@@ -47,6 +47,20 @@ const SPEC = esc(JSON.stringify({
   recommended: '<the label to default to>',
 }, null, 2))
 
+// The two examples the protocol ships with literal text (#1568): the browser-handoff one has a
+// placeholders-plus-punctuation title and real labels, the approval one is literal end to end.
+// Both rendered on a live page and were reported as the session's question.
+const HANDOFF_EXAMPLE = esc(JSON.stringify({
+  title: '<what the human needs to do> (<the page you are stuck on>)',
+  options: [{ label: 'Handled it' }, { label: 'Could not handle it', stop: true }],
+  recommended: 'Could not handle it',
+}, null, 2))
+const APPROVAL_EXAMPLE = esc(JSON.stringify({
+  title: 'Ship this?',
+  options: [{ label: 'Approve' }, { label: 'Decline', stop: true }],
+  recommended: 'Approve',
+}, null, 2))
+
 const cases = [
   ['fenced code block', `<pre><code>${block}</code></pre><div contenteditable="true"></div>`, true],
   ['pre without code', `<pre>${block}</pre><textarea></textarea>`, true],
@@ -65,6 +79,20 @@ const cases = [
   ['protocol spec then the real question', `<pre><code>${SPEC}</code></pre><code>${block}</code><div contenteditable="true"></div>`, true],
   // And on a session that has not asked yet, the spec alone must not count as a question.
   ['protocol spec only', `<pre><code>${SPEC}</code></pre><div contenteditable="true"></div>`, false],
+  // #1568: the browser-handoff example's title is placeholders joined by punctuation and its
+  // labels are literal, so neither of the original isTemplate prongs caught it.
+  ['browser-handoff example only', `<pre><code>${HANDOFF_EXAMPLE}</code></pre><div contenteditable="true"></div>`, false],
+  // #1568: the approval example is literal end to end and can only be matched verbatim.
+  ['approval example only', `<pre><code>${APPROVAL_EXAMPLE}</code></pre><div contenteditable="true"></div>`, false],
+  // #1568: when the page marks messages, everything in the opening one is the rendered prompt —
+  // documentation, not the session asking — and the real question in a later message still wins.
+  [
+    'decoys in the opening message, real question after',
+    `<article><pre><code>${SPEC}</code><code>${HANDOFF_EXAMPLE}</code><code>${APPROVAL_EXAMPLE}</code></pre></article><article><code>${block}</code></article><div contenteditable="true"></div>`,
+    true,
+  ],
+  // #1568: a question-shaped block that only exists inside the opening message is never asked.
+  ['question-shaped block only in the opening message', `<article><code>${block}</code></article><div contenteditable="true"></div>`, false],
 ]
 
 const script = readFileSync(join(here, 'content.js'), 'utf8')

--- a/packages/chrome-extension/content.SPEC.md
+++ b/packages/chrome-extension/content.SPEC.md
@@ -2,7 +2,7 @@ The extension's page half: injected into claude.ai session pages, it finds the q
 
 ## TLDR
 
-- The question is the JSON options block our agents emit, brace-matched out of surrounding prose wherever it hides — code elements, shadow roots, split across highlighter spans — and the page's rendered copy of our own protocol template is a decoy: the last real question wins.
+- The question is the JSON options block our agents emit, brace-matched out of surrounding prose wherever it hides — code elements, shadow roots, split across highlighter spans — and the page's rendered copy of our own protocol is a decoy three ways (#1568): nothing inside the transcript's opening message counts (that is the prompt rendering, examples included), a placeholder-shaped title is the spec talking even when punctuation joins the placeholders, and the protocol's two literal examples are matched verbatim; the last real question among what survives wins.
 - The transcript mirrors as per-message blocks when the page marks them, else as the visible conversation text from the newest end (application chrome and our own panel stripped); only what changed since the last look is sent.
 - Delivering an answer is the one action taken: the pick is typed into the composer and submitted, after patiently waiting for a slow page to render the composer; only the top frame types, so nothing submits twice — and only labels the session itself offered can ever be typed.
 - It re-reads on page mutation with a slow heartbeat backstop (built to run in background tabs), and its collapsible panel reports every stage's status — found, sent, delivered, and why not — because silent failure was the recurring failure.

--- a/packages/chrome-extension/content.js
+++ b/packages/chrome-extension/content.js
@@ -228,12 +228,44 @@ function deepText() {
  * so a session shows a JSON block with `options` before the agent has asked anything. Its
  * values are the spec's placeholders. Round 3 extracted exactly that and reported
  * `<the question>` as the question, which is the decoy working as designed.
+ *
+ * Two more decoys slipped that net on a live session (#1568). The browser-handoff example's
+ * title is placeholders *plus punctuation* — `<what…> (<the page…>)` — so the whole-string
+ * placeholder test missed it, and its labels are literal. And the approval example is literal
+ * end to end (`Ship this?`, Approve/Decline), which no placeholder heuristic can catch — it is
+ * matched verbatim instead, accepting that an agent asking the doc's exact sample question
+ * word-for-word loses (it was told to put a real title there).
  */
 function isTemplate(parsed) {
   const placeholder = v => typeof v === 'string' && /^<.*>$/.test(v.trim())
-  if (placeholder(parsed.title)) return true
+  const title = typeof parsed.title === 'string' ? parsed.title : ''
+  if (placeholder(title)) return true
+  // Placeholders joined by punctuation only: strip every <…> group; a title with no letters
+  // left is the spec talking, while a real title mentioning `<SESSION_NAME>` keeps its words.
+  if (/<[^<>]+>/.test(title) && !/\p{L}/u.test(title.replace(/<[^<>]*>/g, ''))) return true
   const labels = parsed.options.map(o => (typeof o === 'string' ? o : o?.label))
-  return labels.length > 0 && labels.every(placeholder)
+  if (labels.length > 0 && labels.every(placeholder)) return true
+  const set = labels.filter(l => typeof l === 'string').join('|')
+  // The two literal examples the protocol ships, verbatim.
+  if (set === 'Handled it|Could not handle it') return true
+  if (title === 'Ship this?' && set === 'Approve|Decline') return true
+  return false
+}
+
+/**
+ * Whether an element renders inside the transcript's opening message, crossing shadow
+ * boundaries on the way up. The page opens with the run's prompt — which quotes our whole
+ * protocol, examples included — so nothing inside that first message is ever a question the
+ * session asked (#1568). Roots are walked via their host so a block inside a shadowed
+ * highlighter still resolves to the article that carries it.
+ */
+function inFirstMessage(el, first) {
+  if (!first) return false
+  // A shadow tree's top parent is its ShadowRoot, whose `host` re-enters the outer tree.
+  for (let node = el; node; node = node.parentNode ?? node.host ?? null) {
+    if (node === first) return true
+  }
+  return false
 }
 
 /** Every JSON object carrying `options` in the text, in the order they appear. */
@@ -313,15 +345,26 @@ function findPendingChoice() {
   // `code` on its own: the page has <code> blocks with no <pre> wrapper (round 1), and they
   // sit inside shadow roots (round 2). DOM order tracks transcript order, so the last real
   // question wins over both the spec and any earlier answered one.
+  // The opening message is the run's own prompt, which quotes the whole protocol — examples
+  // included — so blocks inside it are documentation, never the session asking (#1568). Only
+  // applied when the page marks messages at all; the page-text fallback has no elements to
+  // scope and leans on isTemplate alone.
+  const firstMessage = deepQueryAll('article')[0]
   const fromElements = []
   for (const el of deepQueryAll('pre code, pre, code')) {
+    if (inFirstMessage(el, firstMessage)) continue
     for (const parsed of extractChoices(el.textContent ?? '')) {
       fromElements.push({ via: el.tagName.toLowerCase(), parsed })
     }
   }
+  // The page-text fallback reads everything, opening message included, so any block that also
+  // renders inside that first message is subtracted from it by value.
+  const inPrompt = new Set(extractChoices(firstMessage?.textContent ?? '').map(p => JSON.stringify(p)))
   const candidates = fromElements.length
     ? fromElements
-    : extractChoices(deepText()).map(parsed => ({ via: 'page-text', parsed }))
+    : extractChoices(deepText())
+        .filter(parsed => !inPrompt.has(JSON.stringify(parsed)))
+        .map(parsed => ({ via: 'page-text', parsed }))
   const real = candidates.filter(c => !isTemplate(c.parsed))
   const found = real.at(-1)
   if (found) reportToDaemon(found.parsed)

--- a/packages/chrome-extension/manifest.json
+++ b/packages/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "The Framework: Claude web bridge",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Shows the question a Claude Code cloud session is parked on in your local The Framework dashboard, and types the answer you pick there back into the session.",
   "permissions": [
     "storage",

--- a/packages/the-framework/src/dashboard/bridge-endpoints.ts
+++ b/packages/the-framework/src/dashboard/bridge-endpoints.ts
@@ -30,7 +30,7 @@ export const BRIDGE_PREFIX = '/_bridge'
  * which reads as a framework bug and burns a debugging session. The extension's manifest must
  * carry the same number; a test keeps the two in lockstep.
  */
-export const EXPECTED_EXTENSION_VERSION = '0.8.0'
+export const EXPECTED_EXTENSION_VERSION = '0.8.1'
 
 /** The header the extension states its version in. Lowercase, as node presents all headers. */
 export const EXTENSION_VERSION_HEADER = 'x-tf-extension-version'


### PR DESCRIPTION
Fixes the live false-positive found today while verifying the reloaded extension: the dashboard showed an answerable question card — `<what the human needs to do> (<the page you are stuck on>)` — for a session that never asked anything, one click from typing into its real composer.

**Root cause:** every TF cloud session page opens with the run's prompt, which quotes the whole protocol. `isTemplate` caught the classic all-placeholder example, but two others slipped it: the browser-handoff example (title is placeholders *joined by punctuation*, labels are literal "Handled it"/"Could not handle it") and the approval example ("Ship this?" / Approve / Decline — literal end to end, uncatchable by any placeholder heuristic).

**Three defenses now, layered:**
1. **Opening-message scoping** — nothing rendered inside the transcript's first message (`article[0]`, the prompt itself) is ever a candidate: element-scoped candidates by shadow-piercing containment, and the page-text fallback subtracts by value any block that also renders in that message. This kills current *and future* prompt examples wholesale when the page marks messages.
2. **Placeholder-plus-punctuation titles** — strip `<…>` groups; a title with no letters left is the spec talking (a real title mentioning `<SESSION_NAME>` keeps its words and survives).
3. **The two literal examples matched verbatim** — accepting the documented trade: an agent that asks the doc's exact sample question word-for-word loses, which the protocol itself tells it not to do.

**Versions move in lockstep** (manifest + `EXPECTED_EXTENSION_VERSION` → 0.8.1), so after this merges and the daemon restarts, the just-reloaded 0.8.0 extension is refused loudly with the exact update path — reload it once more at chrome://extensions.

Tests: 4 new jsdom cases in `check.mjs` (both examples alone → no question; decoys in the opening message with a real question after → the real one wins; a question-shaped block only in the opening message → nothing). All 18 extension checks, 1445 node, 774 dashboard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)