### PR TITLE
RoutineWork test: open the run menu by clicking until it opens

### DIFF
--- a/packages/framework/dashboard/components/RoutineWork.test.tsx
+++ b/packages/framework/dashboard/components/RoutineWork.test.tsx
@@ -213,8 +213,17 @@ describe('RoutineWork (#1159)', () => {
 
   /** Open one row's secondary half — the chevron beside its Run now. */
   const openRunMenu = async (job: AutoPmJob) => {
-    await waitFor(() => expect(screen.getAllByText('Run now').length).toBe(AUTO_PM_ROUTINES.length))
-    fireEvent.click(screen.getByRole('button', { name: `Other ways to run ${routineName(job)}` }))
+    const trigger = await screen.findByRole('button', { name: `Other ways to run ${routineName(job)}` })
+    // Clicked until the trigger reports open, rather than once and hoped: the menu is a Base UI
+    // one, and a click landing before its own handlers are live is silently a no-op — the row
+    // stays at `aria-expanded="false"` and the search below then hunts for an item that was never
+    // rendered. Rare enough to pass locally every time and still fail on a loaded CI runner.
+    // Retrying is safe because the guard only ever clicks a shut menu, so it cannot toggle one
+    // back closed; a menu that genuinely will not open still fails here, on the timeout.
+    await waitFor(() => {
+      if (trigger.getAttribute('aria-expanded') !== 'true') fireEvent.click(trigger)
+      expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    })
     return await screen.findByText('Configure first, then run')
   }
 


### PR DESCRIPTION
Fixes a flaky test that failed on CI in #1698 and is unrelated to that PR's diff.

## The failure

```
TestingLibraryElementError: Unable to find an element with the text: Configure first, then run
 ❯ openRunMenu components/RoutineWork.test.tsx:218:25
```

The dumped DOM shows the row's chevron still at `aria-expanded="false"` — the menu never opened, so the item the helper then looked for had never been rendered.

## Why

`openRunMenu` clicked the trigger once and went straight on:

```js
await waitFor(() => expect(screen.getAllByText('Run now').length).toBe(AUTO_PM_ROUTINES.length))
fireEvent.click(screen.getByRole('button', { name: `Other ways to run ${routineName(job)}` }))
return await screen.findByText('Configure first, then run')
```

The `waitFor` only proves the rows rendered — not that the menu's own handlers are live. The menu is a Base UI `Menu.Trigger`, and a click landing before it is wired is silently a no-op. Nothing retries, so the helper is left waiting on an item that will never appear. Rare enough to pass locally every time and still lose the coin flip on a loaded CI runner.

## The change

Wait for the trigger, click only while it is shut, and don't go on until it reports open. The guard makes retrying safe — it never clicks an already-open menu, so it cannot toggle one back closed — and a menu that genuinely will not open still fails, on the timeout, rather than going green.

## Verification

Reproduced the race by dropping the first `click` dispatched at the trigger:

- old helper under that simulation → fails with the exact CI error
- new helper under the same simulation → 43/43 pass

Plus the ordinary runs: `RoutineWork.test.tsx` 43/43, the full dashboard suite 84 files / 837 tests green twice over, and `pnpm typecheck` clean.

Test-only change; no production code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSWSBVmtSH4RgA4w1tuKGq)_