### PR TITLE
The bridge-store list-status test runs on a fixed clock, not the wall clock (#1332)

### DIFF
--- a/packages/framework/src/dashboard/bridge-store.test.ts
+++ b/packages/framework/src/dashboard/bridge-store.test.ts
@@ -132,20 +132,24 @@ test('an undelivered pick dies with the question it answered (#1237)', () => {
 
 test("claude.ai's list saying a session awaits input makes it waiting, until the session is cleared (#1332)", () => {
   const store = new BridgeQuestions()
-  assert.equal(store.waiting(SESSION), false)
+  // A fixed clock: a list status counts only within the session window, so the test's "now" must
+  // sit inside the window of the timestamps it records — not the wall clock, which walked out of
+  // it twelve hours after the timestamps were written.
+  const now = new Date('2026-08-25T18:05:00.000Z')
+  assert.equal(store.waiting(SESSION, now), false)
   // A question asked in prose carries no block: the list is the only thing that says the session
   // stopped for its user.
   store.recordStatus({ sessionId: SESSION, status: 'awaiting', at: '2026-08-25T18:00:00.000Z' })
-  assert.equal(store.waiting(SESSION), true)
+  assert.equal(store.waiting(SESSION, now), true)
   assert.equal(store.status(SESSION)?.status, 'awaiting')
   // The newest report replaces the older one.
   store.recordStatus({ sessionId: SESSION, status: 'idle', at: '2026-08-25T18:01:00.000Z' })
-  assert.equal(store.waiting(SESSION), false)
+  assert.equal(store.waiting(SESSION, now), false)
   // A parked question makes the session waiting whatever the list said.
   store.record(question())
-  assert.equal(store.waiting(SESSION), true)
+  assert.equal(store.waiting(SESSION, now), true)
   store.clear(SESSION)
-  assert.equal(store.waiting(SESSION), false)
+  assert.equal(store.waiting(SESSION, now), false)
   assert.equal(store.status(SESSION), undefined)
 })
 


### PR DESCRIPTION
`bridge-store.test.ts`'s "claude.ai's list saying a session awaits input makes it waiting…" test recorded a status stamped `2026-08-25T18:00Z` and asked `waiting()` with the default wall-clock `now`. `waiting()` counts a list status only within `CLOUD_SESSION_WINDOW_MS` (12 h), so since 2026-08-26 06:00 UTC the test fails everywhere — seen first on #1714's CI, reproduced locally on `main`. The sibling test in the same file already passes a fixed `now`; this one now does too. No code change.

🤖 *automated · Fable 5, effort high*
