### PR TITLE
Add all the shown tickets to the AI queue, from the Tickets page heading

### DIFF
--- a/FEATURES-SPEC.md
+++ b/FEATURES-SPEC.md
@@ -22,7 +22,6 @@ happens while nobody is at the keyboard.
 - Options gear writing straight to preferences
 - Pre-flight warnings before spending (no `gh`, logged out, repo can't auto-merge)
 - Start an agent from a ticket row
-- Spin up agents working on all the tickets the Tickets page's filters show — one agent per ticket, via the AI queue
 - Start an agent from a queue entry's play button
 - "Run now" on a routine, in a picked project the card remembers across navigations and reloads
 - "Configure first, then run" on a routine — the launcher opens with its prompt, so the model and location can be set first
@@ -99,6 +98,7 @@ happens while nobody is at the keyboard.
 - Ticket detail page
 - A plan page when a plan exists; a button to start an agent writing one when it doesn't
 - Queue a ticket into the AI queue
+- Queue every ticket the filters show into the AI queue, in one click from the page heading
 - Tickets carry a GitHub issue link, so merging closes the issue
 
 ## Handoff and what lands in git

--- a/FEATURES-SPEC.md
+++ b/FEATURES-SPEC.md
@@ -22,7 +22,7 @@ happens while nobody is at the keyboard.
 - Options gear writing straight to preferences
 - Pre-flight warnings before spending (no `gh`, logged out, repo can't auto-merge)
 - Start an agent from a ticket row
-- Spin up an agent working on all the tickets the Tickets page's filters show — one agent per project when the shown set spans several
+- Spin up agents working on all the tickets the Tickets page's filters show — one agent per ticket, via the AI queue
 - Start an agent from a queue entry's play button
 - "Run now" on a routine, in a picked project the card remembers across navigations and reloads
 - "Configure first, then run" on a routine — the launcher opens with its prompt, so the model and location can be set first

--- a/FEATURES-SPEC.md
+++ b/FEATURES-SPEC.md
@@ -22,6 +22,7 @@ happens while nobody is at the keyboard.
 - Options gear writing straight to preferences
 - Pre-flight warnings before spending (no `gh`, logged out, repo can't auto-merge)
 - Start an agent from a ticket row
+- Spin up an agent working on all the tickets the Tickets page's filters show — one agent per project when the shown set spans several
 - Start an agent from a queue entry's play button
 - "Run now" on a routine, in a picked project the card remembers across navigations and reloads
 - "Configure first, then run" on a routine — the launcher opens with its prompt, so the model and location can be set first

--- a/packages/framework/dashboard/components/TicketsPage.SPEC.md
+++ b/packages/framework/dashboard/components/TicketsPage.SPEC.md
@@ -2,7 +2,7 @@ The dashboard's Tickets page: every registered project's `tickets/` backlog on o
 
 ## User story
 
-The user wants to see the whole backlog — not one project's slice of it — decide what to work next, and act on a ticket right there: read it, read its plan, have an agent plan it, or have an agent work it. And when the filters have carved out a coherent slice, they want to hand that whole slice to an agent at once.
+The user wants to see the whole backlog — not one project's slice of it — decide what to work next, and act on a ticket right there: read it, read its plan, have an agent plan it, or have an agent work it. And when the filters have carved out a coherent slice, they want to hand that whole slice to agents at once — one agent per ticket.
 
 ## Business logic — TL;DR
 
@@ -11,7 +11,7 @@ The user wants to see the whole backlog — not one project's slice of it — de
 - **Grouped or flat** - grouped shows one section per project, each with that project's own ticket panel; flat pools every project's tickets into one order, each row naming its project — the only view that can answer which ticket is the highest-priority one anywhere.
 - **Click-to-filter** - clicking a row's topic adds that topic to the filter, clicking its claim marker narrows to claimed tickets; both add to what is already filtered rather than replacing it.
 - **Plan it or work it from the row** - a ticket can be handed to a planning agent or to an unattended work agent without leaving the page.
-- **Spin up the whole shown set** - a button beside the page's heading starts an unattended agent working exactly the tickets the filters show; a shown set spanning several projects fans out one agent per project, and the button's label counts the tickets and the agents one click costs.
+- **Spin up the whole shown set** - a button beside the page's heading spins up one unattended agent per shown ticket, via the AI queue: each unclaimed shown ticket is queued (unless it already is) and gets its own agent working that one entry, and the button's label counts the agents one click costs.
 - **Filtered-away tickets are accounted for** - the page says how many tickets the filters hide and offers to clear them; a project the user deselected disappears silently instead.
 
 ## Business logic
@@ -78,19 +78,19 @@ Every ticket row offers to start a planning agent for that ticket, and to start 
 
 #### User story
 
-The user narrows the backlog to a coherent slice — a topic, a priority band, one project — and wants an agent to sweep through everything left showing, rather than starting the rows one by one.
+The user narrows the backlog to a coherent slice — a topic, a priority band, one project — and wants agents on everything left showing, one agent per ticket, rather than starting the rows one by one.
 
 #### Business logic
 
-Whenever at least one ticket is shown, the page's heading row offers a button that starts the whole shown set: an unattended agent told to work exactly the shown tickets — listed in the shown order — and to start nothing else. The set is exactly what the heading's shown tally counts, so the button never starts work on a ticket the reader cannot see below it. With nothing shown, the button is not offered.
+Whenever the filters leave at least one unclaimed ticket showing, the page's heading row offers a button that spins up one agent per shown ticket, via the AI queue. For each such ticket, in the shown order: the ticket is queued exactly as the ticket detail page's Queue action queues it — unless an open queue entry already links to it, in which case that entry stands and nothing is written twice — and an unattended agent is started on that one entry, exactly as the AI Queue card's per-entry play button starts one, with the ticket named on the agent. Each agent starts in the project its ticket belongs to, so a shown set spanning projects needs no special case.
 
-An agent works inside one project, so when the shown set spans several projects the button starts one unattended agent per project, each told only its own project's shown tickets. The button's label is the spend readout: with one project it reads "Spin up an agent working on all X tickets shown below" (X being the shown tally), and the moment the set spans projects it also says how many agents the click costs; hovering explains the mechanics either way. A single shown ticket is started exactly as that ticket's own row start would start it — same one-ticket ask, same ticket named on the agent.
+Claimed tickets — those an agent already holds — are skipped: they are left to the agents holding them, the same rule the daemon's own fan-out follows. The button's label is the spend readout: one agent per ticket, so it counts what one click costs — "Spin up agents working on all X tickets shown below" — and switches to counting unclaimed tickets the moment the shown set contains claimed ones, so it never promises a ticket it will skip; hovering explains the mechanics and says how many claimed tickets are being left alone. With nothing to start — nothing shown, or everything shown claimed — the button is not offered.
 
-Whatever the batch, the dashboard shell is told about one started agent — the first — rather than being bounced through every one. A start that fails leaves its reason under the heading, in grouped and flat mode alike; agents already started stay started.
+The dashboard shell is told about one started agent — the first — rather than being bounced through every one. The work stops at the first failure, whose reason lands under the heading in grouped and flat mode alike; everything already queued or started stays.
 
 #### Rationale
 
-One agent working a filtered slice is a different offer from the row's one-agent-one-ticket start: related small tickets land as one coherent change instead of N parallel worktrees. And the label carries the counts precisely because the set is a side effect of the filters — the click's cost must be readable before it is paid.
+Routing through the AI queue rather than starting bare agents makes each start durable: a queue entry outlives a failed or interrupted agent, so the routine drain picks up whatever the click could not finish. Reusing an existing open entry matters for the same reason in reverse — a duplicate entry would outlive its agent's check-off as an open entry naming a closed ticket, and the sweep would spend an agent on it. And the label carries the count precisely because the set is a side effect of the filters — the click's cost must be readable before it is paid.
 
 ### Filtered-away tickets are accounted for
 

--- a/packages/framework/dashboard/components/TicketsPage.SPEC.md
+++ b/packages/framework/dashboard/components/TicketsPage.SPEC.md
@@ -2,7 +2,7 @@ The dashboard's Tickets page: every registered project's `tickets/` backlog on o
 
 ## User story
 
-The user wants to see the whole backlog — not one project's slice of it — decide what to work next, and act on a ticket right there: read it, read its plan, have an agent plan it, or have an agent work it. And when the filters have carved out a coherent slice, they want to hand that whole slice to agents at once — one agent per ticket.
+The user wants to see the whole backlog — not one project's slice of it — decide what to work next, and act on a ticket right there: read it, read its plan, have an agent plan it, or have an agent work it. And when the filters have carved out a coherent slice, they want to queue that whole slice for the AI in one click.
 
 ## Business logic — TL;DR
 
@@ -11,7 +11,7 @@ The user wants to see the whole backlog — not one project's slice of it — de
 - **Grouped or flat** - grouped shows one section per project, each with that project's own ticket panel; flat pools every project's tickets into one order, each row naming its project — the only view that can answer which ticket is the highest-priority one anywhere.
 - **Click-to-filter** - clicking a row's topic adds that topic to the filter, clicking its claim marker narrows to claimed tickets; both add to what is already filtered rather than replacing it.
 - **Plan it or work it from the row** - a ticket can be handed to a planning agent or to an unattended work agent without leaving the page.
-- **Spin up the whole shown set** - a button beside the page's heading spins up one unattended agent per shown ticket, via the AI queue: each unclaimed shown ticket is queued (unless it already is) and gets its own agent working that one entry, and the button's label counts the agents one click costs.
+- **Queue the whole shown set** - a button beside the page's heading adds every unclaimed shown ticket to the AI queue (a ticket already queued stays as it is), counting on its label what one click adds; no agent starts — the queue's own consumers do that.
 - **Filtered-away tickets are accounted for** - the page says how many tickets the filters hide and offers to clear them; a project the user deselected disappears silently instead.
 
 ## Business logic
@@ -74,23 +74,23 @@ The user has decided a ticket is next and wants an agent on it now.
 
 Every ticket row offers to start a planning agent for that ticket, and to start an agent that works it. The work agent runs unattended with the ticket named on it, so the agent knows which ticket it is working. Both start in the project the ticket belongs to — in the flat list that is the row's own project, not a page-wide selection — and the dashboard shell is told an agent started so it can show it. A start that fails leaves a message on the page saying the planning agent or the work agent could not be started.
 
-### Spin up the whole shown set
+### Queue the whole shown set
 
 #### User story
 
-The user narrows the backlog to a coherent slice — a topic, a priority band, one project — and wants agents on everything left showing, one agent per ticket, rather than starting the rows one by one.
+The user narrows the backlog to a coherent slice — a topic, a priority band, one project — and wants everything left showing on the AI queue, rather than queueing the rows one by one.
 
 #### Business logic
 
-Whenever the filters leave at least one unclaimed ticket showing, the page's heading row offers a button that spins up one agent per shown ticket, via the AI queue. For each such ticket, in the shown order: the ticket is queued exactly as the ticket detail page's Queue action queues it — unless an open queue entry already links to it, in which case that entry stands and nothing is written twice — and an unattended agent is started on that one entry, exactly as the AI Queue card's per-entry play button starts one, with the ticket named on the agent. Each agent starts in the project its ticket belongs to, so a shown set spanning projects needs no special case.
+Whenever the filters leave at least one unclaimed ticket showing, the page's heading row offers a button that adds the shown tickets to the AI queue — "Add all X tickets shown below to the AI queue". Each ticket is queued exactly as the ticket detail page's Queue action queues it (the entry links back to the ticket and lands in its priority's section), walked in the shown order so entries within a priority section keep the order the reader saw, and each on its own project's queue, so a shown set spanning projects needs no special case. A ticket an open queue entry already links to is left as it stands — "add" means the set ends up queued, never queued twice. No agent starts: the queue is what the framework's own routine drain fans out over and what the AI Queue card's play buttons start one entry at a time.
 
-Claimed tickets — those an agent already holds — are skipped: they are left to the agents holding them, the same rule the daemon's own fan-out follows. The button's label is the spend readout: one agent per ticket, so it counts what one click costs — "Spin up agents working on all X tickets shown below" — and switches to counting unclaimed tickets the moment the shown set contains claimed ones, so it never promises a ticket it will skip; hovering explains the mechanics and says how many claimed tickets are being left alone. With nothing to start — nothing shown, or everything shown claimed — the button is not offered.
+Claimed tickets — those an agent already holds — are skipped: they are being worked, and the label then counts only the unclaimed tickets so it never promises a ticket it will skip; hovering explains the mechanics and says how many claimed tickets are being left alone. With nothing to add — nothing shown, or everything shown claimed — the button is not offered.
 
-The dashboard shell is told about one started agent — the first — rather than being bounced through every one. The work stops at the first failure, whose reason lands under the heading in grouped and flat mode alike; everything already queued or started stays.
+Once a click has queued the shown set, the button reads "Queued" and rests; any change to the shown set — a filter, newly arrived tickets — arms it again for the new set. The work stops at the first failure, whose reason lands under the heading in grouped and flat mode alike; everything already queued stays.
 
 #### Rationale
 
-Routing through the AI queue rather than starting bare agents makes each start durable: a queue entry outlives a failed or interrupted agent, so the routine drain picks up whatever the click could not finish. Reusing an existing open entry matters for the same reason in reverse — a duplicate entry would outlive its agent's check-off as an open entry naming a closed ticket, and the sweep would spend an agent on it. And the label carries the count precisely because the set is a side effect of the filters — the click's cost must be readable before it is paid.
+Queueing rather than starting agents keeps the one click cheap and durable: entries are what the framework already picks up on its own, survive anything that interrupts the work, and spend nothing until an agent actually starts. Skipping already-queued tickets matters because a duplicate entry would outlive its agent's check-off as an open entry naming a closed ticket, costing the sweep an agent.
 
 ### Filtered-away tickets are accounted for
 

--- a/packages/framework/dashboard/components/TicketsPage.SPEC.md
+++ b/packages/framework/dashboard/components/TicketsPage.SPEC.md
@@ -2,7 +2,7 @@ The dashboard's Tickets page: every registered project's `tickets/` backlog on o
 
 ## User story
 
-The user wants to see the whole backlog — not one project's slice of it — decide what to work next, and act on a ticket right there: read it, read its plan, have an agent plan it, or have an agent work it.
+The user wants to see the whole backlog — not one project's slice of it — decide what to work next, and act on a ticket right there: read it, read its plan, have an agent plan it, or have an agent work it. And when the filters have carved out a coherent slice, they want to hand that whole slice to an agent at once.
 
 ## Business logic — TL;DR
 
@@ -11,6 +11,7 @@ The user wants to see the whole backlog — not one project's slice of it — de
 - **Grouped or flat** - grouped shows one section per project, each with that project's own ticket panel; flat pools every project's tickets into one order, each row naming its project — the only view that can answer which ticket is the highest-priority one anywhere.
 - **Click-to-filter** - clicking a row's topic adds that topic to the filter, clicking its claim marker narrows to claimed tickets; both add to what is already filtered rather than replacing it.
 - **Plan it or work it from the row** - a ticket can be handed to a planning agent or to an unattended work agent without leaving the page.
+- **Spin up the whole shown set** - a button beside the page's heading starts an unattended agent working exactly the tickets the filters show; a shown set spanning several projects fans out one agent per project, and the button's label counts the tickets and the agents one click costs.
 - **Filtered-away tickets are accounted for** - the page says how many tickets the filters hide and offers to clear them; a project the user deselected disappears silently instead.
 
 ## Business logic
@@ -72,6 +73,24 @@ The user has decided a ticket is next and wants an agent on it now.
 #### Business logic
 
 Every ticket row offers to start a planning agent for that ticket, and to start an agent that works it. The work agent runs unattended with the ticket named on it, so the agent knows which ticket it is working. Both start in the project the ticket belongs to — in the flat list that is the row's own project, not a page-wide selection — and the dashboard shell is told an agent started so it can show it. A start that fails leaves a message on the page saying the planning agent or the work agent could not be started.
+
+### Spin up the whole shown set
+
+#### User story
+
+The user narrows the backlog to a coherent slice — a topic, a priority band, one project — and wants an agent to sweep through everything left showing, rather than starting the rows one by one.
+
+#### Business logic
+
+Whenever at least one ticket is shown, the page's heading row offers a button that starts the whole shown set: an unattended agent told to work exactly the shown tickets — listed in the shown order — and to start nothing else. The set is exactly what the heading's shown tally counts, so the button never starts work on a ticket the reader cannot see below it. With nothing shown, the button is not offered.
+
+An agent works inside one project, so when the shown set spans several projects the button starts one unattended agent per project, each told only its own project's shown tickets. The button's label is the spend readout: with one project it reads "Spin up an agent working on all X tickets shown below" (X being the shown tally), and the moment the set spans projects it also says how many agents the click costs; hovering explains the mechanics either way. A single shown ticket is started exactly as that ticket's own row start would start it — same one-ticket ask, same ticket named on the agent.
+
+Whatever the batch, the dashboard shell is told about one started agent — the first — rather than being bounced through every one. A start that fails leaves its reason under the heading, in grouped and flat mode alike; agents already started stay started.
+
+#### Rationale
+
+One agent working a filtered slice is a different offer from the row's one-agent-one-ticket start: related small tickets land as one coherent change instead of N parallel worktrees. And the label carries the counts precisely because the set is a side effect of the filters — the click's cost must be readable before it is paid.
 
 ### Filtered-away tickets are accounted for
 

--- a/packages/framework/dashboard/components/TicketsPage.test.SPEC.md
+++ b/packages/framework/dashboard/components/TicketsPage.test.SPEC.md
@@ -6,6 +6,8 @@ Filtering: searching narrows the rows, updates the shown/total tally beside the 
 
 Grouping: the flat mode renders one cross-project list ordered across projects, with each row naming its project and no per-project update controls; opening a flat row still identifies its own project and file; and a flat row's start button runs the work agent in that row's own project, unattended, with the ticket named on it.
 
+The page-wide spin-up button: it starts one unattended agent told exactly the shown files and nothing else, and reports that agent to the shell; filters narrow what it starts, a single shown ticket degrading to the row start's own one-ticket ask with the ticket named on the agent; a shown set spanning projects counts the agents on the button's label and fans out one start per project, each told only its own project's shown files, with the shell pointed at the first started agent only; and with nothing shown the button is absent.
+
 ## Before modifying/creating SPEC.md files
 
 You must always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/framework/dashboard/components/TicketsPage.test.SPEC.md
+++ b/packages/framework/dashboard/components/TicketsPage.test.SPEC.md
@@ -6,7 +6,7 @@ Filtering: searching narrows the rows, updates the shown/total tally beside the 
 
 Grouping: the flat mode renders one cross-project list ordered across projects, with each row naming its project and no per-project update controls; opening a flat row still identifies its own project and file; and a flat row's start button runs the work agent in that row's own project, unattended, with the ticket named on it.
 
-The page-wide spin-up button: each shown ticket is queued the way the ticket detail page queues one (title as the entry, ticket linked, priority picking the section) and gets its own unattended agent started on that one entry with the ticket named on the agent, the shell pointed at the first started agent only; a ticket an open queue entry already links to is not queued twice — its agent is pointed at the existing entry verbatim, and a checked-off entry does not count as queued; claimed tickets are skipped, with the button's label counting only the unclaimed tickets it will start; and the button is absent when nothing is shown or every shown ticket is claimed.
+The page-wide queue-add button: every shown ticket is queued the way the ticket detail page queues one (title as the entry, ticket linked, priority picking the section) and no agent is started; after the click the button reads "Queued" and stays disabled until the shown set changes, when it arms again counting the new set; a ticket an open queue entry already links to is not queued twice, and a checked-off entry does not count as queued; claimed tickets are skipped, with the button's label counting only the unclaimed tickets it will add; and the button is absent when nothing is shown or every shown ticket is claimed.
 
 ## Before modifying/creating SPEC.md files
 

--- a/packages/framework/dashboard/components/TicketsPage.test.SPEC.md
+++ b/packages/framework/dashboard/components/TicketsPage.test.SPEC.md
@@ -6,7 +6,7 @@ Filtering: searching narrows the rows, updates the shown/total tally beside the 
 
 Grouping: the flat mode renders one cross-project list ordered across projects, with each row naming its project and no per-project update controls; opening a flat row still identifies its own project and file; and a flat row's start button runs the work agent in that row's own project, unattended, with the ticket named on it.
 
-The page-wide spin-up button: it starts one unattended agent told exactly the shown files and nothing else, and reports that agent to the shell; filters narrow what it starts, a single shown ticket degrading to the row start's own one-ticket ask with the ticket named on the agent; a shown set spanning projects counts the agents on the button's label and fans out one start per project, each told only its own project's shown files, with the shell pointed at the first started agent only; and with nothing shown the button is absent.
+The page-wide spin-up button: each shown ticket is queued the way the ticket detail page queues one (title as the entry, ticket linked, priority picking the section) and gets its own unattended agent started on that one entry with the ticket named on the agent, the shell pointed at the first started agent only; a ticket an open queue entry already links to is not queued twice — its agent is pointed at the existing entry verbatim, and a checked-off entry does not count as queued; claimed tickets are skipped, with the button's label counting only the unclaimed tickets it will start; and the button is absent when nothing is shown or every shown ticket is claimed.
 
 ## Before modifying/creating SPEC.md files
 

--- a/packages/framework/dashboard/components/TicketsPage.test.tsx
+++ b/packages/framework/dashboard/components/TicketsPage.test.tsx
@@ -3,12 +3,15 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 
 const onAllTickets = vi.hoisted(() => vi.fn())
 // TicketsPanel (rendered per project here) reaches for these too; unmocked they fetch a daemon
-// that is not there, same as TicketsPanel's own suite.
+// that is not there, same as TicketsPanel's own suite. `onQueue` is the spin-up button's
+// click-time read of what is already queued.
 const onTicketsMeta = vi.hoisted(() => vi.fn())
-vi.mock('../rpc/reads.js', () => ({ onAllTickets, onTicketsMeta }))
+const onQueue = vi.hoisted(() => vi.fn())
+vi.mock('../rpc/reads.js', () => ({ onAllTickets, onTicketsMeta, onQueue }))
 vi.mock('../rpc/control.js', () => ({ sendQueueTicket: vi.fn(), sendStart: vi.fn() }))
 
 const { TicketsPage } = await import('./TicketsPage.js')
+const { workOnEntryPrompt } = await import('./AiQueue.js')
 
 const ticket = (over: Record<string, unknown> = {}) => ({
   file: 't.md',
@@ -21,6 +24,7 @@ const ticket = (over: Record<string, unknown> = {}) => ({
 
 beforeEach(() => {
   onTicketsMeta.mockReset().mockResolvedValue({})
+  onQueue.mockReset().mockResolvedValue([])
   // The page reads its view from the URL on mount and mirrors changes back via replaceState, so
   // every test starts from a clean address.
   window.history.replaceState(null, '', '/tickets')
@@ -253,80 +257,103 @@ describe('TicketsPage grouping (#1144)', () => {
   })
 })
 
-// The page-wide spin-up button: the row's play button lifted to the page's heading — one
-// unattended agent working exactly the shown (filtered) set, one agent per project when the
-// shown set spans several.
+// The page-wide spin-up button: the row's play button lifted to the page's heading — one agent
+// per shown ticket, via the AI queue. Each unclaimed shown ticket is queued (unless an open
+// entry already links to it) and gets its own unattended agent working that one entry.
 describe('TicketsPage spin up the shown set', () => {
-  test('the header button works the whole shown set: one start, every shown file on the prompt', async () => {
-    onAllTickets.mockResolvedValue([
-      {
-        projectId: 'p1',
-        projectName: 'Alpha',
-        tickets: [ticket({ file: 'a.md', title: 'First' }), ticket({ file: 'b.md', title: 'Second' })],
-      },
-    ])
-    const { sendStart } = await import('../rpc/control.js')
+  const controls = async () => {
+    const { sendStart, sendQueueTicket } = await import('../rpc/control.js')
     vi.mocked(sendStart).mockClear().mockResolvedValue({ ok: true, agentId: 'a1' })
-    const onAgentStarted = vi.fn()
-    render(<TicketsPage onOpenTicket={() => {}} onAgentStarted={onAgentStarted} />)
-    fireEvent.click(await screen.findByRole('button', { name: 'Spin up an agent working on all 2 tickets shown below' }))
-    // The exact ask (#1187), files in the shown order — and no `ticket` on the options: with
-    // several files, no single ticket is "the" one the agent implements.
-    const prompt = 'Work on all of the following tickets:\n- tickets/a.md\n- tickets/b.md\nDo not start any other ticket.'
-    await waitFor(() => expect(sendStart).toHaveBeenCalledWith('p1', prompt, 'prompt', { unattended: true }))
-    expect(sendStart).toHaveBeenCalledTimes(1)
-    await waitFor(() => expect(onAgentStarted).toHaveBeenCalledWith('p1', prompt, 'a1'))
-  })
+    vi.mocked(sendQueueTicket).mockClear().mockResolvedValue({ ok: true, file: 'TODO_AGENTS.md' })
+    return { sendStart, sendQueueTicket }
+  }
 
-  test('the header button starts only what the filters show — one shown ticket is the row\'s own start', async () => {
+  test('one agent per shown ticket: each is queued and started on its own entry', async () => {
     onAllTickets.mockResolvedValue([
       {
         projectId: 'p1',
         projectName: 'Alpha',
-        tickets: [ticket({ file: 'lock.md', title: 'Improve the lock' }), ticket({ file: 'other.md', title: 'Something else' })],
+        tickets: [ticket({ file: 'a.md', title: 'First', priority: '7' }), ticket({ file: 'b.md', title: 'Second' })],
       },
     ])
-    window.history.replaceState(null, '', '/tickets?q=lock')
-    const { sendStart } = await import('../rpc/control.js')
-    vi.mocked(sendStart).mockClear().mockResolvedValue({ ok: true, agentId: 'a2' })
-    render(<TicketsPage onOpenTicket={() => {}} />)
-    // Filtered to one, the label goes singular and the start degrades to the row's exact ask,
-    // `ticket` riding the options as it does there (#1117).
-    fireEvent.click(await screen.findByRole('button', { name: 'Spin up an agent working on the ticket shown below' }))
-    await waitFor(() =>
-      expect(sendStart).toHaveBeenCalledWith('p1', 'Work on tickets/lock.md. Do not start any other ticket.', 'prompt', {
-        unattended: true,
-        ticket: 'tickets/lock.md',
-      }),
-    )
-    expect(sendStart).toHaveBeenCalledTimes(1)
-  })
-
-  test('a shown set spanning projects says so on the label and fans out one agent per project', async () => {
-    onAllTickets.mockResolvedValue([
-      {
-        projectId: 'p1',
-        projectName: 'Alpha',
-        tickets: [ticket({ file: 'a.md', title: 'First' }), ticket({ file: 'b.md', title: 'Second' })],
-      },
-      { projectId: 'p2', projectName: 'Beta', tickets: [ticket({ file: 'c.md', title: 'Third' })] },
-    ])
-    const { sendStart } = await import('../rpc/control.js')
-    vi.mocked(sendStart).mockClear().mockResolvedValue({ ok: true, agentId: 'a3' })
+    const { sendStart, sendQueueTicket } = await controls()
     const onAgentStarted = vi.fn()
     render(<TicketsPage onOpenTicket={() => {}} onAgentStarted={onAgentStarted} />)
-    fireEvent.click(await screen.findByRole('button', { name: 'Spin up 2 agents working on all 3 tickets shown below' }))
-    // Each project's agent is told its own shown files, nothing cross-repo.
-    const alphaPrompt = 'Work on all of the following tickets:\n- tickets/a.md\n- tickets/b.md\nDo not start any other ticket.'
+    fireEvent.click(await screen.findByRole('button', { name: 'Spin up agents working on all 2 tickets shown below' }))
+    // Queued exactly as the detail page's Queue button queues (#1164): title as the entry, the
+    // ticket named so the entry links back, its priority picking the section.
+    await waitFor(() => expect(sendQueueTicket).toHaveBeenCalledTimes(2))
+    expect(sendQueueTicket).toHaveBeenCalledWith('p1', 'First', { file: 'a.md', priority: '7' })
+    expect(sendQueueTicket).toHaveBeenCalledWith('p1', 'Second', { file: 'b.md' })
+    // Started exactly as the queue card's play button starts (#855): the per-entry ask on the
+    // very line the queue write produced, unattended, the ticket named on the agent (#1117).
+    const firstPrompt = workOnEntryPrompt('[First](tickets/a.md)')
     await waitFor(() => expect(sendStart).toHaveBeenCalledTimes(2))
-    expect(sendStart).toHaveBeenCalledWith('p1', alphaPrompt, 'prompt', { unattended: true })
-    expect(sendStart).toHaveBeenCalledWith('p2', 'Work on tickets/c.md. Do not start any other ticket.', 'prompt', {
+    expect(sendStart).toHaveBeenCalledWith('p1', firstPrompt, 'prompt', { unattended: true, ticket: 'tickets/a.md' })
+    expect(sendStart).toHaveBeenCalledWith('p1', workOnEntryPrompt('[Second](tickets/b.md)'), 'prompt', {
       unattended: true,
-      ticket: 'tickets/c.md',
+      ticket: 'tickets/b.md',
     })
     // The shell is pointed at one agent, not bounced through all of them.
     await waitFor(() => expect(onAgentStarted).toHaveBeenCalledTimes(1))
-    expect(onAgentStarted).toHaveBeenCalledWith('p1', alphaPrompt, 'a3')
+    expect(onAgentStarted).toHaveBeenCalledWith('p1', firstPrompt, 'a1')
+  })
+
+  test('a ticket already on the queue is not queued twice — its open entry is worked as it stands', async () => {
+    onAllTickets.mockResolvedValue([
+      {
+        projectId: 'p1',
+        projectName: 'Alpha',
+        tickets: [ticket({ file: 'a.md', title: 'First' }), ticket({ file: 'b.md', title: 'Second' })],
+      },
+    ])
+    // One open entry already links to a.md (with an agent's own note after the link); b.md's
+    // only entry is checked off, so it does not count as queued.
+    onQueue.mockResolvedValue([
+      {
+        projectId: 'p1',
+        projectName: 'Alpha',
+        open: 1,
+        total: 2,
+        items: [
+          { text: '[First](tickets/a.md) — needs the new API', done: false },
+          { text: '[Second](tickets/b.md)', done: true },
+        ],
+      },
+    ])
+    const { sendStart, sendQueueTicket } = await controls()
+    render(<TicketsPage onOpenTicket={() => {}} />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Spin up agents working on all 2 tickets shown below' }))
+    await waitFor(() => expect(sendStart).toHaveBeenCalledTimes(2))
+    // Only the genuinely unqueued ticket is written; the queued one's agent is pointed at the
+    // existing line verbatim, note and all — that is the line it must find to check off.
+    expect(sendQueueTicket).toHaveBeenCalledTimes(1)
+    expect(sendQueueTicket).toHaveBeenCalledWith('p1', 'Second', { file: 'b.md' })
+    expect(sendStart).toHaveBeenCalledWith('p1', workOnEntryPrompt('[First](tickets/a.md) — needs the new API'), 'prompt', {
+      unattended: true,
+      ticket: 'tickets/a.md',
+    })
+  })
+
+  test('claimed tickets are left to the agents holding them, and the label says so', async () => {
+    onAllTickets.mockResolvedValue([
+      {
+        projectId: 'p1',
+        projectName: 'Alpha',
+        tickets: [ticket({ file: 'a.md', title: 'First' }), ticket({ file: 'b.md', title: 'Second', locked: true, lockedBy: 'agent-1' })],
+      },
+    ])
+    const { sendStart, sendQueueTicket } = await controls()
+    render(<TicketsPage onOpenTicket={() => {}} />)
+    // The label counts only what the click will start, never promising the claimed row.
+    fireEvent.click(await screen.findByRole('button', { name: 'Spin up an agent working on the one unclaimed ticket shown below' }))
+    await waitFor(() => expect(sendStart).toHaveBeenCalledTimes(1))
+    expect(sendQueueTicket).toHaveBeenCalledTimes(1)
+    expect(sendQueueTicket).toHaveBeenCalledWith('p1', 'First', { file: 'a.md' })
+    expect(sendStart).toHaveBeenCalledWith('p1', workOnEntryPrompt('[First](tickets/a.md)'), 'prompt', {
+      unattended: true,
+      ticket: 'tickets/a.md',
+    })
   })
 
   test('nothing shown, no button: an empty shown set is not an offer', async () => {
@@ -336,6 +363,15 @@ describe('TicketsPage spin up the shown set', () => {
     window.history.replaceState(null, '', '/tickets?q=zzz-no-match')
     render(<TicketsPage onOpenTicket={() => {}} />)
     await screen.findByText(/1 ticket hidden by the current filters/i)
-    expect(screen.queryByRole('button', { name: /spin up an agent/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /spin up/i })).toBeNull()
+  })
+
+  test('every shown ticket claimed, no button: the whole set is already being worked', async () => {
+    onAllTickets.mockResolvedValue([
+      { projectId: 'p1', projectName: 'Alpha', tickets: [ticket({ file: 'a.md', title: 'First', locked: true })] },
+    ])
+    render(<TicketsPage onOpenTicket={() => {}} />)
+    await screen.findByText('First')
+    expect(screen.queryByRole('button', { name: /spin up/i })).toBeNull()
   })
 })

--- a/packages/framework/dashboard/components/TicketsPage.test.tsx
+++ b/packages/framework/dashboard/components/TicketsPage.test.tsx
@@ -11,7 +11,6 @@ vi.mock('../rpc/reads.js', () => ({ onAllTickets, onTicketsMeta, onQueue }))
 vi.mock('../rpc/control.js', () => ({ sendQueueTicket: vi.fn(), sendStart: vi.fn() }))
 
 const { TicketsPage } = await import('./TicketsPage.js')
-const { workOnEntryPrompt } = await import('./AiQueue.js')
 
 const ticket = (over: Record<string, unknown> = {}) => ({
   file: 't.md',
@@ -257,10 +256,10 @@ describe('TicketsPage grouping (#1144)', () => {
   })
 })
 
-// The page-wide spin-up button: the row's play button lifted to the page's heading — one agent
-// per shown ticket, via the AI queue. Each unclaimed shown ticket is queued (unless an open
-// entry already links to it) and gets its own unattended agent working that one entry.
-describe('TicketsPage spin up the shown set', () => {
+// The page-wide queue-add button: the detail page's Queue action lifted to the page's heading —
+// every unclaimed shown ticket joins the AI queue (unless an open entry already links to it),
+// and no agent starts: the queue's own consumers do that.
+describe('TicketsPage add the shown set to the AI queue', () => {
   const controls = async () => {
     const { sendStart, sendQueueTicket } = await import('../rpc/control.js')
     vi.mocked(sendStart).mockClear().mockResolvedValue({ ok: true, agentId: 'a1' })
@@ -268,7 +267,7 @@ describe('TicketsPage spin up the shown set', () => {
     return { sendStart, sendQueueTicket }
   }
 
-  test('one agent per shown ticket: each is queued and started on its own entry', async () => {
+  test('every shown ticket joins the queue, and the button rests as Queued until the set changes', async () => {
     onAllTickets.mockResolvedValue([
       {
         projectId: 'p1',
@@ -277,29 +276,24 @@ describe('TicketsPage spin up the shown set', () => {
       },
     ])
     const { sendStart, sendQueueTicket } = await controls()
-    const onAgentStarted = vi.fn()
-    render(<TicketsPage onOpenTicket={() => {}} onAgentStarted={onAgentStarted} />)
-    fireEvent.click(await screen.findByRole('button', { name: 'Spin up agents working on all 2 tickets shown below' }))
+    render(<TicketsPage onOpenTicket={() => {}} />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Add all 2 tickets shown below to the AI queue' }))
     // Queued exactly as the detail page's Queue button queues (#1164): title as the entry, the
     // ticket named so the entry links back, its priority picking the section.
     await waitFor(() => expect(sendQueueTicket).toHaveBeenCalledTimes(2))
     expect(sendQueueTicket).toHaveBeenCalledWith('p1', 'First', { file: 'a.md', priority: '7' })
     expect(sendQueueTicket).toHaveBeenCalledWith('p1', 'Second', { file: 'b.md' })
-    // Started exactly as the queue card's play button starts (#855): the per-entry ask on the
-    // very line the queue write produced, unattended, the ticket named on the agent (#1117).
-    const firstPrompt = workOnEntryPrompt('[First](tickets/a.md)')
-    await waitFor(() => expect(sendStart).toHaveBeenCalledTimes(2))
-    expect(sendStart).toHaveBeenCalledWith('p1', firstPrompt, 'prompt', { unattended: true, ticket: 'tickets/a.md' })
-    expect(sendStart).toHaveBeenCalledWith('p1', workOnEntryPrompt('[Second](tickets/b.md)'), 'prompt', {
-      unattended: true,
-      ticket: 'tickets/b.md',
-    })
-    // The shell is pointed at one agent, not bounced through all of them.
-    await waitFor(() => expect(onAgentStarted).toHaveBeenCalledTimes(1))
-    expect(onAgentStarted).toHaveBeenCalledWith('p1', firstPrompt, 'a1')
+    // Queueing is the whole act — the queue's own consumers start agents, not this button.
+    expect(sendStart).not.toHaveBeenCalled()
+    // Done, the button says so and rests for this exact set…
+    const queued = await screen.findByRole('button', { name: 'Queued' })
+    expect((queued as HTMLButtonElement).disabled).toBe(true)
+    // …and narrowing the shown set arms it again, counting the new set.
+    fireEvent.change(screen.getByRole('textbox', { name: /search tickets/i }), { target: { value: 'First' } })
+    expect(await screen.findByRole('button', { name: 'Add the ticket shown below to the AI queue' })).toBeTruthy()
   })
 
-  test('a ticket already on the queue is not queued twice — its open entry is worked as it stands', async () => {
+  test('a ticket already on the queue is not queued twice', async () => {
     onAllTickets.mockResolvedValue([
       {
         projectId: 'p1',
@@ -321,18 +315,13 @@ describe('TicketsPage spin up the shown set', () => {
         ],
       },
     ])
-    const { sendStart, sendQueueTicket } = await controls()
+    const { sendQueueTicket } = await controls()
     render(<TicketsPage onOpenTicket={() => {}} />)
-    fireEvent.click(await screen.findByRole('button', { name: 'Spin up agents working on all 2 tickets shown below' }))
-    await waitFor(() => expect(sendStart).toHaveBeenCalledTimes(2))
-    // Only the genuinely unqueued ticket is written; the queued one's agent is pointed at the
-    // existing line verbatim, note and all — that is the line it must find to check off.
+    fireEvent.click(await screen.findByRole('button', { name: 'Add all 2 tickets shown below to the AI queue' }))
+    // Only the genuinely unqueued ticket is written; a.md's open entry stands as it is.
+    await screen.findByRole('button', { name: 'Queued' })
     expect(sendQueueTicket).toHaveBeenCalledTimes(1)
     expect(sendQueueTicket).toHaveBeenCalledWith('p1', 'Second', { file: 'b.md' })
-    expect(sendStart).toHaveBeenCalledWith('p1', workOnEntryPrompt('[First](tickets/a.md) — needs the new API'), 'prompt', {
-      unattended: true,
-      ticket: 'tickets/a.md',
-    })
   })
 
   test('claimed tickets are left to the agents holding them, and the label says so', async () => {
@@ -343,17 +332,13 @@ describe('TicketsPage spin up the shown set', () => {
         tickets: [ticket({ file: 'a.md', title: 'First' }), ticket({ file: 'b.md', title: 'Second', locked: true, lockedBy: 'agent-1' })],
       },
     ])
-    const { sendStart, sendQueueTicket } = await controls()
+    const { sendQueueTicket } = await controls()
     render(<TicketsPage onOpenTicket={() => {}} />)
-    // The label counts only what the click will start, never promising the claimed row.
-    fireEvent.click(await screen.findByRole('button', { name: 'Spin up an agent working on the one unclaimed ticket shown below' }))
-    await waitFor(() => expect(sendStart).toHaveBeenCalledTimes(1))
+    // The label counts only what the click will add, never promising the claimed row.
+    fireEvent.click(await screen.findByRole('button', { name: 'Add the one unclaimed ticket shown below to the AI queue' }))
+    await screen.findByRole('button', { name: 'Queued' })
     expect(sendQueueTicket).toHaveBeenCalledTimes(1)
     expect(sendQueueTicket).toHaveBeenCalledWith('p1', 'First', { file: 'a.md' })
-    expect(sendStart).toHaveBeenCalledWith('p1', workOnEntryPrompt('[First](tickets/a.md)'), 'prompt', {
-      unattended: true,
-      ticket: 'tickets/a.md',
-    })
   })
 
   test('nothing shown, no button: an empty shown set is not an offer', async () => {
@@ -363,7 +348,7 @@ describe('TicketsPage spin up the shown set', () => {
     window.history.replaceState(null, '', '/tickets?q=zzz-no-match')
     render(<TicketsPage onOpenTicket={() => {}} />)
     await screen.findByText(/1 ticket hidden by the current filters/i)
-    expect(screen.queryByRole('button', { name: /spin up/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /to the ai queue/i })).toBeNull()
   })
 
   test('every shown ticket claimed, no button: the whole set is already being worked', async () => {
@@ -372,6 +357,6 @@ describe('TicketsPage spin up the shown set', () => {
     ])
     render(<TicketsPage onOpenTicket={() => {}} />)
     await screen.findByText('First')
-    expect(screen.queryByRole('button', { name: /spin up/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /to the ai queue/i })).toBeNull()
   })
 })

--- a/packages/framework/dashboard/components/TicketsPage.test.tsx
+++ b/packages/framework/dashboard/components/TicketsPage.test.tsx
@@ -252,3 +252,90 @@ describe('TicketsPage grouping (#1144)', () => {
     await waitFor(() => expect(onAgentStarted).toHaveBeenCalledWith('p2', expect.any(String), 'r9'))
   })
 })
+
+// The page-wide spin-up button: the row's play button lifted to the page's heading — one
+// unattended agent working exactly the shown (filtered) set, one agent per project when the
+// shown set spans several.
+describe('TicketsPage spin up the shown set', () => {
+  test('the header button works the whole shown set: one start, every shown file on the prompt', async () => {
+    onAllTickets.mockResolvedValue([
+      {
+        projectId: 'p1',
+        projectName: 'Alpha',
+        tickets: [ticket({ file: 'a.md', title: 'First' }), ticket({ file: 'b.md', title: 'Second' })],
+      },
+    ])
+    const { sendStart } = await import('../rpc/control.js')
+    vi.mocked(sendStart).mockClear().mockResolvedValue({ ok: true, agentId: 'a1' })
+    const onAgentStarted = vi.fn()
+    render(<TicketsPage onOpenTicket={() => {}} onAgentStarted={onAgentStarted} />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Spin up an agent working on all 2 tickets shown below' }))
+    // The exact ask (#1187), files in the shown order — and no `ticket` on the options: with
+    // several files, no single ticket is "the" one the agent implements.
+    const prompt = 'Work on all of the following tickets:\n- tickets/a.md\n- tickets/b.md\nDo not start any other ticket.'
+    await waitFor(() => expect(sendStart).toHaveBeenCalledWith('p1', prompt, 'prompt', { unattended: true }))
+    expect(sendStart).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(onAgentStarted).toHaveBeenCalledWith('p1', prompt, 'a1'))
+  })
+
+  test('the header button starts only what the filters show — one shown ticket is the row\'s own start', async () => {
+    onAllTickets.mockResolvedValue([
+      {
+        projectId: 'p1',
+        projectName: 'Alpha',
+        tickets: [ticket({ file: 'lock.md', title: 'Improve the lock' }), ticket({ file: 'other.md', title: 'Something else' })],
+      },
+    ])
+    window.history.replaceState(null, '', '/tickets?q=lock')
+    const { sendStart } = await import('../rpc/control.js')
+    vi.mocked(sendStart).mockClear().mockResolvedValue({ ok: true, agentId: 'a2' })
+    render(<TicketsPage onOpenTicket={() => {}} />)
+    // Filtered to one, the label goes singular and the start degrades to the row's exact ask,
+    // `ticket` riding the options as it does there (#1117).
+    fireEvent.click(await screen.findByRole('button', { name: 'Spin up an agent working on the ticket shown below' }))
+    await waitFor(() =>
+      expect(sendStart).toHaveBeenCalledWith('p1', 'Work on tickets/lock.md. Do not start any other ticket.', 'prompt', {
+        unattended: true,
+        ticket: 'tickets/lock.md',
+      }),
+    )
+    expect(sendStart).toHaveBeenCalledTimes(1)
+  })
+
+  test('a shown set spanning projects says so on the label and fans out one agent per project', async () => {
+    onAllTickets.mockResolvedValue([
+      {
+        projectId: 'p1',
+        projectName: 'Alpha',
+        tickets: [ticket({ file: 'a.md', title: 'First' }), ticket({ file: 'b.md', title: 'Second' })],
+      },
+      { projectId: 'p2', projectName: 'Beta', tickets: [ticket({ file: 'c.md', title: 'Third' })] },
+    ])
+    const { sendStart } = await import('../rpc/control.js')
+    vi.mocked(sendStart).mockClear().mockResolvedValue({ ok: true, agentId: 'a3' })
+    const onAgentStarted = vi.fn()
+    render(<TicketsPage onOpenTicket={() => {}} onAgentStarted={onAgentStarted} />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Spin up 2 agents working on all 3 tickets shown below' }))
+    // Each project's agent is told its own shown files, nothing cross-repo.
+    const alphaPrompt = 'Work on all of the following tickets:\n- tickets/a.md\n- tickets/b.md\nDo not start any other ticket.'
+    await waitFor(() => expect(sendStart).toHaveBeenCalledTimes(2))
+    expect(sendStart).toHaveBeenCalledWith('p1', alphaPrompt, 'prompt', { unattended: true })
+    expect(sendStart).toHaveBeenCalledWith('p2', 'Work on tickets/c.md. Do not start any other ticket.', 'prompt', {
+      unattended: true,
+      ticket: 'tickets/c.md',
+    })
+    // The shell is pointed at one agent, not bounced through all of them.
+    await waitFor(() => expect(onAgentStarted).toHaveBeenCalledTimes(1))
+    expect(onAgentStarted).toHaveBeenCalledWith('p1', alphaPrompt, 'a3')
+  })
+
+  test('nothing shown, no button: an empty shown set is not an offer', async () => {
+    onAllTickets.mockResolvedValue([
+      { projectId: 'p1', projectName: 'Alpha', tickets: [ticket({ file: 'a.md', title: 'First' })] },
+    ])
+    window.history.replaceState(null, '', '/tickets?q=zzz-no-match')
+    render(<TicketsPage onOpenTicket={() => {}} />)
+    await screen.findByText(/1 ticket hidden by the current filters/i)
+    expect(screen.queryByRole('button', { name: /spin up an agent/i })).toBeNull()
+  })
+})

--- a/packages/framework/dashboard/components/TicketsPage.tsx
+++ b/packages/framework/dashboard/components/TicketsPage.tsx
@@ -203,7 +203,7 @@ export function TicketsPage({
                 )}
               </TooltipTrigger>
               <TooltipContent>
-                {'Every ticket joins the AI queue — the work the framework picks up on its own — in the shown order, each in its priority section. A ticket already queued stays as it is.'}
+                {'Every ticket joins the AI queue — the work the framework picks up on its own, worked highest priority first and, within a priority, in the order shown below. A ticket already queued stays as it is.'}
                 {claimedShown === 1 && ' The claimed ticket shown is left to the agent holding it.'}
                 {claimedShown > 1 && ` The ${claimedShown} claimed tickets shown are left to the agents holding them.`}
               </TooltipContent>

--- a/packages/framework/dashboard/components/TicketsPage.tsx
+++ b/packages/framework/dashboard/components/TicketsPage.tsx
@@ -1,10 +1,11 @@
 import { useMemo, useState } from 'react'
 import { Play } from 'lucide-react'
-import type { ProjectTickets } from '../../src/index.js'
-import { onAllTickets } from '../rpc/reads.js'
-import { sendStart } from '../rpc/control.js'
+import type { ProjectTickets, WorkspaceTicket } from '../../src/index.js'
+import { onAllTickets, onQueue } from '../rpc/reads.js'
+import { sendQueueTicket, sendStart } from '../rpc/control.js'
 import { usePolled } from '../lib/use-async.js'
 import { useAction } from '../lib/use-action.js'
+import { queueEntryLabel } from '../lib/queue-entry.js'
 import {
   defaultView,
   filterRows,
@@ -19,19 +20,8 @@ import { ScrollArea } from './ui/scroll-area.js'
 import { Button } from './ui/button.js'
 import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip.js'
 import { TicketFilterBar } from './TicketFilterBar.js'
+import { workOnEntryPrompt } from './AiQueue.js'
 import { TicketsPanel, TicketRow, planPrompt, workOnTicketPrompt } from './TicketsPanel.js'
-
-/**
- * The prompt the page-wide spin-up button fires per project: work every one of that project's
- * shown tickets, nothing else. One shown ticket degrades to `workOnTicketPrompt`'s exact
- * sentence — one ask, one wording, however many rows it was made for. Exported so the test
- * asserts the exact ask rather than a copy (#1187).
- */
-export function workOnTicketsPrompt(files: string[]): string {
-  const [only] = files
-  if (only !== undefined && files.length === 1) return workOnTicketPrompt(only)
-  return ['Work on all of the following tickets:', ...files.map(f => `- tickets/${f}`), 'Do not start any other ticket.'].join('\n')
-}
 
 /** Stable initial for the cross-project tickets poll, so it does not churn on every render. */
 const EMPTY_GROUPS: ProjectTickets[] = []
@@ -108,28 +98,45 @@ export function TicketsPage({
     )
     if (result?.ok) onAgentStarted?.(projectId, prompt, result.agentId)
   }
-  // The page-wide spin-up: one unattended agent per project among the shown tickets, each told to
-  // work exactly its project's shown files in the shown order and nothing else. Per project
-  // because an agent runs inside one repo; a batch of one project — the common case, and the only
-  // one the button calls "an agent" — is a single start. A batch of one *file* rides the same
-  // options the row's own start sends, `ticket` included (#1117); with several files no single
-  // ticket is "the" one the agent implements, so the option stays off and the prompt carries them.
-  const startShown = async (batches: { projectId: string; files: string[] }[]) => {
+  // The page-wide spin-up: one agent per shown ticket, via the AI queue. Each ticket is queued
+  // the way the detail page's Queue button queues it (#1164) — unless an open entry already
+  // links to it, which is reused rather than written twice: a duplicate would outlive its
+  // agent's check-off as an open entry naming a closed ticket, and the sweep would spend an
+  // agent on it. The agent itself is the queue card's own per-entry start (#855): unattended,
+  // on that one entry alone, with the ticket named on its meta (#1117). Sequential, stopping at
+  // the first failure — the daemon's own reason lands in `error`, and everything already queued
+  // or started stays.
+  const startShownAgents = async (targets: { projectId: string; ticket: WorkspaceTicket }[]) => {
     const started = await run(async () => {
+      // The open entries already linking to a ticket, first entry per ticket — read at click
+      // time, so the dedupe judges the queue as it is now, not as some poll last saw it.
+      const queuedEntries = new Map<string, string>()
+      for (const q of await onQueue())
+        for (const item of q.items) {
+          if (item.done) continue
+          const file = queueEntryLabel(item.text).ticket
+          if (file && !queuedEntries.has(`${q.projectId}\n${file}`)) queuedEntries.set(`${q.projectId}\n${file}`, item.text)
+        }
       let first: { projectId: string; prompt: string; agentId?: string | undefined } | undefined
-      for (const { projectId, files } of batches) {
-        const prompt = workOnTicketsPrompt(files)
-        const [only] = files
-        const result = await sendStart(projectId, prompt, 'prompt', {
-          unattended: true,
-          ...(only !== undefined && files.length === 1 ? { ticket: `tickets/${only}` } : {}),
-        })
-        // Surfaces the daemon's own reason via useAction; the agents already started stay started.
+      for (const { projectId, ticket } of targets) {
+        let entry = queuedEntries.get(`${projectId}\n${ticket.file}`)
+        if (entry === undefined) {
+          // The exact text sendQueueTicket writes, so the prompt below names the very line the
+          // agent will find on the queue.
+          entry = `[${ticket.title.trim()}](tickets/${ticket.file})`
+          const queued = await sendQueueTicket(projectId, ticket.title, {
+            file: ticket.file,
+            ...(ticket.priority ? { priority: ticket.priority } : {}),
+          })
+          if (!queued.ok) return { ok: false as const, error: queued.error ?? 'The queue could not be written.' }
+        }
+        const prompt = workOnEntryPrompt(entry)
+        const result = await sendStart(projectId, prompt, 'prompt', { unattended: true, ticket: `tickets/${ticket.file}` })
         if (!result.ok) return result
         first ??= { projectId, prompt, agentId: result.agentId }
       }
       return { ok: true as const, first }
-    }, 'The agent could not be started.')
+    }, 'The agents could not be started.')
     if (started?.ok && started.first) onAgentStarted?.(started.first.projectId, started.first.prompt, started.first.agentId)
   }
 
@@ -138,24 +145,21 @@ export function TicketsPage({
   const shownGroups = view.filters.projects.length > 0 ? groups.filter(g => view.filters.projects.includes(g.projectId)) : groups
   const flatRows = sortRows(visible, view.sort)
 
-  // What the spin-up button acts on: one batch per project among the shown rows, files in the
-  // page's own sort order — the set is exactly the tally's "shown", so the button never starts
-  // work on a ticket the reader cannot see below it.
-  const byProject = new Map<string, string[]>()
-  for (const r of flatRows) {
-    const files = byProject.get(r.projectId)
-    if (files) files.push(r.ticket.file)
-    else byProject.set(r.projectId, [r.ticket.file])
-  }
-  const shownBatches = [...byProject].map(([projectId, files]) => ({ projectId, files }))
-  // The label is the spend readout: it says how many agents one click costs, and goes plural the
-  // moment the shown set spans projects — "an agent" only ever promises a single start.
+  // What the spin-up button acts on: the shown rows minus the claimed ones — a ticket some
+  // agent already holds (#1420) is left to the agent holding it, the same rule the daemon's own
+  // fan-out follows. In the shown order, each row carrying its own project, so a cross-project
+  // view needs no special case: every ticket's agent starts where the ticket lives.
+  const targets = flatRows.filter(r => !r.ticket.locked)
+  const claimedShown = flatRows.length - targets.length
+  // The label is the spend readout: one agent per ticket, so it counts the agents one click
+  // costs — and says "unclaimed" the moment the two counts differ, never promising a ticket it
+  // will skip.
   const spinUpLabel =
-    shownBatches.length > 1
-      ? `Spin up ${shownBatches.length} agents working on all ${flatRows.length} tickets shown below`
-      : flatRows.length === 1
-        ? 'Spin up an agent working on the ticket shown below'
-        : `Spin up an agent working on all ${flatRows.length} tickets shown below`
+    targets.length === 1
+      ? `Spin up an agent working on the ${claimedShown > 0 ? 'one unclaimed ' : ''}ticket shown below`
+      : claimedShown > 0
+        ? `Spin up agents working on the ${targets.length} unclaimed tickets shown below`
+        : `Spin up agents working on all ${targets.length} tickets shown below`
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -177,10 +181,11 @@ export function TicketsPage({
               Every project&apos;s <code className="rounded bg-muted px-1">tickets/</code> backlog — what the agent plans from.
             </p>
           </div>
-          {/* The whole shown set as one start: the row's play button lifted to the page. Rendered
-              only over a non-empty shown set — "all 0 tickets" is not an offer, and the list below
-              already explains an empty one. */}
-          {loaded && flatRows.length > 0 && (
+          {/* The whole shown set as agents: the row's play button lifted to the page, one agent
+              per ticket. Rendered only when there is something to start — "all 0 tickets" is not
+              an offer, the list below already explains an empty set, and an all-claimed one is
+              already being worked. */}
+          {loaded && targets.length > 0 && (
             <Tooltip>
               <TooltipTrigger
                 render={
@@ -189,7 +194,7 @@ export function TicketsPage({
                     size="sm"
                     className="shrink-0 gap-1.5"
                     disabled={busy}
-                    onClick={() => void startShown(shownBatches)}
+                    onClick={() => void startShownAgents(targets)}
                   />
                 }
               >
@@ -197,9 +202,9 @@ export function TicketsPage({
                 {busy ? 'Starting…' : spinUpLabel}
               </TooltipTrigger>
               <TooltipContent>
-                {shownBatches.length > 1
-                  ? "An agent works inside one project, so each project's shown tickets get their own unattended agent."
-                  : 'One unattended agent, told to work exactly what the current filters show and start nothing else.'}
+                {'One agent per ticket, via the AI queue: each ticket is queued — unless it already is — and gets its own unattended agent working that one entry.'}
+                {claimedShown === 1 && ' The claimed ticket shown is left to the agent holding it.'}
+                {claimedShown > 1 && ` The ${claimedShown} claimed tickets shown are left to the agents holding them.`}
               </TooltipContent>
             </Tooltip>
           )}

--- a/packages/framework/dashboard/components/TicketsPage.tsx
+++ b/packages/framework/dashboard/components/TicketsPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { Play } from 'lucide-react'
+import { Check, ListPlus } from 'lucide-react'
 import type { ProjectTickets, WorkspaceTicket } from '../../src/index.js'
 import { onAllTickets, onQueue } from '../rpc/reads.js'
 import { sendQueueTicket, sendStart } from '../rpc/control.js'
@@ -20,7 +20,6 @@ import { ScrollArea } from './ui/scroll-area.js'
 import { Button } from './ui/button.js'
 import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip.js'
 import { TicketFilterBar } from './TicketFilterBar.js'
-import { workOnEntryPrompt } from './AiQueue.js'
 import { TicketsPanel, TicketRow, planPrompt, workOnTicketPrompt } from './TicketsPanel.js'
 
 /** Stable initial for the cross-project tickets poll, so it does not churn on every render. */
@@ -98,46 +97,37 @@ export function TicketsPage({
     )
     if (result?.ok) onAgentStarted?.(projectId, prompt, result.agentId)
   }
-  // The page-wide spin-up: one agent per shown ticket, via the AI queue. Each ticket is queued
-  // the way the detail page's Queue button queues it (#1164) — unless an open entry already
-  // links to it, which is reused rather than written twice: a duplicate would outlive its
-  // agent's check-off as an open entry naming a closed ticket, and the sweep would spend an
-  // agent on it. The agent itself is the queue card's own per-entry start (#855): unattended,
-  // on that one entry alone, with the ticket named on its meta (#1117). Sequential, stopping at
-  // the first failure — the daemon's own reason lands in `error`, and everything already queued
-  // or started stays.
-  const startShownAgents = async (targets: { projectId: string; ticket: WorkspaceTicket }[]) => {
-    const started = await run(async () => {
-      // The open entries already linking to a ticket, first entry per ticket — read at click
-      // time, so the dedupe judges the queue as it is now, not as some poll last saw it.
-      const queuedEntries = new Map<string, string>()
+  // The page-wide queue-add: every unclaimed shown ticket joins the AI queue — the work the
+  // framework picks up on its own — queued exactly as the detail page's Queue action queues one
+  // (#1164): title as the entry, linked back to the ticket, its priority picking the section.
+  // Walked in the shown order, so within a priority section entries keep the order the reader
+  // saw. The queue is read at click time, and a ticket an open entry already links to is left
+  // as it stands: "add" means the set ends up queued, and a duplicate entry would outlive its
+  // agent's check-off as an open entry naming a closed ticket, costing the sweep an agent. No
+  // agent starts here — the queue is what the routine drain fans out over (#1204) and what the
+  // queue card's play buttons work one entry at a time (#855). Stops at the first failure; the
+  // daemon's own reason lands in `error`, and everything already queued stays.
+  const [queuedKey, setQueuedKey] = useState<string | null>(null)
+  const queueShownTickets = async (targets: { projectId: string; ticket: WorkspaceTicket }[], key: string) => {
+    const done = await run(async () => {
+      const alreadyQueued = new Set<string>()
       for (const q of await onQueue())
         for (const item of q.items) {
           if (item.done) continue
           const file = queueEntryLabel(item.text).ticket
-          if (file && !queuedEntries.has(`${q.projectId}\n${file}`)) queuedEntries.set(`${q.projectId}\n${file}`, item.text)
+          if (file) alreadyQueued.add(`${q.projectId}\n${file}`)
         }
-      let first: { projectId: string; prompt: string; agentId?: string | undefined } | undefined
       for (const { projectId, ticket } of targets) {
-        let entry = queuedEntries.get(`${projectId}\n${ticket.file}`)
-        if (entry === undefined) {
-          // The exact text sendQueueTicket writes, so the prompt below names the very line the
-          // agent will find on the queue.
-          entry = `[${ticket.title.trim()}](tickets/${ticket.file})`
-          const queued = await sendQueueTicket(projectId, ticket.title, {
-            file: ticket.file,
-            ...(ticket.priority ? { priority: ticket.priority } : {}),
-          })
-          if (!queued.ok) return { ok: false as const, error: queued.error ?? 'The queue could not be written.' }
-        }
-        const prompt = workOnEntryPrompt(entry)
-        const result = await sendStart(projectId, prompt, 'prompt', { unattended: true, ticket: `tickets/${ticket.file}` })
-        if (!result.ok) return result
-        first ??= { projectId, prompt, agentId: result.agentId }
+        if (alreadyQueued.has(`${projectId}\n${ticket.file}`)) continue
+        const queued = await sendQueueTicket(projectId, ticket.title, {
+          file: ticket.file,
+          ...(ticket.priority ? { priority: ticket.priority } : {}),
+        })
+        if (!queued.ok) return { ok: false as const, error: queued.error ?? 'The tickets could not be queued.' }
       }
-      return { ok: true as const, first }
-    }, 'The agents could not be started.')
-    if (started?.ok && started.first) onAgentStarted?.(started.first.projectId, started.first.prompt, started.first.agentId)
+      return { ok: true as const }
+    }, 'The tickets could not be queued.')
+    if (done?.ok) setQueuedKey(key)
   }
 
   // A project deselected in the Project facet disappears entirely — its section would otherwise
@@ -145,21 +135,24 @@ export function TicketsPage({
   const shownGroups = view.filters.projects.length > 0 ? groups.filter(g => view.filters.projects.includes(g.projectId)) : groups
   const flatRows = sortRows(visible, view.sort)
 
-  // What the spin-up button acts on: the shown rows minus the claimed ones — a ticket some
-  // agent already holds (#1420) is left to the agent holding it, the same rule the daemon's own
-  // fan-out follows. In the shown order, each row carrying its own project, so a cross-project
-  // view needs no special case: every ticket's agent starts where the ticket lives.
+  // What the queue-add button acts on: the shown rows minus the claimed ones — a ticket some
+  // agent already holds (#1420) is being worked, and its entry would outlive that work as queue
+  // noise. In the shown order, each row carrying its own project, so a cross-project view needs
+  // no special case: every ticket lands on its own project's queue.
   const targets = flatRows.filter(r => !r.ticket.locked)
   const claimedShown = flatRows.length - targets.length
-  // The label is the spend readout: one agent per ticket, so it counts the agents one click
-  // costs — and says "unclaimed" the moment the two counts differ, never promising a ticket it
-  // will skip.
-  const spinUpLabel =
+  // One flip per shown set: once this exact set is queued the button says so and rests, and any
+  // change to the set — a filter, a poll bringing new tickets — arms it again.
+  const queueKey = targets.map(r => `${r.projectId}/${r.ticket.file}`).join('\n')
+  const queuedShown = queuedKey === queueKey
+  // The label counts what the click adds — and says "unclaimed" the moment the two counts
+  // differ, never promising a ticket it will skip.
+  const queueLabel =
     targets.length === 1
-      ? `Spin up an agent working on the ${claimedShown > 0 ? 'one unclaimed ' : ''}ticket shown below`
+      ? `Add the ${claimedShown > 0 ? 'one unclaimed ' : ''}ticket shown below to the AI queue`
       : claimedShown > 0
-        ? `Spin up agents working on the ${targets.length} unclaimed tickets shown below`
-        : `Spin up agents working on all ${targets.length} tickets shown below`
+        ? `Add the ${targets.length} unclaimed tickets shown below to the AI queue`
+        : `Add all ${targets.length} tickets shown below to the AI queue`
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -181,10 +174,10 @@ export function TicketsPage({
               Every project&apos;s <code className="rounded bg-muted px-1">tickets/</code> backlog — what the agent plans from.
             </p>
           </div>
-          {/* The whole shown set as agents: the row's play button lifted to the page, one agent
-              per ticket. Rendered only when there is something to start — "all 0 tickets" is not
-              an offer, the list below already explains an empty set, and an all-claimed one is
-              already being worked. */}
+          {/* The whole shown set onto the queue: the detail page's Queue action lifted to the
+              page, one entry per ticket. Rendered only when there is something to add — "all 0
+              tickets" is not an offer, the list below already explains an empty set, and an
+              all-claimed one is already being worked. */}
           {loaded && targets.length > 0 && (
             <Tooltip>
               <TooltipTrigger
@@ -193,24 +186,32 @@ export function TicketsPage({
                     variant="outline"
                     size="sm"
                     className="shrink-0 gap-1.5"
-                    disabled={busy}
-                    onClick={() => void startShownAgents(targets)}
+                    disabled={busy || queuedShown}
+                    onClick={() => void queueShownTickets(targets, queueKey)}
                   />
                 }
               >
-                <Play className="h-3.5 w-3.5" aria-hidden />
-                {busy ? 'Starting…' : spinUpLabel}
+                {queuedShown ? (
+                  <>
+                    <Check className="h-3.5 w-3.5" aria-hidden /> Queued
+                  </>
+                ) : (
+                  <>
+                    <ListPlus className="h-3.5 w-3.5" aria-hidden />
+                    {queueLabel}
+                  </>
+                )}
               </TooltipTrigger>
               <TooltipContent>
-                {'One agent per ticket, via the AI queue: each ticket is queued — unless it already is — and gets its own unattended agent working that one entry.'}
+                {'Every ticket joins the AI queue — the work the framework picks up on its own — in the shown order, each in its priority section. A ticket already queued stays as it is.'}
                 {claimedShown === 1 && ' The claimed ticket shown is left to the agent holding it.'}
                 {claimedShown > 1 && ` The ${claimedShown} claimed tickets shown are left to the agents holding them.`}
               </TooltipContent>
             </Tooltip>
           )}
         </div>
-        {/* Page-level start failures land here, above the toolbar, so grouped mode shows them too —
-            the header owns a start of its own now, not just the flat rows'. */}
+        {/* Page-level failures land here, above the toolbar, so grouped mode shows them too — the
+            header owns an action of its own now, not just the flat rows'. */}
         {error && <p className="text-xs text-danger">{error}</p>}
         <TicketFilterBar
           view={view}

--- a/packages/framework/dashboard/components/TicketsPage.tsx
+++ b/packages/framework/dashboard/components/TicketsPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { Play } from 'lucide-react'
 import type { ProjectTickets } from '../../src/index.js'
 import { onAllTickets } from '../rpc/reads.js'
 import { sendStart } from '../rpc/control.js'
@@ -16,8 +17,21 @@ import {
 } from '../lib/ticket-filter.js'
 import { ScrollArea } from './ui/scroll-area.js'
 import { Button } from './ui/button.js'
+import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip.js'
 import { TicketFilterBar } from './TicketFilterBar.js'
 import { TicketsPanel, TicketRow, planPrompt, workOnTicketPrompt } from './TicketsPanel.js'
+
+/**
+ * The prompt the page-wide spin-up button fires per project: work every one of that project's
+ * shown tickets, nothing else. One shown ticket degrades to `workOnTicketPrompt`'s exact
+ * sentence — one ask, one wording, however many rows it was made for. Exported so the test
+ * asserts the exact ask rather than a copy (#1187).
+ */
+export function workOnTicketsPrompt(files: string[]): string {
+  const [only] = files
+  if (only !== undefined && files.length === 1) return workOnTicketPrompt(only)
+  return ['Work on all of the following tickets:', ...files.map(f => `- tickets/${f}`), 'Do not start any other ticket.'].join('\n')
+}
 
 /** Stable initial for the cross-project tickets poll, so it does not churn on every render. */
 const EMPTY_GROUPS: ProjectTickets[] = []
@@ -94,31 +108,105 @@ export function TicketsPage({
     )
     if (result?.ok) onAgentStarted?.(projectId, prompt, result.agentId)
   }
+  // The page-wide spin-up: one unattended agent per project among the shown tickets, each told to
+  // work exactly its project's shown files in the shown order and nothing else. Per project
+  // because an agent runs inside one repo; a batch of one project — the common case, and the only
+  // one the button calls "an agent" — is a single start. A batch of one *file* rides the same
+  // options the row's own start sends, `ticket` included (#1117); with several files no single
+  // ticket is "the" one the agent implements, so the option stays off and the prompt carries them.
+  const startShown = async (batches: { projectId: string; files: string[] }[]) => {
+    const started = await run(async () => {
+      let first: { projectId: string; prompt: string; agentId?: string | undefined } | undefined
+      for (const { projectId, files } of batches) {
+        const prompt = workOnTicketsPrompt(files)
+        const [only] = files
+        const result = await sendStart(projectId, prompt, 'prompt', {
+          unattended: true,
+          ...(only !== undefined && files.length === 1 ? { ticket: `tickets/${only}` } : {}),
+        })
+        // Surfaces the daemon's own reason via useAction; the agents already started stay started.
+        if (!result.ok) return result
+        first ??= { projectId, prompt, agentId: result.agentId }
+      }
+      return { ok: true as const, first }
+    }, 'The agent could not be started.')
+    if (started?.ok && started.first) onAgentStarted?.(started.first.projectId, started.first.prompt, started.first.agentId)
+  }
 
   // A project deselected in the Project facet disappears entirely — its section would otherwise
   // just say "N hidden by filters", which is noise about a choice the reader made on purpose.
   const shownGroups = view.filters.projects.length > 0 ? groups.filter(g => view.filters.projects.includes(g.projectId)) : groups
   const flatRows = sortRows(visible, view.sort)
 
+  // What the spin-up button acts on: one batch per project among the shown rows, files in the
+  // page's own sort order — the set is exactly the tally's "shown", so the button never starts
+  // work on a ticket the reader cannot see below it.
+  const byProject = new Map<string, string[]>()
+  for (const r of flatRows) {
+    const files = byProject.get(r.projectId)
+    if (files) files.push(r.ticket.file)
+    else byProject.set(r.projectId, [r.ticket.file])
+  }
+  const shownBatches = [...byProject].map(([projectId, files]) => ({ projectId, files }))
+  // The label is the spend readout: it says how many agents one click costs, and goes plural the
+  // moment the shown set spans projects — "an agent" only ever promises a single start.
+  const spinUpLabel =
+    shownBatches.length > 1
+      ? `Spin up ${shownBatches.length} agents working on all ${flatRows.length} tickets shown below`
+      : flatRows.length === 1
+        ? 'Spin up an agent working on the ticket shown below'
+        : `Spin up an agent working on all ${flatRows.length} tickets shown below`
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="space-y-2 border-b border-border px-6 py-3">
-        <div>
-          <h1 className="text-base font-semibold">
-            Tickets
-            {/* Shown/total beside the name it counts (#1144 follow-up) — it describes the page's
-                content, not the toolbar's controls. Unfiltered it reads n/n, doubling as the
-                backlog's total, which the page otherwise says nowhere. */}
-            {loaded && rows.length > 0 && (
-              <span className="ml-2 text-xs font-normal text-muted-foreground">
-                {visible.length}/{rows.length}
-              </span>
-            )}
-          </h1>
-          <p className="text-xs text-muted-foreground">
-            Every project&apos;s <code className="rounded bg-muted px-1">tickets/</code> backlog — what the agent plans from.
-          </p>
+        <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
+          <div>
+            <h1 className="text-base font-semibold">
+              Tickets
+              {/* Shown/total beside the name it counts (#1144 follow-up) — it describes the page's
+                  content, not the toolbar's controls. Unfiltered it reads n/n, doubling as the
+                  backlog's total, which the page otherwise says nowhere. */}
+              {loaded && rows.length > 0 && (
+                <span className="ml-2 text-xs font-normal text-muted-foreground">
+                  {visible.length}/{rows.length}
+                </span>
+              )}
+            </h1>
+            <p className="text-xs text-muted-foreground">
+              Every project&apos;s <code className="rounded bg-muted px-1">tickets/</code> backlog — what the agent plans from.
+            </p>
+          </div>
+          {/* The whole shown set as one start: the row's play button lifted to the page. Rendered
+              only over a non-empty shown set — "all 0 tickets" is not an offer, and the list below
+              already explains an empty one. */}
+          {loaded && flatRows.length > 0 && (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="shrink-0 gap-1.5"
+                    disabled={busy}
+                    onClick={() => void startShown(shownBatches)}
+                  />
+                }
+              >
+                <Play className="h-3.5 w-3.5" aria-hidden />
+                {busy ? 'Starting…' : spinUpLabel}
+              </TooltipTrigger>
+              <TooltipContent>
+                {shownBatches.length > 1
+                  ? "An agent works inside one project, so each project's shown tickets get their own unattended agent."
+                  : 'One unattended agent, told to work exactly what the current filters show and start nothing else.'}
+              </TooltipContent>
+            </Tooltip>
+          )}
         </div>
+        {/* Page-level start failures land here, above the toolbar, so grouped mode shows them too —
+            the header owns a start of its own now, not just the flat rows'. */}
+        {error && <p className="text-xs text-danger">{error}</p>}
         <TicketFilterBar
           view={view}
           rows={rows}
@@ -140,7 +228,6 @@ export function TicketsPage({
             // per-project Update bars here — those belong to the sections, and grouped mode is a
             // menu click away.
             <div className="space-y-2">
-              {error && <p className="text-xs text-danger">{error}</p>}
               {filtered && rows.length - visible.length > 0 && (
                 <div className="flex items-center gap-3 text-xs text-muted-foreground">
                   <span>


### PR DESCRIPTION
Adds the button beside the `/tickets` page heading: **"Add all X tickets shown below to the AI queue"**.

## What it does

- Whenever the filters leave at least one unclaimed ticket showing, the heading row offers one button that adds the whole shown set to the AI queue. Each ticket is queued **exactly as the ticket detail page's Queue action queues one** (#1164) — title as the entry, linked back to the ticket, its priority picking the section — walked **in the shown order**, so entries within a priority section keep the order the reader saw. Each ticket lands on its own project's queue, so cross-project views need no special case.
- **No agent starts.** The queue is what the framework already works from: the routine drain fans out over it (#1204) and the AI Queue card's play buttons start one entry at a time (#855). Queueing keeps the click cheap and durable — entries survive anything that interrupts the work, and spend nothing until an agent actually starts.
- **Idempotent per ticket**: a ticket an open queue entry already links to is left as it stands ("add" means the set ends up queued, never queued twice — a duplicate entry would outlive its agent's check-off as an open entry naming a closed ticket, costing the sweep an agent). Checked-off entries don't count as queued.
- **Claimed tickets are skipped** — they're being worked — and the label then counts only the unclaimed tickets, never promising a row it will skip. The tooltip explains the mechanics (shown order, priority sections, already-queued stays) and names how many claimed tickets are left alone.
- After a successful click the button flips to **"Queued"** (the detail page's own post-queue state) and rests; any change to the shown set — a filter, newly arrived tickets — arms it again for the new set. Failures stop the batch and render their reason under the heading in grouped and flat mode alike; everything already queued stays.
- With nothing to add (nothing shown, or everything shown claimed) there is no button.

## Implementation

- Reuses the existing vocabulary end to end: `sendQueueTicket` (the detail page's Queue), `queueEntryLabel` (entry↔ticket linkage), `onQueue` read once at click time for the dedupe; `ListPlus`/`Check` iconography matches the detail page's Queue button.
- Specs updated per SDD: `TicketsPage.SPEC.md` ("Queue the whole shown set" section, TL;DR, user story), `TicketsPage.test.SPEC.md`, and a `FEATURES-SPEC.md` line under "Tickets" beside "Queue a ticket into the AI queue".

## Tests

- 5 tests in `TicketsPage.test.tsx`: every shown ticket queued with title/link/priority, no agent started, button resting as "Queued" and re-arming when the set changes; already-queued tickets not queued twice (done entries don't count); claimed tickets skipped with the label counting only unclaimed; button absent when nothing is shown; button absent when every shown ticket is claimed.
- Full dashboard suite: **83 files / 811 tests pass**; `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vS2EK2vVFJc3oDCtrgShR