### PR TITLE
Three more from the refactor review: a duplicated host check, a dead waiter, and a rule with an unwritten exception

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -2,7 +2,7 @@
 
 - **The CLI always runs in the foreground.** Ctrl-C closes everything — the dashboard and every session it is running. There is no background/detached daemon mode.
 - **The CLI options are minimal.** Every other setting belongs to the dashboard, which is the product's only user interface.
-- **Only remove what has been pushed to the git remote.** Worktrees, branches, archives — anything deleted must already exist on the remote, so every removal is recoverable from it.
+- **Only remove what has been pushed to the git remote.** Worktrees, branches, archives — anything the framework removes on its own initiative must already exist on the remote, so every removal is recoverable from it. A delete the user asked for and confirmed is the exception: throwing the work away is what it is for.
 - **Never interrupt a running session because of low quota.** Quota gates whether a session may *start*; a session already running is never paused, degraded or cut short.
 - **The unit of work is an *agent*** — not a run or a session. The CLI that drives it (`claude`, `codex`) is the *driver*.
 - **Zero migration code.** Manual migration is good; code that migrates is not. A renamed or deleted thing leaves nothing behind — no fallback to the old name, no key alias, no old-format branch, no upgrade step. Nor a notice about what was dropped: a warning about data nobody has is still code nobody needs.

--- a/packages/the-framework/dashboard/components/Composer.tsx
+++ b/packages/the-framework/dashboard/components/Composer.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react'
 import { ArrowUp, Loader2 } from 'lucide-react'
 import type { ProjectSummary } from '../../src/index.js'
