### PR TITLE
Simplify: one shape for the daemon's project passes, the HTTP surfaces, and the picker menus

### DIFF
--- a/packages/framework/dashboard/components/AgentActionsMenu.tsx
+++ b/packages/framework/dashboard/components/AgentActionsMenu.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import type { FrameworkEvent } from '../../src/index.js'
 import { sessionInfo } from '../../src/client.js'
-import { MoreVertical, Github, FolderOpen, Code, Check, Play, ExternalLink, Square, FolderX, Trash2, Copy, GitMerge } from 'lucide-react'
+import { MoreVertical, Github, FolderOpen, Code, Check, ExternalLink, Square, FolderX, Trash2, Copy, GitMerge } from 'lucide-react'
 import { onGithubUrl } from '../rpc/reads.js'
 import {
   sendOpenInApp,
@@ -10,17 +10,13 @@ import {
   sendRemoveWorktree,
   sendDeleteAgent,
 } from '../rpc/control.js'
-import type { EditorInfo } from '../rpc/preferences.js'
 import { useLoaded } from '../lib/use-async.js'
 import { useAction } from '../lib/use-action.js'
-import { usePreferences, updatePreferences } from '../lib/preferences.js'
-import { useDetectedEditors } from '../lib/editors.js'
 import { isAgentActive } from '../lib/live-state.js'
 import { describeSessionLink } from '../lib/session-link.js'
 import { buildResumeCommand } from '../lib/resume-command.js'
-import { cn } from '../lib/utils.js'
 import { buttonVariants } from './ui/button.js'
-import { OptionLabel } from './ui/option-label.js'
+import { PreferredEditorItems } from './PreferredEditorItems.js'
 import { ConfirmDialog } from './ui/confirm-dialog.js'
 import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip.js'
 import {
@@ -28,8 +24,6 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuGroup,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubTrigger,
@@ -91,11 +85,6 @@ export function AgentActionsMenu({
   }
   // keepPrevious: hold the last repo URL while a new project's loads, so the item does not flicker.
   const githubUrl = useLoaded<string | null>(() => onGithubUrl(projectId), null, [projectId], true)
-
-  const editor = usePreferences().editor
-  const detectedEditors = useDetectedEditors()
-  const editorRows: EditorInfo[] =
-    editor && !detectedEditors.some(e => e.bin === editor) ? [...detectedEditors, { bin: editor, label: editor }] : detectedEditors
 
   const { busy, error, reset, run } = useAction()
 
@@ -174,30 +163,7 @@ export function AgentActionsMenu({
                 <Code className="h-3.5 w-3.5 shrink-0" /> {agentId ? "Open this session's checkout" : 'Open in your editor'}
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuGroup>
-                <DropdownMenuLabel>Preferred editor</DropdownMenuLabel>
-                <DropdownMenuItem
-                  disabled={busy}
-                  closeOnClick={false}
-                  onClick={() => updatePreferences({ editor: '' })}
-                  className="items-start"
-                >
-                  <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', editor ? 'opacity-0' : 'opacity-100')} />
-                  <OptionLabel label="Default" description="$FRAMEWORK_EDITOR, or code" />
-                </DropdownMenuItem>
-                {editorRows.map(e => (
-                  <DropdownMenuItem
-                    key={e.bin}
-                    disabled={busy}
-                    closeOnClick={false}
-                    onClick={() => updatePreferences({ editor: e.bin })}
-                    className="items-start"
-                  >
-                    <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', editor === e.bin ? 'opacity-100' : 'opacity-0')} />
-                    <OptionLabel label={e.label} description={e.bin} />
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuGroup>
+              <PreferredEditorItems busy={busy} />
             </DropdownMenuSubContent>
           </DropdownMenuSub>
           {session && (

--- a/packages/framework/dashboard/components/AgentHistory.tsx
+++ b/packages/framework/dashboard/components/AgentHistory.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { Plus, ChevronDown, Cloud, Laptop, MonitorSmartphone, Settings, LayoutDashboard, FolderGit2, Ticket } from 'lucide-react'
 import type { AgentMeta, AgentStatus, RecentAgent, ProjectSummary } from '../../src/index.js'
 import { DRIVER_LABELS, driverFromImpl, cloudRunState, type CloudRunState } from '../../src/client.js'
@@ -293,9 +293,22 @@ export function AgentHistory({
   )
 }
 
-// Tickets: a project's backlog as its own nav item (#1144), same row style as Overview. Only
-// rendered once a project is selected — there is nothing to open otherwise.
-function TicketsButton({ active, onClick }: { active: boolean; onClick: () => void }) {
+// One rail destination — Overview, Tickets. Same box as New (px-2 py-1.5 gap-2) so every row's
+// icon and label line up exactly, and only the current view carries the active fill.
+function NavRow({
+  icon: Icon,
+  label,
+  active,
+  onClick,
+  children,
+}: {
+  icon: typeof LayoutDashboard
+  label: string
+  active: boolean
+  onClick: () => void
+  /** What sits after the label, e.g. the Overview row's Human Queue badge. */
+  children?: ReactNode
+}) {
   return (
     <button
       type="button"
@@ -306,8 +319,9 @@ function TicketsButton({ active, onClick }: { active: boolean; onClick: () => vo
         active ? 'bg-sidebar-accent text-sidebar-accent-foreground' : 'text-foreground hover:bg-sidebar-accent/60',
       )}
     >
-      <Ticket className="h-4 w-4 shrink-0" aria-hidden />
-      <span className="flex-1 text-left">Tickets</span>
+      <Icon className="h-4 w-4 shrink-0" aria-hidden />
+      <span className="flex-1 text-left">{label}</span>
+      {children}
     </button>
   )
 }
@@ -317,18 +331,7 @@ function TicketsButton({ active, onClick }: { active: boolean; onClick: () => vo
 // highlights while it is the current view.
 function OverviewButton({ active, count, onClick }: { active: boolean; count: number; onClick: () => void }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-current={active ? 'page' : undefined}
-      className={cn(
-        // Same box as New (px-2 py-1.5 gap-2) so the two rows' icons and labels line up exactly.
-        'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors',
-        active ? 'bg-sidebar-accent text-sidebar-accent-foreground' : 'text-foreground hover:bg-sidebar-accent/60',
-      )}
-    >
-      <LayoutDashboard className="h-4 w-4 shrink-0" aria-hidden />
-      <span className="flex-1 text-left">Overview</span>
+    <NavRow icon={LayoutDashboard} label="Overview" active={active} onClick={onClick}>
       {count > 0 && (
         <Tooltip>
           <TooltipTrigger
@@ -343,8 +346,14 @@ function OverviewButton({ active, count, onClick }: { active: boolean; count: nu
           </TooltipContent>
         </Tooltip>
       )}
-    </button>
+    </NavRow>
   )
+}
+
+// Tickets: a project's backlog as its own nav item (#1144), same row as Overview. Only rendered
+// once a project is selected — there is nothing to open otherwise.
+function TicketsButton({ active, onClick }: { active: boolean; onClick: () => void }) {
+  return <NavRow icon={Ticket} label="Tickets" active={active} onClick={onClick} />
 }
 
 // Projects: the project selector as an expandable nav item (Rom), the same row style as Overview,

--- a/packages/framework/dashboard/components/NotificationsMenu.tsx
+++ b/packages/framework/dashboard/components/NotificationsMenu.tsx
@@ -3,7 +3,7 @@ import { useNotificationPermission } from '../lib/notification-permission.js'
 import { usePreferences, updatePreferences, notificationsEnabled, discordEnabled, newActivityEnabled, humanInterventionEnabled } from '../lib/preferences.js'
 import { useNotifyChannels } from '../lib/notify-channels.js'
 import { cn } from '../lib/utils.js'
-import { OptionLabel } from './OptionsMenu.js'
+import { OptionLabel } from './ui/option-label.js'
 import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip.js'
 import {
   DropdownMenu,

--- a/packages/framework/dashboard/components/OnboardingChecklist.tsx
+++ b/packages/framework/dashboard/components/OnboardingChecklist.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import type { DashboardData, OnboardingSuggestion } from '../../src/index.js'
-import { presets } from '../../src/client.js'
-import { RefreshCw, Square, SquareCheckBig, X } from 'lucide-react'
+import { Square, SquareCheckBig, X } from 'lucide-react'
 import { onDashboard } from '../rpc/reads.js'
 import { onOnboarding, sendAddProject } from '../rpc/projects.js'
 import { usePolled } from '../lib/use-async.js'
@@ -10,7 +9,7 @@ import { useNotifyChannels, reloadNotifyChannels } from '../lib/notify-channels.
 import { useNotificationPermission } from '../lib/notification-permission.js'
 import { useStartAgent } from '../lib/use-start-agent.js'
 import { AddProjectPanel } from './AddProjectPanel.js'
-import { StartAgentButton } from './StartAgentButton.js'
+import { UpdateTicketsButton, UPDATE_TICKETS_PROMPT } from './UpdateTicketsButton.js'
 import { DiscordWebhookDialog, DISCORD_WEBHOOK_DESCRIPTION } from './DiscordDialogs.js'
 import { Button } from './ui/button.js'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card.js'
@@ -105,20 +104,13 @@ export function OnboardingChecklist({
     if (permission === 'default') void Notification.requestPermission()
   }
 
-  // The update preset (#1501): its empty branch is the first import, so one preset serves both
-  // this checklist's fresh project and the panel's filled one — one label, one instruction. Read
-  // once here because two controls need it: the start, and the draft its chevron hands the
-  // launcher (#1507).
-  const updateIntent = presets.updateTickets.render()
-
   const populateTickets = async () => {
     if (!targetProjectId) return
-    const intent = updateIntent
     // Unattended (#1279): a checklist-fired routine ends at settle instead of parking in the chat loop.
-    const started = await start(targetProjectId, intent, 'prompt', { unattended: true })
+    const started = await start(targetProjectId, UPDATE_TICKETS_PROMPT, 'prompt', { unattended: true })
     // Land on the session doing the import, not the project's launcher (#1169): its id is what
     // the shell needs to show the live output. A refusal keeps you here, with `startError` shown.
-    if (started) onAgentStarted(targetProjectId, intent, started.agentId)
+    if (started) onAgentStarted(targetProjectId, UPDATE_TICKETS_PROMPT, started.agentId)
   }
 
   const steps: Step[] = [
@@ -159,20 +151,12 @@ export function OnboardingChecklist({
       optional: true,
       action: (
         <div className="flex flex-col items-end gap-1">
-          <StartAgentButton
+          <UpdateTicketsButton
             variant="default"
-            size="sm"
-            icon={<RefreshCw className="h-3.5 w-3.5" aria-hidden />}
-            label="Update from GitHub"
-            menuAriaLabel="Other ways to update from GitHub"
-            tooltip="Bring tickets/ up to date with GitHub. With no import on record, everything open comes across."
             busy={starting}
-            starting={starting}
             disabled={!targetProjectId}
             onStart={() => void populateTickets()}
             onConfigure={() => targetProjectId && onSelectProject(targetProjectId)}
-            prompt={updateIntent}
-            configureDescription="Opens the launcher with the update prompt, so you can set the model and where it runs."
           />
           {!targetProjectId && <span className="text-xs text-muted-foreground">Add a project first</span>}
           {startError && <span className="text-xs text-destructive">{startError}</span>}

--- a/packages/framework/dashboard/components/OptionsMenu.tsx
+++ b/packages/framework/dashboard/components/OptionsMenu.tsx
@@ -28,11 +28,8 @@ import {
 export type { OptionRow } from '../lib/agent-option-rows.js'
 
 
-// Moved to ui/option-label.tsx (#948) so menus without preference wiring can share it;
-// re-exported to keep this module the import site the other menus already use.
 import { OptionLabel } from './ui/option-label.js'
 import { RUN_TARGET_LABELS } from '../lib/agent-settings.js'
-export { OptionLabel }
 
 /**
  * Where an agent executes (#1050/#610). `local` runs on this device; `actions` on a GitHub Actions

--- a/packages/framework/dashboard/components/PreferredEditorItems.SPEC.md
+++ b/packages/framework/dashboard/components/PreferredEditorItems.SPEC.md
@@ -1,0 +1,7 @@
+The "Preferred editor" picker, offered wherever the dashboard can open a checkout in an editor: the project home's action bar and a session's actions menu.
+
+It lists the editors detected on the daemon's machine, and adds the editor currently stored as the preference when that one was not detected — a hand-set editor still gets a row, so the current choice is always visible and can always be changed. Above them sits a "Default" row, meaning whatever the machine's own editor setting resolves to. A tick marks the row in force. Picking a row stores it as the preference and leaves the menu open, so the change is visibly confirmed instead of the menu disappearing.
+
+## Before modifying/creating SPEC.md files
+
+You must always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/framework/dashboard/components/PreferredEditorItems.tsx
+++ b/packages/framework/dashboard/components/PreferredEditorItems.tsx
@@ -1,0 +1,52 @@
+import type { EditorInfo } from '../rpc/preferences.js'
+import { usePreferences, updatePreferences } from '../lib/preferences.js'
+import { useDetectedEditors } from '../lib/editors.js'
+import { cn } from '../lib/utils.js'
+import { Check } from 'lucide-react'
+import { OptionLabel } from './ui/option-label.js'
+import { DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel } from './ui/dropdown-menu.js'
+
+// The "Preferred editor" picker (#727), as one group both menus that offer it render: the project
+// home's action bar (WorkspaceActions) and a session's ⋮ menu (AgentActionsMenu). They showed the
+// same rows from the same two reads, written out twice — so a row added to one silently did not
+// appear in the other.
+
+/**
+ * The editors to offer: the ones detected on the daemon's machine, plus the stored one when it is
+ * not among them (a hand-set `$FRAMEWORK_EDITOR`), so the current choice always has a row.
+ */
+function useEditorRows(editor: string | undefined): EditorInfo[] {
+  const detected = useDetectedEditors()
+  return editor && !detected.some(e => e.bin === editor) ? [...detected, { bin: editor, label: editor }] : detected
+}
+
+/**
+ * The picker's rows: "Default" (whatever `$FRAMEWORK_EDITOR` or `code` resolves to) and one per
+ * editor, ticked where the stored preference points. Each row stores the choice without closing
+ * the menu, so picking is visibly confirmed rather than making the menu vanish.
+ */
+export function PreferredEditorItems({ busy }: { busy: boolean }) {
+  const editor = usePreferences().editor
+  const editorRows = useEditorRows(editor)
+  return (
+    <DropdownMenuGroup>
+      <DropdownMenuLabel>Preferred editor</DropdownMenuLabel>
+      <DropdownMenuItem disabled={busy} closeOnClick={false} onClick={() => updatePreferences({ editor: '' })} className="items-start">
+        <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', editor ? 'opacity-0' : 'opacity-100')} />
+        <OptionLabel label="Default" description="$FRAMEWORK_EDITOR, or code" />
+      </DropdownMenuItem>
+      {editorRows.map(e => (
+        <DropdownMenuItem
+          key={e.bin}
+          disabled={busy}
+          closeOnClick={false}
+          onClick={() => updatePreferences({ editor: e.bin })}
+          className="items-start"
+        >
+          <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', editor === e.bin ? 'opacity-100' : 'opacity-0')} />
+          <OptionLabel label={e.label} description={e.bin} />
+        </DropdownMenuItem>
+      ))}
+    </DropdownMenuGroup>
+  )
+}

--- a/packages/framework/dashboard/components/TicketDetailPage.tsx
+++ b/packages/framework/dashboard/components/TicketDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import type { WorkspaceTicketDetail } from '../../src/index.js'
-import { ArrowLeft, Check, ListPlus, Github, LockOpen } from 'lucide-react'
+import { Check, ListPlus, Github, LockOpen } from 'lucide-react'
 import { onTicket } from '../rpc/reads.js'
 import { sendQueueTicket, sendReleaseTicketLock } from '../rpc/control.js'
 import { usePolled } from '../lib/use-async.js'
@@ -8,7 +8,7 @@ import { useAction } from '../lib/use-action.js'
 import { Button } from './ui/button.js'
 import { Badge } from './ui/badge.js'
 import { Markdown } from './Markdown.js'
-import { ScrollArea } from './ui/scroll-area.js'
+import { TicketPageShell, TicketPageNote } from './TicketPageShell.js'
 import { cn } from '../lib/utils.js'
 import { formatAge, formatDateTime } from '../lib/format-date.js'
 import { priorityTone } from '../lib/ticket-priority.js'
@@ -52,102 +52,93 @@ export function TicketDetailPage({
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="border-b border-border px-4 py-2">
-        <Button variant="ghost" size="sm" className="gap-1.5" onClick={onBack}>
-          <ArrowLeft className="h-4 w-4" /> Tickets
-        </Button>
-      </div>
-      <ScrollArea className="min-h-0 flex-1">
-        <div className="mx-auto max-w-3xl p-6">
-          {!loaded ? (
-            <p className="text-sm text-muted-foreground">Loading…</p>
-          ) : !ticket ? (
-            // Deleted between the list read and this one, or a stale/hand-typed link.
-            <p className="text-sm text-muted-foreground">This ticket does not exist.</p>
-          ) : (
-            <>
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <h1 className="text-lg font-semibold">{ticket.title}</h1>
-                <div className="flex shrink-0 items-center gap-1.5">
-                  {claimed && (
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      disabled={busy}
-                      onClick={() => void release()}
-                      title={ticket.lockedBy ? `Claimed by ${ticket.lockedBy}` : undefined}
-                      className="gap-1.5"
-                    >
-                      <LockOpen className="h-3.5 w-3.5" /> Release lock
-                    </Button>
-                  )}
-                  <Button size="sm" variant="outline" disabled={busy || queued} onClick={() => void queue()} className="gap-1.5">
-                    {queued ? (
-                      <>
-                        <Check className="h-3.5 w-3.5" /> Queued
-                      </>
-                    ) : (
-                      <>
-                        <ListPlus className="h-3.5 w-3.5" /> Queue
-                      </>
-                    )}
-                  </Button>
-                </div>
-              </div>
-              {ticket.summary && <p className="mt-2 text-sm text-muted-foreground">{ticket.summary}</p>}
-              {/* All meta below the description (#1144/#1265): date, priority, then the GitHub
-                  link lead in that order, followed by the rest of what is known about the ticket. */}
-              <div className="mt-2 flex flex-wrap items-center gap-1.5">
-                <span className="text-[10px] text-muted-foreground/70" title={formatDateTime(ticket.date)}>
-                  {formatAge(ticket.date)}
-                </span>
-                {ticket.priority && (
-                  <Badge className={cn('border-transparent px-0 text-[10px]', priorityTone(ticket.priority))}>
-                    Priority: {ticket.priority}
-                  </Badge>
+    <TicketPageShell onBack={onBack}>
+      {!loaded ? (
+        <TicketPageNote>Loading…</TicketPageNote>
+      ) : !ticket ? (
+        // Deleted between the list read and this one, or a stale/hand-typed link.
+        <TicketPageNote>This ticket does not exist.</TicketPageNote>
+      ) : (
+        <>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <h1 className="text-lg font-semibold">{ticket.title}</h1>
+            <div className="flex shrink-0 items-center gap-1.5">
+              {claimed && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={busy}
+                  onClick={() => void release()}
+                  title={ticket.lockedBy ? `Claimed by ${ticket.lockedBy}` : undefined}
+                  className="gap-1.5"
+                >
+                  <LockOpen className="h-3.5 w-3.5" /> Release lock
+                </Button>
+              )}
+              <Button size="sm" variant="outline" disabled={busy || queued} onClick={() => void queue()} className="gap-1.5">
+                {queued ? (
+                  <>
+                    <Check className="h-3.5 w-3.5" /> Queued
+                  </>
+                ) : (
+                  <>
+                    <ListPlus className="h-3.5 w-3.5" /> Queue
+                  </>
                 )}
-                {ticket.github && (
-                  <a
-                    href={ticket.github.url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground hover:underline"
-                  >
-                    <Github className="h-4 w-4" aria-hidden />
-                    {ticket.github.label}
-                  </a>
-                )}
-                {ticket.topics?.map(topic => (
-                  <Badge key={topic} className="border-border px-1.5 text-[10px] text-muted-foreground">
-                    {topic}
-                  </Badge>
-                ))}
-                {ticket.planned && <Badge className="border-transparent px-0 text-[10px] uppercase">planned</Badge>}
-                {/* The holder inline (#1420): the detail page has the room, so the full id is
-                    plainly readable instead of hiding behind a native tooltip. */}
-                {claimed && (
-                  <Badge className="border-transparent px-0 text-[10px] text-warning">
-                    <span className="uppercase">claimed</span>
-                    {ticket.lockedBy && <>&nbsp;· {ticket.lockedBy}</>}
-                  </Badge>
-                )}
-                {ticket.effort !== undefined && (
-                  <Badge className="border-transparent px-0 text-[10px] text-muted-foreground">Effort: {ticket.effort}</Badge>
-                )}
-                {ticket.uncertainty !== undefined && (
-                  <Badge className="border-transparent px-0 text-[10px] text-muted-foreground">Uncertainty: {ticket.uncertainty}</Badge>
-                )}
-                <span className="text-[10px] text-muted-foreground/70">{ticket.file}</span>
-              </div>
-              {error && <p className="mt-2 text-xs text-danger">{error}</p>}
-              <div className="mt-4">
-                <Markdown text={ticket.content} />
-              </div>
-            </>
-          )}
-        </div>
-      </ScrollArea>
-    </div>
+              </Button>
+            </div>
+          </div>
+          {ticket.summary && <p className="mt-2 text-sm text-muted-foreground">{ticket.summary}</p>}
+          {/* All meta below the description (#1144/#1265): date, priority, then the GitHub
+              link lead in that order, followed by the rest of what is known about the ticket. */}
+          <div className="mt-2 flex flex-wrap items-center gap-1.5">
+            <span className="text-[10px] text-muted-foreground/70" title={formatDateTime(ticket.date)}>
+              {formatAge(ticket.date)}
+            </span>
+            {ticket.priority && (
+              <Badge className={cn('border-transparent px-0 text-[10px]', priorityTone(ticket.priority))}>
+                Priority: {ticket.priority}
+              </Badge>
+            )}
+            {ticket.github && (
+              <a
+                href={ticket.github.url}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground hover:underline"
+              >
+                <Github className="h-4 w-4" aria-hidden />
+                {ticket.github.label}
+              </a>
+            )}
+            {ticket.topics?.map(topic => (
+              <Badge key={topic} className="border-border px-1.5 text-[10px] text-muted-foreground">
+                {topic}
+              </Badge>
+            ))}
+            {ticket.planned && <Badge className="border-transparent px-0 text-[10px] uppercase">planned</Badge>}
+            {/* The holder inline (#1420): the detail page has the room, so the full id is
+                plainly readable instead of hiding behind a native tooltip. */}
+            {claimed && (
+              <Badge className="border-transparent px-0 text-[10px] text-warning">
+                <span className="uppercase">claimed</span>
+                {ticket.lockedBy && <>&nbsp;· {ticket.lockedBy}</>}
+              </Badge>
+            )}
+            {ticket.effort !== undefined && (
+              <Badge className="border-transparent px-0 text-[10px] text-muted-foreground">Effort: {ticket.effort}</Badge>
+            )}
+            {ticket.uncertainty !== undefined && (
+              <Badge className="border-transparent px-0 text-[10px] text-muted-foreground">Uncertainty: {ticket.uncertainty}</Badge>
+            )}
+            <span className="text-[10px] text-muted-foreground/70">{ticket.file}</span>
+          </div>
+          {error && <p className="mt-2 text-xs text-danger">{error}</p>}
+          <div className="mt-4">
+            <Markdown text={ticket.content} />
+          </div>
+        </>
+      )}
+    </TicketPageShell>
   )
 }

--- a/packages/framework/dashboard/components/TicketPageShell.SPEC.md
+++ b/packages/framework/dashboard/components/TicketPageShell.SPEC.md
@@ -1,0 +1,7 @@
+The frame both pages under the tickets list sit in: one ticket's own page, and one ticket's plan.
+
+Each opens with the way back to the tickets list, optionally beside the repo-relative file the page is showing, and then the page's content in a single scrolling column of reading width. While a page's read is still in flight, or when there is nothing to show, it says so in the same quiet line either page uses.
+
+## Before modifying/creating SPEC.md files
+
+You must always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/framework/dashboard/components/TicketPageShell.tsx
+++ b/packages/framework/dashboard/components/TicketPageShell.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from 'react'
+import { ArrowLeft } from 'lucide-react'
+import { Button } from './ui/button.js'
+import { ScrollArea } from './ui/scroll-area.js'
+
+// The frame both ticket pages sit in (#1144, #685): the way back to the list, then the ticket's
+// own content in one scrolling column. A page under a list needs the same way out and the same
+// measure wherever it goes, and the two were written out separately — so a change to one left the
+// other reading as a different kind of page.
+
+/** What a ticket page shows while its read is in flight, and when there is nothing to show. */
+export function TicketPageNote({ children }: { children: ReactNode }) {
+  return <p className="text-sm text-muted-foreground">{children}</p>
+}
+
+export function TicketPageShell({
+  onBack,
+  path,
+  children,
+}: {
+  /** Back to the tickets list. */
+  onBack: () => void
+  /** The repo-relative file this page renders, shown beside the way back. Omitted where the page's own heading already names it. */
+  path?: string | undefined
+  children: ReactNode
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex items-center gap-2 border-b border-border px-4 py-2">
+        <Button variant="ghost" size="sm" className="gap-1.5" onClick={onBack}>
+          <ArrowLeft className="h-4 w-4" /> Tickets
+        </Button>
+        {path && <span className="min-w-0 truncate text-xs text-muted-foreground">{path}</span>}
+      </div>
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="mx-auto max-w-3xl p-6">{children}</div>
+      </ScrollArea>
+    </div>
+  )
+}

--- a/packages/framework/dashboard/components/TicketPlanPage.tsx
+++ b/packages/framework/dashboard/components/TicketPlanPage.tsx
@@ -1,10 +1,8 @@
 import type { FileContent } from '../../src/index.js'
-import { ArrowLeft } from 'lucide-react'
 import { onFileContent } from '../rpc/reads.js'
 import { usePolled } from '../lib/use-async.js'
-import { Button } from './ui/button.js'
 import { Markdown } from './Markdown.js'
-import { ScrollArea } from './ui/scroll-area.js'
+import { TicketPageShell, TicketPageNote } from './TicketPageShell.js'
 
 /** Where tickets and their plans live, repo-relative. The literal, not the package's Node-bound
  *  `TICKETS_DIR` const, so nothing drags the server graph into the browser bundle. */
@@ -39,29 +37,19 @@ export function TicketPlanPage({
   const { value: plan, loaded } = usePolled<FileContent | null>(() => onFileContent(projectId, path), null, 10_000, [projectId, path])
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex items-center gap-2 border-b border-border px-4 py-2">
-        <Button variant="ghost" size="sm" className="gap-1.5" onClick={onBack}>
-          <ArrowLeft className="h-4 w-4" /> Tickets
-        </Button>
-        <span className="min-w-0 truncate text-xs text-muted-foreground">{path}</span>
-      </div>
-      <ScrollArea className="min-h-0 flex-1">
-        <div className="mx-auto max-w-3xl p-6">
-          {!loaded ? (
-            <p className="text-sm text-muted-foreground">Loading…</p>
-          ) : !plan || plan.binary ? (
-            // No `.plan.md` beside the ticket — never written, or removed since the list read.
-            <p className="text-sm text-muted-foreground">This ticket has no plan yet.</p>
-          ) : (
-            <>
-              <Markdown text={plan.text} />
-              {/* The confined read caps long files; say so rather than pretending the tail is empty. */}
-              {plan.truncated && <p className="mt-4 text-xs text-muted-foreground">Plan truncated — open the file to read the rest.</p>}
-            </>
-          )}
-        </div>
-      </ScrollArea>
-    </div>
+    <TicketPageShell onBack={onBack} path={path}>
+      {!loaded ? (
+        <TicketPageNote>Loading…</TicketPageNote>
+      ) : !plan || plan.binary ? (
+        // No `.plan.md` beside the ticket — never written, or removed since the list read.
+        <TicketPageNote>This ticket has no plan yet.</TicketPageNote>
+      ) : (
+        <>
+          <Markdown text={plan.text} />
+          {/* The confined read caps long files; say so rather than pretending the tail is empty. */}
+          {plan.truncated && <p className="mt-4 text-xs text-muted-foreground">Plan truncated — open the file to read the rest.</p>}
+        </>
+      )}
+    </TicketPageShell>
   )
 }

--- a/packages/framework/dashboard/components/TicketsPanel.tsx
+++ b/packages/framework/dashboard/components/TicketsPanel.tsx
@@ -3,11 +3,12 @@ import type { TicketsMeta, WorkspaceTicket } from '../../src/index.js'
 // with, one wording with the [Plan tickets] preset's queued entries and the server's own queue
 // write, so no surface carries a hidden second copy (#1187).
 import { planTicketPrompt, presets } from '../../src/client.js'
-import { RefreshCw, Github, ClipboardPlus, ClipboardList, Hammer, Play } from 'lucide-react'
+import { Github, ClipboardPlus, ClipboardList, Hammer, Play } from 'lucide-react'
 import { sendStart } from '../rpc/control.js'
 import { onTicketsMeta } from '../rpc/reads.js'
 import { Button } from './ui/button.js'
 import { StartAgentButton } from './StartAgentButton.js'
+import { UpdateTicketsButton, UPDATE_TICKETS_PROMPT } from './UpdateTicketsButton.js'
 import { Badge } from './ui/badge.js'
 import { Checkbox } from './ui/checkbox.js'
 import { useAction } from '../lib/use-action.js'
@@ -16,17 +17,6 @@ import { formatRelative, formatAge, formatDateTime } from '../lib/format-date.js
 import { priorityTone } from '../lib/ticket-priority.js'
 import { cn } from '../lib/utils.js'
 import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip.js'
-
-/**
- * The prompt behind "Update from GitHub" (#1208), read from the preset rather than written here:
- * this panel and the onboarding checklist offer the same button under the same label, and one
- * label must mean one instruction wherever it is pressed (#697's lesson, when two surfaces sent
- * different texts behind the same words).
- *
- * The one GitHub sync since #1501: the preset's own empty branch treats a bare `tickets/` as the
- * first import, so the separate import preset could go.
- */
-const UPDATE_PROMPT = presets.updateTickets.render()
 
 /** Captured once: `useLoaded` treats a fresh `{}` literal as a new value on every render. */
 const NO_META: TicketsMeta = {}
@@ -342,7 +332,7 @@ export function TicketsPanel({
 
   // Unattended (#1279): an update fired by a button is routine work, not a conversation — it
   // ends at settle and its armed handoff fires, as when the sweep starts the same routine.
-  const updateFromGithub = () => startSession(UPDATE_PROMPT, 'The update could not be started.', { unattended: true })
+  const updateFromGithub = () => startSession(UPDATE_TICKETS_PROMPT, 'The update could not be started.', { unattended: true })
   // Attended, unlike the imports above: a plan is written per-ticket for a human to read and act
   // on, so the session stays a conversation you land in and steer rather than one that settles and
   // hands itself off. The reader reviews the result through the plan column's link.
@@ -379,19 +369,7 @@ export function TicketsPanel({
           plans from.
         </p>
         {error && <p className="text-xs text-danger">{error}</p>}
-        <StartAgentButton
-          size="sm"
-          icon={<RefreshCw className="h-3.5 w-3.5" aria-hidden />}
-          label="Update from GitHub"
-          menuAriaLabel="Other ways to update from GitHub"
-          tooltip="Bring tickets/ up to date with GitHub. With no import on record, everything open comes across."
-          busy={busy}
-          starting={busy}
-          onStart={() => void updateFromGithub()}
-          onConfigure={configure}
-          prompt={UPDATE_PROMPT}
-          configureDescription="Opens the launcher with the update prompt, so you can set the model and where it runs."
-        />
+        <UpdateTicketsButton busy={busy} onStart={() => void updateFromGithub()} onConfigure={configure} />
       </div>
     )
   }
@@ -409,22 +387,11 @@ export function TicketsPanel({
             ? `Updated from GitHub ${formatRelative(meta.lastImportedAt)}`
             : 'No record of an import yet'}
         </span>
-        <StartAgentButton
-          size="sm"
-          icon={<RefreshCw className="h-3.5 w-3.5" aria-hidden />}
-          label="Update from GitHub"
-          menuAriaLabel="Other ways to update from GitHub"
-          tooltip={
-            meta.lastImportedAt
-              ? 'Bring tickets/ up to date with the issues and comments changed since the last import.'
-              : 'Bring tickets/ up to date with GitHub. With no import on record, everything open comes across.'
-          }
+        <UpdateTicketsButton
           busy={busy}
-          starting={busy}
           onStart={() => void updateFromGithub()}
           onConfigure={configure}
-          prompt={UPDATE_PROMPT}
-          configureDescription="Opens the launcher with the update prompt, so you can set the model and where it runs."
+          lastImportedAt={meta.lastImportedAt}
           className="h-6 gap-1 px-2 text-xs"
         />
       </div>

--- a/packages/framework/dashboard/components/UpdateTicketsButton.SPEC.md
+++ b/packages/framework/dashboard/components/UpdateTicketsButton.SPEC.md
@@ -1,0 +1,9 @@
+The "Update from GitHub" button, offered wherever the dashboard shows the state of a project's tickets: the tickets panel's header, its empty state, and the onboarding checklist.
+
+Pressing it starts a session that brings the project's tickets up to date with its GitHub issues. The session is unattended: it ends when the work settles and hands itself off, rather than parking in a conversation. Beside the button sits the offer every start in the dashboard carries — open the launcher with the same instruction instead of spending a session on it, so the model and where it runs can be set first.
+
+The button promises what the update will actually do: with tickets already imported once, only the issues and comments changed since then come across; with no import on record, everything open does. The instruction behind the button is the shared update instruction, so the same label means the same thing on every surface that shows it.
+
+## Before modifying/creating SPEC.md files
+
+You must always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/framework/dashboard/components/UpdateTicketsButton.tsx
+++ b/packages/framework/dashboard/components/UpdateTicketsButton.tsx
@@ -1,0 +1,65 @@
+import { RefreshCw } from 'lucide-react'
+import { presets } from '../../src/client.js'
+import { StartAgentButton } from './StartAgentButton.js'
+
+/**
+ * The prompt behind "Update from GitHub" (#1208), read from the preset rather than written here:
+ * every surface offers the same button under the same label, and one label must mean one
+ * instruction wherever it is pressed (#697's lesson, when two surfaces sent different texts behind
+ * the same words).
+ *
+ * The one GitHub sync since #1501: the preset's own empty branch treats a bare `tickets/` as the
+ * first import, so the separate import preset could go.
+ */
+export const UPDATE_TICKETS_PROMPT = presets.updateTickets.render()
+
+/**
+ * "Update from GitHub", as one button all three surfaces render: the tickets panel's header and
+ * its empty state, and the onboarding checklist. The label, the prompt behind it, and what the
+ * tooltip promises were written out per surface, which is the same drift the shared prompt exists
+ * to prevent — one wording change and two of the three would still say the old thing.
+ */
+export function UpdateTicketsButton({
+  busy,
+  onStart,
+  onConfigure,
+  lastImportedAt,
+  disabled,
+  variant,
+  size = 'sm',
+  className,
+}: {
+  busy: boolean
+  onStart: () => void
+  /** Open the launcher with this prompt instead of spending a session on it. */
+  onConfigure: () => void
+  /** When tickets last came across, so the tooltip can promise the incremental update (#1265). */
+  lastImportedAt?: string | undefined
+  disabled?: boolean | undefined
+  variant?: 'default' | 'outline' | undefined
+  size?: 'xs' | 'sm' | undefined
+  className?: string | undefined
+}) {
+  return (
+    <StartAgentButton
+      {...(variant ? { variant } : {})}
+      size={size}
+      {...(disabled !== undefined ? { disabled } : {})}
+      {...(className ? { className } : {})}
+      icon={<RefreshCw className="h-3.5 w-3.5" aria-hidden />}
+      label="Update from GitHub"
+      menuAriaLabel="Other ways to update from GitHub"
+      tooltip={
+        lastImportedAt
+          ? 'Bring tickets/ up to date with the issues and comments changed since the last import.'
+          : 'Bring tickets/ up to date with GitHub. With no import on record, everything open comes across.'
+      }
+      busy={busy}
+      starting={busy}
+      onStart={onStart}
+      onConfigure={onConfigure}
+      prompt={UPDATE_TICKETS_PROMPT}
+      configureDescription="Opens the launcher with the update prompt, so you can set the model and where it runs."
+    />
+  )
+}

--- a/packages/framework/dashboard/components/WorkspaceActions.tsx
+++ b/packages/framework/dashboard/components/WorkspaceActions.tsx
@@ -1,23 +1,17 @@
 import { useEffect } from 'react'
-import { Github, FolderOpen, Code, Check } from 'lucide-react'
+import { Github, FolderOpen, Code } from 'lucide-react'
 import { onGithubUrl } from '../rpc/reads.js'
 import { sendOpenInApp } from '../rpc/control.js'
-import type { EditorInfo } from '../rpc/preferences.js'
 import { useLoaded } from '../lib/use-async.js'
 import { useAction } from '../lib/use-action.js'
-import { usePreferences, updatePreferences } from '../lib/preferences.js'
-import { useDetectedEditors } from '../lib/editors.js'
-import { cn } from '../lib/utils.js'
 import { Button, buttonVariants } from './ui/button.js'
-import { OptionLabel } from './ui/option-label.js'
+import { PreferredEditorItems } from './PreferredEditorItems.js'
 import { Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip.js'
 import {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
-  DropdownMenuGroup,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
 } from './ui/dropdown-menu.js'
 
@@ -40,15 +34,6 @@ export function WorkspaceActions({
   // back and shove the icon row (within a project it is already stable, keyed on projectId).
   const githubUrl = useLoaded<string | null>(() => onGithubUrl(projectId), null, [projectId], true)
   const { busy, error, reset, run } = useAction()
-  // The preferred editor lives with the action that opens it now (#727), not off in the options
-  // gear: click to open, or pick which editor to remember. The stored one shows as a "custom" row
-  // when it isn't auto-detected (a hand-set $FRAMEWORK_EDITOR), so the choice always appears.
-  const editor = usePreferences().editor
-  const detectedEditors = useDetectedEditors()
-  const editorRows: EditorInfo[] =
-    editor && !detectedEditors.some(e => e.bin === editor)
-      ? [...detectedEditors, { bin: editor, label: editor }]
-      : detectedEditors
 
   // `error` belongs to open(), not to the read, so clearing it on a switch is its own effect:
   // otherwise the last checkout's failure stays on screen next to the new one's actions.
@@ -106,30 +91,7 @@ export function WorkspaceActions({
             {agentId ? "Open this agent's checkout" : 'Open in your editor'}
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuGroup>
-            <DropdownMenuLabel>Preferred editor</DropdownMenuLabel>
-            <DropdownMenuItem
-              disabled={busy}
-              closeOnClick={false}
-              onClick={() => updatePreferences({ editor: '' })}
-              className="items-start"
-            >
-              <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', editor ? 'opacity-0' : 'opacity-100')} />
-              <OptionLabel label="Default" description="$FRAMEWORK_EDITOR, or code" />
-            </DropdownMenuItem>
-            {editorRows.map(e => (
-              <DropdownMenuItem
-                key={e.bin}
-                disabled={busy}
-                closeOnClick={false}
-                onClick={() => updatePreferences({ editor: e.bin })}
-                className="items-start"
-              >
-                <Check className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', editor === e.bin ? 'opacity-100' : 'opacity-0')} />
-                <OptionLabel label={e.label} description={e.bin} />
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuGroup>
+          <PreferredEditorItems busy={busy} />
         </DropdownMenuContent>
       </DropdownMenu>
       {/* Serve (#475) the checkout this bar is about: the project's, or the session's own (#797). */}

--- a/packages/framework/dashboard/components/ui/scroll-area.tsx
+++ b/packages/framework/dashboard/components/ui/scroll-area.tsx
@@ -55,7 +55,7 @@ export function ScrollArea({
   )
 }
 
-export function ScrollBar({ className, ...props }: ComponentProps<typeof ScrollAreaPrimitive.Scrollbar>) {
+function ScrollBar({ className, ...props }: ComponentProps<typeof ScrollAreaPrimitive.Scrollbar>) {
   return (
     <ScrollAreaPrimitive.Scrollbar
       data-slot="scroll-area-scrollbar"

--- a/packages/framework/dashboard/lib/route.ts
+++ b/packages/framework/dashboard/lib/route.ts
@@ -16,7 +16,7 @@
  * Safe to reserve because a project id is never this word: the registry builds one as
  * `<slugified basename>-<hash in base36>`, so every real id carries a `-<hash>` suffix.
  */
-export const SETTINGS_SEGMENT = 'settings'
+const SETTINGS_SEGMENT = 'settings'
 
 /**
  * The one word that names the Tickets view (#1144), whether as the bare first segment (the
@@ -27,14 +27,14 @@ export const SETTINGS_SEGMENT = 'settings'
  * always carries a `-<hash>` suffix, and an agent id is derived from its start time
  * (`agentIdFromStartedAt`) — neither is ever this bare word.
  */
-export const TICKETS_SEGMENT = 'tickets'
+const TICKETS_SEGMENT = 'tickets'
 
 /**
  * The word that names a ticket's plan view (its `.plan.md`), the fourth segment of
  * `/{projectId}/tickets/{slug}/plan`. Reserved past a ticket slug, where it can never collide: a
  * slug is a `.md` filename, so the bare word `plan` is never one.
  */
-export const PLAN_SEGMENT = 'plan'
+const PLAN_SEGMENT = 'plan'
 
 /** What the dashboard is looking at, as carried by the URL. */
 export interface Route {

--- a/packages/framework/dashboard/lib/ticket-filter.ts
+++ b/packages/framework/dashboard/lib/ticket-filter.ts
@@ -146,7 +146,7 @@ function rangeActive(f: RangeFilter): boolean {
 }
 
 /** A ticket's topics, lowercased — the one casing both matching and the facet list use. */
-export function normalTopics(ticket: WorkspaceTicket): string[] {
+function normalTopics(ticket: WorkspaceTicket): string[] {
   return (ticket.topics ?? []).map(t => t.toLowerCase())
 }
 
@@ -178,7 +178,7 @@ function matchesQuery(row: TicketRow, q: string): boolean {
 }
 
 /** The whole predicate: AND across facets, OR within each. */
-export function matchesFilters(row: TicketRow, f: TicketFilters): boolean {
+function matchesFilters(row: TicketRow, f: TicketFilters): boolean {
   const t = row.ticket
   if (!matchesQuery(row, f.q)) return false
   if (!matchesRange(parsePriority(t.priority), f.priority, PRIORITY_BUCKETS)) return false

--- a/packages/framework/src/agent-location.ts
+++ b/packages/framework/src/agent-location.ts
@@ -17,7 +17,7 @@
 export type AgentLocation = 'local' | 'actions' | 'web'
 
 /** Every location, for validating what arrives from a browser or a config file. */
-export const AGENT_LOCATIONS = ['local', 'actions', 'web'] as const
+const AGENT_LOCATIONS = ['local', 'actions', 'web'] as const
 
 /** Whether `value` names a location. */
 export function isAgentLocation(value: unknown): value is AgentLocation {

--- a/packages/framework/src/auto-pm.ts
+++ b/packages/framework/src/auto-pm.ts
@@ -25,7 +25,7 @@ export const DEFAULT_AUTO_PM_INTERVAL_MS = 10 * 60 * 1000
  * takes a moment to appear in the daemon's live-run map, and without this the next tick
  * would see "nothing running, queue still empty" and start a second one.
  */
-export const DEFAULT_AUTO_PM_COOLDOWN_MS = 30 * 60 * 1000
+const DEFAULT_AUTO_PM_COOLDOWN_MS = 30 * 60 * 1000
 
 /** What the policy was told about one project at one moment. */
 export interface AutoPmInputs {

--- a/packages/framework/src/await-gate.ts
+++ b/packages/framework/src/await-gate.ts
@@ -124,7 +124,7 @@ export interface AwaitTurnDeps {
  * `continueWith` is. Keeping one loop is what stopped the per-turn signal emission from
  * having to be added to each copy by hand (#563).
  */
-export async function drainGates<T extends { text: string }>(
+async function drainGates<T extends { text: string }>(
   turn: T,
   deps: AwaitTurnDeps,
   continueWith: (question: string, answer: string) => Promise<T>,

--- a/packages/framework/src/branch-links.ts
+++ b/packages/framework/src/branch-links.ts
@@ -3,6 +3,7 @@ import { nodeGitRunner, type GitRunner } from './project.js'
 import { excludeFromGit } from './git-exclude.js'
 import { FRAMEWORK_DIR, BRANCHES_DIR, worktreeDirEntries, worktreeBranch, type WorktreeDirEntry } from './store/index.js'
 import { isWorktreeDirName } from './branch-names.js'
+import { startProjectPass, type ProjectPass, type ProjectsSource } from './project-pass.js'
 
 // The branches view (#1580): every checkout under `.the-framework/branches/` is a directory named
 // as its birth branch (`tf-agent-<id>`), and this pass keeps the *current* names reachable beside
@@ -32,7 +33,7 @@ export interface LinksFs {
 }
 
 /** A {@link LinksFs} over `node:fs/promises`, dynamically imported like {@link nodeDirLister}. */
-export function nodeLinksFs(): LinksFs {
+function nodeLinksFs(): LinksFs {
   const fs = () => import('node:fs/promises')
   return {
     readdir: dir => fs().then(f => f.readdir(dir)).catch(() => []),
@@ -121,16 +122,9 @@ export async function reconcileBranchLinks(cwd: string, deps: BranchLinksDeps = 
   }
 }
 
-/** A running reconcile pass, in the shape the daemon's other background services use. */
-export interface BranchLinksPass {
-  /** Run one pass now, awaiting it. */
-  tick: () => Promise<void>
-  stop: () => void
-}
-
 /** What {@link startBranchLinksPass} needs from the daemon. */
 export interface BranchLinksOptions {
-  projects: () => Promise<readonly { path: string }[]>
+  projects: ProjectsSource
   /** The per-project reconcile (default {@link reconcileBranchLinks}). */
   reconcile?: (cwd: string) => Promise<void>
 }
@@ -141,31 +135,7 @@ export interface BranchLinksOptions {
  * gets its link immediately because allocation calls the reconcile too. Quiet on purpose: links
  * are presentation, and narrating every rename would drown the log.
  */
-export function startBranchLinksPass(opts: BranchLinksOptions): BranchLinksPass {
+export function startBranchLinksPass(opts: BranchLinksOptions): ProjectPass {
   const reconcile = opts.reconcile ?? reconcileBranchLinks
-  let stopped = false
-
-  const passAll = async (): Promise<void> => {
-    for (const project of await opts.projects().catch(() => [])) {
-      if (stopped) break
-      await reconcile(project.path).catch(() => {})
-    }
-  }
-
-  // Same overlap rule as the worktree sweep: awaiting `tick()` means the pass finished.
-  let inflight: Promise<void> | undefined
-  const tick = (): Promise<void> => {
-    if (stopped) return Promise.resolve()
-    inflight ??= passAll().finally(() => {
-      inflight = undefined
-    })
-    return inflight
-  }
-
-  return {
-    tick,
-    stop: () => {
-      stopped = true
-    },
-  }
+  return startProjectPass(opts.projects, cwd => reconcile(cwd).catch(() => {}))
 }

--- a/packages/framework/src/ci-watch.ts
+++ b/packages/framework/src/ci-watch.ts
@@ -2,6 +2,7 @@ import { listAgents, readLiveMetas, type AgentMeta } from './store/index.js'
 import { mergeAgentPr, resolveAgentPr, type HandoffResult, type PrAgent } from './dashboard/agent-handoff.js'
 import { ghPrCiStatus, type LinkedPr, type PrCiStatus } from './dashboard/gh.js'
 import type { Cached } from './dashboard/cache.js'
+import { startProjectPass, type ProjectPass, type ProjectsSource } from './project-pass.js'
 
 // Watch the PRs the framework is waiting to land, and act on what their CI says (#1418).
 //
@@ -255,17 +256,10 @@ async function requestFix(
   return agentId ? { number: pr.number, agentId } : { number: pr.number, reason: 'declined' }
 }
 
-/** A running watch, in the shape the daemon's other background services use. */
-export interface CiWatch {
-  /** Run one sweep now, awaiting it. Exposed for tests and on-demand callers. */
-  tick: () => Promise<void>
-  stop: () => void
-}
-
 /** What {@link startCiWatch} needs from the daemon. */
 export interface CiWatchOptions {
   /** The registered projects to sweep. */
-  projects: () => Promise<readonly { path: string }[]>
+  projects: ProjectsSource
   log: (message: string) => void
   /** The per-project sweep's seams, {@link CiSweepDeps.fix} included — the daemon wires the gates. */
   deps?: CiSweepDeps
@@ -281,10 +275,9 @@ export interface CiWatchOptions {
  * timer is unref'd, and everything it does is logged — a PR merging with no line explaining why
  * reads as a bug even when it is the feature.
  */
-export function startCiWatch(opts: CiWatchOptions): CiWatch {
+export function startCiWatch(opts: CiWatchOptions): ProjectPass {
   const sweep = opts.sweep ?? sweepProjectCi
   const deps: CiSweepDeps = { attemptedMerges: new Set(), ...opts.deps }
-  let stopped = false
 
   // A red or unmergeable PR stays a candidate for a week, and its line does not get truer with
   // repetition: each distinct line is said once per daemon lifetime.
@@ -295,39 +288,18 @@ export function startCiWatch(opts: CiWatchOptions): CiWatch {
     opts.log(line)
   }
 
-  const sweepAll = async (): Promise<void> => {
-    for (const project of await opts.projects().catch(() => [])) {
-      if (stopped) break
-      const result = await sweep(project.path, deps).catch(
-        (): CiSweepResult => ({ merged: [], failed: [], fixes: [] }),
-      )
-      for (const item of result.merged) {
-        opts.log(`[framework] CI watch: checks passed on PR #${item.number}, merged it${item.url ? ` (${item.url})` : ''} (session ${item.agentId})`)
-      }
-      for (const item of result.failed) {
-        sayOnce(`[framework] CI watch: could not merge PR #${item.number}: ${item.error}`)
-      }
-      for (const item of result.fixes) {
-        if (item.agentId) opts.log(`[framework] CI watch: checks failed on PR #${item.number}, started fix session ${item.agentId}`)
-        else if (item.reason === 'attempts-exhausted') sayOnce(`[framework] CI watch: PR #${item.number} is still red after ${MAX_CI_FIX_ATTEMPTS} fix sessions; leaving it for a human`)
-      }
-    }
-  }
-
-  let inflight: Promise<void> | undefined
-  const tick = (): Promise<void> => {
-    if (stopped) return Promise.resolve()
-    inflight ??= sweepAll().finally(() => {
-      inflight = undefined
-    })
-    return inflight
-  }
-
   // No timer of its own (E4): the daemon's one clock calls `tick`.
-  return {
-    tick,
-    stop: () => {
-      stopped = true
-    },
-  }
+  return startProjectPass(opts.projects, async cwd => {
+    const result = await sweep(cwd, deps).catch((): CiSweepResult => ({ merged: [], failed: [], fixes: [] }))
+    for (const item of result.merged) {
+      opts.log(`[framework] CI watch: checks passed on PR #${item.number}, merged it${item.url ? ` (${item.url})` : ''} (session ${item.agentId})`)
+    }
+    for (const item of result.failed) {
+      sayOnce(`[framework] CI watch: could not merge PR #${item.number}: ${item.error}`)
+    }
+    for (const item of result.fixes) {
+      if (item.agentId) opts.log(`[framework] CI watch: checks failed on PR #${item.number}, started fix session ${item.agentId}`)
+      else if (item.reason === 'attempts-exhausted') sayOnce(`[framework] CI watch: PR #${item.number} is still red after ${MAX_CI_FIX_ATTEMPTS} fix sessions; leaving it for a human`)
+    }
+  })
 }

--- a/packages/framework/src/cli.ts
+++ b/packages/framework/src/cli.ts
@@ -100,7 +100,7 @@ export function chooseSessionLink(opts: Pick<AgentOptions, 'driver'>, fake: bool
  * the daemon token that the daemon's start-queue asks for. Anything less and the run fails
  * saying web runs start from the dashboard.
  */
-export async function extensionStartConfig(env: NodeJS.ProcessEnv): Promise<CloudDriverOptions | undefined> {
+async function extensionStartConfig(env: NodeJS.ProcessEnv): Promise<CloudDriverOptions | undefined> {
   const daemonUrl = env[DAEMON_URL_ENV]
   if (!daemonUrl) return undefined
   const token = await readDaemonToken(undefined, env).catch(() => undefined)

--- a/packages/framework/src/cloud-scratch-refs.ts
+++ b/packages/framework/src/cloud-scratch-refs.ts
@@ -4,6 +4,7 @@ import { ghPrsForBranch, type LinkedPr } from './dashboard/gh.js'
 import { startedAtFromAgentId, FRAMEWORK_DIR, AGENT_BRANCH_PREFIX, LEGACY_AGENT_BRANCH_PREFIX } from './store/index.js'
 import { nodeFs } from './node-fs.js'
 import { errorMessage } from './error-message.js'
+import { startProjectPass, type ProjectPass, type ProjectsSource } from './project-pass.js'
 
 // Sweep the scratch refs a cloud hand-off leaves on origin (#1547).
 //
@@ -55,7 +56,7 @@ const RUN_BRANCH_PREFIXES = [`${AGENT_BRANCH_PREFIX}agent-`, `${LEGACY_AGENT_BRA
  * timestamp and its commit date says nothing — the driver pushes the worktree's HEAD, which is
  * however old the base commit happens to be, not when the hand-off happened.
  */
-export const CLOUD_REFS_FILE = 'cloud-refs.json'
+const CLOUD_REFS_FILE = 'cloud-refs.json'
 
 /** When the sweep first saw each `cloud-*` ref on origin, ISO, keyed by short ref name. */
 interface CloudRefsState {
@@ -318,17 +319,10 @@ export async function sweepCloudScratchRefs(cwd: string, deps: ScratchSweepDeps 
   return result
 }
 
-/** A running sweep, in the shape the daemon's other background services use. */
-export interface CloudScratchSweep {
-  /** Run one sweep now, awaiting it. Exposed for tests and for a caller that wants it on demand. */
-  tick: () => Promise<void>
-  stop: () => void
-}
-
 /** What {@link startCloudScratchSweep} needs from the daemon. */
 export interface CloudScratchSweepOptions {
   /** The registered projects to sweep. */
-  projects: () => Promise<readonly { path: string }[]>
+  projects: ProjectsSource
   log: (message: string) => void
   /** The agents the daemon is still responsible for, whose run branches this must not touch. */
   busy?: () => ReadonlySet<string>
@@ -343,39 +337,17 @@ export interface CloudScratchSweepOptions {
  * enough yet is the normal state of every ref this watches, and a line per tick about it would be
  * noise. A ref vanishing from origin with no line explaining why would read as a bug.
  */
-export function startCloudScratchSweep(opts: CloudScratchSweepOptions): CloudScratchSweep {
+export function startCloudScratchSweep(opts: CloudScratchSweepOptions): ProjectPass {
   const sweep = opts.sweep ?? ((cwd: string) => sweepCloudScratchRefs(cwd, { ...(opts.busy ? { busy: opts.busy() } : {}) }))
-  let stopped = false
-
-  const sweepAll = async (): Promise<void> => {
-    for (const project of await opts.projects().catch(() => [])) {
-      if (stopped) break
-      const { deleted, failed } = await sweep(project.path).catch((): ScratchSweepResult => ({ deleted: [], kept: [], failed: [] }))
-      for (const ref of deleted) {
-        opts.log(`[framework] deleted the leftover cloud hand-off ref ${ref} on origin: its session settled long ago and nothing consumes it (#1547).`)
-      }
-      for (const item of failed) {
-        opts.log(`[framework] could not delete the leftover ref ${item.ref} on origin: ${item.error}`)
-      }
-    }
-  }
-
-  // Overlapping ticks join the sweep already running rather than being dropped, so awaiting
-  // `tick()` means the sweep finished — same rule as the worktree sweep, for the same reason.
-  let inflight: Promise<void> | undefined
-  const tick = (): Promise<void> => {
-    if (stopped) return Promise.resolve()
-    inflight ??= sweepAll().finally(() => {
-      inflight = undefined
-    })
-    return inflight
-  }
 
   // No timer of its own (E4): the daemon's one clock calls `tick`.
-  return {
-    tick,
-    stop: () => {
-      stopped = true
-    },
-  }
+  return startProjectPass(opts.projects, async cwd => {
+    const { deleted, failed } = await sweep(cwd).catch((): ScratchSweepResult => ({ deleted: [], kept: [], failed: [] }))
+    for (const ref of deleted) {
+      opts.log(`[framework] deleted the leftover cloud hand-off ref ${ref} on origin: its session settled long ago and nothing consumes it (#1547).`)
+    }
+    for (const item of failed) {
+      opts.log(`[framework] could not delete the leftover ref ${item.ref} on origin: ${item.error}`)
+    }
+  })
 }

--- a/packages/framework/src/cloud-work.ts
+++ b/packages/framework/src/cloud-work.ts
@@ -5,6 +5,7 @@ import { agentBranchName } from './branch-names.js'
 import { listAgents, nodeStoreFs, startedAtFromAgentId, type AgentMeta, type ArchivePatch } from './store/index.js'
 import { patchArchivedAgentOnDataBranch } from './archived-agent-patch.js'
 import { errorMessage } from './error-message.js'
+import { startProjectPass, type ProjectPass, type ProjectsSource } from './project-pass.js'
 
 // Adopt the branch a cloud session actually worked on (#1601).
 //
@@ -225,17 +226,10 @@ export async function adoptCloudWork(cwd: string, deps: CloudWorkDeps = {}): Pro
   return result
 }
 
-/** A running adoption pass, in the shape the daemon's other background services use. */
-export interface CloudWorkAdoption {
-  /** Run one pass now, awaiting it. Exposed for tests and for a caller that wants it on demand. */
-  tick: () => Promise<void>
-  stop: () => void
-}
-
 /** What {@link startCloudWorkAdoption} needs from the daemon. */
 export interface CloudWorkAdoptionOptions {
   /** The registered projects to pass over. */
-  projects: () => Promise<readonly { path: string }[]>
+  projects: ProjectsSource
   log: (message: string) => void
   /** The per-project pass (default {@link adoptCloudWork}). */
   adopt?: (cwd: string) => Promise<CloudWorkResult>
@@ -248,40 +242,18 @@ export interface CloudWorkAdoptionOptions {
  * pushed yet is the normal state of every run this watches, and a line per tick about it would
  * be noise. A run's row changing branch with no line explaining why would read as a bug.
  */
-export function startCloudWorkAdoption(opts: CloudWorkAdoptionOptions): CloudWorkAdoption {
+export function startCloudWorkAdoption(opts: CloudWorkAdoptionOptions): ProjectPass {
   const adopt = opts.adopt ?? adoptCloudWork
-  let stopped = false
-
-  const passAll = async (): Promise<void> => {
-    for (const project of await opts.projects().catch(() => [])) {
-      if (stopped) break
-      const { adopted, failed } = await adopt(project.path).catch((): CloudWorkResult => ({ adopted: [], failed: [] }))
-      for (const adoption of adopted) {
-        const prLine = adoption.pr ? (adoption.opened ? `; opened its armed draft PR ${adoption.pr.url}` : `; its PR is ${adoption.pr.url}`) : ''
-        opts.log(`[framework] session ${adoption.agentId}'s cloud work landed on ${adoption.branch} — adopted as its branch (#1601)${prLine}`)
-      }
-      for (const failure of failed) {
-        opts.log(`[framework] cloud work adoption for session ${failure.agentId}: ${failure.error}`)
-      }
-    }
-  }
-
-  // Overlapping ticks join the pass already running rather than being dropped, so awaiting
-  // `tick()` means the pass finished — same rule as the worktree sweep, for the same reason.
-  let inflight: Promise<void> | undefined
-  const tick = (): Promise<void> => {
-    if (stopped) return Promise.resolve()
-    inflight ??= passAll().finally(() => {
-      inflight = undefined
-    })
-    return inflight
-  }
 
   // No timer of its own (E4): the daemon's one clock calls `tick`.
-  return {
-    tick,
-    stop: () => {
-      stopped = true
-    },
-  }
+  return startProjectPass(opts.projects, async cwd => {
+    const { adopted, failed } = await adopt(cwd).catch((): CloudWorkResult => ({ adopted: [], failed: [] }))
+    for (const adoption of adopted) {
+      const prLine = adoption.pr ? (adoption.opened ? `; opened its armed draft PR ${adoption.pr.url}` : `; its PR is ${adoption.pr.url}`) : ''
+      opts.log(`[framework] session ${adoption.agentId}'s cloud work landed on ${adoption.branch} — adopted as its branch (#1601)${prLine}`)
+    }
+    for (const failure of failed) {
+      opts.log(`[framework] cloud work adoption for session ${failure.agentId}: ${failure.error}`)
+    }
+  })
 }

--- a/packages/framework/src/config.ts
+++ b/packages/framework/src/config.ts
@@ -38,7 +38,7 @@ export interface FrameworkFileConfig {
 }
 
 /** Config file names read from the workspace root, in precedence order. */
-export const FRAMEWORK_CONFIG_FILES = ['the-framework.yml', 'the-framework.yaml'] as const
+const FRAMEWORK_CONFIG_FILES = ['the-framework.yml', 'the-framework.yaml'] as const
 
 /**
  * The keys whose values come from a closed set, so parsing checks the value rather than the type

--- a/packages/framework/src/daemon-runtime.ts
+++ b/packages/framework/src/daemon-runtime.ts
@@ -76,7 +76,7 @@ const DRIVER_READY_TTL_MS = 30_000
  * back here, so each spawn spawns another: a fork bomb. A real agent passes the compiled bin
  * (or an explicit `binPath`), so the guard only ever trips in tests.
  */
-export function resolveSpawnBin(explicitBinPath: string | undefined): string {
+function resolveSpawnBin(explicitBinPath: string | undefined): string {
   const binPath = explicitBinPath ?? process.argv[1]
   if (!binPath) throw new Error('cannot locate the framework CLI entry')
   if (!explicitBinPath && (process.env.NODE_TEST_CONTEXT || /\.test\.[cm]?[jt]s$/.test(binPath))) {
@@ -110,7 +110,7 @@ async function appendAgentLog(cwd: string, message: string): Promise<void> {
  * `env` is the child's whole environment; the daemon adds its own URL to it (#1328) so a web run
  * can ask this daemon for a cloud session.
  */
-export function spawnDetached(binPath: string, specPath: string, stderrFile?: string, env: NodeJS.ProcessEnv = process.env): ChildProcess {
+function spawnDetached(binPath: string, specPath: string, stderrFile?: string, env: NodeJS.ProcessEnv = process.env): ChildProcess {
   // stderr goes to a file, never a pipe: a detached child must not block on a dead parent's pipe
   // buffer, and the file is what makes a silent boot death diagnosable (#1261). Best-effort — a
   // run must still start when the log cannot be opened.
@@ -132,7 +132,7 @@ export function spawnDetached(binPath: string, specPath: string, stderrFile?: st
 }
 
 /** A spawned run's environment: ours, plus the daemon's URL when it has one (#1328). */
-export function childEnv(daemonUrl: string | undefined, base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+function childEnv(daemonUrl: string | undefined, base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
   return daemonUrl ? { ...base, [DAEMON_URL_ENV]: daemonUrl } : base
 }
 

--- a/packages/framework/src/daemon-services.ts
+++ b/packages/framework/src/daemon-services.ts
@@ -160,7 +160,7 @@ export async function resolveProjectAgentOptions(id: string, env: NodeJS.Process
  * go from a stand-down straight to `ps` and to the run's own page. The worktree-less fallback
  * agent has no id of its own and is named by where it runs.
  */
-export function describeSlot(slot: ActiveAgentSlot): string {
+function describeSlot(slot: ActiveAgentSlot): string {
   const who = slot.agentId ?? 'a run in the project checkout'
   return slot.state === 'starting' ? `${who} (starting)` : `${who} (pid ${slot.pid})`
 }

--- a/packages/framework/src/dashboard-rpc/reads.ts
+++ b/packages/framework/src/dashboard-rpc/reads.ts
@@ -115,7 +115,7 @@ export function markOtherHost(agent: AgentMeta, thisHost: string = hostname()): 
 }
 
 /** Every annotation a run's record gets on its way to the dashboard: what the daemon knows and the disk cannot. */
-export function forDashboard(agent: AgentMeta): AgentMeta {
+function forDashboard(agent: AgentMeta): AgentMeta {
   return markOtherHost(markCloudWaiting(agent))
 }
 

--- a/packages/framework/src/dashboard-rpc/test-context.ts
+++ b/packages/framework/src/dashboard-rpc/test-context.ts
@@ -3,19 +3,17 @@ import { registryPreferencesStore } from '../registry.js'
 import { registryDiscordCredentialsStore } from '../discord-credentials-store.js'
 import { defaultQuotaSource } from '../dashboard/quota.js'
 import type { DashboardContext } from '../dashboard/rpc-serve.js'
+import type { DashboardOptions } from '../dashboard/server.js'
 
 /**
- * Wire the dashboard's capabilities for a test that calls an RPC directly.
- *
- * There is one dashboard host and it wires every capability (D3), so an RPC reads its context as
- * simply there — a missing field is a wiring bug, and it throws. That makes this the one place a
- * test says what the host would have wired, with only the parts it cares about overridden.
- *
- * It sticks until the next call, where Telefunc's request context used to evaporate at the next
- * macrotask (F3) — so a test no longer has to call this immediately before the RPC under test.
+ * What the dashboard host wires (D3), as a test would have it: every capability present, the two
+ * that start work refusing, and the reads answering empty. There is one host and it wires every
+ * capability, so an RPC reads its context as simply there — a missing field is a wiring bug, and
+ * it throws. That makes this the one place a test says what the host would have wired, with only
+ * the parts it cares about overridden.
  */
-export function provideTestContext(over: Partial<DashboardContext> = {}): void {
-  setDashboardContext({
+export function testDashboardContext(over: Partial<DashboardContext> = {}): DashboardContext {
+  return {
     startAgent: () => ({ ok: false, error: 'not wired in this test' }),
     addProject: () => ({ ok: false, error: 'not wired in this test' }),
     eventsSource: () => undefined,
@@ -27,5 +25,24 @@ export function provideTestContext(over: Partial<DashboardContext> = {}): void {
     autoPmSweep: () => {},
     projectErrors: () => [],
     ...over,
-  } satisfies DashboardContext)
+  }
+}
+
+/**
+ * The same wiring as {@link testDashboardContext}, in the shape {@link startDashboard} takes: a
+ * test asserting one route still stands up the same server the product does.
+ */
+export function testDashboardOptions(over: Partial<DashboardOptions> = {}): DashboardOptions {
+  const { startAgent, addProject, ...rest } = testDashboardContext()
+  return { port: 0, onStart: startAgent, onAddProject: addProject, ...rest, ...over }
+}
+
+/**
+ * Wire the dashboard's capabilities for a test that calls an RPC directly.
+ *
+ * It sticks until the next call, where Telefunc's request context used to evaporate at the next
+ * macrotask (F3) — so a test no longer has to call this immediately before the RPC under test.
+ */
+export function provideTestContext(over: Partial<DashboardContext> = {}): void {
+  setDashboardContext(testDashboardContext(over))
 }

--- a/packages/framework/src/dashboard/agent-handoff.ts
+++ b/packages/framework/src/dashboard/agent-handoff.ts
@@ -494,19 +494,26 @@ export async function openBranchPullRequest(
     const args = ['pr', 'create', '--head', branch, '--title', draft.title, '--body', draft.body]
     if (draft.base) args.push('--base', prBaseName(draft.base))
     if (draft.draft) args.push('--draft')
-    const out = (await gh(args, cwd)).trim()
-    // The branch has a PR now, so the cached "no PR" must go or the bar would keep offering to
-    // open one for the next minute (#1028). Both caches: the single-PR view and the history.
-    forgetPr(cwd, branch)
-    forgetBranchPrs(cwd, branch)
-    // gh prints the new PR's URL as its last line, and the number is its last path segment.
-    const url = out.split('\n').filter(Boolean).at(-1)
-    if (!url) return { ok: true }
-    const number = prNumberFromUrl(url)
-    return { ok: true, url, ...(number !== undefined ? { number } : {}) }
+    return createdPr(await gh(args, cwd), cwd, branch)
   } catch (err) {
     return { ok: false, error: errorMessage(err) }
   }
+}
+
+/**
+ * What a `gh pr create` left behind. gh prints the new PR's URL as its last line, and the number is
+ * that URL's last path segment; an output with no URL still reports success, since the PR is open.
+ *
+ * The branch has a PR now, so the cached "no PR" must go or the bar would keep offering to open one
+ * for the next minute (#1028) — both caches: the single-PR view and the history.
+ */
+function createdPr(out: string, cwd: string, branch: string): HandoffResult {
+  forgetPr(cwd, branch)
+  forgetBranchPrs(cwd, branch)
+  const url = out.trim().split('\n').filter(Boolean).at(-1)
+  if (!url) return { ok: true }
+  const number = prNumberFromUrl(url)
+  return { ok: true, url, ...(number !== undefined ? { number } : {}) }
 }
 
 /**
@@ -525,13 +532,8 @@ export async function openRemoteBranchPullRequest(
 ): Promise<HandoffResult> {
   const gh = deps.gh ?? nodeGhRunner()
   try {
-    const out = (await gh(['pr', 'create', '--head', branch, '--title', agentPrTitle(agent), '--body', agentPrBody(agent), '--draft'], cwd)).trim()
-    forgetPr(cwd, branch)
-    forgetBranchPrs(cwd, branch)
-    const url = out.split('\n').filter(Boolean).at(-1)
-    if (!url) return { ok: true }
-    const number = prNumberFromUrl(url)
-    return { ok: true, url, ...(number !== undefined ? { number } : {}) }
+    const args = ['pr', 'create', '--head', branch, '--title', agentPrTitle(agent), '--body', agentPrBody(agent), '--draft']
+    return createdPr(await gh(args, cwd), cwd, branch)
   } catch (err) {
     return { ok: false, error: errorMessage(err) }
   }

--- a/packages/framework/src/dashboard/bridge-endpoints.ts
+++ b/packages/framework/src/dashboard/bridge-endpoints.ts
@@ -1,6 +1,7 @@
 import { timingSafeEqual } from 'node:crypto'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { BridgeOption, BridgeQuestion } from './bridge-question.js'
+import { end, readPost, requireGet, sendJson } from './http.js'
 
 export type { BridgeOption, BridgeQuestion } from './bridge-question.js'
 
@@ -162,7 +163,7 @@ export async function handleBridgeRequest(
     }
   }
   if (pathname === `${BRIDGE_PREFIX}/ping`) {
-    if (req.method !== 'GET') return end(res, 405, 'method not allowed', { allow: 'GET' })
+    if (!requireGet(req, res)) return
     return end(res, 200, 'ok')
   }
   if (pathname === `${BRIDGE_PREFIX}/question`) return handleQuestion(req, res, handlers)
@@ -190,19 +191,32 @@ export function bearerAuthorized(req: IncomingMessage, token: string): boolean {
   return timingSafeEqual(given, expected)
 }
 
+/** When the daemon says it is; injectable so a test can pin the timestamps it records. */
+function now(handlers: BridgeHandlers): Date {
+  return (handlers.now ?? (() => new Date()))()
+}
+
 /** `POST /_bridge/question`: validate hard, record, answer 204. */
 async function handleQuestion(req: IncomingMessage, res: ServerResponse, handlers: BridgeHandlers): Promise<void> {
-  if (req.method !== 'POST') return end(res, 405, 'method not allowed', { allow: 'POST' })
-  let body: unknown
-  try {
-    body = await readJsonBody(req, MAX_BODY)
-  } catch (err) {
-    return end(res, 400, (err as Error).message)
-  }
-  const question = validate(body, (handlers.now ?? (() => new Date()))())
+  const body = await readPost(req, res, MAX_BODY)
+  if (body === undefined) return
+  const question = validate(body, now(handlers))
   if (typeof question === 'string') return end(res, 400, question)
   handlers.record(question)
   end(res, 204, '')
+}
+
+/**
+ * The session a posted body names, or the reason it names none. Both bodies the extension posts
+ * are addressed to one cloud session and are refused the same way when they are not — one rule,
+ * one message, so a caller cannot learn a different thing from each route.
+ */
+function bodySessionId(body: unknown): { sessionId: string; raw: Record<string, unknown> } | string {
+  if (typeof body !== 'object' || body === null) return 'body must be an object'
+  const raw = body as Record<string, unknown>
+  const sessionId = raw.sessionId
+  if (typeof sessionId !== 'string' || !SESSION_ID.test(sessionId)) return 'sessionId must look like session_<id>'
+  return { sessionId, raw }
 }
 
 /**
@@ -210,10 +224,9 @@ async function handleQuestion(req: IncomingMessage, res: ServerResponse, handler
  * refused, so a newer extension posting an extra field still works against an older daemon.
  */
 function validate(body: unknown, now: Date): BridgeQuestion | string {
-  if (typeof body !== 'object' || body === null) return 'body must be an object'
-  const raw = body as Record<string, unknown>
-  const sessionId = raw.sessionId
-  if (typeof sessionId !== 'string' || !SESSION_ID.test(sessionId)) return 'sessionId must look like session_<id>'
+  const named = bodySessionId(body)
+  if (typeof named === 'string') return named
+  const { sessionId, raw } = named
   const title = raw.title
   if (typeof title !== 'string' || !title.trim() || title.length > MAX_TITLE) return `title must be a string of 1 to ${MAX_TITLE} characters`
   if (!Array.isArray(raw.options) || raw.options.length === 0) return 'options must be a non-empty array'
@@ -262,34 +275,27 @@ function validate(body: unknown, now: Date): BridgeQuestion | string {
  * what its last scrape found, so the daemon can be asked instead.
  */
 async function handleHello(req: IncomingMessage, res: ServerResponse, handlers: BridgeHandlers): Promise<void> {
-  if (req.method !== 'POST') return end(res, 405, 'method not allowed', { allow: 'POST' })
-  let body: unknown
-  try {
-    body = await readJsonBody(req, MAX_BODY)
-  } catch (err) {
-    return end(res, 400, (err as Error).message)
-  }
+  const body = await readPost(req, res, MAX_BODY)
+  if (body === undefined) return
   const raw = (typeof body === 'object' && body !== null ? body : {}) as Record<string, unknown>
   handlers.hello?.({
     version: typeof raw.version === 'string' ? raw.version.slice(0, 32) : 'unknown',
     sessionId: typeof raw.sessionId === 'string' && SESSION_ID.test(raw.sessionId) ? raw.sessionId : undefined,
     note: typeof raw.note === 'string' ? raw.note.slice(0, 300) : '',
-    at: (handlers.now ?? (() => new Date()))().toISOString(),
+    at: now(handlers).toISOString(),
   })
   end(res, 204, '')
 }
 
 /** `POST /_bridge/events`: record a batch of transcript entries. */
 async function handleEvents(req: IncomingMessage, res: ServerResponse, handlers: BridgeHandlers): Promise<void> {
+  // The method is checked here rather than left to `readPost`, so that a wrong method is refused
+  // ahead of the un-wired 404: a GET on a daemon with events off is still a wrong method.
   if (req.method !== 'POST') return end(res, 405, 'method not allowed', { allow: 'POST' })
   if (!handlers.recordEvent) return end(res, 404, 'events not enabled')
-  let body: unknown
-  try {
-    body = await readJsonBody(req, MAX_EVENTS_BODY)
-  } catch (err) {
-    return end(res, 400, (err as Error).message)
-  }
-  const events = validateEvents(body, (handlers.now ?? (() => new Date()))())
+  const body = await readPost(req, res, MAX_EVENTS_BODY)
+  if (body === undefined) return
+  const events = validateEvents(body, now(handlers))
   if (typeof events === 'string') return end(res, 400, events)
   for (const event of events) handlers.recordEvent(event)
   end(res, 204, '')
@@ -301,10 +307,9 @@ async function handleEvents(req: IncomingMessage, res: ServerResponse, handlers:
  * from a message that has not arrived yet.
  */
 function validateEvents(body: unknown, now: Date): BridgeEvent[] | string {
-  if (typeof body !== 'object' || body === null) return 'body must be an object'
-  const raw = body as Record<string, unknown>
-  const sessionId = raw.sessionId
-  if (typeof sessionId !== 'string' || !SESSION_ID.test(sessionId)) return 'sessionId must look like session_<id>'
+  const named = bodySessionId(body)
+  if (typeof named === 'string') return named
+  const { sessionId, raw } = named
   if (!Array.isArray(raw.events) || raw.events.length === 0) return 'events must be a non-empty array'
   if (raw.events.length > MAX_EVENT_BATCH) return `events must hold at most ${MAX_EVENT_BATCH} entries`
   const out: BridgeEvent[] = []
@@ -326,23 +331,16 @@ function validateEvents(body: unknown, now: Date): BridgeEvent[] | string {
  * poll it blindly. Degrades to null on a daemon that wired no answer source, same as `sessions`.
  */
 async function handleAnswer(req: IncomingMessage, res: ServerResponse, handlers: BridgeHandlers): Promise<void> {
-  if (req.method !== 'GET') return end(res, 405, 'method not allowed', { allow: 'GET' })
+  if (!requireGet(req, res)) return
   const sessionId = new URL(req.url ?? '', 'http://bridge.invalid').searchParams.get('sessionId')
   if (typeof sessionId !== 'string' || !SESSION_ID.test(sessionId)) return end(res, 400, 'sessionId must look like session_<id>')
-  const answer = handlers.answer?.(sessionId)
-  res.writeHead(200, { 'content-type': 'application/json' })
-  res.end(JSON.stringify({ answer: answer ?? null }))
+  sendJson(res, { answer: handlers.answer?.(sessionId) ?? null })
 }
 
 /** `POST /_bridge/answered`: what the extension's delivery attempt did. */
 async function handleAnswered(req: IncomingMessage, res: ServerResponse, handlers: BridgeHandlers): Promise<void> {
-  if (req.method !== 'POST') return end(res, 405, 'method not allowed', { allow: 'POST' })
-  let body: unknown
-  try {
-    body = await readJsonBody(req, MAX_BODY)
-  } catch (err) {
-    return end(res, 400, (err as Error).message)
-  }
+  const body = await readPost(req, res, MAX_BODY)
+  if (body === undefined) return
   if (typeof body !== 'object' || body === null) return end(res, 400, 'body must be an object')
   const { sessionId, id, ok, note } = body as Record<string, unknown>
   if (typeof sessionId !== 'string' || !SESSION_ID.test(sessionId)) return end(res, 400, 'sessionId must look like session_<id>')
@@ -362,21 +360,14 @@ async function handleAnswered(req: IncomingMessage, res: ServerResponse, handler
  * sessions, so taking it off the queue has to happen in the same step as reading it.
  */
 async function handleStart(req: IncomingMessage, res: ServerResponse, handlers: BridgeHandlers): Promise<void> {
-  if (req.method !== 'GET') return end(res, 405, 'method not allowed', { allow: 'GET' })
-  const start = handlers.start?.()
-  res.writeHead(200, { 'content-type': 'application/json' })
-  res.end(JSON.stringify({ start: start ?? null }))
+  if (!requireGet(req, res)) return
+  sendJson(res, { start: handlers.start?.() ?? null })
 }
 
 /** `POST /_bridge/started`: what the extension's creation attempt did (#1328). */
 async function handleStarted(req: IncomingMessage, res: ServerResponse, handlers: BridgeHandlers): Promise<void> {
-  if (req.method !== 'POST') return end(res, 405, 'method not allowed', { allow: 'POST' })
-  let body: unknown
-  try {
-    body = await readJsonBody(req, MAX_BODY)
-  } catch (err) {
-    return end(res, 400, (err as Error).message)
-  }
+  const body = await readPost(req, res, MAX_BODY)
+  if (body === undefined) return
   if (typeof body !== 'object' || body === null) return end(res, 400, 'body must be an object')
   const { id, ok, sessionId, note } = body as Record<string, unknown>
   if (typeof id !== 'string' || !id || id.length > 64) return end(res, 400, 'id must be the start request id')
@@ -397,40 +388,8 @@ async function handleStarted(req: IncomingMessage, res: ServerResponse, handlers
  * polling an older daemon degrades to doing nothing instead of reporting a fault.
  */
 async function handleAgents(req: IncomingMessage, res: ServerResponse, handlers: BridgeHandlers): Promise<void> {
-  if (req.method !== 'GET') return end(res, 405, 'method not allowed', { allow: 'GET' })
-  const sessions = handlers.sessions ? await handlers.sessions().catch(() => []) : []
-  res.writeHead(200, { 'content-type': 'application/json' })
-  res.end(JSON.stringify({ sessions }))
-}
-
-/** Read a JSON body, refusing anything past the cap rather than buffering it. */
-export function readJsonBody(req: IncomingMessage, maxBytes: number): Promise<unknown> {
-  return new Promise((resolve, reject) => {
-    let size = 0
-    const chunks: Buffer[] = []
-    req.on('data', (chunk: Buffer) => {
-      size += chunk.length
-      if (size > maxBytes) {
-        reject(new Error('body too large'))
-        req.destroy()
-        return
-      }
-      chunks.push(chunk)
-    })
-    req.on('end', () => {
-      try {
-        resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')))
-      } catch {
-        reject(new Error('body must be JSON'))
-      }
-    })
-    req.on('error', () => reject(new Error('read failed')))
-  })
-}
-
-function end(res: ServerResponse, status: number, message: string, headers: Record<string, string> = {}): void {
-  res.writeHead(status, { 'content-type': 'text/plain', ...headers })
-  res.end(message)
+  if (!requireGet(req, res)) return
+  sendJson(res, { sessions: handlers.sessions ? await handlers.sessions().catch(() => []) : [] })
 }
 
 /** Wrap a route so its outcome is recorded whatever it was. */

--- a/packages/framework/src/dashboard/bridge-store.ts
+++ b/packages/framework/src/dashboard/bridge-store.ts
@@ -56,7 +56,7 @@ export interface BridgeVersion {
 }
 
 /** How recently the extension must have spoken to count as present. */
-export const EXTENSION_ALIVE_WINDOW_MS = 3 * 60_000
+const EXTENSION_ALIVE_WINDOW_MS = 3 * 60_000
 
 export class BridgeQuestions {
   private readonly bySession = new Map<string, BridgeQuestion>()

--- a/packages/framework/src/dashboard/http.SPEC.md
+++ b/packages/framework/src/dashboard/http.SPEC.md
@@ -1,0 +1,7 @@
+The request and response conventions every non-RPC HTTP surface of the daemon follows — the browser bridge, the web-start queue, and the device relay.
+
+A failure is answered as a plain-text status line; a payload is answered as JSON. A request body is read up to a size cap and refused past it rather than buffered, so a caller cannot make the daemon hold an unbounded amount of data: a body over the cap is rejected as too large, and one that is not valid JSON is rejected as not JSON, so the caller learns which of the two it hit. A route that only accepts one HTTP method answers "method not allowed" for any other, naming the method it does accept.
+
+## Before modifying/creating SPEC.md files
+
+You must always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/framework/src/dashboard/http.ts
+++ b/packages/framework/src/dashboard/http.ts
@@ -1,0 +1,77 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+
+/**
+ * The plumbing every one of the daemon's non-RPC HTTP surfaces shares: the browser bridge
+ * (`/_bridge`), the web-start queue (`/_web-start`) and the device relay (`/_relay`).
+ *
+ * All three answer plain-text statuses, JSON payloads, and read capped JSON request bodies, and
+ * each carried its own copy — two body readers that differed only in which message they rejected
+ * with, and three identical status responders.
+ */
+
+/** Answer with a plain-text status line. */
+export function end(res: ServerResponse, status: number, message: string, headers: Record<string, string> = {}): void {
+  res.writeHead(status, { 'content-type': 'text/plain', ...headers })
+  res.end(message)
+}
+
+/** Answer with a JSON payload. */
+export function sendJson(res: ServerResponse, payload: unknown, status = 200): void {
+  res.writeHead(status, { 'content-type': 'application/json' })
+  res.end(JSON.stringify(payload))
+}
+
+/**
+ * Read a JSON body, refusing anything past the cap rather than buffering it. Rejects with
+ * `body too large` on overflow and `body must be JSON` on anything unparseable — the messages the
+ * bridge and web-start routes answer 400 with, so a caller learns which of the two it hit.
+ */
+export function readJsonBody(req: IncomingMessage, maxBytes: number): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let size = 0
+    const chunks: Buffer[] = []
+    req.on('data', (chunk: Buffer) => {
+      size += chunk.length
+      if (size > maxBytes) {
+        reject(new Error('body too large'))
+        req.destroy()
+        return
+      }
+      chunks.push(chunk)
+    })
+    req.on('end', () => {
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')))
+      } catch {
+        reject(new Error('body must be JSON'))
+      }
+    })
+    req.on('error', () => reject(new Error('read failed')))
+  })
+}
+
+/**
+ * The preamble every POST route runs: refuse a non-POST, then read the body. Answers the request
+ * itself on either failure and resolves `undefined`, so a caller's whole check is
+ * `const body = await readPost(...); if (body === undefined) return`. JSON has no `undefined`, so
+ * the sentinel cannot collide with a body that parsed.
+ */
+export async function readPost(req: IncomingMessage, res: ServerResponse, maxBytes: number): Promise<unknown> {
+  if (req.method !== 'POST') {
+    end(res, 405, 'method not allowed', { allow: 'POST' })
+    return undefined
+  }
+  try {
+    return await readJsonBody(req, maxBytes)
+  } catch (err) {
+    end(res, 400, (err as Error).message)
+    return undefined
+  }
+}
+
+/** Refuse anything but a GET, answering 405 itself. `false` means the request is already answered. */
+export function requireGet(req: IncomingMessage, res: ServerResponse): boolean {
+  if (req.method === 'GET') return true
+  end(res, 405, 'method not allowed', { allow: 'GET' })
+  return false
+}

--- a/packages/framework/src/dashboard/relay-endpoints.ts
+++ b/packages/framework/src/dashboard/relay-endpoints.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { FrameworkEvent } from '../events.js'
 import type { StartAgentKind, StartAgentOptions, StartAgentResult } from './types.js'
+import { end, readJsonBody, requireGet, sendJson } from './http.js'
 
 /**
  * The device-side of the remote-agent relay (#1067): the two endpoints a daemon exposes so another
@@ -59,9 +60,8 @@ export async function handleRelayRequest(
 /** `GET /_relay/ping` (#1072): answer 200 with an empty body. Starts nothing; only proves this
  * daemon is reachable and the caller's cookie is valid (the shared-token guard (#1051) already enforced that). */
 function handlePing(req: IncomingMessage, res: ServerResponse): void {
-  if (req.method !== 'GET') return end(res, 405, 'method not allowed', { allow: 'GET' })
-  res.writeHead(200, { 'content-type': 'text/plain' })
-  res.end()
+  if (!requireGet(req, res)) return
+  end(res, 200, '')
 }
 
 /** `POST /_relay/start`: read the agent request, start it locally, and answer with the result JSON. */
@@ -84,13 +84,12 @@ async function handleStart(req: IncomingMessage, res: ServerResponse, handlers: 
   } catch (err) {
     result = { ok: false, error: err instanceof Error ? err.message : String(err) }
   }
-  res.writeHead(200, { 'content-type': 'application/json' })
-  res.end(JSON.stringify(result))
+  sendJson(res, result)
 }
 
 /** `GET /_relay/events?run=<id>`: stream the agent's events as newline-delimited JSON. */
 function handleEvents(req: IncomingMessage, res: ServerResponse, handlers: RelayHandlers): void {
-  if (req.method !== 'GET') return end(res, 405, 'method not allowed', { allow: 'GET' })
+  if (!requireGet(req, res)) return
   const agentId = new URL(req.url ?? '/', 'http://localhost').searchParams.get('run')
   if (!agentId) return end(res, 400, 'missing run id')
   res.writeHead(200, { 'content-type': 'application/x-ndjson', 'cache-control': 'no-cache' })
@@ -122,41 +121,9 @@ async function handleRpc(req: IncomingMessage, res: ServerResponse, handlers: Re
   const args = Array.isArray(body.args) ? body.args : []
   if (!fn) return end(res, 400, 'missing rpc name')
   try {
-    const result = await handlers.rpc(fn, args)
-    res.writeHead(200, { 'content-type': 'application/json' })
-    res.end(JSON.stringify({ result }))
+    sendJson(res, { result: await handlers.rpc(fn, args) })
   } catch (err) {
     end(res, 500, err instanceof Error ? err.message : 'rpc failed')
   }
 }
 
-/** Read a capped JSON request body, rejecting on overflow or malformed JSON. */
-function readJsonBody(req: IncomingMessage, maxBytes: number): Promise<unknown> {
-  return new Promise((resolvePromise, rejectPromise) => {
-    const chunks: Buffer[] = []
-    let bytes = 0
-    req.on('data', (chunk: Buffer) => {
-      bytes += chunk.length
-      if (bytes > maxBytes) {
-        rejectPromise(new Error('payload too large'))
-        req.destroy()
-        return
-      }
-      chunks.push(chunk)
-    })
-    req.on('end', () => {
-      try {
-        resolvePromise(JSON.parse(Buffer.concat(chunks).toString('utf8')))
-      } catch (err) {
-        rejectPromise(err instanceof Error ? err : new Error('invalid json'))
-      }
-    })
-    req.on('error', rejectPromise)
-  })
-}
-
-/** Answer a relay request with a plain-text status. */
-function end(res: ServerResponse, status: number, message: string, headers: Record<string, string> = {}): void {
-  res.writeHead(status, { 'content-type': 'text/plain', ...headers })
-  res.end(message)
-}

--- a/packages/framework/src/dashboard/remote-run.integration.test.ts
+++ b/packages/framework/src/dashboard/remote-run.integration.test.ts
@@ -5,9 +5,7 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { EventStream } from '../event-stream.js'
 import { startDashboard } from './server.js'
-import { registryPreferencesStore } from '../registry.js'
-import { registryDiscordCredentialsStore } from '../discord-credentials-store.js'
-import { defaultQuotaSource } from './quota.js'
+import { testDashboardOptions } from '../dashboard-rpc/test-context.js'
 import { relayRpc } from './remote-run.js'
 import { createProjectRuntime, delay } from '../daemon-runtime.js'
 import { dispatchRelayRpc } from '../dashboard-rpc/relay-dispatch.js'
@@ -71,23 +69,16 @@ test('a run submitted with options.remote is created on the other daemon and its
   const cwdB = await mkdtemp(join(tmpdir(), 'relay-b-'))
   const homeIdB = projectId(resolve(cwdB))
   const bRpc = (fn: string, args: unknown[]): Promise<unknown> => dispatchRelayRpc(homeIdB, fn, args)
-  const deviceB = await startDashboard({
-    port: 0,
-    clientBundleDir: bundle,
-    token: TOKEN,
-    onStart: bStart,
-    relay: { tailEvents: bTail, rpc: bRpc },
-    // The rest of the one host's wiring (D3): this test drives the relay endpoints, not these.
-    onAddProject: () => ({ ok: false, error: 'not wired in this test' }),
-    eventsSource: () => undefined,
-    remote: { target: () => undefined, list: () => [] },
-    preferences: registryPreferencesStore(),
-    discord: registryDiscordCredentialsStore(),
-    quota: defaultQuotaSource(),
-    autoPm: () => undefined,
-    autoPmSweep: () => {},
-    projectErrors: () => [],
-  })
+  // The rest of the one host's wiring (D3) comes from the shared defaults: this test drives the
+  // relay endpoints, not the other capabilities.
+  const deviceB = await startDashboard(
+    testDashboardOptions({
+      clientBundleDir: bundle,
+      token: TOKEN,
+      onStart: bStart,
+      relay: { tailEvents: bTail, rpc: bRpc },
+    }),
+  )
 
   // Daemon A: the browser's own daemon, a real project runtime. Its onStart takes the remote branch.
   const cwdA = await mkdtemp(join(tmpdir(), 'relay-a-'))

--- a/packages/framework/src/dashboard/rpc-serve.test.ts
+++ b/packages/framework/src/dashboard/rpc-serve.test.ts
@@ -4,30 +4,15 @@ import { createServer, type Server } from 'node:http'
 import { connect } from 'node:net'
 import { makeRpcMount, type DashboardContext } from './rpc-serve.js'
 import { RPC_HANDLERS } from '../dashboard-rpc/index.js'
-import { registryPreferencesStore } from '../registry.js'
-import { registryDiscordCredentialsStore } from '../discord-credentials-store.js'
-import { defaultQuotaSource } from './quota.js'
+import { testDashboardContext } from '../dashboard-rpc/test-context.js'
 
 // F3: the dashboard's transport is `POST /_rpc/<name>` and `GET /_rpc/events`, where it used to be
 // Telefunc. The CSRF and rebound-Host guards are covered in server.test.ts, which exercises them
 // through the whole dashboard; these pin the dispatch itself.
 
-const context: DashboardContext = {
-  startAgent: () => ({ ok: false, error: 'not wired in this test' }),
-  addProject: () => ({ ok: false, error: 'not wired in this test' }),
-  eventsSource: () => undefined,
-  remote: { target: () => undefined, list: () => [] },
-  preferences: registryPreferencesStore(),
-  discord: registryDiscordCredentialsStore(),
-  quota: defaultQuotaSource(),
-  autoPm: () => undefined,
-  autoPmSweep: () => {},
-  projectErrors: () => [],
-}
-
 /** A server carrying just the mount, so a test can call it over real HTTP. */
 async function mounted(over: Partial<DashboardContext> = {}): Promise<{ url: string; close: () => Promise<void> }> {
-  const mount = makeRpcMount({ ...context, ...over })
+  const mount = makeRpcMount(testDashboardContext(over))
   const server: Server = createServer((req, res) => {
     void mount(req, res).then(handled => {
       if (!handled) {

--- a/packages/framework/src/dashboard/server.test.ts
+++ b/packages/framework/src/dashboard/server.test.ts
@@ -7,33 +7,14 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { startDashboard, type Dashboard, type DashboardOptions } from './server.js'
 import { isExpectedHost, isSameOriginRequest } from './rpc-serve.js'
-import { registryPreferencesStore } from '../registry.js'
-import { registryDiscordCredentialsStore } from '../discord-credentials-store.js'
-import { defaultQuotaSource } from './quota.js'
+import { testDashboardOptions } from '../dashboard-rpc/test-context.js'
 import type { FrameworkEvent } from '../events.js'
 import type { StartAgentKind, StartAgentOptions, StartAgentResult } from './types.js'
 import type { IncomingMessage } from 'node:http'
 
-/**
- * Start a dashboard the way the daemon does — every context capability wired (D3) — with only the
- * parts a test cares about overridden. Since there is one host, the options are required, and a
- * test asserting one route should still stand up the same server the product does.
- */
+/** Start a dashboard the way the daemon does (D3), with only the parts a test cares about overridden. */
 function dashboard(over: Partial<DashboardOptions> = {}): Promise<Dashboard> {
-  return startDashboard({
-    port: 0,
-    onStart: () => ({ ok: false, error: 'not wired in this test' }),
-    onAddProject: () => ({ ok: false, error: 'not wired in this test' }),
-    eventsSource: () => undefined,
-    remote: { target: () => undefined, list: () => [] },
-    preferences: registryPreferencesStore(),
-    discord: registryDiscordCredentialsStore(),
-    quota: defaultQuotaSource(),
-    autoPm: () => undefined,
-    autoPmSweep: () => {},
-    projectErrors: () => [],
-    ...over,
-  })
+  return startDashboard(testDashboardOptions(over))
 }
 
 function fetchText(url: string): Promise<{ status: number; body: string; type: string }> {

--- a/packages/framework/src/dashboard/tickets.ts
+++ b/packages/framework/src/dashboard/tickets.ts
@@ -275,6 +275,33 @@ async function readLock(dir: string, name: string, siblings: Set<string>): Promi
 }
 
 /**
+ * One ticket's row: what the head of its markdown says about itself, plus what the `.plan.md` and
+ * `.lock.md` beside it add. `head` is the whole file for the detail page and the first
+ * {@link MAX_TICKET_BYTES} for a list row — nothing below that is ever shown.
+ */
+async function ticketRow(dir: string, file: string, head: string, date: string, siblings: Set<string>): Promise<WorkspaceTicket> {
+  const stem = file.replace(/\.md$/, '')
+  const { title, summary, priority, topics, github } = describe(head)
+  const [plan, lock] = await Promise.all([
+    readSibling(dir, `${stem}.plan.md`, siblings),
+    readLock(dir, `${stem}.lock.md`, siblings),
+  ])
+  return {
+    file,
+    title: title ?? titleFromFile(file),
+    summary,
+    ...(priority ? { priority } : {}),
+    ...(topics ? { topics } : {}),
+    ...(github ? { github } : {}),
+    date,
+    planned: plan.real,
+    ...(lock.locked ? { locked: true } : {}),
+    ...(lock.lockedBy !== undefined ? { lockedBy: lock.lockedBy } : {}),
+    ...planMeta(plan.md),
+  }
+}
+
+/**
  * The project's tickets, by filename, newest first (#1144). `[]` when the repo has no `tickets/`
  * directory at all, which is the state the view offers to import into.
  *
@@ -295,25 +322,7 @@ export async function readTickets(cwd: string): Promise<WorkspaceTicket[]> {
       ticketDate(dir, file),
     ])
     if (content === undefined) continue
-    const stem = file.replace(/\.md$/, '')
-    const { title, summary, priority, topics, github } = describe(content.slice(0, MAX_TICKET_BYTES))
-    const [plan, lock] = await Promise.all([
-      readSibling(dir, `${stem}.plan.md`, siblings),
-      readLock(dir, `${stem}.lock.md`, siblings),
-    ])
-    tickets.push({
-      file,
-      title: title ?? titleFromFile(file),
-      summary,
-      ...(priority ? { priority } : {}),
-      ...(topics ? { topics } : {}),
-      ...(github ? { github } : {}),
-      date,
-      planned: plan.real,
-      ...(lock.locked ? { locked: true } : {}),
-      ...(lock.lockedBy !== undefined ? { lockedBy: lock.lockedBy } : {}),
-      ...planMeta(plan.md),
-    })
+    tickets.push(await ticketRow(dir, file, content.slice(0, MAX_TICKET_BYTES), date, siblings))
   }
   // Newest first: what changed most recently is what the list is for (#1144), and it is the only
   // ordering that means the same thing for a dated ticket and a bare GitHub-imported one alike.
@@ -351,25 +360,5 @@ export async function readTicket(cwd: string, file: string): Promise<WorkspaceTi
     readdir(dir).catch(() => [] as string[]),
   ])
   if (content === undefined) return null
-  const stem = file.replace(/\.md$/, '')
-  const { title, summary, priority, topics, github } = describe(content)
-  const present = new Set(names)
-  const [plan, lock] = await Promise.all([
-    readSibling(dir, `${stem}.plan.md`, present),
-    readLock(dir, `${stem}.lock.md`, present),
-  ])
-  return {
-    file,
-    title: title ?? titleFromFile(file),
-    summary,
-    ...(priority ? { priority } : {}),
-    ...(topics ? { topics } : {}),
-    ...(github ? { github } : {}),
-    date,
-    planned: plan.real,
-    ...(lock.locked ? { locked: true } : {}),
-    ...(lock.lockedBy !== undefined ? { lockedBy: lock.lockedBy } : {}),
-    ...planMeta(plan.md),
-    content,
-  }
+  return { ...(await ticketRow(dir, file, content, date, new Set(names))), content }
 }

--- a/packages/framework/src/dashboard/web-start-endpoints.ts
+++ b/packages/framework/src/dashboard/web-start-endpoints.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
-import { bearerAuthorized, readJsonBody } from './bridge-endpoints.js'
+import { bearerAuthorized } from './bridge-endpoints.js'
+import { end, readPost, requireGet, sendJson } from './http.js'
 import type { BridgeStartInput, BridgeStartRequest } from './bridge-starts.js'
 
 /**
@@ -54,12 +55,8 @@ export async function handleWebStartRequest(
 async function handleRequest(req: IncomingMessage, res: ServerResponse, handlers: WebStartHandlers): Promise<void> {
   if (req.method !== 'POST') return end(res, 405, 'method not allowed', { allow: 'POST' })
   if (!handlers.extensionAlive()) return end(res, 409, 'no browser extension has spoken to this daemon recently')
-  let body: unknown
-  try {
-    body = await readJsonBody(req, MAX_BODY)
-  } catch (err) {
-    return end(res, 400, (err as Error).message)
-  }
+  const body = await readPost(req, res, MAX_BODY)
+  if (body === undefined) return
   if (typeof body !== 'object' || body === null) return end(res, 400, 'body must be an object')
   const { repo, branch, prompt } = body as Record<string, unknown>
   if (typeof repo !== 'string' || typeof branch !== 'string' || typeof prompt !== 'string') {
@@ -67,27 +64,18 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse, handlers
   }
   const queued = handlers.request({ repo, branch, prompt })
   if (typeof queued === 'string') return end(res, 400, queued)
-  res.writeHead(202, { 'content-type': 'application/json' })
-  res.end(JSON.stringify({ id: queued.id }))
+  sendJson(res, { id: queued.id }, 202)
 }
 
 /** `GET /_web-start/<id>`: where the request stands. */
 async function handleState(req: IncomingMessage, res: ServerResponse, id: string, handlers: WebStartHandlers): Promise<void> {
-  if (req.method !== 'GET') return end(res, 405, 'method not allowed', { allow: 'GET' })
+  if (!requireGet(req, res)) return
   const start = handlers.get(id)
   if (!start) return end(res, 404, 'no such start request')
-  res.writeHead(200, { 'content-type': 'application/json' })
-  res.end(
-    JSON.stringify({
-      state: start.state,
-      ...(start.sessionId ? { sessionId: start.sessionId } : {}),
-      ...(start.url ? { url: start.url } : {}),
-      ...(start.note ? { note: start.note } : {}),
-    }),
-  )
-}
-
-function end(res: ServerResponse, status: number, message: string, headers: Record<string, string> = {}): void {
-  res.writeHead(status, { 'content-type': 'text/plain', ...headers })
-  res.end(message)
+  sendJson(res, {
+    state: start.state,
+    ...(start.sessionId ? { sessionId: start.sessionId } : {}),
+    ...(start.url ? { url: start.url } : {}),
+    ...(start.note ? { note: start.note } : {}),
+  })
 }

--- a/packages/framework/src/data-branch.ts
+++ b/packages/framework/src/data-branch.ts
@@ -266,6 +266,50 @@ export async function withDataBranch(
   })
 }
 
+/**
+ * The file seams a *claim* on the data branch needs — the ticket locks (#1420) and the routine
+ * locks (#1659), which read, write, delete and list plain files inside the checkout the funnel
+ * hands them. Injectable so every operation is unit-testable off disk and git; production takes
+ * the defaults.
+ */
+export interface DataFileDeps {
+  /** Read one file (default `fs.readFile`); a rejection reads as "absent". */
+  read?: (path: string) => Promise<string>
+  /** Write one file, creating parents (default `fs.writeFile`). */
+  write?: (path: string, content: string) => Promise<void>
+  /** Delete one file (default `fs.rm`). */
+  remove?: (path: string) => Promise<void>
+  /** The files under a directory, by filename (default `fs.readdir`); a missing directory reads as none. */
+  list?: (dir: string) => Promise<string[]>
+  /** The data-branch write funnel (default {@link withDataBranch}); a test's fake stands in. */
+  funnel?: typeof withDataBranch
+  /** Progress line. */
+  log?: (message: string) => void
+}
+
+/**
+ * Fill in whatever a caller left out, so an operation reads the same way in tests and out. Parents
+ * are created on write because the directory itself is not a given: retiring the last file removes
+ * it (git keeps no empty dirs), and the branch is born without it.
+ */
+export function resolveDataFileDeps(deps: DataFileDeps): Required<DataFileDeps> {
+  const fs = () => import('node:fs/promises')
+  return {
+    read: deps.read ?? (path => fs().then(f => f.readFile(path, 'utf8'))),
+    write:
+      deps.write ??
+      (async (path, content) => {
+        const f = await fs()
+        await f.mkdir(dirname(path), { recursive: true })
+        await f.writeFile(path, content, 'utf8')
+      }),
+    remove: deps.remove ?? (path => fs().then(f => f.rm(path))),
+    list: deps.list ?? (dir => fs().then(f => f.readdir(dir)).catch((): string[] => [])),
+    funnel: deps.funnel ?? withDataBranch,
+    log: deps.log ?? (() => {}),
+  }
+}
+
 /** How a sync went: converged with origin, or why it could not. */
 export type DataSyncResult = { ok: true } | { ok: false; error: string }
 

--- a/packages/framework/src/maintenance.ts
+++ b/packages/framework/src/maintenance.ts
@@ -15,7 +15,7 @@ import { FRAMEWORK_DIR } from './store/index.js'
  */
 
 /** The per-repo review-state filename under `.the-framework/`. */
-export const MAINTENANCE_FILE = 'maintenance.json'
+const MAINTENANCE_FILE = 'maintenance.json'
 
 /** What a repo's last maintenance review recorded. */
 export interface MaintenanceState {

--- a/packages/framework/src/merged-worktrees.ts
+++ b/packages/framework/src/merged-worktrees.ts
@@ -1,6 +1,7 @@
 import { listProjectWorktrees, removeProjectWorktree, type RemoveResult, type WorktreeRow } from './worktrees.js'
 import { withAgentLock } from './agent-locks.js'
 import { repoHasRemote, worktreePath } from './store/index.js'
+import { startProjectPass, type ProjectPass, type ProjectsSource } from './project-pass.js'
 
 // Reclaim a session's checkout once its work is on the remote (#1036/E5).
 //
@@ -98,17 +99,10 @@ export function describeDeleted(branches: readonly string[]): string {
   return branches.length === 1 ? `its branch ${branches[0]}` : `its branches ${branches.join(' and ')}`
 }
 
-/** A running sweep, in the shape the daemon's other background services use. */
-export interface MergedWorktreeSweep {
-  /** Run one sweep now, awaiting it. Exposed for tests and for a caller that wants it on demand. */
-  tick: () => Promise<void>
-  stop: () => void
-}
-
 /** What {@link startMergedWorktreeSweep} needs from the daemon. */
 export interface MergedSweepOptions {
   /** The registered projects to sweep. */
-  projects: () => Promise<readonly { path: string }[]>
+  projects: ProjectsSource
   log: (message: string) => void
   /**
    * The agents the daemon is still responsible for — spawning, running, or mid-retirement — whose
@@ -130,9 +124,8 @@ export interface MergedSweepOptions {
  * Says what it removed rather than removing it silently: a checkout vanishing from under someone
  * with no line explaining why reads as a bug, even when the work behind it is safe.
  */
-export function startMergedWorktreeSweep(opts: MergedSweepOptions): MergedWorktreeSweep {
+export function startMergedWorktreeSweep(opts: MergedSweepOptions): ProjectPass {
   const sweep = opts.sweep ?? ((cwd: string) => removeMergedWorktrees(cwd, { ...(opts.busy ? { busy: opts.busy() } : {}) }))
-  let stopped = false
   // Each checkout's last-announced keep reason, so a retained checkout is accounted for once per
   // *state* rather than re-announced every ten minutes for the life of the daemon — a permanently
   // unpushable one (no remote, a publish-nothing session) repeats forever. A changed reason is a
@@ -142,44 +135,22 @@ export function startMergedWorktreeSweep(opts: MergedSweepOptions): MergedWorktr
   // state deserves.
   const announced = new Map<string, string>()
 
-  const sweepAll = async (): Promise<void> => {
-    for (const project of await opts.projects().catch(() => [])) {
-      if (stopped) break
-      const { removed, failed } = await sweep(project.path).catch((): MergedSweepResult => ({ removed: [], failed: [] }))
-      for (const item of removed) {
-        announced.delete(item.agentId)
-        opts.log(
-          item.branchesDeleted
-            ? `[framework] removed the worktree for session ${item.agentId} and ${describeDeleted(item.branchesDeleted)}: nothing on it is missing elsewhere. The session is kept.`
-            : `[framework] removed the worktree for session ${item.agentId}: its branch is on the remote. The branch and the session are kept.`,
-        )
-      }
-      for (const item of failed) {
-        if (announced.get(item.agentId) === item.error) continue
-        announced.set(item.agentId, item.error)
-        opts.log(`[framework] kept the worktree for session ${item.agentId}: ${item.error}`)
-      }
-    }
-  }
-
-  // Overlapping ticks join the sweep already running rather than being dropped: awaiting `tick()`
-  // has to mean the sweep finished, or an on-demand caller (and a test) gets a silent no-op
-  // whenever the clock's turn happens to be mid-flight.
-  let inflight: Promise<void> | undefined
-  const tick = (): Promise<void> => {
-    if (stopped) return Promise.resolve()
-    inflight ??= sweepAll().finally(() => {
-      inflight = undefined
-    })
-    return inflight
-  }
-
   // No timer of its own (E4): the daemon's one clock calls `tick`, including once at start-up —
   // the case this exists for is a machine that was off while the work could not be pushed.
-  return {
-    tick,
-    stop: () => {
-      stopped = true
-    },
-  }
+  return startProjectPass(opts.projects, async cwd => {
+    const { removed, failed } = await sweep(cwd).catch((): MergedSweepResult => ({ removed: [], failed: [] }))
+    for (const item of removed) {
+      announced.delete(item.agentId)
+      opts.log(
+        item.branchesDeleted
+          ? `[framework] removed the worktree for session ${item.agentId} and ${describeDeleted(item.branchesDeleted)}: nothing on it is missing elsewhere. The session is kept.`
+          : `[framework] removed the worktree for session ${item.agentId}: its branch is on the remote. The branch and the session are kept.`,
+      )
+    }
+    for (const item of failed) {
+      if (announced.get(item.agentId) === item.error) continue
+      announced.set(item.agentId, item.error)
+      opts.log(`[framework] kept the worktree for session ${item.agentId}: ${item.error}`)
+    }
+  })
 }

--- a/packages/framework/src/project-pass.SPEC.md
+++ b/packages/framework/src/project-pass.SPEC.md
@@ -1,0 +1,7 @@
+The shape shared by every background pass the daemon runs over the registered projects: no timer of its own, one turn per call from the daemon's single clock, and a stop that takes effect between projects.
+
+Each turn walks the registered projects and does the pass's own work on one project at a time. Asking for a turn while one is already running joins the turn in flight rather than starting a second one or being dropped, so waiting for a turn always means a full pass finished. A stopped pass does nothing when asked for a turn, and stopping mid-pass takes effect before the next project rather than interrupting the current one. When the list of projects cannot be read, the turn walks nothing and the next turn tries again.
+
+## Before modifying/creating SPEC.md files
+
+You must always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/framework/src/project-pass.ts
+++ b/packages/framework/src/project-pass.ts
@@ -1,0 +1,56 @@
+/**
+ * The shape every one of the daemon's background passes over the registered projects has (E4):
+ * no timer of its own, one turn per `tick()` call from the daemon's single clock, and a `stop()`
+ * that takes effect between projects.
+ *
+ * Five services walk the projects this way — the merged-worktree sweep (#1036), the CI watch
+ * (#1418), the branch-links pass (#1580), the cloud scratch-ref sweep (#1547) and cloud work
+ * adoption (#1601). They differ only in what they do to one project; the walking, the overlap
+ * rule and the stop flag were written out five times before this.
+ */
+
+/** A running background pass, in the shape the daemon's services are wired as. */
+export interface ProjectPass {
+  /** Run one pass now, awaiting it. Exposed for tests and for a caller that wants it on demand. */
+  tick: () => Promise<void>
+  stop: () => void
+}
+
+/** The registered projects a pass walks, as the daemon hands them over. */
+export type ProjectsSource = () => Promise<readonly { path: string }[]>
+
+/**
+ * Walk every registered project once per `tick()`, calling `visit` with each project's path.
+ *
+ * Overlapping ticks join the pass already running rather than being dropped: awaiting `tick()`
+ * has to mean the pass finished, or an on-demand caller (and a test) gets a silent no-op whenever
+ * the clock's turn happens to be mid-flight. A stopped pass ticks as a no-op, and a `stop()`
+ * during a pass takes effect before the next project rather than mid-project.
+ *
+ * A `projects()` that rejects yields nothing to walk: a registry that cannot be read is this
+ * turn's problem, not the daemon's, and the next tick tries again.
+ */
+export function startProjectPass(projects: ProjectsSource, visit: (cwd: string) => Promise<void>): ProjectPass {
+  let stopped = false
+  let inflight: Promise<void> | undefined
+
+  const passAll = async (): Promise<void> => {
+    for (const project of await projects().catch(() => [])) {
+      if (stopped) break
+      await visit(project.path)
+    }
+  }
+
+  return {
+    tick: () => {
+      if (stopped) return Promise.resolve()
+      inflight ??= passAll().finally(() => {
+        inflight = undefined
+      })
+      return inflight
+    },
+    stop: () => {
+      stopped = true
+    },
+  }
+}

--- a/packages/framework/src/project.ts
+++ b/packages/framework/src/project.ts
@@ -16,7 +16,7 @@ export interface ProjectFs {
 }
 
 /** A {@link ProjectFs} backed by `node:fs/promises`. See {@link nodeFs}. */
-export function nodeProjectFs(): ProjectFs {
+function nodeProjectFs(): ProjectFs {
   const { exists } = nodeFs()
   return { exists }
 }

--- a/packages/framework/src/routine-locks.ts
+++ b/packages/framework/src/routine-locks.ts
@@ -1,7 +1,6 @@
-import { readdir, readFile, rm, writeFile, mkdir } from 'node:fs/promises'
 import { hostname } from 'node:os'
-import { dirname, join } from 'node:path'
-import { withDataBranch } from './data-branch.js'
+import { join } from 'node:path'
+import { resolveDataFileDeps, type DataFileDeps } from './data-branch.js'
 
 // The "one triage at a time" guard (#1659): a `routines/<name>.lock.md` on the data branch.
 //
@@ -19,7 +18,7 @@ import { withDataBranch } from './data-branch.js'
 // tickets can take hours, and a heartbeat would cost code and `tf-data` churn.
 
 /** Where routine state lives on the data branch; only the lock files, for now (#1660). */
-export const ROUTINES_DIR = 'routines'
+const ROUTINES_DIR = 'routines'
 
 /** How long a lock stands before whoever finds it may take it over: four hours, no heartbeat. */
 export const ROUTINE_LOCK_TTL_MS = 4 * 60 * 60 * 1000
@@ -49,39 +48,22 @@ export function routineLockHolder(md: string): RoutineLockHolder | undefined {
 }
 
 /** Injectable seams so every operation is unit-testable off disk and git. */
-export interface RoutineLockDeps {
-  read?: (path: string) => Promise<string>
-  write?: (path: string, content: string) => Promise<void>
-  remove?: (path: string) => Promise<void>
-  /** The lock files under a directory, by filename; a missing directory reads as none. */
-  list?: (dir: string) => Promise<string[]>
-  /** The data-branch write funnel (default {@link withDataBranch}). */
-  funnel?: typeof withDataBranch
+export interface RoutineLockDeps extends DataFileDeps {
+  /** The machine claiming the lock (default this host's name). */
   host?: string
   now?: () => number
-  log?: (message: string) => void
 }
 
 function resolve(deps: RoutineLockDeps) {
   return {
-    read: deps.read ?? ((path: string) => readFile(path, 'utf8')),
-    write:
-      deps.write ??
-      (async (path: string, content: string) => {
-        await mkdir(dirname(path), { recursive: true })
-        await writeFile(path, content, 'utf8')
-      }),
-    remove: deps.remove ?? ((path: string) => rm(path)),
-    list: deps.list ?? ((dir: string) => readdir(dir).catch((): string[] => [])),
-    funnel: deps.funnel ?? withDataBranch,
+    ...resolveDataFileDeps(deps),
     host: deps.host ?? hostname(),
     now: deps.now ?? (() => Date.now()),
-    log: deps.log ?? (() => {}),
   }
 }
 
 /** Whether a lock is past its fixed expiry, as of `now`. An unparseable mint time counts as expired. */
-export function routineLockExpired(holder: RoutineLockHolder, now: number): boolean {
+function routineLockExpired(holder: RoutineLockHolder, now: number): boolean {
   const since = Date.parse(holder.since)
   return !Number.isFinite(since) || now - since >= ROUTINE_LOCK_TTL_MS
 }

--- a/packages/framework/src/ticket-locks.ts
+++ b/packages/framework/src/ticket-locks.ts
@@ -1,7 +1,6 @@
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { join } from 'node:path'
 import { TICKETS_DIR } from './tickets.js'
-import { withDataBranch } from './data-branch.js'
+import { resolveDataFileDeps, type DataFileDeps } from './data-branch.js'
 import type { PlanAssignment } from './auto-pm.js'
 
 // The `.lock.md` claim on a ticket (#1420, replacing #1327's PENDING placeholders).
@@ -65,18 +64,7 @@ export function abandonedReleaseMessage(ticket: string): string {
 }
 
 /** Injectable seams so every operation is unit-testable off disk and git. */
-export interface TicketLockDeps {
-  /** Write one lock file (default `fs.writeFile`). */
-  write?: (path: string, content: string) => Promise<void>
-  /** Read one sibling (default `fs.readFile`); a rejection reads as "absent". */
-  read?: (path: string) => Promise<string>
-  /** Delete one lock file (default `fs.rm`). */
-  remove?: (path: string) => Promise<void>
-  /** The data-branch write funnel (default {@link withDataBranch}); a test's fake stands in. */
-  funnel?: typeof withDataBranch
-  /** Progress line. */
-  log?: (message: string) => void
-}
+export type TicketLockDeps = DataFileDeps
 
 /**
  * Which side of a ticket's life a batch claims for (#1420). A `plan` batch is about to *write*
@@ -108,17 +96,7 @@ export async function acquireTicketLocks(
   deps: TicketLockDeps = {},
   phase: TicketLockPhase = 'plan',
 ): Promise<PlanAssignment[]> {
-  // Creating parents, because `tickets/` itself is not a given: retiring the last ticket removes
-  // the directory (git keeps no empty dirs), and the branch is born without it.
-  const write =
-    deps.write ??
-    (async (path: string, content: string) => {
-      await mkdir(dirname(path), { recursive: true })
-      await writeFile(path, content, 'utf8')
-    })
-  const read = deps.read ?? (path => readFile(path, 'utf8'))
-  const funnel = deps.funnel ?? withDataBranch
-  const log = deps.log ?? (() => {})
+  const { read, write, funnel, log } = resolveDataFileDeps(deps)
 
   let locked: PlanAssignment[] = []
   const result = await funnel(
@@ -183,10 +161,7 @@ export async function releaseTicketLock(
     heldBy?: string
   } = {},
 ): Promise<ReleaseTicketLockResult> {
-  const read = deps.read ?? (path => readFile(path, 'utf8'))
-  const remove = deps.remove ?? (path => rm(path))
-  const funnel = deps.funnel ?? withDataBranch
-  const log = deps.log ?? (() => {})
+  const { read, remove, funnel, log } = resolveDataFileDeps(deps)
 
   const lock = `${TICKETS_DIR}/${ticketLockName(ticket)}`
   let outcome: ReleaseTicketLockResult = 'released'

--- a/packages/framework/src/todo-loop.ts
+++ b/packages/framework/src/todo-loop.ts
@@ -313,7 +313,7 @@ export interface TodoLoopOptions {
 }
 
 /** The default per-agent cap on backlog entries — a backstop beside the budget cap (#322). */
-export const DEFAULT_MAX_TODO_ITEMS = 25
+const DEFAULT_MAX_TODO_ITEMS = 25
 
 /** How many consecutive failed check-off writes before the loop stops rather than spins. */
 const MAX_STALLS = 2


### PR DESCRIPTION
Nine pieces of duplicated structure collapsed into shared ones. No feature changes: the same behaviour, the same tests, ~200 fewer lines of code (the rest of the diff is the branch's existing commits).

## The daemon's five background passes

The merged-worktree sweep, the CI watch, the branch-links pass, the cloud scratch-ref sweep and cloud work adoption each wrote out the same scaffolding: walk the registered projects, break between projects once stopped, join an overlapping tick rather than dropping it, hand back `{tick, stop}` — plus five identically-shaped interfaces under five different names, none of which anything outside its own module named.

`src/project-pass.ts` holds that shape once (`startProjectPass`, `ProjectPass`); each service is now just what it does to one project.

## The three non-RPC HTTP surfaces

The bridge, web-start and relay routes carried two near-identical capped JSON body readers (differing only in which message they rejected with, one of which the caller discarded) and three byte-identical plain-text responders.

`src/dashboard/http.ts` holds `readJsonBody`, `end` and `sendJson`, plus the POST preamble (`readPost`) and the GET-only guard (`requireGet`) that eight routes ran by hand. The bridge's two validators also share the session-id check they both rejected on with the same message.

`handleEvents` keeps its explicit method check on purpose — a GET on a daemon with events off is still a wrong method, not an un-wired one — with a comment saying so.

## The two data-branch claim modules

The ticket locks and the routine locks each resolved the same read/write/remove/list/funnel/log seams, mkdir-parents lambda included. `DataFileDeps` and `resolveDataFileDeps` now live in `data-branch.ts`, beside the funnel they write through; `RoutineLockDeps` extends it with the two seams that are its own.

## Dashboard

- The "Preferred editor" group was written out in both menus that offer it → `PreferredEditorItems`
- "Update from GitHub" was written out in all three surfaces that show it, tooltip prose and all → `UpdateTicketsButton` (the shared prompt already existed for exactly this reason; the button around it did not)
- The two ticket pages shared a frame but not a component → `TicketPageShell`
- The rail's Overview and Tickets rows were one row style copied → `NavRow`
- `OptionLabel`'s re-export through `OptionsMenu` had one straggling consumer left; it imports the real module now and the shim is gone

## Server

- `readTickets` and `readTicket` assembled a ticket row twice → `ticketRow`
- Both `gh pr create` callers parsed its output and invalidated the same two caches → `createdPr`
- Three test files rebuilt the dashboard wiring `test-context.ts` already had; it now builds the value (`testDashboardContext`) and the `startDashboard` options (`testDashboardOptions`) as well as setting the ambient context

## Dead surface

Dropped `export` from 24 names nothing outside their own module consumed, and removed one unused import.

## Specs

Three new source files get their `SPEC.md` siblings. No existing spec changed: business logic is untouched, and the specs describe behaviour rather than code shape.

## Testing

`pnpm typecheck`, `pnpm build` and `pnpm test` — the CI sequence — all pass on this tree: **1596 node tests, 854 dashboard tests, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Rk8i1CS5qbRRLszRXJNQV

---
_Generated by [Claude Code](https://claude.ai/code/session_019Rk8i1CS5qbRRLszRXJNQV)_