### PR TITLE
The post-merge follow-ups promise what the prompt queues

### DIFF
--- a/FEATURES-SPEC.md
+++ b/FEATURES-SPEC.md
@@ -111,7 +111,7 @@ happens while nobody is at the keyboard.
 - Handoff panel: push / open PR / merge, as buttons
 - A withheld merge is reported with its reason
 - Agent history archived on the `tf-data` branch under per-user directories — pushed the moment a session settles
-- Post-merge quality follow-ups queued (maintainability / security / readability)
+- Post-merge quality follow-ups queued (maintainability / security)
 - Knowledge folded back into `DECISIONS.md` / `FACTS.md` / `INSIGHTS.md` at merge
 
 ## Autonomy — what happens when nobody is at the keyboard


### PR DESCRIPTION
Closes the one finding #1614 left for a human call, with that approval now given.

`FEATURES-SPEC.md` promised post-merge quality follow-ups for "maintainability / security / readability", but `on_before_mergeable_prompt.md` has only ever queued the maintainability and security-audit presets — the prompt's history shows no readability line was ever there. Rather than adding a third unattended follow-up per merge (heavy overlap with the maintainability pass, extra quota, duplicate-refactor risk between sibling follow-up PRs), the feature line drops the word: under the spec-driven thesis — humans read specs and stay in control, agents work the code — per-merge readability passes are the one follow-up the methodology itself de-prioritizes.

The Readability preset is untouched: it stays in the catalog, on demand from the dashboard and in the periodic maintenance sweep.

One word removed, no code changes; the features edit is human-approved per the rule in `FEATURES-SPEC.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XvEviGLEJZsp1h6iWzgma

---
_Generated by [Claude Code](https://claude.ai/code/session_011XvEviGLEJZsp1h6iWzgma)_