### PR TITLE
No decide-alone mode for a cloud session: its gates are a local agent's gates (#1554)

### DIFF
--- a/FEATURES-SPEC.md
+++ b/FEATURES-SPEC.md
@@ -163,7 +163,6 @@ happens while nobody is at the keyboard.
 - Run on a Claude Code cloud session
 - Chrome extension bridging claude.ai questions back to the dashboard
 - Answer a cloud agent's question from the dashboard (typed back into claude.ai) — the same gate panel a local agent gets, multi-select and stop options included, listed with every other open question
-- A cloud session may ask its questions only while the bridge is on; with it off it is told to decide alone
 - Browser-bridge token setting
 - Web runs trust the project for Claude Code automatically — no manual trust step
 - A cloud run's row follows the session's real branch and PR, with its armed draft PR opened when the session opens none

--- a/packages/chrome-extension/README.md
+++ b/packages/chrome-extension/README.md
@@ -12,8 +12,8 @@ same "You paused to ask … The user chose …" a local agent is re-prompted wit
 tells the session the user is taking over), and a queued answer can be withdrawn until the
 extension collects it.
 
-With the bridge on, a cloud session started by The Framework is allowed to park on a question at
-all (#1554); with it off, the session is told to decide alone, since nothing could answer it.
+A cloud session started by The Framework asks its questions like a local agent does (#1554); with
+the bridge off it simply waits on claude.ai for an answer typed there.
 
 ## Set it up
 

--- a/packages/the-framework/prompts/protocols/unattended.md
+++ b/packages/the-framework/prompts/protocols/unattended.md
@@ -1,6 +1,0 @@
-## Nobody is attached to answer you — decide alone
-Nothing that can answer a gate is connected to this session. Where these instructions say to
-showChoices() / showMultiSelect() / showMarkdown() and then AWAIT: do not emit the await block and
-do not stop — take the most plausible interpretation, the option you would have marked
-`recommended`, state in one line which assumption you made, and carry the work through to the
-end. The non-blocking blocks (show-markdown, set-session-name, ready-for-merge) are unaffected.

--- a/packages/the-framework/src/agent.test.ts
+++ b/packages/the-framework/src/agent.test.ts
@@ -854,27 +854,19 @@ test('a hand-off run ends at the hand-off: no review passes, no backlog gate (#1
   }
 })
 
