### PR TITLE
Fix typo "priortiy" -> "priority" in the TODO_AGENTS.md format prompt

### DIFF
--- a/packages/framework/prompts/todo_format.md
+++ b/packages/framework/prompts/todo_format.md
@@ -24,4 +24,4 @@ To remove an item (e.g. when done), simply remove it from `TODO_AGENTS.md`.
 
 Priority 10 is rarely used (e.g. critical production bugs) and should be treated as utmost priority.
 
-Within a priority, the first tasks have higher priority (they're the "next" tasks within that "priortiy queue").
+Within a priority, the first tasks have higher priority (they're the "next" tasks within that "priority queue").


### PR DESCRIPTION
`packages/framework/prompts/todo_format.md` described the within-priority ordering as the "priortiy queue". Fixed to "priority".

`src/prompts.generated.ts` was regenerated via `node scripts/gen-prompts.mjs` and now carries the corrected text, but it is gitignored (`.gitignore:27`) so it is not part of this commit — it is a build artifact regenerated at build time.

No SPEC.md changes: this is prose inside a prompt, not a feature or behaviour change.

Opened from The Framework session `typo-priortiy-fix`.