### PR TITLE
Fan out over the top of the AI queue: one agent per top entry, count set beside the button (default 3)

### DIFF
--- a/FEATURES-SPEC.md
+++ b/FEATURES-SPEC.md
@@ -23,6 +23,7 @@ happens while nobody is at the keyboard.
 - Pre-flight warnings before spending (no `gh`, logged out, repo can't auto-merge)
 - Start an agent from a ticket row
 - Start an agent from a queue entry's play button
+- Spin up agents on a project's top queue entries — one agent per entry, the how-many set beside the button (default 3)
 - "Run now" on a routine, in a picked project the card remembers across navigations and reloads
 - "Configure first, then run" on a routine — the launcher opens with its prompt, so the model and location can be set first
 - What a routine's "Run now" is about to spend, on hover — what that routine does, how many agents it costs, which model it will use, and where it runs

--- a/packages/framework/dashboard/components/AiQueue.SPEC.md
+++ b/packages/framework/dashboard/components/AiQueue.SPEC.md
@@ -1,9 +1,10 @@
-The Overview's AI Queue card: every project's open agent queue entries — the work The Framework will pick up on its own — grouped by project, with a way to read an entry and a way to start it now.
+The Overview's AI Queue card: every project's open agent queue entries — the work The Framework will pick up on its own — grouped by project, with a way to read an entry, a way to start it now, and a way to start a project's top entries as one batch.
 
 ## User story
 
 - The user wants to see, in one place, what the framework is going to work on next across all their projects.
 - The user does not want to wait for the drain routine and starts one queued entry right now.
+- The user wants several queued entries worked on at once — one agent each — without clicking every entry's play button one by one.
 - The user wants to read the ticket behind a queued entry before deciding anything.
 
 ## Business logic — TL;DR
@@ -12,6 +13,7 @@ The Overview's AI Queue card: every project's open agent queue entries — the w
 - **Reading an entry and starting it are different acts** - the entry's title opens what the entry names; a separate play button starts an agent on it.
 - **Starting one entry runs it exactly as the drain routine would** - one agent, on that entry alone, unattended, so it finishes and hands off instead of parking on the user.
 - **The click follows the agent it started** - the user is taken to the agent, and to the project while its id is not known yet.
+- **Fanning out over the top of the queue** - a button on each project's header starts one agent per top open entry, as many as the count beside it says (three unless changed), and stays on the Overview.
 
 ## Business logic
 
@@ -66,6 +68,28 @@ The user starts one named entry and wants to watch that agent.
 #### Business logic
 
 Once the agent starts, the dashboard goes to that agent — one agent on one named entry is worth watching, unlike the drain routine's fan-out. When the agent's id is not known yet, the dashboard goes to its project and adopts the agent once the poll surfaces it.
+
+### Fanning out over the top of the queue
+
+#### User story
+
+The user wants several queued entries worked on at once — the drain routine's fan-out, but on their own click — without starting each entry by hand.
+
+#### Business logic
+
+Each project's header carries a fan-out button beside a count. Clicking the button starts one agent per open entry, taken from the top of that project's queue, as many as the count says. The count is edited right beside the button, defaults to three, and is kept between one and the same maximum as the routine panel's concurrent-agents setting. With fewer open entries than the count, the batch is just the open entries — the button's label always names the number of agents a click would actually start.
+
+Each agent of the batch is started exactly as the single play button starts one: pinned to its own entry's raw queue line, unattended. The agents are started one after another, and the first failed start ends the batch — the remaining entries are not started, and the failure is reported under the list the same way a single start's is.
+
+While the batch is starting — including between two of its starts — every start button on the card is disabled, and the clicked project's fan-out button shows itself as busy.
+
+Unlike starting a single entry, the dashboard stays on the Overview: the started agents surface in the working-now card beside this one.
+
+#### Rationale
+
+- One agent pinned per named entry, rather than several agents each told to work the queue: agents started together all read the same queue, so each would pick the same first entry and implement it as many times over — the same reason the drain routine pins the entries of its own batch.
+- Starting one after another, ending at the first refusal: whatever refused a start would refuse the next one a moment later.
+- Staying on the Overview: a batch has no single agent to follow.
 
 ## Before modifying/creating SPEC.md files
 

--- a/packages/framework/dashboard/components/AiQueue.test.SPEC.md
+++ b/packages/framework/dashboard/components/AiQueue.test.SPEC.md
@@ -6,7 +6,12 @@ What the tests cover: the Overview's AI Queue card.
 - The play button says what it does on hover.
 - A start that comes back without an agent id still hands over the project, so the dashboard can adopt the agent once the poll surfaces it.
 - A failed start navigates nowhere and shows the refusal instead of swallowing it.
-- While a start is in flight, every play button is disabled.
+- While a start is in flight, every start button — the play buttons and the fan-out button — is disabled.
+- The fan-out button starts one unattended agent per top open entry — three by default, each prompt pinned to its own raw queue line, in queue order, skipping checked-off entries — and navigates nowhere.
+- The count beside the fan-out button sets how many agents the click starts.
+- The fan-out button promises only what is open: with fewer open entries than the count, its label and the batch shrink to the open entries, and a single open entry reads singular.
+- A refused start ends the fan-out batch: the remaining entries are not started.
+- While a fan-out batch is in flight — including between two of its starts — every start button is disabled, until the batch ends.
 - Checked-off entries, and projects with nothing open, are not listed.
 - Loading and empty read as themselves rather than as each other.
 

--- a/packages/framework/dashboard/components/AiQueue.test.tsx
+++ b/packages/framework/dashboard/components/AiQueue.test.tsx
@@ -15,9 +15,10 @@ vi.mock('../lib/use-start-agent.js', () => ({
   useStartAgent: () => ({ busy, error: startError, reset: () => {}, start }),
 }))
 
-const { AiQueue, workOnEntryPrompt } = await import('./AiQueue.js')
+const { AiQueue, workOnEntryPrompt, fanOutLabel, DEFAULT_FAN_OUT_COUNT } = await import('./AiQueue.js')
 
 const RUN_LABEL = 'Spin up an agent working on this entry'
+const COUNT_LABEL = 'How many agents to spin up'
 
 const queue = (items: { text: string; done?: boolean }[], over: Partial<ProjectQueue> = {}): ProjectQueue => {
   const full = items.map(i => ({ text: i.text, done: i.done ?? false }))
@@ -87,8 +88,8 @@ describe('AiQueue', () => {
     )
     const label = screen.getByText('Apply the maintainability preset')
     expect(label.tagName).toBe('SPAN')
-    // The one button on the row is the play button, not the title.
-    expect(screen.getAllByRole('button')).toHaveLength(1)
+    // The row's play button and the header's fan-out button — the title itself is not one.
+    expect(screen.getAllByRole('button')).toHaveLength(2)
   })
 
   test('the play button starts an unattended run on that one entry and selects it (#1191)', async () => {
@@ -159,7 +160,7 @@ describe('AiQueue', () => {
     expect(screen.getByRole('alert').textContent).toMatch(/already active/)
   })
 
-  test('a start already in flight disables every play button', () => {
+  test('a start already in flight disables every play button, the fan-out included', () => {
     busy = true
     render(
       <AiQueue
@@ -169,9 +170,124 @@ describe('AiQueue', () => {
         onAgentStarted={() => {}}
       />,
     )
-    for (const button of screen.getAllByRole('button', { name: RUN_LABEL })) {
+    // Every button in the card starts agents, so every one of them sits out an in-flight start.
+    for (const button of screen.getAllByRole('button')) {
       expect((button as HTMLButtonElement).disabled).toBe(true)
     }
+  })
+
+  test('the fan-out button starts one unattended agent per top open entry, three by default', async () => {
+    const started: unknown[][] = []
+    // A done entry sits second, so "the top three" is provably the top three OPEN entries.
+    render(
+      <AiQueue
+        queue={[queue([{ text: 'one' }, { text: 'skipped', done: true }, { text: 'two' }, { text: 'three' }, { text: 'four' }])]}
+        loading={false}
+        onOpenTicket={() => {}}
+        onAgentStarted={(...args) => started.push(args)}
+      />,
+    )
+    expect(DEFAULT_FAN_OUT_COUNT).toBe(3)
+    fireEvent.click(screen.getByRole('button', { name: fanOutLabel(3) }))
+    await waitFor(() => expect(start).toHaveBeenCalledTimes(3))
+    // Each agent is pinned to its own entry, in queue order — the raw lines, since each agent must
+    // find exactly its entry to check it off.
+    expect(start.mock.calls.map(call => call[1])).toEqual([
+      workOnEntryPrompt('one'),
+      workOnEntryPrompt('two'),
+      workOnEntryPrompt('three'),
+    ])
+    for (const call of start.mock.calls) {
+      expect(call[0]).toBe('p1')
+      expect(call[2]).toBe('prompt')
+      // Unattended (#1279), exactly like the single play button: the batch is drain work.
+      expect(call[3]).toMatchObject({ unattended: true })
+    }
+    // No navigation: a batch is a fan-out, and fan-outs land in the Agents card.
+    expect(started).toHaveLength(0)
+  })
+
+  test('the count beside the button sets how many agents the click starts', async () => {
+    render(
+      <AiQueue
+        queue={[queue([{ text: 'one' }, { text: 'two' }, { text: 'three' }])]}
+        loading={false}
+        onOpenTicket={() => {}}
+        onAgentStarted={() => {}}
+      />,
+    )
+    fireEvent.change(screen.getByRole('spinbutton', { name: COUNT_LABEL }), { target: { value: '2' } })
+    fireEvent.click(screen.getByRole('button', { name: fanOutLabel(2) }))
+    await waitFor(() => expect(start).toHaveBeenCalledTimes(2))
+    expect(start.mock.calls.map(call => call[1])).toEqual([workOnEntryPrompt('one'), workOnEntryPrompt('two')])
+  })
+
+  test('the button promises only what is open: a two-entry queue caps the default three', async () => {
+    render(
+      <AiQueue
+        queue={[queue([{ text: 'one' }, { text: 'two' }])]}
+        loading={false}
+        onOpenTicket={() => {}}
+        onAgentStarted={() => {}}
+      />,
+    )
+    // The label says two, not the count box's three — and a single-entry queue reads singular.
+    fireEvent.click(screen.getByRole('button', { name: fanOutLabel(2) }))
+    await waitFor(() => expect(start).toHaveBeenCalledTimes(2))
+  })
+
+  test('a single open entry makes the fan-out read singular', () => {
+    render(
+      <AiQueue queue={[queue([{ text: 'only' }])]} loading={false} onOpenTicket={() => {}} onAgentStarted={() => {}} />,
+    )
+    expect(fanOutLabel(1)).toBe('Spin up an agent working on the top entry')
+    expect(screen.getByRole('button', { name: fanOutLabel(1) })).toBeTruthy()
+  })
+
+  test('the batch ends at the first refusal', async () => {
+    start.mockReset()
+    start.mockResolvedValueOnce({ ok: true, agentId: 'run-1' }).mockResolvedValueOnce(undefined)
+    render(
+      <AiQueue
+        queue={[queue([{ text: 'one' }, { text: 'two' }, { text: 'three' }])]}
+        loading={false}
+        onOpenTicket={() => {}}
+        onAgentStarted={() => {}}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: fanOutLabel(3) }))
+    await waitFor(() => expect(start).toHaveBeenCalledTimes(2))
+    // Whatever refused the second start is not going to take the third a moment later.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(start).toHaveBeenCalledTimes(2)
+  })
+
+  test('a fan-out in flight disables every start button until the batch ends', async () => {
+    const releases: Array<(value: unknown) => void> = []
+    start.mockReset()
+    start.mockImplementation(() => new Promise(resolve => releases.push(resolve)))
+    render(
+      <AiQueue
+        queue={[queue([{ text: 'one' }, { text: 'two' }])]}
+        loading={false}
+        onOpenTicket={() => {}}
+        onAgentStarted={() => {}}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: fanOutLabel(2) }))
+    await waitFor(() => expect(start).toHaveBeenCalledTimes(1))
+    // Mid-batch — `busy` is false between two starts, so this pins the batch's own guard.
+    for (const button of screen.getAllByRole('button')) {
+      expect((button as HTMLButtonElement).disabled).toBe(true)
+    }
+    releases[0]!({ ok: true, agentId: 'run-1' })
+    await waitFor(() => expect(start).toHaveBeenCalledTimes(2))
+    releases[1]!({ ok: true, agentId: 'run-2' })
+    await waitFor(() => {
+      for (const button of screen.getAllByRole('button')) {
+        expect((button as HTMLButtonElement).disabled).toBe(false)
+      }
+    })
   })
 
   test('done entries and projects with nothing open are not shown', () => {

--- a/packages/framework/dashboard/components/AiQueue.tsx
+++ b/packages/framework/dashboard/components/AiQueue.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import type { ProjectQueue } from '../../src/index.js'
-import { agentOptionsFromPreferences } from '../../src/client.js'
-import { ListTodo, Loader2, Play } from 'lucide-react'
+import { agentOptionsFromPreferences, MAX_AUTO_PM_CONCURRENCY } from '../../src/client.js'
+import { FastForward, ListTodo, Loader2, Play } from 'lucide-react'
 import { queueEntryLabel } from '../lib/queue-entry.js'
 import { usePreferences } from '../lib/preferences.js'
 import { useStartAgent } from '../lib/use-start-agent.js'
@@ -18,7 +18,9 @@ import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip.js'
 // (#1144) — reading the plan, not starting it. The play button STARTS it: one agent, on that entry
 // alone, the same work the drain sweep would get to (#855) but on your click. The project header
 // stays a header — a project name that jumped to the launcher was the odd redirect #1139 called
-// out, and that is still true.
+// out, and that is still true — but it carries the project's batch act: a fan-out button that
+// starts one agent per top entry, as many as the count beside it says, each pinned to its own
+// entry the way the sweep pins a drain batch (#1204).
 //
 // Its own file rather than inline in DashboardPage, like every other card on the Overview:
 // DashboardPage has no test file, and opening tickets and starting runs are behaviour worth pinning.
@@ -32,6 +34,20 @@ import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip.js'
  */
 export function workOnEntryPrompt(entry: string): string {
   return `Open TODO_AGENTS.md and work on this one open entry only, then check it off. Do not start any other entry. The entry:\n\n${entry}`
+}
+
+/** How many agents the fan-out button starts until its count says otherwise. */
+export const DEFAULT_FAN_OUT_COUNT = 3
+
+/**
+ * What the fan-out button promises, sized to what a click would actually start: the count beside
+ * the button, capped at the entries the project has open. Exported so the tests assert against
+ * this and not a copy.
+ */
+export function fanOutLabel(count: number): string {
+  return count === 1
+    ? 'Spin up an agent working on the top entry'
+    : `Spin up ${count} agents working on the top ${count} entries`
 }
 
 export function AiQueue({
@@ -55,9 +71,18 @@ export function AiQueue({
   // Which entry is in flight, keyed by content rather than index: the list is polled and can
   // shift under a click, and only the clicked row's button should spin.
   const [starting, setStarting] = useState<string | null>(null)
+  // Which project's fan-out is in flight. Its own flag rather than `busy`, because the batch is a
+  // sequence of starts and `busy` drops between two of them — a gap a second click could slip into.
+  const [fanningOut, setFanningOut] = useState<string | null>(null)
+  // The count beside each project's fan-out button. Per project, since queues differ in depth;
+  // plain component state, since it parameterizes the next click rather than recording a setting.
+  const [fanOutCounts, setFanOutCounts] = useState<Record<string, number>>({})
+  const inFlight = busy || fanningOut !== null
+
+  const fanOutCount = (projectId: string) => fanOutCounts[projectId] ?? DEFAULT_FAN_OUT_COUNT
 
   const agentEntry = async (projectId: string, entry: string) => {
-    if (busy) return
+    if (inFlight) return
     const key = `${projectId}\n${entry}`
     const prompt = workOnEntryPrompt(entry)
     setStarting(key)
@@ -70,6 +95,28 @@ export function AiQueue({
     // sweep's fan-out, which lands in the Agents card. With no id yet the shell lands on the
     // project and adopts the running agent once the poll surfaces it.
     if (result) onAgentStarted(projectId, prompt, result.agentId)
+  }
+
+  const fanOutProject = async (project: ProjectQueue) => {
+    if (inFlight) return
+    // The top of the queue, one agent per entry: the same order the drain sweep picks in, and each
+    // prompt pinned to its own entry for the same reason the sweep pins a batch (#1204) — several
+    // agents told "the first open entry" would all implement the same one.
+    const entries = project.items
+      .filter(item => !item.done)
+      .slice(0, fanOutCount(project.projectId))
+      .map(item => item.text)
+    setFanningOut(project.projectId)
+    for (const entry of entries) {
+      // One after another, the way the sweep spawns its batch: each start allocates a worktree and
+      // an id of its own. The batch ends at the first refusal — whatever refused this start is not
+      // going to take the next one a moment later, and the refusal stays on screen under the list.
+      const result = await start(project.projectId, workOnEntryPrompt(entry), 'prompt', { ...agentOptionsFromPreferences(preferences), unattended: true })
+      if (!result) break
+    }
+    setFanningOut(null)
+    // No navigation, unlike the single play button (#1191): a batch is the sweep's fan-out fired
+    // by hand, and it lands in the Agents card sitting right above this one.
   }
 
   const withOpen = queue.filter(q => q.open > 0)
@@ -94,6 +141,59 @@ export function AiQueue({
                 <div className="flex w-full items-center gap-2">
                   <span className="truncate text-sm font-medium">{q.projectName}</span>
                   <span className="ml-auto shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs tabular-nums text-muted-foreground">{q.open}</span>
+                  {/* The project's batch act: how many, then the button the count qualifies. */}
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <input
+                          type="number"
+                          min={1}
+                          max={MAX_AUTO_PM_CONCURRENCY}
+                          step={1}
+                          value={fanOutCount(q.projectId)}
+                          aria-label="How many agents to spin up"
+                          onChange={event => {
+                            // Clamped like the routine panel's concurrency box: a number input
+                            // still hands back whatever was typed, and an emptied box is mid-edit
+                            // rather than a count — `Number('')` is 0, and the clamp would turn a
+                            // cleared field into a saved 1.
+                            const typed = event.target.value.trim()
+                            if (!typed) return
+                            const next = Math.round(Number(typed))
+                            if (!Number.isFinite(next)) return
+                            setFanOutCounts(counts => ({
+                              ...counts,
+                              [q.projectId]: Math.min(Math.max(next, 1), MAX_AUTO_PM_CONCURRENCY),
+                            }))
+                          }}
+                          className="h-7 w-11 shrink-0 rounded border border-border bg-background px-1 text-center text-xs tabular-nums text-foreground"
+                        />
+                      }
+                    />
+                    <TooltipContent>How many agents to spin up — one per entry, from the top of the queue.</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-sm"
+                          aria-label={fanOutLabel(Math.min(fanOutCount(q.projectId), q.open))}
+                          disabled={inFlight}
+                          onClick={() => void fanOutProject(q)}
+                          className="shrink-0 text-muted-foreground hover:text-foreground"
+                        />
+                      }
+                    >
+                      {fanningOut === q.projectId ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+                      ) : (
+                        <FastForward className="h-3.5 w-3.5" aria-hidden />
+                      )}
+                    </TooltipTrigger>
+                    <TooltipContent>{fanOutLabel(Math.min(fanOutCount(q.projectId), q.open))}</TooltipContent>
+                  </Tooltip>
                 </div>
                 <ul className="mt-1.5 space-y-1 pl-0.5">
                   {q.items
@@ -141,7 +241,7 @@ export function AiQueue({
                                   variant="ghost"
                                   size="icon-sm"
                                   aria-label="Spin up an agent working on this entry"
-                                  disabled={busy}
+                                  disabled={inFlight}
                                   onClick={() => void agentEntry(q.projectId, item.text)}
                                   className="shrink-0 text-muted-foreground hover:text-foreground"
                                 />


### PR DESCRIPTION
Adds the requested button to spin up X agents working on the top X queue entries — one agent per entry — with X set by the user and defaulting to 3.

## What it does

Each project header in the Overview's **AI Queue** card now carries, beside the open-entries badge:

- a **count box** (default **3**, clamped to 1…`MAX_AUTO_PM_CONCURRENCY`, the same bound as the routine panel's concurrent-agents setting), and
- a **fan-out button** (fast-forward icon) that starts one unattended agent per top open entry, as many as the count says.

Behavior details:

- **One agent pinned per entry.** Each agent gets the existing `workOnEntryPrompt(entry)` — the raw queue line, not the tidied title — for the same reason the drain sweep pins its batch (#1204): several agents told to work "the first open entry" would all implement the same one.
- **Runs exactly like the single play button** (#1279): unattended, with the user's agent preferences, so gates auto-answer and the armed handoff fires.
- **Sequential starts, first refusal ends the batch** — mirroring the auto-PM sweep's own batch loop; the refusal is shown under the list like a single start's.
- **Honest label.** The button's label/tooltip names what a click would actually start: capped at the open entries (`min(X, open)`), singular wording for one.
- **No navigation**, unlike the single play button (#1191): a batch has no single agent to follow; the started agents surface in the Agents card right above.
- Every start button in the card is disabled while a batch is in flight — including between two of its sequential starts, where the shared `busy` flag briefly drops.

## Spec updates (SDD)

- `AiQueue.SPEC.md`: new "Fanning out over the top of the queue" section + TL;DR/user-story entries.
- `AiQueue.test.SPEC.md`: coverage lines for the new tests.
- `FEATURES-SPEC.md`: feature line under "Starting work" (feature explicitly requested, which I've taken as the human approval the file requires).

## Tests

7 new tests in `AiQueue.test.tsx` (default of 3 skipping done entries, count box driving the batch size, cap at open entries, singular label, stop at first refusal, disabled-while-in-flight incl. mid-batch, no navigation); one existing test updated for the second header button. Dashboard suite: 84 files / 827 tests green; `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rbYrkf4V76bEszetYStXE

---
_Generated by [Claude Code](https://claude.ai/code/session_014rbYrkf4V76bEszetYStXE)_