### PR TITLE
Bridge settings name a token-rejected contact instead of staying silent (#1225)

### DIFF
--- a/packages/the-framework/dashboard/components/BridgeSettings.SPEC.md
+++ b/packages/the-framework/dashboard/components/BridgeSettings.SPEC.md
@@ -1,4 +1,4 @@
-The browser-bridge setup panel: shown while the bridge is on, it explains the extension install and hands over the bridge token — masked until revealed, so a secret is not sitting in every screenshot — or says a restart is needed when no token exists yet. When the daemon last refused the extension over its version, the panel says so with both versions and the update path, instead of the bridge merely looking disconnected.
+The browser-bridge setup panel: shown while the bridge is on, it explains the extension install and hands over the bridge token — masked until revealed, so a secret is not sitting in every screenshot — or says a restart is needed when no token exists yet. When the daemon last refused the extension over its version, the panel says so with both versions and the update path, instead of the bridge merely looking disconnected. When the last contact was rejected over its token — a failure that happens before the version gate can even speak — the panel says that too, pointing at re-saving the token; the version message wins when both apply, since fixing the token is what lets the more specific one appear.
 
 ## Before modifying/creating SPEC.md files
 

--- a/packages/the-framework/dashboard/components/BridgeSettings.test.tsx
+++ b/packages/the-framework/dashboard/components/BridgeSettings.test.tsx
@@ -4,7 +4,7 @@ import { cleanup, render, screen } from '@testing-library/react'
 const onBridgeToken = vi.hoisted(() => vi.fn(async (): Promise<string | null> => 'tok-1'))
 const onBridgeStatus = vi.hoisted(() =>
   vi.fn(async () => ({ lastContact: null, questions: 0, page: null, version: null }) as {
-    lastContact: null
+    lastContact: { at: string; route: string; status: number } | null
     questions: number
     page: null
     version: { got: string; expected: string; blocked: boolean; at: string } | null
@@ -47,5 +47,47 @@ describe('BridgeSettings version gate (#1519)', () => {
     // The token row proves the panel rendered before asserting the absence.
     await screen.findByText(/paste this token/)
     expect(screen.queryByText(/blocked/)).toBeNull()
+  })
+})
+
+describe('BridgeSettings refused contact (#1225)', () => {
+  test('a rejected token is named, with the way out', async () => {
+    // A 401 dies before the version gate, so no version claim exists to render — the
+    // refused-contact slot is the only evidence something is trying with a stale token.
+    onBridgeStatus.mockResolvedValue({
+      lastContact: { at: '2026-08-17T12:00:00.000Z', route: '/_bridge/sessions', status: 401 },
+      questions: 0,
+      page: null,
+      version: null,
+    })
+    render(<BridgeSettings enabled onChange={() => {}} />)
+    const notice = await screen.findByText(/token this dashboard rejects/)
+    expect(notice.textContent).toContain('save the token')
+  })
+
+  test('an accepted contact shows no refused notice', async () => {
+    onBridgeStatus.mockResolvedValue({
+      lastContact: { at: '2026-08-17T12:00:00.000Z', route: '/_bridge/sessions', status: 200 },
+      questions: 0,
+      page: null,
+      version: { got: '0.8.0', expected: '0.8.0', blocked: false, at: '2026-08-17T12:00:00.000Z' },
+    })
+    render(<BridgeSettings enabled onChange={() => {}} />)
+    await screen.findByText(/paste this token/)
+    expect(screen.queryByText(/rejects/)).toBeNull()
+  })
+
+  test('a version block outranks a refused contact left behind by the same extension', async () => {
+    // Fixing the token is step one; once it lands, the version gate speaks and its banner
+    // carries the more specific cure. Both at once would say "do two things" in two colors.
+    onBridgeStatus.mockResolvedValue({
+      lastContact: { at: '2026-08-17T11:00:00.000Z', route: '/_bridge/sessions', status: 401 },
+      questions: 0,
+      page: null,
+      version: { got: '0.7.3', expected: '0.8.0', blocked: true, at: '2026-08-17T12:00:00.000Z' },
+    })
+    render(<BridgeSettings enabled onChange={() => {}} />)
+    await screen.findByText(/blocked/)
+    expect(screen.queryByText(/token this dashboard rejects/)).toBeNull()
   })
 })

--- a/packages/the-framework/dashboard/components/BridgeSettings.tsx
+++ b/packages/the-framework/dashboard/components/BridgeSettings.tsx
@@ -20,20 +20,28 @@ export function BridgeSettings({ enabled, onChange }: { enabled: boolean; onChan
   const [token, setToken] = useState<string | null>(null)
   const [shown, setShown] = useState(false)
   const [blocked, setBlocked] = useState<{ got: string; expected: string } | null>(null)
+  const [refused, setRefused] = useState(false)
 
   // The version gate's visible half (#1519): a refused extension would otherwise look merely
   // disconnected, and "the bridge stopped working" after a pull is exactly this. Polled, because
   // the block clears on the extension's own next call, not on anything this page does.
+  // A rejected token gets the same treatment (#1225): it dies before the version gate, so an
+  // extension that is stale in both copy and token never even records a version claim — the
+  // store's refused-contact slot is the only trace, and without this line that failure is
+  // silent everywhere.
   useEffect(() => {
     if (!enabled) {
       setBlocked(null)
+      setRefused(false)
       return
     }
     let live = true
     const read = () =>
       void onBridgeStatus()
         .then(status => {
-          if (live) setBlocked(status.version?.blocked ? { got: status.version.got, expected: status.version.expected } : null)
+          if (!live) return
+          setBlocked(status.version?.blocked ? { got: status.version.got, expected: status.version.expected } : null)
+          setRefused(status.lastContact?.status === 401)
         })
         .catch(() => {})
     read()
@@ -72,6 +80,12 @@ export function BridgeSettings({ enabled, onChange }: { enabled: boolean; onChan
         <p className="text-danger">
           The extension is blocked: it is v{blocked.got} and this dashboard expects v{blocked.expected}. Update it —
           pull the repo, then reload the extension at chrome://extensions.
+        </p>
+      )}
+      {!blocked && refused && (
+        <p className="text-danger">
+          Something is calling the bridge with a token this dashboard rejects, so the calls get nowhere. Open the
+          extension&apos;s options and save the token shown below again.
         </p>
       )}
       {token === null ? (


### PR DESCRIPTION
Plainly: when the Chrome extension calls the bridge with a wrong (stale) token, nothing anywhere says so — the bridge just looks disconnected. This makes the settings panel say it, with the fix.

## The silent failure (#1225, re-test of 2026-08-17)

A stale extension copy with a stale token dies on the bearer check (401) before the #1519 version gate can record a version claim (`src/dashboard/bridge-endpoints.ts:130` runs before `:136` — deliberate, per the SPEC: an unauthenticated caller learns nothing). So the settings panel's blocked banner never fires, and the run view's mirror sits on "Connecting to the cloud session…" forever.

The evidence was already being kept: `seen()` registers the contact recorder before the auth check (`bridge-endpoints.ts:129`), and `bridge-store.ts` remembers the refused contact — its SPEC even says that exists to tell "a misconfigured extension apart from an absent one". But no component ever read `lastContact`.

## The fix

`BridgeSettings.tsx` now also reads `status.lastContact` from the same 5s poll: a last contact with status 401 renders "Something is calling the bridge with a token this dashboard rejects… save the token shown below again." The version banner outranks it when both apply — fixing the token is exactly what lets the more specific 426 message appear next.

No auth/gate reordering: the version-gate-behind-the-token contract and its test stay untouched.

## Tests

- 3 new `BridgeSettings` cases: 401 named with the way out; 200 shows nothing; version block outranks the refused contact. 5/5 pass, both typechecks clean.
- `daemon.test.js` fails identically on an untouched main checkout on this machine (live daemon holds the port) — unrelated.