### PR TITLE
An agent that committed nothing leaves no branch behind (#1650)

### DIFF
--- a/FEATURES-SPEC.md
+++ b/FEATURES-SPEC.md
@@ -129,6 +129,7 @@ happens while nobody is at the keyboard.
 - CI watch: merge a PR once its checks pass
 - CI watch: one fix agent per red head commit, max two attempts
 - Reclaim the checkout of an agent whose work is on the remote — never by publishing what a `handoff: local` agent refused to
+- An agent that committed nothing leaves no branch behind: its empty branch goes with its checkout, never pushed, so a pinned routine is not stood down by its own last run
 - Release a pinned routine branch left behind by a closed PR — before the schedule fires the routine, and before its "Run now" does
 - The agent drains its own TODO backlog, one entry per turn
 

--- a/packages/the-framework/src/branch-names.ts
+++ b/packages/the-framework/src/branch-names.ts
@@ -60,6 +60,16 @@ export function agentIdFromWorktreeDir(name: string): string {
 }
 
 /**
+ * Whether a branch is one the framework minted for a run (#1650): the run-id spelling, a
+ * session-named `tf-<name>`, or the legacy slashed form — and never the data branch, which
+ * shares the prefix. The only branches the framework may delete on its own.
+ */
+export function isRunBranch(name: string): boolean {
+  if (name === DATA_BRANCH) return false
+  return name.startsWith(AGENT_BRANCH_PREFIX) || name.startsWith(LEGACY_AGENT_BRANCH_PREFIX)
+}
+
+/**
  * Whether a name under `branches/` is a framework checkout directory. The same directory also
  * holds the rename links (#1589) and possibly a user's own entries, and only names the framework
  * mints — the run branch spelling — are checkouts.

--- a/packages/the-framework/src/daemon-runtime.ts
+++ b/packages/the-framework/src/daemon-runtime.ts
@@ -597,6 +597,8 @@ export function createProjectRuntime({ cwd, env, binPath, retryDelayMs, driverPr
         // never depends on the caller having one.
         const outcome = await removeProjectWorktree(projectCwd, agentId ?? agentIdFromWorktreeDir(basename(worktree)))
         if (!outcome.ok) console.log(`[framework] keeping worktree ${worktree}: ${outcome.error}`)
+        else if (outcome.branchDeleted)
+          console.log(`[framework] removed worktree ${worktree} and its branch ${outcome.branchDeleted}: the branch held nothing the remote lacks`)
       } catch {
         // A worktree we could not retire is a worktree left on disk, which is the safe direction.
       }

--- a/packages/the-framework/src/daemon.test.ts
+++ b/packages/the-framework/src/daemon.test.ts
@@ -371,7 +371,27 @@ fs.appendFileSync(${JSON.stringify(join(cwd, 'started.log'))}, agentId + '\\n')
     // accumulated per failed session until a human noticed.
     const failedId = await runWith('failed', 2)
     assert.equal(await archived(failedId), true, "a failed run's history is copied too")
-    assert.equal(await worktreeGone(failedId), true, 'and its checkout goes too, since the remote has its branch')
+    assert.equal(await worktreeGone(failedId), true, 'and its checkout goes too')
+    // This run committed nothing, and its tip — the init commit — is already on origin under the
+    // first run's branch. So nothing is pushed and the branch goes with the checkout (#1650): the
+    // branch's absence is the last thing teardown does, so it is what the test waits on before
+    // pulling the repo out from under the daemon.
+    for (let i = 0; i < 600; i++) {
+      const gone = await git(['show-ref', '--verify', '--quiet', `refs/heads/tf-agent-${failedId}`], cwd).then(
+        () => false,
+        () => true,
+      )
+      if (gone) break
+      await new Promise(r => setTimeout(r, 20))
+    }
+    await assert.rejects(
+      () => git(['show-ref', '--verify', '--quiet', `refs/heads/tf-agent-${failedId}`], cwd),
+      'a run that committed nothing leaves no branch behind',
+    )
+    await assert.rejects(
+      () => git(['rev-parse', '--verify', `refs/remotes/origin/tf-agent-${failedId}`], cwd),
+      'and nothing of it was pushed',
+    )
 
     ac.abort()
     await done

--- a/packages/the-framework/src/merged-worktrees.test.ts
+++ b/packages/the-framework/src/merged-worktrees.test.ts
@@ -106,7 +106,7 @@ test('the sweep says what it removed and what it kept, per project (#1036)', asy
   const lines: string[] = []
   const results: Record<string, MergedSweepResult> = {
     '/a': { removed: [{ agentId: 'r1' }], failed: [] },
-    '/b': { removed: [{ agentId: 'r2' }], failed: [{ agentId: 'r3', error: 'not on the remote' }] },
+    '/b': { removed: [{ agentId: 'r2', branchDeleted: 'tf-triage-quick' }], failed: [{ agentId: 'r3', error: 'not on the remote' }] },
   }
   const sweep = startMergedWorktreeSweep({
     projects: async () => [{ path: '/a' }, { path: '/b' }],
@@ -117,7 +117,7 @@ test('the sweep says what it removed and what it kept, per project (#1036)', asy
   sweep.stop()
   assert.match(lines[0] ?? '', /removed the worktree for session r1: its branch is on the remote/)
   assert.match(lines[0] ?? '', /The branch and the session are kept/, 'a checkout vanishing silently reads as a bug')
-  assert.match(lines[1] ?? '', /removed the worktree for session r2/)
+  assert.match(lines[1] ?? '', /removed the worktree for session r2 and its branch tf-triage-quick: the branch held nothing/, 'a branch going says so (#1650)')
   assert.match(lines[2] ?? '', /kept the worktree for session r3: not on the remote/)
 })
 

--- a/packages/the-framework/src/merged-worktrees.ts
+++ b/packages/the-framework/src/merged-worktrees.ts
@@ -23,6 +23,8 @@ import { repoHasRemote, worktreePath } from './store/index.js'
 export interface RemovedWorktree {
   /** The agent id, which is also the worktree's directory name. */
   agentId: string
+  /** The run branch that went with it, when it held nothing the remote lacks (#1650). */
+  branchDeleted?: string
 }
 
 /** A worktree the sweep tried to reclaim and could not, and why. */
