### PR TITLE
A check-less PR can be auto-merged again: the PR read must keep its creation time

### DIFF
--- a/packages/the-framework/src/dashboard/gh.test.ts
+++ b/packages/the-framework/src/dashboard/gh.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { ghMergePr, ghPrCiStatus, ghRepoAutoMerge, githubToken } from './gh.js'
+import { ghMergePr, ghPrCiStatus, ghPrView, ghRepoAutoMerge, githubToken } from './gh.js'
 import type { GhRunner } from './gh.js'
 
 /** A `gh` that answers with `stdout`, or rejects, and records what it was asked. */
@@ -226,4 +226,45 @@ test('ghRepoAutoMerge reads the repo setting, and an unreadable answer is unknow
   // REST omits allow_auto_merge for viewers without push access — absent is unknown too.
   const { gh: noField } = fakeGh('{"full_name":"acme/repo"}')
   assert.deepEqual(await ghRepoAutoMerge('/repo', noField), { known: false, allowed: false })
+})
+
+// #1334, found by dogfooding: `PR_VIEW_FIELDS` asked for `number,url,state,title` only, and the
+// copy-out below it dropped anything else anyway. So every caller of this path got a `LinkedPr`
+// with no `createdAt` — and the CI watch reads exactly that to decide whether a check-less PR has
+// outlived the window a check suite takes to attach. With the age unknowable, such a PR was never
+// merged at all: an armed auto-merge on a repo without CI hung open forever.
+//
+// Both tests go through the real field list on purpose. The bug survived because every ci-watch
+// test injects its own PR lookup, so the one thing that was wrong — what this function asks `gh`
+// for, and what it keeps of the answer — was the one thing nothing exercised.
+test('the PR read asks gh for every field LinkedPr carries (#1334)', async () => {
+  const { gh, calls } = fakeGh('{}')
+  await ghPrView('/repo', 'tf-thing', gh)
+  const fields = calls[0]?.[calls[0].indexOf('--json') + 1] ?? ''
+  for (const field of ['number', 'url', 'state', 'title', 'createdAt', 'headRefOid'])
+    assert.ok(fields.split(',').includes(field), `--json must ask for ${field}, got "${fields}"`)
+})
+
+test('the PR read keeps the creation time the CI watch decides on (#1334)', async () => {
+  const { gh } = fakeGh(
+    JSON.stringify({
+      number: 2,
+      url: 'https://github.com/o/r/pull/2',
+      state: 'OPEN',
+      title: 'Add a LICENSE file',
+      createdAt: '2026-08-21T10:47:50Z',
+      headRefOid: 'f1789c5ebaab4cfb79e4ea214508daee147a4092',
+    }),
+  )
+  const pr = await ghPrView('/repo', 'tf-thing', gh)
+  assert.equal(pr?.createdAt, '2026-08-21T10:47:50Z')
+  assert.equal(pr?.headRefOid, 'f1789c5ebaab4cfb79e4ea214508daee147a4092')
+})
+
+test('a field gh does not answer with is absent rather than undefined-valued', async () => {
+  // The copy-out stays conditional: a PR read that came back without a creation time must not
+  // manufacture the key, or "we do not know" becomes indistinguishable from "it has none".
+  const { gh } = fakeGh(JSON.stringify({ number: 2, url: 'u', state: 'OPEN', title: 't' }))
+  const pr = await ghPrView('/repo', 'tf-thing', gh)
+  assert.ok(pr && !('createdAt' in pr), 'createdAt must not be present when gh did not answer with it')
 })

--- a/packages/the-framework/src/dashboard/gh.ts
+++ b/packages/the-framework/src/dashboard/gh.ts
@@ -59,9 +59,9 @@ export async function githubToken(
 }
 
 /** A forgiving `gh --json` read: resolves `empty` when gh is missing/unauthed, or its output is not JSON. */
