### PR TITLE
`isTicketFile` refuses a leading dot, as `isTicketPath` already does

### DIFF
--- a/packages/skill-tickets/src/names.SPEC.md
+++ b/packages/skill-tickets/src/names.SPEC.md
@@ -37,11 +37,11 @@ A ticket is `tickets/<DATE>_<SLUG>.md`. Its plan is `<DATE>_<SLUG>.plan.md` and 
 
 #### Business logic
 
-A ticket filename is a `.md` name with no path segment at all, and not one of a ticket's own siblings: a relative segment, a nested path, an absolute path and a `.plan.md`/`.lock.md` name are all refused. A ticket path is the same thing spelled out: `tickets/<name>.md`, and nothing else — a segment that climbs out, a deeper nesting, a dotfile, a URL and a non-markdown file all fail it.
+A ticket filename is a `.md` name with no path segment at all, no leading dot, and not one of a ticket's own siblings: a relative segment, a nested path, an absolute path, a dotfile and a `.plan.md`/`.lock.md` name are all refused. A ticket path is the same thing spelled out: `tickets/<name>.md`, and nothing else — a segment that climbs out, a deeper nesting, a dotfile, a URL and a non-markdown file all fail it.
 
 #### Rationale
 
-One gate, used at both ends: what a queue entry is allowed to be read as, and what a caller is allowed to record. A traversal dressed as a markdown link is refused by the same rule that refuses it as a command argument.
+One gate, used at both ends: what a queue entry is allowed to be read as, and what a caller is allowed to record. A traversal dressed as a markdown link is refused by the same rule that refuses it as a command argument. The two spellings refuse the same names, because a command takes either for the same file: a name the bare form accepts and the path form refuses would leave a caller no rule to read off.
 
 ### The ticket a queue entry came from
 

--- a/packages/skill-tickets/src/names.test.SPEC.md
+++ b/packages/skill-tickets/src/names.test.SPEC.md
@@ -5,7 +5,7 @@ What the tests cover: the conventions the skill names, and the pure rules tying 
 - **A ticket's priority on the queue's scale** - a number 0 to 10 is taken as written, padding included; an unmarked ticket, a word, an out-of-range value and a fractional one all land in the middle rather than being guessed at or clamped.
 - **The ticket behind a queue entry** - a link into `tickets/` gives the ticket; an entry that is just text gives none, and neither does a link to anything else or a traversal dressed as a link.
 - **A ticket path** - only a plain markdown file directly inside `tickets/` counts; a climb out, a nested path, a dotfile, a non-markdown file, an absolute path, a URL, the queue file and the bare folder are all refused.
-- **A bare ticket filename** - no path segment at all, and not a `.plan.md`, a `.lock.md` or `meta.json`.
+- **A bare ticket filename** - no path segment at all, no leading dot (the same name the path form refuses as a dotfile), and not a `.plan.md`, a `.lock.md` or `meta.json`.
 - **The issue a ticket tracks** - read off the `GitHub:` header line, the URL winning over a label that disagrees with it, a hand-written line counting by its label, and no line or no number giving none.
 
 ## Before modifying/creating SPEC.md files

--- a/packages/skill-tickets/src/names.test.ts
+++ b/packages/skill-tickets/src/names.test.ts
@@ -45,14 +45,15 @@ test('ticketFromQueueEntry reads the ticket a queued entry links back to', () =>
 
 test('only a plain file inside tickets/ counts as a ticket path', () => {
   assert.equal(isTicketPath('tickets/2026-07-25_login.md'), true)
+  // A dot-prefixed name is refused in both spellings: `tickets/.hidden.md` here, `.hidden.md` bare.
   for (const bad of ['tickets/../secrets.md', 'tickets/nested/deep.md', 'tickets/.hidden.md', 'tickets/notes.txt', '/etc/passwd', 'https://example.com/x.md', 'TODO_AGENTS.md', 'tickets/']) {
     assert.equal(isTicketPath(bad), false, `expected ${bad} to be rejected`)
   }
 })
 
-test('a bare ticket filename has no path segments and is not a sibling', () => {
+test('a bare ticket filename has no path segments, no leading dot and is not a sibling', () => {
   assert.equal(isTicketFile('2026-07-25_login.md'), true)
-  for (const bad of ['../login.md', 'sub/login.md', '/etc/passwd.md', '2026-07-25_login.plan.md', '2026-07-25_login.lock.md', 'meta.json']) {
+  for (const bad of ['../login.md', 'sub/login.md', '/etc/passwd.md', '.hidden.md', '2026-07-25_login.plan.md', '2026-07-25_login.lock.md', 'meta.json']) {
     assert.equal(isTicketFile(bad), false, `expected ${bad} to be rejected`)
   }
 })

--- a/packages/skill-tickets/src/names.ts
+++ b/packages/skill-tickets/src/names.ts
@@ -40,11 +40,13 @@ export function ticketLockName(file: string): string {
 
 /**
  * A bare ticket filename: a `.md` name with no path segments (so it cannot address another
- * directory) and not one of a ticket's own siblings. The gate every filename that arrives from
- * outside — a command's argument, a browser — goes through.
+ * directory), not starting with a dot, and not one of a ticket's own siblings. The gate every
+ * filename that arrives from outside — a command's argument, a browser — goes through. The two
+ * spellings of a name refuse the same ones: what this refuses bare, `isTicketPath` refuses under
+ * `tickets/`.
  */
 export function isTicketFile(file: string): boolean {
-  return /^[^/\\]+\.md$/.test(file) && !SIBLING.test(file)
+  return /^[^./\\][^/\\]*\.md$/.test(file) && !SIBLING.test(file)
 }
 
 /** Whether a filename inside `tickets/` is a sibling (`.plan.md` / `.lock.md`) rather than a ticket. */


### PR DESCRIPTION
A ticket name is checked in two spellings, bare and under `tickets/`. The two checks disagreed on a leading dot: `.x.md` passed bare and was refused as a path. So `tickets show .x.md` read the file while `tickets show tickets/.x.md` refused with `invalid-path`. No rule a caller could read off a queue entry's link.

Both checks now refuse a dot-prefixed name. One test case each in `names.test.ts`; the two SPEC lines say the same.

Found and fixed by the agent of the 2026-09-05 dogfood run on this repository, in its own checkout. Rebased onto main and pushed by hand.

🤖 *curated · Fable 5.1, effort high*
