### PR TITLE
fix: restore node/vite type resolution under TypeScript 7

### DIFF
--- a/packages/framework/dashboard/tsconfig.json
+++ b/packages/framework/dashboard/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
-    "types": ["node"],
+    "types": ["node", "vite/client"],
     "strict": true,
     "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true,
@@ -15,8 +15,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
-    "allowImportingTsExtensions": true,
-    "baseUrl": "."
+    "allowImportingTsExtensions": true
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules", "dist"]

--- a/packages/the-framework.ai/tsconfig.json
+++ b/packages/the-framework.ai/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
-    "types": ["vike-react"],
+    "types": ["vike-react", "vite/client"],
     "strict": true,
     "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,6 +13,7 @@
     "sourceMap": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   }
 }


### PR DESCRIPTION
## Summary
- Fixes CI failures on #1684 (`chore: typescript@^7.0.2`).
- TypeScript 7 no longer auto-includes `@types/node` the way 5.x did (build failed with `Cannot find name 'process'/'Buffer'/'node:path'` etc. across `src/dashboard/*`), and it now errors (`TS2882`) on side-effect imports — like CSS files — that only resolve through ambient module declarations shipped by `vite/client`.
- Adds explicit `"types": ["node"]` to the shared `tsconfig.base.json`, and `"vite/client"` to the two Vite-based tsconfigs (`packages/framework/dashboard/tsconfig.json`, `packages/the-framework.ai/tsconfig.json`) so `tsc` keeps resolving Node globals and CSS imports.
- Drops `baseUrl` from `packages/framework/dashboard/tsconfig.json` — TS7 removed support for it (`TS5083`), and nothing in the dashboard relies on it (no non-relative imports depend on `baseUrl` resolution).

## Test plan
- [x] `pnpm install`
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm test`

This branch targets `brillout/dev` (the head of #1684) so merging it directly resolves that PR's CI failure.


---
_Generated by [Claude Code](https://claude.ai/code/session_011UonASqBtXeTmPXNmuVHZV)_