### PR TITLE
The folder picker opens on Linux and Windows too, not only macOS (#1150)

### DIFF
--- a/packages/framework/dashboard/components/AddProjectPanel.SPEC.md
+++ b/packages/framework/dashboard/components/AddProjectPanel.SPEC.md
@@ -16,7 +16,7 @@ The user has a repo on this machine that they want The Framework to work on, and
 
 #### Business logic
 
-Opening the dialog immediately asks the daemon to open the OS folder picker; the modal meanwhile says to choose the folder there. Picking a folder moves to the trust confirmation. Dismissing the system picker closes the modal — the user already said "not now". If the picker itself cannot open (for example on a platform where none is wired up), the reason is shown with the option to try again. Esc, Cancel, and clicking outside the modal close it without adding; keyboard focus stays inside the modal and returns to the control that opened it once it closes.
+Opening the dialog immediately asks the daemon to open the OS folder picker; the modal meanwhile says to choose the folder there. Picking a folder moves to the trust confirmation. Dismissing the system picker closes the modal — the user already said "not now". If the picker itself cannot open (for example on a machine with no desktop session), the reason is shown with the option to try again. Esc, Cancel, and clicking outside the modal close it without adding; keyboard focus stays inside the modal and returns to the control that opened it once it closes.
 
 ### Trust gate before installing
 

--- a/packages/framework/dashboard/components/AddProjectPanel.test.tsx
+++ b/packages/framework/dashboard/components/AddProjectPanel.test.tsx
@@ -45,10 +45,10 @@ describe('AddProjectPanel (#1150)', () => {
   })
 
   test('a dialog that could not be opened reports why, and Try again asks again', async () => {
-    sendPickProjectDirectory.mockResolvedValueOnce({ ok: false, error: 'The system folder picker is only available on macOS so far.' })
+    sendPickProjectDirectory.mockResolvedValueOnce({ ok: false, error: 'The machine running The Framework has no desktop session, so no folder dialog can open there.' })
     sendPickProjectDirectory.mockResolvedValueOnce({ ok: true, path: '/Users/dev/my-repo' })
     render(<AddProjectPanel onAdded={() => {}} onClose={() => {}} />)
-    await screen.findByText(/only available on macOS/)
+    await screen.findByText(/no desktop session/)
     fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
     await screen.findByText('/Users/dev/my-repo')
   })

--- a/packages/framework/src/dashboard-rpc/projects.SPEC.md
+++ b/packages/framework/src/dashboard-rpc/projects.SPEC.md
@@ -38,7 +38,7 @@ The user should pick the repo's folder the way they pick any folder on their mac
 
 #### Business logic
 
-The dashboard asks the daemon to open the OS folder picker; the daemon runs on the machine the user is sitting at, so the dialog appears there, and the picked absolute path is handed back. Dismissing the dialog is a normal answer of its own, distinct from a failure. On a platform where no picker is wired up (only macOS is, so far), the answer says so instead of trying.
+The dashboard asks the daemon to open the OS folder picker; the daemon runs on the machine the user is sitting at, so the dialog appears there, and the picked absolute path is handed back. Dismissing the dialog is a normal answer of its own, distinct from a failure. A dialog that cannot open — no desktop session on the daemon's machine, no dialog helper installed on Linux, or a platform with no dialog wired up — comes back as that reason instead of being attempted.
 
 #### Rationale
 

--- a/packages/framework/src/pick-directory.SPEC.md
+++ b/packages/framework/src/pick-directory.SPEC.md
@@ -2,13 +2,55 @@ The system folder picker behind the dashboard's "Add project": the daemon opens 
 
 ## Business logic — TL;DR
 
-- **The dialog is the OS's** - on macOS the standard folder sheet opens, and the picked folder comes back as its absolute path, without the trailing slash the OS reports it with.
+- **The dialog is the OS's** - macOS, Linux and Windows each get their own desktop's standard folder dialog, and the picked folder comes back as its absolute path, without the trailing slash macOS reports it with.
 - **Dismissing is not an error** - a user who cancels the dialog gets a "nothing picked" answer, distinct from a dialog that failed to open, whose reason is reported.
-- **Unwired platforms say so** - only macOS has a picker wired up so far; anywhere else the answer is that plainly, and nothing is attempted.
+- **A dialog that cannot open says why** - a machine with no desktop session, a Linux machine without either dialog helper installed, and a platform with no dialog wired up each report that reason instead of attempting anything.
+
+## Business logic
+
+### The dialog is the OS's
+
+#### User story
+
+The user has a repo on this machine that they want The Framework to work on, and expects to point at it the way they point at any folder — in the dialog their own desktop uses.
+
+#### Business logic
+
+Each platform opens the folder dialog its desktop ships with: the standard folder sheet on macOS, the desktop's dialog helper on Linux, and the folder browser that comes with Windows. Linux has two such helpers in circulation — the GTK one used by GNOME-style desktops and the KDE one — so the GTK helper is asked first and the KDE one is used when it is not installed. Both Linux dialogs open in the user's home directory, since a repo is nearly always kept there.
+
+The answer is the picked folder's absolute path. macOS reports it with a trailing slash, which is dropped, because the project registry stores paths without one.
+
+### Dismissing is not an error
+
+#### User story
+
+A user who opens the dialog and changes their mind has said "not now", which is an answer, not a fault.
+
+#### Business logic
+
+A cancelled dialog comes back as "nothing picked", which the dashboard treats as closing the add-project flow rather than as something to report or retry. Each platform's dialog signals a cancellation its own way, and each is recognised: macOS reports it as AppleScript's "user cancelled", both Linux helpers as their documented cancel exit, and the Windows dialog through an outcome the script reserves for it, so that PowerShell failing on its own is still read as a failure.
+
+### A dialog that cannot open says why
+
+#### User story
+
+When no dialog appears, the user needs to know what would make one appear, rather than watching the dashboard wait on nothing.
+
+#### Business logic
+
+Three situations are answered with their reason and nothing is spawned or retried:
+
+- The machine running The Framework has no desktop session — a daemon started over SSH or inside a container has no screen to draw a dialog on. This is checked before asking for a dialog on Linux.
+- Neither Linux dialog helper is installed, in which case the answer names both, so the user knows what to install.
+- The platform has no dialog wired up at all, in which case the answer names that platform.
+
+Any other failure reports whatever the dialog itself said went wrong.
 
 ## Rationales
 
 A browser page cannot learn the absolute path of anything the user picks in a dialog of its own — that is deliberate browser sandboxing — while the daemon runs on the machine the user is sitting at and can both show the dialog and read the answer.
+
+The dialogs are the desktop programs already installed on the machine, driven as commands, rather than a library: the one Node package for this is unmaintained and ships prebuilt binaries, and each platform's dialog is a single command away.
 
 ## Before modifying/creating SPEC.md files
 

--- a/packages/framework/src/pick-directory.test.SPEC.md
+++ b/packages/framework/src/pick-directory.test.SPEC.md
@@ -1,9 +1,14 @@
-What the tests cover: asking the OS for a folder without ever opening a real dialog.
+What the tests cover: asking each OS for a folder without ever opening a real dialog.
 
-- A picked folder comes back as its absolute path with the OS's trailing slash dropped, and the dialog asked for is the OS's own (macOS's standard folder sheet).
-- Dismissing the dialog is a normal "nothing picked" answer, not an error.
+- On macOS a picked folder comes back as its absolute path with the OS's trailing slash dropped, and the dialog asked for is the standard folder sheet.
+- On Linux the GTK dialog helper is asked first; when it is not installed the KDE one is asked instead, and a Wayland session counts as a desktop session just as an X11 one does.
+- On Windows the folder browser that ships with the OS is what opens, and the path it prints comes back with its line ending dropped.
+- Dismissing the dialog is a normal "nothing picked" answer on every platform, not an error.
+- On Windows a PowerShell failure is still reported as a failure, rather than mistaken for a dismissal.
 - A dialog that failed to open surfaces its reason.
-- A platform with no wired picker answers so directly, without attempting to open anything.
+- A Linux machine with neither dialog helper installed answers by naming both, without attempting to open anything.
+- A Linux daemon with no desktop session answers so directly, without attempting to open anything.
+- A platform with no wired dialog answers so by name, without attempting to open anything.
 
 ## Before modifying/creating SPEC.md files
 

--- a/packages/framework/src/pick-directory.test.ts
+++ b/packages/framework/src/pick-directory.test.ts
@@ -2,36 +2,95 @@ import { strict as assert } from 'node:assert'
 import { test } from 'node:test'
 import { pickDirectory, type DialogRunner } from './pick-directory.js'
 
-const runner = (result: { code: number; stdout?: string; stderr?: string }, calls?: string[][]): DialogRunner => {
+type Exit = { code: number; stdout?: string; stderr?: string }
+
+/** Answers each dialog command from `results`; anything not listed there is not installed (exit 127). */
+const runner = (results: Record<string, Exit>, calls?: string[][]): DialogRunner => {
   return (command, args) => {
     calls?.push([command, ...args])
+    const result = results[command] ?? { code: 127 }
     return Promise.resolve({ code: result.code, stdout: result.stdout ?? '', stderr: result.stderr ?? '' })
   }
 }
 
+const nothingSpawns: DialogRunner = () => {
+  throw new Error('must not spawn anything')
+}
+
+const error = (result: Awaited<ReturnType<typeof pickDirectory>>) => (result.ok ? '' : result.error)
+
 test('a picked folder comes back as its POSIX path, trailing slash dropped (#1150)', async () => {
   const calls: string[][] = []
-  const picked = await pickDirectory('darwin', runner({ code: 0, stdout: '/Users/dev/my-repo/\n' }, calls))
+  const picked = await pickDirectory('darwin', runner({ osascript: { code: 0, stdout: '/Users/dev/my-repo/\n' } }, calls))
   assert.deepEqual(picked, { ok: true, path: '/Users/dev/my-repo' })
   assert.equal(calls[0]?.[0], 'osascript', 'the dialog is the OS one, via osascript')
   assert.match(calls[0]?.[2] ?? '', /choose folder/, 'osascript renders the standard folder sheet')
 })
 
 test('dismissing the dialog is a normal outcome, not an error', async () => {
-  const picked = await pickDirectory('darwin', runner({ code: 1, stderr: 'execution error: User canceled. (-128)' }))
+  const picked = await pickDirectory('darwin', runner({ osascript: { code: 1, stderr: 'execution error: User canceled. (-128)' } }))
   assert.deepEqual(picked, { ok: true, path: null })
 })
 
 test('a dialog failure surfaces its reason', async () => {
-  const picked = await pickDirectory('darwin', runner({ code: 1, stderr: 'osascript: no display' }))
+  const picked = await pickDirectory('darwin', runner({ osascript: { code: 1, stderr: 'osascript: no display' } }))
   assert.deepEqual(picked, { ok: false, error: 'osascript: no display' })
 })
 
-test('a platform without a wired picker says so instead of trying', async () => {
-  const run: DialogRunner = () => {
-    throw new Error('must not spawn anything')
-  }
-  const picked = await pickDirectory('linux', run)
+test('on Linux the GTK helper renders the dialog', async () => {
+  const calls: string[][] = []
+  const picked = await pickDirectory('linux', runner({ zenity: { code: 0, stdout: '/home/dev/my-repo\n' } }, calls), { DISPLAY: ':0', HOME: '/home/dev' })
+  assert.deepEqual(picked, { ok: true, path: '/home/dev/my-repo' })
+  assert.equal(calls[0]?.[0], 'zenity')
+  assert.ok(calls[0]?.includes('--directory'), 'a folder is asked for, not a file')
+})
+
+test('on Linux without the GTK helper the KDE one is asked instead', async () => {
+  const calls: string[][] = []
+  // A Wayland session counts as a desktop session too, not only X11's DISPLAY.
+  const picked = await pickDirectory('linux', runner({ kdialog: { code: 0, stdout: '/home/dev/my-repo\n' } }, calls), { WAYLAND_DISPLAY: 'wayland-0', HOME: '/home/dev' })
+  assert.deepEqual(picked, { ok: true, path: '/home/dev/my-repo' })
+  assert.deepEqual(calls.map(call => call[0]), ['zenity', 'kdialog'], 'the GTK helper is tried first, the KDE one after')
+  assert.ok(calls[1]?.includes('--getexistingdirectory'), 'a folder is asked for, not a file')
+})
+
+test('on Linux a dismissed dialog is a normal outcome, not an error', async () => {
+  const picked = await pickDirectory('linux', runner({ zenity: { code: 1 } }), { DISPLAY: ':0', HOME: '/home/dev' })
+  assert.deepEqual(picked, { ok: true, path: null })
+})
+
+test('on Linux with neither helper installed, the answer names what is missing', async () => {
+  const picked = await pickDirectory('linux', runner({}), { DISPLAY: ':0', HOME: '/home/dev' })
   assert.equal(picked.ok, false)
-  assert.match((picked as { error: string }).error, /macOS/)
+  assert.match(error(picked), /zenity or kdialog/)
+})
+
+test('a Linux daemon with no desktop session says so instead of trying', async () => {
+  const picked = await pickDirectory('linux', nothingSpawns, { HOME: '/home/dev' })
+  assert.equal(picked.ok, false)
+  assert.match(error(picked), /no desktop session/)
+})
+
+test('on Windows PowerShell renders the folder browser', async () => {
+  const calls: string[][] = []
+  const picked = await pickDirectory('win32', runner({ 'powershell.exe': { code: 0, stdout: 'C:\\Users\\dev\\my-repo\r\n' } }, calls))
+  assert.deepEqual(picked, { ok: true, path: 'C:\\Users\\dev\\my-repo' })
+  assert.equal(calls[0]?.[0], 'powershell.exe')
+  assert.match(calls[0]?.at(-1) ?? '', /FolderBrowserDialog/, 'the OS\'s own folder browser, not a prompt')
+})
+
+test('on Windows a dismissed dialog is a normal outcome, not an error', async () => {
+  const picked = await pickDirectory('win32', runner({ 'powershell.exe': { code: 2 } }))
+  assert.deepEqual(picked, { ok: true, path: null })
+})
+
+test('on Windows a PowerShell failure stays a failure, unlike a dismissal', async () => {
+  const picked = await pickDirectory('win32', runner({ 'powershell.exe': { code: 1, stderr: 'Add-Type : Cannot load System.Windows.Forms' } }))
+  assert.deepEqual(picked, { ok: false, error: 'Add-Type : Cannot load System.Windows.Forms' })
+})
+
+test('a platform without a wired picker says so instead of trying', async () => {
+  const picked = await pickDirectory('freebsd', nothingSpawns)
+  assert.equal(picked.ok, false)
+  assert.match(error(picked), /not available on freebsd/)
 })

--- a/packages/framework/src/pick-directory.ts
+++ b/packages/framework/src/pick-directory.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'node:child_process'
+import { execFile, type ExecFileException } from 'node:child_process'
 
 /**
  * The system folder picker behind the dashboard's "Add project" (#1150): the daemon opens the
@@ -11,32 +11,120 @@ export type PickDirectoryResult =
   | { ok: true; path: string | null }
   | { ok: false; error: string }
 
+/** What a dialog command left behind when it exited. */
+export type DialogRun = { code: number; stdout: string; stderr: string }
+
 /** Injectable seam so tests never open a real dialog. */
-export type DialogRunner = (command: string, args: string[]) => Promise<{ code: number; stdout: string; stderr: string }>
+export type DialogRunner = (command: string, args: string[]) => Promise<DialogRun>
+
+/** The exit code standing for "this machine does not have that command", so the next candidate can be tried. */
+const NOT_INSTALLED = 127
+
+/** The exit code the Windows script reports a cancelled dialog with, kept clear of PowerShell's own failure exit of 1. */
+const WINDOWS_CANCELLED = 2
+
+/** What the user is asked for, in every OS's own dialog. */
+const PROMPT = 'Choose a git repository to add as a project'
+
+/** One OS's folder dialog: the command that renders it, and how that command reports a dismissal. */
+type Dialog = { command: string; args: string[]; dismissed: (run: DialogRun) => boolean }
+
+/** macOS: `osascript`'s `choose folder`, which renders the standard folder sheet. */
+const macDialog: Dialog = {
+  command: 'osascript',
+  args: ['-e', `POSIX path of (choose folder with prompt "${PROMPT}")`],
+  // osascript reports a cancelled dialog as error -128, the one exit we translate rather than surface.
+  dismissed: run => run.stderr.includes('-128'),
+}
+
+/**
+ * Windows: PowerShell drives the folder browser that ships with the OS. `-STA` because that dialog
+ * needs a single-threaded apartment, `-NoProfile` so a user's startup script cannot print into the
+ * path read back off stdout.
+ */
+const windowsDialog: Dialog = {
+  command: 'powershell.exe',
+  args: [
+    '-NoProfile',
+    '-STA',
+    '-Command',
+    [
+      'Add-Type -AssemblyName System.Windows.Forms',
+      '$dialog = New-Object System.Windows.Forms.FolderBrowserDialog',
+      `$dialog.Description = '${PROMPT}'`,
+      '$dialog.ShowNewFolderButton = $false',
+      `if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { $dialog.SelectedPath } else { exit ${WINDOWS_CANCELLED} }`,
+    ].join('; '),
+  ],
+  dismissed: run => run.code === WINDOWS_CANCELLED,
+}
+
+/**
+ * Linux: the desktop's own dialog helper, whichever of the two is installed — `zenity` on GTK
+ * desktops, `kdialog` on KDE. Both print the chosen folder and report a cancelled dialog as exit 1,
+ * and both are told where to open, because `kdialog` takes the starting directory as an argument.
+ *
+ * Exit 1 is read as a cancellation even though a helper that cannot reach the display exits that
+ * way too: a session with no display at all is ruled out before we get here, and mistaking the
+ * remaining rarity for a cancellation is better than showing every user who cancels the harmless
+ * warnings these helpers print on startup.
+ */
+function linuxDialogs(home: string): Dialog[] {
+  const dismissed = (run: DialogRun) => run.code === 1
+  return [
+    { command: 'zenity', args: ['--file-selection', '--directory', `--title=${PROMPT}`, `--filename=${home}/`], dismissed },
+    { command: 'kdialog', args: ['--title', PROMPT, '--getexistingdirectory', home], dismissed },
+  ]
+}
+
+/** A command that could not be spawned at all reads as not installed; anything else keeps its own exit code. */
+function exitCode(error: ExecFileException): number {
+  if (error.code === 'ENOENT') return NOT_INSTALLED
+  return typeof error.code === 'number' ? error.code : 1
+}
 
 const nodeDialogRunner: DialogRunner = (command, args) =>
   new Promise(done => {
     execFile(command, args, (error, stdout, stderr) => {
-      const code = error ? (typeof error.code === 'number' ? error.code : 1) : 0
-      done({ code, stdout: String(stdout), stderr: String(stderr) })
+      done({ code: error ? exitCode(error) : 0, stdout: String(stdout), stderr: String(stderr) })
     })
   })
 
 /**
  * Open the OS folder picker and wait for the user's choice.
  *
- * macOS only so far: `osascript`'s `choose folder`, which renders the standard folder sheet.
- * Dismissing the dialog is a normal outcome (`path: null`), not an error — osascript reports it
- * as error -128, which is the one exit we translate rather than surface.
+ * Dismissing the dialog is a normal outcome (`path: null`), not an error. A Linux daemon with no
+ * desktop session to draw on, a Linux machine with neither dialog helper installed, and a platform
+ * with no dialog wired up each answer with that reason instead of trying.
  */
-export async function pickDirectory(platform: NodeJS.Platform = process.platform, run: DialogRunner = nodeDialogRunner): Promise<PickDirectoryResult> {
-  if (platform !== 'darwin') return { ok: false, error: 'The system folder picker is only available on macOS so far.' }
-  const result = await run('osascript', ['-e', 'POSIX path of (choose folder with prompt "Choose a git repository to add as a project")'])
-  if (result.code === 0) {
-    // osascript prints the POSIX path with a trailing slash; the registry stores paths without one.
-    const path = result.stdout.trim().replace(/(.)\/$/, '$1')
-    return path ? { ok: true, path } : { ok: false, error: 'the folder dialog returned no path' }
+export async function pickDirectory(
+  platform: NodeJS.Platform = process.platform,
+  run: DialogRunner = nodeDialogRunner,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<PickDirectoryResult> {
+  if (platform === 'darwin') return openDialog([macDialog], run)
+  if (platform === 'win32') return openDialog([windowsDialog], run)
+  if (platform === 'linux') {
+    // A dialog needs a screen to appear on, and a daemon started over SSH or inside a container has
+    // none — saying so beats spawning a helper that can only fail.
+    if (!env.DISPLAY && !env.WAYLAND_DISPLAY)
+      return { ok: false, error: 'The machine running The Framework has no desktop session, so no folder dialog can open there.' }
+    return openDialog(linuxDialogs(env.HOME ?? '.'), run)
   }
-  if (result.stderr.includes('-128')) return { ok: true, path: null }
-  return { ok: false, error: result.stderr.trim() || 'the folder dialog could not be opened' }
+  return { ok: false, error: `The system folder picker is not available on ${platform}.` }
+}
+
+/** Open the first installed dialog of `dialogs`, and read the user's answer out of what it printed. */
+async function openDialog(dialogs: Dialog[], run: DialogRunner): Promise<PickDirectoryResult> {
+  for (const dialog of dialogs) {
+    const result = await run(dialog.command, dialog.args)
+    if (result.code === NOT_INSTALLED) continue
+    if (dialog.dismissed(result)) return { ok: true, path: null }
+    if (result.code !== 0) return { ok: false, error: result.stderr.trim() || 'The folder dialog could not be opened.' }
+    // macOS prints the POSIX path with a trailing slash; the registry stores paths without one.
+    const path = result.stdout.trim().replace(/(.)\/$/, '$1')
+    return path ? { ok: true, path } : { ok: false, error: 'The folder dialog returned no path.' }
+  }
+  const names = dialogs.map(dialog => dialog.command).join(' or ')
+  return { ok: false, error: `The folder dialog needs ${names}, which the machine running The Framework does not have installed.` }
 }


### PR DESCRIPTION
The system folder picker behind "Add project" was wired up for macOS alone, with every other platform answered by _"The system folder picker is only available on macOS so far."_ There was no reason for that beyond how far [#1682](https://github.com/framework/the-framework/pull/1682) went — the daemon reached for `osascript`, which only macOS has. The rest of the codebase (`browser.ts`, `open-in-app.ts`) already covers all three platforms, so this was a gap rather than a policy.

## Is there a package for this?

Asked first, answer is no. The candidates and why each is out:

| Package | Downloads/mo | Verdict |
| --- | --- | --- |
| `file-dialog` | 48k | Browser package — wraps `<input type=file>`. Not server-side. Last publish 2019. |
| `dialog-node` | 1.5k | Last publish 2018. |
| `node-file-dialog` | 554 | Last publish 2020. Ships prebuilt PyInstaller blobs (an AppImage, a `.exe`) and has **no macOS branch at all**. |
| `native-file-dialog` | 369 | Prebuilt `.node` addon, no source repository listed. |

Nothing maintained, nothing popular, and the plausible ones do exactly what this PR does — spawn the platform's dialog command — only with vendored binaries in the way. The daemon also currently has zero runtime Node dependencies, so adding a native addon would be a notable first. Written directly instead; the rationale is recorded in the SPEC.

## What changed

Each platform now opens the dialog its own desktop ships with:

- **Linux** — `zenity` (GTK desktops) first, `kdialog` (KDE) when that is not installed. Both are told to open in the user's home directory, since `kdialog` takes the starting directory as an argument.
- **Windows** — PowerShell drives the folder browser that comes with the OS. `-STA` because that dialog needs a single-threaded apartment, `-NoProfile` so a user's startup script cannot print into the path read back off stdout. A cancelled dialog exits `2`, chosen so PowerShell's own failure exit of `1` stays a failure.
- **macOS** — unchanged.

The three sit behind one description of a dialog — the command, and how that command reports a cancellation — so the running, the not-installed fallback, and the path normalization are written once. `execFile`'s `ENOENT` maps to exit 127 so "that helper isn't here" is a value the fallback can act on.

A dialog that cannot open now says which of three things is wrong, instead of naming an OS:

- the machine has no desktop session — checked before spawning anything, since a daemon started over SSH or in a container has no screen to draw on;
- neither Linux helper is installed — the answer names both, so the user knows what to install;
- the platform has no dialog wired up — the answer names the platform.

## Tests

- `pick-directory.test.ts` grows from 4 to 12: each platform's pick and cancel, the Linux helper fallback, a Wayland session counting as a desktop session, a PowerShell failure staying a failure rather than reading as a dismissal, and all three cannot-open answers.
- Verified the tests bite by breaking three things in turn — the Linux fallback (`continue` → `break`), the Windows cancel exit code, and the desktop-session check — each mutation fails exactly the test that covers it, and all 12 pass restored.
- `AddProjectPanel.test.tsx` keeps its picker-failure test, with a message that still exists.
- `pnpm build` clean, `tsc --noEmit` clean on the node side, 1588 node tests and 854 dashboard tests pass.

Two things this branch does not verify, stated plainly:

- The real dialogs cannot be clicked through here — this container has none of `zenity`, `kdialog`, `osascript` or `powershell.exe`. Everything up to the spawn is covered; the live click-through on a Linux desktop and on Windows needs a human, as the macOS one did in #1682.
- 8 `daemon.test.ts` failures and 1 `TicketsPage.test.tsx` typecheck error are pre-existing on this branch's base — confirmed by stashing this diff and re-running. Untouched here.

## SPECs (per SDD)

`pick-directory.SPEC.md` rewritten around the three platforms, the cancellation signals and the three cannot-open answers, with the no-package rationale; `pick-directory.test.SPEC.md` updated to the new coverage; `dashboard-rpc/projects.SPEC.md` and `AddProjectPanel.SPEC.md` drop their macOS-only wording.

`FEATURES-SPEC.md` is untouched deliberately: no feature is added or removed, and its "picked in the OS folder picker" line never claimed a platform — it is simply true on more machines now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gHiYEpzpFtK8UJwMBTCSg

---
_Generated by [Claude Code](https://claude.ai/code/session_016gHiYEpzpFtK8UJwMBTCSg)_