### PR TITLE
A skewed framework build is refused by the repo's layout marker (fix #1575)

### DIFF
--- a/.changeset/layout-gate.md
+++ b/.changeset/layout-gate.md
@@ -1,0 +1,5 @@
+---
+'@gemstack/the-framework': minor
+---
+
+The layout gate (#1575): a build refuses to run in a repo whose committed layout marker records a different bookkeeping layout, instead of committing files under names the repo no longer uses. Install records the marker; the repo's own is pinned to the build by a test, so a layout rename cannot land without regenerating it.

--- a/.the-framework/.gitignore
+++ b/.the-framework/.gitignore
@@ -1,6 +1,7 @@
 # The Framework: the committed project DB; session state is transient.
 *
 !.gitignore
+!LAYOUT
 !LOGS.md
 !conversations/
 !conversations/**

--- a/.the-framework/LAYOUT
+++ b/.the-framework/LAYOUT
@@ -1,0 +1,7 @@
+framework-dir: .the-framework
+archive-dir: agents
+branches-dir: branches
+events-file: events.jsonl
+meta-file: agent.json
+tickets-dir: tickets
+queue-file: TODO_AGENTS.md

--- a/packages/the-framework/src/cli.SPEC.md
+++ b/packages/the-framework/src/cli.SPEC.md
@@ -8,6 +8,7 @@ The framework command: serves the dashboard in the foreground, and runs one agen
 - Three shapes share that wiring: the full build flow, a verbatim prompt (research included), and transparent mode — the driver completely raw.
 - Every agent settles identically: the quality follow-up if asked for and earned, then the handoff — commit what it left, push the branch, open a draft PR, merge only when authorized — then a project-log entry, written even for agents that stopped or crashed.
 - Settings that cannot apply say so before the spending; a stopped agent never publishes — publishing what it happened to reach is the opposite of what stopping meant.
+- A build whose bookkeeping layout differs from the one the repo records is refused before it writes anything, with both layouts and the fix named — the stale published build a cloud environment installs must fail in seconds with the cause, not hours later at the main branch's guard.
 - Once an agent starts it is never interrupted for quota. The gate is on starting, and it lives with the daemon that decides whether to start unattended work at all.
 - Ctrl+C aborts the agent itself, the driver's process tree included; a second press force-quits.
 

--- a/packages/the-framework/src/cli.test.ts
+++ b/packages/the-framework/src/cli.test.ts
@@ -6,6 +6,7 @@ import { join, dirname } from 'node:path'
 import { appendControl } from './control.js'
 import { BROWSER_MCP_SERVERS, withBrowser } from './browser.js'
 import { EVENTS_FILE, FRAMEWORK_DIR, ARCHIVE_DIR, type StoreFs } from './store/index.js'
+import { layoutMarker, layoutMarkerPath } from './layout.js'
 import { nodeGitRunner } from './project.js'
 import {
   chooseSessionLink,
@@ -292,6 +293,18 @@ test('runCli errors on a session spec with nothing to run (#353)', async () => {
   const code = await runAgentCli({ prompt: '', kind: 'prompt' }, io, false)
   assert.equal(code, 2)
   assert.ok(err.some(l => /no prompt to run/.test(l)))
+})
+
+test('runCli refuses a session whose repo records another layout, before writing anything (#1575)', async () => {
+  // The stale-published-build case: the repo's tracked marker says `sessions`, this build says
+  // `agents` — the session is refused outright rather than committing wrong-layout bookkeeping.
+  const { io, err } = capture()
+  const cwd = await mkdtemp(join(tmpdir(), 'framework-layout-skew-'))
+  await mkdir(join(cwd, '.the-framework'), { recursive: true })
+  await writeFile(layoutMarkerPath(cwd), layoutMarker().replace('archive-dir: agents', 'archive-dir: sessions'))
+  const code = await runAgentCli({ prompt: 'say hi', kind: 'prompt', cwd }, io)
+  assert.equal(code, 1)
+  assert.ok(err.some(l => /#1575/.test(l)))
 })
 
 test('runCli refuses a session spec it cannot read, rather than running something else (D4)', async () => {

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url'
 import { type ClaudeCodeDriverOptions, type Driver, type DriverSession, type PermissionMode } from './driver/index.js'
 import { DRIVERS, DRIVER_SPECS, isDriverName, type DriverName } from './driver-cli.js'
 import { createAgentDriver } from './agent-driver.js'
+import { checkLayout } from './layout.js'
 import { githubSlugFor } from './dashboard/github.js'
 import { githubToken } from './dashboard/gh.js'
 import type { ActionsDriverOptions } from './driver/index.js'
@@ -683,6 +684,18 @@ async function driveAgent(opts: AgentOptions, io: CliIO): Promise<number> {
   }
 
   const cwd = opts.cwd ?? (fake ? join(tmpdir(), 'framework-fake-workspace') : process.cwd())
+
+  // The layout gate (#1575): a build whose bookkeeping layout differs from what the repo records
+  // is refused outright before it writes anything — no degraded mode, same stance as the
+  // extension gate (#1519). The case it exists for: the cloud environment installs the framework
+  // from npm, and a published build that predates a repo-side rename would otherwise commit its
+  // session archive under a name the repo has moved away from (#1574). An unmarked repo (no
+  // tracked marker — the fake demo's tmp workspace, say) passes ungated.
+  const layout = await checkLayout(cwd)
+  if (!layout.ok) {
+    io.err(layout.error)
+    return 1
+  }
 
   // The project can carry its own defaults in the-framework.yml (#258): the prompt switches and
   // how far a finished agent publishes itself. A bad file is a warning, never a failed agent. Read

--- a/packages/the-framework/src/control.test.ts
+++ b/packages/the-framework/src/control.test.ts
@@ -156,13 +156,13 @@ test('a handoff entry needs both booleans, so a half-written line cannot disarm 
 })
 
 /**
- * The committed half of `.the-framework/` (#313/#857): the ignore file, the session list, the
- * conversations, and each user's session history. Everything else in there is runtime state that
- * belongs to one machine and one moment.
+ * The committed half of `.the-framework/` (#313/#857): the ignore file, the layout marker
+ * (#1575), the session list, the conversations, and each user's session history. Everything else
+ * in there is runtime state that belongs to one machine and one moment.
  */
 function isCommittedFrameworkFile(path: string): boolean {
   const rest = path.slice(path.indexOf(`${FRAMEWORK_DIR}/`) + FRAMEWORK_DIR.length + 1)
-  if (rest === '.gitignore' || rest === 'LOGS.md') return true
+  if (rest === '.gitignore' || rest === 'LAYOUT' || rest === 'LOGS.md') return true
   if (rest.startsWith('conversations/')) return true
   const [, sessions] = rest.split('/')
   return sessions === 'agents'

--- a/packages/the-framework/src/framework-gitignore.SPEC.md
+++ b/packages/the-framework/src/framework-gitignore.SPEC.md
@@ -2,12 +2,12 @@ The `.the-framework/.gitignore`: what a project commits out of its framework dir
 
 ## TLDR
 
-- An agent's live state stays out of git; the agent archive is committed.
+- An agent's live state stays out of git; the agent archive and the layout marker are committed.
 - One file with one content, written whole at install, naming no user.
 
 ## Flows
 
-- Everything under the framework directory is ignored, and then the archive is re-included: the directories on the way down first, since git never descends into an ignored one, and the files under them after.
+- Everything under the framework directory is ignored, and then the committed pieces are re-included: the layout marker, and the archive — its directories on the way down first, since git never descends into an ignored one, and the files under them after.
 - The archive is re-included by a glob covering every user, so someone who has never run an agent is already covered.
 - Only the name the archive directory has now is re-included.
 - Install writes the whole file. A repo activated before the archive existed gets the missing rules appended; a repo that already has them is left alone.

--- a/packages/the-framework/src/framework-gitignore.ts
+++ b/packages/the-framework/src/framework-gitignore.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path'
 import { THE_FRAMEWORK_DIR } from './framework-dir.js'
+import { LAYOUT_FILE } from './layout.js'
 import { ARCHIVE_DIR } from './store/index.js'
 
 /**
@@ -41,9 +42,9 @@ export function archiveGitignore(): string {
   return `!*/\n!*/${ARCHIVE_DIR}/\n!*/${ARCHIVE_DIR}/**\n`
 }
 
-/** The whole file: ignore the transient state, keep the agent archive. */
+/** The whole file: ignore the transient state, keep the agent archive and the layout marker. */
 export function frameworkGitignore(): string {
-  return `# The Framework: agent state is transient; the agent archive is committed.\n*\n!.gitignore\n${archiveGitignore()}`
+  return `# The Framework: agent state is transient; the agent archive is committed.\n*\n!.gitignore\n!${LAYOUT_FILE}\n${archiveGitignore()}`
 }
 
 /** The rule whose presence means the file already un-ignores the agent archive. */

--- a/packages/the-framework/src/install.SPEC.md
+++ b/packages/the-framework/src/install.SPEC.md
@@ -4,7 +4,8 @@ Activates a repo for the framework: it becomes a Git repo if it is not one yet, 
 
 - Pre-existing uncommitted changes are committed first, so the install commit is clean and none of the user's work is mixed into it.
 - The ignore rules keep transient agent state out of Git while committing the durable record (the agent archive); the quality presets are materialized so their references resolve, but regenerate per install rather than being committed.
-- The ignore file is also the activation marker: it is the one file install always writes, so a repo that has it is already activated.
+- The ignore file is also the activation marker: install always writes it, so a repo that has it is already activated.
+- Install also records the layout marker — the committed note of where this build keeps its bookkeeping — so a differently-laid-out build later refuses to run in the repo instead of committing files under the wrong names.
 - Activating an already-activated repo is a harmless no-op, and any failure comes back as an error value, never a throw.
 - Also finds which immediate children of a folder are their own Git repos, for adding a whole directory of projects at once.
 

--- a/packages/the-framework/src/install.test.SPEC.md
+++ b/packages/the-framework/src/install.test.SPEC.md
@@ -1,4 +1,4 @@
-Covers activating a repo: the seeded log and ignore rules (conversations included), materialized quality presets, pre-existing dirty changes committed before the clean install commit, re-activation as a no-op, a non-repo folder initialized first, git failures surfaced as values, and finding which child directories are their own repo roots.
+Covers activating a repo: the seeded log and ignore rules (conversations included), the recorded layout marker, materialized quality presets, pre-existing dirty changes committed before the clean install commit, re-activation as a no-op, a non-repo folder initialized first, git failures surfaced as values, and finding which child directories are their own repo roots.
 
 ## Before modifying/creating SPEC.md files
 

--- a/packages/the-framework/src/install.test.ts
+++ b/packages/the-framework/src/install.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { enumerateGitRepos, installProject, type DirLister } from './install.js'
 import { PRESETS, PRESET_DIR } from './presets.js'
 import { frameworkGitignore, gitignorePath } from './framework-gitignore.js'
+import { layoutMarker, layoutMarkerPath } from './layout.js'
 import type { GitRunner } from './project.js'
 import type { StoreFs } from './store/index.js'
 
@@ -90,6 +91,16 @@ test('installProject seeds .the-framework/.gitignore so only the archive is comm
   assert.match(ignore, /^!\*\/agents\/\*\*$/m)
   // Only that name: the `sessions/` D5 renamed away from is not carried as a second rule.
   assert.doesNotMatch(ignore, /sessions/)
+})
+
+test('installProject records the layout marker, tracked, so a skewed build is refused (#1575)', async () => {
+  const fs = memFs()
+  const { git } = fakeGit(args => (args[0] === 'rev-parse' ? 'true' : ''))
+
+  await installProject(CWD, { git, fs })
+  assert.equal(fs.files.get(layoutMarkerPath(CWD)), layoutMarker())
+  // The seeded ignore un-ignores it: `*` would otherwise keep the marker out of the install commit.
+  assert.match(fs.files.get(gitignorePath(CWD)) ?? '', /^!LAYOUT$/m)
 })
 
 test('installProject on a dirty repo commits the pre-existing changes first', async () => {

--- a/packages/the-framework/src/install.ts
+++ b/packages/the-framework/src/install.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 import { nodeGitRunner, type GitRunner } from './project.js'
 import { THE_FRAMEWORK_DIR } from './framework-dir.js'
 import { frameworkGitignore, gitignorePath } from './framework-gitignore.js'
+import { layoutMarker, layoutMarkerPath } from './layout.js'
 import { nodeStoreFs, type StoreFs } from './store/index.js'
 import { materializePresets } from './presets.js'
 import { errorMessage } from './error-message.js'
@@ -25,8 +26,8 @@ export interface InstallDeps {
 
 /**
  * Activate the repo at `cwd`: commit any pre-existing dirty changes, create `.the-framework/` with
- * its ignore file, and commit the install. A repo whose ignore file is already there is a no-op
- * (`alreadyActivated`) — it is the one file install always writes, and the only one it commits.
+ * its ignore file and layout marker (#1575), and commit the install. A repo whose ignore file is
+ * already there is a no-op (`alreadyActivated`) — the ignore file is the activation marker.
  * Forgiving: any git/fs failure surfaces as `{ ok: false, error }`.
  */
 export async function installProject(cwd: string, deps: InstallDeps = {}): Promise<InstallResult> {
@@ -54,6 +55,9 @@ export async function installProject(cwd: string, deps: InstallDeps = {}): Promi
     // Keep the transient agent state (events.jsonl / agent.json / agents/) out of git and the session
     // archive in it (#313/#1179). The early return above established the file is absent.
     await fs.write(gitignorePath(cwd), frameworkGitignore())
+    // Record the bookkeeping layout this build writes (#1575), so a build whose layout differs —
+    // a stale published one, say — refuses to run here instead of committing wrong-layout files.
+    await fs.write(layoutMarkerPath(cwd), layoutMarker())
 
     // Materialize the quality presets so an on-before-mergeable TODO entry's filePath resolves to a
     // real file the agent can open (#326). The .the-framework/.gitignore above keeps them out

--- a/packages/the-framework/src/layout.SPEC.md
+++ b/packages/the-framework/src/layout.SPEC.md
@@ -1,0 +1,21 @@
+The layout gate: a framework build refuses to run in a repo that records a different bookkeeping layout, instead of committing files under names the repo no longer uses.
+
+## TLDR
+
+- Every activated repo carries a small committed marker naming the layout its bookkeeping is on (where archives, tickets, and the queue live).
+- Before a session starts, the build compares the repo's marker against its own layout; a mismatch refuses the session outright with both sides named and the fix — no degraded mode.
+- A repo without the marker is not gated; installing writes it, so every newly activated repo is gated from the start.
+
+## Flows
+
+- The marker's content is derived from the build itself, so renaming anything in the layout changes the marker by itself; a test pins the repo's checked-in marker to the derivation, so a rename cannot land without regenerating the marker in the same change.
+- The refusal message names the file, both layouts, and how to fix each direction (update the installed framework, or regenerate the marker when the build is the newer side).
+
+## Rationales
+
+- The failure this closes was caught live: the cloud environment installs the framework from npm, the published build predated a rename, and the web run committed its session archive under the old name — rejected hours later by the main branch's guard instead of seconds in, with a message about symptoms rather than the cause.
+- Refuse rather than warn, same stance as the extension version gate: a skewed build does not fail loudly on its own — it half-works, and its wrong-layout commits look plausible to a human.
+
+## Before modifying/creating SPEC.md files
+
+You must always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/src/layout.test.SPEC.md
+++ b/packages/the-framework/src/layout.test.SPEC.md
@@ -1,0 +1,5 @@
+Covers the layout gate: an unmarked repo passes, a matching marker passes, a mismatch refuses with both layouts and the fix named, and the repo's own checked-in marker is pinned to the build's derivation so a layout rename cannot land without regenerating it.
+
+## Before modifying/creating SPEC.md files
+
+You must always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/the-framework/src/layout.test.ts
+++ b/packages/the-framework/src/layout.test.ts
@@ -1,0 +1,65 @@
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { readFileSync } from 'node:fs'
+import { checkLayout, layoutMarker, layoutMarkerPath, LAYOUT_FILE } from './layout.js'
+import type { StoreFs } from './store/index.js'
+
+/** The two calls {@link checkLayout} makes, over an optional single file. */
+function markerFs(content?: string): StoreFs {
+  return {
+    async read(path) {
+      if (content === undefined) throw new Error(`ENOENT: ${path}`)
+      return content
+    },
+    async write() {},
+    async append() {},
+    async exists() {
+      return content !== undefined
+    },
+    async mkdir() {},
+    async readdir() {
+      return []
+    },
+  }
+}
+
+test('a repo without a layout marker is ungated', async () => {
+  assert.deepEqual(await checkLayout('/proj', markerFs()), { ok: true })
+})
+
+test('a marker matching this build passes', async () => {
+  assert.deepEqual(await checkLayout('/proj', markerFs(layoutMarker())), { ok: true })
+})
+
+test('a mismatched marker refuses, naming both layouts and the fix (#1575)', async () => {
+  const recorded = layoutMarker().replace('archive-dir: agents', 'archive-dir: sessions')
+  const result = await checkLayout('/proj', markerFs(recorded))
+  assert.equal(result.ok, false)
+  if (result.ok) return
+  // The refusal carries what a stranded session's log needs: the file, both sides, the cause.
+  assert.match(result.error, /\.the-framework\/LAYOUT/)
+  assert.match(result.error, /archive-dir: agents/)
+  assert.match(result.error, /archive-dir: sessions/)
+  assert.match(result.error, /#1575/)
+  assert.match(result.error, /update/i)
+})
+
+test('the marker derives from the layout constants, so a rename changes it by itself', () => {
+  // Pure data, one `name: value` per line — no comment whose rewording would trip the equality.
+  for (const line of layoutMarker().trimEnd().split('\n')) {
+    assert.match(line, /^[a-z-]+: \S+$/)
+  }
+  assert.equal(layoutMarkerPath('/proj'), `/proj/.the-framework/${LAYOUT_FILE}`)
+})
+
+test('the checked-in marker matches this build (#1575) — regenerate it when a layout name changes', () => {
+  // Same lockstep trick as the extension gate's manifest test: the repo's own marker must equal
+  // the derivation, so the PR renaming a layout constant fails here until the file is regenerated.
+  let recorded: string
+  try {
+    recorded = readFileSync(new URL('../../../.the-framework/LAYOUT', import.meta.url), 'utf8')
+  } catch {
+    return // not the repo checkout (an installed package, say): there is nothing to pin here
+  }
+  assert.equal(recorded, layoutMarker())
+})

--- a/packages/the-framework/src/layout.ts
+++ b/packages/the-framework/src/layout.ts
@@ -1,0 +1,72 @@
+import { join } from 'node:path'
+import { THE_FRAMEWORK_DIR } from './framework-dir.js'
+import { ARCHIVE_DIR, BRANCHES_DIR, EVENTS_FILE, META_FILE, nodeStoreFs, type StoreFs } from './store/index.js'
+import { FLAT_TODO_FILE, TICKETS_DIR } from './tickets.js'
+
+/**
+ * The layout gate (#1575): a build refuses to run in a repo whose recorded bookkeeping layout
+ * differs from its own.
+ *
+ * The failure this closes was caught live (#1574): the cloud environment installs the framework
+ * from npm, the last published build predated the `sessions/` → `agents/` rename, and the web
+ * run's bookkeeping landed under the old name — a wrong-layout commit that main's guard test
+ * rejects, hours after the session could have said it will not work. Same philosophy as the
+ * extension gate (#1519): a skewed build half-works, so it is refused outright with both sides
+ * named, no degraded mode.
+ *
+ * The repo's half is a tracked marker file whose content is *derived from the build's own layout
+ * constants*, so a rename changes the derivation by itself and the lockstep test fails the rename
+ * PR until the checked-in marker is regenerated — nothing to remember to bump. A repo without the
+ * marker is ungated, the way an absent `expectedExtensionVersion` leaves the bridge ungated:
+ * install writes it, so every newly activated repo is gated from the start.
+ */
+
+/** The marker's name under `.the-framework/`. Tracked, so every worktree and clone carries it. */
+export const LAYOUT_FILE = 'LAYOUT'
+
+/** The marker path under `cwd`'s `.the-framework/`. */
+export function layoutMarkerPath(cwd: string): string {
+  return join(cwd, THE_FRAMEWORK_DIR, LAYOUT_FILE)
+}
+
+/**
+ * The layout this build writes, as one comparable string: every name a committed artifact's path
+ * hangs off. Pure data — a comment line would put message wording into the equality.
+ */
+export function layoutMarker(): string {
+  return [
+    `framework-dir: ${THE_FRAMEWORK_DIR}`,
+    `archive-dir: ${ARCHIVE_DIR}`,
+    `branches-dir: ${BRANCHES_DIR}`,
+    `events-file: ${EVENTS_FILE}`,
+    `meta-file: ${META_FILE}`,
+    `tickets-dir: ${TICKETS_DIR}`,
+    `queue-file: ${FLAT_TODO_FILE}`,
+    '',
+  ].join('\n')
+}
+
+/** The outcome of {@link checkLayout}. A failure is a value carrying the refusal, never a throw. */
+export type LayoutCheck = { ok: true } | { ok: false; error: string }
+
+/**
+ * Compare the repo's recorded layout against this build's. A missing marker passes (an unmarked
+ * repo is ungated); a present-but-different one refuses with both sides named and the fix for
+ * each direction — the stale-published-build case this exists for, and the older-repo case.
+ */
+export async function checkLayout(cwd: string, fs: StoreFs = nodeStoreFs()): Promise<LayoutCheck> {
+  const path = layoutMarkerPath(cwd)
+  if (!(await fs.exists(path))) return { ok: true }
+  const recorded = await fs.read(path)
+  if (recorded === layoutMarker()) return { ok: true }
+  return {
+    ok: false,
+    error:
+      `this framework build's bookkeeping layout does not match what the repo records in ` +
+      `${THE_FRAMEWORK_DIR}/${LAYOUT_FILE}, so running it here would commit files under names ` +
+      `the repo does not use (#1575).\n\nthis build writes:\n${layoutMarker()}\nthe repo records:\n${recorded}\n` +
+      `A published build that predates a repo-side rename does this: update ` +
+      `@gemstack/the-framework to a build matching the repo, or — if this build is the newer ` +
+      `side — rewrite the marker with its layout and land that as the rename's own commit.`,
+  }
+}


### PR DESCRIPTION
## The problem, plainly

Cloud web runs don't use your local build — the cloud environment installs the framework from npm, and the published version can be **older than the repo it works on**. That happened in #1574: the repo had renamed its archive folder from `sessions/` to `agents/` weeks earlier, but the published build didn't know, saved a session archive under the old name, and the bad commit sailed into a PR — caught only hours later by main's guard test, with an error about symptoms rather than the cause.

## The fix, plainly

The repo now carries a small committed file, `.the-framework/LAYOUT` — 7 lines saying where the framework keeps its bookkeeping:

```
framework-dir: .the-framework
archive-dir: agents
branches-dir: branches
events-file: events.jsonl
meta-file: agent.json
tickets-dir: tickets
queue-file: TODO_AGENTS.md
```

Before starting any session, the framework compares this file against what the running build would write. If they disagree, the session is **refused immediately** — exit 1, both layouts printed side by side, the fix named — before a single file is written. Same stance as the extension version gate (#1519): refuse, don't warn, because a skewed build doesn't fail loudly on its own — it half-works, and its wrong-layout commits look plausible to a human.

The file's content is **generated from the code's own constants**, and a lockstep test pins the checked-in file to that generation (the `EXPECTED_EXTENSION_VERSION` ↔ `manifest.json` trick). So nobody has to remember to bump anything: renaming a folder in code breaks the test until the file is regenerated in the same PR.

## What changed where

- `src/layout.ts` (new) — the marker derivation + `checkLayout()`. A repo *without* the marker passes ungated (how test fixtures and pre-gate repos keep working; install writes it, so every newly activated repo is gated).
- `src/cli.ts` — the gate runs in `driveAgent` right after the workspace is known, before any write.
- `src/install.ts` — seeds the marker; the seeded `.gitignore` gains `!LAYOUT` (its `*` rule would otherwise keep the marker out of the install commit).
- `src/layout.test.ts` — unit coverage + the lockstep test; `control.test.ts`'s committed-files guard now allows `LAYOUT`.
- `.the-framework/LAYOUT` + `.the-framework/.gitignore` — the repo's own marker, checked in.

## How this fits #1595 (data branch)

Compatible — and complementary. #1595 keeps every name this marker derives from (`tickets`, `TODO_AGENTS.md`, `agents`, …) but changes **where** they live (the `the-framework_data` branch). Two touchpoints:

1. When #1595 lands, add one derived line to the marker — `data-branch: the-framework_data` from its `DATA_BRANCH` constant — so the placement change itself becomes a layout change the gate catches. One line in `layoutMarker()`; the lockstep test then forces the checked-in marker to regenerate in that same change.
2. Ideally this PR merges and gets **published** before the #1595 migration: then a stale pre-#1595 cloud build refuses to run in the migrated repo instead of writing main-style bookkeeping into it — the gate is exactly the protection that migration wants.

Only textual overlap: both touch `.the-framework/.gitignore` (`!LAYOUT` must survive #1595's simplification).

## Limits

- The gate only protects skews **after the next npm publish** — a build published before this PR contains no gate and can't refuse. Publishing once after merge (e.g. the standing version-packages PR #1285) arms it for good.
- Tests: full node suite 1496/1496; live E2E in the comment below (install seeds it, skew refused with zero writes, no marker = ungated, fresh clone passes).