### PR TITLE
Fix the build: /_bridge/statuses reads its body through the shared readPost

### DIFF
--- a/packages/framework/src/dashboard/bridge-endpoints.ts
+++ b/packages/framework/src/dashboard/bridge-endpoints.ts
@@ -360,14 +360,9 @@ function validateEvents(body: unknown, now: Date): BridgeEvent[] | string {
 
 /** `POST /_bridge/statuses`: what claude.ai's session list says about each watched session (#1332). */
 async function handleStatuses(req: IncomingMessage, res: ServerResponse, handlers: BridgeHandlers): Promise<void> {
-  if (req.method !== 'POST') return end(res, 405, 'method not allowed', { allow: 'POST' })
-  let body: unknown
-  try {
-    body = await readJsonBody(req, MAX_BODY)
-  } catch (err) {
-    return end(res, 400, (err as Error).message)
-  }
-  const statuses = validateStatuses(body, (handlers.now ?? (() => new Date()))())
+  const body = await readPost(req, res, MAX_BODY)
+  if (body === undefined) return
+  const statuses = validateStatuses(body, now(handlers))
   if (typeof statuses === 'string') return end(res, 400, statuses)
   handlers.statuses?.(statuses)
   end(res, 204, '')


### PR DESCRIPTION
#1703 added the statuses route on top of the file-local `readJsonBody`, and #1704 moved that reader to `http.ts` in the same hour; the two merged without a textual conflict, so `pnpm build` on main fails with `Cannot find name 'readJsonBody'` (CI run 32896742944).

The route now runs the same POST preamble as the bridge's other routes (`readPost`, `now(handlers)`). No behaviour change: the same 405 and 400 messages, from the shared helper.

`pnpm typecheck` clean; `bridge-endpoints.test.ts` 20/20.

🤖 automated · Fable 5, effort xhigh