@@ -85,7 +87,7 @@ export async function removeMergedWorktrees(cwd: string, deps: MergedSweepDeps =
   }
   for (const row of rows) {
     const outcome = await withAgentLock(worktreePath(cwd, row.agentId), () => remove(cwd, row.agentId))
-    if (outcome.ok) result.removed.push({ agentId: row.agentId })
+    if (outcome.ok) result.removed.push({ agentId: row.agentId, ...(outcome.branchDeleted ? { branchDeleted: outcome.branchDeleted } : {}) })
     else result.failed.push({ agentId: row.agentId, error: outcome.error })
   }
   return result
@@ -142,7 +144,9 @@ export function startMergedWorktreeSweep(opts: MergedSweepOptions): MergedWorktr
       for (const item of removed) {
         announced.delete(item.agentId)
         opts.log(
-          `[framework] removed the worktree for session ${item.agentId}: its branch is on the remote. The branch and the session are kept.`,
+          item.branchDeleted
+            ? `[framework] removed the worktree for session ${item.agentId} and its branch ${item.branchDeleted}: the branch held nothing the remote lacks. The session is kept.`
+            : `[framework] removed the worktree for session ${item.agentId}: its branch is on the remote. The branch and the session are kept.`,
         )
       }
       for (const item of failed) {

--- a/packages/the-framework/src/stale-branch.ts
+++ b/packages/the-framework/src/stale-branch.ts
@@ -15,6 +15,11 @@ import { ghPrsForBranch, type LinkedPr } from './dashboard/gh.js'
 // history proves the work is over: some PR existed and none is open. Deleting is safe exactly
 // then, because the closed PR itself preserves the diff on GitHub — the branch is a leftover
 // name, not the last copy of anything a human still needs.
+//
+// The other leftover — a pinned branch with no commits and no PR, which a triage that only writes
+// the queue makes every time — never reaches this: its checkout's removal deletes it (#1650),
+// because its tip is a commit the remote already has. What arrives here `unproven` is genuinely
+// unprovable: commits of its own and no PR yet.
 
 /** What became of one pinned branch: gone already, genuinely busy, unprovable, or released. */
 export type StaleBranchOutcome = 'absent' | 'pending' | 'unproven' | 'released'

--- a/packages/the-framework/src/store/index.ts
+++ b/packages/the-framework/src/store/index.ts
@@ -45,6 +45,7 @@ export {
   branchPushed,
   repoHasRemote,
   removeWorktree,
+  deleteBranch,
   pruneWorktrees,
   worktreePath,
   agentBranchName,

--- a/packages/the-framework/src/store/worktree.test.ts
+++ b/packages/the-framework/src/store/worktree.test.ts
@@ -7,6 +7,8 @@ import type { GitRunner } from '../project.js'
 import { nodeGitRunner } from '../project.js'
 import {
   addWorktree,
+  attachWorktree,
+  deleteBranch,
   commitPendingWork,
   listWorktrees,
   parseWorktreeList,
@@ -133,6 +135,33 @@ test('add/list/remove round-trips against a real git repo', async () => {
     assert.equal((await listWorktrees(repo, git)).some(w => w.path === path), false, 'removed worktree is no longer listed')
 
     await assert.doesNotReject(() => pruneWorktrees(repo, git))
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})
+
+test('attachWorktree recreates a branch that is gone from HEAD, and still refuses one git will not attach (#1650)', async () => {
+  // The only branch the framework deletes held nothing past a commit the remote already had, so
+  // continuing that agent on a fresh branch from HEAD puts it exactly where it was.
+  const git = nodeGitRunner()
+  const repo = await realpath(await mkdtemp(join(tmpdir(), 'framework-worktree-')))
+  try {
+    await git(['init'], repo)
+    await git(['config', 'user.email', 't@t'], repo)
+    await git(['config', 'user.name', 't'], repo)
+    await writeFile(join(repo, 'README.md'), '# t\n')
+    await git(['add', '-A'], repo)
+    await git(['commit', '-m', 'init'], repo)
+
+    const { path } = await attachWorktree(repo, { agentId: 'run1', branch: 'tf-agent-run1' }, git)
+    assert.equal(await currentBranch(path, git), 'tf-agent-run1', 'the missing branch was created and checked out')
+    await removeWorktree(repo, path, git)
+    await deleteBranch(repo, 'tf-agent-run1', git)
+    await assert.rejects(() => git(['show-ref', '--verify', 'refs/heads/tf-agent-run1'], repo), 'deleteBranch removed it')
+
+    // A branch that exists but is checked out by the main checkout is git's refusal, not ours.
+    const head = (await git(['rev-parse', '--abbrev-ref', 'HEAD'], repo)).trim()
+    await assert.rejects(() => attachWorktree(repo, { agentId: 'run2', branch: head }, git))
   } finally {
     await rm(repo, { recursive: true, force: true })
   }

--- a/packages/the-framework/src/store/worktree.ts
+++ b/packages/the-framework/src/store/worktree.ts
@@ -72,7 +72,10 @@ export async function addWorktree(
  * no `-b`. Continuing an agent puts it back on the branch its work is already on, rather than
  * branching again from HEAD and stranding what it did last time.
  *
- * Rejects on git failure, like {@link addWorktree}: a continued agent needs its checkout.
+ * A branch that is gone is recreated from HEAD (#1650): the only branch the framework deletes is
+ * one that held nothing past a commit the remote already had, so HEAD is where its work was.
+ * Anything else git refuses — the branch checked out elsewhere, say — still rejects, like
+ * {@link addWorktree}: a continued agent needs its checkout.
  */
 export async function attachWorktree(
   repo: string,
@@ -81,7 +84,18 @@ export async function attachWorktree(
 ): Promise<AddedWorktree> {
   if (!isSafeAgentId(opts.agentId)) throw new Error(`unsafe run id: ${opts.agentId}`)
   const path = worktreePath(repo, opts.agentId)
-  await agent(['worktree', 'add', path, opts.branch], repo)
+  try {
+    await agent(['worktree', 'add', path, opts.branch], repo)
+  } catch (err) {
+    // `worktree add <path> <name>` also resolves a remote-only `origin/<name>`, so the existence
+    // check comes after the attempt, not before it.
+    const exists = await agent(['show-ref', '--verify', '--quiet', `refs/heads/${opts.branch}`], repo).then(
+      () => true,
+      () => false,
+    )
+    if (exists) throw err
+    await agent(['worktree', 'add', '-b', opts.branch, path], repo)
+  }
   return { path, branch: opts.branch }
 }
 
@@ -184,6 +198,16 @@ export async function removeWorktree(repo: string, path: string, agent: GitRunne
   } catch {
     // Already removed, or never registered: nothing to do.
   }
+}
+
+/**
+ * Delete a branch that holds nothing (#1650). `-D`, because "merged" in git's eyes is the wrong
+ * test: the caller proved the tip is a commit the remote already has, which is the stronger fact.
+ * Forgiving: the checkout is already gone by the time this runs, and a branch that would not
+ * delete is a leftover name, not lost work.
+ */
+export async function deleteBranch(repo: string, branch: string, agent: GitRunner = nodeGitRunner()): Promise<void> {
+  await agent(['branch', '-D', branch], repo).catch(() => undefined)
 }
 
 /**

--- a/packages/the-framework/src/worktrees.test.ts
+++ b/packages/the-framework/src/worktrees.test.ts
@@ -201,6 +201,51 @@ test('a web run whose checkout holds more than the hand-off carried falls back t
   }
 })
 
+test('a run branch holding nothing the remote lacks goes with its checkout, unpushed (#1650)', async () => {
+  // A triage that wrote only to the data branch, or a run stopped before its first commit: the
+  // branch tip is the commit it started from, which origin already has. Pushing it is what put an
+  // empty `tf-triage-quick` on origin; keeping it is what made the next triage stand down behind
+  // a branch that "already exists" — on any repo where no PR ever carried the name, so the
+  // stale-branch release could not prove it dead.
+  const { repo, path, branch } = await repoWithDirtyWorktree()
+  const git = nodeGitRunner()
+  try {
+    await git(['push', '-q', 'origin', 'HEAD:main'], repo)
+    await git(['checkout', '--', '.'], path)
+    await mkdir(join(repo, '.git', 'info'), { recursive: true })
+    await writeFile(join(repo, '.git', 'info', 'exclude'), '.the-framework/\n')
+    const now = new Date().toISOString()
+    await mkdir(join(path, '.the-framework'), { recursive: true })
+    await writeFile(join(path, '.the-framework', 'agent.json'), JSON.stringify({ status: 'done', id: RUN_ID, startedAt: now, updatedAt: now }))
+    assert.deepEqual(await removeProjectWorktree(repo, RUN_ID), { ok: true })
+    await assert.rejects(() => stat(path), 'the checkout is gone')
+    await assert.rejects(() => git(['rev-parse', '--verify', `refs/remotes/origin/${branch}`], repo), 'nothing reached origin')
+    await assert.rejects(() => git(['rev-parse', '--verify', `refs/heads/${branch}`], repo), 'and the branch went with the checkout')
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})
+
+test('a clean checkout whose commit the remote does not have yet is pushed and keeps its branch (#1650)', async () => {
+  // The carve-out is for a branch that provably holds nothing. A commit origin has never seen is
+  // exactly what the ordinary rule exists to protect, clean tree or not.
+  const { repo, path, branch } = await repoWithDirtyWorktree()
+  const git = nodeGitRunner()
+  try {
+    await git(['push', '-q', 'origin', 'HEAD:main'], repo)
+    await git(['config', 'user.email', 't@t'], path)
+    await git(['config', 'user.name', 't'], path)
+    await git(['add', '-A'], path)
+    await git(['commit', '-q', '-m', 'work'], path)
+    assert.deepEqual(await removeProjectWorktree(repo, RUN_ID), { ok: true })
+    await assert.rejects(() => stat(path), 'the checkout is gone')
+    assert.match(await git(['show', `refs/remotes/origin/${branch}:index.html`], repo), /Welcome!/, 'the commit reached origin')
+    assert.match(await git(['show', `${branch}:index.html`], repo), /Welcome!/, 'and the branch stays')
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})
+
 test('a worktree whose work cannot be committed is refused, not force-removed (#982)', async () => {
   const { repo, path } = await repoWithDirtyWorktree()
   try {

--- a/packages/the-framework/src/worktrees.test.ts
+++ b/packages/the-framework/src/worktrees.test.ts
@@ -217,7 +217,7 @@ test('a run branch holding nothing the remote lacks goes with its checkout, unpu
     const now = new Date().toISOString()
     await mkdir(join(path, '.the-framework'), { recursive: true })
     await writeFile(join(path, '.the-framework', 'agent.json'), JSON.stringify({ status: 'done', id: RUN_ID, startedAt: now, updatedAt: now }))
-    assert.deepEqual(await removeProjectWorktree(repo, RUN_ID), { ok: true })
+    assert.deepEqual(await removeProjectWorktree(repo, RUN_ID), { ok: true, branchDeleted: branch })
     await assert.rejects(() => stat(path), 'the checkout is gone')
     await assert.rejects(() => git(['rev-parse', '--verify', `refs/remotes/origin/${branch}`], repo), 'nothing reached origin')
     await assert.rejects(() => git(['rev-parse', '--verify', `refs/heads/${branch}`], repo), 'and the branch went with the checkout')
@@ -241,6 +241,44 @@ test('a clean checkout whose commit the remote does not have yet is pushed and k
     await assert.rejects(() => stat(path), 'the checkout is gone')
     assert.match(await git(['show', `refs/remotes/origin/${branch}:index.html`], repo), /Welcome!/, 'the commit reached origin')
     assert.match(await git(['show', `${branch}:index.html`], repo), /Welcome!/, 'and the branch stays')
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})
+
+test('a run branch pushed under its own name holds its own work, so it stays (#1650)', async () => {
+  // `origin/<branch>` contains the branch tip by definition. Counting it would read every pushed
+  // run branch — the one with the PR — as holding nothing, and delete the local copy after each run.
+  const { repo, path, branch } = await repoWithDirtyWorktree()
+  const git = nodeGitRunner()
+  try {
+    await git(['config', 'user.email', 't@t'], path)
+    await git(['config', 'user.name', 't'], path)
+    await git(['add', '-A'], path)
+    await git(['commit', '-q', '-m', 'work'], path)
+    await git(['push', '-q', 'origin', branch], path)
+    assert.deepEqual(await removeProjectWorktree(repo, RUN_ID), { ok: true })
+    await assert.rejects(() => stat(path), 'the checkout is gone')
+    assert.match(await git(['show', `${branch}:index.html`], repo), /Welcome!/, 'the branch stays')
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})
+
+test("a leftover checkout on a branch the framework did not mint keeps that branch, empty or not (#1650)", async () => {
+  // Found on the rig: a reclaimed checkout sitting on `main`. It held nothing, and `git branch -D
+  // main` failed only because the primary checkout had it out — git's refusal is not the guard.
+  const { repo, path } = await repoWithDirtyWorktree()
+  const git = nodeGitRunner()
+  try {
+    await git(['push', '-q', 'origin', 'HEAD:main'], repo)
+    await git(['checkout', '--', '.'], path)
+    await git(['checkout', '-q', '-b', 'release'], path)
+    await mkdir(join(repo, '.git', 'info'), { recursive: true })
+    await writeFile(join(repo, '.git', 'info', 'exclude'), '.the-framework/\n')
+    assert.deepEqual(await removeProjectWorktree(repo, RUN_ID), { ok: true })
+    await assert.rejects(() => stat(path), 'the checkout is gone')
+    await git(['rev-parse', '--verify', 'refs/heads/release'], repo)
   } finally {
     await rm(repo, { recursive: true, force: true })
   }

--- a/packages/the-framework/src/worktrees.ts
+++ b/packages/the-framework/src/worktrees.ts
@@ -10,6 +10,7 @@ import {
   worktreeClean,
   currentBranch,
   removeWorktree,
+  deleteBranch,
   pruneWorktrees,
   worktreePath,
   worktreeSize,
@@ -155,6 +156,8 @@ export async function removeProjectWorktree(
         error: `session ${agentId}'s record could not be read (${errorMessage(err)}); its worktree was kept`,
       }
     }
+    // Whether the run's branch goes with the checkout (#1650): only when it provably holds nothing.
+    let emptyBranch = false
     if (meta?.target === 'web' && meta.cloudAnchor && (await webCheckoutCovered(path, branch, meta.cloudAnchor))) {
       // A web run's checkout never holds the work (#1601): the hand-off pushed everything the
       // cloud session clones at, and the work itself lands on the session's own remote branch.
@@ -164,6 +167,16 @@ export async function removeProjectWorktree(
       // recorded anchor). Anything short of that proof — no anchor recorded, the anchor's object
       // gone, a tree or tip that moved — falls through to the ordinary rule below, which is never
       // worse than what every web run got before.
+    } else if (await branchHoldsNothing(cwd, path, branch)) {
+      // A run that committed nothing (#1650) — a triage that wrote only to the data branch, a run
+      // stopped before its first commit — leaves a branch whose tip is a commit the remote already
+      // has. The rule is satisfied before any push: what the checkout holds *is* on the remote.
+      // Pushing anyway is what put an empty `tf-triage-quick` on origin, and keeping the branch
+      // is what jammed the next triage on it ("branch already exists — triage pending"), on any
+      // repo where the stale-branch release (#1293) could not prove it dead: no PR ever carried
+      // the name, so the branch looked like an agent still working toward its handoff. The branch
+      // goes with the checkout. It is not the last copy of anything, by construction.
+      emptyBranch = true
     } else if (meta?.handoff && !meta.handoff.push) {
       // A publish-nothing session's checkout goes only once everything it holds is already on
       // the remote by someone's explicit act: a clean tree on a pushed tip — then removing it
@@ -199,6 +212,8 @@ export async function removeProjectWorktree(
     await opts.beforeRemove?.(agentId)
     await removeWorktree(cwd, path)
     await pruneWorktrees(cwd)
+    // After the checkout: git refuses to delete a branch a worktree still has checked out.
+    if (emptyBranch) await deleteBranch(cwd, branch)
     return { ok: true }
   } catch (err) {
     return { ok: false, error: errorMessage(err) }
@@ -215,6 +230,21 @@ async function webCheckoutCovered(path: string, branch: string, anchor: string):
   const git = nodeGitRunner()
   return git(['merge-base', '--is-ancestor', branch, anchor], path).then(
     () => true,
+    () => false,
+  )
+}
+
+/**
+ * Whether a run's branch holds nothing the remote lacks (#1650): the tree is clean and the tip is
+ * reachable from some remote-tracking branch — a commit `origin` already has, so nothing on the
+ * branch is unique to it. Read from the local remote-tracking refs, which are only ever behind the
+ * remote: a tip they do not cover yet answers false, and the caller falls back to the push.
+ */
+async function branchHoldsNothing(cwd: string, path: string, branch: string): Promise<boolean> {
+  if (!(await worktreeClean(path))) return false
+  const git = nodeGitRunner()
+  return git(['branch', '--remotes', '--contains', `refs/heads/${branch}`], cwd).then(
+    out => out.trim() !== '',
     () => false,
   )
 }

--- a/packages/the-framework/src/worktrees.ts
+++ b/packages/the-framework/src/worktrees.ts
@@ -23,6 +23,7 @@ import {
 } from './store/index.js'
 import { pushAgentBranch } from './dashboard/agent-handoff.js'
 import { dataWorktreePath, withDataBranch } from './data-branch.js'
+import { isRunBranch } from './branch-names.js'
 import { nodeGitRunner } from './project.js'
 
 /** A retained worktree and the agent that left it behind (#752). */
@@ -52,7 +53,13 @@ export interface PruneResult {
 }
 
 /** The outcome of {@link removeProjectWorktree}. */
-export type RemoveResult = { ok: true } | { ok: false; error: string }
+export type RemoveResult =
+  | {
+      ok: true
+      /** The run branch went with the checkout, because it held nothing the remote lacks (#1650). */
+      branchDeleted?: string
+    }
+  | { ok: false; error: string }
 
 /** Surface-specific work {@link removeProjectWorktree} does once removal is decided on. */
 export interface RemoveWorktreeOptions {
@@ -167,7 +174,7 @@ export async function removeProjectWorktree(
       // recorded anchor). Anything short of that proof — no anchor recorded, the anchor's object
       // gone, a tree or tip that moved — falls through to the ordinary rule below, which is never
       // worse than what every web run got before.
-    } else if (await branchHoldsNothing(cwd, path, branch)) {
+    } else if (isRunBranch(branch) && (await branchHoldsNothing(cwd, path, branch))) {
       // A run that committed nothing (#1650) — a triage that wrote only to the data branch, a run
       // stopped before its first commit — leaves a branch whose tip is a commit the remote already
       // has. The rule is satisfied before any push: what the checkout holds *is* on the remote.
@@ -175,7 +182,10 @@ export async function removeProjectWorktree(
       // is what jammed the next triage on it ("branch already exists — triage pending"), on any
       // repo where the stale-branch release (#1293) could not prove it dead: no PR ever carried
       // the name, so the branch looked like an agent still working toward its handoff. The branch
-      // goes with the checkout. It is not the last copy of anything, by construction.
+      // goes with the checkout. It is not the last copy of anything, by construction. Only a
+      // branch the framework minted, though: a leftover checkout can sit on the user's own branch
+      // (one was found on `main`), and deleting that is not this code's call even when it holds
+      // nothing — git's refusal to delete a checked-out branch must never be the guard.
       emptyBranch = true
     } else if (meta?.handoff && !meta.handoff.push) {
       // A publish-nothing session's checkout goes only once everything it holds is already on
@@ -213,7 +223,10 @@ export async function removeProjectWorktree(
     await removeWorktree(cwd, path)
     await pruneWorktrees(cwd)
     // After the checkout: git refuses to delete a branch a worktree still has checked out.
-    if (emptyBranch) await deleteBranch(cwd, branch)
+    if (emptyBranch) {
+      await deleteBranch(cwd, branch)
+      return { ok: true, branchDeleted: branch }
+    }
     return { ok: true }
   } catch (err) {
     return { ok: false, error: errorMessage(err) }
@@ -236,15 +249,21 @@ async function webCheckoutCovered(path: string, branch: string, anchor: string):
 
 /**
  * Whether a run's branch holds nothing the remote lacks (#1650): the tree is clean and the tip is
- * reachable from some remote-tracking branch — a commit `origin` already has, so nothing on the
- * branch is unique to it. Read from the local remote-tracking refs, which are only ever behind the
- * remote: a tip they do not cover yet answers false, and the caller falls back to the push.
+ * reachable from some remote-tracking branch *other than the branch's own* — a commit `origin`
+ * already has under another name, so nothing on the branch is unique to it. Its own remote copy
+ * does not count: a pushed branch with a PR contains its own tip and is exactly the branch that
+ * must stay. Read from the local remote-tracking refs, which are only ever behind the remote: a
+ * tip they do not cover yet answers false, and the caller falls back to the push.
  */
 async function branchHoldsNothing(cwd: string, path: string, branch: string): Promise<boolean> {
   if (!(await worktreeClean(path))) return false
   const git = nodeGitRunner()
-  return git(['branch', '--remotes', '--contains', `refs/heads/${branch}`], cwd).then(
-    out => out.trim() !== '',
+  return git(['branch', '--remotes', '--contains', `refs/heads/${branch}`, '--format=%(refname:short)'], cwd).then(
+    out =>
+      out
+        .split('\n')
+        .map(line => line.trim())
+        .some(name => name !== '' && !name.endsWith(`/${branch}`)),
     () => false,
   )
 }


### PR DESCRIPTION
🤖 *automated*

Closes #1650.

## The bug, plainly

A triage routine writes only `TODO_AGENTS.md`, which lives on the data branch, so its own branch (`tf-triage-quick`) ends with zero commits. Two things then went wrong in teardown, both from the one rule *only what is on the remote may go*:

- it **pushed** the empty branch to origin to make the checkout removable — that is the empty `tf-triage-quick` I deleted from gemstack's origin by hand on 2026-08-23, and the rig's origin had five such refs (`tf-triage-quick`, two `tf-plan-*`, two `tf-agent-*`), all at the install commit;
- it **kept** the branch, and the next triage found the name taken and stood down in seconds as "triage already pending" (#1643 again).

The stale-branch release (#1293, reached by Run now since #1649) could not fix it: it deletes only a branch whose name has PR history, and a queue-only triage (#1644) never opens a PR, so the leftover is `unproven` forever.

## What changes

This is issue #1650's option 2, placed where the leftover is actually made rather than in the auto-PM settle path: `removeProjectWorktree` is the one implementation behind teardown, the sweep and the dashboard's Remove button, so it is the one place that decides.

- **A checkout whose run branch holds nothing the remote lacks goes without a push, and its branch goes with it.** "Holds nothing" is: clean tree, and the tip is reachable from some remote-tracking branch *other than the branch's own* (`origin/main`, typically). That is the #1601 web-run carve-out generalised — the rule is already satisfied before any push, and the branch is by construction not the last copy of anything.
- Two guards, both from the dogfood (below):
  - only a branch the framework minted (`tf-…`, never `tf-data`) is ever deleted. A leftover checkout on any other branch keeps it whatever it holds — one was found sitting on the rig's `main`.
  - a branch's own remote copy does not count as "the remote has it": a pushed run branch with a PR contains its own tip and is exactly the branch that must stay.
- A clean checkout carrying a commit origin has not seen still takes the ordinary commit → push → keep-the-branch path.
- `attachWorktree` recreates a missing branch from HEAD, so *Continue* on such an agent still works instead of falling to "starting a new one". The only branch the framework deletes held nothing past a commit the remote had, so HEAD is where its work was.
- The sweep's line and the teardown say when a branch went (`removed the worktree for session … and its branch tf-triage-quick: the branch held nothing the remote lacks`), instead of the sweep's fixed "the branch and the session are kept".
- No policy change to `stale-branch.ts`; a comment there says why the commitless case never reaches it now.

Reads the local remote-tracking refs only, which are only ever behind the remote: a tip they do not cover yet answers false and falls back to the push — the status quo, never worse. Pre-existing empty copies already on origin are not touched.

## SPEC changes

Rebased past `0646a4ad` ("wipe"), which deleted every per-file `SPEC.md`; the six spec edits this PR carried are dropped with them. For the record, the business-logic change they stated — in case the specs come back:

- *worktrees*: a checkout whose run branch holds nothing the remote lacks — a clean tree whose tip is already inside some *other* remote branch — goes without a push, and its branch is deleted with it. A branch's own remote copy does not count; a clean checkout carrying an unpushed commit is pushed first and keeps its branch; only names the framework minted are ever deleted, a leftover checkout on any other branch (the user's `main`) keeps it.
- *store/worktree*: continuing an agent whose branch no longer exists recreates it from the repo's current commit; any other reason git cannot attach still fails the continue.
- *stale-branch*: a pinned branch with no commits of its own never needs the release; its checkout's removal deletes it.
- *merged-worktrees*: the removal announcement names the branch when it went.

**`FEATURES-SPEC.md`** (kept by the wipe) — one line under *Handoff and what lands in git*.

## Verification

- `pnpm test`: 1556 node green; dashboard 799 green on two runs (one unrelated flake on the first run, in a suite this backend-only diff does not touch).
- First CI run failed on `daemon.test.ts` (`ENOTEMPTY` removing the temp `.git`): the test's second run commits nothing and its tip is on origin under the first run's branch, so it now takes the no-push path and teardown's `git branch -D` was still writing when the test removed the repo. The test now waits for — and asserts — the branch's absence and that nothing was pushed; fails on exactly that assertion against main's `worktrees.ts`.
- New real-git tests: the empty run branch goes unpushed and deleted; a clean checkout with an unpushed commit is pushed and keeps its branch; a run branch pushed under its own name stays; a leftover checkout on a non-framework branch keeps it; `attachWorktree` recreating a gone branch and still refusing one git will not attach; `deleteBranch`; the sweep line naming the branch.
- Broken on purpose: with `src/worktrees.ts` reverted, exactly the one new removal test fails and the guard tests still pass.

## Dogfood on the rig (2026-08-23 14:36–14:40 IDT, Opus, from the first commit's build)

Rig state before: a commitless `tf-triage-quick` at `main`, locally and on origin. The routine card was pointed at the rig, quick-win triage ticked and its Run now clicked.

- The sweep released the stale `tf-triage-quick` first (#1649's path — the name has PR #6 history).
- The agent ran ~2 min, wrote the queue to `tf-data` (`e3c8812 Queue help-flag quick win; note merged sibling tickets`), ended `handoffSkip: no-commits`.
- Teardown: worktree gone, **`tf-triage-quick` gone locally, nothing pushed** — `git ls-remote --heads origin | grep triage` is empty. The next triage click there finds no branch.

What the same run surfaced, and the second commit fixes: the startup sweep also reclaimed the leftover checkout of the #1646 ghost-process session (`2026-08-22T22-06-41-065Z`), which was sitting on **`main`** — the first cut ran `git branch -D main`, stopped only by the primary checkout having it out. Hence the minted-name guard. The own-remote-copy exclusion came from an existing test (`a checkout already pushed is not re-pushed, and still goes`) failing against the first cut. The final code is not re-dogfooded; the rig case (`tf-` name, no remote copy) sits inside both guards, and both are covered against real git.

Residue, not in scope: the agent reached `tf-triage-quick` by `checkout -b` rather than the rename, so its run-id branch `tf-agent-2026-08-23T11-37-03-643Z` stays behind, empty, as seven `tf-agent-*` branches from yesterday's runs do on the rig. Same class (an empty minted branch), different name from the one the checkout is on; a follow-up if wanted.

## Open question for @brillout (issue option 3)

After #1644 the triages change one file on `tf-data`, so two overlapping triages cannot corrupt each other the way two queue rewrites on one branch could. Does the pinned branch still buy anything for the queue-only routines, or could the pin go for them entirely? This PR makes the pin harmless either way; that is a separate, smaller change if you want it.

