### PR TITLE
Six leftovers from the simplification refactor, one commit each

### DIFF
--- a/packages/the-framework/dashboard/components/AgentHistory.test.tsx
+++ b/packages/the-framework/dashboard/components/AgentHistory.test.tsx
@@ -25,7 +25,6 @@ afterEach(cleanup)
 
 function agent(over: Partial<AgentMeta> = {}): AgentMeta {
   return {
-    version: 1,
     status: 'running',
     id: 'run-1',
     startedAt: '2026-07-19T16:05:44.756Z',
@@ -56,7 +55,7 @@ describe('AgentHistory (#785)', () => {
   })
 
   test('an ended run armed to publish reads as publishing… until the handoff report folds in (#1455)', () => {
-    const publishing = agent({ version: 2, status: 'done', handoff: { push: true, pr: true } })
+    const publishing = agent({ status: 'done', handoff: { push: true, pr: true } })
     const { container } = renderRail(
       <AgentHistory projectId="p1" agents={[publishing]} selectedAgentId={null} onSelect={() => {}} />,
     )
@@ -65,15 +64,15 @@ describe('AgentHistory (#785)', () => {
     expect(container.querySelector('.animate-pulse')).toBeTruthy()
   })
 
-  test('a run whose handoff reported — and a pre-fold record — read as plain done (#1455)', () => {
-    // The reported agent's window is closed; the version-1 record predates the fold, so its
-    // missing report says nothing and must not read as forever-publishing.
+  test('a run whose handoff reported reads as plain done, armed or not (#1455)', () => {
+    // Once the report lands the epilogue's window is closed, whichever way it went — and an agent
+    // that never armed a push had no window to begin with.
     renderRail(
       <AgentHistory
         projectId="p1"
         agents={[
-          agent({ id: 'run-1', version: 2, status: 'done', handoff: { push: true, pr: true }, handoffReport: 'done' }),
-          agent({ id: 'run-2', version: 1, status: 'done', handoff: { push: true, pr: true } }),
+          agent({ id: 'run-1', status: 'done', handoff: { push: true, pr: true }, handoffReport: 'done' }),
+          agent({ id: 'run-2', status: 'done', handoff: { push: false, pr: false } }),
         ]}
         selectedAgentId={null}
         onSelect={() => {}}

--- a/packages/the-framework/dashboard/lib/live-state.test.ts
+++ b/packages/the-framework/dashboard/lib/live-state.test.ts
@@ -124,7 +124,6 @@ describe('isPublishing', () => {
 
 describe('isMetaPublishing', () => {
   const meta = (over: Partial<AgentMeta>): AgentMeta => ({
-    version: 2,
     status: 'done',
     id: 'r1',
     startedAt: '2026-01-01T00:00:00.000Z',
@@ -149,8 +148,8 @@ describe('isMetaPublishing', () => {
     expect(isMetaPublishing(unarmed as AgentMeta)).toBe(false)
   })
 
-  test('a pre-fold record (version 1) never reads as publishing — its report just never landed', () => {
-    expect(isMetaPublishing(meta({ version: 1 }))).toBe(false)
+  test('a record that never armed a push is not publishing, whatever its report says', () => {
+    expect(isMetaPublishing(meta({ handoff: { push: false, pr: false } }))).toBe(false)
   })
 })
 

--- a/packages/the-framework/dashboard/lib/live-state.ts
+++ b/packages/the-framework/dashboard/lib/live-state.ts
@@ -154,17 +154,14 @@ export function isPublishing(events: readonly FrameworkEvent[]): boolean {
  * {@link isPublishing}, but off an agent's meta snapshot instead of its event log — for the list
  * surfaces (the Recent-sessions rail) that only ever hold a {@link AgentMeta} (#1455). The rail
  * said "done" while the session's own pill still said "publishing…": `status` flips to `done`
- * the moment `end` lands, and until the `handoff` fold (meta version 2) the report never
- * reached the meta, so a list could not know the epilogue was still pushing.
+ * the moment `end` lands, and the report reaches the meta only when the handoff answers, so
+ * between the two a list could not know the epilogue was still pushing.
  *
- * The version gate is the old-records guard: a meta from before the fold has no
- * `handoffReport` even though its handoff reported long ago, so only a version ≥ 2 record —
- * one whose writer folds the event — may read the field's absence as "still in flight".
  * `handoff.push` must be affirmatively on, the same rule as the event-side check: nothing to
  * wait for when the epilogue was never armed to push.
  */
 export function isMetaPublishing(meta: AgentMeta): boolean {
-  return meta.version >= 2 && meta.status === 'done' && meta.handoff?.push === true && meta.handoffReport === undefined
+  return meta.status === 'done' && meta.handoff?.push === true && meta.handoffReport === undefined
 }
 
 /**

--- a/packages/the-framework/dashboard/vite.config.ts
+++ b/packages/the-framework/dashboard/vite.config.ts
@@ -31,8 +31,8 @@ function frameworkDevDaemon(): Plugin {
         // Node process, outside any transform pipeline, so plain `src/` TypeScript would not load.
         // The specifier is a URL rather than a literal so it stays a runtime import — and the type
         // comes from the source it is built from, so a signature change is still an error here.
-        const built = new URL('../dist/index.js', import.meta.url).href
-        const { runDaemon } = (await import(built)) as typeof import('../src/index.js')
+        const built = new URL('../dist/daemon.js', import.meta.url).href
+        const { runDaemon } = (await import(built)) as typeof import('../src/daemon.js')
         const cwd = process.env.FRAMEWORK_DEV_DAEMON_CWD || process.cwd()
         // Ephemeral port: the dev server owns the address the browser talks to, and binding 4200
         // would collide with a `framework` the developer is running in another terminal.

--- a/packages/the-framework/package.json
+++ b/packages/the-framework/package.json
@@ -30,24 +30,8 @@
   "files": [
     "dist"
   ],
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "bin": {
     "the-framework": "./dist/bin.js"
-  },
-  "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
-    },
-    "./dashboard-rpc": {
-      "import": "./dist/dashboard-rpc/index.js",
-      "types": "./dist/dashboard-rpc/index.d.ts"
-    },
-    "./client": {
-      "import": "./dist/client.js",
-      "types": "./dist/client.d.ts"
-    }
   },
   "scripts": {
     "build": "node scripts/gen-prompts.mjs && tsc -p tsconfig.build.json && cd dashboard && vite build",

--- a/packages/the-framework/src/agent-archive.ts
+++ b/packages/the-framework/src/agent-archive.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path'
 import { THE_FRAMEWORK_DIR } from './framework-dir.js'
-import { frameworkGitignore, gitignorePath, archiveGitignore, SESSIONS_RULE } from './framework-gitignore.js'
+import { frameworkGitignore, gitignorePath, archiveGitignore, ARCHIVE_RULE } from './framework-gitignore.js'
 import { nodeStoreFs, ARCHIVE_DIR, type StoreFs } from './store/index.js'
 import { nodeGitRunner, type GitRunner } from './project.js'
 
@@ -73,7 +73,7 @@ export async function ensureArchiveIgnored(cwd: string, _user: string, fs: Store
     return true
   }
   const current = await fs.read(path)
-  if (current.includes(SESSIONS_RULE)) return false
+  if (current.includes(ARCHIVE_RULE)) return false
   await fs.write(path, current.endsWith('\n') ? current + archiveGitignore() : current + '\n' + archiveGitignore())
   return true
 }

--- a/packages/the-framework/src/agent-commit.ts
+++ b/packages/the-framework/src/agent-commit.ts
@@ -7,7 +7,7 @@ import { nodeGitRunner } from './project.js'
 import { errorMessage } from './error-message.js'
 
 /**
- * Committing the session archives the daemon writes (#912/#1179) into the project checkout.
+ * Committing the agent archives the daemon writes (#912/#1179) into the project checkout.
  *
  * An agent's own worktree sweeps its archive on teardown (`store/worktree.ts`). The main checkout has
  * no such path — `install.ts` commits once at activation and nothing after — so an archive written
@@ -39,7 +39,7 @@ import { errorMessage } from './error-message.js'
  */
 
 /**
- * The committed session archives (#1179), under every user's own directory.
+ * The committed agent archives (#1179), under every user's own directory.
  *
  * `:(glob)` magic so the `*` stops at a path separator — a plain pathspec wildcard matches `/` too,
  * and would reach further down `.the-framework/` than this means to.
@@ -161,7 +161,7 @@ export async function gitBusy(
 const NOTHING_PENDING = 'no session changes'
 
 /**
- * Stage and commit the pending session archives under `cwd`, scoped to {@link ARCHIVE_PATHSPEC}.
+ * Stage and commit the pending agent archives under `cwd`, scoped to {@link ARCHIVE_PATHSPEC}.
  *
  * `add` before `commit` because a brand-new archive is untracked, and `git commit -- <path>` only
  * knows paths git already knows. Both are pathspec-scoped, so the staging is as narrow as the
@@ -197,7 +197,7 @@ export interface AgentCommitter {
   /** Run one poll now. Exposed so the daemon and tests can drive it deterministically. */
   poll: () => Promise<void>
   /**
-   * Commit every project's pending session archives now, skipping the idle window. For shutdown: the
+   * Commit every project's pending agent archives now, skipping the idle window. For shutdown: the
    * daemon is going away, so waiting for quiet would just defer the work to the next boot. Returns
    * how many projects committed.
    */
@@ -234,7 +234,7 @@ interface Pending {
 }
 
 /**
- * Start committing settled session archives, and return the handle that stops it.
+ * Start committing settled agent archives, and return the handle that stops it.
  *
  * The idle window is the poll itself: a project whose pending set is byte-identical to the previous
  * poll's has stopped being written to, so its batch is committed. Anything still moving is recorded

--- a/packages/the-framework/src/ci-watch.test.ts
+++ b/packages/the-framework/src/ci-watch.test.ts
@@ -18,7 +18,6 @@ const NOW = Date.parse('2026-08-01T12:00:00Z')
 
 function meta(overrides: Partial<AgentMeta> = {}): AgentMeta {
   return {
-    version: 2,
     status: 'done',
     id: 'run-1',
     startedAt: '2026-08-01T10:00:00.000Z',

--- a/packages/the-framework/src/cli.test.ts
+++ b/packages/the-framework/src/cli.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join, dirname } from 'node:path'
 import { appendControl } from './control.js'
 import { BROWSER_MCP_SERVERS, withBrowser } from './browser.js'
-import { EVENTS_FILE, FRAMEWORK_DIR, AGENTS_DIR, type StoreFs } from './store/index.js'
+import { EVENTS_FILE, FRAMEWORK_DIR, ARCHIVE_DIR, type StoreFs } from './store/index.js'
 import { nodeGitRunner } from './project.js'
 import {
   chooseSessionLink,
@@ -576,7 +576,7 @@ test('a declined post-merge cleanup lands in the archived event log, not on stdo
     // decline is *reported*: it has to survive into runs/, which close() copies the log into.
     const code = await runAgentCli({ prompt: 'review the auth flow', kind: 'prompt', cwd: dir, options: { onBeforeMergeable: true } }, io)
     assert.equal(code, 0)
-    const agents = join(dir, FRAMEWORK_DIR, AGENTS_DIR)
+    const agents = join(dir, FRAMEWORK_DIR, ARCHIVE_DIR)
     const archived = (await readdir(agents)).filter(f => f.endsWith('.jsonl'))
     assert.equal(archived.length, 1, 'the run was archived')
     const events = (await readFile(join(agents, archived[0]!), 'utf8'))

--- a/packages/the-framework/src/daemon-runtime.ts
+++ b/packages/the-framework/src/daemon-runtime.ts
@@ -23,7 +23,6 @@ import {
   FRAMEWORK_DIR,
   EVENTS_FILE,
   META_FILE,
-  AGENT_META_VERSION,
   isPidAlive,
   type AgentMeta,
 } from './store/index.js'
@@ -148,7 +147,6 @@ export async function markFailedStart(cwd: string, agentId: string, intent: stri
   if (await stat(metaPath).then(() => true, () => false)) return false
   const now = new Date().toISOString()
   const meta: AgentMeta = {
-    version: AGENT_META_VERSION,
     status: 'failed',
     id: agentId,
     startedAt: startedAtFromAgentId(agentId) ?? now,
@@ -639,7 +637,6 @@ export function createProjectRuntime({ cwd, env, binPath, retryDelayMs, driverPr
         // registered here so onAgents can show it and a dashboard reload re-opens it. Never written to disk.
         const now = new Date().toISOString()
         const meta: AgentMeta = {
-          version: AGENT_META_VERSION,
           status: 'running',
           id: result.agentId,
           startedAt: now,

--- a/packages/the-framework/src/daemon-services.ts
+++ b/packages/the-framework/src/daemon-services.ts
@@ -248,7 +248,7 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
     log,
   })
 
-  // Commit the session archives written into the main checkout (#912/#1179). An agent's own worktree
+  // Commit the agent archives written into the main checkout (#912/#1179). An agent's own worktree
   // sweeps its archive on teardown; nothing did the same for one held in the checkout itself, so it
   // sat as an uncommitted change until a human noticed. Path-scoped and debounced, and it skips a
   // repo that is mid-rebase or index-locked rather than committing into someone's work.

--- a/packages/the-framework/src/daemon-workspace.test.ts
+++ b/packages/the-framework/src/daemon-workspace.test.ts
@@ -14,7 +14,7 @@ import type { PreflightResult } from './preflight.js'
  */
 const agentReady = (): Promise<PreflightResult> => Promise.resolve({ ok: true, checks: [] })
 
-import { FRAMEWORK_DIR, WORKTREES_DIR, EVENTS_FILE, META_FILE, worktreePath, agentBranchName, AGENT_META_VERSION, startedAtFromAgentId, type AgentMeta } from './store/index.js'
+import { FRAMEWORK_DIR, WORKTREES_DIR, EVENTS_FILE, META_FILE, worktreePath, agentBranchName, startedAtFromAgentId, type AgentMeta } from './store/index.js'
 import { addProject, projectId } from './registry.js'
 import { nodeGitRunner } from './project.js'
 import type { AgentSpec } from './agent-spec.js'
@@ -143,7 +143,6 @@ async function writeAgentMeta(checkout: string, status: AgentMeta['status'], ext
   const dir = join(checkout, FRAMEWORK_DIR)
   await mkdir(dir, { recursive: true })
   const meta: AgentMeta = {
-    version: AGENT_META_VERSION,
     status,
     id: 'run1',
     startedAt: '2026-07-24T00:00:00.000Z',
@@ -316,7 +315,7 @@ fs.mkdirSync(dir, { recursive: true })
 const now = new Date().toISOString()
 fs.writeFileSync(
   path.join(dir, 'agent.json'),
-  JSON.stringify({ version: ${AGENT_META_VERSION}, status: 'failed', id: agentId, startedAt: now, updatedAt: now, driver: 'claude-code' }),
+  JSON.stringify({ status: 'failed', id: agentId, startedAt: now, updatedAt: now, driver: 'claude-code' }),
 )
 fs.appendFileSync(path.join(dir, 'events.jsonl'), JSON.stringify({ kind: 'end', ok: false, detail: ${JSON.stringify(detail)} }) + '\\n')
 process.exit(1)

--- a/packages/the-framework/src/daemon.test.ts
+++ b/packages/the-framework/src/daemon.test.ts
@@ -54,7 +54,7 @@ import { projectId, listProjects, addProject, writePreferences } from './registr
 import { nodeGitRunner } from './project.js'
 
 // The dashboard steers + starts over the daemon's in-process RPC mount (#405/#426), not the
-// retired /api/* HTTP routes. Post to `/_rpc/<name>` (same-origin) and return the unwrapped `ret`.
+// retired per-read HTTP routes. Post to `/_rpc/<name>` (same-origin) and return the unwrapped `ret`.
 async function callRpc(url: string, name: string, args: unknown[]): Promise<unknown> {
   const res = await fetch(`${url}/_rpc/${name}`, {
     method: 'POST',

--- a/packages/the-framework/src/dashboard-rpc/reads.ts
+++ b/packages/the-framework/src/dashboard-rpc/reads.ts
@@ -25,10 +25,9 @@ import type { BridgeEvent, BridgeHello, BridgeQuestion } from '../dashboard/brid
 import type { BridgeAnswer, BridgeContact, BridgeVersion } from '../dashboard/bridge-store.js'
 import { readDaemonToken, readPreferences, type Preferences } from '../registry.js'
 
-// The read model behind the new dashboard (#405): the agent history, an agent's replay, the
-// surfaced PLAN/TODO docs, and the committed LOGS.md — each keyed by project id and
-// backed by the same readers the daemon's legacy /api/* endpoints use, so the dashboard
-// stays a projection of the same files. They live beside the daemon rather than in the
+// The read model behind the dashboard (#405): the agent history, an agent's replay, the
+// surfaced PLAN/TODO docs, and the committed LOGS.md — each keyed by project id and backed by
+// the readers that own those files, so the dashboard stays a projection of the same files. They live beside the daemon rather than in the
 // browser's own tree so it can serve them in-process; the dashboard calls them by name over
 // `POST /_rpc/<name>`. The live agent stream is its own endpoint (`GET /_rpc/events`).
 

--- a/packages/the-framework/src/dashboard/activity.test.ts
+++ b/packages/the-framework/src/dashboard/activity.test.ts
@@ -7,7 +7,6 @@ import type { AgentMeta } from '../store/index.js'
 const project = (id: string, path: string): ProjectSummary => ({ id, path, name: id, activated: true })
 
 const agent = (over: Partial<AgentMeta> = {}): AgentMeta => ({
-  version: 1,
   status: 'running',
   id: 'r1',
   startedAt: '2026-07-16T00:00:00Z',

--- a/packages/the-framework/src/dashboard/agent-handoff.ts
+++ b/packages/the-framework/src/dashboard/agent-handoff.ts
@@ -251,7 +251,7 @@ function parseHandoffFiles(out: string): HandoffFile[] {
   return parseNumstat(out).map(({ path, added, removed, binary }) => ({ path, insertions: added, deletions: removed, binary }))
 }
 
-/** The framework's own paper trail (#1291): conversation records, LOGS, session archives. */
+/** The framework's own paper trail (#1291): conversation records, LOGS, agent archives. */
 function isBookkeepingPath(path: string): boolean {
   return path === FRAMEWORK_DIR || path.startsWith(`${FRAMEWORK_DIR}/`)
 }

--- a/packages/the-framework/src/dashboard/docs.ts
+++ b/packages/the-framework/src/dashboard/docs.ts
@@ -25,7 +25,7 @@ export interface WorkspaceDoc {
   content: string
 }
 
-/** Cap a single doc so a runaway file can't bloat the `/api/docs` payload. */
+/** Cap a single doc so a runaway file can't bloat the docs payload. */
 const MAX_DOC_BYTES = 200_000
 
 /**

--- a/packages/the-framework/src/dashboard/interventions.test.ts
+++ b/packages/the-framework/src/dashboard/interventions.test.ts
@@ -15,7 +15,6 @@ const noAgents = async (): Promise<LiveAgent[]> => []
 const live = (meta: AgentMeta, cwd = '/a/.the-framework/worktrees/r1'): LiveAgent => ({ ...meta, cwd })
 
 const runningAgentMeta = (over: Partial<AgentMeta> = {}): AgentMeta => ({
-  version: 1,
   status: 'running',
   id: 'r1',
   startedAt: '2026-07-16T00:00:00Z',
@@ -118,7 +117,6 @@ test('interventionKey is the url for a PR and project+gate for an awaiting run',
 // #860: a finished agent whose branch still holds unpushed, unmerged commits.
 
 const doneMeta = (over: Partial<AgentMeta> = {}): AgentMeta => ({
-  version: 1,
   status: 'done',
   id: 'r1',
   startedAt: '2026-07-16T00:00:00Z',

--- a/packages/the-framework/src/dashboard/open-questions.test.ts
+++ b/packages/the-framework/src/dashboard/open-questions.test.ts
@@ -8,7 +8,6 @@ const PROJECTS = [{ id: 'p1', path: '/one', name: 'one', activated: true }]
 
 function liveAgent(overrides: Partial<LiveAgent> = {}): LiveAgent {
   return {
-    version: 2,
     status: 'running',
     id: 'run-1',
     startedAt: '2026-08-01T10:00:00.000Z',

--- a/packages/the-framework/src/dashboard/projects.test.ts
+++ b/packages/the-framework/src/dashboard/projects.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { summarizeProject, type SummarizeDeps } from './projects.js'
 import type { ProjectRecord } from '../registry.js'
-import { AGENT_META_VERSION, type AgentMeta } from '../store/index.js'
+import { type AgentMeta } from '../store/index.js'
 
 const RECORD: ProjectRecord = { id: 'app-a-1', path: '/repos/app-a', addedAt: '2026-07-11T00:00:00.000Z' }
 
@@ -16,7 +16,6 @@ function deps(over: SummarizeDeps): SummarizeDeps {
 }
 
 const agent = (id: string, updatedAt: string): AgentMeta => ({
-  version: AGENT_META_VERSION,
   status: 'stopped',
   id,
   startedAt: updatedAt,

--- a/packages/the-framework/src/dashboard/projects.ts
+++ b/packages/the-framework/src/dashboard/projects.ts
@@ -5,11 +5,9 @@ import { loadFrameworkConfig, type FrameworkFileConfig } from '../config.js'
 import { readAllAgents, type AgentMeta } from '../store/index.js'
 
 /**
- * The multi-project read side (#392): projects the daemon serves come from the
- * registry (#390), and each read endpoint (`/api/logs`, `/api/runs`, `/api/docs`)
- * resolves a `?project=<id>` to that project's path before running the existing
- * per-cwd reader. Live streaming + per-project run start/stop stay single-project
- * for now (#393).
+ * The multi-project read side (#392): projects the daemon serves come from the registry (#390),
+ * and every read resolves a project id to that project's path before running the per-cwd reader
+ * underneath. One daemon serves them all; it runs one agent at a time per project (#393).
  */
 
 /** One project's summary for the Projects sidebar (#314). */
@@ -82,7 +80,7 @@ export async function summarizeProject(record: ProjectRecord, deps: SummarizeDep
  * a fake so the server is exercised without touching the user's registry.
  */
 export interface ProjectsProvider {
-  /** Every registered project, summarized, for `GET /api/projects`. */
+  /** Every registered project, summarized, for the projects read. */
   list(): Promise<ProjectSummary[]>
   /** The absolute path for a registry id, or `undefined` when unknown. */
   resolvePath(id: string): Promise<string | undefined>

--- a/packages/the-framework/src/dashboard/remote-run.test.ts
+++ b/packages/the-framework/src/dashboard/remote-run.test.ts
@@ -3,7 +3,7 @@ import { test } from 'node:test'
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { startRemoteAgent, streamRemoteEvents, pingRemote, relayRpc, RelayedAgents } from './remote-run.js'
-import { AGENT_META_VERSION, type AgentMeta } from '../store/index.js'
+import { type AgentMeta } from '../store/index.js'
 import type { FrameworkEvent } from '../events.js'
 
 // A throwaway loopback server; the handler decides how it answers. Returns its base url + close.
@@ -17,7 +17,7 @@ async function server(handler: (req: IncomingMessage, res: ServerResponse) => vo
 // A minimal running AgentMeta stub, the local list row RelayedAgents keeps for a relayed agent (#1077).
 function stubMeta(id: string, overrides: Partial<AgentMeta> = {}): AgentMeta {
   const now = new Date().toISOString()
-  return { version: AGENT_META_VERSION, status: 'running', id, startedAt: now, updatedAt: now, target: 'remote', ...overrides }
+  return { status: 'running', id, startedAt: now, updatedAt: now, target: 'remote', ...overrides }
 }
 
 // Drain a RelayedAgents stream to completion, so both its `end`-driven settle and its close flip have run.

--- a/packages/the-framework/src/framework-gitignore.ts
+++ b/packages/the-framework/src/framework-gitignore.ts
@@ -7,7 +7,7 @@ import { ARCHIVE_DIR } from './store/index.js'
  *
  * Agent state is transient — `events.jsonl`, `agent.json`, `agents/`, the worktrees — and would
  * otherwise turn every session into a dirty checkout. The one thing under here that is committed
- * is the session archive (#1179), because `git clean -fdx` is an ordinary thing to do to a repo
+ * is the agent archive (#1179), because `git clean -fdx` is an ordinary thing to do to a repo
  * and it used to delete every session a project had ever run.
  *
  * An allow-list: `*` ignores everything, and each directory on the way down has to be re-included
@@ -41,10 +41,10 @@ export function archiveGitignore(): string {
   return `!*/\n!*/${ARCHIVE_DIR}/\n!*/${ARCHIVE_DIR}/**\n`
 }
 
-/** The whole file: ignore the transient state, keep the session archive. */
+/** The whole file: ignore the transient state, keep the agent archive. */
 export function frameworkGitignore(): string {
-  return `# The Framework: session state is transient; the session archive is committed.\n*\n!.gitignore\n${archiveGitignore()}`
+  return `# The Framework: agent state is transient; the agent archive is committed.\n*\n!.gitignore\n${archiveGitignore()}`
 }
 
-/** The rule whose presence means the file already un-ignores the session archive. */
-export const SESSIONS_RULE = `!*/${ARCHIVE_DIR}/**`
+/** The rule whose presence means the file already un-ignores the agent archive. */
+export const ARCHIVE_RULE = `!*/${ARCHIVE_DIR}/**`

--- a/packages/the-framework/src/index.SPEC.md
+++ b/packages/the-framework/src/index.SPEC.md
@@ -1,4 +1,4 @@
-The package's public doorway: re-exports the driver seam, the agent flow, the dashboard, the daemon, and every other public piece, with a top-of-file tour of how the product hangs together.
+The vocabulary the dashboard reads the daemon's answers in: the types its RPCs return, and nothing else.
 
 ## Before modifying/creating SPEC.md files
 

--- a/packages/the-framework/src/index.ts
+++ b/packages/the-framework/src/index.ts
@@ -1,314 +1,40 @@
 /**
- * `@gemstack/the-framework` — **The (AI) Framework**: turnkey, zero-config AI
- * orchestration. It wraps a coding-agent CLI (Claude Code today) as a **black
- * box** and takes a ticket to a reviewed pull request, with a localhost
- * dashboard that foregrounds the orchestration the agent's own chat cannot show.
+ * The types the dashboard reads the daemon's answers as.
  *
- * Two pieces: the **driver** seam that wraps the agent, and the **product shell**
- * (CLI + dashboard) that drives it.
+ * Not a library API: nothing imports this package by name, and the browser gets its *values* from
+ * `client.ts` (the node-free entry) and its data over `POST /_rpc/<name>`. What is left here is the
+ * vocabulary of those answers — one import site for a browser file that would otherwise reach into
+ * two dozen modules to name what an RPC returns.
  *
- * ## Driver seam
- * The one abstraction we wrap a coding-agent CLI behind. We prompt it, let its
- * own loop run, read the code, and gate on the outcome (guardrail: the seam is
- * the code, never the agent's tool calls). Swappable, so Codex / opencode slot
- * in behind the same three methods.
+ * Type-only on purpose. A value re-exported here would pull the module that defines it into the
+ * browser bundle, which is the failure `client.ts` exists to prevent; `export type` erases at build.
  *
- * - {@link Driver} / {@link DriverSession} — the contract
- * - {@link ClaudeCodeDriver} — the first real driver (`claude -p` stream-json)
- * - {@link FakeDriver} — deterministic offline driver for `FRAMEWORK_FAKE` / tests
- *
- * ## Session + product shell
- * - {@link runAgent} — frame the agent, send it one prompt, honor the gates it answers with,
- *   and stream {@link FrameworkEvent}s
- * - {@link startDashboard} — the localhost UI over the event stream
- * - {@link runCli} / {@link parseArgs} — the `framework` command
+ * Every name below is imported by a file under `dashboard/`. That is the whole rule: this file
+ * ends where its consumers end, so a name nothing renders cannot quietly live on in it.
  */
-export * from './driver/index.js'
-export { buildPrompt, extendPrompt, scaffoldPrompt, isWorkspaceEmpty } from './steps.js'
-export { runAgent, type AgentKind, type RunAgentOptions, type RunAgentResult } from './agent.js'
-export { isHandsOff, isAgentLocation, AGENT_LOCATIONS, type AgentLocation } from './agent-location.js'
-export {
-  requestChoices,
-  requestMultiSelect,
-  resolveAwaitGate,
-  type ChoicesOption,
-  type ChoicesDeps,
-  type MultiSelectOption,
-  type MultiSelectDeps,
-} from './await-gate.js'
-export {
-  parseResetsAt,
-  boundaryFromResetsAt,
-  quotaBoundaryStatus,
-  QUOTA_WEEK_MS,
-  type QuotaBoundary,
-  type BoundaryWindow,
-  type QuotaBoundaryStatus,
-} from './quota-boundary.js'
-export { pollerQuotaSource, defaultQuotaSource, type QuotaView, type QuotaSource } from './dashboard/quota.js'
-export {
-  QuotaPoller,
-  DEFAULT_POLL_MS,
-  MAX_POLL_MS,
-  type QuotaEnvelope,
-  type QuotaPollerOptions,
-} from './quota-poller.js'
-export {
-  type FrameworkEvent,
-  type ChoiceOption,
-  type ChoiceRequest,
-  type ChoicePick,
-  type ChoiceBy,
-  type OnBeforeMergeableSkip,
-  pickedIds,
-  OPEN_LOOP_MODES,
-} from './events.js'
-export { formatFrameworkEvent } from './terminal.js'
-export { resolveSessionLink, hasSessionIdPlaceholder, SESSION_ID_PLACEHOLDER } from './session-link.js'
-export {
-  sessionInfo,
-  agentProgress,
-  handoffState,
-  type SessionInfo,
-  type AgentProgress,
-  type HandoffState,
-} from './agent-view.js'
-export {
-  assessRepo,
-  planMaintenanceSweep,
-  maintainSweep,
-  readMaintenanceState,
-  writeMaintenanceState,
-  mergeMaintenanceState,
-  maintenanceDue,
-  maintenanceStatePath,
-  MAINTENANCE_FILE,
-  DEFAULT_MAINTENANCE_INTERVAL_MS,
-  type MaintenanceState,
-  type RepoReview,
-  type MaintenanceAction,
-  type SweepSummary,
-  type SweepDeps,
-  type MaintenanceFs,
-} from './maintenance.js'
-export { startDashboard, summarizeProject, defaultProjectsProvider, readDocs, type Dashboard, type DashboardOptions, type StartAgentKind, type StartAgentResult, type AddProjectResult, type OnboardingSuggestion, type DriverReady, type PreviewResult, type PreviewStatus, type AgentWorktree, type ProjectSummary, type ProjectsProvider, type SummarizeDeps, type WorkspaceDoc, readTickets, readTicket, readTicketsMeta, type WorkspaceTicket, type WorkspaceTicketDetail, type TicketsMeta, type TicketGithubLink, type ProjectQueue, type QueueItem, type Overview, type ActiveAgent, type RecentProject, type RecentAgent, buildRecentAgents, type HotTicket, type HotBucket, buildHotTickets, collectAllTickets, type ProjectTickets, type AllTicketsDeps, type DashboardData, type ProjectStat, type GitStatus, type LinkedPr, type FileDiff, type FileChange, type FileContent, type AgentHandoff, type HandoffCommit, type HandoffFile, type HandoffResult, buildInterventions, type Intervention, type OpenPr, type PrLister, type InterventionsDeps, buildOpenQuestions, openChoiceRequest, type OpenQuestion, type OpenQuestionsDeps, buildActivity, activityKey, pickNewActivity, type Activity, type ActivityDeps, type BridgeQuestion, type BridgeEvent, type BridgeAnswer } from './dashboard/index.js'
-export {
-  AgentStore,
-  nodeStoreFs,
-  applyEventToMeta,
-  metaFromEvents,
-  listAgents,
-  loadAgentEvents,
-  agentIdFromStartedAt,
-  isSafeAgentId,
-  FRAMEWORK_DIR,
-  EVENTS_FILE,
-  META_FILE,
-  AGENTS_DIR,
-  AGENT_META_VERSION,
-  type StoreFs,
-  type AgentMeta,
-  type AgentStatus,
-  type OpenStoreOptions,
-} from './store/index.js'
-export { THE_FRAMEWORK_DIR } from './framework-dir.js'
-export { gitignorePath, frameworkGitignore, archiveGitignore, SESSIONS_RULE } from './framework-gitignore.js'
-export {
-  startAgentCommitter,
-  commitAgents,
-  pendingAgents,
-  gitBusy,
-  commitMessage,
-  nodePathProbe,
-  ARCHIVE_PATHSPEC,
-  COMMIT_MAX_WAIT_MS,
-  type AgentCommitter,
-  type AgentCommitterOptions,
-  type CommitOutcome,
-  type PathProbe,
-} from './agent-commit.js'
-export {
-  theFrameworkDir,
-  isActivated,
-  nodeProjectFs,
-  crawlRepoFiles,
-  isGitRepo,
-  nodeGitRunner,
-  gitTimeoutMs,
-  GIT_READ_TIMEOUT_MS,
-  GIT_WRITE_TIMEOUT_MS,
-  GIT_SLOW_TIMEOUT_MS,
-  type ProjectFs,
-  type GitRunner,
-} from './project.js'
-export { CliTimeoutError, isCliTimeout, type CliTimeout } from './cli-exec.js'
-export {
-  projectId,
-  registryPath,
-  nodeRegistryFs,
-  listProjects,
-  addProject,
-  removeProject,
-  readRegistry,
-  readPreferences,
-  writePreferences,
-  patchPreferences,
-  registryPreferencesStore,
-  sanitizeCustomPresets,
-  REGISTRY_FILE,
-  type ProjectRecord,
-  type Registry,
-  type Preferences,
-  type PreferencesStore,
-  type CustomPreset,
-  type RegistryFs,
-} from './registry.js'
-export {
-  readProjectPresets,
-  writeProjectPresets,
-  PROJECT_PRESETS_FILE,
-} from './project-presets.js'
-export {
-  installProject,
-  enumerateGitRepos,
-  nodeDirLister,
-  type InstallResult,
-  type InstallDeps,
-  type DirLister,
-  type EnumerateDeps,
-} from './install.js'
-export {
-  PACKAGE_NAME,
-  nodeVersionFetcher,
-  compareVersions,
-  checkForUpdate,
-  formatUpdateStatus,
-  type VersionFetcher,
-  type UpdateStatus,
-} from './update-check.js'
-export {
-  runCli,
-  parseArgs,
-  agentOptions,
-  runOnBeforeMergeable,
-  promptAgentSpec,
-  type PromptRunner,
-  type CliIO,
-  type CliArgs,
-  type AgentOptions,
-} from './cli.js'
-export { readAgentSpec, writeAgentSpec, type AgentSpec } from './agent-spec.js'
-export { renderOnBeforeMergeablePrompt, ON_BEFORE_MERGEABLE_PROMPT_TEMPLATE, type OnBeforeMergeableContext } from './on-before-mergeable-prompt.js'
-export {
-  loadFrameworkConfig,
-  parseFrameworkConfig,
-  FRAMEWORK_CONFIG_FILES,
-  type FrameworkFileConfig,
-} from './config.js'
-export {
-  resolveConfigKey,
-  resolveAgentConfig,
-  fileConfigLayer,
-  describeResolvedConfig,
-  RUN_CONFIG_DEFAULTS,
-  type ConfigLayer,
-  type AgentConfigValues,
-  type ResolvedAgentConfig,
-} from './config-layers.js'
-export {
-  systemPromptBlock,
-  composeAgentSystem,
-  renderSystemPrompt,
-  SYSTEM_PROMPT_TEMPLATE,
-  type SystemPromptOptions,
-  type AgentSystemOptions,
-  type TfContext,
-  type RenderedSystemPrompt,
-} from './system-prompt.js'
-// Split out of system-prompt.js so the pure composition stays browser-safe (#520);
-// re-exported here, so this entry's surface is unchanged.
-export { loadUserSystemPrompt, SYSTEM_PROMPT_FILE } from './system-prompt-file.js'
-export { renderTemplate, TemplateFragmentError } from './prompt-template.js'
-export {
-  preflight,
-  type PreflightResult,
-  type PreflightCheck,
-  type PreflightOptions,
-} from './preflight.js'
-export { runDaemon, isProcessAlive, EventTailer, DEFAULT_DAEMON_PORT, type DaemonState, type RunDaemonOptions } from './daemon.js'
-export {
-  appendControl,
-  resetControl,
-  watchControl,
-  controlPath,
-  CONTROL_FILE,
-  type ControlEntry,
-  type ControlWatcher,
-} from './control.js'
-export { AgentMessageQueue, type AgentMessages } from './agent-messages.js'
-export {
-  runTodoLoop,
-  findTodoBacklog,
-  parseTodoEntries,
-  insertTodoEntry,
-  FLAT_TODO_FILE,
-  TICKETS_DIR,
-  todoPriorityForTicket,
-  DEFAULT_MAX_TODO_ITEMS,
-  type TodoBacklog,
-  type TodoLoopOptions,
-  type TodoLoopResult,
-  type TodoLoopReason,
-} from './todo-loop.js'
-export { agentOptionsFromPreferences, preferencesFromFileConfig } from './agent-options.js'
-export {
-  startAutoPm,
-  AUTO_PM_JOBS,
-  AUTO_PM_DRAIN_JOB,
-  AUTO_PM_MAINTENANCE_JOB,
-  AUTO_PM_ROUTINES,
-  autoPmDecision,
-  quotaHeadroom,
-  DEFAULT_AUTO_PM_INTERVAL_MS,
-  DEFAULT_AUTO_PM_COOLDOWN_MS,
-  type AutoPmInputs,
-  type AutoPmDecision,
-  type AutoPmDeps,
-  type AutoPmLoop,
-  type AutoPmProject,
-  type AutoPmJob,
-  type AutoPmReport,
-  type AutoPmOutcome,
-  type AutoPmReporter,
-} from './auto-pm.js'
-export {
-  PRESETS,
-  PRESET_DIR,
-  presetFilePath,
-  presetContext,
-  materializePresets,
-} from './presets.js'
-export { presets, LAUNCHER_PRESETS, type PresetKey } from './preset-catalog.js'
-export {
-  NOTIFICATION_DEFAULTS,
-  notifies,
-  notifyMethodEnabled,
-  notifyCategoryEnabled,
-  type NotifyMethod,
-  type NotifyCategory,
-} from './preference-defaults.js'
-export { interventionKey, pickNewInterventions } from './dashboard/keys.js'
-export { definePreset, defaultWhat, DEFAULT_WHAT, type PresetDef, type PresetParam, type PresetRenderContext } from './preset-prompt.js'
-export {
-  fakeDriver,
-  FAKE_INTENT,
-} from './fake-script.js'
-export {
-  DRIVERS,
-  DRIVER_SPECS,
-  createDriver,
-  isDriverName,
-  type DriverName,
-  type DriverSpec,
-  type CreateDriverOptions,
-} from './driver-cli.js'
+
+export type { HandoffState, SessionInfo } from './agent-view.js'
+export type { AutoPmJob, AutoPmOutcome, AutoPmReport } from './auto-pm.js'
+export type { FrameworkFileConfig } from './config.js'
+export type { ChoiceRequest, FrameworkEvent } from './events.js'
+export type { QuotaBoundaryStatus } from './quota-boundary.js'
+export type { CustomPreset, Preferences } from './registry.js'
+export type { DriverQuotaWindow } from './driver/types.js'
+export type { AgentMeta, AgentStatus } from './store/agent-store.js'
+export type { Activity } from './dashboard/activity.js'
+export type { AgentHandoff } from './dashboard/agent-handoff.js'
+export type { BridgeEvent, BridgeQuestion } from './dashboard/bridge-endpoints.js'
+export type { BridgeAnswer } from './dashboard/bridge-store.js'
+export type { DashboardData } from './dashboard/dashboard.js'
+export type { WorkspaceDoc } from './dashboard/docs.js'
+export type { FileChange, FileDiff } from './dashboard/file-diff.js'
+export type { FileContent } from './dashboard/file-read.js'
+export type { GitStatus } from './dashboard/git-status.js'
+export type { Intervention } from './dashboard/interventions.js'
+export type { OpenQuestion } from './dashboard/open-questions.js'
+export type { ActiveAgent, HotBucket, HotTicket, Overview, ProjectTickets, RecentAgent } from './dashboard/overview.js'
+export type { ProjectSummary } from './dashboard/projects.js'
+export type { ProjectQueue } from './dashboard/queue.js'
+export type { QuotaView } from './dashboard/quota.js'
+export type { TicketsMeta, WorkspaceTicket, WorkspaceTicketDetail } from './dashboard/tickets.js'
+export type { AgentWorktree, OnboardingSuggestion } from './dashboard/types.js'

--- a/packages/the-framework/src/install.test.ts
+++ b/packages/the-framework/src/install.test.ts
@@ -82,7 +82,7 @@ test('installProject seeds .the-framework/.gitignore so only the archive is comm
   const ignore = fs.files.get(gitignorePath(CWD)) ?? ''
   // Agent state (events.jsonl / agent.json / agents/) stays untracked...
   assert.match(ignore, /^\*$/m)
-  // ...and the session archive is un-ignored all the way down, since git never descends into an
+  // ...and the agent archive is un-ignored all the way down, since git never descends into an
   // ignored directory. Written whole at install (B3): with one record there is one content, so
   // nothing has to be appended to it later.
   assert.match(ignore, /^!\*\/$/m)

--- a/packages/the-framework/src/registry.test.ts
+++ b/packages/the-framework/src/registry.test.ts
@@ -11,7 +11,6 @@ import {
   readRegistry,
   registryPreferencesStore,
   registryPath,
-  removeProject,
   writePreferences,
   patchPreferences,
   readSecrets,
@@ -166,24 +165,6 @@ test('addProject normalizes the stored path to an absolute one', async () => {
   const fs = memFs()
   const record = await addProject('/repos/app-a/', APP_A.addedAt, fs, ENV)
   assert.equal(record.path, '/repos/app-a')
-})
-
-test('removeProject drops the matching record and returns true', async () => {
-  const fs = memFs({ [FILE]: JSON.stringify({ projects: [APP_A, APP_B], preferences: {} }) })
-  assert.equal(await removeProject(APP_A.id, fs, ENV), true)
-  assert.deepEqual(await listProjects(fs, ENV), [APP_B])
-})
-
-test('removeProject on an unknown id is false and does not write', async () => {
-  const raw = JSON.stringify({ projects: [APP_A], preferences: {} })
-  const fs = memFs({ [FILE]: raw })
-  assert.equal(await removeProject('nope-123', fs, ENV), false)
-  assert.equal(fs.files.get(FILE), raw) // untouched
-})
-
-test('removeProject on an empty / missing registry is false', async () => {
-  assert.equal(await removeProject(APP_A.id, memFs(), ENV), false)
-  assert.equal(await removeProject(APP_A.id, memFs({ [FILE]: JSON.stringify({ projects: [], preferences: {} }) }), ENV), false)
 })
 
 // Preferences (#410): stored in the same file next to the project list.
@@ -604,7 +585,7 @@ test('the daemon token survives the other registry mutators (#1051)', async () =
   const token = await ensureDaemonToken(fs, ENV)
   await addProject('/repos/app-a', APP_A.addedAt, fs, ENV)
   await writePreferences({ vanilla: true }, fs, ENV)
-  await removeProject(APP_A.id, fs, ENV)
+  await patchPreferences({ theme: 'dark' }, fs, ENV)
   assert.equal(await readDaemonToken(fs, ENV), token)
 })
 

--- a/packages/the-framework/src/registry.ts
+++ b/packages/the-framework/src/registry.ts
@@ -578,25 +578,6 @@ export async function addProject(
   })
 }
 
-/**
- * Drop the project whose id matches and write the list back (preferences preserved).
- * Returns whether a record was removed; an empty/missing registry is a no-write `false`.
- * The project's own overrides (#840) go with it, so re-adding the path starts clean.
- */
-export async function removeProject(
-  id: string,
-  fs: RegistryFs = nodeRegistryFs(),
-  env: NodeJS.ProcessEnv = process.env,
-): Promise<boolean> {
-  return serialize(async () => {
-    const registry = await readRegistry(fs, env)
-    const remaining = registry.projects.filter(project => project.id !== id)
-    if (remaining.length === registry.projects.length) return false
-    await writeRegistry({ ...registry, projects: remaining }, fs, env)
-    return true
-  })
-}
-
 /** The user's dashboard preferences (#410), or `{}` when none are stored. */
 export async function readPreferences(
   fs: RegistryFs = nodeRegistryFs(),

--- a/packages/the-framework/src/store/agent-checkout.test.ts
+++ b/packages/the-framework/src/store/agent-checkout.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
 import { resolveAgentEventsPath } from './agent-checkout.js'
-import { FRAMEWORK_DIR, EVENTS_FILE, WORKTREES_DIR, AGENTS_DIR, ARCHIVE_DIR } from './agent-store.js'
+import { FRAMEWORK_DIR, EVENTS_FILE, WORKTREES_DIR, ARCHIVE_DIR } from './agent-store.js'
 
 // resolveAgentEventsPath probes the real filesystem (same as resolveAgentCheckout), so these
 // tests build a throwaway project directory rather than a memory fs.
@@ -51,7 +51,7 @@ test('resolveAgentEventsPath: an existing worktree resolves to its own journal',
 test('resolveAgentEventsPath: an ended run (worktree gone) resolves to its archived log, not the root journal (#1472)', async () => {
   const cwd = await makeProject()
   try {
-    const events = await seedArchive(cwd, join(cwd, FRAMEWORK_DIR, AGENTS_DIR))
+    const events = await seedArchive(cwd, join(cwd, FRAMEWORK_DIR, ARCHIVE_DIR))
     assert.equal(await resolveAgentEventsPath(cwd, RUN_ID), events)
   } finally {
     await rm(cwd, { recursive: true, force: true })
@@ -71,7 +71,7 @@ test('resolveAgentEventsPath: finds an archive filed under a user sessions dir (
 test('resolveAgentEventsPath: a live worktree beats a stale archive (a resumed run)', async () => {
   const cwd = await makeProject()
   try {
-    await seedArchive(cwd, join(cwd, FRAMEWORK_DIR, AGENTS_DIR))
+    await seedArchive(cwd, join(cwd, FRAMEWORK_DIR, ARCHIVE_DIR))
     const worktree = join(cwd, FRAMEWORK_DIR, WORKTREES_DIR, RUN_ID)
     await mkdir(worktree, { recursive: true })
     assert.equal(await resolveAgentEventsPath(cwd, RUN_ID), join(worktree, FRAMEWORK_DIR, EVENTS_FILE))

--- a/packages/the-framework/src/store/agent-store.test.ts
+++ b/packages/the-framework/src/store/agent-store.test.ts
@@ -17,7 +17,6 @@ import {
   loadAgentEvents,
   agentIdFromStartedAt,
   startedAtFromAgentId,
-  AGENT_META_VERSION,
   type StoreFs,
   type AgentMeta,
 } from './agent-store.js'
@@ -79,7 +78,6 @@ test('fresh open truncates the log and writes an initial meta snapshot', async (
   const store = await AgentStore.open(CWD, { fs, fresh: true, now: AT })
   assert.equal(fs.files.get(EVENTS), '')
   const meta = await store.readMeta()
-  assert.equal(meta?.version, AGENT_META_VERSION)
   assert.equal(meta?.status, 'running')
   assert.equal(meta?.startedAt, AT)
 })
@@ -457,7 +455,7 @@ test('a fresh run archives a prior run that never got closed (crash safety) (#30
 
 const RUNS = join(CWD, '.the-framework', 'agents')
 const runningAgentMeta = (id: string): string =>
-  JSON.stringify({ version: AGENT_META_VERSION, status: 'running', id, startedAt: AT, updatedAt: AT })
+  JSON.stringify({ status: 'running', id, startedAt: AT, updatedAt: AT })
 
 test('listAgents reads every user archive and the transient one, under their one name (#1179)', async () => {
   // Both live locations are listed — the committed per-user archive and the transient one an agent
@@ -465,7 +463,7 @@ test('listAgents reads every user archive and the transient one, under their one
   // are not read: a second spelling per location is four directory probes per listing to find
   // archives that, with no users, nobody has.
   const meta = (id: string): string =>
-    JSON.stringify({ version: AGENT_META_VERSION, status: 'done', id, startedAt: AT, updatedAt: AT, intent: id })
+    JSON.stringify({ status: 'done', id, startedAt: AT, updatedAt: AT, intent: id })
   const user = join(CWD, '.the-framework', 'dev@example.com')
   const fs = memFs({
     [join(user, 'agents', '2026-new.json')]: meta('2026-new'),
@@ -481,7 +479,7 @@ test('reconcileOrphanedAgents flips archived runs stuck at running to stopped (#
   const fs = memFs({
     [join(RUNS, 'a.json')]: runningAgentMeta('a'),
     [join(RUNS, 'b.json')]: runningAgentMeta('b'),
-    [join(RUNS, 'c.json')]: JSON.stringify({ version: AGENT_META_VERSION, status: 'done', id: 'c', startedAt: AT, updatedAt: AT }),
+    [join(RUNS, 'c.json')]: JSON.stringify({ status: 'done', id: 'c', startedAt: AT, updatedAt: AT }),
   })
   const fixed = await reconcileOrphanedAgents(CWD, fs)
   assert.equal(fixed, 2)
@@ -504,7 +502,7 @@ test('reconcileOrphanedAgents flips a live run and archives it, counting it once
 // in-flight run. A second daemon boot then marked genuinely live agents as finished.
 test('reconcileOrphanedAgents leaves a run whose pid is alive on this host (#926)', async () => {
   const owned = (id: string, over: Record<string, unknown> = {}): string =>
-    JSON.stringify({ version: AGENT_META_VERSION, status: 'running', id, startedAt: AT, updatedAt: AT, pid: 42, host: hostname(), ...over })
+    JSON.stringify({ status: 'running', id, startedAt: AT, updatedAt: AT, pid: 42, host: hostname(), ...over })
   const fs = memFs({
     [META]: owned('live'),
     [join(RUNS, 'alive.json')]: owned('alive'),
@@ -527,7 +525,7 @@ test('reconcileOrphanedAgents leaves a run whose pid is alive on this host (#926
 
 test('reconcileOrphanedAgents is a no-op on a clean or empty workspace (#642)', async () => {
   assert.equal(await reconcileOrphanedAgents(CWD, memFs()), 0)
-  const done = memFs({ [META]: JSON.stringify({ version: AGENT_META_VERSION, status: 'done', id: 'd', startedAt: AT, updatedAt: AT }) })
+  const done = memFs({ [META]: JSON.stringify({ status: 'done', id: 'd', startedAt: AT, updatedAt: AT }) })
   assert.equal(await reconcileOrphanedAgents(CWD, done), 0)
 })
 
@@ -535,7 +533,7 @@ test('reconcileOrphanedAgents is a no-op on a clean or empty workspace (#642)', 
 // reader can flip it to `stopped` (and archive it) without waiting for a daemon-restart reconcile.
 const HERE = hostname()
 const ownedMeta = (id: string, pid: number, host: string): string =>
-  JSON.stringify({ version: AGENT_META_VERSION, status: 'running', id, startedAt: AT, updatedAt: AT, pid, host })
+  JSON.stringify({ status: 'running', id, startedAt: AT, updatedAt: AT, pid, host })
 
 test('a fresh open records the owning pid + host so a dead run can be detected (#716)', async () => {
   const fs = memFs()
@@ -857,7 +855,6 @@ test('applyEventToMeta records the branch a branch event names (#1277)', () => {
 const CHOICE_LINE = '{"kind":"choice","id":"todo-next","title":"Start the next backlog item?","options":[{"id":"proceed","label":"Go"},{"id":"stop","label":"Stop"}]}\n'
 const deadGatedMeta = (id: string): string =>
   JSON.stringify({
-    version: AGENT_META_VERSION,
     status: 'running',
     id,
     startedAt: AT,

--- a/packages/the-framework/src/store/agent-store.ts
+++ b/packages/the-framework/src/store/agent-store.ts
@@ -79,9 +79,6 @@ export function startedAtFromAgentId(id: string): string | undefined {
   return match ? `${match[1]}:${match[2]}:${match[3]}.${match[4]}Z` : undefined
 }
 
-/** Bumped when the on-disk shape changes, so a reader can detect an old file. */
-export const AGENT_META_VERSION = 2
-
 /** How an agent ended (or that it is still going). */
 export type AgentStatus = 'running' | 'done' | 'stopped' | 'failed'
 
@@ -90,7 +87,6 @@ export type AgentStatus = 'running' | 'done' | 'stopped' | 'failed'
  * dashboard render a header (and a future agent list) without parsing every line.
  */
 export interface AgentMeta {
-  version: number
   status: AgentStatus
   /** Stable, path-safe id for this agent (derived from {@link startedAt}). */
   id: string
@@ -162,8 +158,7 @@ export interface AgentMeta {
    * What lets a list surface — which reads meta, not the event log — tell "ended, still
    * publishing" from "ended, published": between a clean `end` and this field, an armed agent's
    * epilogue is still pushing / opening the PR, exactly the window the session pill calls
-   * "publishing…" (#1431). Only trustworthy at {@link AgentMeta.version} ≥ 2: older records never
-   * folded the event, so its absence there says nothing and must not read as forever-publishing.
+   * "publishing…" (#1431). Absent until the event lands, which is what a list reads as "still going".
    */
   handoffReport?: 'done' | 'skipped' | 'failed'
   /**
@@ -391,7 +386,6 @@ function freshMeta(
   kind?: 'build' | 'prompt',
 ): AgentMeta {
   return {
-    version: AGENT_META_VERSION,
     status: 'running',
     id: id && isSafeAgentId(id) ? id : agentIdFromStartedAt(startedAt),
     startedAt,

--- a/packages/the-framework/src/store/agent-store.ts
+++ b/packages/the-framework/src/store/agent-store.ts
@@ -38,22 +38,19 @@ export const EVENTS_FILE = 'events.jsonl'
 export const META_FILE = 'agent.json'
 
 /**
- * Where finished agents are archived, so the dashboard can list a project's run
- * history (#303). The live agent stays at `events.jsonl`/`agent.json` (the daemon
- * tails it); on {@link AgentStore.close} a copy lands here as `<id>.jsonl` +
- * `<id>.json`, giving the history sidebar a per-agent log to replay.
- */
-export const AGENTS_DIR = 'agents'
-
-/**
- * Where a project's finished agents are archived (#1179): `.the-framework/<user>/agents/`,
- * which the install-time ignore un-ignores so the history is committed and survives a
- * `git clean -fdx`. {@link AGENTS_DIR} stays the transient location — an agent with no worktree of
- * its own archives there, and so does one archiving inside its own throwaway checkout — so both
- * are read.
+ * Where finished agents are archived, under both placements that name has: a project's committed
+ * `.the-framework/<user>/agents/` (#1179), which the install-time ignore un-ignores so the history
+ * survives a `git clean -fdx`, and the transient `.the-framework/agents/` that an agent with no
+ * worktree of its own — or one archiving inside its own throwaway checkout — writes into. What
+ * separates the two is the user segment, not the directory's name, and {@link archiveDir} is where
+ * a caller picks; both are read when a project's history is listed.
  *
- * The name lives here beside its sibling rather than in `sessions.ts`, which owns the per-user
- * naming: that module reads the store, so the constant travelling the other way would be a cycle.
+ * The live agent stays at `events.jsonl`/`agent.json` (the daemon tails it); on
+ * {@link AgentStore.close} a copy lands here as `<id>.jsonl` + `<id>.json` (#303), giving the
+ * history sidebar a per-agent log to replay.
+ *
+ * The name lives here rather than in `sessions.ts`, which owns the per-user naming: that module
+ * reads the store, so the constant travelling the other way would be a cycle.
  */
 export const ARCHIVE_DIR = 'agents'
 
@@ -647,7 +644,7 @@ export class AgentStore {
  * be kept — the project's copy — never for the copy an agent leaves inside its own worktree.
  */
 function archiveDir(dir: string, user?: string): string {
-  return user ? join(dir, user, ARCHIVE_DIR) : join(dir, AGENTS_DIR)
+  return user ? join(dir, user, ARCHIVE_DIR) : join(dir, ARCHIVE_DIR)
 }
 
 /** Paths of an agent's archived log + meta. */
@@ -685,7 +682,7 @@ async function archiveDirs(fs: StoreFs, dir: string): Promise<string[]> {
     const candidate = join(dir, name, ARCHIVE_DIR)
     if ((await fs.readdir(candidate)).length > 0) dirs.push(candidate)
   }
-  dirs.push(join(dir, AGENTS_DIR))
+  dirs.push(join(dir, ARCHIVE_DIR))
   return dirs
 }
 

--- a/packages/the-framework/src/store/index.ts
+++ b/packages/the-framework/src/store/index.ts
@@ -24,7 +24,6 @@ export {
   WORKTREES_DIR,
   EVENTS_FILE,
   META_FILE,
-  AGENTS_DIR,
   ARCHIVE_DIR,
   type StoreFs,
   type AgentMeta,

--- a/packages/the-framework/src/store/index.ts
+++ b/packages/the-framework/src/store/index.ts
@@ -26,7 +26,6 @@ export {
   META_FILE,
   AGENTS_DIR,
   ARCHIVE_DIR,
-  AGENT_META_VERSION,
   type StoreFs,
   type AgentMeta,
   type LiveAgent as LiveAgent,


### PR DESCRIPTION
Findings 1–6 from a review of what #1536 left behind, each in its own commit. Finding 7 (SPEC structure) is a separate PR.

## `9e770be` — the barrel ends where its consumers end: 341 exports become 41

The headline. `src/index.ts` exported **341 names**. Nothing imports this package by name, nothing inside `src/` imports the barrel, and `bin.ts` — the only thing that ships — takes `runCli` from `cli.js` directly. Its consumers were the dashboard (85 imports, **every one `import type`**) and the dev-mode Vite plugin, which pulled the whole barrel out of `dist/index.js` to get `runDaemon`. **269 of the 341 were referenced nowhere outside their defining module.**

That is the shape A7 dissolved one level down — a 406-symbol export surface with one consumer — surviving at the top. It costs more than tidiness: an exported name reads as "in use" to anyone grepping, so 269 of them made every future deletion pass start by proving a negative. That fog is where the `run.json` and `sessions/` back-reads sat unnoticed.

The file is now the 41 types the dashboard names, grouped by defining module, type-only (a value re-exported there would pull its module into the browser bundle — the failure `client.ts` prevents). The dev plugin imports `dist/daemon.js`. `main`, `types` and the `exports` map go with it: they described a library API for a package that publishes a CLI. `bin` and `files` stay, so what someone installs is unchanged.

## `49389b2` — the meta's `version` field, and the old-records guard that was its only reader

**Correcting my own review here.** I reported this field as written and never read, off a grep that covered `src/` and not `dashboard/`. It had exactly one reader — `isMetaPublishing` in `dashboard/lib/live-state.ts` — whose own comment calls it "the old-records guard".

That makes it the same class #1545 removed everywhere else. A meta written before #1455 folded `handoffReport` has no report though its handoff answered long ago, so the gate stopped a list from reading that absence as "still publishing". With nothing carrying a pre-fold record, the gate only ever answers true — and the field exists only to be gated on. Both go.

## `5f3ebd0` — nothing removes a project, so nothing keeps `removeProject`

No RPC, no CLI path, no dashboard control; only its own three tests. Its doc gave away how long: *"the project's own overrides (#840) go with it"* — the tier that promise was about was deleted in B5.

## `286bd8d` — one name for the archive directory, not two spelling the same string

`AGENTS_DIR` and `ARCHIVE_DIR` were both `'agents'`, both exported, both re-exported. What differs between the two placements is the user segment, not the name — which is what the surviving constant's doc now says.

## `b748fe4` — the archive rule is named for the archive

`SESSIONS_RULE` → `ARCHIVE_RULE`; its value was already built from `ARCHIVE_DIR`. The sweep extends to the prose that carried the same retired word, including the line install writes into every user's repo. **Two deliberately left alone**, because they change what a user sees rather than what a reader reads: the commit message (`[The Framework] a session`) and the daemon's no-op reason (`no session changes`). Both worth renaming; neither is a comment.

## `eec7ad1` — four comments describe HTTP routes that no longer exist

`GET /api/projects`, the `/api/docs` payload, `/api/logs`+`/api/runs`, and a read model "backed by the ... legacy `/api/*` endpoints". `daemon.test.ts` already called them retired.

## Verification

After `pnpm clean`: both typechecks, a full build, **1442 node tests**, **774 dashboard tests (81 files)**. The dev plugin's new import was additionally checked by importing `dist/daemon.js` in a real Node process — that line is the one thing here no test covers.

## Two observations, not fixed here

- **`update-check.ts` polls npm for `@gemstack/the-framework`**, which has never been published, so the CLI's "up to date?" footer silently reads "unknown" on every run. It degrades correctly; it just never says anything.
- **This repo's own `.the-framework/.gitignore` still carries the pre-D5 rules** (`!*/sessions/`, plus `!LOGS.md` and `!conversations/` from records B3 collapsed). The archives already tracked stay tracked, and `ensureArchiveIgnored` appends the current rule on the next agent run, so it self-heals — but until then a *new* user directory's archive would be ignored.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGg6YdQthErYV63HRVPzrw)_