-test('a hand-off run is told to land everything, and to decide alone only when no bridge can answer it (#1234/#1554)', async () => {
-  // Our own prompt says "ambiguous prompt: showChoices + AWAIT". A cloud session that obeys it
-  // with nothing attached parks forever on a question nobody can answer, so without the bridge
-  // it is told to decide alone. With the browser bridge on, the extension carries that question
-  // to the dashboard and types the answer back, so the gates stay exactly as a local agent has
-  // them. Either way the hand-off commits and opens its own PR, which a local run never needs.
-  const systemOf = async (driver: Driver, location: AgentLocation, bridge?: boolean): Promise<string> => {
+test('a hand-off run is told to land everything, a local one is not (#1225)', async () => {
+  // Nothing here sees a cloud session's workspace, so it has to commit and open its own PR. Its
+  // gates are left exactly as a local agent has them (#1554): no decide-alone mode.
+  const systemOf = async (driver: Driver, location: AgentLocation): Promise<string> => {
     const events: FrameworkEvent[] = []
-    await runAgent({ prompt: FAKE_INTENT, driver, location, ...(bridge ? { bridge } : {}), cwd: '/tmp/ws', onEvent: e => events.push(e) })
+    await runAgent({ prompt: FAKE_INTENT, driver, location, cwd: '/tmp/ws', onEvent: e => events.push(e) })
     const prompt = events.find(e => e.kind === 'system-prompt')
     return prompt?.kind === 'system-prompt' ? prompt.text : ''
   }
-  const alone = await systemOf(handsOffDriver().driver, 'web')
-  assert.ok(alone.includes('This session runs detached — land everything'))
-  assert.ok(alone.includes('decide alone'))
-  const bridged = await systemOf(handsOffDriver().driver, 'web', true)
-  assert.ok(bridged.includes('This session runs detached — land everything'))
-  assert.ok(!bridged.includes('decide alone'))
-  const local = await systemOf(new FakeDriver(), 'local')
-  assert.ok(!local.includes('This session runs detached'))
-  assert.ok(!local.includes('decide alone'))
+  const web = await systemOf(handsOffDriver().driver, 'web')
+  assert.ok(web.includes('This session runs detached — land everything'))
+  assert.ok(!web.includes('decide alone'))
+  assert.ok(!(await systemOf(new FakeDriver(), 'local')).includes('This session runs detached'))
 })
 
 test('a hand-off run does not stay open for messages (#1225)', async () => {

--- a/packages/the-framework/src/agent.ts
+++ b/packages/the-framework/src/agent.ts
@@ -41,12 +41,6 @@ export interface RunAgentOptions {
    * see {@link isHandsOff}.
    */
   location?: AgentLocation
-  /**
-   * The browser bridge (#1237) is on, so a gate a hand-off session parks on reaches the dashboard
-   * and its answer is typed back (#1554). Only meaningful with a hand-off {@link location}: it is
-   * what decides whether that session is told to decide alone (bridge off) or may ask (bridge on).
-   */
-  bridge?: boolean
   /** The wrapped coding agent. */
   driver: Driver
   /** Absolute workspace path the agent works in. */
@@ -153,16 +147,12 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunAgentResult> {
   // A hand-off location (#1225): the prompt leaves this machine and the reply never comes back, so
   // the opening turn is the entire session and every phase after it is dropped rather than fed.
   const handsOff = isHandsOff(opts.location)
-  // A hand-off nobody can answer decides alone (#1234); with the bridge on its gates are real
-  // (#1554): the extension carries the question here and types the answer back.
-  const unattended = handsOff && !opts.bridge
   // The built-in #326 system prompt + any user SYSTEM.md frame the session (#301).
   const tf: TfContext = { prompt: opts.prompt }
   const system = composeAgentSystem({
     vanilla: opts.vanilla,
     browser: opts.browser,
     handsOff,
-    unattended,
     transparent: opts.transparent,
     user: opts.systemPrompt,
     tf,

--- a/packages/the-framework/src/cli.ts
+++ b/packages/the-framework/src/cli.ts
@@ -49,7 +49,7 @@ import { appendControl, resetControl, watchControl, type ControlWatcher } from '
 import { AgentMessageQueue } from './agent-messages.js'
 import { createGateKeepalive } from './gate-keepalive.js'
 import { nodeGitRunner } from './project.js'
-import { ensureDaemonToken, readDaemonToken, readPreferences, type Preferences } from './registry.js'
+import { ensureDaemonToken, readDaemonToken, readPreferences } from './registry.js'
 import { DEFAULT_SPEND_OFFSET } from './preference-defaults.js'
 import {
   planMaintenanceSweep,
@@ -1158,18 +1158,11 @@ async function driveAgent(opts: AgentOptions, io: CliIO): Promise<number> {
   // cloud session is created under, so there is no token of ours and no repo config. The
   // session clones this repo's remote at its current branch, so local commits that were never
   // pushed are not in it — say so once here rather than let the cloud session look stale.
-  // Whether the cloud session may park on a gate (#1554): with the browser bridge (#1237) on, the
-  // extension carries its question to the dashboard and types the answer back, so it is told the
-  // gates work; with the bridge off it is told to decide alone (#1234), because nothing could
-  // answer it. Read here, once, at hand-off: the session's instructions cannot change after it.
-  let bridged = false
   if (opts.target === 'web' && !fake) {
     io.out('◆ run on: Claude Code on the web (a cloud session on your own account)')
     if (!(await githubSlugFor(cwd))) {
       io.out('  no GitHub remote here, so the CLI uploads a bundle of this repo instead.')
     }
-    bridged = (await readPreferences().catch((): Preferences => ({}))).bridge === true
-    io.out(bridged ? '  the browser bridge is on: questions it asks show in the dashboard.' : '  the browser bridge is off: it decides its own questions.')
   }
 
   const driver: Driver = fake
@@ -1265,7 +1258,6 @@ async function driveAgent(opts: AgentOptions, io: CliIO): Promise<number> {
     ...sharedAgentOptions,
     kind,
     ...(opts.target ? { location: opts.target } : {}),
-    ...(bridged ? { bridge: true } : {}),
     prompt: isResearch ? presets.research.render(intent) : intent,
     // Resume the stopped leg's conversation (#720/#1467); the prompt above is the continuation
     // message, which `runAgent` then sends verbatim.

--- a/packages/the-framework/src/system-prompt.test.ts
+++ b/packages/the-framework/src/system-prompt.test.ts
@@ -54,7 +54,7 @@ test('CONTEXT_DOCS is the repo-context fragment (#683): business knowledge plus 
   // dependency of the repo it works on, which is what left both specs unopenable (#1163).
   for (const doc of CONTEXT_DOCS) assert.ok(!doc.comment.includes('node_modules/'), `${doc.path} points into node_modules`)
 })
-import { AWAIT_PROTOCOL, BROWSER_PROTOCOL, HANDS_OFF_PROTOCOL, SIGNAL_PROTOCOL, UNATTENDED_PROTOCOL } from './turn-gate.js'
+import { AWAIT_PROTOCOL, BROWSER_PROTOCOL, HANDS_OFF_PROTOCOL, SIGNAL_PROTOCOL } from './turn-gate.js'
 
 test('loadUserSystemPrompt reads and trims SYSTEM.md', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'system-prompt-'))
@@ -264,38 +264,25 @@ test('the browser section survives --vanilla but not transparent (#824)', () => 
   assert.equal(composeAgentSystem({ transparent: true, browser: true }), '')
 })
 
-test('composeAgentSystem stays quiet about hands-off unless the run is one (#1234)', () => {
-  // A local agent's gates work; telling it they do not would auto-answer questions a human is
-  // sitting right there to take. And it lands its work through the framework, not on its own.
+test('composeAgentSystem stays quiet about hands-off unless the run is one (#1225)', () => {
+  // A local agent lands its work through the framework, not on its own.
   assert.ok(!composeAgentSystem().includes(HANDS_OFF_PROTOCOL))
-  assert.ok(!composeAgentSystem().includes(UNATTENDED_PROTOCOL))
 })
 
-test('a hands-off run is told to land everything; one nobody can answer is also told to decide alone (#1234/#1554)', () => {
-  // The two halves of what used to be one block. Every hand-off commits and opens its PR, because
-  // nothing here sees its workspace. Only a hand-off with no bridge is told its gates are
-  // unanswerable: with the bridge on, a cloud session that parks on a question reaches the
-  // dashboard, so it is left the same await protocol a local agent gets.
-  const attended = composeAgentSystem({ handsOff: true })
-  assert.ok(attended.includes(HANDS_OFF_PROTOCOL))
-  assert.ok(!attended.includes(UNATTENDED_PROTOCOL))
-  const alone = composeAgentSystem({ handsOff: true, unattended: true })
-  assert.ok(alone.includes(HANDS_OFF_PROTOCOL))
-  assert.ok(alone.includes(UNATTENDED_PROTOCOL))
-  // The decide-alone block rides right after the await protocol it amends, the land-everything
-  // rule after that, and the signal protocol stays last (#547).
-  assert.ok(alone.indexOf(UNATTENDED_PROTOCOL) > alone.indexOf(AWAIT_PROTOCOL))
-  assert.ok(alone.indexOf(HANDS_OFF_PROTOCOL) > alone.indexOf(UNATTENDED_PROTOCOL))
-  assert.ok(alone.endsWith(SIGNAL_PROTOCOL), 'the signal protocol is still last (#547)')
+test('a hands-off run is told to land everything, after the await protocol it keeps (#1225/#1554)', () => {
+  // Nothing here sees the session's workspace, so it commits and opens its own PR. Its gates are
+  // the same as a local agent's: it parks, and the answer reaches it through the browser bridge
+  // or on claude.ai itself — there is no decide-alone mode. The signal protocol stays last (#547).
+  const system = composeAgentSystem({ handsOff: true })
+  assert.ok(system.includes(HANDS_OFF_PROTOCOL))
+  assert.ok(system.indexOf(HANDS_OFF_PROTOCOL) > system.indexOf(AWAIT_PROTOCOL))
+  assert.ok(!system.includes('decide alone'))
+  assert.ok(system.endsWith(SIGNAL_PROTOCOL), 'the signal protocol is still last (#547)')
 })
 
-test('the hands-off blocks survive --vanilla but not transparent (#1234)', () => {
-  // Availability is a property of the session, not of the built-in prompt: --vanilla still
-  // teaches the gates, so it still has to say they cannot be answered here.
-  const vanilla = composeAgentSystem({ vanilla: true, handsOff: true, unattended: true })
-  assert.ok(vanilla.includes(HANDS_OFF_PROTOCOL))
-  assert.ok(vanilla.includes(UNATTENDED_PROTOCOL))
-  assert.equal(composeAgentSystem({ transparent: true, handsOff: true, unattended: true }), '')
+test('the hands-off block survives --vanilla but not transparent (#1225)', () => {
+  assert.ok(composeAgentSystem({ vanilla: true, handsOff: true }).includes(HANDS_OFF_PROTOCOL))
+  assert.equal(composeAgentSystem({ transparent: true, handsOff: true }), '')
 })
 
 test('composeAgentSystem keeps the emit protocols even with the built-in prompt off (#500/#501)', () => {

--- a/packages/the-framework/src/system-prompt.ts
+++ b/packages/the-framework/src/system-prompt.ts
@@ -1,6 +1,6 @@
 import { renderTemplate } from './prompt-template.js'
 import { DATA_BRANCH_PROTOCOL, SYSTEM_PROMPT, TICKETING_FORMAT, TODO_FORMAT } from './prompts.generated.js'
-import { AWAIT_PROTOCOL, BROWSER_PROTOCOL, HANDS_OFF_PROTOCOL, SIGNAL_PROTOCOL, UNATTENDED_PROTOCOL } from './turn-gate.js'
+import { AWAIT_PROTOCOL, BROWSER_PROTOCOL, HANDS_OFF_PROTOCOL, SIGNAL_PROTOCOL } from './turn-gate.js'
 
 // No Node imports here, deliberately. This module composes the prompt and the
 // dashboard renders it in the browser (#520), so reading the user's SYSTEM.md off
@@ -198,15 +198,6 @@ export interface SystemPromptOptions {
    * has to land its own work: appends {@link HANDS_OFF_PROTOCOL}, the commit-and-open-a-PR rule.
    */
   handsOff?: boolean | undefined
-  /**
-   * Nothing can answer this agent's gates (#1234): a hand-off with the browser bridge (#1237)
-   * off. Appends {@link UNATTENDED_PROTOCOL} right after the await protocol it amends, so an
-   * ambiguous prompt takes its most plausible reading and says so, instead of parking a cloud
-   * session forever on a question nobody attached can answer. With the bridge on the gates are
-   * left available: the session parks, the extension carries the question to the dashboard, and
-   * the answer is typed back (#1554).
-   */
-  unattended?: boolean | undefined
 }
 
 /**
@@ -269,11 +260,9 @@ export function composeAgentSystem(opts: AgentSystemOptions = {}): string {
   // tools are there either way.
   // Ahead of the protocols, so the signal protocol stays the last thing in the channel (#547).
   const browser = opts.browser ? [BROWSER_PROTOCOL] : []
-  // Right after the await protocol it amends (#1234): the gates are taught, then declared
-  // unanswerable, which keeps the emit contract intact for the parser while telling the agent
-  // not to reach for it. Then the hand-off's land-everything rule, and the signal protocol
-  // stays last (#547).
-  const unattended = opts.unattended ? [UNATTENDED_PROTOCOL] : []
+  // The hand-off's land-everything rule after the await protocol — a cloud session's gates are
+  // the same as a local one's: it parks, and the answer reaches it through the browser bridge or
+  // on claude.ai itself (#1554). The signal protocol stays last (#547).
   const handsOff = opts.handsOff ? [HANDS_OFF_PROTOCOL] : []
-  return [...(promptBlock ? [promptBlock] : []), ...browser, AWAIT_PROTOCOL, ...unattended, ...handsOff, SIGNAL_PROTOCOL].join('\n\n')
+  return [...(promptBlock ? [promptBlock] : []), ...browser, AWAIT_PROTOCOL, ...handsOff, SIGNAL_PROTOCOL].join('\n\n')
 }

--- a/packages/the-framework/src/turn-gate.ts
+++ b/packages/the-framework/src/turn-gate.ts
@@ -1,5 +1,5 @@
 import type { FrameworkEvent } from './events.js'
-import { PROTOCOLS_BROWSER, PROTOCOLS_AWAIT, PROTOCOLS_HANDS_OFF, PROTOCOLS_SIGNAL, PROTOCOLS_UNATTENDED } from './prompts.generated.js'
+import { PROTOCOLS_BROWSER, PROTOCOLS_AWAIT, PROTOCOLS_HANDS_OFF, PROTOCOLS_SIGNAL } from './prompts.generated.js'
 import type { ChoicesOption } from './await-gate.js'
 import type { MultiSelectOption } from './await-gate.js'
 
@@ -22,14 +22,6 @@ export const AWAIT_PROTOCOL = PROTOCOLS_AWAIT
  */
 export const HANDS_OFF_PROTOCOL = PROTOCOLS_HANDS_OFF
 
-/**
- * Told to a hands-off agent nothing can answer (#1234): the await gates {@link AWAIT_PROTOCOL}
- * just taught have nobody attached to take them, so an ambiguous prompt takes its most plausible
- * reading instead of parking forever. Left out once the browser bridge (#1237) is on, because
- * then a gate the cloud session parks on reaches the dashboard and is answered from it (#1554).
- * The text lives in `prompts/protocols/unattended.md`.
- */
-export const UNATTENDED_PROTOCOL = PROTOCOLS_UNATTENDED
 
 /**
  * Told to the agent only when the agent has a browser (#824): that it has one, and that anything


### PR DESCRIPTION
🤖 *automated*

Removes the decide-alone mode, per @brillout on #1664.

A cloud session's gates are now exactly a local agent's: it parks on its `await-choices` block, and the answer reaches it through the browser bridge (#1554) or typed on claude.ai itself. With the bridge off it waits over there — the run view links to the session. One path instead of two.

**Deleted:** `prompts/protocols/unattended.md`, `UNATTENDED_PROTOCOL`, the `unattended` option of `composeAgentSystem`, `RunAgentOptions.bridge`, the preference read and its two output lines in `cli.ts`, their tests. `hands_off.md` (commit + open a PR before ending) is unchanged.

8 files, +33 −92.
