### PR TITLE
The skill's SPECs stop narrating the caller's dashboard

### DIFF
--- a/packages/skill-branches/SPEC.md
+++ b/packages/skill-branches/SPEC.md
@@ -1,6 +1,6 @@
 Branch management for coding agents, as an npm package: one git checkout per agent under a project's `.branches/`, named as its branch; the parent checkout's dependencies shared into it; a navigable link per branch name; one retention rule under which a checkout is reclaimed — only once everything it holds is on the remote; and the instructions an agent follows to live inside that rule (`SKILL.md`).
 
-The package knows git and the filesystem, nothing else. The same functions serve every caller: a daemon that starts agents (allocation, teardown, the reclaim sweep), a dashboard (the retained-checkouts list, the Remove and Prune buttons), and an agent's own shell, through the `branches` command a daemon puts on the PATH of every agent it starts on its machine. What a caller knows beyond git — whether an agent is still running, whether its handoff allows a push, what a cloud hand-off already pushed — is passed in; the package never reads an agent's record.
+The package knows git and the filesystem, nothing else. The same functions serve every caller: a daemon that starts agents, a dashboard that lists and reclaims checkouts, and an agent's own shell, through the `branches` command a daemon puts on the PATH of every agent it starts on its machine. What a caller knows beyond git — whether an agent is still running, whether its handoff allows a push, what a cloud hand-off already pushed — is passed in; the package never reads an agent's record.
 
 ## Business logic — TL;DR
 

--- a/packages/skill-branches/src/cli.SPEC.md
+++ b/packages/skill-branches/src/cli.SPEC.md
@@ -4,7 +4,7 @@ The package's command line: the same operations a daemon calls, for an agent (or
 
 - An agent, started inside its own checkout, names its session and learns the branch name it got.
 - An agent checks, before it finishes, that it has left nothing uncommitted.
-- The user, in a terminal, lists and reclaims the checkouts under a project without opening the dashboard.
+- The user, in a terminal, lists and reclaims the checkouts under a project without any other tool.
 
 ## Glossary
 

--- a/packages/skill-branches/src/reclaim.SPEC.md
+++ b/packages/skill-branches/src/reclaim.SPEC.md
@@ -1,4 +1,4 @@
-Reclaiming an agent's checkout: the one implementation behind every surface that removes one — a daemon's sweep and teardown, a dashboard's Remove button, an agent's own command line — so a second surface is never a second behaviour.
+Reclaiming an agent's checkout: the one implementation behind every surface that removes one — a daemon's sweep and teardown, a dashboard's remove action, an agent's own command line — so a second surface is never a second behaviour.
 
 ## User story
 


### PR DESCRIPTION
Reading `packages/skill-branches/SPEC.md` on GitHub after #1743, I saw it still narrates The Framework's dashboard — its checkout list and its Remove/Prune buttons — as if the package had one. A dashboard is a fine example of a caller; its buttons are not the package's business. Three lines, SPEC text only.

---

🤖 *curated · Fable 5, effort high*

- `SPEC.md`: "a daemon that starts agents (allocation, teardown, the reclaim sweep), a dashboard (the retained-checkouts list, the Remove and Prune buttons)" → "a daemon that starts agents, a dashboard that lists and reclaims checkouts".
- `src/cli.SPEC.md`: "without opening the dashboard" → "without any other tool".
- `src/reclaim.SPEC.md`: "a dashboard's Remove button" → "a dashboard's remove action".

Kept: the '"remove this" button' rationale in `worktree.SPEC.md` / `worktree-size.test.SPEC.md` — it explains why the size read is best-effort, and names no product.

Proof: skill-branches 117/117, framework 1471/1471 green in a fresh worktree off `6611a77a`.