-import { DRIVERS, DRIVER_LABELS, LAUNCHER_PRESETS, type DriverName } from '../../src/client.js'
+import { DRIVERS, DRIVER_LABELS, LAUNCHER_PRESETS, type DriverName, isLoopbackHost } from '../../src/client.js'
 import {
   usePreferences,
   updatePreferences,
@@ -21,7 +21,7 @@ import { DriverModelMenu, type DriverOption } from './DriverModelMenu.js'
 import { OptionsMenu, type AgentTarget } from './OptionsMenu.js'
 import { resumeOptionRows, agentOptionRows } from '../lib/agent-option-rows.js'
 import { AddDeviceDialog } from './AddDeviceDialog.js'
-import { useConnectionProfiles, connectLocal, isLoopbackHost, removeProfile, type ConnectionProfile } from '../lib/profiles.js'
+import { useConnectionProfiles, connectLocal, removeProfile, type ConnectionProfile } from '../lib/profiles.js'
 import { useSelectedRemoteDeviceId, selectRemoteDevice } from '../lib/remote-target.js'
 import { useDeviceStatus } from '../lib/use-device-status.js'
 import { stashDraftFromUrl, takePendingDraft } from '../lib/draft-handoff.js'

--- a/packages/the-framework/dashboard/lib/profiles.test.ts
+++ b/packages/the-framework/dashboard/lib/profiles.test.ts
@@ -7,7 +7,6 @@ import {
   connectUrl,
   connectTo,
   currentConnection,
-  isLoopbackHost,
   localOrigin,
   rememberLocalOrigin,
 } from './profiles.js'
@@ -71,12 +70,6 @@ describe('profiles.ts (#1052)', () => {
     expect(url).toContain('token=abc')
     expect(url).toContain('draft=' + encodeURIComponent('my prompt'))
     vi.unstubAllGlobals()
-  })
-
-  test('isLoopbackHost knows the local machine', () => {
-    expect(isLoopbackHost('127.0.0.1')).toBe(true)
-    expect(isLoopbackHost('localhost')).toBe(true)
-    expect(isLoopbackHost('192.168.1.5')).toBe(false)
   })
 
   test('currentConnection labels the daemon the browser is on', () => {

--- a/packages/the-framework/dashboard/lib/profiles.ts
+++ b/packages/the-framework/dashboard/lib/profiles.ts
@@ -1,4 +1,5 @@
 import { useSyncExternalStore } from 'react'
+import { isLoopbackHost } from '../../src/client.js'
 
 // Client connection profiles (#1052): the saved daemons this browser can hop to. "A device I have"
 // is a CONNECTION, not an agent driver — the SPA is served by its daemon and every transport is
@@ -92,11 +93,6 @@ export function parseDeviceUrl(pasted: string): { url: string; token: string } |
   } catch {
     return null
   }
-}
-
-/** Whether a host is loopback (so the dashboard is talking to this machine's own daemon). */
-export function isLoopbackHost(host: string): boolean {
-  return host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1'
 }
 
 /** Remember the loopback origin the dashboard is served from, so "Local" can return to the right

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -1403,15 +1403,3 @@ export async function runOnBeforeMergeable(
 }
 
 
-/** Resolve when the process is interrupted (Ctrl+C), so the dashboard stays up. */
-function waitForInterrupt(): Promise<void> {
-  return new Promise(resolvePromise => {
-    const done = () => {
-      process.off('SIGINT', done)
-      process.off('SIGTERM', done)
-      resolvePromise()
-    }
-    process.once('SIGINT', done)
-    process.once('SIGTERM', done)
-  })
-}

--- a/packages/the-framework/src/client.ts
+++ b/packages/the-framework/src/client.ts
@@ -68,3 +68,7 @@ export {
   type DiscordCredentialStatus,
   type DiscordCredentialsPatch,
 } from './discord-credentials.js'
+// Whether an address is truly local (#1051). The daemon decides the token gate with it and the
+// dashboard labels the connection with it, so they must agree on what "local" means — the browser
+// kept its own looser copy, which answered `false` for every 127.0.0.0/8 address but the first.
+export { isLoopbackHost } from './loopback-host.js'

--- a/packages/the-framework/src/loopback-host.test.SPEC.md
+++ b/packages/the-framework/src/loopback-host.test.SPEC.md
@@ -1,0 +1,5 @@
+Covers what counts as this machine: every loopback name and the whole 127.0.0.0/8 range read as local, a rebound name that merely starts with "127." and any bind-all or routable address read as remote, and a Host header read without its port while an IPv6 literal keeps its brackets.
+
+## Before modifying/creating SPEC.md files
+
+Always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/src/loopback-host.test.ts
+++ b/packages/the-framework/src/loopback-host.test.ts
@@ -1,0 +1,33 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { isLoopbackHost, hostnameFromHostHeader } from './loopback-host.js'
+
+test('the names and addresses that reach this machine without leaving it are local', () => {
+  for (const host of ['localhost', '127.0.0.1', '::1', '[::1]']) {
+    assert.equal(isLoopbackHost(host), true, host)
+  }
+})
+
+test('the whole 127.0.0.0/8 range is local, not just the first address (#1051)', () => {
+  // A daemon bound anywhere in the range is still only reachable from this machine. The dashboard
+  // kept a copy that compared against `127.0.0.1` alone, so it called these remote.
+  for (const host of ['127.0.0.2', '127.1.2.3', '127.255.255.255']) {
+    assert.equal(isLoopbackHost(host), true, host)
+  }
+})
+
+test('a name that merely starts with 127. is not local — that is the rebound host', () => {
+  // The DNS-rebinding case the guard exists for: `127.evil.com` resolves to 127.0.0.1, so a
+  // prefix test would hand it the token gate. Bind-all and routable addresses are not local either.
+  for (const host of ['127.evil.com', '127.0.0.1.evil.com', '0.0.0.0', '::', '10.0.0.5', '']) {
+    assert.equal(isLoopbackHost(host), false, host)
+  }
+})
+
+test('a Host header is read without its port, and an IPv6 literal keeps its brackets', () => {
+  assert.equal(hostnameFromHostHeader('127.0.0.1:4200'), '127.0.0.1')
+  assert.equal(hostnameFromHostHeader('localhost'), 'localhost')
+  // Splitting on the first colon would mangle this into `[`.
+  assert.equal(hostnameFromHostHeader('[::1]:4200'), '[::1]')
+  assert.equal(hostnameFromHostHeader('[::1]'), '[::1]')
+})


### PR DESCRIPTION
Findings 8–10 from the second review pass over #1536, one commit each. Follows #1571 and #1572.

## `e029e82` — one answer to "is this host local", and a test on the copy that decides access

`isLoopbackHost` existed twice and the two disagreed:

| host | `src/loopback-host.ts` | `dashboard/lib/profiles.ts` |
|---|---|---|
| `127.0.0.1` | true | true |
| `127.0.0.2` | true | **false** |
| `127.1.2.3` | true | **false** |
| `127.evil.com` | false | false |

**Nothing was exploitable** — the token gate and the Host check use the strict one; the browser's copy only labels the connection and remembers the local origin. What it was is two answers to one question, with the loose implementation sitting where someone looking for it would find it first.

`loopback-host.ts` imports nothing, so it is already the leaf shape `client.ts` re-exports for the browser — the same arrangement `preference-defaults.ts` uses to keep both sides on one set of values. The dashboard reads it from there now and its copy is gone.

**The part worth more than the deduplication:** the strict implementation had **no test at all**, while the loose one had three. The module that decides whether a request skips the token now has its own — the full 127.0.0.0/8 range, the rebound `127.evil.com` name, bind-all and routable addresses, and the Host header's port and IPv6 brackets.

## `8a5d596` — the CLI's own interrupt waiter went out with the background daemon

`waitForInterrupt` in `cli.ts` had no caller. D4b made the daemon foreground-only and `runDaemon` blocks until signalled — `cli.ts` says exactly that two hundred lines above. The promise-on-SIGINT was what detached mode needed to stay alive after handing the dashboard off.

It is the only uncalled non-exported function in 147 modules, which is a fair report on the rest of that sweep.

## `e8354db` — the removal rule admits the one deletion that is meant to lose work

`MEMORY.md` says anything deleted must already be on the remote, with no exception. `deleteProjectAgent` breaks that deliberately: it force-removes the worktree and discards uncommitted work, because the session is being thrown away — its doc calls it *"the one destructive-of-history action, which is why the surfaces that call it confirm first."*

The entry is the half that is wrong. Making delete push first would publish the work of a user who pressed a button meaning "throw this away". So the rule now binds what the framework does **on its own initiative** — the sweeps, teardown, retention — and names the confirmed delete as the exception.

## What the same pass checked and found sound

E4 (seven jobs, one `setInterval`, no sweep kept a timer), E5 (`removeProjectWorktree` really is the one implementation behind every retention surface; `stale-branch` refuses anything with an open PR or no PR history), E1 (`agent.ts`: "Nothing stops a session for spending"), no unused dependencies, and — apart from the one above — no logic duplicated across the packages A7 merged.

## Verification

After `pnpm clean`: both typechecks, a full build, **1452 node tests** (+10: the new loopback suite), **773 dashboard tests (81 files)** (−1: the loose copy's test moved to the module that owns the behaviour).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGg6YdQthErYV63HRVPzrw)_