### PR TITLE
Fix the typecheck: TicketsPage's capitalised-topic test was missing onSelectProject

### DIFF
--- a/packages/framework/dashboard/components/TicketsPage.test.tsx
+++ b/packages/framework/dashboard/components/TicketsPage.test.tsx
@@ -192,7 +192,7 @@ describe('TicketsPage filters (#1144)', () => {
     // Matching lowercases the ticket's topics, so an `UX` badge added verbatim matched nothing —
     // clicking it emptied the page instead of narrowing it.
     fixture([ticket({ file: 'ux.md', title: 'Polish the rail', topics: ['UX'] }), ticket({ file: 'other.md', title: 'Something else' })])
-    render(<TicketsPage onOpenTicket={() => {}} />)
+    render(<TicketsPage onOpenTicket={() => {}} onSelectProject={() => {}} />)
     await screen.findByText('Polish the rail')
     fireEvent.click(screen.getByRole('button', { name: 'UX' }))
     await waitFor(() => expect(screen.queryByText('Something else')).toBeNull())


### PR DESCRIPTION
`main` does not typecheck, so the `build` check fails on `main` itself and on every open pull request:

```
dashboard/components/TicketsPage.test.tsx(195,13): error TS2741: Property 'onSelectProject'
is missing in type '{ onOpenTicket: () => void; }' but required in type '{ ... }'
```

`onSelectProject` is a required prop of `TicketsPage`. All ~18 of its render call sites in that test file pass it except the one added for the capitalised-topic filter test, which passes only `onOpenTicket`.

## The change

One line, adding the missing prop the way every neighbouring call site already does:

```diff
-    render(<TicketsPage onOpenTicket={() => {}} />)
+    render(<TicketsPage onOpenTicket={() => {}} onSelectProject={() => {}} />)
```

The test itself was already correct — it only lacked the prop.

## Verification

- Reproduced on a clean `origin/main` checkout first, to confirm this is the base's failure and not a branch's.
- `tsc --noEmit` and `tsc --noEmit -p dashboard/tsconfig.json` both clean with the fix.
- All 33 `TicketsPage.test.tsx` tests pass.

No SPEC changes: no business logic moves, and `TicketsPage.test.SPEC.md` already describes this test's coverage.

Found while getting [#1701](https://github.com/framework/the-framework/pull/1701) to green — that PR is blocked on this and stays focused on the folder picker rather than carrying this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gHiYEpzpFtK8UJwMBTCSg

---
_Generated by [Claude Code](https://claude.ai/code/session_016gHiYEpzpFtK8UJwMBTCSg)_