### PR TITLE
A branches/ directory that is not a git worktree is left alone, never acted on as the main checkout (#1654)

### DIFF
--- a/FEATURES-SPEC.md
+++ b/FEATURES-SPEC.md
@@ -130,6 +130,8 @@ happens while nobody is at the keyboard.
 - CI watch: one fix agent per red head commit, max two attempts
 - Reclaim the checkout of an agent whose work is on the remote — never by publishing what a `handoff: local` agent refused to
 - An agent that committed nothing leaves no branch behind: its empty branch goes with its checkout, never pushed, so a pinned routine is not stood down by its own last run
+- A directory under `branches/` that git does not know as a worktree is never committed, pushed, linked or deleted through — it is reported and left alone, so a leftover can never stand in for your own checkout
+- A directory under `branches/` that git does not know as a worktree is never committed, pushed, linked or deleted through — it is reported and left alone, so a leftover can never stand in for your own checkout
 - Release a pinned routine branch left behind by a closed PR — before the schedule fires the routine, and before its "Run now" does
 - The agent drains its own TODO backlog, one entry per turn
 

--- a/FEATURES-SPEC.md
+++ b/FEATURES-SPEC.md
@@ -131,7 +131,6 @@ happens while nobody is at the keyboard.
 - Reclaim the checkout of an agent whose work is on the remote — never by publishing what a `handoff: local` agent refused to
 - An agent that committed nothing leaves no branch behind: its empty branch goes with its checkout, never pushed, so a pinned routine is not stood down by its own last run
 - A directory under `branches/` that git does not know as a worktree is never committed, pushed, linked or deleted through — it is reported and left alone, so a leftover can never stand in for your own checkout
-- A directory under `branches/` that git does not know as a worktree is never committed, pushed, linked or deleted through — it is reported and left alone, so a leftover can never stand in for your own checkout
 - Release a pinned routine branch left behind by a closed PR — before the schedule fires the routine, and before its "Run now" does
 - The agent drains its own TODO backlog, one entry per turn
 

--- a/packages/the-framework/src/branch-links.test.ts
+++ b/packages/the-framework/src/branch-links.test.ts
@@ -1,8 +1,11 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { mkdir, mkdtemp, readdir, realpath, rm, writeFile } from 'node:fs/promises'
+import { nodeGitRunner } from './project.js'
 import { reconcileBranchLinks, startBranchLinksPass, type LinksFs } from './branch-links.js'
-import { FRAMEWORK_DIR, BRANCHES_DIR, type WorktreeDirEntry } from './store/index.js'
+import { FRAMEWORK_DIR, BRANCHES_DIR, addWorktree, worktreePath, type WorktreeDirEntry } from './store/index.js'
 
 const CWD = '/repo'
 const LINKS = join(CWD, FRAMEWORK_DIR, BRANCHES_DIR)
@@ -79,6 +82,31 @@ test('the repo-root branches shortcut is created once, relative, hidden from git
   await reconcileBranchLinks(CWD, { fs: taken.fs, worktrees: async () => [], exclude })
   assert.equal(taken.links.has(ROOT_LINK), false, 'an occupied path is left alone')
   assert.deepEqual(excluded, [], "a user's own entry is never hidden from their git status")
+})
+
+test('a branches/ directory that is not a worktree gets no link, against real git (#1654)', async () => {
+  // Default seams on purpose: the bug was in the default branch read. Git asked in a residue
+  // directory answers with the enclosing repo's branch, which left a `main -> tf-agent-…` link
+  // beside the checkouts on the rig.
+  const git = nodeGitRunner()
+  const repo = await realpath(await mkdtemp(join(tmpdir(), 'framework-links-')))
+  try {
+    await git(['init', '-b', 'main'], repo)
+    await git(['config', 'user.email', 't@t'], repo)
+    await git(['config', 'user.name', 't'], repo)
+    await writeFile(join(repo, 'README.md'), '# t\n')
+    await git(['add', '-A'], repo)
+    await git(['commit', '-m', 'init'], repo)
+    const { path } = await addWorktree(repo, { agentId: 'r1', branch: 'tf-agent-r1' }, git)
+    await git(['checkout', '-q', '-b', 'tf-real-name'], path)
+    await mkdir(join(worktreePath(repo, 'r2'), FRAMEWORK_DIR), { recursive: true })
+
+    await reconcileBranchLinks(repo)
+    const names = (await readdir(join(repo, FRAMEWORK_DIR, BRANCHES_DIR))).sort()
+    assert.deepEqual(names, ['tf-agent-r1', 'tf-agent-r2', 'tf-real-name'], 'the real rename is linked; no `main` link for the residue')
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
 })
 
 test('the pass covers every registered project and a stopped pass does nothing', async () => {

--- a/packages/the-framework/src/branch-links.ts
+++ b/packages/the-framework/src/branch-links.ts
@@ -1,7 +1,7 @@
 import { basename, join } from 'node:path'
 import { nodeGitRunner, type GitRunner } from './project.js'
 import { excludeFromGit } from './git-exclude.js'
-import { FRAMEWORK_DIR, BRANCHES_DIR, worktreeDirEntries, currentBranch, type WorktreeDirEntry } from './store/index.js'
+import { FRAMEWORK_DIR, BRANCHES_DIR, worktreeDirEntries, worktreeBranch, type WorktreeDirEntry } from './store/index.js'
 import { isWorktreeDirName } from './branch-names.js'
 
 // The branches view (#1580): every checkout under `.the-framework/branches/` is a directory named
@@ -50,7 +50,7 @@ export interface BranchLinksDeps {
   fs?: LinksFs
   /** The checkouts on disk (default {@link worktreeDirEntries}). */
   worktrees?: (cwd: string) => Promise<WorktreeDirEntry[]>
-  /** The branch a worktree is on (default {@link currentBranch}). */
+  /** The branch a worktree is on, or none when the path is not a worktree root (default {@link worktreeBranch}). */
   branchOf?: (path: string) => Promise<string | undefined>
   /** Hide a repo-root entry from git (default {@link excludeFromGit} over `git`). */
   exclude?: (repo: string, rule: string) => Promise<void>
@@ -69,7 +69,9 @@ export async function reconcileBranchLinks(cwd: string, deps: BranchLinksDeps = 
   const git = deps.git ?? nodeGitRunner()
   const fs = deps.fs ?? nodeLinksFs()
   const worktrees = deps.worktrees ?? worktreeDirEntries
-  const branchOf = deps.branchOf ?? ((path: string) => currentBranch(path, git))
+  // A `branches/` directory that is not a worktree root reads as no branch (#1654): otherwise
+  // it reads as the enclosing repo's, and a link named after the user's own branch appears.
+  const branchOf = deps.branchOf ?? ((path: string) => worktreeBranch(path, git))
   const exclude = deps.exclude ?? ((repo: string, rule: string) => excludeFromGit(repo, rule, undefined, git))
 
   const linksDir = join(cwd, FRAMEWORK_DIR, BRANCHES_DIR)

--- a/packages/the-framework/src/daemon-runtime.ts
+++ b/packages/the-framework/src/daemon-runtime.ts
@@ -16,7 +16,7 @@ import {
   listAgents,
   findAgent,
   archivedAgentPaths,
-  currentBranch,
+  worktreeBranch,
   readLiveMetas,
   readLiveMeta,
   removeWorktree,
@@ -150,6 +150,14 @@ function exitDetail(code: number | null, signal: NodeJS.Signals | null): string 
 export async function markFailedStart(cwd: string, agentId: string, intent: string, detail: string): Promise<boolean> {
   const metaPath = join(cwd, FRAMEWORK_DIR, META_FILE)
   if (await stat(metaPath).then(() => true, () => false)) return false
+  // Only into a checkout that exists (#1654). A marker written where the worktree is gone — removed
+  // by hand while the child was still alive, or never created — makes a directory under
+  // `branches/` that is not a worktree, and every later git command run in it acts on the
+  // enclosing repo. The daemon's log line below is the record instead.
+  if (!(await stat(cwd).then(s => s.isDirectory(), () => false))) {
+    console.log(`[framework] run ${agentId} failed to start: ${detail}; its checkout is gone, so no marker is written`)
+    return false
+  }
   const now = new Date().toISOString()
   const meta: AgentMeta = {
     status: 'failed',
@@ -572,8 +580,10 @@ export function createProjectRuntime({ cwd, env, binPath, retryDelayMs, driverPr
     withAgentLock(worktree, async () => {
       try {
         // Where the work ended up, recorded before the checkout can go (#799). The branch outlives
-        // the worktree and is the only handle the dashboard has left on a finished session.
-        const branch = await currentBranch(worktree)
+        // the worktree and is the only handle the dashboard has left on a finished session. Read
+        // only from a worktree root (#1654): a directory that is no longer one would answer with
+        // the enclosing repo's branch, and the archive would record the user's `main` as the run's.
+        const branch = await worktreeBranch(worktree)
         // Filed under the identity this repo commits as, onto the data branch (#1179/#1582)
         // through its write funnel: the archive is committed and pushed the moment it lands —
         // durable without a human, and never a commit on main.

--- a/packages/the-framework/src/daemon-workspace.test.ts
+++ b/packages/the-framework/src/daemon-workspace.test.ts
@@ -396,6 +396,19 @@ test('a child that wrote its own lifecycle is left alone by the failed-start mar
   }
 })
 
+test('the failed-start marker is not written where the checkout is gone (#1654)', async () => {
+  // A marker written into a missing path creates a `branches/` directory that is not a worktree,
+  // and every git command later run in it acts on the enclosing repo instead.
+  const base = await realpath(await mkdtemp(join(tmpdir(), 'framework-bootfail-gone-')))
+  try {
+    const gone = join(base, 'removed-checkout')
+    assert.equal(await markFailedStart(gone, 'run1', 'build a thing', 'its process was killed by SIGTERM'), false)
+    assert.equal(await stat(gone).then(() => true, () => false), false, 'no directory is created')
+  } finally {
+    await rm(base, RETRIED_RM)
+  }
+})
+
 test('isTransientAgentFailure names transport deaths, not work failures (#1281)', () => {
   assert.equal(
     isTransientAgentFailure('[framework] claude-code exited (1): API Error: Connection closed mid-response. The response above may be incomplete.'),

--- a/packages/the-framework/src/store/index.ts
+++ b/packages/the-framework/src/store/index.ts
@@ -46,6 +46,8 @@ export {
   repoHasRemote,
   removeWorktree,
   deleteBranch,
+  isWorktreeRoot,
+  worktreeBranch,
   pruneWorktrees,
   worktreePath,
   agentBranchName,

--- a/packages/the-framework/src/store/worktree.test.ts
+++ b/packages/the-framework/src/store/worktree.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { join } from 'node:path'
-import { mkdtemp, rm, writeFile, stat, realpath } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile, stat, realpath } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import type { GitRunner } from '../project.js'
 import { nodeGitRunner } from '../project.js'
@@ -9,6 +9,8 @@ import {
   addWorktree,
   attachWorktree,
   deleteBranch,
+  isWorktreeRoot,
+  worktreeBranch,
   commitPendingWork,
   listWorktrees,
   parseWorktreeList,
@@ -162,6 +164,36 @@ test('attachWorktree recreates a branch that is gone from HEAD, and still refuse
     // A branch that exists but is checked out by the main checkout is git's refusal, not ours.
     const head = (await git(['rev-parse', '--abbrev-ref', 'HEAD'], repo)).trim()
     await assert.rejects(() => attachWorktree(repo, { agentId: 'run2', branch: head }, git))
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})
+
+test('isWorktreeRoot is true for the main checkout and a linked worktree, false inside them and for a plain directory (#1654)', async () => {
+  const git = nodeGitRunner()
+  const repo = await realpath(await mkdtemp(join(tmpdir(), 'framework-worktree-')))
+  try {
+    await git(['init'], repo)
+    await git(['config', 'user.email', 't@t'], repo)
+    await git(['config', 'user.name', 't'], repo)
+    await writeFile(join(repo, 'README.md'), '# t\n')
+    await git(['add', '-A'], repo)
+    await git(['commit', '-m', 'init'], repo)
+    const { path } = await addWorktree(repo, { agentId: 'run1', branch: 'tf-agent-run1' }, git)
+    // The hazard: a `branches/` directory that is not a worktree. Git still answers in it — with
+    // the enclosing repo's toplevel and branch.
+    const residue = worktreePath(repo, 'run2')
+    await mkdir(join(residue, FRAMEWORK_DIR), { recursive: true })
+
+    assert.equal(await isWorktreeRoot(repo, git), true)
+    assert.equal(await isWorktreeRoot(path, git), true)
+    assert.equal(await isWorktreeRoot(join(repo, FRAMEWORK_DIR), git), false, 'a subdirectory of a checkout is not its root')
+    assert.equal(await isWorktreeRoot(residue, git), false, 'and neither is a residue directory')
+    assert.equal(await isWorktreeRoot(join(tmpdir()), git), false, 'nor a directory outside any repo')
+
+    assert.equal(await currentBranch(residue, git), (await currentBranch(repo, git)), 'a plain read in the residue answers with the enclosing repo\'s branch — the bug')
+    assert.equal(await worktreeBranch(residue, git), undefined, 'the guarded read answers with nothing')
+    assert.equal(await worktreeBranch(path, git), 'tf-agent-run1')
   } finally {
     await rm(repo, { recursive: true, force: true })
   }

--- a/packages/the-framework/src/store/worktree.ts
+++ b/packages/the-framework/src/store/worktree.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path'
+import { realpath } from 'node:fs/promises'
 import { nodeGitRunner, type GitRunner } from '../project.js'
 import { FRAMEWORK_DIR, BRANCHES_DIR, isSafeAgentId } from './agent-store.js'
 import { worktreeDirName } from '../branch-names.js'
@@ -208,6 +209,36 @@ export async function removeWorktree(repo: string, path: string, agent: GitRunne
  */
 export async function deleteBranch(repo: string, branch: string, agent: GitRunner = nodeGitRunner()): Promise<void> {
   await agent(['branch', '-D', branch], repo).catch(() => undefined)
+}
+
+/**
+ * Whether `path` is the root of a git worktree — the main checkout's or a linked one (#1654).
+ *
+ * Git answers for any directory *inside* a repository, so a `branches/<run>` directory that is
+ * no longer a worktree (a checkout removed by hand, a marker written after teardown) makes every
+ * git command run in it act on the enclosing repo: the user's own checkout, on the user's own
+ * branch. The one question that tells the two apart is whether git's top level is this very
+ * directory. False on any failure, and the caller leaves the directory alone.
+ */
+export async function isWorktreeRoot(path: string, agent: GitRunner = nodeGitRunner()): Promise<boolean> {
+  try {
+    const top = (await agent(['rev-parse', '--show-toplevel'], path)).trim()
+    if (!top) return false
+    // Both sides resolved: macOS's tmpdir sits behind the /var -> /private/var link, and git
+    // reports the resolved path.
+    return (await realpath(top)) === (await realpath(path))
+  } catch {
+    return false
+  }
+}
+
+/**
+ * The branch checked out at `path` when `path` is a worktree root (#1654), else `undefined` —
+ * the read every consumer of a `branches/<run>` directory wants, so none of them can take the
+ * enclosing repo's branch for the run's.
+ */
+export async function worktreeBranch(path: string, agent: GitRunner = nodeGitRunner()): Promise<string | undefined> {
+  return (await isWorktreeRoot(path, agent)) ? currentBranch(path, agent) : undefined
 }
 
 /**

--- a/packages/the-framework/src/worktrees.test.ts
+++ b/packages/the-framework/src/worktrees.test.ts
@@ -284,6 +284,33 @@ test("a leftover checkout on a branch the framework did not mint keeps that bran
   }
 })
 
+test("a branches/ directory that is not a git worktree is refused before any git runs in it (#1654)", async () => {
+  // Found on the rig: a checkout removed by hand, then a failed-start marker written into the
+  // path. Git, asked in that directory, answers for the enclosing repo — so the ordinary rule
+  // would commit the user's main checkout, push the user's main, and judge it for deletion.
+  const { repo, path: worktree } = await repoWithDirtyWorktree()
+  const git = nodeGitRunner()
+  try {
+    // Turn the run's checkout into residue: gone as a worktree, its directory holding only the
+    // framework's bookkeeping. And leave the user's own checkout dirty, which is what must survive.
+    await git(['worktree', 'remove', '--force', worktree], repo)
+    await mkdir(join(worktree, '.the-framework'), { recursive: true })
+    await writeFile(join(worktree, '.the-framework', 'agent.json'), JSON.stringify({ status: 'failed', id: RUN_ID }))
+    await writeFile(join(repo, 'index.html'), '<h1>half-typed</h1>\n')
+    const before = (await git(['rev-parse', 'HEAD'], repo)).trim()
+
+    const result = await removeProjectWorktree(repo, RUN_ID)
+    assert.equal(result.ok, false)
+    assert.match(result.ok === false ? result.error : '', /not a git worktree; left alone/)
+    assert.equal((await git(['rev-parse', 'HEAD'], repo)).trim(), before, "nothing was committed on the user's checkout")
+    assert.match(await git(['status', '--porcelain'], repo), /index\.html/, "the user's edit is still uncommitted")
+    assert.equal((await git(['ls-remote', '--heads', 'origin'], repo)).trim(), '', 'and nothing was pushed')
+    assert.equal((await stat(worktree)).isDirectory(), true, 'the directory is left where it is')
+  } finally {
+    await rm(repo, { recursive: true, force: true })
+  }
+})
+
 test('a worktree whose work cannot be committed is refused, not force-removed (#982)', async () => {
   const { repo, path } = await repoWithDirtyWorktree()
   try {

--- a/packages/the-framework/src/worktrees.ts
+++ b/packages/the-framework/src/worktrees.ts
@@ -8,6 +8,7 @@ import {
   branchPushed,
   commitPendingWork,
   worktreeClean,
+  isWorktreeRoot,
   currentBranch,
   removeWorktree,
   deleteBranch,
@@ -145,6 +146,13 @@ export async function removeProjectWorktree(
   }
   const path = worktreePath(cwd, agentId)
   try {
+    // Before any git runs in it (#1654): a directory under `branches/` that git does not know as
+    // a worktree root makes every command below act on the enclosing repo — the user's checkout,
+    // the user's branch. Nothing is committed, pushed or deleted through it; it is reported and
+    // left where it is.
+    if (!(await isWorktreeRoot(path))) {
+      return { ok: false, error: `session ${agentId}'s directory is not a git worktree; left alone` }
+    }
     const branch = await currentBranch(path)
     if (!branch) return { ok: false, error: `session ${agentId} is on no branch; its worktree was kept` }
     // The armed handoff decides before anything commits or pushes: a session armed to publish


### PR DESCRIPTION
🤖 *automated*

Closes #1654.

## The bug, plainly

Git answers inside *any* directory of a repository. A directory under `.the-framework/branches/` that is no longer a worktree — on the rig: a checkout I removed by hand, then a failed-start marker written into the path at shutdown — therefore answers for the **enclosing repo**, i.e. the user's own checkout. Every consumer took that answer as the run's:

- the cleanup sweep read the run's branch as `main`, ran the recoverability rule on the user's checkout (`git add -A` + commit — the tree happened to be clean), and tried to push the user's `main` to origin; it failed only because origin was ahead, and logged that every pass for 12 hours
- the rename pass linked `branches/main -> tf-agent-…`
- #1653's first cut judged `main` as "holds nothing" and ran `git branch -D main`, stopped only by the primary checkout having it out

## What changes

One question tells a checkout from residue: **is git's top level this very directory** (`git rev-parse --show-toplevel`, both sides realpath'd). `isWorktreeRoot` in the store, and `worktreeBranch` = the branch read guarded by it. Applied at every place a `branches/<run>` path is acted on:

- `removeProjectWorktree` (teardown, the sweep, the dashboard's Remove button) refuses before any git runs: `session …'s directory is not a git worktree; left alone`. The sweep reports it once, like any other kept checkout. Nothing is committed, pushed, linked or deleted through it.
- the branch-links pass reads no branch from it, so no `main ->` link
- teardown records no branch from it, so the archive cannot say the run was on `main`
- `markFailedStart` no longer writes a marker where the checkout is gone — the daemon's log line is the record instead. That is how the residue directory came to exist (second half of the issue).

The directory itself is left where it is: the framework cannot know what a non-worktree directory holds, so it reports rather than deletes. Removal is a human `rm`.

## Verification

- `pnpm test`: 1560 node + 799 dashboard, green.
- Four new tests against real git, each verified by breaking (each fails on exactly its own guard with main's file swapped in):
  - `isWorktreeRoot` true for the main checkout and a linked worktree, false for a subdirectory, a residue directory, and a directory outside any repo — and the test states the bug directly: a plain `currentBranch` in the residue answers with the enclosing repo's branch, `worktreeBranch` answers nothing
  - removal of a residue directory is refused; the user's dirty main checkout is still dirty, HEAD unchanged, nothing pushed, the directory still there
  - the rename pass with default seams on a real repo: the real rename is linked, no `main` link for the residue (without the guard the test shows `'main'` appearing)
  - the failed-start marker creates no directory where the checkout is gone
- Not dogfooded: the rig residue was removed by hand before this was built, and reproducing it means removing a worktree under a live run. The real-git tests are the reproduction.

No per-file SPEC edits (post-wipe, #1655 regenerates them); one `FEATURES-SPEC.md` line.
