### PR TITLE
framework's bin path without ./: npm 11 drops a ./-prefixed bin at publish

### DIFF
--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/framework/the-framework",
+    "url": "git+https://github.com/framework/the-framework.git",
     "directory": "packages/framework"
   },
   "type": "module",
@@ -30,7 +30,7 @@
     "dist"
   ],
   "bin": {
-    "the-framework": "./dist/bin.js"
+    "the-framework": "dist/bin.js"
   },
   "scripts": {
     "build": "pnpm -C ../branch-management build && node scripts/gen-prompts.mjs && tsc -p tsconfig.build.json && cd dashboard && vite build",


### PR DESCRIPTION
Found while preparing #1731: with npm 11.13, `npm publish --dry-run` in `packages/framework` warns

```
"bin[the-framework]" script name dist/bin.js was invalid and removed
```

for `"./dist/bin.js"` — the tarball's package.json loses its `bin`, so the next `framework` release would install without the `the-framework` command. `npm pkg fix` does not show it (it only strips the prefix); the dry-run does. The published 0.7.0 still carries `bin: dist/bin.js` because an older npm normalized the prefix away.

Two-character fix: `"dist/bin.js"`. The repository URL is written the way npm normalizes it (`git+https://….git`) so the publish runs warning-free. Same fix for `@better-skills/branch-management` is in #1731.

🤖 *automated · Fable 5, effort high*