### PR TITLE
@better-skills/branch-management 0.0.1: the first publish, holding the name (#1725)

### DIFF
--- a/packages/branch-management/package.json
+++ b/packages/branch-management/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-skills/branch-management",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Branch management for coding agents: one git checkout per agent under .the-framework/branches/, named as its branch, reclaimed once its work is on the remote.",
   "license": "MIT",
   "repository": {
@@ -17,7 +17,7 @@
   },
   "files": [
     "dist",
-    "bin",
+    "bin/branch-management",
     "SKILL.md"
   ],
   "bin": {

--- a/packages/branch-management/package.json
+++ b/packages/branch-management/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/framework/the-framework",
+    "url": "git+https://github.com/framework/the-framework.git",
     "directory": "packages/branch-management"
   },
   "type": "module",
@@ -21,7 +21,7 @@
     "SKILL.md"
   ],
   "bin": {
-    "branch-management": "./bin/branch-management"
+    "branch-management": "bin/branch-management"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
Plan §6 step 1 of #1725: publish `@better-skills/branch-management` once so the name is held and the `framework` package's `workspace:*` dependency has something to resolve to at its next release.

- `version` 0.0.0 → 0.0.1.
- `files`: `bin` → `bin/branch-management` — `pnpm pack` was shipping `bin/SPEC.md`, a development note. The tarball is now `dist/`, the bin, `SKILL.md`, `package.json` (41 kB, 47 files).
- `bin`: `./bin/branch-management` → `bin/branch-management`. With npm 11.13, `npm publish` drops a `./`-prefixed bin outright (`"bin[branch-management]" script name bin/branch-management was invalid and removed`) — the first publish attempt showed it, and the package would have installed without its command. `npm pkg fix` does not surface this; `npm publish --dry-run` does. `framework` has the same `./dist/bin.js` — fixed in its own PR.
- `repository.url` in the form npm normalizes to, so the publish runs warning-free.

Publishing is manual (`npm publish --access public` from `packages/branch-management`), same as `framework`. Step 4 (the dogfood of the skill on this repo, #1730) passed before this: the agent ran `branch-management name`, the branch event reached the dashboard, `status` was clean, the hand-off opened its PR on the named branch and the checkout was reclaimed at teardown.

🤖 *automated · Fable 5, effort high*