### PR TITLE
SPEC structure: the 24 files #1570 missed, a section sdd.md forbids, and three worked examples

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -31,6 +31,6 @@ be a package boundary; the dependency survived the merge, the boundary did not.
 - **Proposals vs. decisions.** Agents propose (tickets, plans, PRs); humans decide. The queue holds only confirmed work.
 - **Refuse loudly, degrade quietly.** A guard that cannot be enforced is announced; a read that fails yields an empty result rather than a crash.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/SPEC.md
+++ b/packages/SPEC.md
@@ -1,5 +1,5 @@
 The published family: the product (`the-framework`, which carries its own dashboard UI in `dashboard/`), the claude.ai browser extension (`chrome-extension`), and the product's website (`the-framework.ai`). Nothing depends up.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/chrome-extension/SPEC.md
+++ b/packages/chrome-extension/SPEC.md
@@ -9,6 +9,6 @@ A Chrome extension bridging Claude Code cloud sessions on claude.ai to the local
 - Reading is driven by page changes with a slow heartbeat backstop (it lives in background tabs), and every stage reports its status — on the page's panel and in the settings page's connection test — so a silent misconfiguration is visible.
 - The extension and the daemon insist on matching versions: every call states the manifest version, and a daemon expecting another blocks it with an error naming both and the update path, because a version-skewed pair half-works in ways that read as bugs.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework.ai/SPEC.md
+++ b/packages/the-framework.ai/SPEC.md
@@ -7,6 +7,6 @@ The product's marketing website, the-framework.ai — it pitches The Framework a
 - Three side pages support it: a press page with brand material, a go-to-dashboard page explaining that the dashboard runs on the visitor's own machine, and a hidden banner page that gets screenshotted into the social-preview image.
 - The whole site is pre-rendered into plain static pages — no server.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework.ai/pages/SPEC.md
+++ b/packages/the-framework.ai/pages/SPEC.md
@@ -6,6 +6,6 @@ The website's pages — the landing page plus three small side pages — and the
 - /press offers brand material, /go-to-dashboard explains how to open the locally-running dashboard, and /banner exists only to be screenshotted into the social-preview image.
 - The shared head/config gives every page its title, description, favicon, fonts, and social-preview card, and restores the visitor's remembered package-manager choice before anything is shown.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework.ai/pages/banner/SPEC.md
+++ b/packages/the-framework.ai/pages/banner/SPEC.md
@@ -1,5 +1,5 @@
 The hidden /banner page, whose only purpose is to be screenshotted into the image shown when the site is shared on social media and chat apps.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework.ai/pages/go-to-dashboard/SPEC.md
+++ b/packages/the-framework.ai/pages/go-to-dashboard/SPEC.md
@@ -1,5 +1,5 @@
 The /go-to-dashboard page — where "open the dashboard" links land, explaining that the dashboard runs on the visitor's own machine and how to launch it from the terminal.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework.ai/pages/index/SPEC.md
+++ b/packages/the-framework.ai/pages/index/SPEC.md
@@ -7,6 +7,6 @@ The landing page — the product pitch told top to bottom — plus the shared bu
 - Every command appears in the visitor's chosen package manager, copies with one click, and the choice is remembered across pages and visits.
 - This directory doubles as the site's component library: the other pages reuse its navigation bar, footer, styling, copy-to-clipboard behavior, and package-manager machinery.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework.ai/pages/press/SPEC.md
+++ b/packages/the-framework.ai/pages/press/SPEC.md
@@ -1,5 +1,5 @@
 The /press page — logos, naming, banner, and brand sources for anyone writing about The Framework.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/SPEC.md
+++ b/packages/the-framework/SPEC.md
@@ -52,6 +52,6 @@ flowchart TD
 
 **Prompts and presets.** One assembly path composes the system prompt for every agent — the built-in protocol, the extra protocol each capability brings, the user's own system file, and the picked context — and the exact composed text is recorded, so the dashboard can show precisely what the agent ran under. Two switches dial the wrapping down, where there were five modes: *vanilla* drops the enhanced prompt while keeping the framework integration, and *transparent* is the master off-switch — no framework channel at all, the CLI raw. Presets (triage, research, security audit, drain-the-queue, …) are one catalog with prompt text authored as prose; custom presets save to either the user tier (follows the person, private) or the project tier (travels with the repo, shared). A per-repo config file records which preset and switches a project works under, resolved layer over layer.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/dashboard/SPEC.md