-export async function ghJson<T>(args: string[], cwd: string, empty: T): Promise<T> {
+export async function ghJson<T>(args: string[], cwd: string, empty: T, gh: GhRunner = readGh): Promise<T> {
   try {
-    return JSON.parse(await readGh(args, cwd)) as T
+    return JSON.parse(await gh(args, cwd)) as T
   } catch {
     return empty
   }
@@ -96,7 +96,7 @@ export type PrLookup = (cwd: string, branch?: string) => Promise<LinkedPr | unde
  */
 export type BranchPrLookup = (cwd: string, branch: string) => Promise<LinkedPr | undefined>
 
-const PR_VIEW_FIELDS = 'number,url,state,title'
+const PR_VIEW_FIELDS = 'number,url,state,title,createdAt,headRefOid'
 
 /**
  * The PR for `branch`, or for whatever branch `cwd` is on when none is named. Resolves undefined
@@ -105,11 +105,25 @@ const PR_VIEW_FIELDS = 'number,url,state,title'
  * The named-branch form is what a finished session needs (#799): its worktree may be gone, so the
  * checkout's current branch is the project's, not the session's. The fields are copied out rather
  * than passed through, so a future `--json` addition cannot leak into what callers store.
+ *
+ * Every optional field {@link LinkedPr} declares must be both asked for and copied out here, or it
+ * is silently absent for every caller of this path. `createdAt` was neither, and the CI watch reads
+ * it to decide whether a check-less PR has outlived the window a check suite takes to attach — with
+ * the field missing, that age is unknowable and such a PR could never be merged at all.
  */
-export async function ghPrView(cwd: string, branch?: string): Promise<LinkedPr | undefined> {
+export async function ghPrView(cwd: string, branch?: string, gh: GhRunner = readGh): Promise<LinkedPr | undefined> {
   const args = ['pr', 'view', ...(branch ? [branch] : []), '--json', PR_VIEW_FIELDS]
-  const pr = await ghJson<LinkedPr | undefined>(args, cwd, undefined)
-  return pr ? { number: pr.number, url: pr.url, state: pr.state, title: pr.title } : undefined
+  const pr = await ghJson<LinkedPr | undefined>(args, cwd, undefined, gh)
+  return pr
+    ? {
+        number: pr.number,
+        url: pr.url,
+        state: pr.state,
+        title: pr.title,
+        ...(pr.createdAt ? { createdAt: pr.createdAt } : {}),
+        ...(pr.headRefOid ? { headRefOid: pr.headRefOid } : {}),
+      }
+    : undefined
 }
 
 /**


### PR DESCRIPTION
🤖 *agent PR*

Found by dogfooding #1334's chain end to end on a scratch repo. **An armed auto-merge on a repo with no CI checks never lands** — the run ends `mergeOutcome: "watched"` and the PR hangs open forever. That is #1334's autonomy chain broken at its final step.

## The bug

The CI watch merges a check-less PR only once it has outlived the window a check suite takes to attach (`NO_CHECKS_GRACE_MS`, 3 min), measured from the PR's `createdAt`:

```js
// ci-watch.ts
function pastNoChecksGrace(pr, now) {
  const created = Date.parse(pr.createdAt ?? '')
  return Number.isFinite(created) && now - created > NO_CHECKS_GRACE_MS
}
```

But `gh.ts` never asked for that field:

```js
const PR_VIEW_FIELDS = 'number,url,state,title'
```

…and `ghPrView` re-built its result from four named fields anyway, so the field could not have survived even if requested. Every caller of that path got a `LinkedPr` with no creation time → `Date.parse('')` → `NaN` → `false` → `continue`, on every tick, forever.

`ghPrsForBranch` **does** ask for `createdAt`. The two PR read paths disagreed, which is how this stayed hidden.

## The fix

Ask for `createdAt` and `headRefOid`, and copy both out. `headRefOid` was dropped identically; #1512 wants it to tell "the branch's PR already landed everything" from "the session kept working after its PR merged".

The copy-out stays deliberate rather than passing gh's answer through — its whole point is that a future `--json` addition cannot leak into what callers store. The rule it needs is that **every optional field `LinkedPr` declares must be both asked for and copied out**, which is now stated where the copying happens.

## Why the tests look the way they do

They go through the **real** field list. Injecting a PR lookup is exactly what hid this: every ci-watch test supplies its own `deps.pr`, so what this function asks `gh` for — and what it keeps of the answer — was the one thing nothing exercised. `ghPrView` now takes the same optional `GhRunner` seam `ghPrCiStatus` already had.

**Verified by reverting the fix:** both new tests fail, the second with `actual: undefined` against the expected timestamp. A third test pins that a field `gh` did not answer with stays *absent* rather than present-and-undefined, so "we do not know" cannot become "it has none".

## Proven live

On a scratch repo with a real remote and no CI:

- Before: PR sat unmerged well past the grace; a direct `sweepProjectCi()` returned `{merged:[],failed:[],fixes:[]}` while raw `gh pr view --json createdAt` returned the field fine.
- After: the daemon merged it **80 seconds** after starting — `CI watch: checks passed on PR #2, merged it` — the squash subject carried `(fix #1)`, and the issue auto-closed as COMPLETED.

That last part also closes out #1334's second checkbox, which had been built and unit-tested but never actually exercised.

## Notes

- **No spec change.** `ci-watch.SPEC.md` already describes the intended behaviour ("no checks only counts as green once the PR has outlived the time a check suite takes to attach"). The spec was right; the code did not deliver it.
- No `FEATURES-SPEC.md` change — this restores documented behaviour rather than altering it.
- Suite 1508 + 776, typecheck clean.

## Separate finding from the same run, not fixed here

The drain's PR was titled:

> `Open TODO_AGENTS.md and work on the FIRST open entry only. When the work (fix #1)`

The agent emitted no session name, so `agentPrTitle` fell back to `intent.slice(0, 72)` — the raw preset prompt, truncated mid-sentence. On squash that becomes a permanent commit subject on `main` (it now is one, on the scratch repo). The `(fix #N)` machinery is correct; what it gets appended to is not. Worth its own issue.