### PR TITLE
Dogfood 2026-09-05: `npx tickets` resolves locally, CLI tests drop the daemon's AGENT_ID, two SKILL.md phrases

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "website:test": "cd packages/the-framework.ai/ && echo 'no tests yet'"
   },
   "devDependencies": {
+    "@gemstack/skill-branches": "workspace:*",
+    "@gemstack/skill-tickets": "workspace:*",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/skill-tickets/SKILL.md
+++ b/packages/skill-tickets/SKILL.md
@@ -12,7 +12,7 @@ Read and change them with the `tickets` command, a dependency of this repository
 ## Read
 
 ```
-npx tickets list                 every open ticket, as JSON: file, title, summary, priority, topics,
+npx tickets list                 every open ticket, as one JSON array: file, title, summary, priority, topics,
                                  github, date, planned, effort, uncertainty, locked, lockedBy
                                  (priority, topics, github, effort, uncertainty, locked, lockedBy
                                  absent when unset)
@@ -31,7 +31,8 @@ npx tickets close <file>         once the work is merged: remove the ticket with
                                  `queue done` it
 npx tickets queue add <text> [--priority N] [--ticket <file>]
                                  put an entry on the queue; --priority places it in that section,
-                                 --ticket links it to the ticket and places it by the ticket's
+                                 --ticket makes <text> the label of a link to the ticket (pass the
+                                 label, not a link) and places it by the ticket's
                                  priority (5 when it has none) unless --priority says otherwise;
                                  with neither, it goes at the end of the file
 npx tickets queue done <entry>   remove an entry: one quoted argument, exactly as `npx tickets queue`

--- a/packages/skill-tickets/src/cli.test.ts
+++ b/packages/skill-tickets/src/cli.test.ts
@@ -7,6 +7,9 @@ import { nodeGitRunner, DATA_BRANCH } from '@gemstack/agent-data'
 import { runCli, USAGE } from './cli.js'
 
 const git = nodeGitRunner()
+// The command reads AGENT_ID from the real environment, and a daemon sets it for every agent it
+// starts, this test run included: drop it, so only the one test that sets it on purpose sees it.
+delete process.env['AGENT_ID']
 const RETRIED_RM = { recursive: true, force: true, maxRetries: 10 } as const
 
 /** A bare origin with an `agent-data` branch holding two tickets, plus N clones acting as agents. */

--- a/packages/skill-tickets/src/cli.ts
+++ b/packages/skill-tickets/src/cli.ts
@@ -25,7 +25,7 @@ import { holderOf } from './holder.js'
 
 export const USAGE = `usage: tickets <command>
 
-  list                               every open ticket, as JSON
+  list                               every open ticket, as one JSON array
   show <file>                        one ticket: its text, its plan, who holds it
   queue                              the queue's open entries, in order of work
   queue add <text> [--priority N] [--ticket <file>]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     devDependencies:
+      '@gemstack/skill-branches':
+        specifier: workspace:*
+        version: link:packages/skill-branches
+      '@gemstack/skill-tickets':
+        specifier: workspace:*
+        version: link:packages/skill-tickets
       typescript:
         specifier: ^7.0.2
         version: 7.0.2


### PR DESCRIPTION
Three fixes from the 2026-09-05 dogfood on the real daemon.

**`npx tickets` ran a stranger's package.** The tickets SKILL.md says the command is a dependency of the repository. This repository broke that rule: only `packages/framework` depended on the skills, so the root had no `tickets` or `branches` bin. In an agent's checkout, `npx tickets` fell through to the npm registry and ran `tickets@0.2.2`, a JIRA lookup tool, without failing. The root now depends on both skill packages. `npx tickets` and `npx branches` resolve to the checkout's own bins. A checkout without a build fails loudly on the missing `dist/` instead of running someone else's tool. The daemon's PATH, which carries the main checkout's built bins, is unchanged.

**The CLI tests inherited the daemon's `AGENT_ID`.** `cli.test.ts` calls the CLI in-process, and the CLI reads `AGENT_ID` from the real environment. The daemon sets it for every agent it starts, so `pnpm test` in an agent run failed three tests with the agent's id as holder. The test file now drops the variable at load. The one test that needs it still sets it on purpose. Verified by removing the line and running with `AGENT_ID` set: 3 of 6 fail; with it, 58 of 58 pass.

**Two SKILL.md phrases that the agent guessed wrong.** `list` prints one JSON array, not an object holding one. With `--ticket`, `<text>` becomes the label of the link to the ticket; the agent passed a link and got a double-wrapped entry. Both phrases say what the code does today. The CLI usage line for `list` says the same.

🤖 *curated · Fable 5.1, effort high*
