### PR TITLE
Comment the branch-management bin as a forwarder to dist/cli.js

### DIFF
--- a/packages/branch-management/bin/branch-management
+++ b/packages/branch-management/bin/branch-management
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// This file only forwards to dist/cli.js.
 import { runCli } from '../dist/cli.js'
 
 runCli(process.argv.slice(2), { cwd: process.cwd(), stdout: line => console.log(line), stderr: line => console.error(line) })


### PR DESCRIPTION
`packages/branch-management/bin/branch-management` now carries a one-line comment right after the shebang stating that the file only forwards to `dist/cli.js`. No behavior change.

Opened from The Framework session `bin-forward-comment`.