### PR TITLE
A worktree's node_modules is its own directory of links, so an agent's install never touches the parent checkout (#1262)

### DIFF
--- a/FEATURES-SPEC.md
+++ b/FEATURES-SPEC.md
@@ -103,7 +103,7 @@ happens while nobody is at the keyboard.
 ## Handoff and what lands in git
 
 - Every agent gets its own git worktree and branch; your checkout is never touched
-- Dependency directories shared from the parent checkout instead of reinstalled
+- Dependency directories shared from the parent checkout instead of reinstalled — as directories of links, so an agent's own install stays in its checkout and never rewrites or purges the parent's
 - A checkout whose work is not on the remote is kept — and a publish-nothing (`handoff: local`) agent's is kept until you publish or delete it
 - Commit what the agent left uncommitted
 - Push the branch (on by default)

--- a/packages/framework/src/daemon-runtime.SPEC.md
+++ b/packages/framework/src/daemon-runtime.SPEC.md
@@ -48,7 +48,7 @@ The user runs several agents on the same project at once, and keeps working in t
 
 Each agent is given its own git worktree under the project's `.the-framework/branches/`, on its own `tf-agent-<agent id>` branch. Concurrent agents on one project therefore never fight over a working tree, and the user's own checkout — uncommitted work included — is left untouched.
 
-A fresh worktree has no installed dependencies, since those are not tracked by git, so the project's are linked in and the links are made invisible to git.
+A fresh worktree has no installed dependencies, since those are not tracked by git, so the project's are mirrored in (`store/worktree-deps`).
 
 #### Rationale
 

--- a/packages/framework/src/daemon-runtime.ts
+++ b/packages/framework/src/daemon-runtime.ts
@@ -8,7 +8,6 @@ import {
   addWorktree,
   agentBranchName,
   linkDependencies,
-  excludeDependencyLinks,
   archiveWorktreeAgent,
   restoreArchivedAgent,
   attachWorktree,
@@ -540,10 +539,8 @@ export function createProjectRuntime({ cwd, env, binPath, retryDelayMs, driverPr
   ): Promise<{ ok: true; workspace: { cwd: string; agentId?: string } } | { ok: false; error: string }> => {
     try {
       const worktree = await addWorktree(projectCwd, { agentId, branch: agentBranchName(agentId) })
-      // `node_modules` is gitignored, so a fresh worktree has none: link the parent's in, and
-      // make git ignore the links (a `node_modules/` rule does not match a symlink, #738).
+      // `node_modules` is gitignored, so a fresh worktree has none: link the parent's in.
       await linkDependencies(projectCwd, worktree.path).catch(() => [])
-      await excludeDependencyLinks(projectCwd).catch(() => {})
       // The branches view (#1580) learns about this checkout now rather than at the next tick.
       void reconcileBranchLinks(projectCwd).catch(() => {})
       return { ok: true, workspace: { cwd: worktree.path, agentId } }

--- a/packages/framework/src/store/index.ts
+++ b/packages/framework/src/store/index.ts
@@ -65,7 +65,6 @@ export {
 } from './worktree.js'
 export {
   linkDependencies,
-  excludeDependencyLinks,
   findDependencyDirs,
   nodeLinkFs,
   type LinkFs,

--- a/packages/framework/src/store/worktree-deps.SPEC.md
+++ b/packages/framework/src/store/worktree-deps.SPEC.md
@@ -1,10 +1,16 @@
-Gives a fresh worktree a working dependency tree, so an agent can run the project's commands the moment it starts, and keeps that tree invisible to git so the agent never commits it.
+Gives a fresh worktree a working dependency tree, so an agent can run the project's commands the moment it starts — shared with the parent checkout, yet safe for the agent to install into.
+
+## User story
+
+- The user starts an agent and it works immediately: it can run the tests, the build, the linter. It does not sit for a minute installing, and starting ten agents does not fill the disk.
+- An agent changes a dependency and installs. That install must land in the agent's own checkout — never rewrite, and never delete, the dependencies of the user's checkout, which every later agent is handed.
 
 ## Business logic — TL;DR
 
-- **Dependencies are shared, not copied** - the parent checkout's `node_modules` directories are linked into the worktree at the same relative paths, instantly and at no extra disk cost.
-- **Workspace packages get their own link** - every `node_modules` down to two levels below the repo root is linked, so a monorepo's packages work too.
-- **The links are hidden from git** - the repo is told to ignore them, or the agent would commit dangling links onto its branch and into its pull request.
+- **Dependencies are shared, not copied** - each of the parent checkout's dependency directories is mirrored into the worktree at the same relative path, instantly and at no extra disk cost.
+- **A real directory of links, never a linked directory** - the worktree gets a directory of its own holding one link per dependency entry, so an install inside the worktree writes into the worktree.
+- **The package manager's private state stays behind** - the entries that mark a tree as the package manager's own install are not linked; the packages resolve without them.
+- **Workspace packages get their own tree** - every dependency directory down to two levels below the repo root is mirrored, so a monorepo's packages work too.
 - **Never fatal** - a link that cannot be made is skipped; a worktree with missing dependencies is a worse agent, not a failed one.
 
 ## Business logic
@@ -13,33 +19,35 @@ Gives a fresh worktree a working dependency tree, so an agent can run the projec
 
 #### User story
 
-The user starts an agent and it works immediately: it can run the tests, the build, the linter. It does not sit for a minute installing, and starting ten agents does not fill the disk.
+See `## User story`: the agent works immediately, and ten agents cost no extra disk.
 
 #### Business logic
 
-Dependency directories are ignored by git, so a new worktree is handed an empty one and every command in it fails. Instead of copying or installing, the parent checkout's dependency directories are linked into the worktree at the same relative paths. Anything already present at a link's location is left alone, since the agent may have installed for itself already, and any missing parent directory is created first.
+Dependency directories are ignored by git, so a new worktree is handed an empty one and every command in it fails. Instead of copying or installing, each of the parent checkout's dependency directories is mirrored into the worktree at the same relative path: a real directory is created there, and inside it one link per entry of the parent's directory, pointing at that entry. A tree already present in the worktree is left alone, since the agent may have installed for itself already, and any missing parent directory is created first.
 
-The scan looks for a dependency directory at the repo root and at every directory down to two levels below it, which covers a workspace's per-package dependencies without walking the whole tree. Dependency directories, the git directory, the framework's own directory, build outputs and dot-directories are never descended into. The result is ordered, so linking happens in a stable order.
+The scan looks for a dependency directory at the repo root and at every directory down to two levels below it, which covers a workspace's per-package dependencies without walking the whole tree. Dependency directories, the git directory, the framework's own directory, build outputs and dot-directories are never descended into. The result is ordered, so mirroring happens in a stable order.
 
 #### Rationale
 
-Three options existed: copy the tree (correct, but gigabytes per agent), install into each worktree (correct, but real waiting on every start), or link the parent checkout's trees in (instant, no extra disk, one store shared by all agents). Linking wins. The one case it is wrong for is an agent that changes the dependency manifest — and that agent needs its own install anyway, which it runs itself.
+Three options existed: copy the tree (correct, but gigabytes per agent), install into each worktree (correct, but real waiting on every start), or link the parent checkout's trees in (instant, no extra disk, one store shared by all agents). Linking wins.
 
-Whole directories are linked, rather than their contents, because that is what makes a workspace resolve: the links inside a package's dependency directory still point at their real location in the parent checkout.
-
-### The links are hidden from git
+### A real directory of links, never a linked directory
 
 #### User story
 
-The agent's pull request contains its work and nothing else — no dependency directories, no broken links pointing at a path that only exists on the machine the agent ran on.
+See `## User story`: an agent's install must stay in the agent's checkout.
 
 #### Business logic
 
-A repo's ignore rules normally name the dependency directory with a trailing slash, which matches a real directory only. The linked trees are links, not directories, so those rules do not cover them and they show up as untracked in every agent's worktree. That matters because the agent stages everything it changed, so it would commit those links onto its branch and into its pull request.
+The worktree's dependency directory is a directory of its own, not a link to the parent's. When an agent installs in its worktree — which an agent that changes a dependency must — the package manager rewrites the entries of the worktree's directory and leaves the parent checkout's untouched. After the worktree is removed, the parent checkout's dependencies are exactly as they were.
 
-A rule without the trailing slash is therefore added to the repo's own local exclusions, covering the link form in every worktree. The main checkout is unaffected, because its dependency directory is a real directory already ignored under the same name.
+The package manager's private state — every dot-entry of a dependency directory except the executables directory — is not linked. The executables directory is, because an agent runs the project's tools.
 
-This is best-effort as well: on a project that is not a git repo, or where the exclusion cannot be written, the links simply stay visible to git status.
+#### Rationale
+
+Linking the directory itself made the parent's tree the worktree's install in the package manager's eyes: it resolved through the link, rewrote the parent checkout's workspace links to point into the worktree — which dangled once the worktree was removed — or, when told it was running unattended, purged the parent's tree outright. Either way every later agent died at boot. The private state is what tells the package manager "this tree is mine, installed here", so it stays out of the worktree; the packages resolve without it, because a package entry is itself a relative link into the package manager's store, and a link to that link resolves where the target lives — in the parent checkout.
+
+Since the worktree's dependency directory is a real directory, the repo's own ignore rule for dependency directories covers it, and git never sees the links.
 
 ## Before modifying/creating SPEC.md files
 

--- a/packages/framework/src/store/worktree-deps.test.SPEC.md
+++ b/packages/framework/src/store/worktree-deps.test.SPEC.md
@@ -1,10 +1,10 @@
-What the tests cover: giving a worktree its dependencies and hiding them from git.
+What the tests cover: giving a worktree its dependencies.
 
 - The scan finds the repo root's dependency tree and each workspace package's, and never descends into a dependency tree, the git directory, or the framework's own directory.
-- Each tree is linked into the worktree at the same relative path, creating any missing parent directory; a tree already present in the worktree is left alone, and linking twice adds nothing.
-- A filesystem that refuses to make a link is tolerated: the agent still starts.
-- Against a real repo and a real worktree, the linked tree resolves — a dependency file is readable through it, and it is a link rather than a copy.
-- Against real git: the repo's own ignore rule does not cover the links and leaves the worktree dirty, adding the exclusion makes the worktree clean, and adding it a second time does not duplicate the rule.
+- Each tree is mirrored into the worktree at the same relative path as a real directory holding one link per entry, creating any missing parent directory; a tree already present in the worktree is left alone, and mirroring twice adds nothing.
+- The package manager's private state — every dot-entry but the executables directory — is not linked.
+- A filesystem that refuses to make a link, or the directory, is tolerated: the agent still starts.
+- Against a real repo and a real worktree with a pnpm-shaped tree (a package entry that is a relative link into the store), the mirrored tree resolves — a dependency file is readable through the chain, the worktree's directory is real and holds only the package entries — and replacing an entry in the worktree, as an install would, leaves the parent's tree and its link exactly as they were.
 
 ## Before modifying/creating SPEC.md files
 

--- a/packages/framework/src/store/worktree-deps.test.ts
+++ b/packages/framework/src/store/worktree-deps.test.ts
@@ -1,11 +1,9 @@
 import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { join } from 'node:path'
-import { mkdtemp, rm, mkdir, writeFile, readFile, lstat, realpath } from 'node:fs/promises'
+import { mkdtemp, rm, mkdir, writeFile, readFile, readdir, readlink, lstat, realpath, symlink, unlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { findDependencyDirs, linkDependencies, excludeDependencyLinks, nodeLinkFs, type LinkFs } from './index.js'
-import { nodeFs } from '../node-fs.js'
-import { nodeGitRunner } from '../project.js'
+import { findDependencyDirs, linkDependencies, nodeLinkFs, type LinkFs } from './index.js'
 
 /** A {@link LinkFs} over an in-memory set of directory paths, recording the links made. */
 function fakeFs(dirs: string[]): LinkFs & { links: { target: string; path: string }[] } {
@@ -47,114 +45,127 @@ test('findDependencyDirs finds the root and every workspace package tree (#736)'
     '/repo/packages/a',
     '/repo/packages/a/node_modules',
     '/repo/packages/b',
-    '/repo/packages/b/node_modules',
+    '/repo/examples',
+    '/repo/examples/demo',
+    '/repo/examples/demo/node_modules',
+    // Below MAX_DEPTH: not found.
+    '/repo/packages/a/src',
+    '/repo/packages/a/src/deep',
+    '/repo/packages/a/src/deep/node_modules',
   ])
-  assert.deepEqual(await findDependencyDirs('/repo', fs), [
-    'node_modules',
-    'packages/a/node_modules',
-    'packages/b/node_modules',
-  ])
+  assert.deepEqual(await findDependencyDirs('/repo', fs), ['examples/demo/node_modules', 'node_modules', 'packages/a/node_modules'])
 })
 
 test('findDependencyDirs never descends into node_modules or dot dirs', async () => {
   const fs = fakeFs([
     '/repo',
     '/repo/node_modules',
-    // A nested tree inside node_modules would be linked twice over, and there are
-    // thousands of them: the scan must stop at the top-level tree.
-    '/repo/node_modules/pkg',
-    '/repo/node_modules/pkg/node_modules',
+    '/repo/node_modules/dep',
+    '/repo/node_modules/dep/node_modules',
     '/repo/.git',
     '/repo/.git/node_modules',
     '/repo/.the-framework',
-    '/repo/.the-framework/node_modules',
+    '/repo/.the-framework/worktrees',
+    '/repo/.the-framework/worktrees/x',
+    '/repo/.the-framework/worktrees/x/node_modules',
   ])
   assert.deepEqual(await findDependencyDirs('/repo', fs), ['node_modules'])
 })
 
-test('linkDependencies mirrors each tree into the worktree at the same relative path', async () => {
-  const fs = fakeFs(['/repo', '/repo/node_modules', '/repo/packages', '/repo/packages/a', '/repo/packages/a/node_modules', '/wt'])
+test('linkDependencies mirrors each tree as a real directory of entry links, at the same relative path', async () => {
+  const fs = fakeFs([
+    '/repo',
+    '/repo/node_modules',
+    '/repo/node_modules/dep',
+    '/repo/node_modules/.bin',
+    '/repo/packages',
+    '/repo/packages/a',
+    '/repo/packages/a/node_modules',
+    '/repo/packages/a/node_modules/@scope',
+    '/wt',
+    '/wt/packages',
+    '/wt/packages/a',
+  ])
   const linked = await linkDependencies('/repo', '/wt', fs)
   assert.deepEqual(linked, ['node_modules', 'packages/a/node_modules'])
-  assert.deepEqual(fs.links, [
-    { target: '/repo/node_modules', path: '/wt/node_modules' },
-    // The worktree has the package dir (it is tracked), so only the link is made.
-    { target: '/repo/packages/a/node_modules', path: '/wt/packages/a/node_modules' },
+  assert.equal(await fs.isDirectory('/wt/node_modules'), true, 'a directory of the worktree\'s own, not a link')
+  assert.deepEqual(
+    fs.links.sort((a, b) => a.path.localeCompare(b.path)),
+    [
+      { target: '/repo/node_modules/.bin', path: '/wt/node_modules/.bin' },
+      { target: '/repo/node_modules/dep', path: '/wt/node_modules/dep' },
+      { target: '/repo/packages/a/node_modules/@scope', path: '/wt/packages/a/node_modules/@scope' },
+    ],
+  )
+})
+
+// The #1262 regression: linking the package manager's own state made the parent's tree the
+// worktree's install in pnpm's eyes, and an install in the worktree rewrote or purged it.
+test('linkDependencies leaves the package manager\'s private state out (#1262)', async () => {
+  const fs = fakeFs([
+    '/repo',
+    '/repo/node_modules',
+    '/repo/node_modules/dep',
+    '/repo/node_modules/.bin',
+    '/repo/node_modules/.pnpm',
+    '/repo/node_modules/.modules.yaml',
+    '/repo/node_modules/.pnpm-workspace-state-v1.json',
+    '/wt',
   ])
+  await linkDependencies('/repo', '/wt', fs)
+  assert.deepEqual(fs.links.map(l => l.path).sort(), ['/wt/node_modules/.bin', '/wt/node_modules/dep'])
 })
 
 test('linkDependencies leaves an existing tree alone (a run may have installed its own)', async () => {
-  const fs = fakeFs(['/repo', '/repo/node_modules', '/wt', '/wt/node_modules'])
+  const fs = fakeFs(['/repo', '/repo/node_modules', '/repo/node_modules/dep', '/wt', '/wt/node_modules'])
   assert.deepEqual(await linkDependencies('/repo', '/wt', fs), [])
   assert.deepEqual(fs.links, [])
 })
 
 test('linkDependencies swallows a filesystem that refuses the link (a run still starts)', async () => {
-  const fs = fakeFs(['/repo', '/repo/node_modules', '/wt'])
+  const fs = fakeFs(['/repo', '/repo/node_modules', '/repo/node_modules/dep', '/wt'])
   fs.symlinkDir = async () => {
     throw new Error('EPERM')
   }
-  assert.deepEqual(await linkDependencies('/repo', '/wt', fs), [])
+  assert.deepEqual(await linkDependencies('/repo', '/wt', fs), ['node_modules'])
+  fs.mkdir = async () => {
+    throw new Error('EROFS')
+  }
+  assert.deepEqual(await linkDependencies('/repo', '/wt2', fs), [])
 })
 
-// The point of the module is that a real worktree can resolve a real dependency, so
-// link it on disk and read a file back through the symlink.
-test('linkDependencies gives a real worktree a working dependency tree', async () => {
+// The point of the module is that a real worktree can resolve a real dependency, so link a
+// pnpm-shaped tree on disk — a package entry that is itself a relative link into `.pnpm` —
+// and read a file back through the chain.
+test('linkDependencies gives a real worktree a working dependency tree, and an install there stays there (#736, #1262)', async () => {
   const root = await realpath(await mkdtemp(join(tmpdir(), 'framework-deps-')))
   try {
     const repo = join(root, 'repo')
     const wt = join(root, 'wt')
-    await mkdir(join(repo, 'node_modules', 'dep'), { recursive: true })
-    await writeFile(join(repo, 'node_modules', 'dep', 'index.js'), 'module.exports = 1\n')
+    const store = join(repo, 'node_modules', '.pnpm', 'dep@1.0.0', 'node_modules', 'dep')
+    await mkdir(store, { recursive: true })
+    await writeFile(join(store, 'index.js'), 'module.exports = 1\n')
+    await symlink(join('.pnpm', 'dep@1.0.0', 'node_modules', 'dep'), join(repo, 'node_modules', 'dep'), 'dir')
+    await writeFile(join(repo, 'node_modules', '.modules.yaml'), 'layoutVersion: 5\n')
     await mkdir(join(repo, 'packages', 'a', 'node_modules'), { recursive: true })
     await mkdir(join(wt, 'packages', 'a'), { recursive: true })
 
     const linked = await linkDependencies(repo, wt, nodeLinkFs())
     assert.deepEqual(linked, ['node_modules', 'packages/a/node_modules'])
-    assert.equal((await lstat(join(wt, 'node_modules'))).isSymbolicLink(), true, 'linked, not copied')
+    assert.equal((await lstat(join(wt, 'node_modules'))).isDirectory(), true, 'a real directory of the worktree\'s own')
+    assert.equal((await lstat(join(wt, 'node_modules', 'dep'))).isSymbolicLink(), true, 'its entries are links')
     assert.equal(await readFile(join(wt, 'node_modules', 'dep', 'index.js'), 'utf8'), 'module.exports = 1\n')
+    assert.deepEqual(await readdir(join(wt, 'node_modules')), ['dep'], 'no .pnpm, no .modules.yaml')
+
+    // An install in the worktree replaces the worktree's entries; the parent's tree is untouched.
+    await unlink(join(wt, 'node_modules', 'dep'))
+    await mkdir(join(wt, 'node_modules', 'dep'))
+    await writeFile(join(wt, 'node_modules', 'dep', 'index.js'), 'module.exports = 2\n')
+    assert.equal(await readlink(join(repo, 'node_modules', 'dep')), join('.pnpm', 'dep@1.0.0', 'node_modules', 'dep'))
+    assert.equal(await readFile(join(repo, 'node_modules', 'dep', 'index.js'), 'utf8'), 'module.exports = 1\n')
 
     // Idempotent: a second call over the same worktree links nothing new.
     assert.deepEqual(await linkDependencies(repo, wt, nodeLinkFs()), [])
-  } finally {
-    await rm(root, { recursive: true, force: true })
-  }
-})
-
-// The regression this guards: `.gitignore` says `node_modules/`, which matches a directory and
-// NOT the symlink we create, so without an exclude the agent's `git add -A` commits dangling
-// absolute symlinks onto its branch. Exercised against real git, since the whole claim is about
-// what git actually ignores.
-test('excludeDependencyLinks makes git ignore the linked trees in a worktree (#738)', async () => {
-  const git = nodeGitRunner()
-  const root = await realpath(await mkdtemp(join(tmpdir(), 'framework-deps-git-')))
-  const repo = join(root, 'repo')
-  try {
-    await mkdir(join(repo, 'node_modules', 'dep'), { recursive: true })
-    await git(['init'], repo)
-    await git(['config', 'user.email', 't@t'], repo)
-    await git(['config', 'user.name', 't'], repo)
-    await writeFile(join(repo, '.gitignore'), 'node_modules/\n')
-    await writeFile(join(repo, 'README.md'), '# t\n')
-    await git(['add', '-A'], repo)
-    await git(['commit', '-m', 'init'], repo)
-
-    const wt = join(root, 'wt')
-    await git(['worktree', 'add', wt, '-b', 'tf-agent-1'], repo)
-    await linkDependencies(repo, wt, nodeLinkFs())
-    assert.equal(
-      (await git(['status', '--porcelain'], wt)).includes('node_modules'),
-      true,
-      'the plain .gitignore rule does not cover the symlink',
-    )
-
-    await excludeDependencyLinks(repo, nodeFs(), git)
-    assert.equal((await git(['status', '--porcelain'], wt)).trim(), '', 'the worktree is clean once excluded')
-
-    // Idempotent: a second agent over the same repo must not append the rule again.
-    await excludeDependencyLinks(repo, nodeFs(), git)
-    const exclude = await readFile(join(repo, '.git', 'info', 'exclude'), 'utf8')
-    assert.equal(exclude.split('\n').filter(l => l.trim() === 'node_modules').length, 1)
   } finally {
     await rm(root, { recursive: true, force: true })
   }

--- a/packages/framework/src/store/worktree-deps.ts
+++ b/packages/framework/src/store/worktree-deps.ts
@@ -1,7 +1,4 @@
 import { join, relative } from 'node:path'
-import { nodeFs, type NodeFs } from '../node-fs.js'
-import { excludeFromGit } from '../git-exclude.js'
-import { nodeGitRunner, type GitRunner } from '../project.js'
 import { FRAMEWORK_DIR } from './agent-store.js'
 
 /**
@@ -9,14 +6,22 @@ import { FRAMEWORK_DIR } from './agent-store.js'
  * `git worktree add` hands the agent an empty one and every command in it fails.
  *
  * Three ways to fix that: copy the tree (correct, but gigabytes per agent), install
- * into each worktree (correct, but real latency on every start), or symlink the
+ * into each worktree (correct, but real latency on every start), or link the
  * parent checkout's trees in (instant, no extra disk, one store shared by N runs).
- * We symlink. The one case it is wrong for is an agent that changes the lockfile —
- * that needs its own install regardless, and the agent runs the install itself.
+ * We link — but each *entry* of a dependency directory, into a real directory of
+ * the worktree's own, never the directory itself (#1262). A directory link made the
+ * parent's tree the worktree's modules directory in the package manager's eyes:
+ * an agent that changed a dependency and ran `pnpm install` had pnpm resolve
+ * through the link and rewrite — or, under `CI=true`, purge outright — the parent
+ * checkout's real `node_modules`, and every later agent died at boot. With a real
+ * directory holding links, an install in the worktree writes into the worktree.
  *
- * Directory symlinks are what make this work in a pnpm workspace: linking
- * `packages/foo/node_modules` as a whole means the `.pnpm` symlinks inside it
- * still resolve against their real location in the parent checkout.
+ * The package manager's own state (`.pnpm`, `.modules.yaml`, and the like — every
+ * dot-entry but `.bin`) is deliberately not linked: it is what tells the package
+ * manager "this tree is mine, installed here", and the worktree's is not. The
+ * packages still resolve without it — a package entry in a pnpm tree is a relative
+ * link into `.pnpm`, and a link to that link resolves where the target lives, in
+ * the parent checkout. `.bin` is linked because an agent runs the project's tools.
  */
 
 /** The dependency directory mirrored into a worktree. */
@@ -28,6 +33,12 @@ const MAX_DEPTH = 2
 
 /** Directory names never descended into while scanning for dependency trees. */
 const SKIP = new Set([NODE_MODULES, '.git', FRAMEWORK_DIR, 'dist', 'build', 'coverage'])
+
+/** The one dot-entry of a dependency directory that is linked: the project's executables. */
+const BIN = '.bin'
+
+/** The package manager's private state in a dependency directory: never linked (see above). */
+const isPrivate = (name: string): boolean => name.startsWith('.') && name !== BIN
 
 /** The filesystem this module needs. Injectable so the scan is testable. */
 export interface LinkFs {
@@ -91,53 +102,29 @@ export async function findDependencyDirs(repo: string, fs: LinkFs = nodeLinkFs()
 }
 
 /**
- * Symlink `repo`'s dependency trees into `worktree` at the same relative paths.
- * Returns the paths linked. Best-effort throughout: a worktree with no deps is a
- * worse run, not a failed one, so a link that cannot be made is skipped rather
- * than thrown. An existing entry is left alone (the agent may have installed already).
+ * Mirror `repo`'s dependency trees into `worktree` at the same relative paths: a real
+ * directory per tree, holding a link per entry (the package manager's private state
+ * left out, see above). Returns the trees mirrored. Best-effort throughout: a worktree
+ * with no deps is a worse run, not a failed one, so a link that cannot be made is
+ * skipped rather than thrown. A tree already present is left alone (the agent may
+ * have installed already).
  */
 export async function linkDependencies(repo: string, worktree: string, fs: LinkFs = nodeLinkFs()): Promise<string[]> {
   const linked: string[] = []
   for (const rel of await findDependencyDirs(repo, fs)) {
-    const target = join(repo, rel)
-    const link = join(worktree, rel)
+    const source = join(repo, rel)
+    const dir = join(worktree, rel)
     try {
-      if (await fs.entryExists(link)) continue
-      const parent = join(link, '..')
-      if (!(await fs.isDirectory(parent))) await fs.mkdir(parent)
-      await fs.symlinkDir(target, link)
+      if (await fs.entryExists(dir)) continue
+      await fs.mkdir(dir)
+      for (const name of await fs.readdir(source)) {
+        if (isPrivate(name)) continue
+        await fs.symlinkDir(join(source, name), join(dir, name)).catch(() => {})
+      }
       linked.push(rel)
     } catch {
-      // Raced, or a filesystem that refuses the link: the agent still starts.
+      // Raced, or a filesystem that refuses the directory: the agent still starts.
     }
   }
   return linked
-}
-
-/** The exclude rule that covers a linked tree. Deliberately slash-free: see below. */
-const EXCLUDE_RULE = NODE_MODULES
-
-/**
- * Make git ignore the dependency links (#738). A repo's `.gitignore` says `node_modules/`, and
- * a trailing slash matches a *directory* only — the links {@link linkDependencies} makes are
- * symlinks, so they are not covered, and they show up as untracked in every agent's worktree.
- * That is not cosmetic: the agent runs `git add -A`, so the agent would commit dangling absolute
- * symlinks into its branch and onto the PR.
- *
- * A slash-free `node_modules` in the repo-level exclude ({@link excludeFromGit}) covers the
- * symlink form in every worktree, and the main checkout is unaffected in practice: its
- * `node_modules` is a real directory, already ignored by the same name.
- *
- * Best-effort: an agent whose links are merely untracked is still an agent.
- */
-export async function excludeDependencyLinks(
-  repo: string,
-  fs: NodeFs = nodeFs(),
-  agent: GitRunner = nodeGitRunner(),
-): Promise<void> {
-  try {
-    await excludeFromGit(repo, EXCLUDE_RULE, fs, agent)
-  } catch {
-    // Not a repo, or an unwritable git dir: the links just stay visible to git status.
-  }
 }


### PR DESCRIPTION
🤖 *automated*

Closes #1262.

**The bug, re-measured today (pnpm 11.5.3, scratch workspace + a real worktree).** With the parent's `node_modules` *directory* linked into the worktree, an agent that changes a dependency and runs `pnpm install` gets one of two outcomes — both worse than the issue describes:
- no TTY (an agent's shell): pnpm wants to **purge** what it sees as a foreign modules directory — the parent checkout's real `node_modules` — and aborts: *"Aborted removal of modules directory due to no TTY"*. The agent's install fails.
- `CI=true`: it purges. The parent checkout's `node_modules` and every `packages/*/node_modules` came back **empty**; the root could no longer resolve its own workspace packages.

The July mechanism (workspace links rewritten to point into the worktree, dangling after teardown) is the same root cause: pnpm realpaths through the linked directory and treats the parent's tree as the worktree's install.

**The fix — prevent, not heal.** `linkDependencies` now creates a real directory per dependency tree in the worktree and links each *entry* of the parent's directory into it. The package manager's private state (`.pnpm`, `.modules.yaml`, `.pnpm-workspace-state-*` — every dot-entry but `.bin`) is not linked: that state is what says "this tree is mine, installed here". Packages still resolve without it, because a pnpm package entry is itself a relative link into `.pnpm`, and a link to that link resolves where the target lives (the parent). An install inside the worktree now writes into the worktree's own directory and leaves the parent untouched.

Since the worktree's `node_modules` is a real directory, the repo's own `node_modules/` ignore rule covers it — `excludeDependencyLinks` and the slash-free exclude rule from #738 are removed.

**Verified.**
- Scratch pnpm workspace (`liba` → `@scratch/libb` + `is-odd`): entry links resolve before any install; adding `is-even` in the worktree and `pnpm install` there succeeds with no TTY and no purge; the root's `@scratch/libb -> ../../../libb` and its resolution are unchanged after the install and after `git worktree remove`.
- On gemstack itself (via tsx, into a scratch worktree): 18 trees mirrored as real directories holding only package entries + `.bin`; vitest runs through `.bin`; a dependency added in `packages/framework` + `pnpm install` in the worktree resolves there and not at the root; the root's link set (every symlink in `node_modules` and `packages/*/node_modules`, target included) is byte-identical before, after the install, and after teardown; the root's `dist` still imports.
- Unit: 7 tests (two new — private state left out; a pnpm-shaped real tree resolves through the chain and an install-shaped replacement in the worktree leaves the parent's link and file untouched). Both new guards break-checked: linking the private state fails 2, linking the directory itself fails 4. Typecheck clean; node + 806 vitest green.

One thing unchanged, for the record: a workspace package entry (`@gemstack/x`) still resolves to the **parent's** copy of that package, exactly as before this PR — sibling-package edits in a worktree are seen only after that worktree installs (or builds) for itself.

SPEC.md updated: `store/worktree-deps` (+ test spec) rewritten for the new rule, `daemon-runtime.SPEC.md` line, `FEATURES-SPEC.md`.