### PR TITLE
skill-tickets SKILL.md: a description YAML can parse

### DIFF
--- a/packages/skill-tickets/SKILL.md
+++ b/packages/skill-tickets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tickets
-description: The project's tickets and its agent queue: where they live, how to read and change them, how to claim a ticket so no two agents work the same one, and the formats.
+description: Where the project's tickets and its agent queue live, how to read and change them, how to claim a ticket so no two agents work the same one, and the formats.
 ---
 
 # Tickets and the agent queue


### PR DESCRIPTION
The `description` in `packages/skill-tickets/SKILL.md` held `: ` after "agent queue". YAML reads that as a second key inside the value, so GitHub rendered "mapping values are not allowed in this context at line 2 column 55", and a skill loader parsing the frontmatter the same way would stumble too. The line predates #1752 (it came with #1749).

Rephrased without the colon; both SKILL.md frontmatters now parse.

🤖 *curated · Fable 5.1, effort high* — one line, checked with a YAML parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDPvXJ7KN5Msffxmc3vYvi