### PR TITLE
An empty first poll is not a baseline: the notifier learns which projects it actually read

### DIFF
--- a/packages/the-framework/src/daemon-services.ts
+++ b/packages/the-framework/src/daemon-services.ts
@@ -394,6 +394,7 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
             projects,
             build: items => buildInterventions(items, { dashboardUrl: deps.dashboardUrl }),
             keyOf: interventionKey,
+            scopeOf: item => item.projectId,
             onNew: async items => {
               if (!notifies(await prefs(), 'discord', 'humanIntervention')) return
               const delivered = await postInterventionsDiscord(webhook, items).catch(() => false)
@@ -404,6 +405,7 @@ export function startBackgroundServices(deps: BackgroundServiceDeps): Background
             projects,
             build: buildActivity,
             keyOf: activityKey,
+            scopeOf: item => item.projectId,
             onNew: async items => {
               if (!notifies(await prefs(), 'discord', 'newActivity')) return
               const delivered = await postActivityDiscord(webhook, items).catch(() => false)

--- a/packages/the-framework/src/dashboard-rpc/reads.ts
+++ b/packages/the-framework/src/dashboard-rpc/reads.ts
@@ -214,7 +214,7 @@ export async function onHotTickets(): Promise<HotTicket[]> {
 
 /** The cross-project interventions queue (#632, Queue #624): open PRs that need review, newest first. */
 export async function onInterventions(): Promise<Intervention[]> {
-  return withProjects(buildInterventions)
+  return (await withProjects(buildInterventions)).items
 }
 
 /** Every session's open question with its full gate (#1455), longest-waiting first: the launcher's hub. */
@@ -224,7 +224,7 @@ export async function onOpenQuestions(): Promise<OpenQuestion[]> {
 
 /** The cross-project "New activity" feed (#627): recent run started/finished transitions, newest first. */
 export async function onActivity(): Promise<Activity[]> {
-  return withProjects(buildActivity)
+  return (await withProjects(buildActivity)).items
 }
 
 /** The Overview dashboard page (#471): the {@link onOverview} rollup plus agent counts, run-status totals, and activity. */

--- a/packages/the-framework/src/dashboard/activity.SPEC.md
+++ b/packages/the-framework/src/dashboard/activity.SPEC.md
@@ -9,7 +9,7 @@ The activity feed: the cross-project stream of agent lifecycle moments — an ag
 - Each project's recent agents contribute one item apiece: "started" while it runs, "finished" once it ends, tagged by how it ended so a stop reads differently from a success.
 - A start and a finish are separate events, so an agent notifies at most twice — and one that starts and ends between two polls notifies once, as finished.
 - Activity is off by default: it is the "for your information" counterpart to the always-on interventions feed, the list of what needs the user.
-- Several updates post to Discord as one message; a project whose history cannot be read contributes nothing.
+- Several updates post to Discord as one message; a project whose history cannot be read contributes nothing — and is reported as unread, so it is not mistaken for a project that has simply never run anything.
 
 ## Before modifying/creating SPEC.md files
 

--- a/packages/the-framework/src/dashboard/activity.test.SPEC.md
+++ b/packages/the-framework/src/dashboard/activity.test.SPEC.md
@@ -1,4 +1,4 @@
-Covers the activity feed: running and finished agents mapping to started/finished items (newest first, capped per project, unreadable projects skipped), the start and finish of one agent counting as two distinct events, and only unseen events being picked as new.
+Covers the activity feed: running and finished agents mapping to started/finished items (newest first, capped per project, unreadable projects skipped and reported as unread rather than as having no history), the start and finish of one agent counting as two distinct events, and only unseen events being picked as new.
 
 ## Before modifying/creating SPEC.md files
 

--- a/packages/the-framework/src/dashboard/activity.test.ts
+++ b/packages/the-framework/src/dashboard/activity.test.ts
@@ -20,7 +20,7 @@ test('buildActivity maps a running run to started and a terminal run to finished
     '/b': [agent({ id: 'r2', status: 'done', intent: 'fix login', updatedAt: '2026-07-16T01:00:00Z' })],
   }
   const readAgents = async (cwd: string): Promise<AgentMeta[]> => agentsByPath[cwd] ?? []
-  const items = await buildActivity([project('a', '/a'), project('b', '/b')], { readAgents })
+  const { items } = await buildActivity([project('a', '/a'), project('b', '/b')], { readAgents })
 
   // Newest first.
   assert.deepEqual(
@@ -34,7 +34,7 @@ test('buildActivity maps a running run to started and a terminal run to finished
 
 test('buildActivity carries the terminal status so a stop reads differently from a done', async () => {
   const readAgents = async (): Promise<AgentMeta[]> => [agent({ status: 'stopped', updatedAt: '2026-07-16T02:00:00Z' })]
-  const items = await buildActivity([project('a', '/a')], { readAgents })
+  const { items } = await buildActivity([project('a', '/a')], { readAgents })
   assert.deepEqual({ kind: items[0]!.kind, status: items[0]!.status }, { kind: 'finished', status: 'stopped' })
 })
 
@@ -43,7 +43,7 @@ test('buildActivity emits one item per run across a project history', async () =
     agent({ id: 'live', status: 'running', updatedAt: '2026-07-16T05:00:00Z' }),
     agent({ id: 'old', status: 'done', updatedAt: '2026-07-15T00:00:00Z' }),
   ]
-  const items = await buildActivity([project('a', '/a')], { readAgents })
+  const { items } = await buildActivity([project('a', '/a')], { readAgents })
   assert.deepEqual(items.map(i => [i.agentId, i.kind]), [['live', 'started'], ['old', 'finished']])
 })
 
@@ -52,17 +52,25 @@ test('buildActivity caps each project to the most recent runs', async () => {
     agent({ id: `r${i}`, status: 'done', updatedAt: `2026-07-16T00:${String(i).padStart(2, '0')}:00Z` }),
   )
   const readAgents = async (): Promise<AgentMeta[]> => many
-  const items = await buildActivity([project('a', '/a')], { readAgents })
+  const { items } = await buildActivity([project('a', '/a')], { readAgents })
   assert.equal(items.length, 20)
 })
 
-test('buildActivity skips a project whose run read throws', async () => {
+test('buildActivity skips a project whose run read throws, and does not call it read (#1623)', async () => {
   const readAgents = async (cwd: string): Promise<AgentMeta[]> => {
     if (cwd === '/boom') throw new Error('disk exploded')
     return [agent({ id: 'ok', status: 'done' })]
   }
-  const items = await buildActivity([project('boom', '/boom'), project('ok', '/ok')], { readAgents })
+  const { items, whole } = await buildActivity([project('boom', '/boom'), project('ok', '/ok')], { readAgents })
   assert.deepEqual(items.map(i => i.projectId), ['ok'])
+  assert.deepEqual(whole, ['ok'])
+})
+
+test('buildActivity calls a project read when it has no runs at all (#1623)', async () => {
+  const readAgents = async (): Promise<AgentMeta[]> => []
+  const { items, whole } = await buildActivity([project('fresh', '/fresh')], { readAgents })
+  assert.deepEqual(items, [])
+  assert.deepEqual(whole, ['fresh'])
 })
 
 test('activityKey separates a run start from its finish', () => {

--- a/packages/the-framework/src/dashboard/activity.ts
+++ b/packages/the-framework/src/dashboard/activity.ts
@@ -1,6 +1,6 @@
 import { readAllAgents, type AgentMeta, type AgentStatus } from '../store/index.js'
 import { postDiscordWebhook } from './discord-webhook.js'
-import type { ProjectSummary } from './projects.js'
+import type { ProjectSummary, ProjectionRead } from './projects.js'
 
 // The identity + diff live in the leaf `keys.ts` so the dashboard can share them (they are pure);
 // re-exported here so this stays the import site for anything that already reads them from the
@@ -62,22 +62,30 @@ function activityFor(project: ProjectSummary, agent: AgentMeta): Activity {
 /**
  * Build the cross-project activity feed: for each registered project's most recent agents, one
  * item per agent reflecting where it is now (`started` while it runs, `finished` once it lands),
- * newest first. Forgiving — a project whose agents cannot be read simply contributes nothing.
+ * newest first. Forgiving — a project whose agents cannot be read simply contributes nothing, and
+ * comes back named as one that was *not* read whole (#1623), since "nothing happened there" and
+ * "I could not look" are the same empty list to everyone but the notification watcher.
  *
  * The `started` and `finished` items for one agent carry distinct keys ({@link activityKey}), so a
  * run that is still going notifies once (started) and again when it lands (finished). An agent that
  * both starts and finishes between two polls is only ever seen terminal, so it notifies once
  * (finished) — one quick agent, one line.
  */
-export async function buildActivity(projects: ProjectSummary[], deps: ActivityDeps = {}): Promise<Activity[]> {
+export async function buildActivity(
+  projects: ProjectSummary[],
+  deps: ActivityDeps = {},
+): Promise<ProjectionRead<Activity>> {
   const readAgents = deps.readAgents ?? readAllAgents
   const items: Activity[] = []
+  const whole: string[] = []
   for (const project of projects) {
-    const agents = (await readAgents(project.path).catch(() => [])).slice(0, RECENT_RUNS)
-    for (const agent of agents) items.push(activityFor(project, agent))
+    const read = await readAgents(project.path).catch(() => undefined)
+    if (!read) continue
+    whole.push(project.id)
+    for (const agent of read.slice(0, RECENT_RUNS)) items.push(activityFor(project, agent))
   }
   items.sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''))
-  return items
+  return { items, whole }
 }
 
 

--- a/packages/the-framework/src/dashboard/gh.SPEC.md
+++ b/packages/the-framework/src/dashboard/gh.SPEC.md
@@ -8,7 +8,7 @@ Everything the dashboard asks or tells GitHub — pull request lookups, merging,
 
 ## Flows
 
-- Reads are quick, cached, and forgiving: an unreachable GitHub reads as nothing, never a failed page.
+- Reads are quick, cached, and forgiving: an unreachable GitHub reads as nothing, never a failed page. The one exception is the list of a project's open pull requests, which says so when GitHub could not answer: its reader has to tell that apart from a project with no open pull requests, and a page showing nothing is a smaller cost than a notification flood.
 - An agent's PR is picked from its branch's whole history — an open PR always counts, a closed one only if created after the agent began — so a reused branch name cannot wear a predecessor's merged PR.
 - Merging prefers GitHub's auto-merge, so the PR lands when its checks pass. Where the repo refuses auto-merge, a merge the user asked for goes through directly; the automatic path merges only on green checks and otherwise hands the PR to the daemon's CI watch, which merges it once its checks pass — unverified work never lands.
 - A draft in the way is marked ready and retried: asking for the merge says its review already happened.

--- a/packages/the-framework/src/dashboard/gh.test.SPEC.md
+++ b/packages/the-framework/src/dashboard/gh.test.SPEC.md
@@ -1,4 +1,4 @@
-Covers the GitHub adapter: token resolution (environment first, then the existing login, blanks never counting), the merge ladder (auto-merge, draft-ready retry, direct fallback only on the known refusals, watch mode deferring to CI rather than merging early), CI verdicts where an unreadable status is never green, and the repo's auto-merge setting read as on, off, or unknown.
+Covers the GitHub adapter: token resolution (environment first, then the existing login, blanks never counting), the merge ladder (auto-merge, draft-ready retry, direct fallback only on the known refusals, watch mode deferring to CI rather than merging early), CI verdicts where an unreadable status is never green, the open-PR list reporting a gh that could not answer instead of calling it an empty queue, and the repo's auto-merge setting read as on, off, or unknown.
 
 ## Before modifying/creating SPEC.md files
 

--- a/packages/the-framework/src/dashboard/gh.test.ts
+++ b/packages/the-framework/src/dashboard/gh.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { ghMergePr, ghPrCiStatus, ghPrView, ghRepoAutoMerge, githubToken } from './gh.js'
+import { ghMergePr, ghPrCiStatus, ghPrList, ghPrView, ghRepoAutoMerge, githubToken } from './gh.js'
 import type { GhRunner } from './gh.js'
 
 /** A `gh` that answers with `stdout`, or rejects, and records what it was asked. */
@@ -267,4 +267,18 @@ test('a field gh does not answer with is absent rather than undefined-valued', a
   const { gh } = fakeGh(JSON.stringify({ number: 2, url: 'u', state: 'OPEN', title: 't' }))
   const pr = await ghPrView('/repo', 'tf-thing', gh)
   assert.ok(pr && !('createdAt' in pr), 'createdAt must not be present when gh did not answer with it')
+})
+
+test('ghPrList reports a gh that could not answer, rather than calling it an empty queue (#1623)', async () => {
+  // Every other read here forgives its own failure. This one must not: its caller keeps a baseline
+  // of what it has already announced, and "no PRs" swallowed from "no answer" makes the next good
+  // read announce the entire open backlog as new.
+  const { gh } = fakeGh(new Error('gh: not authenticated'))
+  await assert.rejects(ghPrList('/repo', gh))
+})
+
+test('ghPrList reads the open PRs when gh answers (#1623)', async () => {
+  const { gh, calls } = fakeGh(JSON.stringify([{ number: 3, title: 'a fix', url: 'u3', isDraft: false }]))
+  assert.deepEqual((await ghPrList('/repo', gh)).map(pr => pr.number), [3])
+  assert.ok(calls[0]!.includes('--json'))
 })

--- a/packages/the-framework/src/dashboard/gh.ts
+++ b/packages/the-framework/src/dashboard/gh.ts
@@ -434,13 +434,21 @@ export interface OpenPr {
   createdAt?: string
 }
 
-/** A checkout's open PRs; resolves `[]` when there is no remote or gh is unavailable. */
-export async function ghPrList(cwd: string): Promise<OpenPr[]> {
+/**
+ * A checkout's open PRs. Unlike the other reads here it *rejects* when gh could not answer — no
+ * remote, not authenticated, GitHub unreachable — instead of resolving `[]`.
+ *
+ * "No PRs are open" and "I could not look" are different answers, and its caller keeps a baseline
+ * of what it has already announced (#1623): taking the second for the first makes the next
+ * successful read announce every already-open PR as new. The caller decides what a failure costs;
+ * it cannot decide what it never hears about.
+ */
+export async function ghPrList(cwd: string, gh: GhRunner = readGh): Promise<OpenPr[]> {
   const fields = 'number,title,url,isDraft,headRefName,createdAt'
   const args = ['pr', 'list', '--state', 'open', '--limit', '50', '--json', fields]
-  return ghJson<OpenPr[]>(args, cwd, [])
+  return JSON.parse(await gh(args, cwd)) as OpenPr[]
 }
 
-/** Lists a checkout's open PRs; resolves `[]` when there is no remote / gh is unavailable. */
+/** Lists a checkout's open PRs; rejects when there is no remote / gh is unavailable. */
 export type PrLister = (cwd: string) => Promise<OpenPr[]>
 

--- a/packages/the-framework/src/dashboard/index.ts
+++ b/packages/the-framework/src/dashboard/index.ts
@@ -4,6 +4,7 @@ export {
   summarizeProject,
   defaultProjectsProvider,
   type ProjectSummary,
+  type ProjectionRead,
   type ProjectsProvider,
   type SummarizeDeps,
 } from './projects.js'

--- a/packages/the-framework/src/dashboard/interventions.SPEC.md
+++ b/packages/the-framework/src/dashboard/interventions.SPEC.md
@@ -12,6 +12,7 @@ The cross-project "needs you" queue: everything currently waiting on the human, 
 - A draft PR the user opened by hand stays off the queue — it is not asking for review yet. An agent's own draft stays on: the automatic handoff opens draft PRs precisely so reviewers are not pinged, and the queue is then the only place the work is visible at all.
 - Unpushed work is surfaced, never acted on, and only a project's few most recent finished agents are inspected — work sitting unpushed for ages is not news.
 - Forgiving and deduplicated: an unreadable project contributes nothing, and the same repo registered twice contributes each item once.
+- The queue also reports which projects it managed to read in full, because "nothing is waiting here" and "this project could not be read" look identical otherwise — a difference that matters to whoever decides what is new enough to notify about.
 - Also phrases the queue as a Discord message, one line per item, worded by kind.
 
 ## Before modifying/creating SPEC.md files

--- a/packages/the-framework/src/dashboard/interventions.test.SPEC.md
+++ b/packages/the-framework/src/dashboard/interventions.test.SPEC.md
@@ -1,4 +1,4 @@
-The tests cover assembling the needs-you queue: open PRs rolled up newest-first with hand-made drafts excluded, parked agents and unpushed work included, duplicates from twice-registered repos collapsed, and unreadable projects skipped.
+The tests cover assembling the needs-you queue: open PRs rolled up newest-first with hand-made drafts excluded, parked agents and unpushed work included, duplicates from twice-registered repos collapsed, and unreadable projects skipped — and reported as unread, so a project that answered with an empty queue is told apart from one that could not answer at all.
 
 ## Before modifying/creating SPEC.md files
 

--- a/packages/the-framework/src/dashboard/interventions.test.ts
+++ b/packages/the-framework/src/dashboard/interventions.test.ts
@@ -32,7 +32,7 @@ test('buildInterventions rolls up open non-draft PRs across projects, newest fir
     '/c': [], // no open PRs -> contributes nothing
   }
   const prs = async (cwd: string): Promise<OpenPr[]> => prsByPath[cwd] ?? []
-  const items = await buildInterventions([project('a', '/a'), project('b', '/b'), project('c', '/c')], { prs, liveAgents: noAgents })
+  const { items } = await buildInterventions([project('a', '/a'), project('b', '/b'), project('c', '/c')], { prs, liveAgents: noAgents })
 
   // Newest PR first; the draft is gone.
   assert.deepEqual(
@@ -45,24 +45,44 @@ test('buildInterventions rolls up open non-draft PRs across projects, newest fir
   assert.ok(items.every(i => i.kind === 'pr'))
 })
 
-test('buildInterventions skips a project whose PR lookup throws', async () => {
+test('buildInterventions skips a project whose PR lookup throws, and does not call it read (#1623)', async () => {
   const prs = async (cwd: string): Promise<OpenPr[]> => {
     if (cwd === '/boom') throw new Error('gh exploded')
     return [{ number: 1, title: 'ok', url: 'u1', isDraft: false }]
   }
-  const items = await buildInterventions([project('boom', '/boom'), project('ok', '/ok')], { prs, liveAgents: noAgents })
+  const { items, whole } = await buildInterventions([project('boom', '/boom'), project('ok', '/ok')], { prs, liveAgents: noAgents })
   assert.deepEqual(items.map(i => i.projectId), ['ok'])
+  // Both projects contributed nothing visible about /boom; only `whole` says which silence was real.
+  assert.deepEqual(whole, ['ok'])
+})
+
+test('buildInterventions calls a project read when it answers with nothing (#1623)', async () => {
+  const prs = async (): Promise<OpenPr[]> => []
+  const { items, whole } = await buildInterventions([project('quiet', '/quiet')], { prs, liveAgents: noAgents })
+  assert.deepEqual(items, [])
+  assert.deepEqual(whole, ['quiet'])
+})
+
+test('buildInterventions does not call a project read when its live-agent read throws (#1623)', async () => {
+  const liveAgents = async (): Promise<LiveAgent[]> => {
+    throw new Error('store unreadable')
+  }
+  const prs = async (): Promise<OpenPr[]> => [{ number: 7, title: 'open', url: 'u7', isDraft: false }]
+  const { items, whole } = await buildInterventions([project('a', '/a')], { prs, liveAgents })
+  // The PRs it did read are still shown — forgiving as ever — but the project is not a baseline.
+  assert.deepEqual(items.map(i => i.number), [7])
+  assert.deepEqual(whole, [])
 })
 
 test('buildInterventions returns [] when nothing is open anywhere', async () => {
   const prs = async (): Promise<OpenPr[]> => []
-  assert.deepEqual(await buildInterventions([project('a', '/a')], { prs, liveAgents: noAgents }), [])
+  assert.deepEqual((await buildInterventions([project('a', '/a')], { prs, liveAgents: noAgents })).items, [])
 })
 
 test('buildInterventions dedupes a PR shared by two registered projects (same repo), keeping one', async () => {
   const shared: OpenPr = { number: 285, title: 'release', url: 'https://gh/pr/285', isDraft: false, createdAt: '2026-07-05T00:00:00Z' }
   const prs = async (): Promise<OpenPr[]> => [shared] // both projects resolve to the same repo
-  const items = await buildInterventions([project('root', '/repo'), project('sub', '/repo/packages/x')], { prs, liveAgents: noAgents })
+  const { items } = await buildInterventions([project('root', '/repo'), project('sub', '/repo/packages/x')], { prs, liveAgents: noAgents })
   assert.deepEqual(items.map(i => i.number), [285])
 })
 
@@ -71,7 +91,7 @@ const noPrs = async (): Promise<OpenPr[]> => []
 test('buildInterventions adds an awaiting item for a running run parked on a choice (#636)', async () => {
   const liveAgents = async (cwd: string): Promise<LiveAgent[]> =>
     cwd === '/a' ? [live(runningAgentMeta({ pendingChoice: { id: 'gate-1', title: 'Cache the auth store?' } }))] : []
-  const items = await buildInterventions([project('a', '/a'), project('b', '/b')], { prs: noPrs, liveAgents })
+  const { items } = await buildInterventions([project('a', '/a'), project('b', '/b')], { prs: noPrs, liveAgents })
 
   assert.equal(items.length, 1)
   assert.deepEqual(
@@ -83,14 +103,14 @@ test('buildInterventions adds an awaiting item for a running run parked on a cho
 test('buildInterventions ignores a pendingChoice on a run that is no longer running', async () => {
   const liveAgents = async (): Promise<LiveAgent[]> =>
     [live(runningAgentMeta({ status: 'done', pendingChoice: { id: 'gate-1', title: 'stale' } }))]
-  assert.deepEqual(await buildInterventions([project('a', '/a')], { prs: noPrs, liveAgents }), [])
+  assert.deepEqual((await buildInterventions([project('a', '/a')], { prs: noPrs, liveAgents })).items, [])
 })
 
 test('buildInterventions links an awaiting item to the dashboard URL when given, else empty', async () => {
   const liveAgents = async (): Promise<LiveAgent[]> => [live(runningAgentMeta({ pendingChoice: { id: 'g', title: 'q?' } }))]
-  const withUrl = await buildInterventions([project('a', '/a')], { prs: noPrs, liveAgents, dashboardUrl: 'http://localhost:4200' })
+  const { items: withUrl } = await buildInterventions([project('a', '/a')], { prs: noPrs, liveAgents, dashboardUrl: 'http://localhost:4200' })
   assert.equal(withUrl[0]!.url, 'http://localhost:4200')
-  const withoutUrl = await buildInterventions([project('a', '/a')], { prs: noPrs, liveAgents })
+  const { items: withoutUrl } = await buildInterventions([project('a', '/a')], { prs: noPrs, liveAgents })
   assert.equal(withoutUrl[0]!.url, '')
 })
 
@@ -99,7 +119,7 @@ test('buildInterventions surfaces PRs and awaiting runs together, newest first',
     cwd === '/a' ? [{ number: 5, title: 'pr', url: 'u5', isDraft: false, createdAt: '2026-07-10T00:00:00Z' }] : []
   const liveAgents = async (cwd: string): Promise<LiveAgent[]> =>
     cwd === '/b' ? [live(runningAgentMeta({ updatedAt: '2026-07-16T00:00:00Z', pendingChoice: { id: 'g', title: 'q?' } }))] : []
-  const items = await buildInterventions([project('a', '/a'), project('b', '/b')], { prs, liveAgents })
+  const { items } = await buildInterventions([project('a', '/a'), project('b', '/b')], { prs, liveAgents })
   assert.deepEqual(items.map(i => i.kind), ['awaiting', 'pr']) // awaiting is newer
 })
 
@@ -151,7 +171,7 @@ const onlyUnpushed = (agents: AgentMeta[], handoff: (cwd: string, branch: string
 })
 
 test('a finished run with unpushed commits lands on the queue (#860)', async () => {
-  const items = await buildInterventions(
+  const { items } = await buildInterventions(
     [project('a', '/a')],
     onlyUnpushed([doneMeta()], async () => waiting()),
   )
@@ -174,7 +194,7 @@ test('nothing is waiting when the work already went somewhere (#860)', async () 
     ['there is nowhere to push', { hasRemote: false }],
   ]
   for (const [why, over] of cases) {
-    const items = await buildInterventions(
+    const { items } = await buildInterventions(
       [project('a', '/a')],
       onlyUnpushed([doneMeta()], async () => waiting(over)),
     )
@@ -184,7 +204,7 @@ test('nothing is waiting when the work already went somewhere (#860)', async () 
 
 test('a still-running run is not unpushed work (#860)', async () => {
   // It is still writing; the overview already shows it.
-  const items = await buildInterventions(
+  const { items } = await buildInterventions(
     [project('a', '/a')],
     onlyUnpushed([doneMeta({ status: 'running' })], async () => waiting()),
   )
@@ -192,7 +212,7 @@ test('a still-running run is not unpushed work (#860)', async () => {
 })
 
 test('an unreadable branch is skipped rather than throwing (#860)', async () => {
-  const items = await buildInterventions(
+  const { items } = await buildInterventions(
     [project('a', '/a')],
     onlyUnpushed([doneMeta()], async () => {
       throw new Error('not a repo')
@@ -208,7 +228,7 @@ test('only the most recent finished runs are inspected (#860)', async () => {
     doneMeta({ id: `r${i}`, startedAt: `2026-07-${String(i + 1).padStart(2, '0')}T00:00:00Z`, branch: `b${i}` }),
   )
   const inspected: string[] = []
-  const items = await buildInterventions(
+  const { items } = await buildInterventions(
     [project('a', '/a')],
     { ...onlyUnpushed(agents, async (_cwd, branch) => (inspected.push(branch), waiting({ branch }))), handoffLimit: 3 },
   )
@@ -236,7 +256,7 @@ test("a session's own draft PR still reaches the queue; a hand-made draft does n
     { number: 9, title: 'session work', url: 'u9', isDraft: true, headRefName: 'the-framework/x', createdAt: '2026-07-16T00:00:00Z' },
     { number: 10, title: 'my own wip', url: 'u10', isDraft: true, headRefName: 'feat/mine', createdAt: '2026-07-17T00:00:00Z' },
   ]
-  const items = await buildInterventions([project('a', '/a')], { prs, liveAgents: noAgents, agents: async () => [] })
+  const { items } = await buildInterventions([project('a', '/a')], { prs, liveAgents: noAgents, agents: async () => [] })
   assert.deepEqual(items.map(i => i.number), [9])
 })
 
@@ -244,6 +264,6 @@ test('a draft with no branch recorded is still treated as hand-made (#1102)', as
   // `headRefName` is new: an older gh, or a lookup that did not ask for it, must not turn every
   // draft in the repo into a "needs you".
   const prs = async (): Promise<OpenPr[]> => [{ number: 11, title: 'wip', url: 'u11', isDraft: true }]
-  const items = await buildInterventions([project('a', '/a')], { prs, liveAgents: noAgents, agents: async () => [] })
+  const { items } = await buildInterventions([project('a', '/a')], { prs, liveAgents: noAgents, agents: async () => [] })
   assert.deepEqual(items, [])
 })

--- a/packages/the-framework/src/dashboard/interventions.ts
+++ b/packages/the-framework/src/dashboard/interventions.ts
@@ -1,5 +1,5 @@
 import { listAgents, readLiveMetas, type LiveAgent, type AgentMeta } from '../store/index.js'
-import type { ProjectSummary } from './projects.js'
+import type { ProjectSummary, ProjectionRead } from './projects.js'
 import { isAgentBranch, readAgentHandoff, agentBranchFor, type AgentHandoff } from './agent-handoff.js'
 import { ghPrList, type OpenPr, type PrLister } from './gh.js'
 import { interventionKey } from './keys.js'
@@ -77,16 +77,29 @@ const HANDOFF_LIMIT = 5
  * (or an unreadable one) simply contributes nothing. Hand-opened draft PRs are excluded: they are
  * not yet asking for review. A session's own draft is not (#1102), because that is how
  * auto-handoff hands work back.
+ *
+ * Which projects were read whole comes back alongside the items (#1623): forgiveness here is what
+ * lets one unreachable project keep the queue useful, and it is also what would let that project's
+ * whole backlog announce itself as new the moment it came back. The queue's panels ignore this;
+ * the notification watcher is the caller that cannot.
  */
 export async function buildInterventions(
   projects: ProjectSummary[],
   deps: InterventionsDeps = {},
-): Promise<Intervention[]> {
+): Promise<ProjectionRead<Intervention>> {
   const prs = deps.prs ?? ghPrList
   const liveAgents = deps.liveAgents ?? readLiveMetas
   const items: Intervention[] = []
+  const whole: string[] = []
   for (const project of projects) {
-    const open = await prs(project.path).catch(() => [])
+    // A project is read whole only when every one of its sources answered. Each `unread()` below is
+    // a source that did not, and contributed nothing for a reason other than nothing being there.
+    let sawEverything = true
+    const unread = () => {
+      sawEverything = false
+      return []
+    }
+    const open = await prs(project.path).catch(unread)
     for (const pr of open) {
       // A draft opened by hand is not asking for review, so it stays off the queue. A draft the
       // framework opened for a session is the opposite (#1102): auto-handoff opens it as a draft
@@ -107,7 +120,7 @@ export async function buildInterventions(
     // still `running` and has an unresolved choice gate. An agent parks on one gate at a time, but
     // a project now has several concurrent agents (#736), so each parked agent contributes its own
     // item — keyed on the gate id, plus the agent id so two agents are told apart.
-    for (const meta of await liveAgents(project.path).catch(() => [])) {
+    for (const meta of await liveAgents(project.path).catch(unread)) {
       if (meta.status !== 'running' || !meta.pendingChoice) continue
       items.push({
         projectId: project.id,
@@ -128,13 +141,15 @@ export async function buildInterventions(
     // Surfacing only: this says there is a decision waiting, it does not take it. Since #1102 a
     // session usually pushes itself, so what reaches here is the remainder — auto-handoff turned
     // off for the project, or turned off for that session, or tried and failed.
-    for (const item of await unpushedFor(project, deps).catch(() => [])) items.push(item)
+    for (const item of await unpushedFor(project, deps, unread).catch(unread)) items.push(item)
+    if (sawEverything) whole.push(project.id)
   }
   items.sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''))
   // The same repo can be registered under two projects (e.g. a monorepo root + a subdir), so a
   // PR would otherwise appear once per entry. Collapse by identity, keeping the first (newest-sorted).
   const seen = new Set<string>()
-  return items.filter(item => (seen.has(interventionKey(item)) ? false : (seen.add(interventionKey(item)), true)))
+  const unique = items.filter(item => (seen.has(interventionKey(item)) ? false : (seen.add(interventionKey(item)), true)))
+  return { items: unique, whole }
 }
 
 /**
@@ -143,7 +158,11 @@ export async function buildInterventions(
  * Only the most recent {@link InterventionsDeps.handoffLimit} finished agents are inspected: each
  * costs several git reads and this runs on a poll.
  */
-async function unpushedFor(project: ProjectSummary, deps: InterventionsDeps): Promise<Intervention[]> {
+async function unpushedFor(
+  project: ProjectSummary,
+  deps: InterventionsDeps,
+  unread: () => void,
+): Promise<Intervention[]> {
   const agents = deps.agents ?? listAgents
   const handoff =
     deps.handoff ??
@@ -161,7 +180,10 @@ async function unpushedFor(project: ProjectSummary, deps: InterventionsDeps): Pr
   const items: Intervention[] = []
   for (const agent of finished) {
     const branch = agentBranchFor(agent)
-    const state = await handoff(project.path, branch).catch(() => undefined)
+    const state = await handoff(project.path, branch).catch(() => {
+      unread()
+      return undefined
+    })
     // Every condition is a reason this is *not* waiting on anyone: the branch is gone, the session
     // wrote nothing, it already landed, it is already on the remote, or there is nowhere to push.
     if (!state || !state.exists || state.empty || state.merged || state.pushed || !state.hasRemote) continue

--- a/packages/the-framework/src/dashboard/keyed-watcher.SPEC.md
+++ b/packages/the-framework/src/dashboard/keyed-watcher.SPEC.md
@@ -4,12 +4,14 @@ The notification engine: a background poll over the registered projects that ann
 
 - The user hears about what newly needs them, or newly happened, without keeping a dashboard open.
 - The user is not flooded at daemon start: what already existed by then is never announced.
+- The user is not flooded by a start-up that could not reach GitHub either: a project nothing could be read from is not mistaken for a project with nothing in it.
 
 ## Flows
 
-- The first look only takes a baseline — whatever already existed when the daemon started is never announced; the user only hears about what happens while it watches.
+- The first look at a project only takes a baseline — whatever already existed there when the daemon started is never announced; the user only hears about what happens while it watches.
 - What makes two items "the same" is the caller's decision, so one engine serves both callers: the "needs you" queue (open PRs, parked questions, unpushed work) and the activity feed (agents started and finished).
-- Forgiving: a failed scan or projection simply announces nothing that cycle, and never counts as the baseline — the first *successful* look is the one that seeds it.
+- What counts as a baseline is decided per project: a project earns one from the first look that read it completely, so a project that was unreachable at start-up is simply not being watched yet, rather than being watched against an empty picture of itself.
+- Forgiving, and honest about it: a failed scan or projection announces nothing that cycle and earns no baseline, and one project that can never be read — a repo with no remote, say — leaves the others notifying normally instead of silencing them or flooding them.
 - It owns no timer of its own — the daemon's one clock calls it — so its cadence is declared where every other background job's is.
 
 ## Before modifying/creating SPEC.md files

--- a/packages/the-framework/src/dashboard/keyed-watcher.test.SPEC.md
+++ b/packages/the-framework/src/dashboard/keyed-watcher.test.SPEC.md
@@ -1,4 +1,4 @@
-The tests cover the announce-only-what-is-new behavior: the first poll seeds a silent baseline, identity is the caller's (an agent starting and finishing are two separate announcements), and a failed scan or projection announces nothing.
+The tests cover the announce-only-what-is-new behavior: the first poll seeds a silent baseline, identity is the caller's (an agent starting and finishing are two separate announcements), and a failed scan or projection announces nothing. They also cover the baseline being per project: a poll that reached no project earns no baseline (so a start-up without GitHub cannot flood), a project that only becomes readable later is baselined then rather than announced, and one permanently unreadable project does not stop the others notifying.
 
 ## Before modifying/creating SPEC.md files
 

--- a/packages/the-framework/src/dashboard/keyed-watcher.test.ts
+++ b/packages/the-framework/src/dashboard/keyed-watcher.test.ts
@@ -14,25 +14,27 @@ const pr = (n: number, url: string, project = 'p'): Intervention => ({
   url,
 })
 
+const projectOf = (item: { projectId: string }): string => item.projectId
+
 const started = (agentId: string): Activity => ({ projectId: 'p', projectName: 'p', kind: 'started', agentId })
 const finished = (agentId: string): Activity => ({ projectId: 'p', projectName: 'p', kind: 'finished', agentId, status: 'done' })
 
 test('SeenTracker seeds a baseline on the first poll, then returns only new items', () => {
-  const tracker = new SeenTracker(interventionKey)
+  const tracker = new SeenTracker(interventionKey, projectOf)
   // First poll = the queue that already existed at start-up: baseline, nothing announced.
-  assert.deepEqual(tracker.observe([pr(1, 'u1')]), [])
+  assert.deepEqual(tracker.observe([pr(1, 'u1')], ['p']), [])
   // A new PR appears next poll -> just that one.
-  assert.deepEqual(tracker.observe([pr(1, 'u1'), pr(2, 'u2')]).map(i => i.number), [2])
+  assert.deepEqual(tracker.observe([pr(1, 'u1'), pr(2, 'u2')], ['p']).map(i => i.number), [2])
   // Nothing new -> empty.
-  assert.deepEqual(tracker.observe([pr(1, 'u1'), pr(2, 'u2')]), [])
+  assert.deepEqual(tracker.observe([pr(1, 'u1'), pr(2, 'u2')], ['p']), [])
 })
 
 test('SeenTracker keys on the caller\'s identity, so a run started and finished are two announcements', () => {
-  const tracker = new SeenTracker(activityKey)
-  assert.deepEqual(tracker.observe([started('r1')]), [])
+  const tracker = new SeenTracker(activityKey, projectOf)
+  assert.deepEqual(tracker.observe([started('r1')], ['p']), [])
   // The same agent finishing is a new key -> announced.
-  assert.deepEqual(tracker.observe([finished('r1')]).map(i => i.kind), ['finished'])
-  assert.deepEqual(tracker.observe([finished('r1')]), [])
+  assert.deepEqual(tracker.observe([finished('r1')], ['p']).map(i => i.kind), ['finished'])
+  assert.deepEqual(tracker.observe([finished('r1')], ['p']), [])
 })
 
 test('startKeyedWatcher announces only items that appear after the first poll', async () => {
@@ -41,8 +43,9 @@ test('startKeyedWatcher announces only items that appear after the first poll', 
   const announced: number[][] = []
   const watcher = startKeyedWatcher({
     projects,
-    build: async () => current,
+    build: async () => ({ items: current, whole: ['p'] }),
     keyOf: interventionKey,
+    scopeOf: projectOf,
     onNew: items => void announced.push(items.map(i => i.number!)),
   })
   try {
@@ -68,6 +71,7 @@ test('startKeyedWatcher yields no new items when the scan or the projection fail
       throw new Error('projection failed')
     },
     keyOf: interventionKey,
+    scopeOf: projectOf,
     onNew: items => void announced.push(items),
   })
   try {
@@ -84,11 +88,12 @@ test('a failed first poll does not seed the baseline, so the backlog is not anno
   const announced: number[][] = []
   const watcher = startKeyedWatcher({
     projects,
-    build: async (): Promise<Intervention[]> => {
+    build: async () => {
       if (failing) throw new Error('projection failed')
-      return [pr(1, 'u1')]
+      return { items: [pr(1, 'u1')], whole: ['p'] }
     },
     keyOf: interventionKey,
+    scopeOf: projectOf,
     onNew: items => void announced.push(items.map(i => i.number!)),
   })
   try {
@@ -98,6 +103,84 @@ test('a failed first poll does not seed the baseline, so the backlog is not anno
     assert.deepEqual(announced, [])
     await watcher.poll() // and it stays silent on the next poll too — seen, not new
     assert.deepEqual(announced, [])
+  } finally {
+    watcher.stop()
+  }
+})
+
+test('a first poll that read nothing whole is not a baseline: the backlog is not announced (#1623)', async () => {
+  const projects = async (): Promise<ProjectSummary[]> => [{ id: 'p', path: '/p', name: 'p', activated: true }]
+  // What a boot with no GitHub reach actually looks like from here: the poll *succeeds*, with an
+  // empty list, because every read underneath it forgave its own failure.
+  let reachable = false
+  const announced: number[][] = []
+  const watcher = startKeyedWatcher({
+    projects,
+    build: async () => (reachable ? { items: [pr(1, 'u1'), pr(2, 'u2')], whole: ['p'] } : { items: [], whole: [] }),
+    keyOf: interventionKey,
+    scopeOf: projectOf,
+    onNew: items => void announced.push(items.map(i => i.number!)),
+  })
+  try {
+    await watcher.poll() // empty because unreachable — earns no baseline
+    reachable = true
+    await watcher.poll() // the first real read: two pre-existing PRs, and neither is news
+    assert.deepEqual(announced, [])
+  } finally {
+    watcher.stop()
+  }
+})
+
+test('one unreadable project neither floods nor silences the others (#1623)', async () => {
+  const projects = async (): Promise<ProjectSummary[]> => [
+    { id: 'a', path: '/a', name: 'a', activated: true },
+    { id: 'b', path: '/b', name: 'b', activated: true },
+  ]
+  // `a` answers from the start; `b` — a repo with no remote, say — only later.
+  let bReadable = false
+  const announced: number[][] = []
+  const watcher = startKeyedWatcher({
+    projects,
+    build: async () =>
+      bReadable
+        ? { items: [pr(1, 'u1', 'a'), pr(2, 'u2', 'b')], whole: ['a', 'b'] }
+        : { items: [pr(1, 'u1', 'a')], whole: ['a'] },
+    keyOf: interventionKey,
+    scopeOf: projectOf,
+    onNew: items => void announced.push(items.map(i => i.number!)),
+  })
+  try {
+    await watcher.poll() // baseline for `a` only
+    // `a` keeps working while `b` is unreadable — the point of holding the baseline per project.
+    await watcher.poll()
+    assert.deepEqual(announced, [])
+    bReadable = true
+    await watcher.poll() // `b`'s pre-existing PR is not news either: this is `b`'s first whole read
+    assert.deepEqual(announced, [])
+  } finally {
+    watcher.stop()
+  }
+})
+
+test('a project that is readable keeps announcing while another one cannot be read (#1623)', async () => {
+  const projects = async (): Promise<ProjectSummary[]> => [
+    { id: 'a', path: '/a', name: 'a', activated: true },
+    { id: 'b', path: '/b', name: 'b', activated: true },
+  ]
+  let aItems = [pr(1, 'u1', 'a')]
+  const announced: number[][] = []
+  const watcher = startKeyedWatcher({
+    projects,
+    build: async () => ({ items: aItems, whole: ['a'] }), // `b` never answers
+    keyOf: interventionKey,
+    scopeOf: projectOf,
+    onNew: items => void announced.push(items.map(i => i.number!)),
+  })
+  try {
+    await watcher.poll()
+    aItems = [pr(1, 'u1', 'a'), pr(3, 'u3', 'a')]
+    await watcher.poll()
+    assert.deepEqual(announced, [[3]])
   } finally {
     watcher.stop()
   }

--- a/packages/the-framework/src/dashboard/keyed-watcher.ts
+++ b/packages/the-framework/src/dashboard/keyed-watcher.ts
@@ -1,4 +1,4 @@
-import type { ProjectSummary } from './projects.js'
+import type { ProjectSummary, ProjectionRead } from './projects.js'
 
 // The daemon-side half of notifications (#627): a background poll of a projection over the
 // registered projects that fires even when no dashboard is open — that is what a Discord
@@ -10,22 +10,37 @@ import type { ProjectSummary } from './projects.js'
  * Tracks which items have been announced, so only new ones notify. Identity is the caller's
  * (`keyOf`), since what makes two items "the same" is a property of what is being watched.
  * Testable without timers.
+ *
+ * The baseline is kept per project (`scopeOf`), not once for the whole poll (#1623). A poll that
+ * reached three projects out of four knows what already existed on those three and knows nothing
+ * about the fourth, and announcing is a per-project decision anyway. Held globally, one project
+ * that can never be read — a registered repo with no remote is an ordinary case — would either
+ * silence every project's notifications or hand the whole set a baseline it had not earned.
  */
 export class SeenTracker<T> {
   private readonly seen = new Set<string>()
-  private warmedUp = false
+  private readonly warmedUp = new Set<string>()
 
-  constructor(private readonly keyOf: (item: T) => string) {}
+  constructor(
+    private readonly keyOf: (item: T) => string,
+    private readonly scopeOf: (item: T) => string,
+  ) {}
 
   /**
-   * Fold a poll's items into the baseline and return the ones not seen before. The first call
-   * only establishes the baseline (returns `[]`), so whatever already existed at start-up is
-   * never announced — you only hear about what happens while the daemon is watching.
+   * Fold a poll's items into the baseline and return the ones worth announcing: the items not seen
+   * before, from projects this watcher has a real baseline for. `whole` names the projects the poll
+   * read completely, and only those earn a baseline — so whatever already existed at start-up is
+   * never announced, and a project that could not be read stays quiet until it can be.
+   *
+   * Items keep being folded in either way: a partial read can only under-report, never invent, so
+   * anything it did see is still something the user should not later hear about as new.
    */
-  observe(items: T[]): T[] {
-    const fresh = this.warmedUp ? items.filter(item => !this.seen.has(this.keyOf(item))) : []
+  observe(items: T[], whole: Iterable<string>): T[] {
+    const fresh = items.filter(
+      item => this.warmedUp.has(this.scopeOf(item)) && !this.seen.has(this.keyOf(item)),
+    )
     for (const item of items) this.seen.add(this.keyOf(item))
-    this.warmedUp = true
+    for (const project of whole) this.warmedUp.add(project)
     return fresh
   }
 }
@@ -41,25 +56,30 @@ export interface KeyedWatcher {
 export interface KeyedWatcherOptions<T> {
   /** The projects to scan each poll (the daemon passes the registry, mapped to summaries). */
   projects: () => Promise<ProjectSummary[]>
-  /** Project the scanned projects into the items being watched. */
-  build: (projects: ProjectSummary[]) => Promise<T[]>
+  /**
+   * Project the scanned projects into the items being watched, and name the projects that were read
+   * whole — the ones whose share of the items is all of it, rather than all that could be reached.
+   */
+  build: (projects: ProjectSummary[]) => Promise<ProjectionRead<T>>
   /** The stable identity of an item, so the same one is only ever announced once. */
   keyOf: (item: T) => string
+  /** Which project an item belongs to: the baseline is kept per project (#1623). */
+  scopeOf: (item: T) => string
   /** Called with the genuinely-new items each poll (empty polls are skipped). */
   onNew: (items: T[]) => void | Promise<void>
 }
 
 /**
- * Watch a projection and hand each poll's new items to `onNew`. The first successful poll only
- * seeds the baseline. Forgiving — a failed project scan or projection just yields no new items
- * that cycle, and never counts as a poll: the baseline must come from a real read, or a failed
- * first poll would make the next good one announce everything pre-existing as new.
+ * Watch a projection and hand each poll's new items to `onNew`. A project's first *whole* read only
+ * seeds that project's baseline. Forgiving — a failed project scan or projection just yields no new
+ * items that cycle, and earns no baseline: the baseline must come from a real read, or a first poll
+ * that could not reach GitHub would make the next good one announce everything pre-existing as new.
  *
  * Owns no timer (E4): the daemon's one clock calls {@link KeyedWatcher.poll}, so the cadence is
  * declared where every other background job's is.
  */
 export function startKeyedWatcher<T>(opts: KeyedWatcherOptions<T>): KeyedWatcher {
-  const tracker = new SeenTracker(opts.keyOf)
+  const tracker = new SeenTracker(opts.keyOf, opts.scopeOf)
   let stopped = false
   let running = false
 
@@ -67,13 +87,13 @@ export function startKeyedWatcher<T>(opts: KeyedWatcherOptions<T>): KeyedWatcher
     if (stopped || running) return
     running = true
     try {
-      let items: T[]
+      let read: ProjectionRead<T>
       try {
-        items = await opts.build(await opts.projects())
+        read = await opts.build(await opts.projects())
       } catch {
         return
       }
-      const fresh = tracker.observe(items)
+      const fresh = tracker.observe(read.items, read.whole)
       if (fresh.length > 0 && !stopped) await opts.onNew(fresh)
     } finally {
       running = false

--- a/packages/the-framework/src/dashboard/projects.ts
+++ b/packages/the-framework/src/dashboard/projects.ts
@@ -38,6 +38,21 @@ export interface ProjectSummary {
   errors?: ProjectError[]
 }
 
+/**
+ * A projection over the registered projects, together with the projects it could actually see.
+ *
+ * A project whose sources cannot be read contributes no items — which is exactly what a project
+ * with nothing waiting contributes. `whole` is what tells the two apart (#1623). Only a caller
+ * that keeps a baseline of what it has already announced needs the distinction; the panels that
+ * simply render the list read `items` and ignore it.
+ */
+export interface ProjectionRead<T> {
+  /** What was found. Possibly only part of it, when some project could not be read. */
+  items: T[]
+  /** The ids of the projects every source answered for, so their share of `items` is all of it. */
+  whole: string[]
+}
+
 /** Injectable readers so {@link summarizeProject} is unit-testable off disk. */
 export interface SummarizeDeps {
   isActivated?: (path: string) => Promise<boolean>


### PR DESCRIPTION
Closes #1623.

A daemon that starts up unable to reach GitHub announced every already-open pull request
to Discord as new, on the first poll that worked.

## What was wrong

`keyed-watcher.ts` was already written against this: it returns before `observe()` when the
read throws, precisely so a failed first poll cannot become the baseline. But **neither of
its inputs could throw.** Every read underneath forgave its own failure:

- `ghPrList` — `ghJson(args, cwd, [])`, so an unauthenticated or unreachable `gh` resolves `[]`
- `buildInterventions` — `.catch(() => [])` per project, for PRs, live agents and unpushed work
- `buildActivity` — `.catch(() => [])` per project

So a boot with no GitHub reach did not fail. It *succeeded, empty*. The tracker warmed up
against an empty baseline, and the first poll that reached GitHub reported the entire open
backlog as new, on both watchers.

(The issue — and an earlier draft of this — says "one message per pre-existing item". That
overstates it: both posters compose a single message, `🔔 N items need you:` followed by every
item. One notification, announcing a whole backlog as if it had just appeared.)

The issue names `interventions.ts:89` as the flattening point. That catch is real, but for
the GitHub case it never fires: `ghPrList` had already swallowed the failure a layer deeper.

## The fix

The builders now report which projects they read *whole*, and only a whole read earns a
baseline.

- `ghPrList` rejects when `gh` could not answer, instead of resolving `[]`. It is the one read
  in `gh.ts` that does — its caller is the one that has to tell "no PRs" from "no answer".
- `buildInterventions` / `buildActivity` return `{ items, whole }`: the same forgiving item list
  as before, plus the ids of the projects every source answered for.
- `SeenTracker` keeps the baseline **per project** rather than one flag for the whole poll.

## Why per project, and not one flag

One flag looks simpler and is wrong. A registered repo with no remote is an ordinary,
supported case — the interventions doc has always said so — and its PR read fails on *every*
poll. With a single flag, that one project would hold the baseline down forever and the user
would get no Discord notifications at all, from any project. Silence that looks exactly like
"nothing is happening" is a worse bug than the flood.

Per project, each project earns its own baseline from its own first whole read: the
unreachable one is simply not being watched yet, and the others carry on.

`listSummaries`'s `.catch(() => [])` — the other flattening the issue names — needs no change
once the baseline is per project: an unreadable registry yields no projects, so no project is
read whole, so nothing earns a baseline. It falls out rather than being handled.

Items from a partial read are still folded into `seen`. A partial read can only under-report,
never invent, so anything it did see should not later arrive as news.

## Dogfooded

Ran the real daemon against a real repo with pre-existing open PRs, with a `gh` on PATH that
fails the way an offline machine fails, and a local sink standing in for the Discord webhook
(`DISCORD_WEBHOOK`, `notifyDiscord` on):

1. **GitHub unreachable** — two polls, **0 posts**, and no baseline taken.
2. **GitHub comes back**, with two PRs already open — the first whole read. **0 posts.** This is
   the poll that floods today.
3. **A third PR opened while watching** — **exactly one post**, naming only it:
   `🔔 Needs you (tf-1334-dogfood): #5 Dogfood #1623: a second item, opened while watching`.

Step 3 is the one that makes steps 1 and 2 mean anything: the watcher is quiet because it knows
what was already there, not because it stopped working.

## Also

`SPEC.md` files touched: `keyed-watcher`, `interventions`, `activity`, `gh` and their test
specs — the keyed-watcher spec had promised the un-floodable behaviour that the code did not
have, and now describes the baseline as per-project.

## Not in this PR

The dashboard's in-browser notifications have the same seam one layer up:
`dashboard/lib/use-notifications.ts` counts observations (`WARMUP = 2`) rather than asking
whether the read was whole, so a page loaded while GitHub is unreachable takes an empty
baseline too. Fixing it means carrying `whole` through the RPC and keying the hook's warm-up
per project, which is a bigger change than the daemon-side flood this issue is about. Worth
its own ticket.