+++ b/packages/the-framework/dashboard/SPEC.md
@@ -21,6 +21,6 @@ The dashboard UI: a browser app served by the daemon that renders everything the
 
 **Settings** covers appearance, driver and model defaults, the options every new agent starts with, saved devices, notification channels, automation (the idle sweep and the spend slider), and the cloud-session bridge token.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/dashboard/components/SPEC.md
+++ b/packages/the-framework/dashboard/components/SPEC.md
@@ -9,6 +9,6 @@ The dashboard's React component catalog: every page, panel and control the brows
 - Everything renders state the daemon owns (reads poll or stream, writes are daemon calls; components keep only view state), and the house rule is honesty: controls name what will actually happen, no state rides on colour alone, warnings teach before an agent is spent but never block, and empty states name their reason instead of dead-ending.
 - Two sub-kits supply the raw material: the hand-ported UI primitives and the composer's mention-aware prompt-editor engine.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/dashboard/components/prompt-editor/SPEC.md
+++ b/packages/the-framework/dashboard/components/prompt-editor/SPEC.md
@@ -12,6 +12,6 @@ The machinery behind the composer's in-editor triggers and token chips: typing a
 
 - The one invariant: chips change how the prompt looks, never what it says — the submitted text stays exactly what the agent already parses, so presets and everything downstream are untouched.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/dashboard/components/ui/SPEC.md
+++ b/packages/the-framework/dashboard/components/ui/SPEC.md
@@ -8,6 +8,6 @@ The dashboard's shared kit of basic interface pieces — buttons, inputs, menus,
 - The sidebar shell adapts by screen: a collapsible rail on desktop whose state survives reloads, a slide-in drawer on mobile.
 - Popups (menus, popovers, tooltips) share one surface look, and a trigger stays highlighted while its popup is open.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/dashboard/design/SPEC.md
+++ b/packages/the-framework/dashboard/design/SPEC.md
@@ -7,6 +7,6 @@ The dashboard's design gallery: static pages that show the design foundations (c
 - Cards are pure pages with nothing to click; hover and open states appear as separately rendered instances.
 - The build turns the card registry into one page per card, each self-contained and showing light and dark side by side, ready for the design-sync upload.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/dashboard/lib/SPEC.md
