### PR TITLE
The extension reloads itself when its files on disk change (#1711)

### DIFF
--- a/FEATURES-SPEC.md
+++ b/FEATURES-SPEC.md
@@ -168,6 +168,7 @@ happens while nobody is at the keyboard.
 - A web run's cloud session is created by the Chrome extension in your own browser, through claude.ai's repository picker — repo-bound, so it can push and open its pull request; without the extension (or with the browser bridge off) the run stops and says which is missing
 - Chrome extension bridging claude.ai questions back to the dashboard
 - One pinned "The Framework Driver" tab serves every recent cloud session: it reads claude.ai's own session list (the status beside each session), visits a session when the list's word for it changed to awaiting input, unread or idle, an awaiting one again every five minutes, and any session holding a queued answer — navigating inside the app, one page load a minute — and shows a full-page overlay naming what it is, with collapsible debug logs; closing the tab pauses the bridge until the extension's options page reopens it or the browser restarts
+- The extension reloads itself when its files change on disk: an edit in the checkout is running within half a minute, never mid-cycle, with no trip to chrome://extensions
 - A cloud run's row says "waiting" when claude.ai's session list shows its session awaiting input, even when the question was asked in prose rather than as a choice block
 - A cloud session's conversation mirrored into the run view, turn by turn, as it is written
 - Answer a cloud agent's question from the dashboard (typed back into claude.ai) — the same gate panel a local agent gets, multi-select and stop options included, listed with every other open question

--- a/packages/chrome-extension/README.md
+++ b/packages/chrome-extension/README.md
@@ -70,7 +70,11 @@ the Driver: reading the session list by label and paging it, a cycle that visits
 the question, types and waits for the send, then returns to the list under the overlay, an answer
 the page did not take, a session missing from the list, and the visit planner.
 
-After editing any file here, reload the extension on `chrome://extensions` AND reload the open
-claude.ai tabs: reloading the extension does not re-inject content scripts, and an orphaned
-script cannot hear the new worker. The panel shows the manifest version, which is how you tell
-a stale script from a current one.
+After editing any file here, nothing to click: the worker fingerprints the extension's files
+every beat (30 s) and reloads the extension itself when any changed, never mid-cycle
+(#1711). The Driver tab gets the new content script on the next cycle's page load; your own
+claude.ai tabs still need a reload, since reloading the extension does not re-inject content
+scripts and an orphaned script cannot hear the new worker. The panel shows the manifest
+version, which is how you tell a stale script from a current one. Leave developer mode on in
+`chrome://extensions`: with it off, Chrome 137+ disables an unpacked extension on reload instead
+of reloading it, and only a click there brings it back.

--- a/packages/chrome-extension/SPEC.md
+++ b/packages/chrome-extension/SPEC.md
@@ -4,7 +4,7 @@ It exists because an agent with run target `web` is hands-off: the daemon hands 
 
 A cloud session asks the same way a local agent does — its gates are never framed away. The bridge is what carries the question home; with the bridge off, the question simply waits in the session on claude.ai until the user finds it there.
 
-Five parts: the content script (the page half — reads claude.ai's session list and session pages, types answers, draws the Driver overlay), the service worker (the daemon half — holds the token, makes every daemon call, runs the Driver cycle), the visit planner the worker and the harness share, the options page (setup and connection proof), and an offline check harness that proves the reading, driving and typing against synthetic pages without a browser.
+Six parts: the content script (the page half — reads claude.ai's session list and session pages, types answers, draws the Driver overlay), the service worker (the daemon half — holds the token, makes every daemon call, runs the Driver cycle, reloads the extension when its files change), the visit planner and the file fingerprint the worker and the harness share, the options page (setup and connection proof), and an offline check harness that proves the reading, driving, typing and the fingerprint against synthetic pages without a browser.
 
 ## User story
 
@@ -29,6 +29,7 @@ Five parts: the content script (the page half — reads claude.ai's session list
 - **One Driver tab for every session** - the daemon publishes which cloud sessions are its; the extension keeps one pinned, inactive tab (opt-in) that reads claude.ai's session list, visits only the sessions waiting on their user or holding a queued answer — navigating inside the app, with one page load a minute to refresh the list — reports each session's list status to the daemon, and covers itself with a full-page overlay saying what it is, with collapsible debug logs. Closing the tab pauses the bridge until the options page reopens it or the browser restarts.
 - **The trust boundary** - the bridge token and all daemon traffic live in the service worker; the content script, which shares its tab with claude.ai, holds no secret and calls no daemon.
 - **Version lockstep** - every daemon call states the extension's version, and a daemon expecting another refuses it outright, naming both versions; the two halves must ship the same number.
+- **It reloads itself when its files change** - the extension is unpacked and edited in place; the service worker fingerprints its own files every beat and reloads the extension when any changed on disk, never mid-cycle, so an edit in the checkout is running within half a minute without a visit to chrome://extensions.
 - **Where it runs and why each permission exists** - a content script on every claude.ai page and frame; host access to the localhost origins for the worker's CORS-free daemon calls; storage, tabs and alarms for the token, the Driver tab's bookkeeping, and a cycle that survives the worker's idle termination.
 
 ## Business logic
@@ -102,6 +103,20 @@ See `## User story`, first item — a bridge that half-works is worse than one t
 #### Business logic
 
 Every daemon call states the extension's version in the `x-tf-extension-version` header. A daemon expecting a different version refuses the call outright with an error naming both versions and the way out, because a version-skewed extension does not fail loudly — it half-works, which reads as dashboard bugs. The options page shows that refusal verbatim. The extension and the daemon must therefore ship the same version number.
+
+### It reloads itself when its files change
+
+#### User story
+
+The extension is dogfood-only and unpacked: it runs straight from the checkout. A developer who edits it wants the change running without the click on chrome://extensions that Chrome otherwise requires before it re-reads an unpacked extension's files.
+
+#### Business logic
+
+The service worker takes a fingerprint of the extension's own files when it starts — every file Chrome loads for the extension — and again every beat; when any of them changed on disk, it reloads the extension instead of running that beat's cycle, and never while a cycle is running. The reload is recorded as the last cycle's outcome, naming the changed files. Content scripts already injected — the Driver tab's included — are orphaned by the reload, as by a manual one; the Driver's is replaced by the next cycle's page load, and the user's own claude.ai tabs get the new script on their next load. The fingerprint's rules are in `fingerprint.SPEC.md`, the worker's in `background.SPEC.md`.
+
+#### Rationale
+
+Chrome offers no way for anything but a click to reload an unpacked extension — chrome:// pages are off-limits to extensions and the daemon has no handle on the browser — but an extension may reload itself, and its worker can read its own files as they are on disk. The trigger the click used to supply is the worker noticing the change.
 
 ### Where it runs and why each permission exists
 

--- a/packages/chrome-extension/background.SPEC.md
+++ b/packages/chrome-extension/background.SPEC.md
@@ -25,6 +25,7 @@ A `web`-target agent hands its task to a cloud session and ends; nothing streams
 - **Closing the Driver tab pauses the bridge** - until the options page reopens it or the browser restarts; closing its window does not. A tab someone moved off claude.ai is forgotten, never brought back, and after a restart a lone pinned claude.ai tab is taken to be the Driver Chrome restored rather than doubled.
 - **Sessions are created in the Driver tab** - the worker claims the daemon's next session request each cycle and the Driver creates it first thing, before the visits, from claude.ai's new-session page the cycle starts on; the outcome is reported under the request's id, and a Driver that is off or paused reports the request failed at once rather than leaving it queued.
 - **Every cycle records what it did** - the outcome of the last cycle is kept so the options page can state it, including every reason a cycle did nothing.
+- **It reloads itself when its files change** - the worker fingerprints the extension's own files when it starts and again every beat; when any of them changed on disk it reloads the extension, never in the middle of a cycle, and records the reload as the last cycle's outcome.
 
 ## Business logic
 
@@ -148,6 +149,22 @@ Each cycle claims the daemon's next session request, if any, and hands it to the
 
 Creation navigates the page, and so do visits; running both inside one cycle, one after the other, keeps them from racing each other's controls. A report that fails to reach the daemon is not retried here: the daemon's claim expires on its own and the request is offered again.
 
+### Reloading itself when its files change
+
+#### User story
+
+A developer edits the extension in its checkout — the content script, the worker, the manifest — and wants the running extension to pick the change up on its own. Chrome re-reads an unpacked extension's files only on a reload, which used to be a click on chrome://extensions after every edit.
+
+#### Business logic
+
+When the worker starts it takes the fingerprint of the extension's files — see `fingerprint.SPEC.md` for which files and what counts as a change. Every beat, before running the cycle, it takes the fingerprint again; when any file changed, it records "reloading the extension" naming the changed files as the last cycle's outcome and reloads the extension instead of running the cycle. The reload is never done while a cycle is running: a beat that lands on a running cycle does nothing at all, and the next beat checks again. While the files cannot be read, nothing is reloaded. The new worker takes a fresh fingerprint at its start, so one edit is one reload.
+
+After the reload the Driver tab's content script is an orphan, as after a manual reload, and is replaced by the next cycle's page load (see `### A Driver that cannot hear the worker`).
+
+#### Rationale
+
+The worker can read its own files as they are on disk right now — measured on 2026-08-26: a fetch of the extension's own URL from the worker returns the current file, not a cached copy — so no other process has to watch the checkout. A reload mid-cycle would end a drive with answers handed over and unaccounted for; waiting a beat costs half a minute. With developer mode switched off on chrome://extensions, Chrome (137 and later) disables an unpacked extension on reload rather than reloading it; the mode is on for anyone who loaded the extension unpacked, and the extension's README says to leave it on.
+
 ### Waking up on a schedule rather than on a timer
 
 #### User story
@@ -156,7 +173,7 @@ None directly — this is what makes every scheduled behavior above actually hap
 
 #### Business logic
 
-The cycle runs off one browser alarm, twice a minute, and once when the service worker starts.
+The beat — the file check and then the cycle — runs off one browser alarm, twice a minute; the cycle also runs once when the service worker starts.
 
 #### Rationale
 

--- a/packages/chrome-extension/background.js
+++ b/packages/chrome-extension/background.js
@@ -9,7 +9,7 @@
 // It also keeps the token out of the page. A content script shares a tab with claude.ai, and
 // nothing on that page should ever be able to read the secret that talks to a daemon.
 
-importScripts('driver-plan.js')
+importScripts('driver-plan.js', 'fingerprint.js')
 
 const DEFAULT_DAEMON = 'http://localhost:4200'
 
@@ -475,6 +475,54 @@ chrome.tabs.onRemoved.addListener(async (tabId, info) => {
 // dashboard watching an answer's spinner, and a run may be waiting for its session.
 chrome.alarms.create('tf-cycle', { periodInMinutes: CYCLE_MINUTES })
 chrome.alarms.onAlarm.addListener(alarm => {
-  if (alarm.name === 'tf-cycle') void cycle()
+  if (alarm.name === 'tf-cycle') void beat()
 })
+
+// ---------------------------------------------------------------------------
+// Reloading itself when its files change (#1711). The extension is unpacked and edited in place,
+// and Chrome re-reads its files only on a reload; that used to be a click on chrome://extensions
+// after every change. The worker can read its own files as they are on disk, so it takes their
+// fingerprint at start and compares each beat. Reloading orphans the content script in the
+// Driver tab, which the next cycle's page load replaces, as after a manual reload.
+//
+// One thing to know: with developer mode switched off on chrome://extensions, Chrome (137 and
+// later) disables an unpacked extension on reload instead of reloading it, and only a click on
+// chrome://extensions brings it back. The mode is on for anyone who loaded the extension
+// unpacked; leave it on.
+
+/** The files' hashes when this worker started, or undefined until the first read succeeds. */
+let filesAtStart
+
+/** The extension's own file as it is on disk now. */
+const readOwnFile = file => fetch(chrome.runtime.getURL(file)).then(res => res.text())
+
+/** The watched files that changed since this worker started; none while a read fails. */
+async function filesChanged() {
+  try {
+    const now = await fingerprint(readOwnFile)
+    if (!filesAtStart) {
+      filesAtStart = now
+      return []
+    }
+    return changedFiles(filesAtStart, now)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * One beat: reload the extension if its files changed, else run a cycle. Never mid-cycle — a
+ * reload would kill a drive with answers handed over and unaccounted for — so a beat that lands
+ * on a running cycle merely does nothing, and the next one checks again. The reload is recorded
+ * as the last cycle's outcome, so the options page can say why the worker restarted.
+ */
+async function beat() {
+  if (cycling) return
+  const changed = await filesChanged()
+  if (changed.length === 0 || cycling) return cycle()
+  await note({ ok: true, reason: `reloading the extension: ${changed.join(', ')} changed on disk` })
+  chrome.runtime.reload()
+}
+
+void filesChanged()
 void cycle()

--- a/packages/chrome-extension/check.SPEC.md
+++ b/packages/chrome-extension/check.SPEC.md
@@ -1,4 +1,4 @@
-Runs the Claude web bridge's page half and its visit planner against synthetic claude.ai pages, so the reading, driving and writing of the page can be checked without a browser, an installed extension, or a live cloud session.
+Runs the Claude web bridge's page half, its visit planner and its file fingerprint against synthetic claude.ai pages and files, so the reading, driving and writing of the page and the rule for reloading the extension can be checked without a browser, an installed extension, or a live cloud session.
 
 ## What the tests cover
 
@@ -49,6 +49,8 @@ The Driver, on a synthetic app built like the live one was observed to be — a 
 - A status word on a row beats its pull-request label; a row showing only a pull request is idle when the pull request is open or a draft and landed when it is merged or closed.
 
 The visit planner: an awaiting, unread or idle session is visited when never seen and when its status changed; after five minutes unchanged only an awaiting session is visited again, an unread or idle one is not; a queued answer forces a visit whatever the status; running, landed and missing sessions are never visited on their own.
+
+The file fingerprint, which decides when the extension reloads itself: the watched files are exactly the ones Chrome loads for the extension — those the manifest names, those the service worker imports, and the options page's script — with nothing missing and nothing extra; unchanged files change nothing; one edited file is named; and a file that cannot be read fails the fingerprint rather than counting as a change.
 
 ## Rationale
 

--- a/packages/chrome-extension/check.mjs
+++ b/packages/chrome-extension/check.mjs
@@ -804,5 +804,56 @@ function appPage({ sessions = SESSIONS, firstPage = 6, sendAppendsRow = true } =
   dom.window.close()
 }
 
+// ---------------------------------------------------------------------------
+// The extension reloads itself when its files change (fingerprint.js, #1711): the worker
+// fingerprints its own files at start and again every beat, and a difference in any of them is
+// what triggers the reload. Every file Chrome loads for the extension is watched, and a file
+// that cannot be read is never taken for a change: a reload on a transient read failure would
+// loop.
+
+{
+  const src = readFileSync(join(here, 'fingerprint.js'), 'utf8')
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', { runScripts: 'outside-only' })
+  dom.window.eval(src)
+  const { WATCHED_FILES, fingerprint, changedFiles } = dom.window.__tfFingerprint
+  {
+    // The manifest's files, what the worker imports, and the options page's script.
+    const manifest = JSON.parse(readFileSync(join(here, 'manifest.json'), 'utf8'))
+    const worker = readFileSync(join(here, 'background.js'), 'utf8')
+    const options = readFileSync(join(here, manifest.options_page), 'utf8')
+    const imported = [...worker.matchAll(/importScripts\(([^)]*)\)/g)].flatMap(m => [...m[1].matchAll(/'([^']+)'/g)].map(x => x[1]))
+    const loaded = new Set([
+      'manifest.json',
+      manifest.background.service_worker,
+      ...imported,
+      ...manifest.content_scripts.flatMap(c => c.js),
+      manifest.options_page,
+      ...[...options.matchAll(/<script src="([^"]+)"/g)].map(m => m[1]),
+    ])
+    const missing = [...loaded].filter(f => !WATCHED_FILES.includes(f))
+    const extra = WATCHED_FILES.filter(f => !loaded.has(f))
+    const ok = missing.length === 0 && extra.length === 0
+    if (!ok) failed++
+    console.log(`${ok ? 'PASS' : 'FAIL'}  every file Chrome loads for the extension is watched, and nothing else  (watched=${WATCHED_FILES.join(',')}, unwatched=${missing.join(',') || 'none'}, not loaded=${extra.join(',') || 'none'})`)
+  }
+  {
+    const files = new Map(WATCHED_FILES.map(f => [f, `the text of ${f}`]))
+    const read = async f => {
+      if (!files.has(f)) throw new Error(`cannot read ${f}`)
+      return files.get(f)
+    }
+    const before = await fingerprint(read)
+    const same = changedFiles(before, await fingerprint(read))
+    files.set('content.js', 'the text of content.js // edited')
+    const edited = changedFiles(before, await fingerprint(read))
+    files.delete('driver-plan.js')
+    const unreadable = await fingerprint(read).then(() => 'taken', err => `refused: ${err.message}`)
+    const ok = same.length === 0 && JSON.stringify(edited) === JSON.stringify(['content.js']) && unreadable.startsWith('refused')
+    if (!ok) failed++
+    console.log(`${ok ? 'PASS' : 'FAIL'}  unchanged files change nothing, one edited file is named, and a file that cannot be read refuses the fingerprint rather than counting as a change  (same=${same.length}, edited=${edited}, unreadable=${unreadable})`)
+  }
+  dom.window.close()
+}
+
 console.log(failed ? `\n${failed} case(s) failed` : '\nall cases passed')
 process.exit(failed ? 1 : 0)

--- a/packages/chrome-extension/fingerprint.SPEC.md
+++ b/packages/chrome-extension/fingerprint.SPEC.md
@@ -1,0 +1,49 @@
+Tells whether the extension's own files changed on disk since the service worker started: the rule the worker uses to reload the extension by itself, shared with the offline check harness.
+
+## User story
+
+A developer edits the extension in its checkout. They want the running extension to pick the change up on its own, instead of every edit needing a click on chrome://extensions.
+
+## Glossary
+
+- **fingerprint** — the hash of each of the extension's files, taken together; two fingerprints differ exactly when some file's text differs.
+
+## Business logic — TL;DR
+
+- **Every file Chrome loads is watched** - the manifest, the service worker and the scripts it imports, the content script, and the options page and its script.
+- **A difference in any watched file is a change** - reported by file name, in a fixed order.
+- **A file that cannot be read is never a change** - the fingerprint fails as a whole, and the caller treats that as nothing changed.
+
+## Business logic
+
+### Which files count
+
+#### User story
+
+See `## User story`.
+
+#### Business logic
+
+The watched files are exactly the ones Chrome loads for the extension: `manifest.json`, the service worker and the scripts it imports, the content script, and the options page and its script. A fingerprint is the hash of each of them, read through whatever reader the caller supplies. Comparing two fingerprints names the files whose hash differs, in the watched order, and names nothing when none does.
+
+#### Rationale
+
+A file Chrome does not load cannot change what the extension does, so it earns no reload; a file it does load and this did not watch would be the one edit that still needed the click.
+
+### A file that cannot be read is never a change
+
+#### User story
+
+See `## User story`.
+
+#### Business logic
+
+When any watched file cannot be read, the fingerprint fails instead of being taken with that file counted as changed.
+
+#### Rationale
+
+A read can fail for a moment — a file being rewritten, a checkout mid-switch. Taking that for a change would reload the extension, whose new worker would read the file fine and find nothing to reload for, or fail again and reload again: a loop for nothing.
+
+## Before modifying/creating SPEC.md files
+
+You must always read and respect https://raw.githubusercontent.com/brillout/sdd/refs/heads/main/sdd.md

--- a/packages/chrome-extension/fingerprint.js
+++ b/packages/chrome-extension/fingerprint.js
@@ -1,0 +1,43 @@
+// Whether the extension's own files changed on disk (#1711). Shared by the service worker, which
+// reloads the extension when they did, and the offline harness, which pins the rule; loaded as a
+// plain script in both.
+//
+// This exists because the extension is unpacked and edited in place, and Chrome re-reads an
+// unpacked extension's files only on a reload — which used to be a human click on
+// chrome://extensions after every change. The worker can read its own files as they are on disk
+// right now (measured 2026-08-26: a fetch of the extension's own URL returns the current file,
+// not a cached copy), so it fingerprints them at start, again every beat, and reloads itself on
+// a difference.
+
+/** Every file Chrome loads for this extension: the manifest, the worker and what it imports, the content script, and the options page and its script. */
+const WATCHED_FILES = ['manifest.json', 'background.js', 'driver-plan.js', 'fingerprint.js', 'content.js', 'options.html', 'options.js']
+
+/** FNV-1a over the text, as eight hex digits. Enough to tell an edit; nobody is attacking it. */
+function hashText(text) {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193) >>> 0
+  }
+  return hash.toString(16).padStart(8, '0')
+}
+
+/**
+ * The hash of each watched file, read through `readText(file)`. A file that cannot be read fails
+ * the whole fingerprint rather than standing in as a change: a reload on a read that merely
+ * failed this once would loop.
+ */
+async function fingerprint(readText) {
+  const hashes = {}
+  for (const file of WATCHED_FILES) hashes[file] = hashText(await readText(file))
+  return hashes
+}
+
+/** The watched files whose hash differs between two fingerprints, in watched order. */
+function changedFiles(before, after) {
+  return WATCHED_FILES.filter(file => before[file] !== after[file])
+}
+
+// The worker loads this with importScripts, where a top-level binding is already global; jsdom
+// evaluates it the same way. Nothing else to export.
+if (typeof globalThis !== 'undefined') globalThis.__tfFingerprint = { WATCHED_FILES, fingerprint, changedFiles }


### PR DESCRIPTION
Closes #1711.

Every change to the unpacked extension needed a click on chrome://extensions before Chrome re-read its files (#1703, #1709, #1710 each went through that click). Now the extension reloads itself: the service worker takes a fingerprint of the extension's own files when it starts and again every beat (30 s), and calls `chrome.runtime.reload()` when any of them changed on disk — never while a cycle is running, and recorded as the last cycle's outcome naming the changed files. The Driver tab's content script is orphaned by the reload as by a manual one, and the next cycle's page load replaces it.

**The spike, measured 2026-08-26 in Chrome for Testing 150 with a throwaway extension (unattended, no click):**

- `fetch(chrome.runtime.getURL('probe.js'))` from the worker returns the **current** disk file, same worker, plain fetch — no cache to defeat. Option 1 from the issue, as recommended.
- `chrome.runtime.reload()` from the worker boots a new worker on the edited files (verified by the new worker's baseline hash being the edited file's).
- One thing found on the way: with developer mode switched **off** on chrome://extensions, Chrome (137+) *disables* an unpacked extension on reload — `DISABLE_UNSUPPORTED_DEVELOPER_EXTENSION` — instead of reloading it, and only a click there brings it back. Developer mode is on for anyone who loaded the extension unpacked; the README now says to leave it on. (A `--load-extension` command-line install is disabled the same way regardless, so the daemon-owned Chrome for Testing of #1332 will need the CDP `Extensions.loadUnpacked` install plus developer mode on for this to work there.)

**What changed**

- `fingerprint.js` (new): the watched files — every file Chrome loads for the extension: `manifest.json`, `background.js` and what it imports, `content.js`, `options.html` and `options.js` — hashed (FNV-1a) and compared; a file that cannot be read fails the fingerprint rather than counting as a change, so a transient read failure (a file mid-write, a checkout mid-switch) cannot reload in a loop.
- `background.js`: the alarm now runs a *beat* — the file check, then the cycle. A beat landing on a running cycle does nothing; the next one checks again. The reload is noted as the last cycle's outcome (`reloading the extension: content.js changed on disk`).
- `check.mjs`: two cases, written red first and break-checked three ways (an always-empty comparison, an unreadable file counted as a change, a file dropped from the watched list — each turned the right case red): the watched list equals what the manifest, `importScripts` and the options page load — nothing missing, nothing extra — and unchanged/edited/unreadable behave as above.
- Specs: `fingerprint.SPEC.md` (new), `background.SPEC.md`, the extension `SPEC.md`, `check.SPEC.md`; `FEATURES-SPEC.md` gets the feature; the README's "reload the extension on chrome://extensions" paragraph is rewritten.

**Not covered here**: the user's own claude.ai tabs still run the old content script until they reload — as after a manual reload; only the Driver tab is the extension's to reload.

**Dogfood**: one last manual reload to get this worker running, then an edit to a comment in `content.js` and the Driver's `page loaded on /code` self-report arriving with no click — posted below when done.

🤖 *automated · Fable 5, effort high*
