### PR TITLE
Haiku is out of scope, and the reason is written down (#1334)

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -6,6 +6,7 @@
 - **Never interrupt a running session because of low quota.** Quota gates whether a session may *start*; a session already running is never paused, degraded or cut short.
 - **The unit of work is an *agent*** — not a run or a session. The CLI that drives it (`claude`, `codex`) is the *driver*.
 - **Zero migration code.** Manual migration is good; code that migrates is not. A renamed or deleted thing leaves nothing behind — no fallback to the old name, no key alias, no old-format branch, no upgrade step. Nor a notice about what was dropped: a warning about data nobody has is still code nobody needs.
+- **Haiku is out of scope.** It skips the session-finish protocol, so unattended work started on it always ends as an unmerged draft PR that a human has to finish. We deliberately don't work around this: no model floor that overrides the model a user picked, and no refusal to arm the hand-off. The dashboard's warning is the whole treatment — it teaches and never blocks.
 
 ## Before modifying this file
 


### PR DESCRIPTION
Rom's answer on #1334: *"Again, let's skip Haiku support for now. (Save this in MEMORY.md with reason why.)"*

That answers the question the issue was blocked on. I had offered two options — a model floor on unattended runs, or refusing to arm the merge. **Neither is built.** Haiku is simply not supported, and the existing warn-never-block from #1439 stays the whole treatment.

One bullet under `## Decisions`:

> - **Haiku is out of scope.** It skips the session-finish protocol, so unattended work started on it always ends as an unmerged draft PR that a human has to finish. We deliberately don't work around this: no model floor that overrides the model a user picked, and no refusal to arm the hand-off. The dashboard's warning is the whole treatment — it teaches and never blocks.

**Why memory and not a code comment.** `StartAgentForm.tsx:207-215` already says Haiku skips the finish step. What the code cannot say is that two workarounds were weighed and rejected — a future session reading only the warning would reasonably propose the floor again. That rationale is exactly what the [memory format](https://raw.githubusercontent.com/brillout/ai-memory/refs/heads/main/memory.md) asks `## Decisions` to hold: human-communicated, not inferable from code.

No feature added or removed, so `FEATURES-SPEC.md` is unchanged.