+++ b/packages/the-framework/dashboard/lib/SPEC.md
@@ -9,6 +9,6 @@ The dashboard's client-side logic layer: the dashboard owns no facts of its own,
 - Attention plumbing keeps a backgrounded tab honest: browser notifications for new needs-you items and agent activity (sharing the daemon notifier's idea of "new"), the needs-you count folded into the tab title, and the tab icon animating while an agent works.
 - Rules that can be pure are pure, wrapped thinly for the pages — so the behavior above is testable without a browser.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/prompts/SPEC.md
+++ b/packages/the-framework/prompts/SPEC.md
@@ -13,6 +13,6 @@ Every word the framework says to a coding agent, authored as markdown: the built
 
 - Prompting lives as prose and is compiled into the code at build time, so a prompt change lands as a readable markdown diff that gets a review round like any other product change. These files are the source of truth: the system prompt used to be authored on a GitHub issue and copied here, with a daily job checking the two had not drifted — a second home for the text, and a checker to paper over having one.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/scripts/SPEC.md
+++ b/packages/the-framework/scripts/SPEC.md
@@ -6,6 +6,6 @@ Build-time helpers that keep the prompting authored as markdown, and make the pu
 - Tests run against a throwaway home for the machine's global state, so the developer's live daemon can never leak into the suite and hang it. There are two suites and two runners: `node --test` over the compiled `src/`, and the dashboard's own browser-shaped tests.
 - Copying the dashboard bundle is no longer a step: the dashboard is part of this package now, and its build writes straight into the `dist/` the daemon serves from.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/src/SPEC.md
+++ b/packages/the-framework/src/SPEC.md
@@ -32,6 +32,6 @@ flowchart LR
 - Worktrees exist so concurrent agents never fight and the user's checkout — uncommitted work included — is never touched; one retention rule decides every removal, and it asks whether the work is on the remote rather than how the agent ended, so cleanup commits and pushes before removing anything and every deletion is recoverable.
 - The CLI is treated as a black box on purpose: the framework never runs its own model calls for the coding work, and swapping which CLI does the work means swapping one driver.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/src/config.SPEC.md
+++ b/packages/the-framework/src/config.SPEC.md
@@ -2,11 +2,23 @@ The per-repo defaults every agent starts from, persisted in a small YAML file (`
 
 ## TLDR
 
-- One canonical key list drives parsing, layering and narration alike, so a new setting is declared once and flows through everywhere.
+- A project's settings travel with its code, and a bad file never fails an agent.
+- One list of keys, and only today's spelling of each.
+
+## Flows
+
+- The file is read from the workspace root; a missing one yields nothing, and a malformed one is a warning and nothing.
+- Every key it declares is parsed, layered under any explicit flag, and narrated back from one canonical list.
+- Most keys are checked by type. The one whose values come from a closed set — how far a finished agent publishes itself — is checked by value, so an unknown rung is refused by name.
+- Only today's spelling of a key is read: a key a rename retired is an unknown key, and unknown keys are ignored.
+
+## Rationales
+
+- One key list drives parsing, layering and narration alike, so a new setting is declared once instead of added in three places.
 - A setting spells its key and its polarity the same way here as everywhere else, so crossing the file boundary is a copy rather than a rename plus a negation — the one key that did neither had three separate comments apologising for it.
-- Most keys are checked by type; the one whose values come from a closed set is checked by value instead, so a mistyped rung of the publish ladder is refused by name rather than silently ignored — a repo that meant "keep it local" must never end up publishing because of a typo.
-- Only today's spelling of a setting is read. A file still using an older one — the three booleans the publish ladder replaced, or the earlier name of the mode key — is not translated: those settings simply stop applying, until someone rewrites the file by hand.
-- A missing file yields nothing; a malformed one is a warning and nothing — a bad config must never fail an agent; explicit flags override whatever the file says.
+- The publish rung is checked by value because silently ignoring a typo there would leave a repo that meant "keep it local" publishing.
+- A retired spelling is ignored rather than translated: those settings stop applying until someone rewrites the file by hand, which is the whole of this project's migration story.
+- A bad config must never fail an agent, so a malformed file degrades to nothing rather than to an error.
 
 ## Before modifying/creating SPEC.md files
 

--- a/packages/the-framework/src/dashboard-rpc/SPEC.md
+++ b/packages/the-framework/src/dashboard-rpc/SPEC.md
@@ -21,6 +21,6 @@ flowchart LR
 
 - Files are the seam on purpose: the dashboard shares no process with an agent, so steering and watching both travel through files the agent already owns — which is why a remote device steers an agent exactly the way a dashboard click does.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/src/dashboard/SPEC.md
+++ b/packages/the-framework/src/dashboard/SPEC.md
@@ -20,6 +20,6 @@ The daemon's serving and projection layer: the HTTP host behind the dashboard, t
 
 **The live browser.** The dashboard cannot reach an agent's Chrome directly (wrong origin), so the daemon proxies the screencast and the clicks — and the port comes from the agent's own record, never from the client, which is what keeps the proxy from being an open relay into anything else on the machine.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/src/driver/SPEC.md
+++ b/packages/the-framework/src/driver/SPEC.md
@@ -14,6 +14,6 @@ The driver seam: the one abstraction a coding-agent CLI is wrapped behind, so th
 - **Quota and cost.** Drivers that can, report the account's quota window: read via the CLI's own usage command, and for free between turns from the telemetry the stream already carries. A transient failure (network, timeout, reworded readout) leaves the last good reading in force; "the CLI isn't installed / has no subscription" invalidates it. A driver that cannot price turns reports cost as unknown — never zero — so an unpriced agent never reads as free.
 - **The fake.** A scripted, offline driver that exercises every path deterministically — the product's whole lifecycle is testable without spending a token.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/src/e2e/SPEC.md
+++ b/packages/the-framework/src/e2e/SPEC.md
@@ -6,6 +6,6 @@ The product's end-to-end stories: each test walks a user journey through the dae
 - Stories observe the product exactly where users do — the dashboard's reads and the live event feed; the one extra window is the recorded child invocation, since a detached spawn is otherwise unobservable.
 - The harness gives every story a throwaway world with its own global state and a daemon-shaped teardown, so stories are isolated, parallel-safe, and repeatable.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/src/event-stream.SPEC.md
+++ b/packages/the-framework/src/event-stream.SPEC.md
@@ -5,10 +5,6 @@ A replayable, multi-consumer stream of events: every event is buffered, live con
 - One producer, many consumers: pushing an event wakes every waiting iterator, and a consumer that arrives late replays what it missed from an offset rather than starting blank.
 - Closing is final and idempotent: pushes after a close are ignored and every live iterator ends, so a finished agent cannot leave a reader hanging.
 
-## Notes
-
-- Absorbed from `@gemstack/ai-autopilot` when that package was deleted. Its element type used to default to the supervisor's event type; the only caller here passes `FrameworkEvent`, so the type parameter is required.
-
 ## Before modifying/creating SPEC.md files
 
 Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/src/framework-gitignore.SPEC.md
+++ b/packages/the-framework/src/framework-gitignore.SPEC.md
@@ -2,11 +2,22 @@ The `.the-framework/.gitignore`: what a project commits out of its framework dir
 
 ## TLDR
 
-- An agent's live state is transient and must never make a checkout dirty; its archive is committed, because `git clean -fdx` is an ordinary thing to do to a repo and it used to delete every agent a project had ever run.
-- An allow-list, so every directory on the way down to a committed file has to be re-included — git never descends into an ignored one.
-- The archive rules name no user: a rule per person meant everyone who ever ran an agent appended their own lines to a tracked file, so their checkout went dirty, the next safety commit swept the edit into a branch, and two machines doing it near each other conflicted.
-- Only the archive's current name is re-included. This file is written into everyone's repo, so it says what is true now rather than listing every name that directory has ever had.
-- One content, written once at install. It grew a rule per record while there were several, each added lazily by whichever feature needed it and each with its own "is this a file we wrote" check; with one record left, the only question is whether the file is already there.
+- An agent's live state stays out of git; the agent archive is committed.
+- One file with one content, written whole at install, naming no user.
+
+## Flows
+
+- Everything under the framework directory is ignored, and then the archive is re-included: the directories on the way down first, since git never descends into an ignored one, and the files under them after.
+- The archive is re-included by a glob covering every user, so someone who has never run an agent is already covered.
+- Only the name the archive directory has now is re-included.
+- Install writes the whole file. A repo activated before the archive existed gets the missing rules appended; a repo that already has them is left alone.
+
+## Rationales
+
+- The archive is the one thing under here that is committed, because `git clean -fdx` is an ordinary thing to do to a repo and it used to delete every agent a project had ever run.
+- Naming each user meant everyone who ever ran an agent appended their own lines to a tracked file: their checkout went dirty, the next safety commit swept the edit into a branch, and two machines doing it near each other conflicted.
+- The name the directory was renamed away from is not carried as a second rule, because this file is written into everyone's repo and should say what is true now rather than list every name that directory has ever had.
+- It grew a rule per record while there were several, each added lazily by whichever feature needed it and each with its own "is this a file we wrote" check. With one record left, the only question is whether the file is already there.
 
 ## Before modifying/creating SPEC.md files
 

--- a/packages/the-framework/src/store/SPEC.md
+++ b/packages/the-framework/src/store/SPEC.md
@@ -8,6 +8,6 @@ Agent persistence and workspaces: the append-only event log every surface is a p
 - Each agent works in its own worktree on its own branch (named after its id until it picks a session name); teardown commits leftover work first, so the branch outlives the checkout. The parent checkout's installed dependencies are symlinked in instead of reinstalled — instant, no extra disk — and hidden from git so a sweeping commit cannot drag them onto the PR.
 - Nothing is resumed at boot. Ctrl-C closed the last dashboard and every agent it was running, which is a deliberate act rather than a crash to recover from; what the next boot does instead is mark as stopped anything a dead process left claiming to be running.
 
-## Before writing SPEC.md files
+## Before modifying/creating SPEC.md files
 
-Read https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/src/store/agent-store.SPEC.md
+++ b/packages/the-framework/src/store/agent-store.SPEC.md
@@ -2,13 +2,28 @@ Agent persistence: an agent's history is its append-only event log, and everythi
 
 ## TLDR
 
-- Each event is appended and folded into a small snapshot for cheap list reads; a restarted dashboard rehydrates by replaying the log — no second source of truth to drift. Only orchestration events are stored; the agent's own transcript belongs to the agent.
-- Finished agents are archived into the repo under per-user directories and committed, so a project's history survives a `git clean`; every user's archive is listed (the history is a team record) beside the transient one, duplicates show once, and an agent's live copy beats its archived one — a continued agent is both at once.
-- Everything here is known by one name. The snapshot and the archive directories were renamed, and what they used to be called is not looked for — an agent whose state is still under the old names reads as absent.
-- The snapshot is rewritten by the agent's own process while everyone else polls it from outside, so it is renamed into place rather than written over: a reader sees a whole snapshot or the whole previous one, never a truncated one. A live agent must never blink out of a listing — readers act on that absence — so a snapshot that still will not parse is read again before it is called corrupt.
-- An agent that crashed without saying goodbye is healed wherever it is found: once its process is provably dead, the missing ending is written on its behalf — into the log too, so its last question stops rendering as answerable forever. An owner that cannot be probed (no record, another machine) is cleaned up only at boot, never by a routine read.
+- The log is the truth; the snapshot beside it is a fold of the log, kept for cheap reads.
+- Finished agents are archived into the repo per user, so a project's history is a team record that survives a `git clean`.
+- An agent that died without saying goodbye is given its ending, wherever it is found.
+
+## Flows
+
+- Each event is appended to the log and folded into a small snapshot, so a list read costs one file instead of a replay. A restarted dashboard rehydrates by replaying the log itself.
+- Only orchestration events are stored; the agent's own transcript belongs to the agent.
+- On close, a finished agent's log and snapshot are copied into the archive: the project's committed per-user directory, or the transient one when the agent has no worktree of its own.
+- Listing a project's history reads every user's archive and the transient one, shows an agent once when it appears in both, and prefers an agent's live copy to its archived one.
+- The snapshot is renamed into place rather than written over, so a reader outside the agent's process sees a whole snapshot or the whole previous one. One that arrives unreadable is read again before it is called corrupt.
+- An agent whose process is provably dead has its missing ending written on its behalf — into the log as well as the snapshot. An owner that cannot be probed is left alone until boot.
+- An archived snapshot can be patched afterwards with a fact discovered once the agent's process is gone, such as the pull request opened for its work.
 - Ids are timestamps made path-safe, so id order is time order.
-- An archived snapshot can be patched afterwards for a fact discovered once the agent's process is gone — the pull request opened for its work. A record is the right home for it either way, and a surface should not have to know which path produced it.
+
+## Rationales
+
+- A live agent must never blink out of a listing, because readers act on that absence: it is why a torn snapshot is re-read, and why the write is a rename rather than a truncate.
+- The ending is written into the log too, or the agent's last question renders as answerable forever.
+- An owner on another machine, or one with no record of its process, is cleaned up only at boot: a routine read must not kill an agent another machine is still driving.
+- Everything here is known by one name. What the snapshot and the archive directories were called before is not looked for, so state left under the old names reads as absent.
+- A record is the right home for a late fact either way, so a surface reading it never has to know which path produced it.
 
 ## Before modifying/creating SPEC.md files
 


### PR DESCRIPTION
Finding 7 from the #1536 review, kept separate from the code fixes in #1571. Independent of that PR — no overlapping files.

## The 24 files #1570 missed

#1570 renamed the footer to `## Before modifying/creating SPEC.md files` in every `*.SPEC.md`. It matched that pattern, so it skipped the 24 **directory-level** `SPEC.md` files — including the root `SPEC.md` and every package and subsystem one. They still said *"Before **writing** SPEC.md files"* and *"Read"* rather than *"Always read and respect"*.

Worth naming why that wording matters, since I am the evidence: "before writing" is what I read as *authoring a new file*, which is how I edited six SPECs in `10f280c` without opening the spec at all. The files most likely to be read first were the ones still carrying it.

## A section sdd.md forbids

`event-stream.SPEC.md` had a `## Notes` section. sdd.md lists the allowed sections and says never to invent others. What it held: the history of a package that was deleted, and a note that a type parameter is required — one belongs in git, the other in the code. Removed.

After both, every one of the 543 SPEC files carries the required section, uses only sections sdd.md lists, and orders them as the spec does.

## The part that cannot be done in bulk — and a decision to make

`sdd.md` defines `## TLDR` as *"a summary of the content below"*, and since [brillout/sdd@d6f417f](https://github.com/brillout/sdd/commit/d6f417f14341102c167474c324c5c70a0d60b6ad) says `## Flows` describes what the code does with **no context and no history**, which belongs in `## Rationales`.

**180 SPEC files here have a TLDR and nothing below it** — one bullet list carrying flows, rationale and history together, summarising nothing. (333 files are a single sentence, which the spec explicitly allows; 21 have Rationales, 7 have Flows.) That means the new Flows rule has nothing to bite on, and the altitude defect I introduced in my own six SPECs was structurally invited.

Three files are restructured here as worked examples — `framework-gitignore`, `config`, and `store/agent-store`, the biggest of them. Same content, sorted: what it does under Flows, why it is that way under Rationales, and a TLDR that is now actually a summary.

**The other 177 are left for your call rather than a script.** Splitting a bullet into what-happens and why is a judgement per sentence; done mechanically across 177 files it would produce exactly the prose the spec exists to prevent, in your voice rather than mine. The three here are what the answer looks like — if it is the right answer, the rest is a known and finite job, and I would rather do it with a yes than assume one.

## Verification

Docs only — no source, no test, no build input changed. A conformance check over all 543 files reports no violations: required section present everywhere, no section sdd.md does not list, and TLDR → Flows → Rationales in that order wherever they appear.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGg6YdQthErYV63HRVPzrw)_