### PR TITLE
Two SKILL.md sentences reworded: close once the work is done and published; install only when the command fails for a missing node_modules

### DIFF
--- a/packages/skill-logs/SKILL.md
+++ b/packages/skill-logs/SKILL.md
@@ -7,7 +7,7 @@ description: The record of every run agents made on this project — what was as
 
 Every run an agent made on this project leaves a record on the branch `agent-data`, never on a code branch; your checkout does not contain it. A run is two files under `agents/<who>/`: the card, `<id>.json` — what was asked, the ticket, the branch, the pull request, how it ended, what it cost — and the diary, `<id>.jsonl` — what the agent said along the way, its result.
 
-Read them with the `logs` command, a dependency of this repository (`@gemstack/skill-logs`). With no `node_modules`, install first with the lockfile's package manager (`npm install` for `package-lock.json`). Then run it as `npx logs`. The command only reads: the program that ran an agent records its run, at its end. A refusal exits 1 with a line on stderr; a wrong command line exits 2 with the usage.
+Read them with the `logs` command, a dependency of this repository (`@gemstack/skill-logs`), run as `npx logs`. When that fails for a missing `node_modules`, install with the lockfile's package manager (`npm install` for `package-lock.json`) and run it again. The command only reads: the program that ran an agent records its run, at its end. A refusal exits 1 with a line on stderr; a wrong command line exits 2 with the usage.
 
 ## Read
 

--- a/packages/skill-queue/SKILL.md
+++ b/packages/skill-queue/SKILL.md
@@ -7,7 +7,7 @@ description: Where the project's agent queue lives, how to read it and change it
 
 The agent queue (`TODO_AGENTS.md`) lives on the branch `agent-data`, never on a code branch; your checkout does not contain it. It lists every task agents will work on next, in the order they will be taken.
 
-Read and change it with the `queue` command, a dependency of this repository (`@gemstack/skill-queue`). With no `node_modules`, install first with the lockfile's package manager (`npm install` for `package-lock.json`). Then run it as `npx queue`. Every change it makes is one commit pushed straight to the `agent-data` branch. A refusal exits 1 with a line on stderr; a wrong command line exits 2 with the usage.
+Read and change it with the `queue` command, a dependency of this repository (`@gemstack/skill-queue`), run as `npx queue`. When that fails for a missing `node_modules`, install with the lockfile's package manager (`npm install` for `package-lock.json`) and run it again. Every change it makes is one commit pushed straight to the `agent-data` branch. A refusal exits 1 with a line on stderr; a wrong command line exits 2 with the usage.
 
 ## Read
 

--- a/packages/skill-tickets/SKILL.md
+++ b/packages/skill-tickets/SKILL.md
@@ -7,7 +7,7 @@ description: Where the project's tickets live, how to read and change them, how 
 
 The tickets (`tickets/<DATE>_<SLUG>.md`, with their `.plan.md` and `.lock.md` siblings) live on the branch `agent-data`, never on a code branch. A `tickets` link at the repository root, if present, shows a possibly stale copy; never write there. The command reads fresh.
 
-Read and change them with the `tickets` command, a dependency of this repository (`@gemstack/skill-tickets`). With no `node_modules`, install first with the lockfile's package manager (`npm install` for `package-lock.json`). Then run it as `npx tickets`. Every change it makes is one commit pushed straight to the `agent-data` branch. A refusal exits 1 with a line on stderr; a wrong command line exits 2 with the usage.
+Read and change them with the `tickets` command, a dependency of this repository (`@gemstack/skill-tickets`), run as `npx tickets`. When that fails for a missing `node_modules`, install with the lockfile's package manager (`npm install` for `package-lock.json`) and run it again. Every change it makes is one commit pushed straight to the `agent-data` branch. A refusal exits 1 with a line on stderr; a wrong command line exits 2 with the usage.
 
 ## Read
 
@@ -25,8 +25,8 @@ npx tickets show <file>          one ticket: its text, its plan, who holds it
 npx tickets put <file>           write one file under tickets/ from stdin, the whole file, creating it if new;
                                  empty stdin writes an empty file
                                  (npx tickets put <file> < draft.md): a ticket or a plan
-npx tickets close <file>         once the work is merged: remove the ticket with its plan and lock;
-                                 refused while someone else holds it; its queue entry, if any,
+npx tickets close <file>         once the work is done and published: remove the ticket with its plan
+                                 and lock; refused while someone else holds it; its queue entry, if any,
                                  stays: `npx queue done` it
 ```
 
@@ -38,7 +38,7 @@ When the repository has the `queue` skill, a ticket goes on the agent queue as a
 npx queue add "[<title>](tickets/<file>)" --priority <N>
 ```
 
-Once the work is merged, `npx tickets close <file>` and `npx queue done` the entry.
+Once the work is done and published, `npx tickets close <file>` and `npx queue done` the entry.
 
 ## Claim before you plan or work a ticket
 


### PR DESCRIPTION
Two sentences in the skills' SKILL.md files sent agents the wrong way in the Q2 experiment (#1774).

**"Once the work is merged" → "once the work is done and published."** A plain agent run has no merge step. Opus read "merged" literally and stalled before committing, with its claims held. Two places in the tickets SKILL.md.

**"With no `node_modules`, install first" → "run as `npx …`; when that fails for a missing `node_modules`, install and run it again."** Sonnet read the old sentence as an order and ran `npm install` before reading anything, in three runs. Now the install is a fallback on a failed run. Same sentence in the tickets, queue and logs SKILL.md; all three changed the same way.

No code change. The framework's generated prompts pick the new text up at build.

Checked on the experiment's rig with the same prompt. Sonnet went straight to the commands, no `npm install` attempt. Opus stopped before the close step in its run, so that run says nothing about the first change; under the rules prompt it closed correctly with the old wording too. The first change is a correction of the words, not a measured fix.

🤖 *automated · Fable 5.1*
