### PR TITLE
CLAUDE.md imports AGENTS.md so Claude Code sessions load the rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
One line. Claude Code injects `CLAUDE.md` into every session's context; this repo only had `AGENTS.md`, so its rules were literally absent from those sessions — which is how #1589 grew compat bloat despite the zero-users rule. The `@AGENTS.md` import makes AGENTS.md the single source of truth and puts it in context everywhere.

(TF-driven runs get the #326 system prompt instead, which also doesn't carry AGENTS.md — that half is yours, flagged in the AC issue.)

